### PR TITLE
refactor(runtime): Move connectivity page onto runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityGapSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityGapSnapshot.java
@@ -1,0 +1,19 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached snapshot of one recorded connectivity gap.
+ *
+ * <p>A connectivity gap represents a span with no matching traffic for one tracker entry, followed
+ * by the packet that ended that quiet period. The connectivity page uses these values only in
+ * advanced mode, where operators compare recent packet history for peers and IP addresses without
+ * touching daemon-side tracker objects directly.
+ *
+ * <p>This record is immutable and uses epoch-based millisecond values, so callers can format times
+ * or compute relative durations in their own layer.
+ *
+ * @param gapLengthMillis duration, in milliseconds, between the derived interval start and the
+ *     packet that ended the gap
+ * @param receivedPacketAtMillis absolute wall-clock time, in milliseconds since the epoch, when the
+ *     packet ending the gap was received
+ */
+public record ConnectivityGapSnapshot(long gapLengthMillis, long receivedPacketAtMillis) {}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityListenerPortSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityListenerPortSnapshot.java
@@ -1,0 +1,19 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached snapshot of one listener port configuration used by the connectivity page.
+ *
+ * <p>The connectivity view shows several listener families, such as FProxy, FCP, and the TMCI
+ * console. This record carries only the small amount of state needed to render those rows: whether
+ * the listener is enabled and which port number the daemon currently advertises for it. The SPI
+ * keeps the payload deliberately narrow, so HTTP code does not depend on daemon configuration
+ * objects.
+ *
+ * <p>Instances are immutable and can be reused freely within a single page render or test fixture.
+ *
+ * @param enabled whether the listener is currently enabled and expected to accept inbound
+ *     connections
+ * @param port configured listener port when enabled, or an implementation-defined placeholder when
+ *     the listener is disabled
+ */
+public record ConnectivityListenerPortSnapshot(boolean enabled, int port) {}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityNoticeSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityNoticeSnapshot.java
@@ -1,0 +1,36 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Detached snapshot of the current connection-type notice shown on the connectivity page.
+ *
+ * <p>The legacy connectivity page can surface more than a plain string. Depending on the detected
+ * NAT or UDP state, the page may need to preserve the full alert infobox, including severity
+ * styling, operator guidance links, and dismiss controls. This record therefore carries both a
+ * localized plain-text representation and an optional pre-rendered HTML fragment that keeps the old
+ * behavior when the HTTP layer is no longer coupled to daemon alert classes.
+ *
+ * <p>The rendered fragment may be blank when the adapter cannot produce alert HTML. Callers should
+ * then fall back to the plain title and body fields.
+ *
+ * @param title localized notice title suitable for fallback rendering or tests
+ * @param text localized plain-text notice body suitable for fallback rendering or tests
+ * @param renderedAlertHtml rendered alert HTML preserving the legacy infobox, help link, and
+ *     dismiss UI, or an empty string when plain-text fallback should be used
+ */
+public record ConnectivityNoticeSnapshot(String title, String text, String renderedAlertHtml) {
+  /**
+   * Creates an immutable notice snapshot.
+   *
+   * <p>All components are required. Callers that do not have rendered alert markup available should
+   * pass an empty string rather than {@code null}.
+   *
+   * @throws NullPointerException if any component is {@code null}
+   */
+  public ConnectivityNoticeSnapshot {
+    Objects.requireNonNull(title, "title");
+    Objects.requireNonNull(text, "text");
+    Objects.requireNonNull(renderedAlertHtml, "renderedAlertHtml");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityPort.java
@@ -1,0 +1,28 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Exposes the narrow connectivity-read capabilities needed by the HTTP admin page.
+ *
+ * <p>This port is intentionally scoped to the connectivity toadlet and nothing more. It returns a
+ * detached snapshot containing listener-port configuration, UDP socket summary status, the current
+ * connection-type notice when active, and optional advanced per-peer or per-IP tracker details. The
+ * contract keeps daemon internals such as {@code Node}, {@code AddressTracker}, UDP socket
+ * handlers, and alert-framework classes on the daemon side of the boundary.
+ *
+ * <p>Implementations should remain read-only. Callers are expected to request one snapshot per HTTP
+ * response and render from that immutable view instead of reaching back into live daemon objects.
+ */
+public interface ConnectivityPort {
+  /**
+   * Returns a point-in-time snapshot of the node's connectivity state.
+   *
+   * <p>The {@code includeAdvancedDetails} flag preserves the current cost boundary used by the HTTP
+   * page: callers that only need the summary view can skip the tracker-table export, while callers
+   * in advanced mode can request the additional per-peer and per-IP rows.
+   *
+   * @param includeAdvancedDetails whether advanced tracker-table details should be included in the
+   *     returned snapshot
+   * @return detached connectivity snapshot describing the current runtime state at call time
+   */
+  ConnectivitySnapshot snapshot(boolean includeAdvancedDetails);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityPortForwardStatus.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityPortForwardStatus.java
@@ -1,0 +1,29 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached connectivity-status states for the connectivity admin page.
+ *
+ * <p>These values mirror the legacy address-tracker status states closely enough that the
+ * connectivity page can keep its existing localization keys and presentation logic. The enum lives
+ * in {@code runtime-spi} so HTTP code can describe UDP reachability without depending on daemon
+ * tracker classes or their serialization details.
+ *
+ * <p>The ordering is not significant. Callers should treat the values as named states rather than
+ * as an ordered severity scale.
+ */
+public enum ConnectivityPortForwardStatus {
+  /** Confirms that inbound UDP reachability is blocked by network address translation. */
+  DEFINITELY_NATED,
+
+  /** Suggests that the node is likely behind NAT, but the tracker does not have final evidence. */
+  MAYBE_NATED,
+
+  /** Indicates that the tracker has not observed enough data to classify the connection yet. */
+  DONT_KNOW,
+
+  /** Suggests that inbound UDP reachability may work, but the conclusion is not final. */
+  MAYBE_PORT_FORWARDED,
+
+  /** Confirms that the node appears reachable from the wider network on this socket. */
+  DEFINITELY_PORT_FORWARDED
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivitySnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivitySnapshot.java
@@ -1,0 +1,52 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detached snapshot of the data needed to render the connectivity admin page.
+ *
+ * <p>This record is the main payload returned by {@link ConnectivityPort}. It combines the small
+ * set of listener-port details shown near the top of the page with per-socket UDP reachability
+ * information and, when available, the current connection-type notice. Advanced tracker-table
+ * details are nested under each socket snapshot, so the caller can request summary-only or
+ * full-detail views without changing the overall shape of the response.
+ *
+ * <p>The record is immutable. Collection components are defensively copied, so callers can keep the
+ * snapshot for the lifetime of a request without worrying about concurrent daemon mutations.
+ *
+ * @param darknetFnpPort configured darknet FNP port exposed by the node
+ * @param opennetFnpPort configured opennet FNP port, or a non-positive value when opennet is
+ *     disabled
+ * @param fproxyListener detached snapshot of the current FProxy listener configuration
+ * @param fcpListener detached snapshot of the current FCP listener configuration
+ * @param consoleListener detached snapshot of the current TMCI listener configuration
+ * @param connectionTypeNotice optional detached connection-type notice, or {@code null} when no
+ *     notice is active
+ * @param sockets detached UDP socket snapshots in encounter order for page rendering
+ */
+public record ConnectivitySnapshot(
+    int darknetFnpPort,
+    int opennetFnpPort,
+    ConnectivityListenerPortSnapshot fproxyListener,
+    ConnectivityListenerPortSnapshot fcpListener,
+    ConnectivityListenerPortSnapshot consoleListener,
+    ConnectivityNoticeSnapshot connectionTypeNotice,
+    List<ConnectivitySocketSnapshot> sockets) {
+  /**
+   * Creates an immutable connectivity snapshot.
+   *
+   * <p>The constructor copies the socket list defensively. The optional connection-type notice may
+   * be absent, but every other component must be present.
+   *
+   * @throws NullPointerException if any required component except {@code connectionTypeNotice} is
+   *     {@code null}
+   */
+  public ConnectivitySnapshot {
+    Objects.requireNonNull(fproxyListener, "fproxyListener");
+    Objects.requireNonNull(fcpListener, "fcpListener");
+    Objects.requireNonNull(consoleListener, "consoleListener");
+    Objects.requireNonNull(sockets, "sockets");
+    sockets = List.copyOf(sockets);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivitySocketSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivitySocketSnapshot.java
@@ -1,0 +1,48 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detached snapshot of one UDP socket handler's connectivity status.
+ *
+ * <p>Each UDP socket displayed by the connectivity page gets one of these records. The snapshot
+ * contains the localized title used by the page, the current port-forwarding classification, and
+ * optional advanced tracker-table rows for peer and IP history. The advanced data is intentionally
+ * nested here, so callers can skip expensive tracker export work when rendering the summary view.
+ *
+ * <p>The record is immutable and copies its collections defensively, which makes it safe to pass
+ * between adapter, UI, and test layers without retaining the live tracker state.
+ *
+ * @param title human-readable handler title shown on the connectivity page
+ * @param portForwardStatus detached connectivity status for this handler
+ * @param longestSendReceiveGapMillis longest observed send-to-receive gap in milliseconds, or
+ *     {@code -1} when the advanced tracker export was not requested
+ * @param peerEntries detached per-peer tracker rows in display order; empty when advanced details
+ *     were omitted
+ * @param ipEntries detached per-IP tracker rows in display order; empty when advanced details were
+ *     omitted
+ */
+public record ConnectivitySocketSnapshot(
+    String title,
+    ConnectivityPortForwardStatus portForwardStatus,
+    long longestSendReceiveGapMillis,
+    List<ConnectivityTrafficEntrySnapshot> peerEntries,
+    List<ConnectivityTrafficEntrySnapshot> ipEntries) {
+  /**
+   * Creates an immutable socket snapshot.
+   *
+   * <p>The constructor copies both tracker-entry lists defensively, so the snapshot remains stable
+   * for the lifetime of an HTTP response.
+   *
+   * @throws NullPointerException if any required component is {@code null}
+   */
+  public ConnectivitySocketSnapshot {
+    Objects.requireNonNull(title, "title");
+    Objects.requireNonNull(portForwardStatus, "portForwardStatus");
+    Objects.requireNonNull(peerEntries, "peerEntries");
+    Objects.requireNonNull(ipEntries, "ipEntries");
+    peerEntries = List.copyOf(peerEntries);
+    ipEntries = List.copyOf(ipEntries);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityTrafficEntrySnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityTrafficEntrySnapshot.java
@@ -1,0 +1,51 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detached snapshot of one advanced connectivity tracker table row.
+ *
+ * <p>This record models a single peer or IP row in the advanced connectivity tables. It includes
+ * the rendered address label, basic send and receive counters, a coarse initiator classification,
+ * and lead-time values that describe when traffic first appeared after the node startup. Recent gap
+ * history is exported separately, so the HTTP layer can render the existing table layout without
+ * holding references to daemon tracker items.
+ *
+ * <p>All timing values use milliseconds. Negative lead times indicate that the relevant event has
+ * not been observed for this row.
+ *
+ * @param address rendered peer or IP address label exactly as the page should display it
+ * @param packetsSent total packets sent to this address since the tracker started collecting data
+ * @param packetsReceived total packets received from this address since the tracker started
+ *     collecting data
+ * @param initiator whether traffic appears locally initiated, remotely initiated, or unanswered
+ * @param firstSendLeadTimeMillis delay in milliseconds from startup to the first sent packet, or
+ *     {@code -1} if none has been observed
+ * @param firstReceiveLeadTimeMillis delay in milliseconds from startup to the first received
+ *     packet, or {@code -1} if none has been observed
+ * @param gaps detached recent gap history in newest-first order
+ */
+public record ConnectivityTrafficEntrySnapshot(
+    String address,
+    long packetsSent,
+    long packetsReceived,
+    ConnectivityTrafficInitiator initiator,
+    long firstSendLeadTimeMillis,
+    long firstReceiveLeadTimeMillis,
+    List<ConnectivityGapSnapshot> gaps) {
+  /**
+   * Creates an immutable tracker-row snapshot.
+   *
+   * <p>The constructor copies the gap list defensively so later tracker updates do not affect an
+   * already-created snapshot.
+   *
+   * @throws NullPointerException if any required component is {@code null}
+   */
+  public ConnectivityTrafficEntrySnapshot {
+    Objects.requireNonNull(address, "address");
+    Objects.requireNonNull(initiator, "initiator");
+    Objects.requireNonNull(gaps, "gaps");
+    gaps = List.copyOf(gaps);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityTrafficInitiator.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectivityTrafficInitiator.java
@@ -1,0 +1,20 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached initiator states for advanced connectivity tracker rows.
+ *
+ * <p>The connectivity page presents a coarse answer to a simple operator question: did the node
+ * appear to send first, receive first, or never get a reply at all for a tracked address. This enum
+ * carries that answer without exposing the daemon's tracker item implementation details to the HTTP
+ * layer.
+ */
+public enum ConnectivityTrafficInitiator {
+  /** The node has sent traffic, but no reply has been recorded for this tracker row. */
+  NO_REPLY,
+
+  /** The first observed traffic for this row originated from the local node. */
+  LOCAL,
+
+  /** The first observed traffic for this row originated from the remote side. */
+  REMOTE
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -19,6 +19,7 @@ package network.crypta.runtime.spi;
  * @see TransferAccessPort
  * @see LifecyclePort
  * @see ConfigPort
+ * @see ConnectivityPort
  * @see NodeInfoPort
  * @see PeerPort
  * @see RequestQueuePort
@@ -81,6 +82,19 @@ public interface RuntimePorts {
    * @return configuration runtime port for export, update, and persistence operations
    */
   ConfigPort config();
+
+  /**
+   * Returns the connectivity capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port lets higher layers request one detached snapshot containing the current listener
+   * port configuration, UDP socket status summary, optional connection-type notice, and, when
+   * requested, advanced tracker tables. It intentionally exposes only JDK-only DTOs, so callers can
+   * render the connectivity page without depending on daemon-only trackers, socket handlers, or
+   * alert classes.
+   *
+   * @return connectivity runtime port for read-only connectivity snapshots
+   */
+  ConnectivityPort connectivity();
 
   /**
    * Returns the persistent-request queue-control capability exposed to infrastructure code.

--- a/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
@@ -280,8 +280,10 @@ public class ConnectivityToadlet extends Toadlet {
     row.addChild("td", initiatorLabel(entry.initiator(), noreply, local, remote));
     row.addChild("td", TimeUtil.formatTime(entry.firstSendLeadTimeMillis()));
     row.addChild("td", TimeUtil.formatTime(entry.firstReceiveLeadTimeMillis()));
-    for (ConnectivityGapSnapshot gap : entry.gaps()) {
-      row.addChild("td", gapLabel(gap, now));
+    List<ConnectivityGapSnapshot> gaps = entry.gaps();
+    for (int i = 0; i < GAP_COLUMNS; i++) {
+      String gap = i < gaps.size() ? gapLabel(gaps.get(i), now) : "";
+      row.addChild("td", gap);
     }
   }
 

--- a/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
@@ -2,59 +2,40 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.io.AddressTracker;
-import network.crypta.io.AddressTrackerItem.Gap;
-import network.crypta.io.AddressTrackerItem;
-import network.crypta.io.InetAddressAddressTrackerItem;
-import network.crypta.io.PeerAddressTrackerItem;
-import network.crypta.io.comm.UdpSocketHandler;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.FSParseException;
-import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConnectivityGapSnapshot;
+import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
+import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.ConnectivityPortForwardStatus;
+import network.crypta.runtime.spi.ConnectivitySnapshot;
+import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficInitiator;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.TimeUtil;
 import network.crypta.support.api.HTTPRequest;
 
 /**
- * Toadlet that renders a human-readable dashboard about the node's current network connectivity. It
- * surfaces live data gathered by {@link AddressTracker} instances backing each UDP socket handler
- * and formats it into tables and infoboxes that are consumable through the web console.
+ * Toadlet that renders a human-readable dashboard about the node's current network connectivity.
  *
  * <p>The page is intended for operators who want to verify whether ports are reachable, how far
- * packets are travelling before receiving replies, and whether the node is exchanging traffic with
- * darknet peers or opennet introductions. The handler uses the {@link PageMaker} to assemble
- * localized sections covering port configuration, connectivity summaries, and per-peer or per-IP
- * traffic histories. When advanced mode is enabled it expands the page with gap timing breakdowns
- * and initiator information so administrators can diagnose asymmetric paths or stalled peers.
- *
- * <p>Instances are lightweight and stateless beyond a reference to the {@link Node}; they query the
- * node each time a request is processed, ensuring the view reflects the most recent tracker
- * readings. All rendering occurs on the request thread; no mutable state is shared across requests,
- * making the class thread-safe as long as the injected {@code Node} and client remain thread-safe.
- * Typical usage registers the toadlet on the web interface under {@link #CONNECTIVITY_PATH} so that
- * authenticated users can inspect connectivity without restarting the node.
- *
- * <ul>
- *   <li>Shows port enablement and configured bindings for HTTP, FCP, and console interfaces.
- *   <li>Displays port-forwarding status for each UDP socket handler with localized summaries.
- *   <li>Provides advanced per-peer and per-address gap timelines when advanced mode is requested.
- * </ul>
- *
- * @author toad
- * @see AddressTracker
- * @see network.crypta.clients.http.DarknetConnectionsToadlet
+ * packets are traveling before receiving replies, and whether the node is exchanging traffic with
+ * darknet peers or opennet introductions. The handler renders detached snapshots from {@link
+ * ConnectivityPort}, keeping daemon-only connectivity trackers and alert implementations out of the
+ * HTTP layer while preserving the current route and page structure.
  */
 public class ConnectivityToadlet extends Toadlet {
 
   private static final String HTML_CLASS_ATTR = "class";
-  private static final String ENABLED_KEY = "enabled";
   private static final String TABLE_TAG = "table";
   private static final String EMPTY_HEADER_LABEL = " ";
   private static final String CONNECTIVITY_PORT_CLASS = "connectivity-port";
   private static final String CONNECTIVITY_IP_CLASS = "connectivity-ip";
   private static final String PATH_DELIMITER = "/";
+  private static final int GAP_COLUMNS = 5;
 
   /**
    * Publicly visible path segment for registering the connectivity dashboard endpoint, including
@@ -65,64 +46,37 @@ public class ConnectivityToadlet extends Toadlet {
 
   private record TrafficContext(String noreply, String local, String remote, long now) {}
 
-  private final Node node;
+  private final ConnectivityPort connectivity;
 
   /**
-   * Creates a new connectivity toadlet bound to the given client and node.
+   * Creates a new connectivity toadlet bound to the given client and connectivity port.
    *
-   * <p>The constructor keeps only lightweight references; all connectivity data is fetched lazily
-   * during each request. Callers are expected to register the instance with the hosting web
-   * interface under {@link #CONNECTIVITY_PATH} so authenticated visitors can access the dashboard.
-   *
-   * @param client high-level HTTP client used by the superclass for rendering utilities; must not
-   *     be {@code null}.
-   * @param node node whose address trackers and configuration are rendered on incoming requests; it
-   *     should remain alive for the lifetime of this toadlet.
+   * @param client high-level HTTP client used by the superclass for rendering utilities
+   * @param connectivity read-only runtime connectivity port backing this page
    */
-  protected ConnectivityToadlet(HighLevelSimpleClient client, Node node) {
+  protected ConnectivityToadlet(HighLevelSimpleClient client, ConnectivityPort connectivity) {
     super(client);
-    this.node = node;
+    this.connectivity = connectivity;
   }
 
-  /**
-   * Handles HTTP GET requests by rendering the connectivity dashboard for the current node state.
-   *
-   * <p>The method constructs infobox sections describing port configuration, port-forwarding
-   * summaries for each UDP socket handler, and optionally advanced per-peer and per-address tables
-   * when advanced mode is enabled in the {@link ToadletContext}. All content is localized through
-   * {@link NodeL10n} and written as an HTML response without mutating node state. The call is
-   * idempotent and safe to repeat for periodic status polling.
-   *
-   * @param uri request URI; only the path is used for rendering context and localization.
-   * @param request parsed HTTP request containing parameters and authentication context; never
-   *     modified by this method.
-   * @param ctx toadlet execution context providing page builders and permission checks; must be
-   *     open and authorized for the caller.
-   * @throws ToadletContextClosedException if the client disconnects before the response is fully
-   *     written or the context is otherwise closed mid-render.
-   * @throws IOException if HTML generation or writing to the response stream fails for transport
-   *     reasons such as socket errors.
-   */
   @Override
   public void handleMethodGET(URI uri, final HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     PageMaker pageMaker = ctx.getPageMaker();
+    boolean includeAdvancedDetails = ctx.isAdvancedModeEnabled();
+    ConnectivitySnapshot snapshot = connectivity.snapshot(includeAdvancedDetails);
 
     PageNode page =
         pageMaker.getPageNode(NodeL10n.getBase().getString("ConnectivityToadlet.title"), ctx);
     HTMLNode contentNode = page.getContentNode();
 
     addAlerts(ctx, contentNode);
-    addPortInfobox(contentNode);
+    addPortInfobox(contentNode, snapshot);
+    addConnectionTypeNotice(contentNode, pageMaker, snapshot.connectionTypeNotice());
+    addSummary(contentNode, pageMaker, snapshot.sockets());
 
-    node.network().ipDetector().addConnectionTypeBox(contentNode);
-
-    UdpSocketHandler[] handlers = node.network().packetSocketHandlers();
-
-    addSummary(contentNode, pageMaker, handlers);
-
-    if (ctx.isAdvancedModeEnabled()) {
-      addAdvancedDetails(contentNode, pageMaker, handlers);
+    if (includeAdvancedDetails) {
+      addAdvancedDetails(contentNode, pageMaker, snapshot.sockets());
     }
 
     writeHTMLReply(ctx, 200, "OK", page.generate());
@@ -134,67 +88,78 @@ public class ConnectivityToadlet extends Toadlet {
     }
   }
 
-  private void addPortInfobox(HTMLNode contentNode) {
+  private void addPortInfobox(HTMLNode contentNode, ConnectivitySnapshot snapshot) {
     HTMLNode portInfobox = contentNode.addChild("div", HTML_CLASS_ATTR, "infobox infobox-normal");
     portInfobox.addChild("div", HTML_CLASS_ATTR, "infobox-header", l10nConn("nodePortsTitle"));
     HTMLNode portInfoboxContent = portInfobox.addChild("div", HTML_CLASS_ATTR, "infobox-content");
     HTMLNode portInfoList = portInfoboxContent.addChild("ul");
-    SimpleFieldSet fproxyConfig = exportConfigSubset("fproxy");
-    SimpleFieldSet fcpConfig = exportConfigSubset("fcp");
-    SimpleFieldSet tmciConfig = exportConfigSubset("console");
     portInfoList.addChild(
         "li",
         NodeL10n.getBase()
             .getString(
                 "DarknetConnectionsToadlet.darknetFnpPort",
                 new String[] {"port"},
-                new String[] {Integer.toString(node.network().fnpPort())}));
-    int opennetPort = node.network().opennetFnpPort();
-    if (opennetPort > 0) {
+                new String[] {Integer.toString(snapshot.darknetFnpPort())}));
+    if (snapshot.opennetFnpPort() > 0) {
       portInfoList.addChild(
           "li",
           NodeL10n.getBase()
               .getString(
                   "DarknetConnectionsToadlet.opennetFnpPort",
                   new String[] {"port"},
-                  new String[] {Integer.toString(opennetPort)}));
+                  new String[] {Integer.toString(snapshot.opennetFnpPort())}));
     }
-    try {
-      addPortConfigLine(
-          portInfoList,
-          fproxyConfig,
-          "DarknetConnectionsToadlet.fproxyPort",
-          l10nConn("fproxyDisabled"));
-      addPortConfigLine(
-          portInfoList, fcpConfig, "DarknetConnectionsToadlet.fcpPort", l10nConn("fcpDisabled"));
-      addPortConfigLine(
-          portInfoList, tmciConfig, "DarknetConnectionsToadlet.tmciPort", l10nConn("tmciDisabled"));
-    } catch (FSParseException _) {
-      // Ignore malformed config so the page still renders.
-    }
+    addListenerPort(
+        portInfoList,
+        snapshot.fproxyListener(),
+        "DarknetConnectionsToadlet.fproxyPort",
+        l10nConn("fproxyDisabled"));
+    addListenerPort(
+        portInfoList,
+        snapshot.fcpListener(),
+        "DarknetConnectionsToadlet.fcpPort",
+        l10nConn("fcpDisabled"));
+    addListenerPort(
+        portInfoList,
+        snapshot.consoleListener(),
+        "DarknetConnectionsToadlet.tmciPort",
+        l10nConn("tmciDisabled"));
   }
 
-  private SimpleFieldSet exportConfigSubset(String subsetName) {
-    return node.getConfig().get(subsetName).exportFieldSet(true);
-  }
-
-  private void addPortConfigLine(
-      HTMLNode portInfoList, SimpleFieldSet config, String l10nKey, String disabledLabel)
-      throws FSParseException {
-    if (config.getBoolean(ENABLED_KEY, false)) {
+  private void addListenerPort(
+      HTMLNode portInfoList,
+      ConnectivityListenerPortSnapshot listener,
+      String l10nKey,
+      String disabledLabel) {
+    if (listener.enabled()) {
       portInfoList.addChild(
           "li",
           NodeL10n.getBase()
               .getString(
                   l10nKey,
                   new String[] {"port"},
-                  new String[] {Integer.toString(config.getInt("port"))}));
+                  new String[] {Integer.toString(listener.port())}));
       return;
     }
     portInfoList.addChild("li", disabledLabel);
   }
 
-  private void addSummary(HTMLNode contentNode, PageMaker pageMaker, UdpSocketHandler[] handlers) {
+  private void addConnectionTypeNotice(
+      HTMLNode contentNode, PageMaker pageMaker, ConnectivityNoticeSnapshot notice) {
+    if (notice == null) {
+      return;
+    }
+    if (!notice.renderedAlertHtml().isBlank()) {
+      contentNode.addChild(new HTMLNode("%", notice.renderedAlertHtml()));
+      return;
+    }
+    HTMLNode noticeContent =
+        pageMaker.getInfobox("#", notice.title(), contentNode, "connectivity-notice", false);
+    noticeContent.addChild("div", notice.text());
+  }
+
+  private void addSummary(
+      HTMLNode contentNode, PageMaker pageMaker, List<ConnectivitySocketSnapshot> sockets) {
     HTMLNode summaryContent =
         pageMaker.getInfobox(
             "#",
@@ -205,32 +170,29 @@ public class ConnectivityToadlet extends Toadlet {
 
     HTMLNode table = summaryContent.addChild(TABLE_TAG, "border", "0");
 
-    for (UdpSocketHandler handler : handlers) {
-      AddressTracker tracker = handler.getAddressTracker();
+    for (ConnectivitySocketSnapshot socket : sockets) {
       HTMLNode row = table.addChild("tr");
-      row.addChild("td", handler.getTitle());
-      row.addChild("td", AddressTracker.statusString(tracker.getPortForwardStatus()));
+      row.addChild("td", socket.title());
+      row.addChild("td", statusString(socket.portForwardStatus()));
     }
   }
 
   private void addAdvancedDetails(
-      HTMLNode contentNode, PageMaker pageMaker, UdpSocketHandler[] handlers) {
+      HTMLNode contentNode, PageMaker pageMaker, List<ConnectivitySocketSnapshot> sockets) {
     TrafficContext trafficContext =
         new TrafficContext(
             localize("noreply"), localize("local"), localize("remote"), System.currentTimeMillis());
 
-    for (UdpSocketHandler handler : handlers) {
-      AddressTracker tracker = handler.getAddressTracker();
-      addPeerSection(contentNode, pageMaker, handler, tracker, trafficContext);
-      addIpSection(contentNode, pageMaker, handler, tracker, trafficContext);
+    for (ConnectivitySocketSnapshot socket : sockets) {
+      addPeerSection(contentNode, pageMaker, socket, trafficContext);
+      addIpSection(contentNode, pageMaker, socket, trafficContext);
     }
   }
 
   private void addPeerSection(
       HTMLNode contentNode,
       PageMaker pageMaker,
-      UdpSocketHandler handler,
-      AddressTracker tracker,
+      ConnectivitySocketSnapshot socket,
       TrafficContext trafficContext) {
     HTMLNode portsContent =
         pageMaker.getInfobox(
@@ -240,21 +202,19 @@ public class ConnectivityToadlet extends Toadlet {
                     "ConnectivityToadlet.byPortTitle",
                     new String[] {"port", "status", "tunnelLength"},
                     new String[] {
-                      handler.getTitle(),
-                      AddressTracker.statusString(tracker.getPortForwardStatus()),
-                      TimeUtil.formatTime(tracker.getLongestSendReceiveGap())
+                      socket.title(),
+                      statusString(socket.portForwardStatus()),
+                      TimeUtil.formatTime(socket.longestSendReceiveGapMillis())
                     }),
             contentNode,
             CONNECTIVITY_PORT_CLASS,
             false);
-    PeerAddressTrackerItem[] items = tracker.getPeerAddressTrackerItems();
     HTMLNode table = portsContent.addChild(TABLE_TAG);
     addHeaderRow(table);
-    for (PeerAddressTrackerItem item : items) {
+    for (ConnectivityTrafficEntrySnapshot entry : socket.peerEntries()) {
       addTrackerRow(
           table,
-          item,
-          item.peer.toString(),
+          entry,
           trafficContext.noreply,
           trafficContext.local,
           trafficContext.remote,
@@ -265,8 +225,7 @@ public class ConnectivityToadlet extends Toadlet {
   private void addIpSection(
       HTMLNode contentNode,
       PageMaker pageMaker,
-      UdpSocketHandler handler,
-      AddressTracker tracker,
+      ConnectivitySocketSnapshot socket,
       TrafficContext trafficContext) {
     HTMLNode portsContent =
         pageMaker.getInfobox(
@@ -276,21 +235,19 @@ public class ConnectivityToadlet extends Toadlet {
                     "ConnectivityToadlet.byIPTitle",
                     new String[] {"ip", "status", "tunnelLength"},
                     new String[] {
-                      handler.getTitle(),
-                      AddressTracker.statusString(tracker.getPortForwardStatus()),
-                      TimeUtil.formatTime(tracker.getLongestSendReceiveGap())
+                      socket.title(),
+                      statusString(socket.portForwardStatus()),
+                      TimeUtil.formatTime(socket.longestSendReceiveGapMillis())
                     }),
             contentNode,
             CONNECTIVITY_IP_CLASS,
             false);
-    InetAddressAddressTrackerItem[] ipItems = tracker.getInetAddressTrackerItems();
     HTMLNode table = portsContent.addChild(TABLE_TAG);
     addHeaderRow(table);
-    for (InetAddressAddressTrackerItem item : ipItems) {
+    for (ConnectivityTrafficEntrySnapshot entry : socket.ipEntries()) {
       addTrackerRow(
           table,
-          item,
-          item.addr.toString(),
+          entry,
           trafficContext.noreply,
           trafficContext.local,
           trafficContext.remote,
@@ -305,46 +262,45 @@ public class ConnectivityToadlet extends Toadlet {
     row.addChild("th", localize("localRemoteTitle"));
     row.addChild("th", localize("firstSendLeadTime"));
     row.addChild("th", localize("firstReceiveLeadTime"));
-    for (int j = 0; j < AddressTrackerItem.TRACK_GAPS; j++) {
+    for (int i = 0; i < GAP_COLUMNS; i++) {
       row.addChild("th", EMPTY_HEADER_LABEL);
     }
   }
 
   private void addTrackerRow(
       HTMLNode table,
-      AddressTrackerItem item,
-      String address,
+      ConnectivityTrafficEntrySnapshot entry,
       String noreply,
       String local,
       String remote,
       long now) {
     HTMLNode row = table.addChild("tr");
-    row.addChild("td", address);
-    row.addChild("td", item.packetsSent() + "/ " + item.packetsReceived());
-    row.addChild("td", initiatorLabel(item, noreply, local, remote));
-    row.addChild("td", TimeUtil.formatTime(item.timeFromStartupToFirstSentPacket()));
-    row.addChild("td", TimeUtil.formatTime(item.timeFromStartupToFirstReceivedPacket()));
-    Gap[] gaps = item.getGaps();
-    for (int k = 0; k < AddressTrackerItem.TRACK_GAPS; k++) {
-      row.addChild("td", gapLabel(gaps[k], now));
+    row.addChild("td", entry.address());
+    row.addChild("td", entry.packetsSent() + "/ " + entry.packetsReceived());
+    row.addChild("td", initiatorLabel(entry.initiator(), noreply, local, remote));
+    row.addChild("td", TimeUtil.formatTime(entry.firstSendLeadTimeMillis()));
+    row.addChild("td", TimeUtil.formatTime(entry.firstReceiveLeadTimeMillis()));
+    for (ConnectivityGapSnapshot gap : entry.gaps()) {
+      row.addChild("td", gapLabel(gap, now));
     }
   }
 
   private String initiatorLabel(
-      AddressTrackerItem item, String noreply, String local, String remote) {
-    if (item.packetsReceived() == 0) {
-      return noreply;
-    }
-    return item.weSentFirst() ? local : remote;
+      ConnectivityTrafficInitiator initiator, String noreply, String local, String remote) {
+    return switch (initiator) {
+      case NO_REPLY -> noreply;
+      case LOCAL -> local;
+      case REMOTE -> remote;
+    };
   }
 
-  private String gapLabel(Gap gap, long now) {
-    if (gap.receivedPacketAt() == 0) {
+  private String gapLabel(ConnectivityGapSnapshot gap, long now) {
+    if (gap.receivedPacketAtMillis() == 0) {
       return "";
     }
-    return TimeUtil.formatTime(gap.gapLength())
+    return TimeUtil.formatTime(gap.gapLengthMillis())
         + " @ "
-        + TimeUtil.formatTime(now - gap.receivedPacketAt())
+        + TimeUtil.formatTime(now - gap.receivedPacketAtMillis())
         + " ago";
   }
 
@@ -356,16 +312,10 @@ public class ConnectivityToadlet extends Toadlet {
     return NodeL10n.getBase().getString("ConnectivityToadlet." + key);
   }
 
-  /**
-   * Returns the HTTP path under which this toadlet should be registered.
-   *
-   * <p>The path is returned with leading and trailing slashes to match the routing expectations of
-   * the hosting web server. It does not perform access checks; registration code should ensure only
-   * authenticated callers reach {@link #handleMethodGET(URI, HTTPRequest, ToadletContext)}.
-   *
-   * @return {@code "/connectivity/"} for routing the connectivity status page within the web
-   *     console.
-   */
+  private String statusString(ConnectivityPortForwardStatus status) {
+    return NodeL10n.getBase().getString("ConnectivityToadlet.status." + status);
+  }
+
   @Override
   public String path() {
     return CONNECTIVITY_PATH;

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -340,7 +340,8 @@ final class FProxyRegistrar {
             true,
             null));
 
-    ConnectivityToadlet connectivityToadlet = new ConnectivityToadlet(client, node);
+    ConnectivityToadlet connectivityToadlet =
+        new ConnectivityToadlet(client, core.getRuntimePorts().connectivity());
     server.register(
         connectivityToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/node/IPDetectorManager.java
+++ b/src/main/java/network/crypta/node/IPDetectorManager.java
@@ -26,6 +26,7 @@ import network.crypta.node.useralerts.AbstractUserAlert;
 import network.crypta.node.useralerts.ProxyUserAlert;
 import network.crypta.node.useralerts.SimpleUserAlert;
 import network.crypta.node.useralerts.UserAlert;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.transport.ip.IPUtil;
@@ -1183,6 +1184,31 @@ public class IPDetectorManager implements ForwardPortCallback {
     }
     if (proxyAlert.isValid())
       contentNode.addChild(node.services().clientCore().getAlerts().renderAlert(proxyAlert));
+  }
+
+  /**
+   * Returns the current connection-type notice as a detached snapshot, if one is active.
+   *
+   * <p>Precondition: {@link #start()} has been called. If not, a log entry is emitted and the
+   * method returns {@code null}. The returned value includes both plain-text fields and a rendered
+   * HTML alert fragment so HTTP surfaces can preserve the legacy alert infobox, forwarding-help
+   * links, and dismissal controls without depending on daemon-only alert types.
+   *
+   * @return detached notice snapshot, or {@code null} when no connection-type notice is active
+   */
+  public ConnectivityNoticeSnapshot connectionTypeNotice() {
+    if (node.services().clientCore() == null) return null;
+    var alerts = node.services().clientCore().getAlerts();
+    if (alerts == null) return null;
+    if (proxyAlert == null) {
+      LOG.error("start() not called yet");
+      return null;
+    }
+    if (!proxyAlert.isValid()) {
+      return null;
+    }
+    return new ConnectivityNoticeSnapshot(
+        proxyAlert.getTitle(), proxyAlert.getText(), alerts.renderAlert(proxyAlert).generate());
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeIPDetector.java
+++ b/src/main/java/network/crypta/node/NodeIPDetector.java
@@ -26,6 +26,7 @@ import network.crypta.node.useralerts.IPUndetectedUserAlert;
 import network.crypta.node.useralerts.InvalidAddressOverrideUserAlert;
 import network.crypta.node.useralerts.SimpleUserAlert;
 import network.crypta.node.useralerts.UserAlert;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.StringCallback;
@@ -944,8 +945,14 @@ public class NodeIPDetector {
   }
 
   /** Adds the connection type UI box content via the detector manager. */
+  @SuppressWarnings("unused")
   public void addConnectionTypeBox(HTMLNode contentNode) {
     ipDetectorManager.addConnectionTypeBox(contentNode);
+  }
+
+  /** Returns the current connection-type notice as a detached snapshot, if active. */
+  public ConnectivityNoticeSnapshot connectionTypeNotice() {
+    return ipDetectorManager.connectionTypeNotice();
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyConnectivityPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyConnectivityPort.java
@@ -1,0 +1,224 @@
+package network.crypta.node.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import network.crypta.io.AddressTracker;
+import network.crypta.io.AddressTrackerItem;
+import network.crypta.io.InetAddressAddressTrackerItem;
+import network.crypta.io.PeerAddressTrackerItem;
+import network.crypta.io.comm.UdpSocketHandler;
+import network.crypta.node.FSParseException;
+import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConnectivityGapSnapshot;
+import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
+import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.ConnectivityPortForwardStatus;
+import network.crypta.runtime.spi.ConnectivitySnapshot;
+import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficInitiator;
+import network.crypta.support.SimpleFieldSet;
+
+/**
+ * Adapts the daemon's legacy connectivity state to the runtime SPI's {@link ConnectivityPort}.
+ *
+ * <p>This bridge keeps knowledge of {@link Node}, {@link UdpSocketHandler}, {@link AddressTracker},
+ * and the legacy tracker item types inside the daemon root module while exposing only detached
+ * JDK-only snapshots to the HTTP layer. It is intentionally read-only and preserves the current
+ * connectivity page semantics without exposing daemon configuration objects to callers.
+ *
+ * <p>The adapter takes one live pass over the daemon state when {@link #snapshot(boolean)} is
+ * called. Summary-only requests avoid the per-entry tracker export work used by the advanced page,
+ * which keeps this slice aligned with the current HTTP cost boundary.
+ */
+final class LegacyConnectivityPort implements ConnectivityPort {
+  /** Configuration key used by listener subsets to report whether the listener is enabled. */
+  private static final String ENABLED_KEY = "enabled";
+
+  /** Live daemon root used only while building detached snapshots for the SPI layer. */
+  private final Node node;
+
+  /**
+   * Creates a connectivity adapter backed by the legacy daemon root.
+   *
+   * @param node live node whose runtime state is exported through detached SPI snapshots
+   */
+  LegacyConnectivityPort(Node node) {
+    this.node = Objects.requireNonNull(node);
+  }
+
+  @Override
+  public ConnectivitySnapshot snapshot(boolean includeAdvancedDetails) {
+    UdpSocketHandler[] handlers = node.network().packetSocketHandlers();
+    List<ConnectivitySocketSnapshot> sockets = new ArrayList<>(handlers.length);
+    for (UdpSocketHandler handler : handlers) {
+      sockets.add(toSocketSnapshot(handler, includeAdvancedDetails));
+    }
+    return new ConnectivitySnapshot(
+        node.network().fnpPort(),
+        node.network().opennetFnpPort(),
+        listenerPort("fproxy"),
+        listenerPort("fcp"),
+        listenerPort("console"),
+        connectionTypeNotice(),
+        List.copyOf(sockets));
+  }
+
+  /**
+   * Reads one listener subset from the legacy configuration tree.
+   *
+   * <p>The connectivity page only needs the enabled flag and the configured port. Parse failures
+   * are treated as a disabled listener, so the read-only admin view remains resilient to incomplete
+   * or transient configuration state.
+   *
+   * @param subsetName configuration subset name such as {@code fproxy}, {@code fcp}, or {@code
+   *     console}
+   * @return detached listener snapshot derived from the current node configuration
+   */
+  private ConnectivityListenerPortSnapshot listenerPort(String subsetName) {
+    try {
+      SimpleFieldSet config = node.getConfig().get(subsetName).exportFieldSet(true);
+      boolean enabled = config.getBoolean(ENABLED_KEY, false);
+      int port = enabled ? config.getInt("port") : 0;
+      return new ConnectivityListenerPortSnapshot(enabled, port);
+    } catch (FSParseException _) {
+      return new ConnectivityListenerPortSnapshot(false, 0);
+    }
+  }
+
+  /**
+   * Exports the current connection-type notice when the detector has one available.
+   *
+   * <p>The returned snapshot is already detached from the daemon alert classes and may include a
+   * rendered alert fragment that preserves the old connectivity-page infobox behavior.
+   *
+   * @return detached connection-type notice, or {@code null} when no notice is active
+   */
+  private ConnectivityNoticeSnapshot connectionTypeNotice() {
+    return node.network().ipDetector().connectionTypeNotice();
+  }
+
+  /**
+   * Converts one live UDP socket handler into a detached socket snapshot.
+   *
+   * <p>When advanced details are disabled, the method returns only the summary fields needed by the
+   * basic connectivity page. Advanced mode includes the tracker-derived gap and table data.
+   *
+   * @param handler live UDP socket handler to inspect
+   * @param includeAdvancedDetails whether tracker-table details should be exported
+   * @return detached socket snapshot for the current handler state
+   */
+  private ConnectivitySocketSnapshot toSocketSnapshot(
+      UdpSocketHandler handler, boolean includeAdvancedDetails) {
+    AddressTracker tracker = handler.getAddressTracker();
+    if (!includeAdvancedDetails) {
+      return new ConnectivitySocketSnapshot(
+          handler.getTitle(),
+          toPortForwardStatus(tracker.getPortForwardStatus()),
+          -1,
+          List.of(),
+          List.of());
+    }
+
+    return new ConnectivitySocketSnapshot(
+        handler.getTitle(),
+        toPortForwardStatus(tracker.getPortForwardStatus()),
+        tracker.getLongestSendReceiveGap(),
+        peerEntries(tracker.getPeerAddressTrackerItems()),
+        ipEntries(tracker.getInetAddressTrackerItems()));
+  }
+
+  /**
+   * Converts peer tracker items into detached table rows.
+   *
+   * @param items live peer tracker items returned by the daemon address tracker
+   * @return immutable list of detached peer-entry snapshots in iteration order
+   */
+  private List<ConnectivityTrafficEntrySnapshot> peerEntries(PeerAddressTrackerItem[] items) {
+    List<ConnectivityTrafficEntrySnapshot> entries = new ArrayList<>(items.length);
+    for (PeerAddressTrackerItem item : items) {
+      entries.add(toTrafficEntry(item.peer.toString(), item));
+    }
+    return List.copyOf(entries);
+  }
+
+  /**
+   * Converts IP tracker items into detached table rows.
+   *
+   * @param items live IP tracker items returned by the daemon address tracker
+   * @return immutable list of detached IP-entry snapshots in iteration order
+   */
+  private List<ConnectivityTrafficEntrySnapshot> ipEntries(InetAddressAddressTrackerItem[] items) {
+    List<ConnectivityTrafficEntrySnapshot> entries = new ArrayList<>(items.length);
+    for (InetAddressAddressTrackerItem item : items) {
+      entries.add(toTrafficEntry(item.addr.toString(), item));
+    }
+    return List.copyOf(entries);
+  }
+
+  /**
+   * Converts one tracker item into the detached row model used by the SPI.
+   *
+   * @param address rendered peer or IP label that should appear in the advanced table
+   * @param trackerItem live tracker item supplying counters, timing, and gap history
+   * @return detached traffic-entry snapshot with immutable gap history
+   */
+  private ConnectivityTrafficEntrySnapshot toTrafficEntry(
+      String address, AddressTrackerItem trackerItem) {
+    return new ConnectivityTrafficEntrySnapshot(
+        address,
+        trackerItem.packetsSent(),
+        trackerItem.packetsReceived(),
+        toInitiator(trackerItem),
+        trackerItem.timeFromStartupToFirstSentPacket(),
+        trackerItem.timeFromStartupToFirstReceivedPacket(),
+        gapSnapshots(trackerItem.getGaps()));
+  }
+
+  /**
+   * Converts the tracker gap array into immutable detached snapshots.
+   *
+   * @param gaps live tracker gap array in daemon order
+   * @return immutable list of detached gap snapshots in the same order
+   */
+  private List<ConnectivityGapSnapshot> gapSnapshots(AddressTrackerItem.Gap[] gaps) {
+    List<ConnectivityGapSnapshot> snapshots = new ArrayList<>(gaps.length);
+    for (AddressTrackerItem.Gap gap : gaps) {
+      snapshots.add(new ConnectivityGapSnapshot(gap.gapLength(), gap.receivedPacketAt()));
+    }
+    return List.copyOf(snapshots);
+  }
+
+  /**
+   * Maps the legacy tracker initiator view to the detached SPI enum.
+   *
+   * @param trackerItem live tracker item whose counters indicate who sent first
+   * @return detached initiator classification for the advanced tracker table
+   */
+  private ConnectivityTrafficInitiator toInitiator(AddressTrackerItem trackerItem) {
+    if (trackerItem.packetsReceived() == 0) {
+      return ConnectivityTrafficInitiator.NO_REPLY;
+    }
+    return trackerItem.weSentFirst()
+        ? ConnectivityTrafficInitiator.LOCAL
+        : ConnectivityTrafficInitiator.REMOTE;
+  }
+
+  /**
+   * Maps the daemon's address-tracker status enum to the SPI status enum.
+   *
+   * @param status legacy address-tracker status for one UDP socket
+   * @return detached port-forwarding status used by the HTTP layer
+   */
+  private ConnectivityPortForwardStatus toPortForwardStatus(AddressTracker.Status status) {
+    return switch (status) {
+      case DEFINITELY_NATED -> ConnectivityPortForwardStatus.DEFINITELY_NATED;
+      case MAYBE_NATED -> ConnectivityPortForwardStatus.MAYBE_NATED;
+      case DONT_KNOW -> ConnectivityPortForwardStatus.DONT_KNOW;
+      case MAYBE_PORT_FORWARDED -> ConnectivityPortForwardStatus.MAYBE_PORT_FORWARDED;
+      case DEFINITELY_PORT_FORWARDED -> ConnectivityPortForwardStatus.DEFINITELY_PORT_FORWARDED;
+    };
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConnectivityPort;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
@@ -36,6 +37,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final TransferAccessPort transferAccessPort;
   private final LifecyclePort lifecyclePort;
   private final ConfigPort configPort;
+  private final ConnectivityPort connectivityPort;
   private final RequestQueuePort requestQueuePort;
   private final NodeInfoPort nodeInfoPort;
   private final PeerPort peerPort;
@@ -119,6 +121,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
           }
         };
     this.configPort = new LegacyConfigPort(node, core);
+    this.connectivityPort = new LegacyConnectivityPort(node);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
@@ -175,6 +178,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public ConfigPort config() {
     return configPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps all legacy connectivity tracking, listener-port exports, and
+   * connection-type notice collection inside the daemon root module while exposing only detached
+   * SPI-local snapshots upstream.
+   */
+  @Override
+  public ConnectivityPort connectivity() {
+    return connectivityPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/ConnectivityToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ConnectivityToadletTest.java
@@ -124,6 +124,66 @@ class ConnectivityToadletTest {
   }
 
   @Test
+  void handleMethodGET_whenGapHistoryShorterThanHeader_padsRenderedGapCells() throws Exception {
+    HTMLNode content = new HTMLNode("div");
+    PageMaker pageMaker = stubPageMaker(content);
+    when(connectivity.snapshot(true))
+        .thenReturn(
+            advancedSnapshot(
+                List.of(
+                    new ConnectivityGapSnapshot(10_000L, 20_000L),
+                    new ConnectivityGapSnapshot(5_000L, 15_000L)),
+                null));
+
+    UserAlertManager alertManager = mock(UserAlertManager.class);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert"));
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(true);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/connectivity/"), request, ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+
+    assertEquals(12, renderedTableCellCount(html), "Should render five gap cells for the row");
+  }
+
+  @Test
+  void handleMethodGET_whenGapHistoryLongerThanHeader_clampsRenderedGapCells() throws Exception {
+    HTMLNode content = new HTMLNode("div");
+    PageMaker pageMaker = stubPageMaker(content);
+    when(connectivity.snapshot(true))
+        .thenReturn(
+            advancedSnapshot(
+                null,
+                List.of(
+                    new ConnectivityGapSnapshot(10_000L, 20_000L),
+                    new ConnectivityGapSnapshot(20_000L, 30_000L),
+                    new ConnectivityGapSnapshot(30_000L, 40_000L),
+                    new ConnectivityGapSnapshot(40_000L, 50_000L),
+                    new ConnectivityGapSnapshot(50_000L, 60_000L),
+                    new ConnectivityGapSnapshot(60_000L, 70_000L))));
+
+    UserAlertManager alertManager = mock(UserAlertManager.class);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert"));
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(true);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/connectivity/"), request, ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+
+    assertEquals(12, renderedTableCellCount(html), "Should clamp the row to five gap cells");
+  }
+
+  @Test
   void handleMethodGET_whenNoticePresent_rendersDetachedConnectionTypeAlertHtml() throws Exception {
     HTMLNode content = new HTMLNode("div");
     PageMaker pageMaker = stubPageMaker(content);
@@ -201,6 +261,11 @@ class ConnectivityToadletTest {
   }
 
   private ConnectivitySnapshot advancedSnapshot() {
+    return advancedSnapshot(gapHistory(), gapHistory());
+  }
+
+  private ConnectivitySnapshot advancedSnapshot(
+      List<ConnectivityGapSnapshot> peerGaps, List<ConnectivityGapSnapshot> ipGaps) {
     return new ConnectivitySnapshot(
         54321,
         0,
@@ -213,24 +278,26 @@ class ConnectivityToadletTest {
                 "udp-9999",
                 ConnectivityPortForwardStatus.DEFINITELY_PORT_FORWARDED,
                 12_345L,
-                List.of(
-                    new ConnectivityTrafficEntrySnapshot(
-                        "1.1.1.1:4242",
-                        1,
-                        1,
-                        ConnectivityTrafficInitiator.LOCAL,
-                        1_000L,
-                        3_000L,
-                        gapHistory())),
-                List.of(
-                    new ConnectivityTrafficEntrySnapshot(
-                        "/2.2.2.2",
-                        1,
-                        1,
-                        ConnectivityTrafficInitiator.REMOTE,
-                        2_000L,
-                        4_000L,
-                        gapHistory())))));
+                peerEntries(peerGaps),
+                ipEntries(ipGaps))));
+  }
+
+  private List<ConnectivityTrafficEntrySnapshot> peerEntries(List<ConnectivityGapSnapshot> gaps) {
+    if (gaps == null) {
+      return List.of();
+    }
+    return List.of(
+        new ConnectivityTrafficEntrySnapshot(
+            "1.1.1.1:4242", 1, 1, ConnectivityTrafficInitiator.LOCAL, 1_000L, 3_000L, gaps));
+  }
+
+  private List<ConnectivityTrafficEntrySnapshot> ipEntries(List<ConnectivityGapSnapshot> gaps) {
+    if (gaps == null) {
+      return List.of();
+    }
+    return List.of(
+        new ConnectivityTrafficEntrySnapshot(
+            "/2.2.2.2", 1, 1, ConnectivityTrafficInitiator.REMOTE, 2_000L, 4_000L, gaps));
   }
 
   private List<ConnectivityGapSnapshot> gapHistory() {
@@ -240,6 +307,10 @@ class ConnectivityToadletTest {
         new ConnectivityGapSnapshot(0L, 0L),
         new ConnectivityGapSnapshot(0L, 0L),
         new ConnectivityGapSnapshot(0L, 0L));
+  }
+
+  private int renderedTableCellCount(String html) {
+    return html.split(java.util.regex.Pattern.quote("<td"), -1).length - 1;
   }
 
   private PageMaker stubPageMaker(HTMLNode content) {

--- a/src/test/java/network/crypta/clients/http/ConnectivityToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ConnectivityToadletTest.java
@@ -1,22 +1,22 @@
 package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
-import java.net.InetAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.config.PersistentConfig;
-import network.crypta.config.SubConfig;
-import network.crypta.io.AddressTracker;
-import network.crypta.io.InetAddressAddressTrackerItem;
-import network.crypta.io.PeerAddressTrackerItem;
-import network.crypta.io.comm.Peer;
-import network.crypta.io.comm.UdpSocketHandler;
-import network.crypta.node.Node;
-import network.crypta.node.NodeIPDetector;
+import network.crypta.l10n.NodeL10n;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.ConnectivityGapSnapshot;
+import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
+import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.ConnectivityPortForwardStatus;
+import network.crypta.runtime.spi.ConnectivitySnapshot;
+import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficInitiator;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,20 +41,16 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ConnectivityToadletTest {
 
-  @Mock HighLevelSimpleClient client;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  Node node;
-
-  @Mock PersistentConfig config;
-  @Mock ToadletContext ctx;
-  @Mock HTTPRequest request;
+  @Mock private HighLevelSimpleClient client;
+  @Mock private ConnectivityPort connectivity;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
 
   private ConnectivityToadlet toadlet;
 
   @BeforeEach
   void setUp() {
-    toadlet = new ConnectivityToadlet(client, node);
+    toadlet = new ConnectivityToadlet(client, connectivity);
   }
 
   @Test
@@ -66,26 +62,11 @@ class ConnectivityToadletTest {
   void handleMethodGET_whenAdvancedDisabled_rendersPortSummaryAndAlertBox() throws Exception {
     HTMLNode content = new HTMLNode("div");
     PageMaker pageMaker = stubPageMaker(content);
-
-    setConfigPorts(true, 8080, false, 0, false, 0);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.fnpPort()).thenReturn(12345);
-    when(network.opennetFnpPort()).thenReturn(33333);
-    when(node.getConfig()).thenReturn(config);
-    when(network.packetSocketHandlers()).thenReturn(new UdpSocketHandler[0]);
-
-    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
-    when(network.ipDetector()).thenReturn(ipDetector);
-    doAnswer(invocation -> ((HTMLNode) invocation.getArgument(0)).addChild("div", "ip"))
-        .when(ipDetector)
-        .addConnectionTypeBox(any(HTMLNode.class));
+    when(connectivity.snapshot(false)).thenReturn(nonAdvancedSnapshot(null));
 
     UserAlertManager alertManager = mock(UserAlertManager.class);
     when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert"));
     when(ctx.getAlertManager()).thenReturn(alertManager);
-
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     when(ctx.isAdvancedModeEnabled()).thenReturn(false);
     when(ctx.getPageMaker()).thenReturn(pageMaker);
@@ -99,9 +80,17 @@ class ConnectivityToadletTest {
     assertTrue(html.contains("12345"), "Should list darknet FNP port");
     assertTrue(html.contains("33333"), "Should list opennet FNP port when configured");
     assertTrue(html.contains("8080"), "Should list enabled fproxy port");
+    assertTrue(html.contains("udp-9999"), "Should render the socket summary row");
+    assertTrue(
+        html.contains(
+            NodeL10n.getBase()
+                .getString(
+                    "ConnectivityToadlet.status."
+                        + ConnectivityPortForwardStatus.DEFINITELY_PORT_FORWARDED)),
+        "Should render the localized socket status");
     assertTrue(html.contains("alert"), "Should render alert summary for full access users");
 
-    verify(ipDetector).addConnectionTypeBox(content);
+    verify(connectivity).snapshot(false);
     verify(ctx).sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
   }
 
@@ -109,49 +98,11 @@ class ConnectivityToadletTest {
   void handleMethodGET_whenAdvancedEnabled_rendersPeerAndIpTables() throws Exception {
     HTMLNode content = new HTMLNode("div");
     PageMaker pageMaker = stubPageMaker(content);
-
-    setConfigPorts(false, 9090, true, 9481, true, 2222);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.fnpPort()).thenReturn(54321);
-    when(network.opennetFnpPort()).thenReturn(0);
-    when(node.getConfig()).thenReturn(config);
-
-    PeerAddressTrackerItem peerItem =
-        new PeerAddressTrackerItem(0, 0, new Peer("1.1.1.1:4242", false));
-    peerItem.sentPacket(1_000L);
-    peerItem.receivedPacket(AddressTracker.MAYBE_TUNNEL_LENGTH + 2_000L);
-
-    InetAddressAddressTrackerItem ipItem =
-        new InetAddressAddressTrackerItem(0, 0, InetAddress.getByName("2.2.2.2"));
-    ipItem.sentPacket(2_000L);
-    ipItem.receivedPacket(AddressTracker.MAYBE_TUNNEL_LENGTH + 4_000L);
-
-    AddressTracker tracker = mock(AddressTracker.class);
-    when(tracker.getPortForwardStatus())
-        .thenReturn(AddressTracker.Status.DEFINITELY_PORT_FORWARDED);
-    when(tracker.getLongestSendReceiveGap()).thenReturn(12_345L);
-    when(tracker.getPeerAddressTrackerItems()).thenReturn(new PeerAddressTrackerItem[] {peerItem});
-    when(tracker.getInetAddressTrackerItems())
-        .thenReturn(new InetAddressAddressTrackerItem[] {ipItem});
-
-    UdpSocketHandler handler = mock(UdpSocketHandler.class);
-    when(handler.getTitle()).thenReturn("udp-9999");
-    when(handler.getAddressTracker()).thenReturn(tracker);
-
-    when(network.packetSocketHandlers()).thenReturn(new UdpSocketHandler[] {handler});
-
-    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
-    when(network.ipDetector()).thenReturn(ipDetector);
-    doAnswer(invocation -> ((HTMLNode) invocation.getArgument(0)).addChild("div", "ip"))
-        .when(ipDetector)
-        .addConnectionTypeBox(any(HTMLNode.class));
+    when(connectivity.snapshot(true)).thenReturn(advancedSnapshot());
 
     UserAlertManager alertManager = mock(UserAlertManager.class);
     when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert"));
     when(ctx.getAlertManager()).thenReturn(alertManager);
-
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     when(ctx.isAdvancedModeEnabled()).thenReturn(true);
     when(ctx.getPageMaker()).thenReturn(pageMaker);
@@ -163,8 +114,132 @@ class ConnectivityToadletTest {
     String html = body.toString(StandardCharsets.UTF_8);
 
     assertTrue(html.contains("1.1.1.1:4242"), "Peer table should include peer address");
-    assertTrue(html.contains("2.2.2.2"), "IP table should include raw IP");
+    assertTrue(html.contains("/2.2.2.2"), "IP table should include raw IP");
     assertTrue(html.contains("udp-9999"), "Summary should list handler title");
+    assertTrue(
+        html.contains(NodeL10n.getBase().getString("ConnectivityToadlet.local")),
+        "Advanced table should render initiator labels");
+
+    verify(connectivity).snapshot(true);
+  }
+
+  @Test
+  void handleMethodGET_whenNoticePresent_rendersDetachedConnectionTypeAlertHtml() throws Exception {
+    HTMLNode content = new HTMLNode("div");
+    PageMaker pageMaker = stubPageMaker(content);
+    ConnectivityNoticeSnapshot notice =
+        new ConnectivityNoticeSnapshot(
+            "Connection Type",
+            "Port restricted NAT detected",
+            """
+            <div class="infobox infobox-warning">
+            \t<div class="infobox-header">Connection Type</div>
+            \t<div class="infobox-content"><a href="/help">Forward a port</a><form><div><input type="submit" name="dismiss-user-alert" value="Hide" /></div></form></div>
+            </div>
+            """);
+    when(connectivity.snapshot(false)).thenReturn(nonAdvancedSnapshot(notice));
+
+    UserAlertManager alertManager = mock(UserAlertManager.class);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert"));
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(false);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/connectivity/"), request, ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+
+    assertTrue(html.contains("infobox-warning"), "Should preserve the alert severity infobox");
+    assertTrue(html.contains("Forward a port"), "Should preserve the actionable help link");
+    assertTrue(html.contains("dismiss-user-alert"), "Should preserve the dismiss control");
+  }
+
+  @Test
+  void handleMethodGET_whenRenderedNoticeHtmlUnavailable_rendersDetachedConnectionTypeNotice()
+      throws Exception {
+    HTMLNode content = new HTMLNode("div");
+    PageMaker pageMaker = stubPageMaker(content);
+    ConnectivityNoticeSnapshot notice =
+        new ConnectivityNoticeSnapshot("Connection Type", "Port restricted NAT detected", "");
+    when(connectivity.snapshot(false)).thenReturn(nonAdvancedSnapshot(notice));
+
+    UserAlertManager alertManager = mock(UserAlertManager.class);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert"));
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(false);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/connectivity/"), request, ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+
+    assertTrue(html.contains(notice.title()), "Should render the notice title");
+    assertTrue(html.contains(notice.text()), "Should render the notice body");
+  }
+
+  private ConnectivitySnapshot nonAdvancedSnapshot(ConnectivityNoticeSnapshot notice) {
+    return new ConnectivitySnapshot(
+        12345,
+        33333,
+        new ConnectivityListenerPortSnapshot(true, 8080),
+        new ConnectivityListenerPortSnapshot(false, 0),
+        new ConnectivityListenerPortSnapshot(false, 0),
+        notice,
+        List.of(
+            new ConnectivitySocketSnapshot(
+                "udp-9999",
+                ConnectivityPortForwardStatus.DEFINITELY_PORT_FORWARDED,
+                -1,
+                List.of(),
+                List.of())));
+  }
+
+  private ConnectivitySnapshot advancedSnapshot() {
+    return new ConnectivitySnapshot(
+        54321,
+        0,
+        new ConnectivityListenerPortSnapshot(false, 0),
+        new ConnectivityListenerPortSnapshot(true, 9481),
+        new ConnectivityListenerPortSnapshot(true, 2222),
+        null,
+        List.of(
+            new ConnectivitySocketSnapshot(
+                "udp-9999",
+                ConnectivityPortForwardStatus.DEFINITELY_PORT_FORWARDED,
+                12_345L,
+                List.of(
+                    new ConnectivityTrafficEntrySnapshot(
+                        "1.1.1.1:4242",
+                        1,
+                        1,
+                        ConnectivityTrafficInitiator.LOCAL,
+                        1_000L,
+                        3_000L,
+                        gapHistory())),
+                List.of(
+                    new ConnectivityTrafficEntrySnapshot(
+                        "/2.2.2.2",
+                        1,
+                        1,
+                        ConnectivityTrafficInitiator.REMOTE,
+                        2_000L,
+                        4_000L,
+                        gapHistory())))));
+  }
+
+  private List<ConnectivityGapSnapshot> gapHistory() {
+    return List.of(
+        new ConnectivityGapSnapshot(10_000L, 20_000L),
+        new ConnectivityGapSnapshot(0L, 0L),
+        new ConnectivityGapSnapshot(0L, 0L),
+        new ConnectivityGapSnapshot(0L, 0L),
+        new ConnectivityGapSnapshot(0L, 0L));
   }
 
   private PageMaker stubPageMaker(HTMLNode content) {
@@ -181,6 +256,7 @@ class ConnectivityToadletTest {
               HTMLNode parent = invocation.getArgument(2);
               HTMLNode infobox = new HTMLNode("div", "class", "infobox");
               parent.addChild(infobox);
+              infobox.addChild("div", "class", "header", invocation.getArgument(1));
               return infobox.addChild("div", "class", "content");
             })
         .when(pageMaker)
@@ -188,35 +264,9 @@ class ConnectivityToadletTest {
     return pageMaker;
   }
 
-  private void setConfigPorts(
-      boolean fproxyEnabled,
-      int fproxyPort,
-      boolean fcpEnabled,
-      int fcpPort,
-      boolean tmciEnabled,
-      int tmciPort) {
-    when(config.get("fproxy")).thenReturn(mockSubConfig(fproxyEnabled, fproxyPort));
-    when(config.get("fcp")).thenReturn(mockSubConfig(fcpEnabled, fcpPort));
-    when(config.get("console")).thenReturn(mockSubConfig(tmciEnabled, tmciPort));
-  }
-
-  private SubConfig mockSubConfig(boolean enabled, int port) {
-    SimpleFieldSet fs = new SimpleFieldSet(true);
-    fs.put("enabled", enabled);
-    fs.put("port", port);
-    return mock(
-        SubConfig.class,
-        invocation -> {
-          if ("exportFieldSet".equals(invocation.getMethod().getName())) {
-            return fs;
-          }
-          return org.mockito.Answers.RETURNS_DEFAULTS.answer(invocation);
-        });
-  }
-
   private ByteArrayOutputStream captureBody(ToadletContext context) throws Exception {
     ByteArrayOutputStream body = new ByteArrayOutputStream();
-    doAnswer(invocation -> null)
+    doAnswer(_ -> null)
         .when(context)
         .sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
     doAnswer(

--- a/src/test/java/network/crypta/node/runtime/LegacyConnectivityPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyConnectivityPortTest.java
@@ -1,0 +1,216 @@
+package network.crypta.node.runtime;
+
+import java.net.InetAddress;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.io.AddressTracker;
+import network.crypta.io.InetAddressAddressTrackerItem;
+import network.crypta.io.PeerAddressTrackerItem;
+import network.crypta.io.comm.Peer;
+import network.crypta.io.comm.UdpSocketHandler;
+import network.crypta.node.Node;
+import network.crypta.node.NodeIPDetector;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
+import network.crypta.runtime.spi.ConnectivityPortForwardStatus;
+import network.crypta.runtime.spi.ConnectivitySnapshot;
+import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficInitiator;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class LegacyConnectivityPortTest {
+
+  @Mock private Node node;
+  @Mock private NodeNetworkSubsystem network;
+  @Mock private PersistentConfig config;
+  @Mock private NodeIPDetector ipDetector;
+
+  private LegacyConnectivityPort port;
+
+  @BeforeEach
+  void setUp() {
+    port = new LegacyConnectivityPort(node);
+    when(node.network()).thenReturn(network);
+    when(node.getConfig()).thenReturn(config);
+    when(network.ipDetector()).thenReturn(ipDetector);
+    when(network.packetSocketHandlers()).thenReturn(new UdpSocketHandler[0]);
+    when(network.fnpPort()).thenReturn(12345);
+    when(network.opennetFnpPort()).thenReturn(33333);
+  }
+
+  @Test
+  void snapshot_whenCalled_mapsPortNumbersAndListenerConfig() {
+    setConfigPorts(true, 8080, 9481, true, 2222);
+
+    ConnectivitySnapshot snapshot = port.snapshot(false);
+
+    assertEquals(12345, snapshot.darknetFnpPort());
+    assertEquals(33333, snapshot.opennetFnpPort());
+    assertEquals(new ConnectivityListenerPortSnapshot(true, 8080), snapshot.fproxyListener());
+    assertEquals(new ConnectivityListenerPortSnapshot(false, 0), snapshot.fcpListener());
+    assertEquals(new ConnectivityListenerPortSnapshot(true, 2222), snapshot.consoleListener());
+    assertNull(snapshot.connectionTypeNotice());
+  }
+
+  @ParameterizedTest
+  @EnumSource(AddressTracker.Status.class)
+  void snapshot_whenSocketStatusPresent_mapsLegacyStatus(AddressTracker.Status status) {
+    setConfigPorts(false, 0, 0, false, 0);
+    AddressTracker tracker = mock(AddressTracker.class);
+    when(tracker.getPortForwardStatus()).thenReturn(status);
+
+    UdpSocketHandler handler = mock(UdpSocketHandler.class);
+    when(handler.getTitle()).thenReturn("udp-9999");
+    when(handler.getAddressTracker()).thenReturn(tracker);
+    when(network.packetSocketHandlers()).thenReturn(new UdpSocketHandler[] {handler});
+
+    ConnectivitySnapshot snapshot = port.snapshot(false);
+
+    assertEquals(expectedStatus(status), snapshot.sockets().getFirst().portForwardStatus());
+  }
+
+  @Test
+  void snapshot_whenAdvancedDetailsDisabled_skipsTrackerTableExport() {
+    setConfigPorts(false, 0, 0, false, 0);
+    AddressTracker tracker = mock(AddressTracker.class);
+    when(tracker.getPortForwardStatus()).thenReturn(AddressTracker.Status.DONT_KNOW);
+
+    UdpSocketHandler handler = mock(UdpSocketHandler.class);
+    when(handler.getTitle()).thenReturn("udp-9999");
+    when(handler.getAddressTracker()).thenReturn(tracker);
+    when(network.packetSocketHandlers()).thenReturn(new UdpSocketHandler[] {handler});
+
+    ConnectivitySocketSnapshot summaryOnly = port.snapshot(false).sockets().getFirst();
+
+    assertEquals(-1, summaryOnly.longestSendReceiveGapMillis());
+    assertTrue(summaryOnly.peerEntries().isEmpty());
+    assertTrue(summaryOnly.ipEntries().isEmpty());
+    verify(tracker, never()).getLongestSendReceiveGap();
+    verify(tracker, never()).getPeerAddressTrackerItems();
+    verify(tracker, never()).getInetAddressTrackerItems();
+
+    clearInvocations(tracker);
+    when(tracker.getLongestSendReceiveGap()).thenReturn(12_345L);
+    when(tracker.getPeerAddressTrackerItems()).thenReturn(new PeerAddressTrackerItem[0]);
+    when(tracker.getInetAddressTrackerItems()).thenReturn(new InetAddressAddressTrackerItem[0]);
+
+    ConnectivitySocketSnapshot withAdvanced = port.snapshot(true).sockets().getFirst();
+
+    assertEquals(12_345L, withAdvanced.longestSendReceiveGapMillis());
+    verify(tracker).getLongestSendReceiveGap();
+    verify(tracker).getPeerAddressTrackerItems();
+    verify(tracker).getInetAddressTrackerItems();
+  }
+
+  @Test
+  void snapshot_whenAdvancedDetailsEnabled_mapsTrackerRowsAndGaps() throws Exception {
+    setConfigPorts(false, 0, 0, false, 0);
+    PeerAddressTrackerItem peerItem =
+        new PeerAddressTrackerItem(0, 0, new Peer("1.1.1.1:4242", false));
+    peerItem.sentPacket(1_000L);
+    peerItem.receivedPacket(AddressTracker.MAYBE_TUNNEL_LENGTH + 2_000L);
+
+    InetAddressAddressTrackerItem ipItem =
+        new InetAddressAddressTrackerItem(0, 0, InetAddress.getByName("2.2.2.2"));
+    ipItem.receivedPacket(2_000L);
+    ipItem.sentPacket(AddressTracker.MAYBE_TUNNEL_LENGTH + 4_000L);
+
+    AddressTracker tracker = mock(AddressTracker.class);
+    when(tracker.getPortForwardStatus())
+        .thenReturn(AddressTracker.Status.DEFINITELY_PORT_FORWARDED);
+    when(tracker.getLongestSendReceiveGap()).thenReturn(12_345L);
+    when(tracker.getPeerAddressTrackerItems()).thenReturn(new PeerAddressTrackerItem[] {peerItem});
+    when(tracker.getInetAddressTrackerItems())
+        .thenReturn(new InetAddressAddressTrackerItem[] {ipItem});
+
+    UdpSocketHandler handler = mock(UdpSocketHandler.class);
+    when(handler.getTitle()).thenReturn("udp-9999");
+    when(handler.getAddressTracker()).thenReturn(tracker);
+    when(network.packetSocketHandlers()).thenReturn(new UdpSocketHandler[] {handler});
+
+    ConnectivitySocketSnapshot socket = port.snapshot(true).sockets().getFirst();
+
+    assertEquals(12_345L, socket.longestSendReceiveGapMillis());
+    assertEquals(
+        ConnectivityPortForwardStatus.DEFINITELY_PORT_FORWARDED, socket.portForwardStatus());
+
+    ConnectivityTrafficEntrySnapshot peerEntry = socket.peerEntries().getFirst();
+    assertEquals("1.1.1.1:4242", peerEntry.address());
+    assertEquals(1, peerEntry.packetsSent());
+    assertEquals(1, peerEntry.packetsReceived());
+    assertEquals(ConnectivityTrafficInitiator.LOCAL, peerEntry.initiator());
+    assertEquals(5, peerEntry.gaps().size());
+    assertTrue(peerEntry.gaps().getFirst().gapLengthMillis() > 0);
+    assertTrue(peerEntry.gaps().getFirst().receivedPacketAtMillis() > 0);
+
+    ConnectivityTrafficEntrySnapshot ipEntry = socket.ipEntries().getFirst();
+    assertEquals("/2.2.2.2", ipEntry.address());
+    assertEquals(ConnectivityTrafficInitiator.REMOTE, ipEntry.initiator());
+  }
+
+  @Test
+  void snapshot_whenConnectionTypeNoticePresent_exportsDetachedNotice() {
+    setConfigPorts(false, 0, 0, false, 0);
+    ConnectivityNoticeSnapshot notice =
+        new ConnectivityNoticeSnapshot(
+            "Connection Type",
+            "Port restricted NAT detected",
+            "<div class=\"infobox infobox-warning\">notice</div>");
+    when(ipDetector.connectionTypeNotice()).thenReturn(notice);
+
+    ConnectivitySnapshot snapshot = port.snapshot(false);
+
+    assertEquals(notice, snapshot.connectionTypeNotice());
+  }
+
+  private ConnectivityPortForwardStatus expectedStatus(AddressTracker.Status status) {
+    return switch (status) {
+      case DEFINITELY_NATED -> ConnectivityPortForwardStatus.DEFINITELY_NATED;
+      case MAYBE_NATED -> ConnectivityPortForwardStatus.MAYBE_NATED;
+      case DONT_KNOW -> ConnectivityPortForwardStatus.DONT_KNOW;
+      case MAYBE_PORT_FORWARDED -> ConnectivityPortForwardStatus.MAYBE_PORT_FORWARDED;
+      case DEFINITELY_PORT_FORWARDED -> ConnectivityPortForwardStatus.DEFINITELY_PORT_FORWARDED;
+    };
+  }
+
+  private void setConfigPorts(
+      boolean fproxyEnabled, int fproxyPort, int fcpPort, boolean tmciEnabled, int tmciPort) {
+    when(config.get("fproxy")).thenReturn(mockSubConfig(fproxyEnabled, fproxyPort));
+    when(config.get("fcp")).thenReturn(mockSubConfig(false, fcpPort));
+    when(config.get("console")).thenReturn(mockSubConfig(tmciEnabled, tmciPort));
+  }
+
+  private SubConfig mockSubConfig(boolean enabled, int portNumber) {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.put("enabled", enabled);
+    fieldSet.put("port", portNumber);
+    return mock(
+        SubConfig.class,
+        invocation -> {
+          if ("exportFieldSet".equals(invocation.getMethod().getName())) {
+            return fieldSet;
+          }
+          return org.mockito.Answers.RETURNS_DEFAULTS.answer(invocation);
+        });
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow `ConnectivityPort` SPI plus detached connectivity DTOs and enums for the admin connectivity page
- wire `RuntimePorts` and `LegacyRuntimePorts`, and add `LegacyConnectivityPort` to adapt daemon state without exposing `Node` to the toadlet
- update `ConnectivityToadlet`, `FProxyRegistrar`, and the focused tests, while preserving connection-type alert rendering semantics and adding Javadoc for the new production files

## How to test
- `./gradlew test --tests "network.crypta.clients.http.ConnectivityToadletTest" --tests "network.crypta.node.runtime.LegacyConnectivityPortTest"`
- `./gradlew classes`
- run per-file `javadoc -Xdoclint:all` for the new `runtime-spi` connectivity types and `javadoc -private -Xdoclint:all` for `src/main/java/network/crypta/node/runtime/LegacyConnectivityPort.java`

## Notes
- base branch: `develop`
- branch: `feature/connectivity-runtime-slice`