### PR TITLE
refactor(fcp): Remove Node from message execution

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.PeerAddFailureReason;
 import network.crypta.runtime.spi.PeerAddRejectedException;
@@ -37,9 +36,9 @@ import org.slf4j.LoggerFactory;
  * <p>Instances of this class are constructed from a {@link SimpleFieldSet} received over an FCP
  * connection. The constructor parses common metadata such as {@code Identifier}, {@code Trust}, and
  * {@code Visibility}, and, when present, the peer reference itself or an indirection to it using a
- * {@code URL} or {@code File} field. During {@link #run(FCPConnectionHandler, Node)} the message
- * resolves the reference, validates that it is well-formed and not a self reference, and finally
- * installs the new peer in the node's darknet or opennet peer table.
+ * {@code URL} or {@code File} field. During {@link #run(FCPConnectionHandler)} the message resolves
+ * the reference, validates that it is well-formed and not a self reference, and finally installs
+ * the new peer in the node's darknet or opennet peer table.
  *
  * <p>The implementation enforces full-access permissions, rejects duplicate peers, and translates
  * low-level parsing or network errors into {@link MessageInvalidException} instances that are
@@ -258,14 +257,12 @@ public final class AddPeer extends FCPMessage {
    *
    * @param handler connection handler representing the client session that issued the AddPeer
    *     request; used to send back the resulting {@link PeerMessage} or error messages
-   * @param node running node instance supplied by the legacy FCP dispatch signature; unused because
-   *     peer-management is delegated through the runtime SPI
    * @throws MessageInvalidException if access is denied, the peer reference cannot be parsed or
    *     verified, the reference describes the node itself, or a peer with the same identity already
    *     exists on the node
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     ensureFullAccess(handler);
     fs = resolveFieldSetForReference(handler);
     try {

--- a/src/main/java/network/crypta/clients/fcp/AllDataMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/AllDataMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 
@@ -138,11 +137,10 @@ public class AllDataMessage extends DataCarryingMessage {
    * an explicit error.
    *
    * @param handler connection handler that attempted execution; recorded only for diagnostics
-   * @param node node context in which this outbound response originated; otherwise unused
    * @throws MessageInvalidException always thrown to indicate the directionality violation
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "AllData goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
@@ -10,7 +10,6 @@ import java.util.Locale;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
@@ -368,11 +367,9 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
    * identifiers and client tokens.
    *
    * @param handler active connection handler orchestrating ClientGet lifecycle and status relays.
-   * @param node node instance whose datastore, routing, and scheduler components execute the
-   *     request.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) {
+  public void run(FCPConnectionHandler handler) {
     handler.startClientGet(this);
   }
 

--- a/src/main/java/network/crypta/clients/fcp/ClientHelloMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientHelloMessage.java
@@ -16,10 +16,10 @@ import network.crypta.support.SimpleFieldSet;
  * when exercising integration tests or diagnostics.
  *
  * <p>The class is effectively immutable once constructed, so it can be safely passed across threads
- * as part of the connection pipeline. Invocation of {@link #run(FCPConnectionHandler, Node)} is
- * expected to happen on the per-connection handler thread; after it completes the handler registers
- * the supplied client name and the node replies with a {@link NodeHelloMessage}. No synchronization
- * is and remains thread-safe as long as the surrounding {@link FCPConnectionHandler} keeps its
+ * as part of the connection pipeline. Invocation of {@link #run(FCPConnectionHandler)} is expected
+ * to happen on the per-connection handler thread; after it completes the handler registers the
+ * supplied client name and the node replies with a {@link NodeHelloMessage}. No synchronization is
+ * and remains thread-safe as long as the surrounding {@link FCPConnectionHandler} keeps its
  * single-threaded contract.
  *
  * <ul>
@@ -122,15 +122,14 @@ public final class ClientHelloMessage extends FCPMessage {
    *
    * <pre>{@code
    * ClientHelloMessage hello = ...;
-   * hello.run(handler, node);
+   * hello.run(handler);
    * }</pre>
    *
    * @param handler connection handler sending {@link NodeHelloMessage} and storing the announced
    *     client label.
-   * @param node owning node reference reserved for future behavior, currently unused.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) {
+  public void run(FCPConnectionHandler handler) {
     // We know the Hello is valid.
     NodeGreetingSnapshot greeting = handler.getServer().runtime().nodeInfo().greeting();
     FCPMessage msg =

--- a/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import network.crypta.client.Metadata;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
@@ -234,11 +233,10 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
    * feedback.
    *
    * @param handler active connection handler responsible for initiating the put job
-   * @param node legacy execution parameter retained by the message API; unused here
    * @throws MessageInvalidException if conversion detects disallowed files or inconsistent input
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     // Convert the hierarchical hashmap's of DirPutFile's to hierarchical hashmap's
     // of ManifestElement's.
     // Then simply create the ClientPutDir.

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDiskDirMessage.java
@@ -7,7 +7,6 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.ManifestElement;
@@ -25,11 +24,11 @@ import org.slf4j.LoggerFactory;
  * handling, and recursive traversal semantics. Every directory level is unfolded eagerly to size
  * files, attach {@link DefaultMIMETypes}, and guard against unreadable paths before the actual
  * network transfer begins. Callers typically instantiate this message during request construction,
- * then rely on {@link #run(FCPConnectionHandler, Node)} to build the manifest map and hand it to
- * the node core. The class is thread-confined: each instance is used by a single connection
- * handler, but the generated bucket map may be consumed by asynchronous upload workers. Error
- * reporting is immediate, so missing directories or unreadable files fail fast instead of producing
- * partial manifests.
+ * then rely on {@link #run(FCPConnectionHandler)} to build the manifest map and hand it to the node
+ * core. The class is thread-confined: each instance is used by a single connection handler, but the
+ * generated bucket map may be consumed by asynchronous upload workers. Error reporting is
+ * immediate, so missing directories or unreadable files fail fast instead of producing partial
+ * manifests.
  *
  * <p><strong>Responsibilities</strong>
  *
@@ -97,12 +96,11 @@ public final class ClientPutDiskDirMessage extends ClientPutDirMessage {
    * the returned buckets may be consumed asynchronously by upload workers.
    *
    * @param handler connection handler owning this message; must be non-null and connected.
-   * @param node legacy execution parameter retained by the message API; unused here.
    * @throws MessageInvalidException if the directory is not permitted, or traversal fails under the
    *     configured validation rules.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.getServer().runtime().transferAccess().allowUploadFrom(dirname))
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
@@ -506,11 +506,10 @@ public final class ClientPutMessage extends DataCarryingMessage {
    *
    * @param handler connection handler that accepted the message and coordinates streaming
    *     back-pressure
-   * @param node node instance used to resolve persistence settings and enforce configured limits
    * @throws MessageInvalidException if the handler detects inconsistency during late validation
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     handler.startClientPut(this);
   }
 

--- a/src/main/java/network/crypta/clients/fcp/CloseConnectionDuplicateClientNameMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/CloseConnectionDuplicateClientNameMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -95,13 +94,11 @@ public class CloseConnectionDuplicateClientNameMessage extends FCPMessage {
    * be closed immediately after propagating it.
    *
    * @param handler connection-specific context that surfaced the offending message; never null.
-   * @param node node instance receiving the invalid inbound request and orchestrating shutdown
-   *     sequencing; never null.
    * @throws MessageInvalidException always thrown to stop processing because the message direction
    *     is unsupported and represents a client error.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "CloseConnectionDuplicateClientName goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/CompatibilityMode.java
+++ b/src/main/java/network/crypta/clients/fcp/CompatibilityMode.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.CompatibilityAnalyser;
-import network.crypta.node.Node;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 
@@ -15,7 +14,7 @@ import network.crypta.support.SimpleFieldSet;
  * instance once an analyser settles on definitive values, set the {@code identifier} that ties the
  * message back to their request queue, and send it over an {@link FCPConnectionHandler} so the node
  * can acknowledge whether it understands the announced range. Because the message is purely
- * descriptive, the {@link #run(FCPConnectionHandler, Node)} hook is intentionally unsupported.
+ * descriptive, the {@link #run(FCPConnectionHandler)} hook is intentionally unsupported.
  *
  * <p>The class keeps a reference to the analyser rather than copying individual values, ensuring
  * that {@link #getFieldSet()} always reflects the analyser's most recent view when serialization
@@ -121,12 +120,11 @@ public class CompatibilityMode extends FCPMessage {
    *
    * @param handler connection handler provided by the FCP framework; ignored because the method is
    *     unsupported.
-   * @param node node instance associated with the FCP server; ignored for the same reason.
    * @throws MessageInvalidException declared for compatibility with the superclass but never thrown
    *     because the method terminates earlier with {@link UnsupportedOperationException}.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/network/crypta/clients/fcp/ConfigData.java
+++ b/src/main/java/network/crypta/clients/fcp/ConfigData.java
@@ -4,7 +4,6 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.ConfigFieldSet;
 import network.crypta.runtime.spi.ConfigSection;
 import network.crypta.runtime.spi.ConfigSnapshot;
@@ -144,12 +143,10 @@ public class ConfigData extends FCPMessage {
    *
    * @param handler connection that attempted to process the message; ignored because validation
    *     always fails earlier.
-   * @param node node that received the invalid message; provided for interface completeness but not
-   *     consulted.
    * @throws MessageInvalidException always thrown to signal the unsupported direction.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "ConfigData goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/DataFoundMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/DataFoundMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.FetchResult;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -16,9 +15,9 @@ import network.crypta.support.SimpleFieldSet;
  * as long as the surrounding FCP infrastructure treats {@link SimpleFieldSet} instances immutably.
  *
  * <p>Lifecycle wise, this object is created on the server (node) side and never sent from a client.
- * The {@link #run(FCPConnectionHandler, Node)} method therefore always rejects inbound invocations,
- * which protects the server against malformed or malicious transmissions that attempt to mimic
- * server messages. Consumers normally only call {@link #getFieldSet()} and {@link #getName()} when
+ * The {@link #run(FCPConnectionHandler)} method therefore always rejects inbound invocations, which
+ * protects the server against malformed or malicious transmissions that attempt to mimic server
+ * messages. Consumers normally only call {@link #getFieldSet()} and {@link #getName()} when
  * serializing the message to the wire. Concurrency guarantees are limited to constructor-time
  * publication; callers should not mutate returned field-set instances without copying them first.
  *
@@ -147,11 +146,10 @@ public class DataFoundMessage extends FCPMessage {
    * offending client.
    *
    * @param handler active connection handler attempting to execute the inbound message frame.
-   * @param node node instance receiving the message; unused because execution is forbidden.
    * @throws MessageInvalidException always thrown to preserve protocol directionality semantics.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "DataFound goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/DisconnectMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/DisconnectMessage.java
@@ -15,9 +15,9 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>Instances are immutable and therefore thread-safe; a single instance can be reused whenever
  * the protocol stack needs to convey the same action. Lifecycle management is straightforward: once
- * {@link #run(FCPConnectionHandler, Node)} executes, resources such as socket registrations,
- * throttling counters, and per-request callbacks are released as part of the handler's {@code
- * close()} routine, ensuring accounting remains balanced even under load.
+ * {@link #run(FCPConnectionHandler)} executes, resources such as socket registrations, throttling
+ * counters, and per-request callbacks are released as part of the handler's {@code close()}
+ * routine, ensuring accounting remains balanced even under load.
  *
  * <ul>
  *   <li>Preserves explicit shutdown semantics rather than relying on TCP FIN/RST heuristics.
@@ -91,18 +91,16 @@ public class DisconnectMessage extends FCPMessage {
    *
    * <pre>{@code
    * // Example: proactively terminate a misbehaving client
-   * message.run(connectionHandler, node);
+   * message.run(connectionHandler);
    * }</pre>
    *
    * @param handler Active connection handler whose {@code close()} method performs the shutdown and
    *     must not be {@code null} when this message executes.
-   * @param node Node instance coordinating the broader session; provided for interface symmetry
-   *     even though Disconnect does not manipulate node-local state.
    * @throws MessageInvalidException if the handler rejects the transition or detects a protocol
    *     violation while attempting to close.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     handler.close();
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/EndListPeerNotesMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/EndListPeerNotesMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -83,21 +82,19 @@ public class EndListPeerNotesMessage extends FCPMessage {
   /**
    * Rejects execution because the message is server-to-client only.
    *
-   * <p>Although {@link FCPMessage#run(FCPConnectionHandler, Node)} usually processes
-   * client-originated requests, this message exists solely to inform clients that a server-side
-   * listing completed. Therefore, invoking {@code run} always throws {@link
-   * MessageInvalidException} with {@link ProtocolErrorMessage#INVALID_MESSAGE}. Callers should
-   * never attempt to enqueue this message for inbound processing; instead, serialize it directly to
-   * the client connection.
+   * <p>Although {@link FCPMessage#run(FCPConnectionHandler)} usually processes client-originated
+   * requests, this message exists solely to inform clients that a server-side listing completed.
+   * Therefore, invoking {@code run} always throws {@link MessageInvalidException} with {@link
+   * ProtocolErrorMessage#INVALID_MESSAGE}. Callers should never attempt to enqueue this message for
+   * inbound processing; instead, serialize it directly to the client connection.
    *
    * @param handler connection handler attempting to process the message; unused because execution
    *     is forbidden.
-   * @param node local node context; unused.
    * @throws MessageInvalidException always thrown to signal that the command is invalid in this
    *     direction and must not be executed.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "EndListPeerNotes goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/EndListPeersMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/EndListPeersMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -97,12 +96,11 @@ public class EndListPeersMessage extends FCPMessage {
    * because the server cannot trust the client-supplied identifier in this misuse scenario.
    *
    * @param handler connection handler invoking the message; ignored because execution always fails.
-   * @param node node instance owning the FCP connection; ignored because execution always fails.
    * @throws MessageInvalidException always thrown to indicate that clients must not send this
    *     message to the node.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "EndListPeers goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/EndListPersistentRequestsMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/EndListPersistentRequestsMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -21,7 +20,7 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <ul>
  *   <li>Responsibilities: encode the identifier and advertise the canonical message name.
- *   <li>Limitations: never sent by clients; {@link #run(FCPConnectionHandler, Node)} always throws.
+ *   <li>Limitations: never sent by clients; {@link #run(FCPConnectionHandler)} always throws.
  *   <li>Observability: the {@link #NAME} constant allows tests to verify correct wiring.
  * </ul>
  *
@@ -96,11 +95,10 @@ public class EndListPersistentRequestsMessage extends FCPMessage {
    * spoofed completion notices that could otherwise truncate legitimate listings.
    *
    * @param handler connection handler requesting execution; ignored because the call always fails.
-   * @param node reference to the running node; unused because the message is outbound-only.
    * @throws MessageInvalidException always thrown to signal protocol misuse by the client.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "EndListPersistentRequests goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/EnterFiniteCooldown.java
+++ b/src/main/java/network/crypta/clients/fcp/EnterFiniteCooldown.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -96,7 +95,7 @@ public class EnterFiniteCooldown extends FCPMessage {
    *     base class contract.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     // Not supported
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ExpectedDataLength.java
+++ b/src/main/java/network/crypta/clients/fcp/ExpectedDataLength.java
@@ -23,7 +23,7 @@ import network.crypta.support.SimpleFieldSet;
  * <ul>
  *   <li>Immutable view of expected data lengths for a single identifier.
  *   <li>Safe to reuse across protocol layers as long as no caller mutates the emitted field set.
- *   <li>Contains no side effects when executed via {@link #run(FCPConnectionHandler, Node)}.
+ *   <li>Contains no side effects when executed via {@link #run(FCPConnectionHandler)}.
  * </ul>
  */
 public class ExpectedDataLength extends FCPMessage {
@@ -96,12 +96,11 @@ public class ExpectedDataLength extends FCPMessage {
    * method is safe and idempotent on any thread because the body contains no shared state access.
    *
    * @param handler active connection handler receiving the event; ignored while honoring the API.
-   * @param node node instance backing the handler; ignored because no processing occurs.
    * @throws MessageInvalidException never thrown; declared to honor the {@link FCPMessage}
    *     contract.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     // Not supported
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ExpectedHashes.java
+++ b/src/main/java/network/crypta/clients/fcp/ExpectedHashes.java
@@ -4,7 +4,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.crypt.HashResult;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,12 +184,11 @@ public class ExpectedHashes extends FCPMessage implements Serializable {
    *
    * @param handler connection handler representing the peer endpoint; unused because execution is
    *     unsupported
-   * @param node running node instance; included for interface symmetry but never dereferenced here
    * @throws MessageInvalidException declared for interface compatibility, though the method always
    *     fails with {@link UnsupportedOperationException}
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ExpectedMIME.java
+++ b/src/main/java/network/crypta/clients/fcp/ExpectedMIME.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -25,8 +24,7 @@ import network.crypta.support.SimpleFieldSet;
  *       instance carries no additional state; repeated {@link #getFieldSet()} calls allocate new
  *       {@link SimpleFieldSet} objects.
  *   <li><strong>Usage pattern:</strong> create the message, emit it via {@link #send}, and expect
- *       no server-side action because {@link #run(FCPConnectionHandler, Node)} is intentionally a
- *       no-op.
+ *       no server-side action because {@link #run(FCPConnectionHandler)} is intentionally a no-op.
  * </ul>
  *
  * @see FCPMessage
@@ -88,11 +86,10 @@ public class ExpectedMIME extends FCPMessage {
    * contract and communicates that receiving this message should not attempt side effects.
    *
    * @param handler connection handler that received the message; unused but required by the API.
-   * @param node node instance hosting the handler; unused because the message is declarative.
    * @throws MessageInvalidException never thrown because the method does not perform validation.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     // Not supported
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
@@ -262,7 +262,7 @@ public class FCPConnectionInputHandler implements Runnable {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Parsed message: {} for {}", msg, handler);
       }
-      msg.run(handler, handler.getServer().getNode());
+      msg.run(handler);
       return true;
     } catch (MessageInvalidException e) {
       sendProtocolError(e);

--- a/src/main/java/network/crypta/clients/fcp/FCPMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.PersistentTempBucketFactory;
@@ -17,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * <p>Each instance represents a single message on the wire, consisting of a textual message name
  * followed by a {@link SimpleFieldSet} of name–value pairs. Subclasses provide the concrete mapping
  * between protocol-level fields and internal structures, as well as the handling logic executed by
- * {@link #run(FCPConnectionHandler, Node)}.
+ * {@link #run(FCPConnectionHandler)}.
  *
  * <p>The core responsibilities of this type are:
  *
@@ -26,8 +25,8 @@ import org.slf4j.LoggerFactory;
  *   <li>providing factory methods {@link #create(String, SimpleFieldSet, BucketFactory,
  *       PersistentTempBucketFactory)} and {@link #create(String, SimpleFieldSet)} to reify messages
  *       received from the network
- *   <li>defining an execution hook {@link #run(FCPConnectionHandler, Node)} for processing messages
- *       on the server side
+ *   <li>defining an execution hook {@link #run(FCPConnectionHandler)} for processing messages on
+ *       the server side
  * </ul>
  *
  * <p>This abstraction does not define any concurrency guarantees. Callers should treat message
@@ -401,8 +400,8 @@ public abstract class FCPMessage {
    * Returns an FCP message that wraps another message and adds a list request identifier.
    *
    * <p>The returned wrapper delegates {@link #send(OutputStream)}, {@link #getFieldSet()}, {@link
-   * #getName()} and {@link #run(FCPConnectionHandler, Node)} to the supplied {@code fcpMessage},
-   * but injects a {@code "ListRequestIdentifier"} field into the {@link SimpleFieldSet} returned by
+   * #getName()} and {@link #run(FCPConnectionHandler)} to the supplied {@code fcpMessage}, but
+   * injects a {@code "ListRequestIdentifier"} field into the {@link SimpleFieldSet} returned by
    * {@link #getFieldSet()}. This is useful when the same underlying message needs to be associated
    * with a particular list operation on the client side without changing the original
    * implementation.
@@ -446,8 +445,8 @@ public abstract class FCPMessage {
       }
 
       @Override
-      public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-        fcpMessage.run(handler, node);
+      public void run(FCPConnectionHandler handler) throws MessageInvalidException {
+        fcpMessage.run(handler);
       }
     };
   }
@@ -457,15 +456,13 @@ public abstract class FCPMessage {
    *
    * <p>This method is typically invoked by an {@link FCPConnectionHandler} after a message has been
    * parsed from the client connection. Implementations are expected to inspect the message fields,
-   * interact with the supplied {@link Node}, and send any responses or follow-up messages through
-   * the handler. The exact side effects depend on the concrete message type.
+   * resolve any required server context from the handler, and send responses or follow-up messages
+   * through that same handler. The exact side effects depend on the concrete message type.
    *
    * @param handler connection handler representing the client session that sent this message; used
    *     to enqueue replies and status updates
-   * @param node running node instance on which the message should operate; provides access to core
-   *     services and configuration
    * @throws MessageInvalidException if the message is syntactically correct but cannot be processed
    *     due to invalid field combinations or state constraints
    */
-  public abstract void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException;
+  public abstract void run(FCPConnectionHandler handler) throws MessageInvalidException;
 }

--- a/src/main/java/network/crypta/clients/fcp/FCPResponse.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPResponse.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -20,8 +19,8 @@ import network.crypta.support.SimpleFieldSet;
  * <ul>
  *   <li><strong>Responsibilities:</strong> hold metadata common to responses, enforce identifier
  *       propagation, and expose the name for routing/logging.
- *   <li><strong>Notable behavior:</strong> {@link #run(FCPConnectionHandler, Node)} always signals
- *       an error if invoked because responses are node-originated only.
+ *   <li><strong>Notable behavior:</strong> {@link #run(FCPConnectionHandler)} always signals an
+ *       error if invoked because responses are node-originated only.
  * </ul>
  *
  * @see FCPMessage
@@ -95,17 +94,15 @@ public abstract class FCPResponse extends FCPMessage {
    * accidentally sending a response message upstream. The exception embeds {@link
    * ProtocolErrorMessage#INVALID_MESSAGE} so callers can map the failure to a protocol error frame
    * and audit the misuse. Although this override never performs handler interactions, it keeps the
-   * signature identical to {@link FCPMessage#run(FCPConnectionHandler, Node)} for uniformity.
+   * signature identical to {@link FCPMessage#run(FCPConnectionHandler)} for uniformity.
    *
    * @param handler Handler instance that attempted to process the inbound message despite it being
    *     node-originated only.
-   * @param node Node that detected the misuse; not otherwise touched because execution aborts
-   *     immediately.
    * @throws MessageInvalidException Always thrown to reject client-originated attempts to send
    *     response-only envelope types.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         getName() + " is a reply from the node; the client should not send it.",

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -10,7 +10,6 @@ import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.config.Config;
 import network.crypta.io.AllowedHosts;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.Bucket;
@@ -52,9 +51,6 @@ public class FCPServer implements Runnable, DownloadCache {
 
   /* It’s not the field that is deprecated, but accessing it directly is. */
   private final NodeClientCore core;
-
-  /* It’s not the field that is deprecated, but accessing it directly is. */
-  private final Node node;
 
   private final RuntimePorts runtime;
 
@@ -109,7 +105,6 @@ public class FCPServer implements Runnable, DownloadCache {
     this.allowedHostsFullAccess = new AllowedHosts(config.allowedHostsFullAccess());
     this.port = config.port();
     this.enabled = config.enabled();
-    this.node = dependencies.node();
     this.core = dependencies.core();
     this.runtime = dependencies.runtimePorts();
     this.assumeDownloadDDAIsAllowed = config.assumeDownloadDDAAllowed();
@@ -134,7 +129,6 @@ public class FCPServer implements Runnable, DownloadCache {
    * @param allowedHostsFullAccess allowlist used for privileged operations that bypass client-side
    *     restrictions.
    * @param port TCP port number for the FCP listener, in the host byte order.
-   * @param node owning {@link Node} providing daemon services still required by legacy FCP code.
    * @param core node client core exposing persistence, download directories, and cache factories.
    * @param runtime runtime SPI bridge for infrastructure code that avoids daemon internals.
    * @param isEnabled whether networked FCP should start.
@@ -150,7 +144,6 @@ public class FCPServer implements Runnable, DownloadCache {
       String allowedHosts,
       String allowedHostsFullAccess,
       int port,
-      Node node,
       NodeClientCore core,
       RuntimePorts runtime,
       boolean isEnabled,
@@ -170,7 +163,7 @@ public class FCPServer implements Runnable, DownloadCache {
             assumeDDAUploadAllowed,
             neverDropAMessage,
             maxMessageQueueLength),
-        new FcpServerDependencies(node, core, runtime, persistentRoot));
+        new FcpServerDependencies(core, runtime, persistentRoot));
   }
 
   /**
@@ -217,10 +210,9 @@ public class FCPServer implements Runnable, DownloadCache {
    * <p>This factory wires the FCP-related settings into the {@code fcp} configuration subtree and
    * constructs the server with immutable values derived from that configuration. It does not start
    * network listeners; callers still invoke {@link #maybeStart()} at the appropriate lifecycle
-   * point. The returned server is fully wired to the supplied node, client core, and persistence
-   * root, so it can immediately serve FCP traffic once started.
+   * point. The returned server is fully wired to the supplied client core and persistence root, so
+   * it can immediately serve FCP traffic once started.
    *
-   * @param node the owning node providing daemon services still required by legacy FCP code.
    * @param core client core used for persistence and endpoint access.
    * @param runtime runtime SPI bridge used by infrastructure code inside the server.
    * @param config configuration registry where the {@code fcp} subsection is registered.
@@ -228,12 +220,8 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return configured server instance ready to be started by the caller.
    */
   public static FCPServer maybeCreate(
-      Node node,
-      NodeClientCore core,
-      RuntimePorts runtime,
-      Config config,
-      PersistentRequestRoot root) {
-    return FcpServerConfigRegistrar.maybeCreate(node, core, runtime, config, root);
+      NodeClientCore core, RuntimePorts runtime, Config config, PersistentRequestRoot root) {
+    return FcpServerConfigRegistrar.maybeCreate(core, runtime, config, root);
   }
 
   /**
@@ -755,19 +743,6 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public RuntimePorts runtime() {
     return runtime;
-  }
-
-  /**
-   * Returns the owning {@link Node} instance.
-   *
-   * <p>The owning node provides executors, configuration, and lifecycle coordination. The returned
-   * reference is the same instance passed to the constructor and should be treated as a shared
-   * mutable state. Callers should avoid long-lived synchronization on the node object.
-   *
-   * @return node that created and manages this server.
-   */
-  public Node getNode() {
-    return node;
   }
 
   AllowedHosts getAllowedHostsFullAccess() {

--- a/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
@@ -8,7 +8,6 @@ import network.crypta.config.SubConfig;
 import network.crypta.crypt.SSL;
 import network.crypta.io.NetworkInterface;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.BooleanCallback;
@@ -31,7 +30,7 @@ import network.crypta.support.api.StringCallback;
  * <ul>
  *   <li>Registering the {@code fcp} option set with deterministic ordering and defaults.
  *   <li>Binding config callbacks that guard runtime changes and apply validation.
- *   <li>Building the {@link FCPServer} with dependencies from the owning {@link Node}.
+ *   <li>Building the {@link FCPServer} with dependencies from the node client core.
  * </ul>
  *
  * @see FCPServer
@@ -54,12 +53,10 @@ final class FcpServerConfigRegistrar {
    *
    * <pre>{@code
    * Config config = new Config();
-   * FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, runtimePorts, config,
-   * root);
+   * FCPServer server = FcpServerConfigRegistrar.maybeCreate(core, runtimePorts, config, root);
    * server.maybeStart();
    * }</pre>
    *
-   * @param node the owning node providing executors and core services for the server.
    * @param core client core used for endpoint access and persisted settings lookups.
    * @param runtimePorts runtime SPI bridge passed to the created server.
    * @param config root configuration registry where the {@code fcp} subsection is registered.
@@ -67,11 +64,7 @@ final class FcpServerConfigRegistrar {
    * @return configured {@link FCPServer} instance ready for {@link FCPServer#maybeStart()}.
    */
   static FCPServer maybeCreate(
-      Node node,
-      NodeClientCore core,
-      RuntimePorts runtimePorts,
-      Config config,
-      PersistentRequestRoot root) {
+      NodeClientCore core, RuntimePorts runtimePorts, Config config, PersistentRequestRoot root) {
     SubConfig fcpConfig = config.createSubConfig("fcp");
     short sortOrder = 0;
     fcpConfig.register(
@@ -173,7 +166,7 @@ final class FcpServerConfigRegistrar {
             fcpConfig.getBoolean("assumeUploadDDAIsAllowed"),
             fcpConfig.getBoolean("neverDropAMessage"),
             fcpConfig.getInt("maxMessageQueueLength"));
-    FcpServerDependencies dependencies = new FcpServerDependencies(node, core, runtimePorts, root);
+    FcpServerDependencies dependencies = new FcpServerDependencies(core, runtimePorts, root);
     FCPServer fcp = new FCPServer(serverConfig, dependencies);
 
     cb4.server = fcp;

--- a/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
@@ -1,19 +1,14 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
  * Core node services required to construct an {@link FCPServer}.
  *
- * @param node owning {@link Node} providing executors and lifecycle hooks.
  * @param core node client core exposing persistence, download directories, and cache factories.
  * @param runtimePorts runtime SPI bridge for infrastructure code that avoids daemon internals.
  * @param persistentRoot persistence root used to access global clients and caches.
  */
 public record FcpServerDependencies(
-    Node node,
-    NodeClientCore core,
-    RuntimePorts runtimePorts,
-    PersistentRequestRoot persistentRoot) {}
+    NodeClientCore core, RuntimePorts runtimePorts, PersistentRequestRoot persistentRoot) {}

--- a/src/main/java/network/crypta/clients/fcp/FeedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FeedMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import java.nio.charset.StandardCharsets;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
@@ -116,13 +115,11 @@ public class FeedMessage extends MultipleDataCarryingMessage {
    * @param handler connection handler associated with the FCP session; ignored by this
    *     implementation because feed messages are not processed on the server side when received
    *     from clients.
-   * @param node node instance that would normally provide access to core services; ignored here
-   *     because the method always fails fast with a protocol error.
    * @throws MessageInvalidException always thrown to indicate that {@code FeedMessage} instances
    *     must not be sent from client to server in this direction.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         getName() + " goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/FilterMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FilterMessage.java
@@ -15,7 +15,6 @@ import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.node.FSParseException;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -310,13 +309,11 @@ public final class FilterMessage extends DataCarryingMessage {
    *
    * @param handler connection handler responsible for sending replies back over the client's FCP
    *     socket and exposing the server core; must remain valid for the call duration.
-   * @param node node instance containing the wider runtime context; used indirectly when retrieving
-   *     the {@link ClientContext} from the server.
    * @throws MessageInvalidException if the payload bucket is absent or a transient allocation error
    *     prevents preparing buckets for the filtering process.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (bucket == null) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.MISSING_FIELD, "Must contain data", identifier, false);

--- a/src/main/java/network/crypta/clients/fcp/FilterResultMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FilterResultMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 
@@ -137,7 +136,7 @@ public class FilterResultMessage extends DataCarryingMessage {
    *     by attempting to send this message toward the node
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         NAME + " goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/FinishedCompressionMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FinishedCompressionMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.events.FinishedCompressionEvent;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.compress.Compressor;
 
@@ -113,12 +112,11 @@ public class FinishedCompressionMessage extends FCPMessage {
    *
    * @param handler active FCP connection handler invoking this method; ignored during validation
    *     because the message is not supposed to originate from clients.
-   * @param node current node instance; provided for interface completeness but unused here.
    * @throws MessageInvalidException always thrown to signal that this message must not be received
    *     from an FCP client under the protocol rules.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "FinishedCompression goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/GenerateSSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GenerateSSKMessage.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -14,12 +13,12 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>The instance is intentionally lightweight and stateless: all protocol information lives in the
  * supplied {@link SimpleFieldSet}, and all cryptographic material is produced during {@link
- * #run(FCPConnectionHandler, Node)}. This makes it safe to reuse a single instance per incoming
- * request in a multithreaded FCP server loop. The generated keypair is ephemeral until persisted
- * elsewhere; no on-disk side effects occur in this class. The optional client identifier is echoed
- * back so callers can correlate responses to their session or outstanding command queue. Typical
- * usage calls {@link #getFieldSet()} during serialization, then {@link #run(FCPConnectionHandler,
- * Node)} when the command should be fulfilled.
+ * #run(FCPConnectionHandler)}. This makes it safe to reuse a single instance per incoming request
+ * in a multithreaded FCP server loop. The generated keypair is ephemeral until persisted elsewhere;
+ * no on-disk side effects occur in this class. The optional client identifier is echoed back so
+ * callers can correlate responses to their session or outstanding command queue. Typical usage
+ * calls {@link #getFieldSet()} during serialization, then {@link #run(FCPConnectionHandler)} when
+ * the command should be fulfilled.
  *
  * <ul>
  *   <li>Parses the caller-supplied identifier, if present, from the inbound field set.
@@ -74,13 +73,11 @@ public class GenerateSSKMessage extends FCPMessage {
    *
    * @param handler active connection handler that delivers the generated keypair back to the
    *     requesting client; must not be {@code null}.
-   * @param node running node supplied by the unchanged FCP message signature; not consulted for
-   *     randomness because the handler's server runtime provides that capability.
    * @throws MessageInvalidException if the response message cannot be encoded or sent according to
    *     FCP protocol rules, or if the handler rejects the outbound payload.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     InsertableClientSSK key =
         InsertableClientSSK.createRandom(
             FcpRuntimeAdapters.secureRandomSource(handler.getServer().runtime().randomness()), "");

--- a/src/main/java/network/crypta/clients/fcp/GeneratedMetadataMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GeneratedMetadataMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -148,11 +147,10 @@ public class GeneratedMetadataMessage extends BaseDataCarryingMessage {
    * runnable behavior when expecting inbound execution.
    *
    * @param handler connection handler provided by the FCP server infrastructure; not used here
-   * @param node local node instance; not used because the message is not executed
    * @throws MessageInvalidException never thrown; declared to satisfy superclass signature
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/GetConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/GetConfig.java
@@ -16,9 +16,9 @@ import network.crypta.support.SimpleFieldSet;
  * connections as long as each instance is used once.
  *
  * <p>Typical usage constructs {@code GetConfig} immediately after parsing inbound fields and calls
- * {@link #run(FCPConnectionHandler, Node)} to validate access and send a {@link ConfigData}
- * response. The message refuses to run when the connection lacks full access, preventing
- * configuration disclosure to limited clients and aligning with the FCP access-control contract.
+ * {@link #run(FCPConnectionHandler)} to validate access and send a {@link ConfigData} response. The
+ * message refuses to run when the connection lacks full access, preventing configuration disclosure
+ * to limited clients and aligning with the FCP access-control contract.
  *
  * <ul>
  *   <li>Responsibilities: capture client preferences and dispatch the configuration payload.
@@ -110,12 +110,10 @@ public class GetConfig extends FCPMessage {
    *
    * @param handler connection context responsible for permission checks and outbound delivery; must
    *     not be {@code null} and must expose full access for the call to proceed.
-   * @param node backing node that supplies the configuration values reflected in the response; may
-   *     be queried but is not modified during processing.
    * @throws MessageInvalidException if the caller lacks full access or message validation fails.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/GetFailedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GetFailedMessage.java
@@ -7,7 +7,6 @@ import network.crypta.client.FailureCodeTracker;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.StorageFormatException;
 import org.slf4j.Logger;
@@ -259,7 +258,6 @@ public final class GetFailedMessage extends FCPMessage implements Serializable {
    * server-originated notification, so any inbound appearance is treated as invalid traffic.
    *
    * @param handler active connection handler receiving the message.
-   * @param node local node instance; unused but part of the dispatcher contract.
    * @throws MessageInvalidException always thrown to signal misuse of the message direction.
    *     <p><strong>Implementation note:</strong> This implementation never dispatches to the node;
    *     it simply raises an exception, ensuring that servers cannot be coerced into processing
@@ -267,7 +265,7 @@ public final class GetFailedMessage extends FCPMessage implements Serializable {
    *     bookkeeping.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "GetFailed goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/GetNode.java
+++ b/src/main/java/network/crypta/clients/fcp/GetNode.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.support.SimpleFieldSet;
 
@@ -97,13 +96,11 @@ public class GetNode extends FCPMessage {
    *
    * @param handler connection handler performing access checks and delivering responses; must be
    *     authenticated.
-   * @param node backing node reference retained for {@link FCPMessage} signature parity; the
-   *     runtime SPI supplies the serialized snapshot.
    * @throws MessageInvalidException if the client lacks full access or the request violates
    *     protocol constraints.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/GetRequestStatusMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/GetRequestStatusMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -13,8 +12,8 @@ import network.crypta.support.SimpleFieldSet;
  * <p>The instance is immutable: the identifier and accompanying flags are captured from the parsed
  * {@link SimpleFieldSet} and reused whenever the message is serialized or executed. Typical callers
  * construct it from an inbound request, hand it to the active {@link FCPConnectionHandler}, and let
- * {@link #run(FCPConnectionHandler, Node)} walk the reboot-time and persistent queues. When a match
- * is found, pending progress or data messages are forwarded; missing identifiers trigger a {@link
+ * {@link #run(FCPConnectionHandler)} walk the reboot-time and persistent queues. When a match is
+ * found, pending progress or data messages are forwarded; missing identifiers trigger a {@link
  * ProtocolErrorMessage} with {@link ProtocolErrorMessage#NO_SUCH_IDENTIFIER}.
  *
  * <p>Concurrency: the object is thread-safe through immutability. Execution normally occurs on the
@@ -30,7 +29,7 @@ import network.crypta.support.SimpleFieldSet;
  * <pre>{@code
  * // Example: forwarding a parsed message to the handler
  * var message = new GetRequestStatusMessage(parsedFields);
- * message.run(handler, node);
+ * message.run(handler);
  * }</pre>
  */
 public class GetRequestStatusMessage extends FCPMessage {
@@ -103,13 +102,11 @@ public class GetRequestStatusMessage extends FCPMessage {
    *
    * @param handler connection-scoped dispatcher that resolves client requests and emits replies;
    *     must not be null and typically represents the active FCP session.
-   * @param node owning node instance providing access to client cores and persistence; expected to
-   *     be fully initialized for job submission.
    * @throws MessageInvalidException if the handler detects protocol-level validation problems
    *     unrelated to missing identifiers.
    */
   @Override
-  public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(final FCPConnectionHandler handler) throws MessageInvalidException {
     ClientRequest req = handler.getRebootRequest(global, handler, requestIdentifier);
     if (req == null) {
       RequestQueuePort requestQueuePort = handler.getServer().runtime().requestQueue();

--- a/src/main/java/network/crypta/clients/fcp/IdentifierCollisionMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/IdentifierCollisionMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -14,9 +13,8 @@ import network.crypta.support.SimpleFieldSet;
  * <p>The class only serializes the collision metadata; it does not attempt to resolve or mutate any
  * node state. It is safe for concurrent use because all fields are final and no mutable state is
  * exposed. Typical usage is server-side construction followed by {@link #getFieldSet()} when
- * marshalling an outbound FCP response. The {@link #run(FCPConnectionHandler, Node)} method
- * intentionally rejects inbound execution because this message must not be sent from clients to the
- * node.
+ * marshalling an outbound FCP response. The {@link #run(FCPConnectionHandler)} method intentionally
+ * rejects inbound execution because this message must not be sent from clients to the node.
  *
  * <ul>
  *   <li>Encapsulates the offending client identifier and collision scope.
@@ -92,12 +90,11 @@ public class IdentifierCollisionMessage extends FCPMessage {
    *
    * @param handler connection handler that received the message; ignored because execution always
    *     aborts.
-   * @param node node instance tied to the connection; ignored because no processing occurs.
    * @throws MessageInvalidException always thrown to signal the invalid message direction before
    *     any state is modified or work is scheduled.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "IdentifierCollision goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/ListPeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeerMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.PeerSnapshot;
 import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
@@ -40,9 +39,8 @@ public class ListPeerMessage extends FCPMessage {
    * <p>The supplied {@link SimpleFieldSet} must include an {@code Identifier} entry used for
    * correlating responses; it is extracted and deleted immediately to avoid forwarding client
    * metadata unnecessarily. Callers may populate additional fields such as {@code NodeIdentifier}
-   * before invoking {@link #run(FCPConnectionHandler, Node)}. The constructor keeps a direct
-   * reference to the field set, so external mutations after construction will be visible during
-   * execution.
+   * before invoking {@link #run(FCPConnectionHandler)}. The constructor keeps a direct reference to
+   * the field set, so external mutations after construction will be visible during execution.
    *
    * @param fs mutable field set containing request metadata; must include {@code Identifier} and
    *     should eventually include {@code NodeIdentifier}; must not be {@code null}.
@@ -57,8 +55,8 @@ public class ListPeerMessage extends FCPMessage {
    * Provides the outgoing field set for serialization.
    *
    * <p>This implementation returns a new, empty {@link SimpleFieldSet} because all request data is
-   * consumed during {@link #run(FCPConnectionHandler, Node)}. Callers may mutate the returned set
-   * without affecting the original message.
+   * consumed during {@link #run(FCPConnectionHandler)}. Callers may mutate the returned set without
+   * affecting the original message.
    *
    * @return a freshly created, empty {@link SimpleFieldSet} instance.
    */
@@ -92,11 +90,10 @@ public class ListPeerMessage extends FCPMessage {
    *
    * @param handler connection handler that validates permissions and dispatches replies; must not
    *     be {@code null}.
-   * @param node target node queried for peer information; must not be {@code null}.
    * @throws MessageInvalidException when access is denied or required, fields are absent.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
@@ -12,9 +12,9 @@ import network.crypta.support.SimpleFieldSet;
  * provided request identifier so responses can be correlated by the requester. The message is
  * effectively read-only after construction: it strips the {@code Identifier} field from the field
  * set to prevent accidental forwarding and retains only the minimal state needed for routing.
- * Typical use flows through {@link #run(FCPConnectionHandler, Node)} exactly once, where the
- * handler performs access checks, resolves the targeted peer, and returns the current note content
- * followed by {@link EndListPeerNotesMessage}.
+ * Typical use flows through {@link #run(FCPConnectionHandler)} exactly once, where the handler
+ * performs access checks, resolves the targeted peer, and returns the current note content followed
+ * by {@link EndListPeerNotesMessage}.
  *
  * <p>Concurrency considerations: each instance is used by a single handler invocation and stores no
  * mutable global state, so it is thread-confined by design. The lifetime is short-lived, created
@@ -96,13 +96,11 @@ public class ListPeerNotesMessage extends FCPMessage {
    *
    * @param handler connection context used to check privileges and emit responses; must not be
    *     {@code null}
-   * @param node local node context supplied by the legacy FCP dispatch signature; unused because
-   *     peer-note access is delegated through the runtime SPI
    * @throws MessageInvalidException if access is denied, required fields are missing, or the target
    *     peer is not a darknet peer
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeersMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.PeerSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
@@ -91,13 +90,11 @@ public class ListPeersMessage extends FCPMessage {
    *
    * @param handler connection handler responsible for sending responses; must already be
    *     authenticated for full access.
-   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
-   *     enumeration is delegated through the runtime SPI
    * @throws MessageInvalidException when the handler lacks required access rights or when message
    *     validation fails before any peer data is returned.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/ListPersistentRequestsMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPersistentRequestsMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -250,7 +249,7 @@ public class ListPersistentRequestsMessage extends FCPMessage {
   }
 
   @Override
-  public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(final FCPConnectionHandler handler) throws MessageInvalidException {
     RequestQueuePort requestQueuePort = handler.getServer().runtime().requestQueue();
     FCPConnectionOutputHandler outputHandler = handler.getOutputHandler();
     Runnable endListing =

--- a/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyConfig.java
@@ -4,7 +4,6 @@ import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConfigSection;
 import network.crypta.support.SimpleFieldSet;
@@ -15,8 +14,8 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>This message consumes a {@link SimpleFieldSet} whose keys mirror dotted option names in the
  * node configuration. The constructor captures the request identifier up front and strips it from
- * the field set so only option overrides remain. During {@link #run(FCPConnectionHandler, Node)}
- * the overrides are handed to the runtime SPI, which preserves the legacy config-update semantics.
+ * the field set so only option overrides remain. During {@link #run(FCPConnectionHandler)} the
+ * overrides are handed to the runtime SPI, which preserves the legacy config-update semantics.
  *
  * <p>The message requires the connection to possess full access; otherwise it terminates early with
  * a {@link MessageInvalidException}. After the update pass, the configuration is persisted and a
@@ -98,18 +97,16 @@ public class ModifyConfig extends FCPMessage {
    *
    * <pre>{@code
    * // Typical server-side handling path
-   * new ModifyConfig(requestFields).run(handler, node);
+   * new ModifyConfig(requestFields).run(handler);
    * }</pre>
    *
    * @param handler connection-specific dispatcher required to validate access and send responses;
    *     must not be {@code null} and should support full access for this message.
-   * @param node target node whose configuration is adjusted; expected to be initialized and ready
-   *     for persistence operations.
    * @throws MessageInvalidException if the connection lacks full access, or the message is not
    *     permitted in the current context.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
 import network.crypta.runtime.spi.PeerSnapshot;
@@ -92,13 +91,11 @@ public class ModifyPeer extends FCPMessage {
    *
    * @param handler connection handler that mediates access checks and message delivery for the
    *     caller; must support full-access operations.
-   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
-   *     mutation is delegated through the runtime SPI
    * @throws MessageInvalidException if access is denied, required fields are missing, or the target
    *     peer is not available as a darknet peer.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -50,7 +50,7 @@ public class ModifyPeerNote extends FCPMessage {
    * this message, including the client {@code Identifier} and all note-related values. The
    * constructor extracts and stores the identifier for later use, then removes it from the backing
    * field set so that only message-specific fields remain. No validation of required fields is
-   * performed here; it is deferred to {@link #run(FCPConnectionHandler, Node)}.
+   * performed here; it is deferred to {@link #run(FCPConnectionHandler)}.
    *
    * @param fs the non-{@code null} field set describing the request, including {@code Identifier}
    *     and note-related fields supplied by the FCP client
@@ -107,13 +107,11 @@ public class ModifyPeerNote extends FCPMessage {
    *
    * @param handler the connection handler that received the request and is used to send any reply
    *     or error messages back to the client; must have full access for the operation to proceed
-   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
-   *     note mutation is delegated through the runtime SPI
    * @throws MessageInvalidException if the caller lacks access rights, required fields are missing
    *     or malformed, or the peer cannot be updated under the current protocol rules
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
@@ -191,7 +189,6 @@ public class ModifyPeerNote extends FCPMessage {
    *
    * @param handler connection handler used to send protocol error responses back to the client
    * @param peerPort runtime peer-management port used to resolve the target peer
-   * @param nodeIdentifier peer identifier supplied by the FCP client
    * @return {@code true} if the peer exists and supports darknet notes, otherwise {@code false}
    *     after sending the appropriate unknown-node response
    * @throws MessageInvalidException if the peer exists but is not a darknet peer

--- a/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
@@ -147,13 +146,11 @@ public final class ModifyPersistentRequest extends FCPMessage {
    *
    * @param handler connection handler used to resolve the request identifier and send any protocol
    *     error responses; must not be {@code null}
-   * @param node node instance providing access to the client core, persistent job runner, and FCP
-   *     server used to apply the modification; must not be {@code null}
    * @throws MessageInvalidException if the identifier or request parameters violate protocol
    *     constraints while attempting to execute the modification
    */
   @Override
-  public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(final FCPConnectionHandler handler) throws MessageInvalidException {
 
     ClientRequest req = handler.getRebootRequest(global, handler, requestIdentifier);
     if (req == null) {

--- a/src/main/java/network/crypta/clients/fcp/NodeData.java
+++ b/src/main/java/network/crypta/clients/fcp/NodeData.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.support.SimpleFieldSet;
@@ -106,13 +105,11 @@ public class NodeData extends FCPMessage {
    * correctness.
    *
    * @param handler connection handler that attempted to route the message; ignored after failure.
-   * @param node node instance associated with the connection; not used because execution is
-   *     blocked.
    * @throws MessageInvalidException whenever invoked because clients must not send {@code
    *     NodeData}.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "NodeData goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/NodeHelloMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/NodeHelloMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import java.util.Objects;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
@@ -99,13 +98,11 @@ public class NodeHelloMessage extends FCPMessage {
    *
    * @param handler connection context that delivered the message; never {@code null}; not used in
    *     the rejection path but present to satisfy {@link FCPMessage} dispatch signatures.
-   * @param node node instance backing the handler; never {@code null}; unused because the operation
-   *     always fails.
    * @throws MessageInvalidException always thrown to signal that {@code NodeHello} is outbound-only
    *     and must not be received from clients.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "NodeHello goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PeerMessage.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.PeerFieldSet;
 import network.crypta.runtime.spi.PeerSnapshot;
 import network.crypta.support.SimpleFieldSet;
@@ -85,11 +84,10 @@ public class PeerMessage extends FCPMessage {
    * node.
    *
    * @param handler connection handler that attempted to execute the message; not mutated here
-   * @param node node instance associated with the connection; unused because execution is rejected
    * @throws MessageInvalidException always thrown to indicate the direction is unsupported
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "Peer goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/PeerNote.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.Base64;
 import network.crypta.support.SimpleFieldSet;
 
@@ -48,7 +47,6 @@ public class PeerNote extends FCPMessage {
    * PeerNote note = new PeerNote(peerId, "Peer capacity changed", 2, "note-42");
    * }</pre>
    *
-   * @param nodeIdentifier stable identifier of the peer that the note concerns; never {@code null}.
    * @param noteText human-readable note body in UTF-8; empty strings are permitted but discouraged.
    * @param peerNoteType integer classification flag understood by the remote endpoint; non-negative
    *     values typically map to predefined categories.
@@ -105,12 +103,10 @@ public class PeerNote extends FCPMessage {
    * response that explains the violation. No state is modified prior to raising the exception.
    *
    * @param handler connection context invoking the message handler; used only for validation.
-   * @param node active node instance representing the running server; not used when rejecting the
-   *     message but provided to satisfy the superclass contract.
    * @throws MessageInvalidException always thrown to signal that the message direction is invalid.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PeerNote goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PeerRemoved.java
+++ b/src/main/java/network/crypta/clients/fcp/PeerRemoved.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -17,7 +16,7 @@ import network.crypta.support.SimpleFieldSet;
  * reuse or modify it across threads. The class itself is thread-safe because it exposes only final
  * state, but concurrent dispatchers should still avoid sharing mutable transport buffers. As part
  * of the server-to-client event stream it obeys the FCP rule that clients never send this message
- * back to the server; attempts to do so are rejected by {@link #run(FCPConnectionHandler, Node)}.
+ * back to the server; attempts to do so are rejected by {@link #run(FCPConnectionHandler)}.
  *
  * <ul>
  *   <li>Represents a peer removal event originating from the server.
@@ -45,7 +44,6 @@ public class PeerRemoved extends FCPMessage {
    * immutable and can be safely shared for read-only use across components that emit FCP messages.
    *
    * @param identity canonical identity string for the removed peer; never {@code null}
-   * @param nodeIdentifier local node identifier associated with the peer; never {@code null}
    * @param identifier optional client correlation token; may be {@code null} when unspecified
    */
   public PeerRemoved(String identity, String nodeIdentifier, String identifier) {
@@ -96,11 +94,10 @@ public class PeerRemoved extends FCPMessage {
    * side effects and is intentionally non-idempotent only in that it always throws.
    *
    * @param handler connection handler that attempted to process the message; never {@code null}
-   * @param node current node instance that received the invalid message; never {@code null}
    * @throws MessageInvalidException always thrown to signal that the direction is unsupported
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PeerRemoved goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PersistentGet.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentGet.java
@@ -5,7 +5,6 @@ import java.util.Locale;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -22,7 +21,7 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>Typical usage: the node builds one per request when replying to a listing. Clients call {@link
  * #getFieldSet()} to emit FCP wire fields or hydrate UI-facing models. Inbound execution is
- * rejected by {@link #run(FCPConnectionHandler, Node)} to enforce directionality.
+ * rejected by {@link #run(FCPConnectionHandler)} to enforce directionality.
  *
  * @see ClientGet
  * @see ClientRequest
@@ -142,13 +141,11 @@ public final class PersistentGet extends FCPMessage {
    *
    * @param handler connection handler that attempted to process the message; not used beyond error
    *     reporting.
-   * @param node node instance receiving the message; present to satisfy the {@link FCPMessage}
-   *     contract but unused here.
    * @throws MessageInvalidException always thrown to signal that this message must not be sent from
    *     client to server in normal operation.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PersistentGet goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PersistentPut.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPut.java
@@ -6,7 +6,6 @@ import network.crypta.client.InsertContext;
 import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 
@@ -17,7 +16,7 @@ import network.crypta.support.SimpleFieldSet;
  * including URIs, compression preferences, and retry behavior, so they can be serialized into a
  * {@link SimpleFieldSet} for transmission. Instances are constructed on the server side when
  * enumerating or mirroring client requests and are never executed in the inbound direction, as
- * {@link #run(FCPConnectionHandler, Node)} always rejects client-sourced messages.
+ * {@link #run(FCPConnectionHandler)} always rejects client-sourced messages.
  *
  * <p>Use this type when a caller needs to:
  *
@@ -167,11 +166,10 @@ public class PersistentPut extends FCPMessage {
    * invalid direction while preserving the identifier and global flag for diagnostics.
    *
    * @param handler connection handler that attempted to process the message
-   * @param node node reference supplied by the caller, unused because of rejection
    * @throws MessageInvalidException always thrown to indicate the invalid message direction
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PersistentPut goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
@@ -7,7 +7,6 @@ import network.crypta.client.async.BaseManifestPutter;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.crypt.EncryptedRandomAccessBucket;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
@@ -260,13 +259,11 @@ public final class PersistentPutDir extends FCPMessage {
    *
    * @param handler connection handler associated with the client session; not used beyond error
    *     reporting in this implementation.
-   * @param node node instance that received the message; supplied for interface completeness and
-   *     unchanged here.
    * @throws MessageInvalidException always thrown to indicate the message direction is incorrect
    *     when arriving from a client.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PersistentPut goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestModifiedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestModifiedMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -147,12 +146,11 @@ public class PersistentRequestModifiedMessage extends FCPMessage {
    * logging because the responsibility lies with higher protocol layers to enforce directionality.
    *
    * @param handler connection handler that attempted to route the message; never modified.
-   * @param node node instance processing the inbound message; unused because execution aborts.
    * @throws MessageInvalidException always thrown to indicate that clients must not send this
    *     message type to the server.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PersistentRequestModified goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestRemovedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestRemovedMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -99,13 +98,11 @@ public class PersistentRequestRemovedMessage extends FCPMessage {
    *
    * @param handler connection handler that attempted to route the message; never modified by this
    *     method.
-   * @param node node instance receiving the message; included for interface parity and not used
-   *     here.
    * @throws MessageInvalidException always thrown to indicate that this message is invalid when
    *     sent toward the node.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PersistentRequestRemoved goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/ProbeRefused.java
+++ b/src/main/java/network/crypta/clients/fcp/ProbeRefused.java
@@ -20,9 +20,9 @@ package network.crypta.clients.fcp;
  *   <li><strong>Responsibilities:</strong> label the refusal event and propagate the FCP
  *       identifier, enabling clients to reconcile probes with outcomes.
  *   <li><strong>Notable behavior:</strong> {@link
- *       FCPResponse#run(network.crypta.clients.fcp.FCPConnectionHandler, network.crypta.node.Node)}
- *       remains the inherited guard that always raises {@link MessageInvalidException} if a client
- *       attempts to send this response upstream.
+ *       FCPResponse#run(network.crypta.clients.fcp.FCPConnectionHandler)} remains the inherited
+ *       guard that always raises {@link MessageInvalidException} if a client attempts to send this
+ *       response upstream.
  * </ul>
  *
  * @see FCPResponse

--- a/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.FSParseException;
-import network.crypta.node.Node;
 import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Probe;
@@ -14,16 +13,16 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>This message is created from a parsed {@link SimpleFieldSet} and validates the probe type and
  * optional hop budget before execution. Callers typically get it through the FCP dispatch layer and
- * then invoke {@link #run(FCPConnectionHandler, Node)} to start the probe asynchronously. The
- * request retains the identifier, type, and hop budget as an immutable state; it is not intended to
- * be reused across unrelated client sessions. A {@code null} identifier is supported and results in
+ * then invoke {@link #run(FCPConnectionHandler)} to start the probe asynchronously. The request
+ * retains the identifier, type, and hop budget as an immutable state; it is not intended to be
+ * reused across unrelated client sessions. A {@code null} identifier is supported and results in
  * response messages that omit the {@code Identifier} field.
  *
- * <p>Execution requires full-access credentials. When authorized, {@link #run(FCPConnectionHandler,
- * Node)} constructs a {@link Listener} that adapts probe callbacks into concrete {@link FCPMessage}
- * responses, gets a secure probe UID from the handler's server runtime, and delegates to {@code
- * node.network().startProbe(...)}. The method does not block for completion; responses arrive
- * asynchronously via the handler.
+ * <p>Execution requires full-access credentials. When authorized, {@link
+ * #run(FCPConnectionHandler)} constructs a {@link Listener} that adapts probe callbacks into
+ * concrete {@link FCPMessage} responses, gets a secure probe UID from the handler's server runtime,
+ * and delegates to {@code node.network().startProbe(...)}. The method does not block for
+ * completion; responses arrive asynchronously via the handler.
  *
  * <ul>
  *   <li><strong>Responsibilities:</strong> validate fields, enforce access, and bridge callbacks.
@@ -144,12 +143,10 @@ public final class ProbeRequest extends FCPMessage {
    * FCPConnectionHandler#send(FCPMessage)}.
    *
    * @param handler connection handler used to authorize and send probe responses.
-   * @param node node instance that executes the probe while the handler's server runtime supplies
-   *     the probe UID.
    * @throws MessageInvalidException if the caller lacks full access for probe execution.
    */
   @Override
-  public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(final FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,
@@ -219,6 +216,11 @@ public final class ProbeRequest extends FCPMessage {
           }
         };
     long probeUid = FcpRuntimeAdapters.nextSecureLong(handler.getServer().runtime().randomness());
-    node.network().startProbe(hopsToLive, probeUid, probeType, listener);
+    handler
+        .getServer()
+        .getCore()
+        .getNode()
+        .network()
+        .startProbe(hopsToLive, probeUid, probeType, listener);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/ProtocolErrorMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ProtocolErrorMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,10 +248,9 @@ public final class ProtocolErrorMessage extends FCPMessage implements Serializab
    *
    * @param handler active FCP connection handler receiving the message; never {@code null} during
    *     normal operation
-   * @param node current node instance that owns the connection; used by higher-level handlers
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) {
+  public void run(FCPConnectionHandler handler) {
     LOG.error("Client reported protocol error");
   }
 

--- a/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PutFailedMessage.java
@@ -11,7 +11,6 @@ import network.crypta.client.FailureCodeTracker;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -280,11 +279,10 @@ public final class PutFailedMessage extends FCPMessage implements Serializable {
    * global flag for logging. The method is intentionally non-idempotent because it always throws.
    *
    * @param handler connection handler that attempted to process the outbound message.
-   * @param node node instance associated with the connection; unused but required by signature.
    * @throws MessageInvalidException always thrown to signal protocol misuse by the client.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PutFailed goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PutFetchableMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PutFetchableMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -83,13 +82,11 @@ public class PutFetchableMessage extends FCPMessage {
    *
    * @param handler connection handler receiving the message; must not be {@code null} but is unused
    *     because execution always fails on the client side.
-   * @param node active node instance associated with the connection; not consulted before the
-   *     exception is raised.
    * @throws MessageInvalidException always thrown to signal that the message cannot be executed
    *     from client to server.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "PutFetchable goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/PutSuccessfulMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/PutSuccessfulMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -15,8 +14,8 @@ import network.crypta.support.SimpleFieldSet;
  * class focuses on faithfully mirroring the wire format rather than enforcing business logic. In
  * typical flows, the node constructs the message immediately after verifying storage and announces
  * it to the originating client before any further cleanup. Attempted execution from a client is
- * rejected by {@link #run(FCPConnectionHandler, Node)} to preserve protocol directionality and
- * protect the server from spoofed success messages.
+ * rejected by {@link #run(FCPConnectionHandler)} to preserve protocol directionality and protect
+ * the server from spoofed success messages.
  *
  * <ul>
  *   <li>Encapsulates the success path for FCP insert operations.
@@ -147,11 +146,10 @@ public class PutSuccessfulMessage extends FCPMessage {
    * unused because the method always throws.
    *
    * @param handler active connection handler that attempted to process the inbound message frame.
-   * @param node node receiving the message; present for API symmetry but not used during handling.
    * @throws MessageInvalidException always thrown to enforce protocol directionality.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "InsertSuccessful goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/RemovePeer.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePeer.java
@@ -23,8 +23,8 @@ import network.crypta.support.SimpleFieldSet;
  *   <li>Emitting protocol-level acknowledgments that reflect success or descriptive failure.
  * </ul>
  *
- * <p>Instances are short-lived and not thread-safe; a single {@link #run(FCPConnectionHandler,
- * Node)} invocation should be used per incoming request on the handler thread. The original {@link
+ * <p>Instances are short-lived and not thread-safe; a single {@link #run(FCPConnectionHandler)}
+ * invocation should be used per incoming request on the handler thread. The original {@link
  * SimpleFieldSet} is retained by reference, so callers should not reuse it concurrently.
  *
  * @see PeerRemoved
@@ -45,11 +45,11 @@ public class RemovePeer extends FCPMessage {
    * <p>The constructor reads the {@code Identifier} field from the supplied {@link SimpleFieldSet}
    * to keep it available for later replies and removes it from the mutable field set to avoid
    * accidental forwarding. The remaining fields, including {@code NodeIdentifier}, are processed
-   * during {@link #run(FCPConnectionHandler, Node)}. Reference retains the supplied field set, so
-   * callers should not modify it after construction if consistent behavior is required.
+   * during {@link #run(FCPConnectionHandler)}. Reference retains the supplied field set, so callers
+   * should not modify it after construction if consistent behavior is required.
    *
    * @param fs inbound protocol fields for this request; must contain {@code Identifier} and is
-   *     expected to contain {@code NodeIdentifier} when {@link #run(FCPConnectionHandler, Node)} is
+   *     expected to contain {@code NodeIdentifier} when {@link #run(FCPConnectionHandler)} is
    *     invoked; must be non-null and remain stable for the lifetime of this instance.
    */
   public RemovePeer(SimpleFieldSet fs) {
@@ -102,18 +102,16 @@ public class RemovePeer extends FCPMessage {
    * <pre>{@code
    * // Example: remove a peer by its node identifier
    * var message = new RemovePeer(fields);
-   * message.run(handler, node);
+   * message.run(handler);
    * }</pre>
    *
    * @param handler connection handler responsible for sending responses; must provide full-access
    *     privileges for the operation to proceed and must not be null.
-   * @param node node instance supplied by the legacy FCP dispatch signature; unused because peer
-   *     removal is delegated through the runtime SPI
    * @throws MessageInvalidException when access is denied or required, fields are absent, halting
    *     further processing and surfacing a protocol-level error to the caller.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED,

--- a/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePersistentRequest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -15,8 +14,8 @@ import org.slf4j.LoggerFactory;
  * registered for persistence, regardless of whether it has finished or is still queued. It carries
  * the opaque request identifier and a flag indicating whether the request was global. Instances are
  * immutable after creation; they simply transport the parameters required for removal and delegate
- * the actual work to the {@link FCPConnectionHandler} when {@link #run(FCPConnectionHandler, Node)}
- * is invoked. Because persistence and request queues may span multiple subsystems, the class favors
+ * the actual work to the {@link FCPConnectionHandler} when {@link #run(FCPConnectionHandler)} is
+ * invoked. Because persistence and request queues may span multiple subsystems, the class favors
  * clarity and explicit branching over silent failure.
  *
  * <p>The handler treats three stages distinctly: removal from reboot-persistent queues, removal
@@ -109,13 +108,11 @@ public final class RemovePersistentRequest extends FCPMessage {
    *
    * @param handler connection handler responsible for coordinating client requests; must not be
    *     {@code null} and is assumed to execute callbacks on its internal dispatcher thread.
-   * @param node current node instance supplied by the dispatcher; the parameter is reserved for
-   *     interface compliance and is not modified by this implementation.
    * @throws MessageInvalidException if the handler detects that the request parameters violate
    *     protocol rules or if downstream validation fails during removal.
    */
   @Override
-  public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(final FCPConnectionHandler handler) throws MessageInvalidException {
     ClientRequest req = handler.removePersistentRebootRequest(global, requestIdentifier);
     if (req == null && !global) {
       req = handler.removeRequestByIdentifier(requestIdentifier, true);

--- a/src/main/java/network/crypta/clients/fcp/SSKKeypairMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SSKKeypairMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -109,13 +108,11 @@ public class SSKKeypairMessage extends FCPMessage {
    *
    * @param handler the connection handler receiving the message; must not be {@code null} even
    *     though the message is never executed successfully.
-   * @param node the local node instance; present for signature consistency and not used prior to
-   *     throwing the exception.
    * @throws MessageInvalidException always thrown to signal the message is invalid in this
    *     direction; callers should treat this as a protocol error.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "SSKKeypair goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.Node;
 import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
 
@@ -11,10 +10,9 @@ import network.crypta.support.SimpleFieldSet;
  * <p>This abstraction is used by higher-level client protocols whenever they need to stream a
  * reply, queue update, or diagnostic snapshot to a known peer without exposing the common routing
  * boilerplate in each concrete message. Subclasses parse their payload up front, then invoke {@link
- * #run(FCPConnectionHandler, Node)} to resolve the peer, enforce darknet-only constraints, and
- * finally call {@link #handleFeed(DarknetPeerNode)} to transmit data. Instances are stateful
- * because they cache identifiers and the optional data length reported to peers during capability
- * negotiation.
+ * #run(FCPConnectionHandler)} to resolve the peer, enforce darknet-only constraints, and finally
+ * call {@link #handleFeed(DarknetPeerNode)} to transmit data. Instances are stateful because they
+ * cache identifiers and the optional data length reported to peers during capability negotiation.
  *
  * <p>Implementations are expected to be short-lived and not thread-safe; callers should create a
  * fresh instance per inbound FCP command. The base class never mutates shared node structures
@@ -124,14 +122,12 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
    *
    * @param handler connection handler responsible for sending replies back to the client; must not
    *     be {@code null} and should already be authenticated.
-   * @param node local node instance used to resolve {@link PeerNode} references; must be live and
-   *     fully initialized.
    * @throws MessageInvalidException if the peer is not a darknet peer or if {@code handleFeed}
    *     reports an application-specific validation failure.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    PeerNode pn = node.network().getPeerNode(nodeIdentifier);
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
+    PeerNode pn = handler.getServer().getCore().getNode().network().getPeerNode(nodeIdentifier);
     if (pn == null) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
       handler.send(msg);

--- a/src/main/java/network/crypta/clients/fcp/SendingToNetworkMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendingToNetworkMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -16,7 +15,7 @@ import network.crypta.support.SimpleFieldSet;
  * network.crypta.client.events.SendingToNetworkEvent}, translate it into this message, and queue it
  * on an {@link FCPConnectionHandler}. Clients use the identifier to align UI or bookkeeping with
  * their pending request before subsequent progress events arrive. Because the notification is
- * informational only, {@link #run(FCPConnectionHandler, Node)} intentionally performs no action on
+ * informational only, {@link #run(FCPConnectionHandler)} intentionally performs no action on
  * inbound paths.
  *
  * <ul>
@@ -106,12 +105,11 @@ public class SendingToNetworkMessage extends FCPMessage {
    * with the abstract signature, yet no exception is thrown here.
    *
    * @param handler Connection context invoking execution, ignored for this outbound message.
-   * @param node Node instance supplied by caller but unused because no work occurs.
    * @throws MessageInvalidException Retained for interface compliance; not thrown by this
    *     implementation.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     // Not possible
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SentPeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SentPeerMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -12,8 +11,8 @@ import network.crypta.support.SimpleFieldSet;
  * asynchronous outcomes, even when multiple sends are queued over the same FCP connection. The
  * class is immutable, carries no side effects, and is intended to be serialized immediately after
  * construction rather than retained long term. Because it is purely a response envelope, invoking
- * {@link #run(FCPConnectionHandler, Node)} is invalid and will always raise a protocol error to
- * guard against direction mistakes.
+ * {@link #run(FCPConnectionHandler)} is invalid and will always raise a protocol error to guard
+ * against direction mistakes.
  *
  * <ul>
  *   <li>Echoes the client-provided identifier for correlation with outstanding requests.
@@ -58,8 +57,6 @@ public class SentPeerMessage extends FCPMessage {
    *
    * @param identifier client-provided token used to match responses to requests; may be {@code
    *     null} when the client omitted the field in its send command.
-   * @param nodeStatus integer status reported by peer-handling logic; range and meaning are defined
-   *     by the originating send command implementation.
    */
   public SentPeerMessage(String identifier, int nodeStatus) {
     this.clientIdentifier = identifier;
@@ -109,13 +106,11 @@ public class SentPeerMessage extends FCPMessage {
    *
    * @param handler active connection handler that attempted to dispatch the message; never used for
    *     successful execution because the message should not arrive from a client.
-   * @param node local node instance supplied by the dispatcher; unused because execution always
-   *     aborts before any node interaction.
    * @throws MessageInvalidException always thrown to indicate the message cannot be sent by a
    *     client under the FCP protocol rules.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         getName() + " goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
@@ -88,12 +88,11 @@ public class ShutdownMessage extends FCPMessage {
    *
    * @param handler connection handler that issued the request; must provide full-access rights or
    *     the call fails with an exception
-   * @param node target node instance that will perform the actual process termination on approval
    * @throws MessageInvalidException when the connection lacks required privileges or protocol
    *     validation fails prior to triggering the shutdown
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.hasFullAccess()) {
       throw new MessageInvalidException(
           ProtocolErrorMessage.ACCESS_DENIED, "Shutdown requires full access", null, false);
@@ -102,6 +101,6 @@ public class ShutdownMessage extends FCPMessage {
         new ProtocolErrorMessage(
             ProtocolErrorMessage.SHUTTING_DOWN, true, "The node is shutting down", "Node", false);
     handler.send(msg);
-    node.exit("Received FCP shutdown message");
+    handler.getServer().getCore().getNode().exit("Received FCP shutdown message");
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SimpleProgressMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SimpleProgressMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.time.Instant;
 import java.util.Objects;
 import network.crypta.client.events.SplitfileProgressEvent;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -143,13 +142,11 @@ public class SimpleProgressMessage extends FCPMessage {
    *
    * @param handler connection handler representing the client session that attempted to send the
    *     message; not used because the method always fails fast.
-   * @param node current node instance; retained for interface compatibility but unused in the
-   *     rejection path.
    * @throws MessageInvalidException always thrown to signal that the message direction is invalid
    *     when initiated by a client.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "SimpleProgress goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/StartedCompressionMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/StartedCompressionMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
 
@@ -16,15 +15,15 @@ import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
  *
  * <p>Instances are immutable and safe to share across threads because all state is provided at
  * construction time and never mutated. Typical callers build the message server-side, hand it to
- * the FCP output pipeline, and never invoke {@link #run(FCPConnectionHandler, Node)} because this
- * type is not meant to be received from clients. Client-side receipt is treated as a protocol
- * violation and rejected immediately.
+ * the FCP output pipeline, and never invoke {@link #run(FCPConnectionHandler)} because this type is
+ * not meant to be received from clients. Client-side receipt is treated as a protocol violation and
+ * rejected immediately.
  *
  * <ul>
  *   <li>Serializes as a {@link SimpleFieldSet} with {@code Identifier}, {@code Codec}, and {@code
  *       Global} keys.
  *   <li>Always reports the canonical FCP name {@code StartedCompression}.
- *   <li>{@link #run(FCPConnectionHandler, Node)} exists only to guard against misrouted traffic.
+ *   <li>{@link #run(FCPConnectionHandler)} exists only to guard against misrouted traffic.
  * </ul>
  *
  * @see FCPMessage
@@ -107,12 +106,11 @@ public class StartedCompressionMessage extends FCPMessage {
    *
    * @param handler connection handler requesting execution; ignored because the message is invalid
    *     inbound
-   * @param node active node instance; not used because execution always aborts
    * @throws MessageInvalidException always thrown to signal that the message direction violates the
    *     FCP contract
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "StartedCompression goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.net.MalformedURLException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
-import network.crypta.node.Node;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
 
@@ -137,14 +136,12 @@ public final class SubscribeUSKMessage extends FCPMessage {
    *
    * @param handler connection-scoped handler responsible for sending replies and managing session
    *     state; must not be {@code null}
-   * @param node node instance that provides client core access and scheduling services; must not be
-   *     {@code null}
    * @throws MessageInvalidException if validation fails while creating the backend subscription
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     try {
-      new SubscribeUSK(this, node.services().clientCore(), handler);
+      new SubscribeUSK(this, handler.getServer().getCore(), handler);
     } catch (IdentifierCollisionException _) {
       handler.send(new IdentifierCollisionMessage(clientIdentifier, false));
       return;

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKMessage.java
@@ -112,13 +112,11 @@ public class SubscribedUSKMessage extends FCPMessage {
    *
    * @param handler active FCP connection context that attempted to process the message; not
    *     modified by this method.
-   * @param node node instance receiving the invalid message; provided for parity with other message
-   *     handlers but unused because processing always aborts.
    * @throws MessageInvalidException always thrown to indicate the directional violation and halt
    *     further processing of the inbound payload.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         NAME + " goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessage.java
@@ -92,14 +92,13 @@ public class SubscribedUSKRoundFinishedMessage extends FCPMessage {
    *
    * @param handler connection handler associated with the subscription; never used because the
    *     method aborts immediately.
-   * @param node node instance representing the local Crypta daemon; unused in this guard path.
    * @throws MessageInvalidException never thrown directly here but retained for signature parity
    *     with the superclass contract and related message types.
    * @throws UnsupportedOperationException always thrown to indicate that this message is not meant
    *     to be executed on the receiving side.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -71,23 +70,21 @@ public class SubscribedUSKSendingToNetworkMessage extends FCPMessage {
   /**
    * This message is outbound-only and should never be executed as an inbound command.
    *
-   * <p>The FCP dispatcher calls {@link FCPMessage#run(FCPConnectionHandler, Node)} for messages
-   * received from peers. Because {@code SubscribedUSKSendingToNetwork} is emitted by clients rather
-   * than consumed by them, invoking this method represents a protocol misuse and results in an
-   * {@link UnsupportedOperationException}. No state is changed and the provided handler and node
+   * <p>The FCP dispatcher calls {@link FCPMessage#run(FCPConnectionHandler)} for messages received
+   * from peers. Because {@code SubscribedUSKSendingToNetwork} is emitted by clients rather than
+   * consumed by them, invoking this method represents a protocol misuse and results in an {@link
+   * UnsupportedOperationException}. No state is changed and the provided handler and node
    * references are left untouched.
    *
    * @param handler active connection context for the current FCP session; never used here but
    *     required by the interface
-   * @param node target node instance associated with the connection; unused because the message is
-   *     not processed inbound
    * @throws MessageInvalidException declared for interface compatibility; never intentionally
    *     thrown by this implementation
    * @throws UnsupportedOperationException always thrown to signal that inbound execution is
    *     unsupported
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKUpdate.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKUpdate.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.USK;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -104,12 +103,10 @@ public class SubscribedUSKUpdate extends FCPMessage {
    * intentionally non-idempotent because each invocation raises a new exception instance.
    *
    * @param handler connection handler attempting to process the message; expected to be non-null
-   * @param node local node context; supplied for interface completeness but unused in this
-   *     implementation
    * @throws MessageInvalidException always thrown to signal server-only directionality violations
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "SubscribedUSKUpdate goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
@@ -166,11 +165,10 @@ public class TestDdaCompleteMessage extends FCPMessage {
    *
    * @param handler connection handler that attempted to execute the message; ignored because the
    *     method always fails fast.
-   * @param node node instance associated with the handler; unused in this implementation.
    * @throws MessageInvalidException always thrown to indicate the message direction is invalid.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         NAME + " goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/TestDdaReplyMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaReplyMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -116,12 +115,11 @@ public class TestDdaReplyMessage extends FCPMessage {
    * same inbound frame.
    *
    * @param handler connection handler consuming the message; supplied by dispatcher and never null.
-   * @param node active node context for symmetry; unused because inbound delivery is invalid.
    * @throws MessageInvalidException always thrown to signal the directionality error and terminate
    *     processing of the malformed inbound message.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         NAME + " goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
@@ -17,8 +17,8 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>Instances are immutable after construction and are expected to be short-lived; they are not
  * reused across multiple checks. The class performs no I/O itself and is thread-confined to the
- * handler thread that calls {@link #run(FCPConnectionHandler, Node)}. Incoming field values are
- * used exactly as provided; callers should avoid reusing paths that may change between checks.
+ * handler thread that calls {@link #run(FCPConnectionHandler)}. Incoming field values are used
+ * exactly as provided; callers should avoid reusing paths that may change between checks.
  *
  * <ul>
  *   <li>Validates client intent and basic safety assumptions.
@@ -145,12 +145,11 @@ public final class TestDdaRequestMessage extends FCPMessage {
    *
    * @param handler connection-scoped handler responsible for scheduling DDA checks and sending
    *     replies synchronously.
-   * @param node owning node instance for contextual compatibility; not dereferenced by this method.
    * @throws MessageInvalidException if handler rejects the directory or if validation fails during
    *     enqueueing.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     DdaCheckJob job;
     try {
       job = handler.enqueueDDACheck(requestedDirectory, wantRead, wantWrite);

--- a/src/main/java/network/crypta/clients/fcp/TestDdaResponseMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaResponseMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -50,9 +49,9 @@ public final class TestDdaResponseMessage extends FCPMessage {
    *
    * <p>The constructor performs structural validation: it requires a non-empty directory path and
    * optionally accepts the payload read from the node-provided test file. It does not touch the
-   * filesystem and leaves permission evaluation to {@link #run(FCPConnectionHandler, Node)}. The
-   * instance is fully initialized after construction and can be executed immediately or queued for
-   * later handling.
+   * filesystem and leaves permission evaluation to {@link #run(FCPConnectionHandler)}. The instance
+   * is fully initialized after construction and can be executed immediately or queued for later
+   * handling.
    *
    * @param sfs parsed fields from the FCP layer, expected to contain directory and optional read
    *     content values; must not be {@code null}.
@@ -109,13 +108,11 @@ public final class TestDdaResponseMessage extends FCPMessage {
    *
    * @param handler active connection handler coordinating DDA checks for this client; must not be
    *     {@code null} and must have a pending check entry for the directory.
-   * @param node current node instance; present for interface symmetry but unused directly in this
-   *     implementation.
    * @throws MessageInvalidException if the directory is unknown, required content is absent, or the
    *     handler rejects the lookup parameters.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     DdaCheckJob job;
     try {
       job = handler.popDDACheck(directory);

--- a/src/main/java/network/crypta/clients/fcp/URIGeneratedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/URIGeneratedMessage.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -20,7 +19,7 @@ import network.crypta.support.SimpleFieldSet;
  *   <li>Expose the generated URI and identifier in the FCP wire format.
  *   <li>Advertise the standard message name {@code URIGenerated} to the protocol layer.
  *   <li>Guard against incorrect client-to-server usage by rejecting {@link
- *       #run(FCPConnectionHandler, Node)} calls.
+ *       #run(FCPConnectionHandler)} calls.
  * </ul>
  *
  * Concurrency: the object is immutable once constructed. Protocol handlers may reuse it across
@@ -77,12 +76,11 @@ public class URIGeneratedMessage extends FCPMessage {
    * in the FCP protocol.
    *
    * @param handler active connection handler attempting to process the message.
-   * @param node reference to the local node instance; unused because execution always fails.
    * @throws MessageInvalidException always thrown to indicate incorrect message direction on the
    *     wire.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "URIGenerated goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -13,11 +12,10 @@ import network.crypta.support.SimpleFieldSet;
  * and immutable: once constructed, the identifier values are stored verbatim and rendered into a
  * {@link SimpleFieldSet} without further validation. Typical call paths originate on the server
  * when validating inbound traffic; the client side should not emit this message, and {@link
- * #run(FCPConnectionHandler, Node)} throws if execution is attempted in that direction. Instances
- * are lightweight and thread-safe because they carry only final string fields and perform no
- * mutable operations. Use this type when you need a structured way to surface “unknown
- * NodeIdentifier” errors back to an FCP client while preserving the identifiers needed for
- * diagnostics and logging.
+ * #run(FCPConnectionHandler)} throws if execution is attempted in that direction. Instances are
+ * lightweight and thread-safe because they carry only final string fields and perform no mutable
+ * operations. Use this type when you need a structured way to surface “unknown NodeIdentifier”
+ * errors back to an FCP client while preserving the identifiers needed for diagnostics and logging.
  *
  * <ul>
  *   <li>Immutable payload carrying the unrecognized node identifier.
@@ -95,12 +93,11 @@ public class UnknownNodeIdentifierMessage extends FCPMessage {
    *
    * @param handler connection handler provided by the caller; ignored because the method always
    *     throws to block processing.
-   * @param node node context supplied by the caller; ignored because no processing occurs.
    * @throws MessageInvalidException always thrown to indicate the message direction is invalid when
    *     executed on the client side.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "UnknownNodeIdentifier goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/UnknownPeerNoteTypeMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/UnknownPeerNoteTypeMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -18,7 +17,7 @@ import network.crypta.support.SimpleFieldSet;
  *       not map to any known peer note schema.
  *   <li>Transmission: {@link #getFieldSet()} serializes the numeric type and optional identifier to
  *       the wire format understood by the FCP layer.
- *   <li>Handling: {@link #run(FCPConnectionHandler, Node)} always fails fast with a {@link
+ *   <li>Handling: {@link #run(FCPConnectionHandler)} always fails fast with a {@link
  *       MessageInvalidException}, preventing the unknown type from propagating deeper into server
  *       logic.
  * </ul>
@@ -84,13 +83,11 @@ public class UnknownPeerNoteTypeMessage extends FCPMessage {
    *
    * @param handler connection handler invoking the message; not used beyond validation but must be
    *     non-null when provided by the framework.
-   * @param node active node instance for context; unused because the method never proceeds to node
-   *     operations.
    * @throws MessageInvalidException always thrown to signal that the message direction is invalid
    *     for the server and processing cannot continue.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     throw new MessageInvalidException(
         ProtocolErrorMessage.INVALID_MESSAGE,
         "UnknownPeerNoteType goes from server to client not the other way around",

--- a/src/main/java/network/crypta/clients/fcp/UnsubscribeUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/UnsubscribeUSKMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -15,8 +14,8 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <p>Instances are immutable and represent a single unsubscribe request. The lifecycle is short:
  * the message is parsed from the incoming field set, validated for the presence of the identifier,
- * and then executed once via {@link #run(FCPConnectionHandler, Node)}. Thread-safety is provided by
- * the caller; this class maintains no shared state. Use this type when tearing down long-lived USK
+ * and then executed once via {@link #run(FCPConnectionHandler)}. Thread-safety is provided by the
+ * caller; this class maintains no shared state. Use this type when tearing down long-lived USK
  * feeds to avoid unnecessary bandwidth and server-side cache usage.
  *
  * <ul>
@@ -40,7 +39,7 @@ public final class UnsubscribeUSKMessage extends FCPMessage {
    *
    * <p>The constructor reads the {@code Identifier} field supplied by the client. If the field is
    * missing or empty, it raises a {@link MessageInvalidException} to signal malformed input to the
-   * caller. Successful construction guarantees that {@link #run(FCPConnectionHandler, Node)} can
+   * caller. Successful construction guarantees that {@link #run(FCPConnectionHandler)} can
    * reference a non-null identifier when delegating to the connection handler.
    *
    * @param fs parsed fields for this message; must contain an Identifier entry.
@@ -97,13 +96,11 @@ public final class UnsubscribeUSKMessage extends FCPMessage {
    * identifiers as no-ops.
    *
    * @param handler connection-scoped dispatcher that tracks USK subscriptions for this client.
-   * @param node node instance receiving the command; not used directly but provided for parity with
-   *     other message handlers.
    * @throws MessageInvalidException if the handler rejects the identifier or cannot remove the
    *     subscription.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     handler.unsubscribeUSK(subscriptionIdentifier);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/UnsupportedPluginMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/UnsupportedPluginMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.FileUtil;
@@ -110,7 +109,7 @@ final class UnsupportedPluginMessage extends BaseDataCarryingMessage {
   }
 
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     handler.send(
         new ProtocolErrorMessage(
             ProtocolErrorMessage.INVALID_MESSAGE,

--- a/src/main/java/network/crypta/clients/fcp/WatchFeedsMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/WatchFeedsMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -75,15 +74,13 @@ public class WatchFeedsMessage extends FCPMessage {
    *
    * @param handler connection handler representing the client session; must be non-{@code null} and
    *     already associated with the target node.
-   * @param node server node that owns the alert subsystem used to register or unregister the
-   *     handler.
    * @throws MessageInvalidException if the connection state rejects alert watching, matching base
    *     FCP error propagation semantics.
    */
   @Override
-  public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
-    if (enabled) node.services().clientCore().getAlerts().watch(handler);
-    else node.services().clientCore().getAlerts().unwatch(handler);
+  public void run(FCPConnectionHandler handler) throws MessageInvalidException {
+    if (enabled) handler.getServer().getCore().getAlerts().watch(handler);
+    else handler.getServer().getCore().getAlerts().unwatch(handler);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
+++ b/src/main/java/network/crypta/clients/fcp/WatchGlobal.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -46,7 +45,7 @@ public final class WatchGlobal extends FCPMessage {
    * processing for the current request.
    *
    * <p>Usage is straightforward: instantiate within an FCP handler when a {@code WatchGlobal}
-   * message arrives, then invoke {@link #run(FCPConnectionHandler, Node)} to apply the preference.
+   * message arrives, then invoke {@link #run(FCPConnectionHandler)} to apply the preference.
    *
    * @param fs non-null set of key/value pairs received from the peer; expects {@code Enabled}
    *     (boolean) and optional {@code VerbosityMask} (integer) entries and tolerates absent fields.
@@ -115,18 +114,16 @@ public final class WatchGlobal extends FCPMessage {
    *
    * <pre>{@code
    * var msg = new WatchGlobal(fields);
-   * msg.run(connectionHandler, node);
+   * msg.run(connectionHandler);
    * }</pre>
    *
    * @param handler active connection handler that owns both persistent and in-memory clients; must
    *     not be {@code null} and is expected to originate the incoming FCP message.
-   * @param node the current node instance supplying the client core and FCP server used to register
-   *     the watch; must expose a non-null client core when invoked.
    * @throws MessageInvalidException if subordinate clients reject the configuration change, or the
    *     handler signals a protocol-level validation failure.
    */
   @Override
-  public void run(final FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+  public void run(final FCPConnectionHandler handler) throws MessageInvalidException {
     if (!handler.getRebootClient().setWatchGlobal(enabled, verbosityMask, handler.getServer())) {
       FCPMessage err =
           new ProtocolErrorMessage(

--- a/src/main/java/network/crypta/node/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/node/NodeClientPersistence.java
@@ -253,10 +253,10 @@ public final class NodeClientPersistence {
   /**
    * Creates the FCP server configured for this node and client core.
    *
-   * <p>The server is constructed via {@link FCPServer#maybeCreate(Node, NodeClientCore,
-   * RuntimePorts, network.crypta.config.Config, PersistentRequestRoot)} and shares this instance's
-   * persistent request root so durable requests can be managed consistently across reconnections.
-   * This method performs no side effects beyond the delegation.
+   * <p>The server is constructed via {@link FCPServer#maybeCreate(NodeClientCore, RuntimePorts,
+   * network.crypta.config.Config, PersistentRequestRoot)} and shares this instance's persistent
+   * request root so durable requests can be managed consistently across reconnections. This method
+   * performs no side effects beyond the delegation.
    *
    * @param node node instance supplying configuration and shared services.
    * @param core client core used by the FCP server for callbacks.
@@ -264,7 +264,7 @@ public final class NodeClientPersistence {
    * @return the configured FCP server instance from {@code maybeCreate}.
    */
   public FCPServer createFcpServer(Node node, NodeClientCore core, RuntimePorts runtimePorts) {
-    return FCPServer.maybeCreate(node, core, runtimePorts, node.getConfig(), persistentRoot);
+    return FCPServer.maybeCreate(core, runtimePorts, node.getConfig(), persistentRoot);
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -169,7 +169,7 @@ class AddPeerTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
     assertEquals("AddPeer requires full access", exception.getMessage());
@@ -188,7 +188,7 @@ class AddPeerTest {
     when(peerPort.add(any(PeerFieldSet.class), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES)))
         .thenReturn(snapshot);
 
-    addPeer.run(handler, node);
+    addPeer.run(handler);
 
     ArgumentCaptor<PeerFieldSet> referenceCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
     verify(peerPort).add(referenceCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
@@ -210,7 +210,7 @@ class AddPeerTest {
     when(peerPort.add(any(PeerFieldSet.class), any(PeerTrust.class), any(PeerVisibility.class)))
         .thenReturn(snapshot);
 
-    addPeer.run(handler, node);
+    addPeer.run(handler);
 
     ArgumentCaptor<PeerTrust> trustCaptor = ArgumentCaptor.forClass(PeerTrust.class);
     ArgumentCaptor<PeerVisibility> visibilityCaptor = ArgumentCaptor.forClass(PeerVisibility.class);
@@ -260,7 +260,7 @@ class AddPeerTest {
     when(handler.hasFullAccess()).thenReturn(true);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler));
 
     assertEquals(ProtocolErrorMessage.NOT_A_FILE_ERROR, exception.protocolCode);
     verifyNoInteractions(server, runtimePorts, peerPort, node);
@@ -275,7 +275,7 @@ class AddPeerTest {
         .thenThrow(new PeerAddRejectedException(reason, "detail-" + reason.name()));
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler));
 
     assertEquals(protocolCode, exception.protocolCode);
     assertEquals("detail-" + reason.name(), exception.getMessage());

--- a/src/test/java/network/crypta/clients/fcp/AllDataMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AllDataMessageTest.java
@@ -71,7 +71,7 @@ class AllDataMessageTest {
         new AllDataMessage(bucket, IDENTIFIER, true, STARTUP_TIME, COMPLETION_TIME, MIME_TYPE);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(IDENTIFIER, exception.ident);

--- a/src/test/java/network/crypta/clients/fcp/ClientGetMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetMessageTest.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucketFactory;
@@ -31,9 +30,6 @@ import static org.mockito.Mockito.verify;
 class ClientGetMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void parseReturnTypeFCP_whenStringIsNull_returnsDirect() throws MessageInvalidException {
@@ -153,7 +149,7 @@ class ClientGetMessageTest {
   void run_whenInvoked_delegatesToConnectionHandler() throws MessageInvalidException {
     ClientGetMessage message = new ClientGetMessage(baseFieldSet());
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler).startClientGet(message);
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientHelloMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientHelloMessageTest.java
@@ -87,7 +87,7 @@ class ClientHelloMessageTest {
     when(nodeInfoPort.greeting()).thenReturn(greeting);
     when(handler.getConnectionIdentifierUUID()).thenReturn(identifier);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     InOrder order = inOrder(nodeInfoPort, handler);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
@@ -53,9 +52,6 @@ class ClientPutComplexDirMessageTest {
   @Mock private FCPServer server;
   @Mock private RuntimePorts runtimePorts;
   @Mock private TransferAccessPort transferAccess;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @TempDir Path tempDir;
 
@@ -139,7 +135,7 @@ class ClientPutComplexDirMessageTest {
         new ClientPutComplexDirMessage(fs, tempBucketFactory, persistentBucketFactory);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     verify(handler, never()).startClientPutDir(any(), any(), anyBoolean());
@@ -157,7 +153,7 @@ class ClientPutComplexDirMessageTest {
         new ClientPutComplexDirMessage(fs, tempBucketFactory, persistentBucketFactory);
 
     message.readFrom(new ByteArrayInputStream(directBytes), tempBucketFactory, server);
-    message.run(handler, node);
+    message.run(handler);
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<HashMap<String, Object>> manifestCaptor = ArgumentCaptor.forClass(HashMap.class);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
@@ -7,7 +7,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
@@ -45,9 +44,6 @@ class ClientPutDiskDirMessageTest {
   @Mock private FCPServer server;
   @Mock private RuntimePorts runtimePorts;
   @Mock private TransferAccessPort transferAccess;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Mock private InputStream inputStream;
   @Mock private BucketFactory bucketFactory;
@@ -87,7 +83,7 @@ class ClientPutDiskDirMessageTest {
     ClientPutDiskDirMessage message = newMessage(tempDir);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     verify(handler, never()).startClientPutDir(any(), any(), anyBoolean());
@@ -109,7 +105,7 @@ class ClientPutDiskDirMessageTest {
 
     ClientPutDiskDirMessage message = newMessage(tempDir);
 
-    message.run(handler, node);
+    message.run(handler);
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<HashMap<String, Object>> bucketsCaptor = ArgumentCaptor.forClass(HashMap.class);
@@ -149,7 +145,7 @@ class ClientPutDiskDirMessageTest {
       ClientPutDiskDirMessage message = newMessage(tempDir);
 
       MessageInvalidException ex =
-          assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+          assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
       assertEquals(ProtocolErrorMessage.FILE_NOT_FOUND, ex.protocolCode);
     } finally {
@@ -171,7 +167,7 @@ class ClientPutDiskDirMessageTest {
       ArgumentCaptor<HashMap<String, Object>> bucketsCaptor =
           ArgumentCaptor.forClass(HashMap.class);
 
-      assertDoesNotThrow(() -> message.run(handler, node));
+      assertDoesNotThrow(() -> message.run(handler));
       verify(handler).startClientPutDir(eq(message), bucketsCaptor.capture(), eq(true));
 
       HashMap<String, Object> buckets = bucketsCaptor.getValue();
@@ -188,7 +184,7 @@ class ClientPutDiskDirMessageTest {
 
     ClientPutDiskDirMessage message = newMessage(tempDir, false, true);
 
-    message.run(handler, node);
+    message.run(handler);
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<HashMap<String, Object>> bucketsCaptor = ArgumentCaptor.forClass(HashMap.class);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
@@ -121,7 +120,7 @@ class ClientPutMessageTest {
     ClientPutMessage message = newDirectMessage("put-run", 8L);
     FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
 
-    message.run(handler, Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS));
+    message.run(handler);
 
     Mockito.verify(handler).startClientPut(message);
   }

--- a/src/test/java/network/crypta/clients/fcp/CloseConnectionDuplicateClientNameMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CloseConnectionDuplicateClientNameMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CloseConnectionDuplicateClientNameMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenInvoked_returnsEmptyFieldSet() {
@@ -52,7 +48,7 @@ class CloseConnectionDuplicateClientNameMessageTest {
         new CloseConnectionDuplicateClientNameMessage();
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/CompatibilityModeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CompatibilityModeTest.java
@@ -74,7 +74,7 @@ class CompatibilityModeTest {
   void run_whenInvoked_expectUnsupportedOperation() {
     CompatibilityMode message = new CompatibilityMode("id", true, analyser);
 
-    assertThrows(UnsupportedOperationException.class, () -> message.run(null, null));
+    assertThrows(UnsupportedOperationException.class, () -> message.run(null));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ConfigDataTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.util.EnumMap;
 import java.util.Map;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.ConfigFieldSet;
 import network.crypta.runtime.spi.ConfigSection;
 import network.crypta.runtime.spi.ConfigSnapshot;
@@ -22,8 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ConfigDataTest {
 
   @Mock private FCPConnectionHandler connectionHandler;
-
-  @Mock private Node node;
 
   @Test
   void getFieldSet_whenAllSectionsRequested_expectCorrespondingSubsets() {
@@ -101,7 +98,7 @@ class ConfigDataTest {
     ConfigData configData = new ConfigData(ConfigSnapshot.empty(), null);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> configData.run(connectionHandler, node));
+        assertThrows(MessageInvalidException.class, () -> configData.run(connectionHandler));
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(
         "ConfigData goes from server to client not the other way around", exception.getMessage());

--- a/src/test/java/network/crypta/clients/fcp/DataFoundMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DataFoundMessageTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.FetchResult;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 
@@ -56,11 +55,7 @@ class DataFoundMessageTest {
 
     MessageInvalidException exception =
         assertThrows(
-            MessageInvalidException.class,
-            () ->
-                message.run(
-                    mock(FCPConnectionHandler.class),
-                    mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+            MessageInvalidException.class, () -> message.run(mock(FCPConnectionHandler.class)));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/DisconnectMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/DisconnectMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,9 +20,6 @@ import static org.mockito.Mockito.verify;
 class DisconnectMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenInvoked_returnsIndependentEmptyFieldSet() {
@@ -50,7 +46,7 @@ class DisconnectMessageTest {
   void run_whenCalled_invokesHandlerClose() throws MessageInvalidException {
     DisconnectMessage message = new DisconnectMessage(new SimpleFieldSet(true));
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler).close();
   }
@@ -61,8 +57,7 @@ class DisconnectMessageTest {
     RuntimeException failure = new RuntimeException("boom");
     doThrow(failure).when(handler).close();
 
-    RuntimeException thrown =
-        assertThrows(RuntimeException.class, () -> message.run(handler, node));
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> message.run(handler));
 
     assertSame(failure, thrown);
   }

--- a/src/test/java/network/crypta/clients/fcp/EndListPeerNotesMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/EndListPeerNotesMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +19,6 @@ class EndListPeerNotesMessageTest {
   private static final String IDENTIFIER = "req-456";
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenIdentifierProvided_expectBothKeys() {
@@ -58,7 +54,7 @@ class EndListPeerNotesMessageTest {
     EndListPeerNotesMessage message = new EndListPeerNotesMessage(NODE_IDENTIFIER, IDENTIFIER);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/EndListPeersMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/EndListPeersMessageTest.java
@@ -43,7 +43,7 @@ class EndListPeersMessageTest {
     EndListPeersMessage message = new EndListPeersMessage(IDENTIFIER);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/EndListPersistentRequestsMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/EndListPersistentRequestsMessageTest.java
@@ -54,7 +54,7 @@ class EndListPersistentRequestsMessageTest {
     EndListPersistentRequestsMessage message = new EndListPersistentRequestsMessage(IDENTIFIER);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/EnterFiniteCooldownTest.java
+++ b/src/test/java/network/crypta/clients/fcp/EnterFiniteCooldownTest.java
@@ -47,7 +47,7 @@ class EnterFiniteCooldownTest {
     FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
     Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verifyNoInteractions(handler, node);
   }

--- a/src/test/java/network/crypta/clients/fcp/ExpectedDataLengthTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ExpectedDataLengthTest.java
@@ -60,7 +60,7 @@ class ExpectedDataLengthTest {
   void run_whenCalled_expectNoInteractions() {
     ExpectedDataLength message = new ExpectedDataLength("identifier", true, 2048);
 
-    assertDoesNotThrow(() -> message.run(handler, node));
+    assertDoesNotThrow(() -> message.run(handler));
     verifyNoInteractions(handler, node);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ExpectedHashesTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ExpectedHashesTest.java
@@ -4,10 +4,8 @@ import java.util.Arrays;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.crypt.HashResult;
 import network.crypta.crypt.HashType;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -94,9 +92,8 @@ class ExpectedHashesTest {
     ExpectedHashes expectedHashes = new ExpectedHashes(new HashResult[0], "run", false);
     //noinspection resource
     FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
-    Node node = Mockito.mock(Node.class, Answers.RETURNS_DEEP_STUBS);
 
-    assertThrows(UnsupportedOperationException.class, () -> expectedHashes.run(handler, node));
+    assertThrows(UnsupportedOperationException.class, () -> expectedHashes.run(handler));
   }
 
   private static HashResult createHash(HashType type, byte fillValue) {

--- a/src/test/java/network/crypta/clients/fcp/ExpectedMIMETest.java
+++ b/src/test/java/network/crypta/clients/fcp/ExpectedMIMETest.java
@@ -54,7 +54,7 @@ class ExpectedMIMETest {
   void run_whenInvoked_expectNoInteractionsOrExceptions() {
     ExpectedMIME expectedMIME = new ExpectedMIME("identifier", true, "application/json");
 
-    assertDoesNotThrow(() -> expectedMIME.run(handler, node));
+    assertDoesNotThrow(() -> expectedMIME.run(handler));
     verifyNoInteractions(handler, node);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -13,7 +13,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
@@ -272,7 +271,6 @@ class FCPConnectionInputHandlerTest {
     ctx.handler = mock(FCPConnectionHandler.class);
     ctx.bucketFactory = mock(TempBucketFactory.class);
     ctx.server = mock(FCPServer.class);
-    ctx.node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
     ctx.core = mock(NodeClientCore.class);
     ctx.runtimePorts = mock(RuntimePorts.class);
     ctx.nodeInfoPort = mock(NodeInfoPort.class);
@@ -282,7 +280,6 @@ class FCPConnectionInputHandlerTest {
     when(ctx.handler.getSocket()).thenReturn(ctx.socket);
     when(ctx.socket.getInputStream()).thenReturn(stream);
     when(ctx.handler.getServer()).thenReturn(ctx.server);
-    lenient().when(ctx.server.getNode()).thenReturn(ctx.node);
     lenient().when(ctx.server.getCore()).thenReturn(ctx.core);
     lenient().when(ctx.server.runtime()).thenReturn(ctx.runtimePorts);
     lenient().when(ctx.runtimePorts.nodeInfo()).thenReturn(ctx.nodeInfoPort);
@@ -335,7 +332,6 @@ class FCPConnectionInputHandlerTest {
     FCPConnectionInputHandler inputHandler;
     FCPConnectionHandler handler;
     FCPServer server;
-    Node node;
     NodeClientCore core;
     RuntimePorts runtimePorts;
     NodeInfoPort nodeInfoPort;
@@ -360,7 +356,7 @@ class FCPConnectionInputHandlerTest {
     }
 
     @Override
-    public void run(FCPConnectionHandler handler, Node node) {
+    public void run(FCPConnectionHandler handler) {
       // Intentionally empty: run() must remain inert so that tests focus solely on readFrom().
     }
 
@@ -409,7 +405,7 @@ class FCPConnectionInputHandlerTest {
     }
 
     @Override
-    public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+    public void run(FCPConnectionHandler handler) throws MessageInvalidException {
       if (runHook != null) {
         runHook.run();
       }

--- a/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import org.junit.jupiter.api.Test;
@@ -64,9 +63,8 @@ class FCPMessageTest {
   void wrappedMessageDelegatesRun() throws MessageInvalidException {
     FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
     FCPConnectionHandler connectionHandler = mock(FCPConnectionHandler.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    wrappedMessage.run(connectionHandler, node);
-    verify(originalMessage).run(connectionHandler, node);
+    wrappedMessage.run(connectionHandler);
+    verify(originalMessage).run(connectionHandler);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -4,7 +4,6 @@ import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -22,9 +21,6 @@ import static org.mockito.ArgumentMatchers.isA;
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class FCPServerTest {
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Mock private NodeClientCore core;
   @Mock private RuntimePorts runtimePorts;
@@ -44,7 +40,7 @@ class FCPServerTest {
             false,
             10);
     return new FCPServer(
-        config, new FcpServerDependencies(node, core, runtimePorts, new PersistentRequestRoot()));
+        config, new FcpServerDependencies(core, runtimePorts, new PersistentRequestRoot()));
   }
 
   @Test
@@ -110,8 +106,7 @@ class FCPServerTest {
             false,
             false,
             10);
-    FCPServer server =
-        new FCPServer(config, new FcpServerDependencies(node, core, runtimePorts, root));
+    FCPServer server = new FCPServer(config, new FcpServerDependencies(core, runtimePorts, root));
     PersistentRequestClient forever = root.registerForeverClient("forever", null);
 
     // Act

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -4,7 +4,6 @@ import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.SubConfig;
 import network.crypta.io.NetworkInterface;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -27,9 +26,6 @@ import static org.mockito.Mockito.when;
 class FcpServerConfigRegistrarTest {
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private NodeClientCore core;
 
   @Mock private RuntimePorts runtimePorts;
@@ -43,7 +39,7 @@ class FcpServerConfigRegistrarTest {
     when(runtimePorts.execution()).thenReturn(executionPort);
 
     // Act
-    FCPServer server = FcpServerConfigRegistrar.maybeCreate(node, core, runtimePorts, config, root);
+    FCPServer server = FcpServerConfigRegistrar.maybeCreate(core, runtimePorts, config, root);
     SubConfig subConfig = config.get("fcp");
 
     // Assert
@@ -237,6 +233,6 @@ class FcpServerConfigRegistrarTest {
             false,
             10);
     return new FCPServer(
-        config, new FcpServerDependencies(node, core, runtimePorts, new PersistentRequestRoot()));
+        config, new FcpServerDependencies(core, runtimePorts, new PersistentRequestRoot()));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FeedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FeedMessageTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import java.nio.charset.StandardCharsets;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,11 +82,10 @@ class FeedMessageTest {
   void run_whenInvoked_expectMessageInvalidExceptionWithInvalidMessageCode() {
     // Arrange
     FeedMessage message = new FeedMessage("header", "short", "text", (short) 2, 123_456_789L);
-    Node node = org.mockito.Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
 
     // Act
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     // Assert
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);

--- a/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
@@ -14,7 +14,6 @@ import network.crypta.client.filter.ContentFilterCallbacks;
 import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
@@ -154,11 +153,7 @@ class FilterMessageTest {
     FCPConnectionHandler handler = handlerWithContext(Mockito.mock(ClientContext.class));
 
     MessageInvalidException exception =
-        assertThrows(
-            MessageInvalidException.class,
-            () ->
-                message.run(
-                    handler, Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
     assertEquals("req-run-nobucket", exception.ident);
@@ -183,11 +178,7 @@ class FilterMessageTest {
     FCPConnectionHandler handler = handlerWithContext(Mockito.mock(ClientContext.class));
 
     MessageInvalidException exception =
-        assertThrows(
-            MessageInvalidException.class,
-            () ->
-                message.run(
-                    handler, Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, exception.protocolCode);
     assertEquals("req-run-bf", exception.ident);
@@ -222,7 +213,7 @@ class FilterMessageTest {
                 return status;
               });
 
-      message.run(handler, Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS));
+      message.run(handler);
     }
 
     Mockito.verify(handler).send(responseCaptor.capture());
@@ -278,7 +269,7 @@ class FilterMessageTest {
                       Mockito.any(ContentFilterCallbacks.class)))
           .thenThrow(unsafe);
 
-      message.run(handler, Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS));
+      message.run(handler);
     }
 
     Mockito.verify(handler).send(responseCaptor.capture());

--- a/src/test/java/network/crypta/clients/fcp/FilterResultMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FilterResultMessageTest.java
@@ -93,7 +93,7 @@ class FilterResultMessageTest {
             new SimpleReadOnlyArrayBucket(new byte[] {1, 2}));
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/FinishedCompressionMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FinishedCompressionMessageTest.java
@@ -64,7 +64,7 @@ class FinishedCompressionMessageTest {
             "identifier", true, new FinishedCompressionEvent(-1, 5L, 5L));
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/GenerateSSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GenerateSSKMessageTest.java
@@ -4,7 +4,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
@@ -66,7 +65,6 @@ class GenerateSSKMessageTest {
     FCPServer server = mock(FCPServer.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
-    Node node = mock(Node.class);
     when(handler.getServer()).thenReturn(server);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
@@ -92,7 +90,7 @@ class GenerateSSKMessageTest {
                 return generatedKey;
               });
 
-      message.run(handler, node);
+      message.run(handler);
 
       mocked.verify(
           () -> InsertableClientSSK.createRandom(any(RandomSource.class), eq("")), times(1));
@@ -118,7 +116,6 @@ class GenerateSSKMessageTest {
     FCPServer server = mock(FCPServer.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
-    Node node = mock(Node.class);
     when(handler.getServer()).thenReturn(server);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
@@ -142,7 +139,7 @@ class GenerateSSKMessageTest {
                 return generatedKey;
               });
 
-      message.run(handler, node);
+      message.run(handler);
 
       verify(randomnessPort, times(1)).fillSecureRandom(any(byte[].class));
 

--- a/src/test/java/network/crypta/clients/fcp/GeneratedMetadataMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GeneratedMetadataMessageTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.Bucket;
@@ -26,9 +25,6 @@ class GeneratedMetadataMessageTest {
   @Mock private BucketFactory bucketFactory;
   @Mock private FCPServer server;
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void dataLength_whenBucketHasSize_returnsBucketSize() {
@@ -92,6 +88,6 @@ class GeneratedMetadataMessageTest {
     GeneratedMetadataMessage message =
         new GeneratedMetadataMessage("id", false, new SimpleReadOnlyArrayBucket(new byte[0]));
 
-    assertThrows(UnsupportedOperationException.class, () -> message.run(handler, node));
+    assertThrows(UnsupportedOperationException.class, () -> message.run(handler));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetConfigTest.java
@@ -92,7 +92,7 @@ class GetConfigTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> getConfig.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> getConfig.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
     assertEquals("req-123", thrown.ident);
@@ -125,7 +125,7 @@ class GetConfigTest {
     when(runtimePorts.config()).thenReturn(configPort);
     when(configPort.export(any())).thenReturn(snapshot);
 
-    getConfig.run(handler, node);
+    getConfig.run(handler);
 
     ArgumentCaptor<Set<ConfigSection>> sectionsCaptor = ArgumentCaptor.forClass(Set.class);
     verify(configPort).export(sectionsCaptor.capture());

--- a/src/test/java/network/crypta/clients/fcp/GetFailedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetFailedMessageTest.java
@@ -9,7 +9,6 @@ import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.StorageFormatException;
 import org.junit.jupiter.api.Test;
@@ -28,9 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class GetFailedMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenGlobalFalse_setsGlobalFalse() {
@@ -139,7 +135,7 @@ class GetFailedMessageTest {
     GetFailedMessage message = new GetFailedMessage(exception, "run-id", true);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals("run-id", thrown.ident);
     assertTrue(thrown.global);

--- a/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetNodeTest.java
@@ -111,7 +111,7 @@ class GetNodeTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> getNode.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> getNode.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
     assertEquals("restricted-client", exception.ident);
@@ -145,7 +145,7 @@ class GetNodeTest {
     when(nodeInfoPort.exportReference(expectedView, true)).thenReturn(snapshot);
     ArgumentCaptor<NodeData> messageCaptor = ArgumentCaptor.forClass(NodeData.class);
 
-    getNode.run(handler, node);
+    getNode.run(handler);
 
     verify(nodeInfoPort).exportReference(expectedView, true);
     verify(handler).send(messageCaptor.capture());

--- a/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/GetRequestStatusMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
 import network.crypta.runtime.spi.RequestQueueTask;
@@ -32,7 +31,6 @@ class GetRequestStatusMessageTest {
 
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPConnectionOutputHandler outputHandler;
-  @Mock private Node node;
   @Mock private FCPServer server;
   @Mock private RuntimePorts runtimePorts;
   @Mock private RequestQueuePort requestQueuePort;
@@ -86,7 +84,7 @@ class GetRequestStatusMessageTest {
     when(handler.getRebootRequest(false, handler, identifier)).thenReturn(request);
     when(handler.getOutputHandler()).thenReturn(outputHandler);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(request).sendPendingMessages(outputHandler, identifier, true, true);
     verify(handler, never()).send(any());
@@ -103,7 +101,7 @@ class GetRequestStatusMessageTest {
     when(handler.getRebootRequest(false, handler, identifier)).thenReturn(null);
     when(requestQueuePort.isPersistenceDatabaseKilled()).thenReturn(true);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler, never()).send(any());
     verify(requestQueuePort).isPersistenceDatabaseKilled();
@@ -125,7 +123,7 @@ class GetRequestStatusMessageTest {
     when(handler.getOutputHandler()).thenReturn(outputHandler);
     when(requestQueuePort.isPersistenceDatabaseKilled()).thenReturn(false);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
     verify(requestQueuePort)
@@ -151,7 +149,7 @@ class GetRequestStatusMessageTest {
     when(handler.getForeverRequest(false, handler, identifier)).thenReturn(null);
     when(requestQueuePort.isPersistenceDatabaseKilled()).thenReturn(false);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
     verify(requestQueuePort)
@@ -184,7 +182,7 @@ class GetRequestStatusMessageTest {
         .when(requestQueuePort)
         .submitPersistentJob(any(), eq(RequestQueuePriority.NORMAL));
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);

--- a/src/test/java/network/crypta/clients/fcp/IdentifierCollisionMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/IdentifierCollisionMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,9 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class IdentifierCollisionMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenIdentifierAndGlobalProvided_expectFieldsSet() {
@@ -58,7 +54,7 @@ class IdentifierCollisionMessageTest {
     IdentifierCollisionMessage message = new IdentifierCollisionMessage(ident, global);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerMessageTest.java
@@ -60,7 +60,7 @@ class ListPeerMessageTest {
     ListPeerMessage message = new ListPeerMessage(fs);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
     assertEquals("ListPeer requires full access", thrown.getMessage());
@@ -78,7 +78,7 @@ class ListPeerMessageTest {
     ListPeerMessage message = new ListPeerMessage(fs);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, thrown.protocolCode);
     assertEquals("Error: NodeIdentifier field missing", thrown.getMessage());
@@ -101,7 +101,7 @@ class ListPeerMessageTest {
     fs.putSingle("NodeIdentifier", "node-unknown");
     ListPeerMessage message = new ListPeerMessage(fs);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
@@ -128,7 +128,7 @@ class ListPeerMessageTest {
     fs.putSingle("NodeIdentifier", "node-42");
     ListPeerMessage message = new ListPeerMessage(fs);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());

--- a/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeerNotesMessageTest.java
@@ -81,7 +81,7 @@ class ListPeerNotesMessageTest {
     ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
     assertEquals("ListPeerNotes requires full access", thrown.getMessage());
@@ -99,7 +99,7 @@ class ListPeerNotesMessageTest {
     ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, thrown.protocolCode);
     assertEquals("Error: NodeIdentifier field missing", thrown.getMessage());
@@ -122,7 +122,7 @@ class ListPeerNotesMessageTest {
     fs.putSingle("NodeIdentifier", "node-unknown");
     ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
@@ -147,7 +147,7 @@ class ListPeerNotesMessageTest {
     ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.DARKNET_ONLY, thrown.protocolCode);
     assertEquals("ModifyPeer only available for darknet peers", thrown.getMessage());
@@ -168,7 +168,7 @@ class ListPeerNotesMessageTest {
     fs.putSingle("NodeIdentifier", "node-3");
     ListPeerNotesMessage message = new ListPeerNotesMessage(fs);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(2)).send(captor.capture());

--- a/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPeersMessageTest.java
@@ -73,7 +73,7 @@ class ListPeersMessageTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     assertEquals("id-1", ex.ident);
@@ -92,7 +92,7 @@ class ListPeersMessageTest {
     when(runtimePorts.peer()).thenReturn(peerPort);
     when(peerPort.list(true, true)).thenReturn(List.of(peerOne, peerTwo));
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(3)).send(captor.capture());
@@ -126,7 +126,7 @@ class ListPeersMessageTest {
     when(runtimePorts.peer()).thenReturn(peerPort);
     when(peerPort.list(false, false)).thenReturn(List.of());
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());

--- a/src/test/java/network/crypta/clients/fcp/ListPersistentRequestsMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ListPersistentRequestsMessageTest.java
@@ -64,7 +64,7 @@ class ListPersistentRequestsMessageTest {
     mockQueuesReturningEmpty(identifier, outputHandler, rebootClient, foreverClient);
     executePersistentTasksImmediately();
 
-    message.run(handler, null);
+    message.run(handler);
 
     ArgumentCaptor<EndListPersistentRequestsMessage> captor =
         ArgumentCaptor.forClass(EndListPersistentRequestsMessage.class);
@@ -97,7 +97,7 @@ class ListPersistentRequestsMessageTest {
     mockQueuesReturningEmpty(identifier, outputHandler, globalRebootClient, globalForeverClient);
     executePersistentTasksImmediately();
 
-    message.run(handler, null);
+    message.run(handler);
 
     verify(handler).send(any(EndListPersistentRequestsMessage.class));
     verify(requestQueuePort, times(1)).submitPersistentJob(any(), eq(RequestQueuePriority.LISTING));

--- a/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyConfigTest.java
@@ -79,7 +79,7 @@ class ModifyConfigTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> modifyConfig.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyConfig.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
     assertEquals("blocked-id", thrown.ident);
@@ -107,7 +107,7 @@ class ModifyConfigTest {
     when(runtimePorts.config()).thenReturn(configPort);
     when(configPort.export(EnumSet.of(ConfigSection.CURRENT))).thenReturn(snapshot);
 
-    modifyConfig.run(handler, node);
+    modifyConfig.run(handler);
 
     InOrder order = inOrder(configPort, handler);
     ArgumentCaptor<Map<String, String>> overridesCaptor = ArgumentCaptor.forClass(Map.class);

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerNoteTest.java
@@ -78,7 +78,7 @@ class ModifyPeerNoteTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -94,7 +94,7 @@ class ModifyPeerNoteTest {
     when(handler.hasFullAccess()).thenReturn(true);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -112,7 +112,7 @@ class ModifyPeerNoteTest {
     when(peerPort.readPrivateDarknetComment(NODE_IDENTIFIER))
         .thenThrow(new UnknownPeerException(NODE_IDENTIFIER));
 
-    modifyPeerNote.run(handler, node);
+    modifyPeerNote.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
@@ -133,7 +133,7 @@ class ModifyPeerNoteTest {
         .thenThrow(new DarknetPeerRequiredException(NODE_IDENTIFIER));
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.DARKNET_ONLY, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -149,7 +149,7 @@ class ModifyPeerNoteTest {
     stubPeerPort();
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -166,7 +166,7 @@ class ModifyPeerNoteTest {
     stubPeerPort();
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -183,7 +183,7 @@ class ModifyPeerNoteTest {
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     stubPeerPort();
 
-    modifyPeerNote.run(handler, node);
+    modifyPeerNote.run(handler);
 
     verify(handler, never()).send(any());
     verify(peerPort, never()).writePrivateDarknetComment(any(), any());
@@ -198,7 +198,7 @@ class ModifyPeerNoteTest {
     ModifyPeerNote modifyPeerNote = new ModifyPeerNote(fs);
     stubPeerPort();
 
-    modifyPeerNote.run(handler, node);
+    modifyPeerNote.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
@@ -221,7 +221,7 @@ class ModifyPeerNoteTest {
     when(peerPort.readPrivateDarknetComment(NODE_IDENTIFIER))
         .thenThrow(new UnknownPeerException(NODE_IDENTIFIER));
 
-    modifyPeerNote.run(handler, node);
+    modifyPeerNote.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
@@ -241,7 +241,7 @@ class ModifyPeerNoteTest {
         .thenThrow(new DarknetPeerRequiredException(NODE_IDENTIFIER));
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.DARKNET_ONLY, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -259,7 +259,7 @@ class ModifyPeerNoteTest {
     stubPeerPort();
     when(peerPort.writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT)).thenReturn(NOTE_TEXT);
 
-    modifyPeerNote.run(handler, node);
+    modifyPeerNote.run(handler);
 
     verify(peerPort, times(1)).readPrivateDarknetComment(NODE_IDENTIFIER);
     verify(peerPort, times(1)).writePrivateDarknetComment(NODE_IDENTIFIER, NOTE_TEXT);

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
@@ -67,7 +67,7 @@ class ModifyPeerTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -83,7 +83,7 @@ class ModifyPeerTest {
     when(handler.hasFullAccess()).thenReturn(true);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -102,7 +102,7 @@ class ModifyPeerTest {
     when(peerPort.updateDarknetPeer(any(), any()))
         .thenThrow(new UnknownPeerException(NODE_IDENTIFIER));
 
-    modifyPeer.run(handler, node);
+    modifyPeer.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
@@ -124,7 +124,7 @@ class ModifyPeerTest {
         .thenThrow(new DarknetPeerRequiredException(NODE_IDENTIFIER));
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> modifyPeer.run(handler));
 
     assertEquals(ProtocolErrorMessage.DARKNET_ONLY, ex.protocolCode);
     assertEquals(IDENTIFIER, ex.ident);
@@ -150,7 +150,7 @@ class ModifyPeerTest {
                 java.util.Map.of("identity", NODE_IDENTIFIER), java.util.Map.of()));
     when(peerPort.updateDarknetPeer(any(), any())).thenReturn(snapshot);
 
-    modifyPeer.run(handler, node);
+    modifyPeer.run(handler);
 
     ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
         ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
@@ -187,7 +187,7 @@ class ModifyPeerTest {
                 new network.crypta.runtime.spi.PeerFieldSet(
                     java.util.Map.of("identity", NODE_IDENTIFIER), java.util.Map.of())));
 
-    modifyPeer.run(handler, node);
+    modifyPeer.run(handler);
 
     ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
         ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
@@ -219,7 +219,7 @@ class ModifyPeerTest {
                 new network.crypta.runtime.spi.PeerFieldSet(
                     java.util.Map.of("identity", NODE_IDENTIFIER), java.util.Map.of())));
 
-    modifyPeer.run(handler, node);
+    modifyPeer.run(handler);
 
     ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
         ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);

--- a/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPersistentRequestTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
 import network.crypta.runtime.spi.RequestQueueTask;
@@ -32,7 +31,6 @@ import static org.mockito.Mockito.when;
 class ModifyPersistentRequestTest {
 
   @Mock private FCPConnectionHandler handler;
-  @Mock private Node node;
   @Mock private FCPServer server;
   @Mock private RuntimePorts runtimePorts;
   @Mock private RequestQueuePort requestQueuePort;
@@ -149,7 +147,7 @@ class ModifyPersistentRequestTest {
     when(handler.getRebootRequest(false, handler, "req-7")).thenReturn(rebootRequest);
     when(handler.getServer()).thenReturn(server);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(rebootRequest).modifyRequest("tok", (short) 1, server);
     verifyNoInteractions(requestQueuePort);
@@ -171,7 +169,7 @@ class ModifyPersistentRequestTest {
     when(handler.getRebootRequest(false, handler, "req-8")).thenReturn(null);
     when(handler.getForeverRequest(false, handler, "req-8")).thenReturn(foreverRequest);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
     verify(requestQueuePort)
@@ -196,7 +194,7 @@ class ModifyPersistentRequestTest {
     when(handler.getRebootRequest(false, handler, "req-9")).thenReturn(null);
     when(handler.getForeverRequest(false, handler, "req-9")).thenReturn(null);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
     verify(requestQueuePort)
@@ -232,7 +230,7 @@ class ModifyPersistentRequestTest {
     ArgumentCaptor<ProtocolErrorMessage> errorCaptor =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler).send(errorCaptor.capture());
     verify(handler, never()).getForeverRequest(eq(true), eq(handler), eq("req-10"));

--- a/src/test/java/network/crypta/clients/fcp/NodeDataTest.java
+++ b/src/test/java/network/crypta/clients/fcp/NodeDataTest.java
@@ -1,13 +1,11 @@
 package network.crypta.clients.fcp;
 
 import java.util.Map;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,8 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class NodeDataTest {
-
-  @Mock private Node node;
 
   @Test
   void getFieldSet_whenSnapshotContainsNestedValues_rebuildsFieldSetRecursively() {
@@ -84,7 +80,7 @@ class NodeDataTest {
     NodeData nodeData = new NodeData(NodeReferenceSnapshot.empty(), identifier);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> nodeData.run(null, node));
+        assertThrows(MessageInvalidException.class, () -> nodeData.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(
@@ -98,7 +94,7 @@ class NodeDataTest {
     NodeData nodeData = new NodeData(NodeReferenceSnapshot.empty(), null);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> nodeData.run(null, node));
+        assertThrows(MessageInvalidException.class, () -> nodeData.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertNull(exception.ident);

--- a/src/test/java/network/crypta/clients/fcp/NodeHelloMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/NodeHelloMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
@@ -59,10 +58,7 @@ class NodeHelloMessageTest {
     MessageInvalidException exception =
         assertThrows(
             MessageInvalidException.class,
-            () ->
-                message.run(
-                    org.mockito.Mockito.mock(FCPConnectionHandler.class),
-                    org.mockito.Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+            () -> message.run(org.mockito.Mockito.mock(FCPConnectionHandler.class)));
 
     assertAll(
         () -> assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode),

--- a/src/test/java/network/crypta/clients/fcp/PeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PeerMessageTest.java
@@ -79,7 +79,7 @@ class PeerMessageTest {
     PeerMessage message = new PeerMessage(PeerSnapshot.empty(), null);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
     assertEquals("Peer goes from server to client not the other way around", thrown.getMessage());

--- a/src/test/java/network/crypta/clients/fcp/PeerNoteTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PeerNoteTest.java
@@ -62,7 +62,7 @@ class PeerNoteTest {
     PeerNote peerNote = new PeerNote(NODE_IDENTIFIER, NOTE_TEXT, PEER_NOTE_TYPE, IDENTIFIER);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> peerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> peerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
     assertEquals("PeerNote goes from server to client not the other way around", ex.getMessage());
@@ -76,7 +76,7 @@ class PeerNoteTest {
     PeerNote peerNote = new PeerNote(NODE_IDENTIFIER, NOTE_TEXT, PEER_NOTE_TYPE, null);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> peerNote.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> peerNote.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
     assertEquals("PeerNote goes from server to client not the other way around", ex.getMessage());

--- a/src/test/java/network/crypta/clients/fcp/PeerRemovedTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PeerRemovedTest.java
@@ -50,7 +50,7 @@ class PeerRemovedTest {
     PeerRemoved message = new PeerRemoved("identity-123", "node-abc", "request-42");
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/PersistentGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentGetTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,9 +25,6 @@ class PersistentGetTest {
   private static final String IDENTIFIER = "test-id";
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void constructor_whenUriIsNull_throwsNullPointerException(@TempDir Path tempDir) {
@@ -104,7 +100,7 @@ class PersistentGetTest {
     PersistentGet persistentGet = new PersistentGet(requestParams, descriptor);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> persistentGet.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> persistentGet.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(IDENTIFIER, exception.ident);

--- a/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
@@ -288,7 +288,7 @@ class PersistentPutDirTest {
     PersistentPutDir message = buildRunMessage(manifest);
 
     MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler));
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
     assertEquals("ident", ex.ident);
     assertTrue(ex.global);

--- a/src/test/java/network/crypta/clients/fcp/PersistentPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentPutTest.java
@@ -6,7 +6,6 @@ import network.crypta.client.InsertContext;
 import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
@@ -140,11 +139,7 @@ class PersistentPutTest {
 
     MessageInvalidException ex =
         assertThrows(
-            MessageInvalidException.class,
-            () ->
-                put.run(
-                    mock(FCPConnectionHandler.class),
-                    mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+            MessageInvalidException.class, () -> put.run(mock(FCPConnectionHandler.class)));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestModifiedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestModifiedMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,9 +20,6 @@ class PersistentRequestModifiedMessageTest {
   private static final String CLIENT_TOKEN = "token-abc";
 
   @Mock private FCPConnectionHandler connectionHandler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_withPriorityOnly_setsIdentifierGlobalAndPriority() {
@@ -80,7 +76,7 @@ class PersistentRequestModifiedMessageTest {
         new PersistentRequestModifiedMessage(IDENTIFIER, true, (short) 2);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(IDENTIFIER, exception.ident);

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestRemovedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestRemovedMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,9 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class PersistentRequestRemovedMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @ParameterizedTest
   @CsvSource({"req-123,true", "another-id,false"})
@@ -53,7 +49,7 @@ class PersistentRequestRemovedMessageTest {
         new PersistentRequestRemovedMessage(identifier, global);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/ProbeRefusedTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProbeRefusedTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,9 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ProbeRefusedTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void constructor_whenIdentifierProvided_expectIdentifierStored() {
@@ -49,7 +45,7 @@ class ProbeRefusedTest {
     ProbeRefused message = new ProbeRefused("req-789");
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
 import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Probe;
@@ -110,7 +111,7 @@ class ProbeRequestTest {
     when(node.network()).thenReturn(network);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> request.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> request.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
     assertEquals("probe-1", exception.ident);
@@ -126,14 +127,17 @@ class ProbeRequestTest {
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
+    NodeClientCore core = mock(NodeClientCore.class);
     when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.getNode()).thenReturn(node);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
     when(node.network()).thenReturn(network);
     ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
 
-    request.run(handler, node);
+    request.run(handler);
 
     verify(network)
         .startProbe(eq(Probe.MAX_HTL), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
@@ -148,14 +152,17 @@ class ProbeRequestTest {
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
+    NodeClientCore core = mock(NodeClientCore.class);
     when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.getNode()).thenReturn(node);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
     when(node.network()).thenReturn(network);
     ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
 
-    request.run(handler, node);
+    request.run(handler);
 
     verify(network)
         .startProbe(eq((byte) 12), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
@@ -367,7 +374,10 @@ class ProbeRequestTest {
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
+    NodeClientCore core = mock(NodeClientCore.class);
     when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.getNode()).thenReturn(node);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
@@ -381,7 +391,7 @@ class ProbeRequestTest {
         .when(network)
         .startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
 
-    request.run(handler, node);
+    request.run(handler);
 
     return listenerRef.get();
   }

--- a/src/test/java/network/crypta/clients/fcp/ProtocolErrorMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProtocolErrorMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,9 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ProtocolErrorMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenAllFieldsProvided_containsExpectedValues() {
@@ -72,7 +68,7 @@ class ProtocolErrorMessageTest {
   void run_whenInvoked_doesNotThrow() {
     ProtocolErrorMessage message = new ProtocolErrorMessage(1, false, null, null, false);
 
-    assertDoesNotThrow(() -> message.run(handler, node));
+    assertDoesNotThrow(() -> message.run(handler));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/PutFailedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PutFailedMessageTest.java
@@ -183,7 +183,7 @@ class PutFailedMessageTest {
     PutFailedMessage message = new PutFailedMessage(exception, "insert-4", true);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
     assertEquals("insert-4", thrown.ident);

--- a/src/test/java/network/crypta/clients/fcp/PutFetchableMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PutFetchableMessageTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +19,6 @@ class PutFetchableMessageTest {
   private static final String IDENTIFIER = "test-id";
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenUriProvided_expectIdentifierGlobalAndUriFields() {
@@ -61,7 +57,7 @@ class PutFetchableMessageTest {
 
     // Act
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     // Assert
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);

--- a/src/test/java/network/crypta/clients/fcp/PutSuccessfulMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PutSuccessfulMessageTest.java
@@ -48,7 +48,7 @@ class PutSuccessfulMessageTest {
     PutSuccessfulMessage message = new PutSuccessfulMessage("id-123", false, null, 0L, 0L);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/RemovePeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RemovePeerTest.java
@@ -75,7 +75,7 @@ class RemovePeerTest {
     RemovePeer removePeer = new RemovePeer(buildFieldSet("node-abc", "id-123"));
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> removePeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> removePeer.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
     assertEquals("RemovePeer requires full access", exception.getMessage());
@@ -92,7 +92,7 @@ class RemovePeerTest {
     RemovePeer removePeer = new RemovePeer(fieldSet);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> removePeer.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> removePeer.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
     assertEquals("Error: NodeIdentifier field missing", exception.getMessage());
@@ -110,7 +110,7 @@ class RemovePeerTest {
     when(peerPort.remove("node-missing")).thenThrow(new UnknownPeerException("node-missing"));
     RemovePeer removePeer = new RemovePeer(buildFieldSet("node-missing", "id-789"));
 
-    removePeer.run(handler, node);
+    removePeer.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
@@ -132,7 +132,7 @@ class RemovePeerTest {
         .thenReturn(new RemovedPeerSnapshot("identity-xyz", "node-123"));
     RemovePeer removePeer = new RemovePeer(buildFieldSet("node-123", "id-555"));
 
-    removePeer.run(handler, node);
+    removePeer.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());

--- a/src/test/java/network/crypta/clients/fcp/RemovePersistentRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RemovePersistentRequestTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
 import network.crypta.runtime.spi.RequestQueueTask;
@@ -34,7 +33,6 @@ class RemovePersistentRequestTest {
   private static final String IDENTIFIER = "req-id";
 
   @Mock private FCPConnectionHandler handler;
-  @Mock private Node node;
   @Mock private FCPServer server;
   @Mock private RuntimePorts runtimePorts;
   @Mock private RequestQueuePort requestQueuePort;
@@ -81,7 +79,7 @@ class RemovePersistentRequestTest {
     RemovePersistentRequest message = new RemovePersistentRequest(fs);
     when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(clientRequest);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler).removePersistentRebootRequest(false, IDENTIFIER);
     verify(handler, never()).removeRequestByIdentifier(any(), anyBoolean());
@@ -96,7 +94,7 @@ class RemovePersistentRequestTest {
     when(handler.removePersistentRebootRequest(false, IDENTIFIER)).thenReturn(null);
     when(handler.removeRequestByIdentifier(IDENTIFIER, true)).thenReturn(clientRequest);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler).removePersistentRebootRequest(false, IDENTIFIER);
     verify(handler).removeRequestByIdentifier(IDENTIFIER, true);
@@ -115,7 +113,7 @@ class RemovePersistentRequestTest {
     when(handler.removePersistentRebootRequest(true, IDENTIFIER)).thenReturn(null);
     when(handler.removePersistentForeverRequest(true, IDENTIFIER)).thenReturn(clientRequest);
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<RequestQueueTask> taskCaptor = ArgumentCaptor.forClass(RequestQueueTask.class);
     verify(requestQueuePort)
@@ -140,7 +138,7 @@ class RemovePersistentRequestTest {
         .when(requestQueuePort)
         .submitPersistentJob(any(), eq(RequestQueuePriority.HIGH));
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(messageCaptor.capture());

--- a/src/test/java/network/crypta/clients/fcp/SSKKeypairMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SSKKeypairMessageTest.java
@@ -70,7 +70,7 @@ class SSKKeypairMessageTest {
             new FreenetURI(INSERT_URI_STRING), new FreenetURI(REQUEST_URI_STRING), identifier);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/SendingToNetworkMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendingToNetworkMessageTest.java
@@ -49,7 +49,7 @@ class SendingToNetworkMessageTest {
   void run_whenInvoked_expectNoInteractions() {
     SendingToNetworkMessage message = new SendingToNetworkMessage("id", false);
 
-    assertDoesNotThrow(() -> message.run(handler, node));
+    assertDoesNotThrow(() -> message.run(handler));
 
     verifyNoInteractions(handler, node);
   }

--- a/src/test/java/network/crypta/clients/fcp/SentPeerMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SentPeerMessageTest.java
@@ -64,7 +64,7 @@ class SentPeerMessageTest {
 
     // Act
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     // Assert
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);

--- a/src/test/java/network/crypta/clients/fcp/ShutdownMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ShutdownMessageTest.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,8 @@ import static org.mockito.Mockito.when;
 class ShutdownMessageTest {
 
   @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
+  @Mock private NodeClientCore core;
 
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
@@ -51,7 +54,7 @@ class ShutdownMessageTest {
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, thrown.protocolCode);
     assertEquals("Shutdown requires full access", thrown.getMessage());
@@ -66,10 +69,13 @@ class ShutdownMessageTest {
       throws MessageInvalidException {
     ShutdownMessage message = new ShutdownMessage();
     when(handler.hasFullAccess()).thenReturn(true);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(core);
+    when(core.getNode()).thenReturn(node);
     ArgumentCaptor<ProtocolErrorMessage> sentMessage =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler).send(sentMessage.capture());
     verify(node).exit("Received FCP shutdown message");

--- a/src/test/java/network/crypta/clients/fcp/SimpleProgressMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SimpleProgressMessageTest.java
@@ -65,7 +65,7 @@ class SimpleProgressMessageTest {
     SimpleProgressMessage message = new SimpleProgressMessage(IDENTIFIER, true, event);
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(null, null));
+        assertThrows(MessageInvalidException.class, () -> message.run(null));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
     assertEquals(IDENTIFIER, thrown.ident);

--- a/src/test/java/network/crypta/clients/fcp/StartedCompressionMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/StartedCompressionMessageTest.java
@@ -57,7 +57,7 @@ class StartedCompressionMessageTest {
         new StartedCompressionMessage("identifier", true, COMPRESSOR_TYPE.LZMA);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.USKManager;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
@@ -37,12 +36,10 @@ class SubscribeUSKMessageTest {
       "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,"
           + "3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
   @Mock private NodeClientCore nodeClientCore;
   @Mock private USKManager uskManager;
   @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
   @Mock private PersistentRequestClient rebootClient;
   @Mock private RequestClient requestClient;
 
@@ -140,14 +137,12 @@ class SubscribeUSKMessageTest {
     wireHandlerForSuccessfulSubscribe();
     SubscribeUSKMessage message = new SubscribeUSKMessage(baseFields());
 
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    lenient().when(node.services()).thenReturn(services);
-    lenient().when(services.clientCore()).thenReturn(nodeClientCore);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(nodeClientCore);
     when(nodeClientCore.getUskManager()).thenReturn(uskManager);
     doNothing().when(uskManager).subscribe(any(), any(), anyBoolean(), anyBoolean(), any());
 
-    message.run(handler, node);
+    message.run(handler);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
@@ -158,17 +153,15 @@ class SubscribeUSKMessageTest {
 
   @Test
   void run_whenIdentifierCollides_sendsIdentifierCollisionMessage() throws Exception {
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    lenient().when(node.services()).thenReturn(services);
-    lenient().when(services.clientCore()).thenReturn(nodeClientCore);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(nodeClientCore);
     doThrow(new IdentifierCollisionException())
         .when(handler)
         .addUSKSubscription(any(), any(SubscribeUSK.class));
 
     SubscribeUSKMessage message = new SubscribeUSKMessage(baseFields());
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler).send(isA(IdentifierCollisionMessage.class));
     verify(handler, never()).send(isA(SubscribedUSKMessage.class));
@@ -184,10 +177,8 @@ class SubscribeUSKMessageTest {
   private void wireHandlerForSuccessfulSubscribe() throws IdentifierCollisionException {
     lenient().when(handler.getRebootClient()).thenReturn(rebootClient);
     lenient().when(rebootClient.lowLevelClient(false)).thenReturn(requestClient);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    lenient().when(node.services()).thenReturn(services);
-    lenient().when(services.clientCore()).thenReturn(nodeClientCore);
+    lenient().when(handler.getServer()).thenReturn(server);
+    lenient().when(server.getCore()).thenReturn(nodeClientCore);
     doNothing().when(handler).addUSKSubscription(any(), any(SubscribeUSK.class));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/SubscribedUSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribedUSKMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,9 +21,6 @@ class SubscribedUSKMessageTest {
       "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/";
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -53,7 +49,7 @@ class SubscribedUSKMessageTest {
     SubscribedUSKMessage message = new SubscribedUSKMessage(buildSubscribeUSKMessage("id", false));
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,9 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class SubscribedUSKRoundFinishedMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getName_whenCalled_returnsSubscribedUSKRoundFinished() {
@@ -54,6 +50,6 @@ class SubscribedUSKRoundFinishedMessageTest {
     SubscribedUSKRoundFinishedMessage message =
         new SubscribedUSKRoundFinishedMessage("irrelevant-id");
 
-    assertThrows(UnsupportedOperationException.class, () -> message.run(handler, node));
+    assertThrows(UnsupportedOperationException.class, () -> message.run(handler));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribedUSKSendingToNetworkMessageTest.java
@@ -69,6 +69,6 @@ class SubscribedUSKSendingToNetworkMessageTest {
     SubscribedUSKSendingToNetworkMessage message = new SubscribedUSKSendingToNetworkMessage("id");
 
     // Act & Assert
-    assertThrows(UnsupportedOperationException.class, () -> message.run(null, null));
+    assertThrows(UnsupportedOperationException.class, () -> message.run(null));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/SubscribedUSKUpdateTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribedUSKUpdateTest.java
@@ -6,7 +6,6 @@ import network.crypta.keys.Key;
 import network.crypta.keys.KeyBlock;
 import network.crypta.keys.NodeSSK;
 import network.crypta.keys.USK;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,11 +58,7 @@ class SubscribedUSKUpdateTest {
 
     MessageInvalidException exception =
         assertThrows(
-            MessageInvalidException.class,
-            () ->
-                update.run(
-                    mock(FCPConnectionHandler.class),
-                    mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS)));
+            MessageInvalidException.class, () -> update.run(mock(FCPConnectionHandler.class)));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(identifier, exception.ident);

--- a/src/test/java/network/crypta/clients/fcp/TestDdaCompleteMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/TestDdaCompleteMessageTest.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Random;
-import network.crypta.node.Node;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,9 +24,6 @@ class TestDdaCompleteMessageTest {
   @TempDir File tempDir;
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getName_whenInvoked_returnsConstantName() {
@@ -115,7 +111,7 @@ class TestDdaCompleteMessageTest {
     DdaCheckJob job = new DdaCheckJob(new Random(6L), tempDir, null, null);
     TestDdaCompleteMessage message = new TestDdaCompleteMessage(handler, job, job.readContent);
 
-    assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+    assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     verifyNoMoreInteractions(handler);
   }

--- a/src/test/java/network/crypta/clients/fcp/TestDdaReplyMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/TestDdaReplyMessageTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.io.File;
 import java.util.Random;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,9 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class TestDdaReplyMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void getFieldSet_whenReadAndWriteProvided_containsDirectoryReadWriteAndContent() {
@@ -86,7 +82,7 @@ class TestDdaReplyMessageTest {
     TestDdaReplyMessage message = new TestDdaReplyMessage(job);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(TestDdaReplyMessage.NAME, exception.ident);

--- a/src/test/java/network/crypta/clients/fcp/TestDdaResponseMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/TestDdaResponseMessageTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.io.File;
 import java.util.Random;
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,9 +23,6 @@ class TestDdaResponseMessageTest {
   private static final String DIRECTORY = "/tmp/dir";
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void constructor_whenDirectoryMissing_throwsMessageInvalidException() {
@@ -59,7 +55,7 @@ class TestDdaResponseMessageTest {
         .thenThrow(new IllegalArgumentException("unsupported directory"));
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
     assertEquals("unsupported directory", exception.getMessage());
@@ -73,7 +69,7 @@ class TestDdaResponseMessageTest {
     when(handler.popDDACheck(DIRECTORY)).thenReturn(null);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertTrue(exception.getMessage().contains(DIRECTORY));
@@ -88,7 +84,7 @@ class TestDdaResponseMessageTest {
     when(handler.popDDACheck(DIRECTORY)).thenReturn(job);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.MISSING_FIELD, exception.protocolCode);
     assertTrue(exception.getMessage().contains(TestDdaResponseMessage.READ_CONTENT));
@@ -104,7 +100,7 @@ class TestDdaResponseMessageTest {
     ArgumentCaptor<TestDdaCompleteMessage> captor =
         ArgumentCaptor.forClass(TestDdaCompleteMessage.class);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(handler, times(1)).popDDACheck(DIRECTORY);
     verify(handler).send(captor.capture());

--- a/src/test/java/network/crypta/clients/fcp/URIGeneratedMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/URIGeneratedMessageTest.java
@@ -70,7 +70,7 @@ class URIGeneratedMessageTest {
 
     // Act + Assert
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UnknownNodeIdentifierMessageTest.java
@@ -55,7 +55,7 @@ class UnknownNodeIdentifierMessageTest {
     UnknownNodeIdentifierMessage message = new UnknownNodeIdentifierMessage("node-id", "ident");
 
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, thrown.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/UnknownPeerNoteTypeMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UnknownPeerNoteTypeMessageTest.java
@@ -59,7 +59,7 @@ class UnknownPeerNoteTypeMessageTest {
     UnknownPeerNoteTypeMessage message = new UnknownPeerNoteTypeMessage(5, identifier);
 
     MessageInvalidException exception =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
 
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, exception.protocolCode);
     assertEquals(

--- a/src/test/java/network/crypta/clients/fcp/UnsubscribeUSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/UnsubscribeUSKMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,9 +17,6 @@ import static org.mockito.Mockito.verify;
 class UnsubscribeUSKMessageTest {
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
 
   @Test
   void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
@@ -67,7 +63,7 @@ class UnsubscribeUSKMessageTest {
     UnsubscribeUSKMessage message = new UnsubscribeUSKMessage(fieldSet);
 
     // Act
-    message.run(handler, node);
+    message.run(handler);
 
     // Assert
     verify(handler).unsubscribeUSK("abc");
@@ -86,7 +82,7 @@ class UnsubscribeUSKMessageTest {
 
     // Act & Assert
     MessageInvalidException thrown =
-        assertThrows(MessageInvalidException.class, () -> message.run(handler, node));
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
     assertEquals(failure, thrown);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/WatchFeedsMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/WatchFeedsMessageTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.SimpleFieldSet;
@@ -20,12 +19,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class WatchFeedsMessageTest {
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
   @Mock private NodeClientCore clientCore;
   @Mock private UserAlertManager alertManager;
   @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
 
   @Test
   void constructor_whenEnabledMissing_defaultsToTrue() {
@@ -62,13 +59,11 @@ class WatchFeedsMessageTest {
     fs.put("Enabled", true);
     WatchFeedsMessage message = new WatchFeedsMessage(fs);
 
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(clientCore);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(clientCore);
     when(clientCore.getAlerts()).thenReturn(alertManager);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(alertManager).watch(handler);
     verify(alertManager, never()).unwatch(handler);
@@ -80,13 +75,11 @@ class WatchFeedsMessageTest {
     fs.put("Enabled", false);
     WatchFeedsMessage message = new WatchFeedsMessage(fs);
 
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(clientCore);
+    when(handler.getServer()).thenReturn(server);
+    when(server.getCore()).thenReturn(clientCore);
     when(clientCore.getAlerts()).thenReturn(alertManager);
 
-    message.run(handler, node);
+    message.run(handler);
 
     verify(alertManager).unwatch(handler);
     verify(alertManager, never()).watch(handler);

--- a/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
+++ b/src/test/java/network/crypta/clients/fcp/WatchGlobalTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +23,6 @@ class WatchGlobalTest {
   @Mock private FCPConnectionHandler handler;
   @Mock private PersistentRequestClient rebootClient;
   @Mock private PersistentRequestClient foreverClient;
-  @Mock private Node node;
   @Mock private FCPServer handlerFcpServer;
 
   @Test
@@ -79,7 +77,7 @@ class WatchGlobalTest {
 
     WatchGlobal watchGlobal = new WatchGlobal(fieldSet(true, 3));
 
-    watchGlobal.run(handler, node);
+    watchGlobal.run(handler);
 
     ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(messageCaptor.capture());
@@ -102,7 +100,7 @@ class WatchGlobalTest {
 
     WatchGlobal watchGlobal = new WatchGlobal(fieldSet(false, 9));
 
-    watchGlobal.run(handler, node);
+    watchGlobal.run(handler);
 
     verify(rebootClient).setWatchGlobal(false, 9, handlerFcpServer);
     verify(handler, never()).send(any(FCPMessage.class));
@@ -118,7 +116,7 @@ class WatchGlobalTest {
 
     WatchGlobal watchGlobal = new WatchGlobal(fieldSet(false, 7));
 
-    watchGlobal.run(handler, node);
+    watchGlobal.run(handler);
 
     verify(rebootClient).setWatchGlobal(false, 7, handlerFcpServer);
     verify(foreverClient).setWatchGlobal(false, 7, handlerFcpServer);

--- a/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
@@ -483,11 +483,7 @@ class NodeClientPersistenceTest {
           .when(
               () ->
                   FCPServer.maybeCreate(
-                      eq(node),
-                      eq(core),
-                      eq(runtimePorts),
-                      eq(config),
-                      any(PersistentRequestRoot.class)))
+                      eq(core), eq(runtimePorts), eq(config), any(PersistentRequestRoot.class)))
           .thenReturn(expected);
 
       FCPServer result = persistence.createFcpServer(node, core, runtimePorts);
@@ -497,11 +493,7 @@ class NodeClientPersistenceTest {
       fcpServerMock.verify(
           () ->
               FCPServer.maybeCreate(
-                  eq(node),
-                  eq(core),
-                  eq(runtimePorts),
-                  eq(config),
-                  any(PersistentRequestRoot.class)));
+                  eq(core), eq(runtimePorts), eq(config), any(PersistentRequestRoot.class)));
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the explicit `Node` parameter from `FCPMessage.run(...)` and update FCP message implementations and wrappers to execute from `FCPConnectionHandler` alone
- reroute the remaining node-dependent paths through existing handler/server/core accessors instead of storing `Node` on `FCPServer`
- update FCP wiring and unit tests to match the new execution signature without changing behavior

## How to test
- `./gradlew spotlessApply`
- `./gradlew compileJava compileTestJava`