### PR TITLE
feat(runtime): SPI-ify connections page GET rendering

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPageKind.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPageKind.java
@@ -1,0 +1,16 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Identifies which legacy connections page the runtime adapter should render.
+ *
+ * <p>The current legacy admin UI still exposes two distinct peer-list pages with different table
+ * columns and action capabilities: the darknet friends page and the opennet strangers page. This
+ * enum keeps that choice explicit while remaining detached from daemon-only peer or HTTP classes.
+ */
+public enum ConnectionsPageKind {
+  /** Renders the legacy darknet friends page. */
+  DARKNET,
+
+  /** Renders the legacy opennet strangers page. */
+  OPENNET
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPagePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPagePort.java
@@ -1,0 +1,33 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Exposes the narrow legacy connections-page capability needed by the admin HTTP endpoints.
+ *
+ * <p>This port is intentionally page-oriented and transitional. The legacy friends and strangers
+ * pages still mix large read-only peer traversals with HTML-shaped rendering, while request-context
+ * form generation remains in the HTTP layer. Callers therefore request one detached page snapshot
+ * per render rather than a reusable peer-management API or a monolithic full-page HTML blob.
+ *
+ * <p>The port is read-only. It does not perform access control, does not model POST mutations, and
+ * does not expose daemon-only types such as {@code Node}, {@code NodeClientCore}, {@code
+ * PeerNodeStatus}, {@code HTMLNode}, or {@code ToadletContext}. Implementations may traverse the
+ * live daemon state while producing one snapshot, but callers receive only immutable JDK-only DTOs
+ * that are safe to retain for the lifetime of one request.
+ *
+ * @see ConnectionsPageRequest
+ * @see ConnectionsPageSnapshot
+ */
+public interface ConnectionsPagePort {
+  /**
+   * Returns one detached snapshot of the requested legacy connections page.
+   *
+   * <p>The returned snapshot preserves the current page-oriented structure: outer content before
+   * the peer table, the peer table fragment itself, and any trailing content after the table. The
+   * HTTP layer remains responsible for request-context-only behavior such as alert summaries and
+   * form wrapping.
+   *
+   * @param request detached render request describing the page kind and active view flags
+   * @return immutable connections-page snapshot for the requested render
+   */
+  ConnectionsPageSnapshot render(ConnectionsPageRequest request);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPageRequest.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPageRequest.java
@@ -1,0 +1,34 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Immutable request parameters for one detached legacy connections-page render.
+ *
+ * <p>The legacy connections area is still page-oriented rather than API-oriented, so callers pass
+ * the small set of request flags that influence how the historical page is assembled: which peer
+ * set to read, whether advanced sections are enabled, whether the message-type drill-down is
+ * active, and how the peer rows should be sorted. The record remains JDK-only and does not expose
+ * HTTP or daemon-owned types.
+ *
+ * @param kind which legacy connections page should be rendered?
+ * @param advancedMode whether advanced-only sections and columns should be included
+ * @param drawMessageTypes whether per-peer message-type rows should be included
+ * @param sortBy requested sort key, or {@code null} to keep default ordering
+ * @param reversed whether the selected sort should be inverted
+ */
+public record ConnectionsPageRequest(
+    ConnectionsPageKind kind,
+    boolean advancedMode,
+    boolean drawMessageTypes,
+    String sortBy,
+    boolean reversed) {
+  /**
+   * Creates a detached connections-page render request.
+   *
+   * @throws NullPointerException if {@code kind} is {@code null}
+   */
+  public ConnectionsPageRequest {
+    Objects.requireNonNull(kind, "kind");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPageSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsPageSnapshot.java
@@ -1,0 +1,39 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Detached snapshot of one legacy connections-page render.
+ *
+ * <p>The snapshot carries the page title, peer count, whether the peer table must be wrapped in a
+ * request-context form, and three detached HTML fragments. The outer HTTP layer still owns alert
+ * injection, access checks, reply writing, and form-password handling, so the adapter returns the
+ * peer-table fragment separately from the surrounding content. This keeps the SPI page-oriented and
+ * practical without leaking {@code ToadletContext}, {@code HTMLNode}, or daemon peer types.
+ *
+ * @param pageTitle localized page title for the response shell
+ * @param peerCount number of peers included in the rendered page snapshot
+ * @param peerActionsEnabled whether the peer table content expects a request-context form wrapper
+ * @param contentHtmlBeforePeerTable detached HTML fragment emitted before {@code peerTableHtml}
+ * @param peerTableHtml detached peer-table fragment, or other peer-section body content
+ * @param contentHtmlAfterPeerTable detached HTML fragment emitted after {@code peerTableHtml}
+ */
+public record ConnectionsPageSnapshot(
+    String pageTitle,
+    int peerCount,
+    boolean peerActionsEnabled,
+    String contentHtmlBeforePeerTable,
+    String peerTableHtml,
+    String contentHtmlAfterPeerTable) {
+  /**
+   * Creates an immutable connections-page snapshot.
+   *
+   * @throws NullPointerException if any HTML fragment or the page title is {@code null}
+   */
+  public ConnectionsPageSnapshot {
+    Objects.requireNonNull(pageTitle, "pageTitle");
+    Objects.requireNonNull(contentHtmlBeforePeerTable, "contentHtmlBeforePeerTable");
+    Objects.requireNonNull(peerTableHtml, "peerTableHtml");
+    Objects.requireNonNull(contentHtmlAfterPeerTable, "contentHtmlAfterPeerTable");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -20,6 +20,7 @@ package network.crypta.runtime.spi;
  * @see LifecyclePort
  * @see ConfigPort
  * @see ConnectivityPort
+ * @see ConnectionsPagePort
  * @see DiagnosticPort
  * @see StatisticsPort
  * @see NodeInfoPort
@@ -97,6 +98,20 @@ public interface RuntimePorts {
    * @return connectivity runtime port for read-only connectivity snapshots
    */
   ConnectivityPort connectivity();
+
+  /**
+   * Returns the legacy connections-page capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port lets higher layers request one detached page snapshot for either the darknet
+   * friends page or the opennet strangers page without depending on daemon-only node, peer, stats,
+   * or HTML builder types. Request-context-only concerns such as alert summaries and form-password
+   * protected peer-action wrappers remain in the HTTP layer, but the returned object keeps the
+   * large legacy peer traversal, sorting, and HTML fragment rendering inside the daemon root
+   * module.
+   *
+   * @return connections-page runtime port for detached legacy friends and strangers snapshots
+   */
+  ConnectionsPagePort connectionsPage();
 
   /**
    * Returns the diagnostic-report capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -5,13 +5,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringTokenizer;
@@ -20,12 +16,9 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.fcp.AddPeer;
 import network.crypta.clients.http.complexhtmlnodes.PeerTrustInputForAddPeerBoxNode;
 import network.crypta.clients.http.complexhtmlnodes.PeerVisibilityInputForAddPeerBoxNode;
-import network.crypta.clients.http.geoip.IPConverter.Country;
-import network.crypta.clients.http.geoip.IPConverter;
 import network.crypta.config.ConfigException;
 import network.crypta.io.comm.PeerParseException;
 import network.crypta.io.comm.ReferenceSignatureVerificationException;
-import network.crypta.io.xfer.PacketThrottle;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
@@ -34,30 +27,23 @@ import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.FSParseException;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.NodeFile;
-import network.crypta.node.NodeStats;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNode;
-import network.crypta.node.PeerNodeLoadTracker.IncomingLoadSummaryStats;
 import network.crypta.node.PeerNodeStatus;
-import network.crypta.node.PeerStatusCounts;
 import network.crypta.node.PeerTooOldException;
 import network.crypta.node.Version;
+import network.crypta.runtime.spi.ConnectionsPageKind;
+import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.ConnectionsPageRequest;
+import network.crypta.runtime.spi.ConnectionsPageSnapshot;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.SizeUtil;
-import network.crypta.support.TimeUtil;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.io.FileUtil;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Base HTTP toadlet used by both darknet and opennet connection pages.
@@ -91,17 +77,11 @@ public abstract class ConnectionsToadlet extends Toadlet {
   private static final String INFOBOX_HEADER_CLASS = "infobox-header";
   private static final String INFOBOX_CONTENT_CLASS = "infobox-content";
   private static final String DISPLAY_MESSAGE_TYPES = "displaymessagetypes.html";
-  private static final String DARKNET_CONNECTIONS = "darknet_connections";
-  private static final String ATTR_TITLE = "title";
-  private static final String ATTR_STYLE = "style";
-  private static final String HELP_STYLE = "border-bottom: 1px dotted; cursor: help;";
   private static final String ELEMENT_INPUT = "input";
   private static final String TRUST = "trust";
-  private static final String COUNT = "count";
   private static final String REF_FILE = "reffile";
   private static final String PEER_PRIVATE_NOTE = "peerPrivateNote";
   private static final String REPORT_OF_NODE_ADDITION = "reportOfNodeAddition";
-  private static final String PEER_IDLE_CLASS = "peer-idle";
 
   /**
    * Comparator that orders {@link PeerNodeStatus} instances for table rendering.
@@ -111,7 +91,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * callers can reuse one comparator for ascending and descending views without allocating extra
    * helpers.
    */
-  protected class ComparatorByStatus implements Comparator<PeerNodeStatus> {
+  protected static class ComparatorByStatus implements Comparator<PeerNodeStatus> {
     /** Column key requested by the client, may be {@code null} for default ordering. */
     protected final String sortBy;
 
@@ -138,7 +118,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
      */
     @Override
     public int compare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      isReversed = reversed;
       int result = compareWithSort(firstNode, secondNode);
       if (result == 0) {
         result = compareByStatus(firstNode, secondNode);
@@ -267,17 +246,11 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /** Core services used for filesystem paths, configuration, and network integration. */
   protected final NodeClientCore core;
 
-  /** Node statistics helper used to populate dashboard sections. */
-  protected final NodeStats stats;
-
   /** Peer manager providing live peer state and addition helpers. */
   protected final PeerManager peers;
 
-  /** Tracks whether the user requested the current comparator reversed flag. */
-  protected boolean isReversed = false;
-
-  /** Whether trivial FOAF connections should be displayed alongside non-trivial groups. */
-  protected boolean showTrivialFoafConnections = false;
+  /** Page-oriented runtime port used for detached GET-only connections page rendering. */
+  private final ConnectionsPagePort connectionsPage;
 
   /**
    * Outcomes returned when attempting to add a peer from a supplied noderef.
@@ -310,27 +283,20 @@ public abstract class ConnectionsToadlet extends Toadlet {
    *     noderef files.
    * @param client high-level client used to retrieve noderefs via Freenet or HTTP when users submit
    *     URLs instead of pasted references.
+   * @param connectionsPage read-only runtime page port backing the detached GET render path.
    */
-  protected ConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
+  protected ConnectionsToadlet(
+      Node n,
+      NodeClientCore core,
+      HighLevelSimpleClient client,
+      ConnectionsPagePort connectionsPage) {
     super(client);
     this.node = n;
     this.core = core;
-    this.stats = n.network().stats();
     this.peers = n.network().peers();
+    this.connectionsPage = Objects.requireNonNull(connectionsPage);
     refLink = HTMLNode.link(path() + "myref.fref").setReadOnly();
     reftextLink = HTMLNode.link(path() + "myref.txt").setReadOnly();
-  }
-
-  abstract SimpleColumn[] endColumnHeaders(boolean advancedModeEnabled);
-
-  abstract static class SimpleColumn {
-    protected abstract void drawColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus);
-
-    public abstract String getSortString();
-
-    public abstract String getTitleKey();
-
-    public abstract String getExplanationKey();
   }
 
   /**
@@ -361,39 +327,36 @@ public abstract class ConnectionsToadlet extends Toadlet {
       return;
     }
 
-    DecimalFormat percentageFormat = new DecimalFormat("##0.0%");
     boolean drawMessageTypes = path.endsWith(DISPLAY_MESSAGE_TYPES);
-
-    PeerNodeStatus[] peerNodeStatuses = getPeerNodeStatuses(!drawMessageTypes);
-    Arrays.sort(
-        peerNodeStatuses,
-        comparator(request.getParam("sortBy", null), request.isParameterSet("reversed")));
-
-    PeerStatusCounts counts = computePeerStatusCounts(peerNodeStatuses);
-    String titleCountString = buildTitleCountString(counts);
-
-    PageNode page = ctx.getPageMaker().getPageNode(getPageTitle(titleCountString), ctx);
     boolean advancedMode = ctx.isAdvancedModeEnabled();
+    ConnectionsPageSnapshot snapshot =
+        connectionsPage.render(
+            new ConnectionsPageRequest(
+                isOpennet() ? ConnectionsPageKind.OPENNET : ConnectionsPageKind.DARKNET,
+                advancedMode,
+                drawMessageTypes,
+                request.getParam("sortBy", null),
+                request.isParameterSet("reversed")));
+
+    if (snapshot.peerCount() == 0 && !isOpennet()) {
+      throw new RedirectException(URI.create("/addfriend/"));
+    }
+
+    PageNode page = ctx.getPageMaker().getPageNode(snapshot.pageTitle(), ctx);
     HTMLNode contentNode = page.getContentNode();
-    long now = System.currentTimeMillis();
 
     if (ctx.isAllowedFullAccess()) {
       contentNode.addChild(ctx.getAlertManager().createSummary());
     }
 
-    RenderMode renderMode = new RenderMode(advancedMode, drawMessageTypes);
-    RenderTiming renderTiming = new RenderTiming(now, percentageFormat);
-    RenderContext renderContext =
-        new RenderContext(
-            new RenderPageContext(ctx, path, contentNode),
-            new RenderPeerSnapshot(peerNodeStatuses, counts),
-            renderMode,
-            renderTiming);
-    renderContent(renderContext);
-
-    if (peerNodeStatuses.length == 0) {
-      handleMissingPeers();
+    contentNode.addChild("%", snapshot.contentHtmlBeforePeerTable());
+    if (snapshot.peerActionsEnabled() && snapshot.peerCount() > 0) {
+      HTMLNode peerForm = ctx.addFormChild(contentNode, ".", "peersForm");
+      peerForm.addChild("%", snapshot.peerTableHtml());
+    } else {
+      contentNode.addChild("%", snapshot.peerTableHtml());
     }
+    contentNode.addChild("%", snapshot.contentHtmlAfterPeerTable());
 
     if (shouldDrawNoderefBox(advancedMode)) {
       drawAddPeerBox(contentNode, ctx);
@@ -426,807 +389,12 @@ public abstract class ConnectionsToadlet extends Toadlet {
     return false;
   }
 
-  private PeerStatusCounts computePeerStatusCounts(PeerNodeStatus[] peerNodeStatuses) {
-    int connected =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED);
-    int routingBackedOff =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF);
-    int tooNew =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW);
-    int tooOld =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD);
-    int disconnected =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED);
-    int neverConnected =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED);
-    int disabled =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED);
-    int bursting =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING);
-    int listening =
-        PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING);
-    int listenOnly =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY);
-    int routingDisabled =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED);
-    int clockProblem =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM);
-    int connError =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR);
-    int disconnecting =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING);
-    int noLoadStats =
-        PeerNodeStatus.getPeerStatusCount(
-            peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS);
-
-    return new PeerStatusCounts(
-        connected,
-        routingBackedOff,
-        tooNew,
-        tooOld,
-        disconnected,
-        neverConnected,
-        disabled,
-        bursting,
-        listening,
-        listenOnly,
-        0,
-        0,
-        routingDisabled,
-        clockProblem,
-        connError,
-        disconnecting,
-        noLoadStats);
-  }
-
-  private String buildTitleCountString(PeerStatusCounts counts) {
-    if (!node.isAdvancedModeEnabled()) {
-      int numberOfSimpleConnected = counts.connected() + counts.routingBackedOff();
-      int numberOfNotConnected = counts.notConnected();
-      return (numberOfNotConnected + numberOfSimpleConnected) > 0
-          ? String.valueOf(numberOfSimpleConnected)
-          : "";
-    }
-
-    return "("
-        + counts.connected()
-        + '/'
-        + counts.routingBackedOff()
-        + '/'
-        + counts.tooNew()
-        + '/'
-        + counts.tooOld()
-        + '/'
-        + counts.noLoadStats()
-        + '/'
-        + counts.routingDisabled()
-        + '/'
-        + counts.notConnected()
-        + ')';
-  }
-
-  private void renderContent(RenderContext renderContext) {
-    if (renderContext.advancedMode()) {
-      addOverviewSection(
-          renderContext.contentNode(),
-          renderContext.percentageFormat(),
-          renderContext.now(),
-          renderContext.counts());
-    }
-
-    addPeerTableSection(renderContext);
-
-    if (renderContext.advancedMode()) {
-      addFoafTable(renderContext.contentNode(), renderContext.peerNodeStatuses());
-    }
-  }
-
-  private void addOverviewSection(
-      HTMLNode contentNode, DecimalFormat percentageFormat, long now, PeerStatusCounts counts) {
-    long nodeUptimeSeconds = SECONDS.convert(now - node.getStartupTime(), MILLISECONDS);
-    int bwlimitDelayTime = (int) stats.getBwlimitDelayTime();
-    int nodeAveragePingTime = (int) stats.getNodeAveragePingTime();
-    int networkSizeEstimateSession = stats.getDarknetSizeEstimate(-1);
-    int networkSizeEstimateRecent = 0;
-    if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
-      networkSizeEstimateRecent = stats.getDarknetSizeEstimate(now - HOURS.toMillis(48));
-    }
-    DecimalFormat routingFormat = new DecimalFormat("0.0000");
-    double routingMissDistanceLocal = stats.routingMissDistanceLocal.currentValue();
-    double routingMissDistanceRemote = stats.routingMissDistanceRemote.currentValue();
-    double routingMissDistanceOverall = stats.routingMissDistanceOverall.currentValue();
-    double routingMissDistanceBulk = stats.routingMissDistanceBulk.currentValue();
-    double routingMissDistanceRT = stats.routingMissDistanceRT.currentValue();
-    double backedOffPercent = stats.backedOffPercent.currentValue();
-    String nodeUptimeString = TimeUtil.formatTime(MILLISECONDS.convert(nodeUptimeSeconds, SECONDS));
-
-    HTMLNode overviewTable = contentNode.addChild(ELEMENT_TABLE, ATTR_CLASS, "column");
-    HTMLNode overviewTableRow = overviewTable.addChild("tr");
-    HTMLNode nextTableCell = overviewTableRow.addChild("td", ATTR_CLASS, "first");
-
-    HTMLNode overviewInfobox = nextTableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
-    overviewInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, "Node status overview");
-    HTMLNode overviewInfoboxContent =
-        overviewInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
-    HTMLNode overviewList = overviewInfoboxContent.addChild("ul");
-    overviewList.addChild("li", "bwlimitDelayTime:\u00a0" + bwlimitDelayTime + "ms");
-    overviewList.addChild("li", "nodeAveragePingTime:\u00a0" + nodeAveragePingTime + "ms");
-    overviewList.addChild(
-        "li", "darknetSizeEstimateSession:\u00a0" + networkSizeEstimateSession + "\u00a0nodes");
-    if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
-      overviewList.addChild(
-          "li", "darknetSizeEstimateRecent:\u00a0" + networkSizeEstimateRecent + "\u00a0nodes");
-    }
-    overviewList.addChild("li", "nodeUptime:\u00a0" + nodeUptimeString);
-    overviewList.addChild(
-        "li", "routingMissDistanceLocal:\u00a0" + routingFormat.format(routingMissDistanceLocal));
-    overviewList.addChild(
-        "li", "routingMissDistanceRemote:\u00a0" + routingFormat.format(routingMissDistanceRemote));
-    overviewList.addChild(
-        "li",
-        "routingMissDistanceOverall:\u00a0" + routingFormat.format(routingMissDistanceOverall));
-    overviewList.addChild(
-        "li", "routingMissDistanceBulk:\u00a0" + routingFormat.format(routingMissDistanceBulk));
-    overviewList.addChild(
-        "li", "routingMissDistanceRT:\u00a0" + routingFormat.format(routingMissDistanceRT));
-    overviewList.addChild(
-        "li", "backedOffPercent:\u00a0" + percentageFormat.format(backedOffPercent));
-    overviewList.addChild(
-        "li", "pInstantReject:\u00a0" + percentageFormat.format(stats.pRejectIncomingInstantly()));
-    nextTableCell = overviewTableRow.addChild("td");
-
-    addActivitySection(nextTableCell, nodeUptimeSeconds);
-    addPeerStatsSection(nextTableCell, counts);
-  }
-
-  private void addActivitySection(HTMLNode tableCell, long nodeUptimeSeconds) {
-    int numARKFetchers = node.network().numArkFetchers();
-
-    HTMLNode activityInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
-    activityInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, l10n("activityTitle"));
-    HTMLNode activityInfoboxContent =
-        activityInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
-    HTMLNode activityList = StatisticsToadlet.drawActivity(activityInfoboxContent, node);
-    if (activityList != null) {
-      if (numARKFetchers > 0) {
-        activityList.addChild("li", "ARK\u00a0Fetch\u00a0Requests:\u00a0" + numARKFetchers);
-      }
-      StatisticsToadlet.drawBandwidth(activityList, node, nodeUptimeSeconds);
-    }
-  }
-
-  private void addPeerStatsSection(HTMLNode tableCell, PeerStatusCounts counts) {
-    HTMLNode peerStatsInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
-    StatisticsToadlet.drawPeerStatsBox(peerStatsInfobox, true, counts, node);
-
-    addBackoffReasonBoxes(tableCell);
-  }
-
-  private void addBackoffReasonBoxes(HTMLNode tableCell) {
-    addBackoffReasonBox(tableCell, true, "Peer backoff reasons (realtime)");
-    addBackoffReasonBox(tableCell, false, "Peer backoff reasons (bulk)");
-  }
-
-  private void addBackoffReasonBox(HTMLNode tableCell, boolean realtime, String headerText) {
-    HTMLNode backoffReasonInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
-    HTMLNode title =
-        backoffReasonInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, headerText);
-    HTMLNode backoffReasonContent =
-        backoffReasonInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
-    String[] routingBackoffReasons = peers.getPeerNodeRoutingBackoffReasons(realtime);
-    int total = 0;
-    if (routingBackoffReasons.length == 0) {
-      backoffReasonContent.addChild(
-          "#", NodeL10n.getBase().getString("StatisticsToadlet.notBackedOff"));
-    } else {
-      HTMLNode reasonList = backoffReasonContent.addChild("ul");
-      for (String routingBackoffReason : routingBackoffReasons) {
-        int reasonCount = peers.getPeerNodeRoutingBackoffReasonSize(routingBackoffReason, realtime);
-        if (reasonCount > 0) {
-          total += reasonCount;
-          reasonList.addChild("li", routingBackoffReason + '\u00a0' + reasonCount);
-        }
-      }
-    }
-    if (total > 0) {
-      title.addChild("#", ": " + total);
-    }
-  }
-
-  private void addPeerTableSection(RenderContext renderContext) {
-    boolean enablePeerActions = showPeerActionsBox();
-    boolean fProxyJavascriptEnabled = node.isFProxyJavascriptEnabled();
-
-    if (fProxyJavascriptEnabled) {
-      injectJavascript(renderContext.contentNode());
-    }
-
-    HTMLNode peerTableInfobox =
-        renderContext.contentNode().addChild("div", ATTR_CLASS, INFOBOX_NORMAL_CLASS);
-    HTMLNode peerTableInfoboxHeader =
-        peerTableInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS);
-    peerTableInfoboxHeader.addChild("#", getPeerListTitle());
-    if (renderContext.advancedMode() && !renderContext.path().endsWith(DISPLAY_MESSAGE_TYPES)) {
-      peerTableInfoboxHeader.addChild("#", " ");
-      peerTableInfoboxHeader.addChild(
-          "a", "href", DISPLAY_MESSAGE_TYPES, l10n("bracketedMoreDetailed"));
-    }
-    HTMLNode peerTableInfoboxContent =
-        peerTableInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
-
-    if (!isOpennet()) {
-      addNameSection(peerTableInfoboxContent);
-    }
-
-    if (renderContext.peerNodeStatuses().length == 0) {
-      addNoPeersMessage(peerTableInfoboxContent);
-      return;
-    }
-
-    PeerTableContext peerTableContext =
-        buildPeerTable(
-            renderContext.ctx(),
-            peerTableInfoboxContent,
-            enablePeerActions,
-            fProxyJavascriptEnabled,
-            renderContext.advancedMode());
-
-    fillPeerTable(
-        peerTableContext,
-        renderContext.peerNodeStatuses(),
-        renderContext.drawMessageTypes(),
-        renderContext.percentageFormat(),
-        renderContext.advancedMode(),
-        renderContext.now());
-  }
-
-  private void injectJavascript(HTMLNode contentNode) {
-    String js =
-        """
-          function peerNoteChange() {
-            document.getElementById("action").value = "update_notes";            document.getElementById("peersForm").doAction.click();
-          }
-        """;
-    contentNode.addChild("script", "type", "text/javascript").addChild("%", js);
-    contentNode.addChild(
-        "script",
-        new String[] {"type", "src"},
-        new String[] {"text/javascript", "/static/js/checkall.js"});
-  }
-
-  private void addNameSection(HTMLNode peerTableInfoboxContent) {
-    HTMLNode myName = peerTableInfoboxContent.addChild("p");
-    myName.addChild(
-        "span",
-        NodeL10n.getBase().getString("DarknetConnectionsToadlet.myName", "name", node.getMyName()));
-    myName.addChild("span", " [");
-    myName
-        .addChild("span")
-        .addChild(
-            "a",
-            "href",
-            "/config/node#name",
-            NodeL10n.getBase().getString("DarknetConnectionsToadlet.changeMyName"));
-    myName.addChild("span", "]");
-  }
-
-  private void addNoPeersMessage(HTMLNode peerTableInfoboxContent) {
-    NodeL10n.getBase()
-        .addL10nSubstitution(
-            peerTableInfoboxContent,
-            "DarknetConnectionsToadlet.noPeersWithHomepageLink",
-            new String[] {"link"},
-            new HTMLNode[] {HTMLNode.link("/")});
-  }
-
-  private PeerTableContext buildPeerTable(
-      ToadletContext ctx,
-      HTMLNode peerTableInfoboxContent,
-      boolean enablePeerActions,
-      boolean fProxyJavascriptEnabled,
-      boolean advancedMode) {
-    HTMLNode peerForm = null;
-    HTMLNode peerTable;
-    if (enablePeerActions) {
-      peerForm = ctx.addFormChild(peerTableInfoboxContent, ".", "peersForm");
-      peerTable = peerForm.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
-    } else {
-      peerTable = peerTableInfoboxContent.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
-    }
-    HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
-    addPeerTableHeader(
-        enablePeerActions, fProxyJavascriptEnabled, peerTableHeaderRow, advancedMode);
-
-    SimpleColumn[] endCols = endColumnHeaders(advancedMode);
-    if (endCols != null) {
-      for (SimpleColumn col : endCols) {
-        HTMLNode header = peerTableHeaderRow.addChild("th");
-        String sortString = col.getSortString();
-        if (sortString != null) {
-          header = header.addChild("a", "href", sortString(isReversed, sortString));
-        }
-        header.addChild(
-            "span",
-            new String[] {ATTR_TITLE, ATTR_STYLE},
-            new String[] {NodeL10n.getBase().getString(col.getExplanationKey()), HELP_STYLE},
-            NodeL10n.getBase().getString(col.getTitleKey()));
-      }
-    }
-
-    List<SimpleColumn> endColsList = endCols == null ? List.of() : List.of(endCols);
-    return new PeerTableContext(peerForm, peerTable, endColsList);
-  }
-
-  private void addPeerTableHeader(
-      boolean enablePeerActions,
-      boolean fProxyJavascriptEnabled,
-      HTMLNode peerTableHeaderRow,
-      boolean advancedMode) {
-    if (enablePeerActions) {
-      if (fProxyJavascriptEnabled) {
-        peerTableHeaderRow
-            .addChild("th")
-            .addChild(
-                ELEMENT_INPUT,
-                new String[] {"type", "onclick"},
-                new String[] {"checkbox", "checkAll(this, 'darknet_connections')"});
-      } else {
-        peerTableHeaderRow.addChild("th");
-      }
-    }
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "status"))
-        .addChild("#", l10n("statusTitle"));
-    if (hasNameColumn()) {
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "name"))
-          .addChild(
-              "span",
-              new String[] {ATTR_TITLE, ATTR_STYLE},
-              new String[] {l10n("nameClickToMessage"), HELP_STYLE},
-              l10n("nameTitle"));
-    }
-    if (hasTrustColumn()) {
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, TRUST))
-          .addChild(
-              "span",
-              new String[] {ATTR_TITLE, ATTR_STYLE},
-              new String[] {l10n("trustMessage"), HELP_STYLE},
-              l10n("trustTitle"));
-    }
-    if (hasVisibilityColumn()) {
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, TRUST))
-          .addChild(
-              "span",
-              new String[] {ATTR_TITLE, ATTR_STYLE},
-              new String[] {
-                l10n("visibilityMessage" + (advancedMode ? "Advanced" : "Simple")), HELP_STYLE
-              },
-              l10n("visibilityTitle"));
-    }
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "address"))
-        .addChild(
-            "span",
-            new String[] {ATTR_TITLE, ATTR_STYLE},
-            new String[] {l10n("ipAddress"), HELP_STYLE},
-            l10n("ipAddressTitle"));
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "version"))
-        .addChild("#", l10n("versionTitle"));
-    if (advancedMode) {
-      addAdvancedPeerTableHeaders(peerTableHeaderRow);
-    }
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "idle"))
-        .addChild(
-            "span",
-            new String[] {ATTR_TITLE, ATTR_STYLE},
-            new String[] {l10n("idleTime"), HELP_STYLE},
-            l10n("idleTimeTitle"));
-    if (hasPrivateNoteColumn()) {
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "privnote"))
-          .addChild(
-              "span",
-              new String[] {ATTR_TITLE, ATTR_STYLE},
-              new String[] {l10n("privateNote"), HELP_STYLE},
-              l10n("privateNoteTitle"));
-    }
-
-    if (advancedMode) {
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "time_routable"))
-          .addChild("#", "%\u00a0Time Routable");
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "selection_percentage"))
-          .addChild("#", "%\u00a0Selection");
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "total_traffic"))
-          .addChild("#", "Total\u00a0Traffic\u00a0(in/out/resent)");
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "total_traffic_since_startup"))
-          .addChild("#", "Total\u00a0Traffic\u00a0(in/out) since startup");
-      peerTableHeaderRow.addChild("th", "Congestion\u00a0Control");
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "time_delta"))
-          .addChild("#", "Time\u00a0Delta");
-      peerTableHeaderRow
-          .addChild("th")
-          .addChild("a", "href", sortString(isReversed, "uptime"))
-          .addChild("#", "Reported\u00a0Uptime");
-      peerTableHeaderRow.addChild("th", "Transmit\u00a0Queue");
-      peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Bulk");
-      peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Realtime");
-    }
-  }
-
-  private void addAdvancedPeerTableHeaders(HTMLNode peerTableHeaderRow) {
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "location"))
-        .addChild("#", l10n("locationTitle"));
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "backoffRT"))
-        .addChild(
-            "span",
-            new String[] {ATTR_TITLE, ATTR_STYLE},
-            new String[] {
-              "Other node busy (realtime)? Display: Percentage of time the node is"
-                  + " overloaded, Current wait time remaining (0=not overloaded)/total/last"
-                  + " overload reason",
-              HELP_STYLE
-            },
-            "Backoff (realtime)");
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "backoffBulk"))
-        .addChild(
-            "span",
-            new String[] {ATTR_TITLE, ATTR_STYLE},
-            new String[] {
-              "Other node busy (bulk)? Display: Percentage of time the node is overloaded,"
-                  + " Current wait time remaining (0=not overloaded)/total/last overload"
-                  + " reason",
-              HELP_STYLE
-            },
-            "Backoff (bulk)");
-
-    peerTableHeaderRow
-        .addChild("th")
-        .addChild("a", "href", sortString(isReversed, "overload_p"))
-        .addChild(
-            "span",
-            new String[] {ATTR_TITLE, ATTR_STYLE},
-            new String[] {
-              "Probability of the node rejecting a request due to overload or causing a timeout.",
-              HELP_STYLE
-            },
-            "Overload Probability");
-  }
-
-  private void fillPeerTable(
-      PeerTableContext peerTableContext,
-      PeerNodeStatus[] peerNodeStatuses,
-      boolean drawMessageTypes,
-      DecimalFormat percentageFormat,
-      boolean advancedMode,
-      long now) {
-    double totalSelectionRate = 0.0;
-    RenderMode renderMode = new RenderMode(advancedMode, drawMessageTypes);
-    RenderTiming renderTiming = new RenderTiming(now, percentageFormat);
-    PeerNodeStatus[] allPeerNodeStatuses =
-        node.network().peers().statusBook().getPeerNodeStatuses(true);
-    for (PeerNodeStatus status : allPeerNodeStatuses) {
-      totalSelectionRate += status.getSelectionRate();
-    }
-    for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
-      RowContext rowContext =
-          new RowContext(
-              new PeerRowContext(
-                  peerTableContext.peerTable(), peerNodeStatus, peerTableContext.endCols()),
-              renderMode,
-              new PeerRowFlags(
-                  node.isFProxyJavascriptEnabled(), peerTableContext.peerForm() != null),
-              renderTiming,
-              new PeerSelectionStats(totalSelectionRate));
-      drawRow(rowContext);
-    }
-
-    if (peerTableContext.peerForm() != null) {
-      drawPeerActionSelectBox(peerTableContext.peerForm(), advancedMode);
-    }
-  }
-
-  private void addFoafTable(HTMLNode peerTableInfoboxContent, PeerNodeStatus[] peerNodeStatuses) {
-    FoafGrouping grouping = buildFoafGrouping(peerNodeStatuses);
-    addFoafSummary(peerTableInfoboxContent, grouping);
-    addFoafRows(peerTableInfoboxContent, peerNodeStatuses, grouping);
-  }
-
-  private void addFoafSummary(HTMLNode peerTableInfoboxContent, FoafGrouping grouping) {
-    peerTableInfoboxContent.addChild(
-        "b",
-        l10nCount(
-            "secondDegreeConnectionsCountTitle", Integer.toString(grouping.locations().size())));
-    peerTableInfoboxContent.addChild("br");
-    if (!showTrivialFoafConnections) {
-      peerTableInfoboxContent.addChild(
-          "i",
-          l10nCount("secondDegreeTrivialHiddenCount", Integer.toString(grouping.trivialCount())));
-    } else {
-      peerTableInfoboxContent.addChild(
-          "i",
-          l10nCount("secondDegreeNonTrivialCount", Integer.toString(grouping.nonTrivialCount())));
-    }
-  }
-
-  private void addFoafRows(
-      HTMLNode peerTableInfoboxContent, PeerNodeStatus[] peerNodeStatuses, FoafGrouping grouping) {
-    HTMLNode foafTable =
-        peerTableInfoboxContent.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
-    HTMLNode foafRow = foafTable.addChild("tr");
-    foafRow.addChild("th", l10n("locationTitle"));
-    foafRow.addChild("th", l10n("countTitle"));
-    foafRow.addChild("th", l10n("foafReachableThroughTitle"));
-    int max = grouping.locations().size();
-    int transitiveCount = 0;
-    for (int i = 0; i < max; i++) {
-      double location = grouping.locations().get(i);
-      List<PeerNodeStatus> peersWithFriend = grouping.peerGroups().get(i);
-      boolean isTransitivePeer = isTransitivePeer(peerNodeStatuses, location);
-      if (peersWithFriend.size() == 1 && !showTrivialFoafConnections && !isTransitivePeer) {
-        continue;
-      }
-      foafRow = foafTable.addChild("tr");
-      if (isTransitivePeer) {
-        foafRow.addChild("td").addChild("b", String.valueOf(location));
-      } else {
-        foafRow.addChild("td", String.valueOf(location));
-      }
-      foafRow.addChild("td", String.valueOf(peersWithFriend.size()));
-      HTMLNode locationCell = foafRow.addChild("td", ATTR_CLASS, "peer-location");
-      for (PeerNodeStatus peerNodeStatus : peersWithFriend) {
-        String address =
-            (peerNodeStatus.getPeerAddress() != null)
-                ? peerNodeStatus.getPeerAddressAndPort()
-                : l10n("unknownAddress");
-        locationCell.addChild("i", address);
-        locationCell.addChild("br");
-      }
-      if (isTransitivePeer) {
-        transitiveCount++;
-      }
-    }
-    if (transitiveCount > 0) {
-      peerTableInfoboxContent.addChild(
-          "i", l10nCount("secondDegreeAlsoOurs", Integer.toString(transitiveCount)));
-    }
-  }
-
-  private FoafGrouping buildFoafGrouping(PeerNodeStatus[] peerNodeStatuses) {
-    List<Double> locations = new ArrayList<>();
-    List<List<PeerNodeStatus>> peerGroups = new ArrayList<>();
-    for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
-      double[] peersLoc = peerNodeStatus.getPeersLocation();
-      if (peersLoc == null) {
-        continue;
-      }
-      for (double location : peersLoc) {
-        int i = 0;
-        int max = locations.size();
-        while (i < max && locations.get(i) < location) {
-          i++;
-        }
-        List<PeerNodeStatus> peerGroup;
-        if (i < max && locations.get(i) == location) {
-          peerGroup = peerGroups.get(i);
-        } else {
-          peerGroup = new ArrayList<>();
-          locations.add(i, location);
-          peerGroups.add(i, peerGroup);
-        }
-        peerGroup.add(peerNodeStatus);
-      }
-    }
-    return new FoafGrouping(locations, peerGroups);
-  }
-
-  private boolean isTransitivePeer(PeerNodeStatus[] peerNodeStatuses, double location) {
-    for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
-      if (location == peerNodeStatus.getLocation()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private void handleMissingPeers() throws RedirectException {
-    if (isOpennet()) {
-      return;
-    }
-    throw new RedirectException(URI.create("/addfriend/"));
-  }
-
-  private record PeerTableContext(
-      HTMLNode peerForm, HTMLNode peerTable, List<SimpleColumn> endCols) {}
-
-  private record FoafGrouping(List<Double> locations, List<List<PeerNodeStatus>> peerGroups) {
-    int trivialCount() {
-      return (int) peerGroups.stream().filter(list -> list.size() == 1).count();
-    }
-
-    int nonTrivialCount() {
-      return (int) peerGroups.stream().filter(list -> list.size() > 1).count();
-    }
-  }
-
   private record AddPeerRequestData(
       String urltext,
       String reftext,
       String privateComment,
       FRIEND_TRUST trust,
       FRIEND_VISIBILITY visibility) {}
-
-  private record RenderPageContext(ToadletContext ctx, String path, HTMLNode contentNode) {}
-
-  @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
-  private static final class RenderPeerSnapshot {
-    private final PeerNodeStatus[] peerNodeStatuses;
-    private final PeerStatusCounts counts;
-
-    private RenderPeerSnapshot(PeerNodeStatus[] peerNodeStatuses, PeerStatusCounts counts) {
-      this.peerNodeStatuses = peerNodeStatuses;
-      this.counts = counts;
-    }
-
-    PeerNodeStatus[] peerNodeStatuses() {
-      return peerNodeStatuses;
-    }
-
-    PeerStatusCounts counts() {
-      return counts;
-    }
-  }
-
-  private record RenderMode(boolean advancedModeEnabled, boolean drawMessageTypes) {}
-
-  private record RenderTiming(long now, DecimalFormat percentageFormat) {}
-
-  @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
-  private static final class RenderContext {
-    private final RenderPageContext pageContext;
-    private final RenderPeerSnapshot peerSnapshot;
-    private final RenderMode renderMode;
-    private final RenderTiming renderTiming;
-
-    private RenderContext(
-        RenderPageContext pageContext,
-        RenderPeerSnapshot peerSnapshot,
-        RenderMode renderMode,
-        RenderTiming renderTiming) {
-      this.pageContext = pageContext;
-      this.peerSnapshot = peerSnapshot;
-      this.renderMode = renderMode;
-      this.renderTiming = renderTiming;
-    }
-
-    ToadletContext ctx() {
-      return pageContext.ctx();
-    }
-
-    String path() {
-      return pageContext.path();
-    }
-
-    PeerNodeStatus[] peerNodeStatuses() {
-      return peerSnapshot.peerNodeStatuses();
-    }
-
-    boolean drawMessageTypes() {
-      return renderMode.drawMessageTypes();
-    }
-
-    DecimalFormat percentageFormat() {
-      return renderTiming.percentageFormat();
-    }
-
-    boolean advancedMode() {
-      return renderMode.advancedModeEnabled();
-    }
-
-    HTMLNode contentNode() {
-      return pageContext.contentNode();
-    }
-
-    long now() {
-      return renderTiming.now();
-    }
-
-    PeerStatusCounts counts() {
-      return peerSnapshot.counts();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (!(o instanceof RenderContext that)) return false;
-      return Objects.equals(pageContext, that.pageContext)
-          && Objects.equals(renderMode, that.renderMode)
-          && Objects.equals(renderTiming, that.renderTiming)
-          && Objects.equals(peerSnapshot.counts(), that.peerSnapshot.counts())
-          && Arrays.equals(peerSnapshot.peerNodeStatuses(), that.peerSnapshot.peerNodeStatuses());
-    }
-
-    @Override
-    public int hashCode() {
-      int result = Objects.hash(pageContext, renderMode, renderTiming, peerSnapshot.counts());
-      result = 31 * result + Arrays.hashCode(peerSnapshot.peerNodeStatuses());
-      return result;
-    }
-
-    @Override
-    public @NotNull String toString() {
-      return "RenderContext{"
-          + "ctx="
-          + pageContext.ctx()
-          + ", path='"
-          + pageContext.path()
-          + '\''
-          + ", peerNodeStatuses="
-          + Arrays.toString(peerSnapshot.peerNodeStatuses())
-          + ", drawMessageTypes="
-          + renderMode.drawMessageTypes()
-          + ", percentageFormat="
-          + renderTiming.percentageFormat()
-          + ", advancedMode="
-          + renderMode.advancedModeEnabled()
-          + ", contentNode="
-          + pageContext.contentNode()
-          + ", now="
-          + renderTiming.now()
-          + ", counts="
-          + peerSnapshot.counts()
-          + '}';
-    }
-  }
-
-  private record PeerRowContext(
-      HTMLNode peerTable, PeerNodeStatus peerNodeStatus, List<SimpleColumn> endCols) {}
-
-  private record PeerRowFlags(boolean fProxyJavascriptEnabled, boolean enablePeerActions) {}
-
-  private record PeerSelectionStats(double totalSelectionRate) {}
-
-  private record RowContext(
-      PeerRowContext peerRowContext,
-      RenderMode renderMode,
-      PeerRowFlags peerRowFlags,
-      RenderTiming renderTiming,
-      PeerSelectionStats selectionStats) {}
 
   /**
    * Indicates whether noderef POST submissions are accepted for this toadlet.
@@ -1499,7 +667,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
             .addChild(
                 new HTMLNode(
                     "tr",
-                    ATTR_STYLE,
+                    "style",
                     "color:" + (returnCode == PeerAdditionReturnCodes.OK ? "green" : "red")))
             .addChildren(
                 new HTMLNode[] {
@@ -1634,17 +802,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   /**
-   * Supplies the primary heading displayed above the peers table.
-   *
-   * <p>Implementations return a localization key or literal that signals whether the view targets
-   * darknet or opennet users. The value is combined with counts in {@link #buildTitleCountString}
-   * to form the browser-visible page title and the on-page heading.
-   *
-   * @return title text or localization key describing the current connection view.
-   */
-  protected abstract String getPeerListTitle();
-
-  /**
    * Indicates whether bulk peer actions should be presented to the user.
    *
    * <p>When {@code true}, the renderer adds checkboxes next to each peer row and invokes {@link
@@ -1738,18 +895,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   /**
-   * Computes the full page title, optionally including connection counts.
-   *
-   * <p>The title appears in the browser chrome and at the top of the page. Implementations may
-   * append the supplied count string or replace it entirely to match opennet/darknet conventions.
-   * The method should remain deterministic for a given count input to aid testing.
-   *
-   * @param titleCountString preformatted count string built from {@link PeerStatusCounts}.
-   * @return complete title text to render for the current request.
-   */
-  protected abstract String getPageTitle(String titleCountString);
-
-  /**
    * Draws the add-a-peer box that follows the main peers table.
    *
    * <p>The box includes textarea input, file upload control, and an optional private note field.
@@ -1835,469 +980,14 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   /**
-   * Retrieves peer statuses to render, optionally omitting heavy computations.
-   *
-   * @param noHeavy when {@code true}, callers request a lightweight snapshot without expensive
-   *     statistics; used for message-type drill-downs.
-   * @return array of peer statuses; never {@code null}, may be empty when no peers exist.
-   */
-  protected abstract PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy);
-
-  /**
    * Returns the node's own reference for download or display.
    *
    * @return immutable {@link SimpleFieldSet} representing this node's noderef.
    */
   protected abstract SimpleFieldSet getNoderef();
 
-  private void drawRow(RowContext rowContext) {
-    PeerNodeStatus peerNodeStatus = rowContext.peerRowContext().peerNodeStatus();
-    double totalSelectionRate = rowContext.selectionStats().totalSelectionRate();
-    DecimalFormat fix1 = rowContext.renderTiming().percentageFormat();
-    HTMLNode peerTable = rowContext.peerRowContext().peerTable();
-    boolean advancedModeEnabled = rowContext.renderMode().advancedModeEnabled();
-    boolean enablePeerActions = rowContext.peerRowFlags().enablePeerActions();
-    int peerSelectionPercentage = calculateSelectionPercentage(totalSelectionRate, peerNodeStatus);
-    HTMLNode peerRow =
-        peerTable.addChild(
-            "tr",
-            ATTR_CLASS,
-            "darknet_connections_"
-                + (peerSelectionPercentage > PeerNode.SELECTION_PERCENTAGE_WARNING
-                    ? "warning"
-                    : "normal"));
-
-    if (enablePeerActions) {
-      addSelectionCheckbox(peerRow, peerNodeStatus);
-    }
-
-    addStatusColumn(peerRow, peerNodeStatus, advancedModeEnabled);
-
-    drawNameColumn(peerRow, peerNodeStatus, advancedModeEnabled);
-    drawTrustColumn(peerRow, peerNodeStatus);
-    drawVisibilityColumn(peerRow, peerNodeStatus, advancedModeEnabled);
-    addAddressColumn(peerRow, peerNodeStatus);
-    addVersionColumn(peerRow, peerNodeStatus);
-
-    if (advancedModeEnabled) {
-      addLocationColumn(peerRow, peerNodeStatus);
-      addBackoffColumns(peerRow, peerNodeStatus, rowContext.renderTiming().now(), fix1);
-      addPRejectColumn(peerRow, peerNodeStatus, fix1);
-    }
-
-    addIdleColumn(peerRow, peerNodeStatus, rowContext.renderTiming().now());
-
-    if (hasPrivateNoteColumn()) {
-      drawPrivateNoteColumn(
-          peerRow, peerNodeStatus, rowContext.peerRowFlags().fProxyJavascriptEnabled());
-    }
-
-    if (advancedModeEnabled) {
-      addAdvancedStatistics(
-          peerRow, peerNodeStatus, fix1, peerSelectionPercentage, totalSelectionRate);
-    }
-
-    addEndColumns(peerRow, peerNodeStatus, rowContext.peerRowContext().endCols());
-
-    if (rowContext.renderMode().drawMessageTypes()) {
-      drawMessageTypes(peerTable, peerNodeStatus);
-    }
-  }
-
-  private int calculateSelectionPercentage(
-      double totalSelectionRate, PeerNodeStatus peerNodeStatus) {
-    if (totalSelectionRate <= 0) {
-      return 0;
-    }
-    return (int) (peerNodeStatus.getSelectionRate() * 100 / totalSelectionRate);
-  }
-
-  private void addSelectionCheckbox(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    peerRow
-        .addChild("td", ATTR_CLASS, "peer-marker")
-        .addChild(
-            ELEMENT_INPUT,
-            new String[] {"type", "name"},
-            new String[] {"checkbox", "node_" + peerNodeStatus.hashCode()});
-  }
-
-  private void addStatusColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
-    String statusString = peerNodeStatus.getStatusName();
-    if (!advancedModeEnabled
-        && (peerNodeStatus.getStatusValue() == PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF)) {
-      statusString = "BUSY";
-    }
-    final String key = "ConnectionsToadlet.nodeStatus." + statusString.replace(' ', '_');
-    peerRow
-        .addChild("td", ATTR_CLASS, "peer-status")
-        .addChild(
-            "span",
-            ATTR_CLASS,
-            peerNodeStatus.getStatusCSSName(),
-            NodeL10n.getBase().getString(key) + (peerNodeStatus.isFetchingARK() ? "*" : ""));
-  }
-
-  private void addAddressColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    String pingTime = "";
-    if (peerNodeStatus.isConnected()) {
-      pingTime =
-          " ("
-              + (int) peerNodeStatus.getAveragePingTime()
-              + "ms / "
-              + (int) peerNodeStatus.getAveragePingTimeCorrected()
-              + "ms)";
-    }
-    HTMLNode addressRow = peerRow.addChild("td", ATTR_CLASS, "peer-address");
-    IPConverter ipc = IPConverter.getInstance(NodeFile.IPV4_TO_COUNTRY.getFile(node));
-    byte[] addr = peerNodeStatus.getPeerAddressBytes();
-
-    Country country = ipc.locateIP(addr);
-    if (country != null) {
-      country.renderFlagIcon(addressRow);
-    }
-
-    String address =
-        peerNodeStatus.getPeerAddress() != null
-            ? peerNodeStatus.getPeerAddressAndPort()
-            : l10n("unknownAddress");
-    addressRow.addChild("#", address + pingTime);
-  }
-
-  private void addVersionColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    HTMLNode versionCell = peerRow.addChild("td", ATTR_CLASS, "peer-version");
-    if (peerNodeStatus.getStatusValue() != PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED
-        && (peerNodeStatus.isPublicInvalidVersion()
-            || peerNodeStatus.isPublicReverseInvalidVersion())) {
-      versionCell.addChild(
-          "span",
-          ATTR_CLASS,
-          "peer_version_problem",
-          Integer.toString(peerNodeStatus.getSimpleVersion()));
-      return;
-    }
-    versionCell.addChild("#", Integer.toString(peerNodeStatus.getSimpleVersion()));
-  }
-
-  private void addLocationColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    HTMLNode locationNode = peerRow.addChild("td", ATTR_CLASS, "peer-location");
-    locationNode.addChild("b", String.valueOf(peerNodeStatus.getLocation()));
-    locationNode.addChild("br");
-    double[] peersLoc = peerNodeStatus.getPeersLocation();
-    if (peersLoc != null) {
-      locationNode.addChild("i", "+" + peersLoc.length + " friends");
-    }
-  }
-
-  private void addBackoffColumns(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, long now, DecimalFormat fix1) {
-    addBackoffColumn(peerRow, peerNodeStatus, now, fix1, true);
-    addBackoffColumn(peerRow, peerNodeStatus, now, fix1, false);
-  }
-
-  private void addBackoffColumn(
-      HTMLNode peerRow,
-      PeerNodeStatus peerNodeStatus,
-      long now,
-      DecimalFormat fix1,
-      boolean realtime) {
-    HTMLNode backoffCell = peerRow.addChild("td", ATTR_CLASS, "peer-backoff");
-    backoffCell.addChild("#", fix1.format(peerNodeStatus.getBackedOffPercent(realtime)));
-    int backoff = (int) Math.max(peerNodeStatus.getRoutingBackedOffUntil(realtime) - now, 0);
-    if ((backoff > 0) && (backoff < 1000)) {
-      backoff = 1000;
-    }
-    backoffCell.addChild(
-        "#",
-        ' '
-            + String.valueOf(backoff / 1000)
-            + '/'
-            + peerNodeStatus.getRoutingBackoffLength(realtime) / 1000);
-    backoffCell.addChild(
-        "#",
-        (peerNodeStatus.getLastBackoffReason(realtime) == null)
-            ? ""
-            : '/' + peerNodeStatus.getLastBackoffReason(realtime));
-  }
-
-  private void addPRejectColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, DecimalFormat fix1) {
-    HTMLNode pRejectCell = peerRow.addChild("td", ATTR_CLASS, "peer-backoff");
-    pRejectCell.addChild("#", fix1.format(peerNodeStatus.getPReject()));
-  }
-
-  private void addIdleColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus, long now) {
-    long idle = peerNodeStatus.getTimeLastRoutable();
-    if (peerNodeStatus.isRoutable()) {
-      idle = peerNodeStatus.getTimeLastConnectionCompleted();
-    } else if (peerNodeStatus.getStatusValue() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED) {
-      idle = peerNodeStatus.getPeerAddedTime();
-    }
-    HTMLNode idleNode;
-    if (!peerNodeStatus.isConnected() && (now - idle) > (2 * 7 * 24 * 60 * 60 * 1000L)) {
-      idleNode = peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS);
-      idleNode.addChild("span", ATTR_CLASS, "peer_idle_old", idleToString(now, idle));
-      return;
-    }
-    peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS, idleToString(now, idle));
-  }
-
-  private void addAdvancedStatistics(
-      HTMLNode peerRow,
-      PeerNodeStatus peerNodeStatus,
-      DecimalFormat fix1,
-      int peerSelectionPercentage,
-      double totalSelectionRate) {
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild("#", fix1.format(peerNodeStatus.getPercentTimeRoutableConnection()));
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild("#", (totalSelectionRate > 0 ? (peerSelectionPercentage + "%") : "N/A"));
-    addTrafficColumns(peerRow, peerNodeStatus, fix1);
-    addTrafficSinceStartupColumn(peerRow, peerNodeStatus);
-    addCongestionControl(peerRow, peerNodeStatus);
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild("#", TimeUtil.formatTime(peerNodeStatus.getClockDelta()));
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild("#", peerNodeStatus.getReportedUptimePercentage() + "%");
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild(
-            "#",
-            SizeUtil.formatSize(peerNodeStatus.getMessageQueueLengthBytes())
-                + ":"
-                + TimeUtil.formatTime(peerNodeStatus.getMessageQueueLengthTime()));
-    addIncomingLoad(peerRow, peerNodeStatus.incomingLoadStatsBulk);
-    addIncomingLoad(peerRow, peerNodeStatus.incomingLoadStatsRealTime);
-  }
-
-  private void addTrafficColumns(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, DecimalFormat fix1) {
-    long sent = peerNodeStatus.getTotalOutputBytes();
-    long resent = peerNodeStatus.getResendBytesSent();
-    long received = peerNodeStatus.getTotalInputBytes();
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild(
-            "#",
-            SizeUtil.formatSize(received)
-                + " / "
-                + SizeUtil.formatSize(sent)
-                + "/"
-                + SizeUtil.formatSize(resent)
-                + " ("
-                + fix1.format(((double) resent) / ((double) sent))
-                + ")");
-  }
-
-  private void addTrafficSinceStartupColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild(
-            "#",
-            SizeUtil.formatSize(peerNodeStatus.getTotalInputSinceStartup())
-                + " / "
-                + SizeUtil.formatSize(peerNodeStatus.getTotalOutputSinceStartup()));
-  }
-
-  private void addCongestionControl(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    PacketThrottle throttle = peerNodeStatus.getThrottle();
-    String val;
-    if (throttle == null) {
-      val = "none";
-    } else {
-      val =
-          (int) throttle.getBandwidth()
-              + "B/sec delay "
-              + throttle.getDelay()
-              + "ms (RTT "
-              + throttle.getRoundTripTime()
-              + "ms window "
-              + throttle.getWindowSize()
-              + ')';
-    }
-    peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS).addChild("#", val);
-  }
-
-  private void addIncomingLoad(HTMLNode peerRow, IncomingLoadSummaryStats loadStats) {
-    if (loadStats == null) {
-      peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS);
-      return;
-    }
-    peerRow
-        .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
-        .addChild(
-            "#",
-            loadStats.runningRequestsTotal
-                + "reqs:out:"
-                + SizeUtil.formatSize(loadStats.usedCapacityOutputBytes)
-                + "/"
-                + SizeUtil.formatSize(loadStats.othersUsedCapacityOutputBytes)
-                + "/"
-                + SizeUtil.formatSize(loadStats.peerCapacityOutputBytes)
-                + "/"
-                + SizeUtil.formatSize(loadStats.totalCapacityOutputBytes)
-                + ":in:"
-                + SizeUtil.formatSize(loadStats.usedCapacityInputBytes)
-                + "/"
-                + SizeUtil.formatSize(loadStats.othersUsedCapacityInputBytes)
-                + "/"
-                + SizeUtil.formatSize(loadStats.peerCapacityInputBytes)
-                + "/"
-                + SizeUtil.formatSize(loadStats.totalCapacityInputBytes));
-  }
-
-  private void addEndColumns(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, List<SimpleColumn> endCols) {
-    if (endCols == null || endCols.isEmpty()) {
-      return;
-    }
-    for (SimpleColumn col : endCols) {
-      col.drawColumn(peerRow, peerNodeStatus);
-    }
-  }
-
-  /**
-   * Indicates whether the peer table should include a trust column.
-   *
-   * <p>Darknet views usually show user-configurable trust, while opennet hides it. Subclasses
-   * should return a stable value so column layouts remain predictable.
-   *
-   * @return {@code true} when a trust column should be rendered; {@code false} otherwise.
-   */
-  protected boolean hasTrustColumn() {
-    return false;
-  }
-
-  /**
-   * Renders the trust column when enabled by {@link #hasTrustColumn()}.
-   *
-   * @param peerRow row node corresponding to the peer being rendered.
-   * @param peerNodeStatus status snapshot containing trust information to display.
-   */
-  protected void drawTrustColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    // Do nothing
-  }
-
-  /**
-   * Indicates whether a visibility column should be shown for peers.
-   *
-   * @return {@code true} to render visibility, {@code false} to omit it from the table.
-   */
-  protected boolean hasVisibilityColumn() {
-    return false;
-  }
-
-  /**
-   * Renders the visibility column when enabled.
-   *
-   * @param peerRow row node receiving the visibility cell.
-   * @param peerNodeStatus peer status with visibility settings.
-   * @param advancedModeEnabled whether advanced UI should expose additional context.
-   */
-  protected void drawVisibilityColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
-    // Do nothing
-  }
-
-  /**
-   * Indicates whether a peer name column should be displayed.
-   *
-   * @return {@code true} to show names; {@code false} when names are not applicable.
-   */
-  protected abstract boolean hasNameColumn();
-
-  /**
-   * Draws the name column immediately after the status column when enabled.
-   *
-   * @param peerRow row node to which the name cell should be appended.
-   * @param peerNodeStatus peer status that may contain a user-defined name.
-   * @param advanced flag indicating whether advanced UI elements may be shown.
-   */
-  protected abstract void drawNameColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advanced);
-
-  /**
-   * Indicates whether a private note column should be rendered for peers.
-   *
-   * @return {@code true} when private notes should appear; {@code false} otherwise.
-   */
-  protected abstract boolean hasPrivateNoteColumn();
-
-  /**
-   * Draws the private note column when enabled by {@link #hasPrivateNoteColumn()}.
-   *
-   * @param peerRow row node receiving the private note cell.
-   * @param peerNodeStatus peer status containing any private notes.
-   * @param fProxyJavascriptEnabled whether JavaScript helpers are available for the view.
-   */
-  protected abstract void drawPrivateNoteColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled);
-
-  private void drawMessageTypes(HTMLNode peerTable, PeerNodeStatus peerNodeStatus) {
-    HTMLNode messageCountRow = peerTable.addChild("tr", ATTR_CLASS, "message-status");
-    messageCountRow.addChild("td", "colspan", "2");
-    HTMLNode messageCountCell =
-        messageCountRow.addChild(
-            "td", "colspan", "9"); // = total table row width - 2 from the above colspan
-    HTMLNode messageCountTable =
-        messageCountCell.addChild(ELEMENT_TABLE, ATTR_CLASS, "message-count");
-    HTMLNode countHeaderRow = messageCountTable.addChild("tr");
-    countHeaderRow.addChild("th", "Message");
-    countHeaderRow.addChild("th", "Incoming");
-    countHeaderRow.addChild("th", "Outgoing");
-    List<String> messageNames = new ArrayList<>();
-    Map<String, Long[]> messageCounts = new HashMap<>();
-    for (Map.Entry<String, Long> entry : peerNodeStatus.getLocalMessagesReceived().entrySet()) {
-      String messageName = entry.getKey();
-      Long messageCount = entry.getValue();
-      messageNames.add(messageName);
-      messageCounts.put(messageName, new Long[] {messageCount, 0L});
-    }
-    for (Map.Entry<String, Long> entry : peerNodeStatus.getLocalMessagesSent().entrySet()) {
-      String messageName = entry.getKey();
-      Long messageCount = entry.getValue();
-      if (!messageNames.contains(messageName)) {
-        messageNames.add(messageName);
-      }
-      Long[] existingCounts = messageCounts.get(messageName);
-      if (existingCounts == null) {
-        messageCounts.put(messageName, new Long[] {0L, messageCount});
-      } else {
-        existingCounts[1] = messageCount;
-      }
-    }
-    messageNames.sort(String::compareToIgnoreCase);
-    for (String messageName : messageNames) {
-      Long[] messageCount = messageCounts.get(messageName);
-      HTMLNode messageRow = messageCountTable.addChild("tr");
-      messageRow.addChild("td", messageName);
-      messageRow.addChild("td", ATTR_CLASS, "right-align", String.valueOf(messageCount[0]));
-      messageRow.addChild("td", ATTR_CLASS, "right-align", String.valueOf(messageCount[1]));
-    }
-  }
-
-  private String idleToString(long now, long idle) {
-    if (idle <= 0) {
-      return " ";
-    }
-    long idleMilliseconds = now - idle;
-    return TimeUtil.formatTime(idleMilliseconds);
-  }
-
   private static String l10n(String string) {
     return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + string);
-  }
-
-  private static String l10nCount(String string, String value) {
-    return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + string, COUNT, value);
-  }
-
-  private String sortString(boolean isReversed, String type) {
-    return (isReversed ? ("?sortBy=" + type) : ("?sortBy=" + type + "&reversed"));
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -16,6 +16,7 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
@@ -49,7 +50,6 @@ import org.slf4j.LoggerFactory;
  */
 public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(DarknetConnectionsToadlet.class);
-  private static final String ATTR_CLASS = "class";
   private static final String ELEMENT_INPUT = "input";
   private static final String ELEMENT_SELECT = "select";
   private static final String ELEMENT_OPTION = "option";
@@ -81,8 +81,12 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
           Map.entry("set_allow_local", pn -> pn.setAllowLocalAddresses(true)),
           Map.entry("clear_allow_local", pn -> pn.setAllowLocalAddresses(false)));
 
-  DarknetConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
-    super(n, core, client);
+  DarknetConnectionsToadlet(
+      Node n,
+      NodeClientCore core,
+      HighLevelSimpleClient client,
+      ConnectionsPagePort connectionsPage) {
+    super(n, core, client, connectionsPage);
   }
 
   private static String l10n(String string) {
@@ -100,7 +104,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * ordering. Instances are short-lived and created per request to avoid storing mutable sorting
    * preferences globally.
    */
-  protected class DarknetComparator extends ComparatorByStatus {
+  protected static class DarknetComparator extends ComparatorByStatus {
 
     DarknetComparator(String sortBy, boolean reversed) {
       super(sortBy, reversed);
@@ -165,180 +169,6 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   /**
-   * Indicate that the darknet table always displays a peer name column.
-   *
-   * <p>The name column serves as the primary identifier for friends, enabling both navigation to
-   * the confidential messaging form and, in advanced mode, access to downloadable references.
-   * Hiding it would prevent users from distinguishing peers, so the method consistently returns
-   * {@code true} regardless of UI mode or configuration.
-   *
-   * @return {@code true}, signalling that a name column must be rendered for every row.
-   */
-  @Override
-  protected boolean hasNameColumn() {
-    return true;
-  }
-
-  /**
-   * Render the peer name cell with an optional noderef download link for advanced users.
-   *
-   * <p>The method writes a table cell containing the peer's display name and a link to the
-   * confidential messaging endpoint. When advanced mode is active and a full noderef is available,
-   * it also exposes a secondary link that triggers a download of the sanitized friend reference.
-   * The cell contents remain purely presentational; selection and bulk actions are handled
-   * elsewhere in the form.
-   *
-   * @param peerRow table row receiving the name content; must be non-null and part of the page.
-   * @param peerNodeStatus status wrapper for the darknet peer whose name is shown.
-   * @param advanced whether to include the noderef download link beside the name.
-   */
-  @Override
-  protected void drawNameColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advanced) {
-    // name column
-    HTMLNode cell = peerRow.addChild("td", ATTR_CLASS, "peer-name");
-    cell.addChild(
-        "a",
-        "href",
-        "/send_n2ntm/?peernode_hashcode=" + peerNodeStatus.hashCode(),
-        ((DarknetPeerNodeStatus) peerNodeStatus).getName());
-    if (advanced && peerNodeStatus.hasFullNoderef) {
-      cell.addChild("#", " (");
-      cell.addChild(
-          "a",
-          "href",
-          path() + FRIEND_PREFIX + peerNodeStatus.hashCode() + FREF_SUFFIX,
-          l10n("noderefLink"));
-      cell.addChild("#", ")");
-    }
-  }
-
-  /**
-   * Signal that the trust column should always be rendered for darknet peers.
-   *
-   * <p>Trust is a primary tuning mechanism for darknet routing, so the column remains visible in
-   * both basic and advanced modes. The consistent presence of the column also keeps the table
-   * layout stable when users toggle feature flags.
-   *
-   * @return {@code true}, indicating the trust column is required in the output table.
-   */
-  @Override
-  protected boolean hasTrustColumn() {
-    return true;
-  }
-
-  /**
-   * Populate the trust column with the peer's configured trust enum value.
-   *
-   * <p>The method writes a simple text cell that mirrors the underlying {@link FRIEND_TRUST} value
-   * so users can quickly scan relative trust levels. No editing controls are embedded here;
-   * adjustments are performed through the bulk actions box to avoid per-row form sprawl.
-   *
-   * @param peerRow row node that will receive the trust cell; must already exist in the DOM.
-   * @param peerNodeStatus status describing the peer whose trust value is being rendered.
-   */
-  @Override
-  protected void drawTrustColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-    peerRow
-        .addChild("td", ATTR_CLASS, "peer-trust")
-        .addChild("#", ((DarknetPeerNodeStatus) peerNodeStatus).getTrustLevel().name());
-  }
-
-  /**
-   * Declare that visibility settings should always be displayed for darknet peers.
-   *
-   * <p>Visibility reflects whether peers may reveal each other's identity to others, making it a
-   * critical safety control. Showing it unconditionally keeps the user aware of both inbound and
-   * outbound sharing preferences and avoids layout shifts between basic and advanced views.
-   *
-   * @return {@code true}, ensuring the visibility column is rendered.
-   */
-  @Override
-  protected boolean hasVisibilityColumn() {
-    return true;
-  }
-
-  /**
-   * Render local and optionally remote visibility settings in a compact text cell.
-   *
-   * <p>The local visibility always appears so users can confirm how their node shares the
-   * connection. When advanced mode is enabled, the peer's visibility toward this node is appended
-   * in parentheses to highlight asymmetries. No formatting or icons are used to keep the table
-   * printable and screen-reader friendly.
-   *
-   * @param peerRow destination row that receives the visibility cell.
-   * @param peerNodeStatus status object containing local and remote visibility values.
-   * @param advancedModeEnabled whether to append the peer's visibility toward this node.
-   */
-  @Override
-  protected void drawVisibilityColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
-    String content = ((DarknetPeerNodeStatus) peerNodeStatus).getOurVisibility().name();
-    if (advancedModeEnabled)
-      content += " (" + ((DarknetPeerNodeStatus) peerNodeStatus).getTheirVisibility().name() + ")";
-    peerRow.addChild("td", ATTR_CLASS, "peer-trust").addChild("#", content);
-  }
-
-  /**
-   * Indicate that the private note column should always be present on the friends table.
-   *
-   * <p>Private notes allow operators to annotate friends with context or trust cues; keeping the
-   * column consistently visible avoids data loss and maintains table alignment across modes.
-   *
-   * @return {@code true}, signalling that note inputs should be rendered for each peer.
-   */
-  @Override
-  protected boolean hasPrivateNoteColumn() {
-    return true;
-  }
-
-  /**
-   * Render the editable private note field for a peer, enabling JS onchange when available.
-   *
-   * <p>The method emits an {@code input type="text"} element sized for short annotations and limits
-   * user input to 250 characters. When the FProxy JavaScript helpers are enabled, an {@code
-   * onChange} hook triggers the client-side note tracking logic; otherwise a plain input is
-   * provided so accessibility and non-scripted environments remain functional.
-   *
-   * @param peerRow row node to which the note input cell is appended.
-   * @param peerNodeStatus status describing the peer whose note value is being edited.
-   * @param fProxyJavascriptEnabled whether to attach the JavaScript change handler attribute.
-   */
-  @Override
-  protected void drawPrivateNoteColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled) {
-    // private darknet node comment note column
-    DarknetPeerNodeStatus status = (DarknetPeerNodeStatus) peerNodeStatus;
-    if (fProxyJavascriptEnabled) {
-      peerRow
-          .addChild("td", ATTR_CLASS, "peer-private-darknet-comment-note")
-          .addChild(
-              ELEMENT_INPUT,
-              new String[] {"type", "name", "size", "maxlength", "onChange", ATTR_VALUE},
-              new String[] {
-                "text",
-                PEER_PRIVATE_NOTE_PREFIX + peerNodeStatus.hashCode(),
-                "16",
-                "250",
-                "peerNoteChange();",
-                status.getPrivateDarknetCommentNote()
-              });
-    } else {
-      peerRow
-          .addChild("td", ATTR_CLASS, "peer-private-darknet-comment-note")
-          .addChild(
-              ELEMENT_INPUT,
-              new String[] {"type", "name", "size", "maxlength", ATTR_VALUE},
-              new String[] {
-                "text",
-                PEER_PRIVATE_NOTE_PREFIX + peerNodeStatus.hashCode(),
-                "16",
-                "250",
-                status.getPrivateDarknetCommentNote()
-              });
-    }
-  }
-
-  /**
    * Export the local node's public darknet reference for distribution.
    *
    * <p>The exported field set omits private data and contains only the values needed for a remote
@@ -353,43 +183,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   /**
-   * Collect status snapshots for all darknet peers, optionally skipping heavy calculations.
-   *
-   * <p>When {@code noHeavy} is true, the returned statuses avoid expensive metrics so lightweight
-   * pages can render quickly. The array ordering matches that provided by the node's peer manager
-   * and is later sorted by {@link #comparator(String, boolean)} according to user preferences.
-   *
-   * @param noHeavy whether to omit heavy computations such as aggregated statistics.
-   * @return array of {@link DarknetPeerNodeStatus} instances representing current darknet peers.
-   */
-  @Override
-  protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
-    return node.network().peers().statusBook().getDarknetPeerNodeStatuses(noHeavy);
-  }
-
-  /**
-   * Build a localized page title that embeds the formatted friend count.
-   *
-   * <p>The title text is fetched from localization resources and accepts the {@code counts}
-   * placeholder, allowing the caller to present short summaries such as "(5 friends)" without
-   * duplicating translation keys. Returning the fully interpolated string keeps the template logic
-   * centralized within the toadlet rather than scattering title construction throughout the UI
-   * layer.
-   *
-   * @param titleCountString localized or numeric friend count already formatted for display.
-   * @return localized title string ready for insertion into the page header.
-   */
-  @Override
-  protected String getPageTitle(String titleCountString) {
-    return NodeL10n.getBase()
-        .getString(
-            "DarknetConnectionsToadlet.fullTitle",
-            new String[] {"counts"},
-            new String[] {titleCountString});
-  }
-
-  /**
-   * Determine whether the page should include the self noderef download box.
+   * Determine whether the page should include the self-noderef download box.
    *
    * <p>The box is useful for power users distributing their own references but can overwhelm new
    * users. By tying visibility to the advanced mode flag, the method keeps the standard workflow
@@ -412,7 +206,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * so the actions box is never hidden. The contained controls gate advanced operations internally
    * rather than being removed from the DOM.
    *
-   * @return {@code true}, signalling callers to render the actions box unconditionally.
+   * @return {@code true}, signaling callers to render the actions box unconditionally.
    */
   @Override
   protected boolean showPeerActionsBox() {
@@ -428,7 +222,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * hidden from basic users. The controls rely on the parent form to provide checkbox selections
    * whose names follow the {@code node_<hashcode>} convention.
    *
-   * @param peerForm form node to which controls are appended; must already exist in the page.
+   * @param peerForm the form node to which controls are appended; must already exist in the page.
    * @param advancedModeEnabled whether to include advanced-only routing and security options.
    */
   @Override
@@ -504,21 +298,6 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       changeVisibilitySelect.addChild(
           ELEMENT_OPTION, ATTR_VALUE, trust.name(), l10n("peerVisibility." + trust.name()));
     }
-  }
-
-  /**
-   * Return the localized heading that labels the darknet friends table.
-   *
-   * <p>The title is intentionally short to keep table layouts compact while still providing clear
-   * context when embedded inside larger pages or infoboxes. It is reused by multiple rendering
-   * paths so the same wording appears in both standard and advanced layouts, reducing localization
-   * overhead and preserving consistency when the table is refreshed after POST actions.
-   *
-   * @return localized string representing the section title for friends.
-   */
-  @Override
-  protected String getPeerListTitle() {
-    return l10n("myFriends");
   }
 
   /**
@@ -811,24 +590,9 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   /**
-   * Provide additional column headers appended after the standard set.
-   *
-   * <p>Darknet connections do not require trailing columns beyond those defined in the base class,
-   * so this implementation returns an empty array. Advanced mode status does not influence the
-   * outcome, preserving a consistent column layout.
-   *
-   * @param advancedMode whether advanced mode is enabled for the current render.
-   * @return an empty array, indicating no extra headers are added.
-   */
-  @Override
-  SimpleColumn[] endColumnHeaders(boolean advancedMode) {
-    return new SimpleColumn[0];
-  }
-
-  /**
    * Expose the URL path handled by this toadlet for routing purposes.
    *
-   * <p>The path is shared across GET and POST handlers so form actions and links consistently
+   * <p>The path is shared across GET and POST handlers, so form actions and links consistently
    * resolve to the friends' endpoint. Centralizing the path string here avoids duplication in
    * templates and makes it easy for callers to build absolute links when issuing redirects or
    * constructing downloadable noderef URLs.
@@ -853,7 +617,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * @param request HTTP request wrapper carrying query parameters and advanced-mode state.
    * @param ctx toadlet context used to write the HTML page or attachment response.
    * @throws ToadletContextClosedException if the client disconnects during output.
-   * @throws IOException if streaming the response fails.
+   * @throws IOException if streaming, the response fails.
    * @throws RedirectException if the superclass initiates a redirect during page handling.
    */
   @Override

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -253,7 +253,8 @@ final class FProxyRegistrar {
     server.register(
         coreActionToadlet, ToadletRegistration.basic(null, CORE_UPDATE_PATH, true, false));
 
-    DarknetConnectionsToadlet friendsToadlet = new DarknetConnectionsToadlet(node, core, client);
+    DarknetConnectionsToadlet friendsToadlet =
+        new DarknetConnectionsToadlet(node, core, client, core.getRuntimePorts().connectionsPage());
     server.register(
         friendsToadlet,
         ToadletRegistration.menuLink(
@@ -277,7 +278,8 @@ final class FProxyRegistrar {
             true,
             null));
 
-    OpennetConnectionsToadlet opennetToadlet = new OpennetConnectionsToadlet(node, core, client);
+    OpennetConnectionsToadlet opennetToadlet =
+        new OpennetConnectionsToadlet(node, core, client, core.getRuntimePorts().connectionsPage());
     server.register(
         opennetToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -2,14 +2,13 @@ package network.crypta.clients.http;
 
 import java.util.Comparator;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.TimeUtil;
 
 /**
  * Toadlet that renders the opennet peer list for the FProxy UI, focusing on anonymous stranger
@@ -46,69 +45,12 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    * @param client high-level client for UI links and redirects; expected to be configured for
    *     opennet-safe operations.
    */
-  protected OpennetConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
-    super(n, core, client);
-  }
-
-  /**
-   * Suppresses name rendering for opennet peers because identities are intentionally unavailable.
-   * This override keeps the table layout consistent with the base class while ensuring no empty
-   * cells or misleading headings are produced when names cannot be derived safely.
-   *
-   * @param peerRow table row node that would normally receive the name cell output.
-   * @param peerNodeStatus status snapshot for the peer whose row is being rendered in the table.
-   * @param advanced whether advanced UI mode is active; retained for signature compatibility only.
-   */
-  @Override
-  protected void drawNameColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advanced) {
-    // Do nothing - no names on opennet
-  }
-
-  /**
-   * Disables the private-note column because the opennet model lacks user-managed trust metadata.
-   * Keeping this method as a no-op prevents accidental rendering of fields that would suggest
-   * mutable annotations on strangers, which the UI and persistence layers do not support.
-   *
-   * @param peerRow table row node for the current peer being rendered in the list view.
-   * @param peerNodeStatus status object describing connectivity and performance for the peer.
-   * @param fProxyJavascriptEnabled flag indicating whether JavaScript helpers are available in the
-   *     browser session; unused because the column is suppressed unconditionally.
-   */
-  @Override
-  protected void drawPrivateNoteColumn(
-      HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled) {
-    // Do nothing - no private notes either (no such thing as negative trust in cyberspace)
-  }
-
-  /**
-   * Indicates that the opennet table omits the name column entirely.
-   *
-   * <p>Opennet peers present only cryptographic identifiers, so exposing a name column would either
-   * remain blank or mislead users into thinking a stable label exists. Keeping this flag false also
-   * simplifies column counts elsewhere in the table layout and prevents localization strings for
-   * names from being loaded unnecessarily.
-   *
-   * @return always {@code false} because opennet peers are not associated with human-readable
-   *     names.
-   */
-  @Override
-  protected boolean hasNameColumn() {
-    return false;
-  }
-
-  /**
-   * Reports that the private note column is unavailable for opennet peers.
-   *
-   * <p>The design intentionally removes ad hoc annotations on strangers to reduce risk of leaking
-   * identifiable hints or encouraging user-managed reputation for anonymous participants.
-   * Downstream renderers and CSV exporters can rely on this flag to avoid allocating unused cells
-   * or headers and to align other columns correctly when opennet mode is active.
-   *
-   * @return always {@code false} because private annotations are not supported in opennet mode.
-   */
-  @Override
-  protected boolean hasPrivateNoteColumn() {
-    return false;
+  protected OpennetConnectionsToadlet(
+      Node n,
+      NodeClientCore core,
+      HighLevelSimpleClient client,
+      ConnectionsPagePort connectionsPage) {
+    super(n, core, client, connectionsPage);
   }
 
   /**
@@ -125,21 +67,6 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
   }
 
   /**
-   * Retrieves the current opennet peer status snapshots used to populate the table rows. The caller
-   * controls whether heavy data (such as bandwidth histories) should be excluded to reduce
-   * rendering cost when the page is not in advanced mode.
-   *
-   * @param noHeavy when {@code true}, request lightweight status objects that omit expensive
-   *     metrics to keep UI responses fast.
-   * @return array of {@link PeerNodeStatus} entries describing each opennet peer known to the node;
-   *     never {@code null} but may be empty.
-   */
-  @Override
-  protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
-    return node.network().peers().statusBook().getOpennetPeerNodeStatuses(noHeavy);
-  }
-
-  /**
    * Checks whether opennet support is currently enabled on the hosting node before serving the
    * toadlet. Requests are only allowed when opennet is active, preventing exposure of partial UI
    * state while the feature is disabled or unavailable.
@@ -151,24 +78,6 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
   @Override
   public boolean isEnabled(ToadletContext ctx) {
     return node.network().isOpennetEnabled();
-  }
-
-  /**
-   * Builds the localized page title string, embedding the formatted peer count supplied by the base
-   * class. The title is used by the surrounding FProxy layout and should remain short while still
-   * distinguishing opennet content from friend connections.
-   *
-   * @param titleCountString pre-formatted text representing the current peer counts shown in the
-   *     header.
-   * @return localized title string describing the opennet connections page with embedded counts.
-   */
-  @Override
-  protected String getPageTitle(String titleCountString) {
-    return NodeL10n.getBase()
-        .getString(
-            "OpennetConnectionsToadlet.fullTitle",
-            new String[] {"counts"},
-            new String[] {titleCountString});
   }
 
   /**
@@ -210,22 +119,6 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
   @Override
   protected void drawPeerActionSelectBox(HTMLNode peerForm, boolean advancedModeEnabled) {
     // Do nothing, see showPeerActionsBox().
-  }
-
-  /**
-   * Supplies the localized title for the opennet peers list. The title appears above the table and
-   * clarifies that entries correspond to stranger connections rather than friend nodes.
-   *
-   * <p>Localization is resolved on each request so the title reflects the active language choice of
-   * the current user, and separating the text from code keeps the wording aligned with the rest of
-   * the UI. The returned string is short to fit within common header constraints while remaining
-   * distinct from friend connection screens.
-   *
-   * @return localized list title pulled from the node localization bundle.
-   */
-  @Override
-  protected String getPeerListTitle() {
-    return NodeL10n.getBase().getString("OpennetConnectionsToadlet.peersListTitle");
   }
 
   /**
@@ -282,7 +175,7 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    * <p>The comparator is created per request to encapsulate the active sort key and direction,
    * ensuring thread-safety and allowing multiple concurrent sorts without shared mutable state.
    */
-  protected class OpennetComparator extends ComparatorByStatus {
+  protected static class OpennetComparator extends ComparatorByStatus {
 
     OpennetComparator(String sortBy, boolean reversed) {
       super(sortBy, reversed);
@@ -325,52 +218,6 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
   @Override
   protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
     return new OpennetComparator(sortBy, reversed);
-  }
-
-  /**
-   * Defines the trailing columns for the peer table. In advanced mode the method adds a single
-   * column showing the elapsed time since the last successful communication with each peer; in
-   * basic mode it returns an empty array to keep the layout compact.
-   *
-   * @param advancedMode flag indicating whether advanced UI elements should be included in the
-   *     response.
-   * @return array of simple column definitions to append to the table; never {@code null}.
-   */
-  @Override
-  SimpleColumn[] endColumnHeaders(boolean advancedMode) {
-    if (!advancedMode) return new SimpleColumn[0];
-    return new SimpleColumn[] {
-      new SimpleColumn() {
-
-        @Override
-        protected void drawColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
-          OpennetPeerNodeStatus status = (OpennetPeerNodeStatus) peerNodeStatus;
-          long tLastSuccess = status.timeLastSuccess;
-          peerRow.addChild(
-              "td",
-              "class",
-              "peer-last-success",
-              tLastSuccess > 0
-                  ? TimeUtil.formatTime(System.currentTimeMillis() - tLastSuccess)
-                  : "NEVER");
-        }
-
-        @Override
-        public String getExplanationKey() {
-          return "OpennetConnectionsToadlet.successTime";
-        }
-
-        @Override
-        public String getSortString() {
-          return "successTime";
-        }
-
-        @Override
-        public String getTitleKey() {
-          return "OpennetConnectionsToadlet.successTimeTitle";
-        }
-      }
-    };
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyConnectionsPagePort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyConnectionsPagePort.java
@@ -1,0 +1,2264 @@
+package network.crypta.node.runtime;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.clients.http.geoip.IPConverter.Country;
+import network.crypta.clients.http.geoip.IPConverter;
+import network.crypta.config.SubConfig;
+import network.crypta.io.xfer.BlockReceiver;
+import network.crypta.io.xfer.BlockTransmitter;
+import network.crypta.io.xfer.PacketThrottle;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.node.DarknetPeerNodeStatus;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeFile;
+import network.crypta.node.NodeStats;
+import network.crypta.node.OpennetManager;
+import network.crypta.node.OpennetPeerNodeStatus;
+import network.crypta.node.PeerManager;
+import network.crypta.node.PeerNode;
+import network.crypta.node.PeerNodeLoadTracker.IncomingLoadSummaryStats;
+import network.crypta.node.PeerNodeStatus;
+import network.crypta.node.PeerStatusCounts;
+import network.crypta.node.RequestTracker;
+import network.crypta.node.Version;
+import network.crypta.runtime.spi.ConnectionsPageKind;
+import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.ConnectionsPageRequest;
+import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.support.BandwidthStatsContainer;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.SizeUtil;
+import network.crypta.support.TimeUtil;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Renders the legacy friends and strangers pages behind the runtime connections-page SPI.
+ *
+ * <p>This adapter keeps the heavy read-only traversal in the daemon layer while returning detached
+ * {@link ConnectionsPageSnapshot} fragments to the HTTP toadlets. Each render reads the current
+ * peer, routing, and bandwidth state and applies the historical sort and table rules for darknet or
+ * opennet. It emits localized HTML fragments that match the legacy admin UI structure closely
+ * enough for the existing toadlets to keep their outer shell and POST behavior unchanged.
+ *
+ * <p>The class is intentionally transitional rather than reusable outside the legacy admin UI. It
+ * still depends on daemon-local node services and HTML helpers internally, but it hides those
+ * details behind JDK-only SPI DTOs. Instances retain only references to live node services, so
+ * callers should treat each render as a point-in-time snapshot of a mutable daemon state rather
+ * than a cached or stable model.
+ */
+final class LegacyConnectionsPagePort implements ConnectionsPagePort {
+  /** HTML attribute name for CSS classes in generated fragments. */
+  private static final String ATTR_CLASS = "class";
+
+  /** HTML attribute name for inline styles in generated fragments. */
+  private static final String ATTR_STYLE = "style";
+
+  /** HTML attribute name for localized tooltip text. */
+  private static final String ATTR_TITLE = "title";
+
+  /** HTML attribute name for form control values. */
+  private static final String ATTR_VALUE = "value";
+
+  /** HTML element name for peer and overview tables. */
+  private static final String ELEMENT_TABLE = "table";
+
+  /** HTML element name for form inputs. */
+  private static final String ELEMENT_INPUT = "input";
+
+  /** HTML element name for select boxes. */
+  private static final String ELEMENT_SELECT = "select";
+
+  /** HTML element name for select options. */
+  private static final String ELEMENT_OPTION = "option";
+
+  /** CSS class used for standard infobox containers. */
+  private static final String INFOBOX_CLASS = "infobox";
+
+  /** CSS class used for normal infobox variants. */
+  private static final String INFOBOX_NORMAL_CLASS = "infobox infobox-normal";
+
+  /** CSS class used for infobox headers. */
+  private static final String INFOBOX_HEADER_CLASS = "infobox-header";
+
+  /** CSS class used for infobox body content. */
+  private static final String INFOBOX_CONTENT_CLASS = "infobox-content";
+
+  /** Request path suffix that enables per-peer message-type output. */
+  private static final String DISPLAY_MESSAGE_TYPES = "displaymessagetypes.html";
+
+  /** CSS identifier for the detached darknet peer table. */
+  private static final String DARKNET_CONNECTIONS = "darknet_connections";
+
+  /** Inline style applied to help-text headers that expose tooltips. */
+  private static final String HELP_STYLE = "border-bottom: 1px dotted; cursor: help;";
+
+  /** Sort key for the darknet trust column. */
+  private static final String TRUST = "trust";
+
+  /** Replacement token used for count-oriented localization entries. */
+  private static final String COUNT = "count";
+
+  /** CSS class used when a peer is considered idle. */
+  private static final String PEER_IDLE_CLASS = "peer-idle";
+
+  /** Prefix used for peer checkbox and form field identifiers. */
+  private static final String NODE_PREFIX = "node_";
+
+  /** Prefix used for private-note form field identifiers. */
+  private static final String PEER_PRIVATE_NOTE_PREFIX = "peerPrivateNote_";
+
+  /** Form submit control name used by the legacy peer actions form. */
+  private static final String SUBMIT = "submit";
+
+  /** Request parameter name for peer actions. */
+  private static final String ACTION = "action";
+
+  /** Request parameter name that triggers action execution. */
+  private static final String DO_ACTION = "doAction";
+
+  /** Request parameter value for trust-level changes. */
+  private static final String CHANGE_TRUST = "changeTrust";
+
+  /** Request parameter value for visibility changes. */
+  private static final String CHANGE_VISIBILITY = "changeVisibility";
+
+  /** Request parameter value for peer removal. */
+  private static final String REMOVE = "remove";
+
+  /** Filename prefix used when exporting darknet references. */
+  private static final String FRIEND_PREFIX = "friend-";
+
+  /** Filename suffix used when exporting darknet references. */
+  private static final String FREF_SUFFIX = ".fref";
+
+  /** Path separator reused when assembling local admin paths. */
+  private static final char PATH_SEPARATOR = '/';
+
+  /** Legacy admin path for the darknet friends page. */
+  private static final String FRIENDS_PATH = PATH_SEPARATOR + "friends" + PATH_SEPARATOR;
+
+  /** Placeholder inserted before the detached peer table is spliced into the page shell. */
+  private static final String PEER_TABLE_PLACEHOLDER = "<!--CRYPTA_CONNECTIONS_PEER_TABLE-->";
+
+  /** Localization prefix shared with the legacy statistics toadlet strings. */
+  private static final String STATS_PREFIX = "StatisticsToadlet.";
+
+  /** Replacement token used for total-byte localization entries. */
+  private static final String TOTAL_KEY = "total";
+
+  /** Replacement token used for percentage-oriented localization entries. */
+  private static final String PERCENT_KEY = "percent";
+
+  /** CSS class name used for connected peers. */
+  private static final String CLASS_CONNECTED = "connected";
+
+  /** CSS class used for peers that are listening and connectable. */
+  private static final String PEER_LISTENING_CLASS = "peer_listening";
+
+  /** CSS class used for peers that can only accept inbound connections. */
+  private static final String PEER_LISTEN_ONLY_CLASS = "peer_listen_only";
+
+  /** Non-breaking space used in legacy header labels. */
+  private static final String NBSP = "\u00a0";
+
+  /** Colon followed by a non-breaking space for compact labels. */
+  private static final String COLON_NBSP = ":" + NBSP;
+
+  /** Live daemon node used as the source of page state during each render. */
+  private final Node node;
+
+  /** Shared node statistics facade used by the overview and table renderers. */
+  private final NodeStats stats;
+
+  /** Shared peer manager facade used for status lookups and routing metadata. */
+  private final PeerManager peers;
+
+  /**
+   * Creates the daemon-side adapter for the legacy connections pages.
+   *
+   * @param node live node that supplies peer, routing, and bandwidth state for each render
+   * @param core live client core validated to preserve the legacy wiring contract for this adapter
+   * @throws NullPointerException if either argument is {@code null}
+   */
+  LegacyConnectionsPagePort(Node node, NodeClientCore core) {
+    this.node = Objects.requireNonNull(node);
+    Objects.requireNonNull(core);
+    this.stats = node.network().stats();
+    this.peers = node.network().peers();
+  }
+
+  @Override
+  public ConnectionsPageSnapshot render(ConnectionsPageRequest request) {
+    return rendererFor(request.kind()).render(request);
+  }
+
+  /**
+   * Returns the per-kind renderer used for one detached page render.
+   *
+   * @param kind requested legacy connections page kind
+   * @return fresh renderer configured for darknet or opennet output
+   */
+  private ConnectionsRenderer rendererFor(ConnectionsPageKind kind) {
+    return switch (kind) {
+      case DARKNET -> new DarknetRenderer();
+      case OPENNET -> new OpennetRenderer();
+    };
+  }
+
+  /** Describes one renderer-specific trailing table column and its header metadata. */
+  private abstract static class SimpleColumn {
+    protected abstract void drawColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus);
+
+    abstract String getSortString();
+
+    abstract String getTitleKey();
+
+    abstract String getExplanationKey();
+  }
+
+  /**
+   * Implements the shared detached-render pipeline for one legacy connections page kind.
+   *
+   * <p>Subclasses provide the peer source, localized titles, and any renderer-specific columns or
+   * row fragments. The base implementation owns the common work: sorting, overview infoboxes, peer
+   * table assembly, and splitting the final content around the peer-table placeholder so the HTTP
+   * layer can decide whether to wrap the table in a request-context form.
+   */
+  private abstract class ConnectionsRenderer {
+    ConnectionsPageSnapshot render(ConnectionsPageRequest request) {
+      PeerNodeStatus[] peerNodeStatuses = getPeerNodeStatuses(!request.drawMessageTypes());
+      Arrays.sort(peerNodeStatuses, comparator(request.sortBy(), request.reversed()));
+
+      PeerStatusCounts counts = computePeerStatusCounts(peerNodeStatuses);
+      String pageTitle = getPageTitle(buildTitleCountString(counts));
+      long now = System.currentTimeMillis();
+      DecimalFormat percentageFormat = new DecimalFormat("##0.0%");
+
+      HTMLNode contentNode = new HTMLNode("#");
+      if (request.advancedMode()) {
+        addOverviewSection(contentNode, percentageFormat, now, counts);
+      }
+
+      addPeerTableSectionTemplate(contentNode, request);
+      if (request.advancedMode()) {
+        addFoafTable(contentNode, peerNodeStatuses);
+      }
+
+      String peerTableHtml = buildPeerTableHtml(peerNodeStatuses, request, percentageFormat, now);
+      String contentHtml = contentNode.generate();
+      int placeholderIndex = contentHtml.indexOf(PEER_TABLE_PLACEHOLDER);
+      if (placeholderIndex < 0) {
+        throw new IllegalStateException("Connections page placeholder missing from detached HTML");
+      }
+
+      String contentHtmlBeforePeerTable = contentHtml.substring(0, placeholderIndex);
+      String contentHtmlAfterPeerTable =
+          contentHtml.substring(placeholderIndex + PEER_TABLE_PLACEHOLDER.length());
+
+      return new ConnectionsPageSnapshot(
+          pageTitle,
+          peerNodeStatuses.length,
+          peerActionsEnabled(),
+          contentHtmlBeforePeerTable,
+          peerTableHtml,
+          contentHtmlAfterPeerTable);
+    }
+
+    protected abstract String getPageTitle(String titleCountString);
+
+    protected abstract String getPeerListTitle();
+
+    protected abstract boolean isOpennet();
+
+    protected boolean peerActionsEnabled() {
+      return false;
+    }
+
+    protected boolean hasTrustColumn() {
+      return false;
+    }
+
+    protected void drawTrustColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+      // No-op by default.
+    }
+
+    protected boolean hasVisibilityColumn() {
+      return false;
+    }
+
+    protected void drawVisibilityColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
+      // No-op by default.
+    }
+
+    protected abstract boolean hasNameColumn();
+
+    protected abstract void drawNameColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled);
+
+    protected abstract boolean hasPrivateNoteColumn();
+
+    protected abstract void drawPrivateNoteColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled);
+
+    protected abstract PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy);
+
+    protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
+      return new ComparatorByStatus(sortBy, reversed);
+    }
+
+    /**
+     * Returns any renderer-specific trailing columns for the peer table.
+     *
+     * @param advancedMode whether the current request is rendering the advanced table variant;
+     *     subclasses may use this to expose extra columns
+     */
+    protected List<SimpleColumn> endColumnHeaders(boolean advancedMode) {
+      return List.of();
+    }
+
+    protected void drawPeerActionSelectBox(HTMLNode peerForm, boolean advancedModeEnabled) {
+      // No-op by default.
+    }
+
+    private void addOverviewSection(
+        HTMLNode contentNode, DecimalFormat percentageFormat, long now, PeerStatusCounts counts) {
+      long nodeUptimeSeconds = SECONDS.convert(now - node.getStartupTime(), MILLISECONDS);
+      int bwlimitDelayTime = (int) stats.getBwlimitDelayTime();
+      int nodeAveragePingTime = (int) stats.getNodeAveragePingTime();
+      int networkSizeEstimateSession = stats.getDarknetSizeEstimate(-1);
+      int networkSizeEstimateRecent = 0;
+      if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
+        networkSizeEstimateRecent = stats.getDarknetSizeEstimate(now - HOURS.toMillis(48));
+      }
+      DecimalFormat routingFormat = new DecimalFormat("0.0000");
+      double routingMissDistanceLocal = stats.routingMissDistanceLocal.currentValue();
+      double routingMissDistanceRemote = stats.routingMissDistanceRemote.currentValue();
+      double routingMissDistanceOverall = stats.routingMissDistanceOverall.currentValue();
+      double routingMissDistanceBulk = stats.routingMissDistanceBulk.currentValue();
+      double routingMissDistanceRT = stats.routingMissDistanceRT.currentValue();
+      double backedOffPercent = stats.backedOffPercent.currentValue();
+      String nodeUptimeString =
+          TimeUtil.formatTime(MILLISECONDS.convert(nodeUptimeSeconds, SECONDS));
+
+      HTMLNode overviewTable = contentNode.addChild(ELEMENT_TABLE, ATTR_CLASS, "column");
+      HTMLNode overviewTableRow = overviewTable.addChild("tr");
+      HTMLNode nextTableCell = overviewTableRow.addChild("td", ATTR_CLASS, "first");
+
+      HTMLNode overviewInfobox = nextTableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+      overviewInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, "Node status overview");
+      HTMLNode overviewInfoboxContent =
+          overviewInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+      HTMLNode overviewList = overviewInfoboxContent.addChild("ul");
+      overviewList.addChild("li", "bwlimitDelayTime:\u00a0" + bwlimitDelayTime + "ms");
+      overviewList.addChild("li", "nodeAveragePingTime:\u00a0" + nodeAveragePingTime + "ms");
+      overviewList.addChild(
+          "li", "darknetSizeEstimateSession:\u00a0" + networkSizeEstimateSession + "\u00a0nodes");
+      if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
+        overviewList.addChild(
+            "li", "darknetSizeEstimateRecent:\u00a0" + networkSizeEstimateRecent + "\u00a0nodes");
+      }
+      overviewList.addChild("li", "nodeUptime:\u00a0" + nodeUptimeString);
+      overviewList.addChild(
+          "li", "routingMissDistanceLocal:\u00a0" + routingFormat.format(routingMissDistanceLocal));
+      overviewList.addChild(
+          "li",
+          "routingMissDistanceRemote:\u00a0" + routingFormat.format(routingMissDistanceRemote));
+      overviewList.addChild(
+          "li",
+          "routingMissDistanceOverall:\u00a0" + routingFormat.format(routingMissDistanceOverall));
+      overviewList.addChild(
+          "li", "routingMissDistanceBulk:\u00a0" + routingFormat.format(routingMissDistanceBulk));
+      overviewList.addChild(
+          "li", "routingMissDistanceRT:\u00a0" + routingFormat.format(routingMissDistanceRT));
+      overviewList.addChild(
+          "li", "backedOffPercent:\u00a0" + percentageFormat.format(backedOffPercent));
+      overviewList.addChild(
+          "li",
+          "pInstantReject:\u00a0" + percentageFormat.format(stats.pRejectIncomingInstantly()));
+      nextTableCell = overviewTableRow.addChild("td");
+
+      addActivitySection(nextTableCell, nodeUptimeSeconds);
+      addPeerStatsSection(nextTableCell, counts);
+    }
+
+    private void addActivitySection(HTMLNode tableCell, long nodeUptimeSeconds) {
+      int numArkFetchers = node.network().numArkFetchers();
+
+      HTMLNode activityInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+      activityInfobox.addChild(
+          "div", ATTR_CLASS, INFOBOX_HEADER_CLASS, connectionsL10n("activityTitle"));
+      HTMLNode activityInfoboxContent =
+          activityInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+      HTMLNode activityList = drawActivity(activityInfoboxContent);
+      if (activityList != null) {
+        if (numArkFetchers > 0) {
+          activityList.addChild("li", "ARK\u00a0Fetch\u00a0Requests:\u00a0" + numArkFetchers);
+        }
+        drawBandwidth(activityList, nodeUptimeSeconds);
+      }
+    }
+
+    private void addPeerStatsSection(HTMLNode tableCell, PeerStatusCounts counts) {
+      HTMLNode peerStatsInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+      drawPeerStatsBox(peerStatsInfobox, counts);
+      addBackoffReasonBoxes(tableCell);
+    }
+
+    private void addBackoffReasonBoxes(HTMLNode tableCell) {
+      addBackoffReasonBox(tableCell, true, "Peer backoff reasons (realtime)");
+      addBackoffReasonBox(tableCell, false, "Peer backoff reasons (bulk)");
+    }
+
+    private void addBackoffReasonBox(HTMLNode tableCell, boolean realtime, String headerText) {
+      HTMLNode backoffReasonInfobox = tableCell.addChild("div", ATTR_CLASS, INFOBOX_CLASS);
+      HTMLNode title =
+          backoffReasonInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS, headerText);
+      HTMLNode backoffReasonContent =
+          backoffReasonInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+      String[] routingBackoffReasons = peers.getPeerNodeRoutingBackoffReasons(realtime);
+      int total = 0;
+      if (routingBackoffReasons.length == 0) {
+        backoffReasonContent.addChild(
+            "#", NodeL10n.getBase().getString("StatisticsToadlet.notBackedOff"));
+      } else {
+        HTMLNode reasonList = backoffReasonContent.addChild("ul");
+        for (String routingBackoffReason : routingBackoffReasons) {
+          int reasonCount =
+              peers.getPeerNodeRoutingBackoffReasonSize(routingBackoffReason, realtime);
+          if (reasonCount > 0) {
+            total += reasonCount;
+            reasonList.addChild("li", routingBackoffReason + '\u00a0' + reasonCount);
+          }
+        }
+      }
+      if (total > 0) {
+        title.addChild("#", ": " + total);
+      }
+    }
+
+    private void addPeerTableSectionTemplate(HTMLNode contentNode, ConnectionsPageRequest request) {
+      if (node.isFProxyJavascriptEnabled()) {
+        injectJavascript(contentNode);
+      }
+
+      HTMLNode peerTableInfobox = contentNode.addChild("div", ATTR_CLASS, INFOBOX_NORMAL_CLASS);
+      HTMLNode peerTableInfoboxHeader =
+          peerTableInfobox.addChild("div", ATTR_CLASS, INFOBOX_HEADER_CLASS);
+      peerTableInfoboxHeader.addChild("#", getPeerListTitle());
+      if (request.advancedMode() && !request.drawMessageTypes()) {
+        peerTableInfoboxHeader.addChild("#", " ");
+        peerTableInfoboxHeader.addChild(
+            "a", "href", DISPLAY_MESSAGE_TYPES, connectionsL10n("bracketedMoreDetailed"));
+      }
+
+      HTMLNode peerTableInfoboxContent =
+          peerTableInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+
+      if (!isOpennet()) {
+        addNameSection(peerTableInfoboxContent);
+      }
+
+      peerTableInfoboxContent.addChild("%", PEER_TABLE_PLACEHOLDER);
+    }
+
+    private String buildPeerTableHtml(
+        PeerNodeStatus[] peerNodeStatuses,
+        ConnectionsPageRequest request,
+        DecimalFormat percentageFormat,
+        long now) {
+      HTMLNode peerTableContent = new HTMLNode("#");
+      if (peerNodeStatuses.length == 0) {
+        addNoPeersMessage(peerTableContent);
+        return peerTableContent.generate();
+      }
+
+      HTMLNode peerTable =
+          peerTableContent.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
+      HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
+      boolean enablePeerActions = peerActionsEnabled();
+      boolean fProxyJavascriptEnabled = node.isFProxyJavascriptEnabled();
+      addPeerTableHeader(
+          enablePeerActions,
+          fProxyJavascriptEnabled,
+          peerTableHeaderRow,
+          request.advancedMode(),
+          request.reversed());
+
+      List<SimpleColumn> endCols = endColumnHeaders(request.advancedMode());
+      double totalSelectionRate = 0.0;
+      PeerNodeStatus[] allPeerNodeStatuses = peers.statusBook().getPeerNodeStatuses(true);
+      for (PeerNodeStatus status : allPeerNodeStatuses) {
+        totalSelectionRate += status.getSelectionRate();
+      }
+      RowRenderContext rowRenderContext =
+          new RowRenderContext(
+              endCols,
+              request,
+              fProxyJavascriptEnabled,
+              enablePeerActions,
+              percentageFormat,
+              now,
+              totalSelectionRate);
+
+      for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
+        drawRow(peerTable, peerNodeStatus, rowRenderContext);
+      }
+
+      if (enablePeerActions) {
+        drawPeerActionSelectBox(peerTableContent, request.advancedMode());
+      }
+
+      return peerTableContent.generate();
+    }
+
+    private void injectJavascript(HTMLNode contentNode) {
+      String js =
+          """
+            function peerNoteChange() {
+              document.getElementById("action").value = "update_notes";            document.getElementById("peersForm").doAction.click();
+            }
+          """;
+      contentNode.addChild("script", "type", "text/javascript").addChild("%", js);
+      contentNode.addChild(
+          "script",
+          new String[] {"type", "src"},
+          new String[] {"text/javascript", "/static/js/checkall.js"});
+    }
+
+    private void addNameSection(HTMLNode peerTableInfoboxContent) {
+      HTMLNode myName = peerTableInfoboxContent.addChild("p");
+      myName.addChild(
+          "span",
+          NodeL10n.getBase()
+              .getString("DarknetConnectionsToadlet.myName", "name", node.getMyName()));
+      myName.addChild("span", " [");
+      myName
+          .addChild("span")
+          .addChild(
+              "a",
+              "href",
+              "/config/node#name",
+              NodeL10n.getBase().getString("DarknetConnectionsToadlet.changeMyName"));
+      myName.addChild("span", "]");
+    }
+
+    private void addNoPeersMessage(HTMLNode peerTableInfoboxContent) {
+      NodeL10n.getBase()
+          .addL10nSubstitution(
+              peerTableInfoboxContent,
+              "DarknetConnectionsToadlet.noPeersWithHomepageLink",
+              new String[] {"link"},
+              new HTMLNode[] {HTMLNode.link("/")});
+    }
+
+    private void addPeerTableHeader(
+        boolean enablePeerActions,
+        boolean fProxyJavascriptEnabled,
+        HTMLNode peerTableHeaderRow,
+        boolean advancedMode,
+        boolean reversed) {
+      if (enablePeerActions) {
+        if (fProxyJavascriptEnabled) {
+          peerTableHeaderRow
+              .addChild("th")
+              .addChild(
+                  ELEMENT_INPUT,
+                  new String[] {"type", "onclick"},
+                  new String[] {"checkbox", "checkAll(this, 'darknet_connections')"});
+        } else {
+          peerTableHeaderRow.addChild("th");
+        }
+      }
+
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "status"))
+          .addChild("#", connectionsL10n("statusTitle"));
+
+      if (hasNameColumn()) {
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "name"))
+            .addChild(
+                "span",
+                new String[] {ATTR_TITLE, ATTR_STYLE},
+                new String[] {connectionsL10n("nameClickToMessage"), HELP_STYLE},
+                connectionsL10n("nameTitle"));
+      }
+
+      if (hasTrustColumn()) {
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, TRUST))
+            .addChild(
+                "span",
+                new String[] {ATTR_TITLE, ATTR_STYLE},
+                new String[] {connectionsL10n("trustMessage"), HELP_STYLE},
+                connectionsL10n("trustTitle"));
+      }
+
+      if (hasVisibilityColumn()) {
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, TRUST))
+            .addChild(
+                "span",
+                new String[] {ATTR_TITLE, ATTR_STYLE},
+                new String[] {
+                  connectionsL10n("visibilityMessage" + (advancedMode ? "Advanced" : "Simple")),
+                  HELP_STYLE
+                },
+                connectionsL10n("visibilityTitle"));
+      }
+
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "address"))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {connectionsL10n("ipAddress"), HELP_STYLE},
+              connectionsL10n("ipAddressTitle"));
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "version"))
+          .addChild("#", connectionsL10n("versionTitle"));
+
+      if (advancedMode) {
+        addAdvancedPeerTableHeaders(peerTableHeaderRow, reversed);
+      }
+
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "idle"))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {connectionsL10n("idleTime"), HELP_STYLE},
+              connectionsL10n("idleTimeTitle"));
+
+      if (hasPrivateNoteColumn()) {
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "privnote"))
+            .addChild(
+                "span",
+                new String[] {ATTR_TITLE, ATTR_STYLE},
+                new String[] {connectionsL10n("privateNote"), HELP_STYLE},
+                connectionsL10n("privateNoteTitle"));
+      }
+
+      if (advancedMode) {
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "time_routable"))
+            .addChild("#", "%\u00a0Time Routable");
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "selection_percentage"))
+            .addChild("#", "%\u00a0Selection");
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "total_traffic"))
+            .addChild("#", "Total\u00a0Traffic\u00a0(in/out/resent)");
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "total_traffic_since_startup"))
+            .addChild("#", "Total\u00a0Traffic\u00a0(in/out) since startup");
+        peerTableHeaderRow.addChild("th", "Congestion\u00a0Control");
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "time_delta"))
+            .addChild("#", "Time\u00a0Delta");
+        peerTableHeaderRow
+            .addChild("th")
+            .addChild("a", "href", sortString(reversed, "uptime"))
+            .addChild("#", "Reported\u00a0Uptime");
+        peerTableHeaderRow.addChild("th", "Transmit\u00a0Queue");
+        peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Bulk");
+        peerTableHeaderRow.addChild("th", "Peer\u00a0Capacity\u00a0Realtime");
+      }
+
+      for (SimpleColumn col : endColumnHeaders(advancedMode)) {
+        HTMLNode header = peerTableHeaderRow.addChild("th");
+        String sortString = col.getSortString();
+        if (sortString != null) {
+          header = header.addChild("a", "href", sortString(reversed, sortString));
+        }
+        header.addChild(
+            "span",
+            new String[] {ATTR_TITLE, ATTR_STYLE},
+            new String[] {NodeL10n.getBase().getString(col.getExplanationKey()), HELP_STYLE},
+            NodeL10n.getBase().getString(col.getTitleKey()));
+      }
+    }
+
+    private void addAdvancedPeerTableHeaders(HTMLNode peerTableHeaderRow, boolean reversed) {
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "location"))
+          .addChild("#", connectionsL10n("locationTitle"));
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "backoffRT"))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {
+                "Other node busy (realtime)? Display: Percentage of time the node is"
+                    + " overloaded, Current wait time remaining (0=not overloaded)/total/last"
+                    + " overload reason",
+                HELP_STYLE
+              },
+              "Backoff (realtime)");
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "backoffBulk"))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {
+                "Other node busy (bulk)? Display: Percentage of time the node is overloaded,"
+                    + " Current wait time remaining (0=not overloaded)/total/last overload"
+                    + " reason",
+                HELP_STYLE
+              },
+              "Backoff (bulk)");
+      peerTableHeaderRow
+          .addChild("th")
+          .addChild("a", "href", sortString(reversed, "overload_p"))
+          .addChild(
+              "span",
+              new String[] {ATTR_TITLE, ATTR_STYLE},
+              new String[] {
+                "Probability of the node rejecting a request due to overload or causing a timeout.",
+                HELP_STYLE
+              },
+              "Overload Probability");
+    }
+
+    private void drawRow(
+        HTMLNode peerTable, PeerNodeStatus peerNodeStatus, RowRenderContext rowRenderContext) {
+      ConnectionsPageRequest request = rowRenderContext.request();
+      DecimalFormat percentageFormat = rowRenderContext.percentageFormat();
+      long now = rowRenderContext.now();
+      double totalSelectionRate = rowRenderContext.totalSelectionRate();
+      int peerSelectionPercentage =
+          totalSelectionRate <= 0
+              ? 0
+              : (int) (peerNodeStatus.getSelectionRate() * 100 / totalSelectionRate);
+      HTMLNode peerRow =
+          peerTable.addChild(
+              "tr",
+              ATTR_CLASS,
+              "darknet_connections_"
+                  + (peerSelectionPercentage > PeerNode.SELECTION_PERCENTAGE_WARNING
+                      ? "warning"
+                      : "normal"));
+
+      if (rowRenderContext.enablePeerActions()) {
+        peerRow
+            .addChild("td", ATTR_CLASS, "peer-marker")
+            .addChild(
+                ELEMENT_INPUT,
+                new String[] {"type", "name"},
+                new String[] {"checkbox", NODE_PREFIX + peerNodeStatus.hashCode()});
+      }
+
+      addStatusColumn(peerRow, peerNodeStatus, request.advancedMode());
+      drawNameColumn(peerRow, peerNodeStatus, request.advancedMode());
+      drawTrustColumn(peerRow, peerNodeStatus);
+      drawVisibilityColumn(peerRow, peerNodeStatus, request.advancedMode());
+      addAddressColumn(peerRow, peerNodeStatus);
+      addVersionColumn(peerRow, peerNodeStatus);
+
+      if (request.advancedMode()) {
+        addLocationColumn(peerRow, peerNodeStatus);
+        addBackoffColumns(peerRow, peerNodeStatus, now, percentageFormat);
+        addPRejectColumn(peerRow, peerNodeStatus, percentageFormat);
+      }
+
+      addIdleColumn(peerRow, peerNodeStatus, now);
+
+      if (hasPrivateNoteColumn()) {
+        drawPrivateNoteColumn(peerRow, peerNodeStatus, rowRenderContext.fProxyJavascriptEnabled());
+      }
+
+      if (request.advancedMode()) {
+        addAdvancedStatistics(
+            peerRow, peerNodeStatus, percentageFormat, peerSelectionPercentage, totalSelectionRate);
+      }
+
+      for (SimpleColumn col : rowRenderContext.endCols()) {
+        col.drawColumn(peerRow, peerNodeStatus);
+      }
+
+      if (request.drawMessageTypes()) {
+        drawMessageTypes(peerTable, peerNodeStatus);
+      }
+    }
+
+    private void addStatusColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
+      String statusString = peerNodeStatus.getStatusName();
+      if (!advancedModeEnabled
+          && peerNodeStatus.getStatusValue() == PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF) {
+        statusString = "BUSY";
+      }
+      String key = "ConnectionsToadlet.nodeStatus." + statusString.replace(' ', '_');
+      peerRow
+          .addChild("td", ATTR_CLASS, "peer-status")
+          .addChild(
+              "span",
+              ATTR_CLASS,
+              peerNodeStatus.getStatusCSSName(),
+              NodeL10n.getBase().getString(key) + (peerNodeStatus.isFetchingARK() ? "*" : ""));
+    }
+
+    private void addAddressColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+      String pingTime = "";
+      if (peerNodeStatus.isConnected()) {
+        pingTime =
+            " ("
+                + (int) peerNodeStatus.getAveragePingTime()
+                + "ms / "
+                + (int) peerNodeStatus.getAveragePingTimeCorrected()
+                + "ms)";
+      }
+
+      HTMLNode addressRow = peerRow.addChild("td", ATTR_CLASS, "peer-address");
+      IPConverter ipc = IPConverter.getInstance(NodeFile.IPV4_TO_COUNTRY.getFile(node));
+      Country country = ipc.locateIP(peerNodeStatus.getPeerAddressBytes());
+      if (country != null) {
+        country.renderFlagIcon(addressRow);
+      }
+
+      String address =
+          peerNodeStatus.getPeerAddress() != null
+              ? peerNodeStatus.getPeerAddressAndPort()
+              : connectionsL10n("unknownAddress");
+      addressRow.addChild("#", address + pingTime);
+    }
+
+    private void addVersionColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+      HTMLNode versionCell = peerRow.addChild("td", ATTR_CLASS, "peer-version");
+      if (peerNodeStatus.getStatusValue() != PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED
+          && (peerNodeStatus.isPublicInvalidVersion()
+              || peerNodeStatus.isPublicReverseInvalidVersion())) {
+        versionCell.addChild(
+            "span",
+            ATTR_CLASS,
+            "peer_version_problem",
+            Integer.toString(peerNodeStatus.getSimpleVersion()));
+        return;
+      }
+      versionCell.addChild("#", Integer.toString(peerNodeStatus.getSimpleVersion()));
+    }
+
+    private void addLocationColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+      HTMLNode locationNode = peerRow.addChild("td", ATTR_CLASS, "peer-location");
+      locationNode.addChild("b", String.valueOf(peerNodeStatus.getLocation()));
+      locationNode.addChild("br");
+      double[] peersLoc = peerNodeStatus.getPeersLocation();
+      if (peersLoc != null) {
+        locationNode.addChild("i", "+" + peersLoc.length + " friends");
+      }
+    }
+
+    private void addBackoffColumns(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, long now, DecimalFormat percentageFormat) {
+      addBackoffColumn(peerRow, peerNodeStatus, now, percentageFormat, true);
+      addBackoffColumn(peerRow, peerNodeStatus, now, percentageFormat, false);
+    }
+
+    private void addBackoffColumn(
+        HTMLNode peerRow,
+        PeerNodeStatus peerNodeStatus,
+        long now,
+        DecimalFormat percentageFormat,
+        boolean realtime) {
+      HTMLNode backoffCell = peerRow.addChild("td", ATTR_CLASS, "peer-backoff");
+      backoffCell.addChild(
+          "#", percentageFormat.format(peerNodeStatus.getBackedOffPercent(realtime)));
+      int backoff = (int) Math.max(peerNodeStatus.getRoutingBackedOffUntil(realtime) - now, 0);
+      if (backoff > 0 && backoff < 1000) {
+        backoff = 1000;
+      }
+      backoffCell.addChild(
+          "#",
+          ' '
+              + String.valueOf(backoff / 1000)
+              + '/'
+              + peerNodeStatus.getRoutingBackoffLength(realtime) / 1000);
+      backoffCell.addChild(
+          "#",
+          peerNodeStatus.getLastBackoffReason(realtime) == null
+              ? ""
+              : '/' + peerNodeStatus.getLastBackoffReason(realtime));
+    }
+
+    private void addPRejectColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, DecimalFormat percentageFormat) {
+      peerRow
+          .addChild("td", ATTR_CLASS, "peer-backoff")
+          .addChild("#", percentageFormat.format(peerNodeStatus.getPReject()));
+    }
+
+    private void addIdleColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus, long now) {
+      long idle = peerNodeStatus.getTimeLastRoutable();
+      if (peerNodeStatus.isRoutable()) {
+        idle = peerNodeStatus.getTimeLastConnectionCompleted();
+      } else if (peerNodeStatus.getStatusValue() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED) {
+        idle = peerNodeStatus.getPeerAddedTime();
+      }
+
+      if (!peerNodeStatus.isConnected() && (now - idle) > (2L * 7 * 24 * 60 * 60 * 1000)) {
+        HTMLNode idleNode = peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS);
+        idleNode.addChild("span", ATTR_CLASS, "peer_idle_old", idleToString(now, idle));
+        return;
+      }
+
+      peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS, idleToString(now, idle));
+    }
+
+    private void addAdvancedStatistics(
+        HTMLNode peerRow,
+        PeerNodeStatus peerNodeStatus,
+        DecimalFormat percentageFormat,
+        int peerSelectionPercentage,
+        double totalSelectionRate) {
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild(
+              "#", percentageFormat.format(peerNodeStatus.getPercentTimeRoutableConnection()));
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild("#", totalSelectionRate > 0 ? peerSelectionPercentage + "%" : "N/A");
+      addTrafficColumns(peerRow, peerNodeStatus, percentageFormat);
+      addTrafficSinceStartupColumn(peerRow, peerNodeStatus);
+      addCongestionControl(peerRow, peerNodeStatus);
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild("#", TimeUtil.formatTime(peerNodeStatus.getClockDelta()));
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild("#", peerNodeStatus.getReportedUptimePercentage() + "%");
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild(
+              "#",
+              SizeUtil.formatSize(peerNodeStatus.getMessageQueueLengthBytes())
+                  + ":"
+                  + TimeUtil.formatTime(peerNodeStatus.getMessageQueueLengthTime()));
+      addIncomingLoad(peerRow, peerNodeStatus.incomingLoadStatsBulk);
+      addIncomingLoad(peerRow, peerNodeStatus.incomingLoadStatsRealTime);
+    }
+
+    private void addTrafficColumns(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, DecimalFormat percentageFormat) {
+      long sent = peerNodeStatus.getTotalOutputBytes();
+      long resent = peerNodeStatus.getResendBytesSent();
+      long received = peerNodeStatus.getTotalInputBytes();
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild(
+              "#",
+              SizeUtil.formatSize(received)
+                  + " / "
+                  + SizeUtil.formatSize(sent)
+                  + "/"
+                  + SizeUtil.formatSize(resent)
+                  + " ("
+                  + percentageFormat.format(((double) resent) / ((double) sent))
+                  + ")");
+    }
+
+    private void addTrafficSinceStartupColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild(
+              "#",
+              SizeUtil.formatSize(peerNodeStatus.getTotalInputSinceStartup())
+                  + " / "
+                  + SizeUtil.formatSize(peerNodeStatus.getTotalOutputSinceStartup()));
+    }
+
+    private void addCongestionControl(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+      PacketThrottle throttle = peerNodeStatus.getThrottle();
+      String val;
+      if (throttle == null) {
+        val = "none";
+      } else {
+        val =
+            (int) throttle.getBandwidth()
+                + "B/sec delay "
+                + throttle.getDelay()
+                + "ms (RTT "
+                + throttle.getRoundTripTime()
+                + "ms window "
+                + throttle.getWindowSize()
+                + ')';
+      }
+      peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS).addChild("#", val);
+    }
+
+    private void addIncomingLoad(HTMLNode peerRow, IncomingLoadSummaryStats loadStats) {
+      if (loadStats == null) {
+        peerRow.addChild("td", ATTR_CLASS, PEER_IDLE_CLASS);
+        return;
+      }
+
+      peerRow
+          .addChild("td", ATTR_CLASS, PEER_IDLE_CLASS)
+          .addChild(
+              "#",
+              loadStats.runningRequestsTotal
+                  + "reqs:out:"
+                  + SizeUtil.formatSize(loadStats.usedCapacityOutputBytes)
+                  + "/"
+                  + SizeUtil.formatSize(loadStats.othersUsedCapacityOutputBytes)
+                  + "/"
+                  + SizeUtil.formatSize(loadStats.peerCapacityOutputBytes)
+                  + "/"
+                  + SizeUtil.formatSize(loadStats.totalCapacityOutputBytes)
+                  + ":in:"
+                  + SizeUtil.formatSize(loadStats.usedCapacityInputBytes)
+                  + "/"
+                  + SizeUtil.formatSize(loadStats.othersUsedCapacityInputBytes)
+                  + "/"
+                  + SizeUtil.formatSize(loadStats.peerCapacityInputBytes)
+                  + "/"
+                  + SizeUtil.formatSize(loadStats.totalCapacityInputBytes));
+    }
+
+    private void drawMessageTypes(HTMLNode peerTable, PeerNodeStatus peerNodeStatus) {
+      HTMLNode messageCountRow = peerTable.addChild("tr", ATTR_CLASS, "message-status");
+      messageCountRow.addChild("td", "colspan", "2");
+      HTMLNode messageCountCell = messageCountRow.addChild("td", "colspan", "9");
+      HTMLNode messageCountTable =
+          messageCountCell.addChild(ELEMENT_TABLE, ATTR_CLASS, "message-count");
+      HTMLNode countHeaderRow = messageCountTable.addChild("tr");
+      countHeaderRow.addChild("th", "Message");
+      countHeaderRow.addChild("th", "Incoming");
+      countHeaderRow.addChild("th", "Outgoing");
+
+      List<String> messageNames = new ArrayList<>();
+      Map<String, Long[]> messageCounts = new HashMap<>();
+      for (Map.Entry<String, Long> entry : peerNodeStatus.getLocalMessagesReceived().entrySet()) {
+        String messageName = entry.getKey();
+        Long messageCount = entry.getValue();
+        messageNames.add(messageName);
+        messageCounts.put(messageName, new Long[] {messageCount, 0L});
+      }
+      for (Map.Entry<String, Long> entry : peerNodeStatus.getLocalMessagesSent().entrySet()) {
+        String messageName = entry.getKey();
+        Long messageCount = entry.getValue();
+        if (!messageNames.contains(messageName)) {
+          messageNames.add(messageName);
+        }
+        Long[] existingCounts = messageCounts.get(messageName);
+        if (existingCounts == null) {
+          messageCounts.put(messageName, new Long[] {0L, messageCount});
+        } else {
+          existingCounts[1] = messageCount;
+        }
+      }
+
+      messageNames.sort(String::compareToIgnoreCase);
+      for (String messageName : messageNames) {
+        Long[] messageCount = messageCounts.get(messageName);
+        HTMLNode messageRow = messageCountTable.addChild("tr");
+        messageRow.addChild("td", messageName);
+        messageRow.addChild("td", ATTR_CLASS, "right-align", String.valueOf(messageCount[0]));
+        messageRow.addChild("td", ATTR_CLASS, "right-align", String.valueOf(messageCount[1]));
+      }
+    }
+
+    private void addFoafTable(HTMLNode contentNode, PeerNodeStatus[] peerNodeStatuses) {
+      FoafGrouping grouping = buildFoafGrouping(peerNodeStatuses);
+      addFoafSummary(contentNode, grouping);
+      addFoafRows(contentNode, peerNodeStatuses, grouping);
+    }
+
+    private void addFoafSummary(HTMLNode contentNode, FoafGrouping grouping) {
+      contentNode.addChild(
+          "b",
+          connectionsL10nCount(
+              "secondDegreeConnectionsCountTitle", Integer.toString(grouping.locations().size())));
+      contentNode.addChild("br");
+      contentNode.addChild(
+          "i",
+          connectionsL10nCount(
+              "secondDegreeTrivialHiddenCount", Integer.toString(grouping.trivialCount())));
+    }
+
+    private void addFoafRows(
+        HTMLNode contentNode, PeerNodeStatus[] peerNodeStatuses, FoafGrouping grouping) {
+      HTMLNode foafTable = contentNode.addChild(ELEMENT_TABLE, ATTR_CLASS, DARKNET_CONNECTIONS);
+      HTMLNode foafRow = foafTable.addChild("tr");
+      foafRow.addChild("th", connectionsL10n("locationTitle"));
+      foafRow.addChild("th", connectionsL10n("countTitle"));
+      foafRow.addChild("th", connectionsL10n("foafReachableThroughTitle"));
+      int max = grouping.locations().size();
+      int transitiveCount = 0;
+      for (int i = 0; i < max; i++) {
+        double location = grouping.locations().get(i);
+        List<PeerNodeStatus> peersWithFriend = grouping.peerGroups().get(i);
+        boolean isTransitivePeer = isTransitivePeer(peerNodeStatuses, location);
+        if (peersWithFriend.size() == 1 && !isTransitivePeer) {
+          continue;
+        }
+        foafRow = foafTable.addChild("tr");
+        if (isTransitivePeer) {
+          foafRow.addChild("td").addChild("b", String.valueOf(location));
+        } else {
+          foafRow.addChild("td", String.valueOf(location));
+        }
+        foafRow.addChild("td", String.valueOf(peersWithFriend.size()));
+        HTMLNode locationCell = foafRow.addChild("td", ATTR_CLASS, "peer-location");
+        for (PeerNodeStatus peerNodeStatus : peersWithFriend) {
+          String address =
+              peerNodeStatus.getPeerAddress() != null
+                  ? peerNodeStatus.getPeerAddressAndPort()
+                  : connectionsL10n("unknownAddress");
+          locationCell.addChild("i", address);
+          locationCell.addChild("br");
+        }
+        if (isTransitivePeer) {
+          transitiveCount++;
+        }
+      }
+      if (transitiveCount > 0) {
+        contentNode.addChild(
+            "i", connectionsL10nCount("secondDegreeAlsoOurs", Integer.toString(transitiveCount)));
+      }
+    }
+
+    private FoafGrouping buildFoafGrouping(PeerNodeStatus[] peerNodeStatuses) {
+      List<Double> locations = new ArrayList<>();
+      List<List<PeerNodeStatus>> peerGroups = new ArrayList<>();
+      for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
+        double[] peersLoc = peerNodeStatus.getPeersLocation();
+        if (peersLoc == null) {
+          continue;
+        }
+        for (double location : peersLoc) {
+          int i = 0;
+          int max = locations.size();
+          while (i < max && locations.get(i) < location) {
+            i++;
+          }
+          List<PeerNodeStatus> peerGroup;
+          if (i < max && locations.get(i) == location) {
+            peerGroup = peerGroups.get(i);
+          } else {
+            peerGroup = new ArrayList<>();
+            locations.add(i, location);
+            peerGroups.add(i, peerGroup);
+          }
+          peerGroup.add(peerNodeStatus);
+        }
+      }
+      return new FoafGrouping(locations, peerGroups);
+    }
+
+    private boolean isTransitivePeer(PeerNodeStatus[] peerNodeStatuses, double location) {
+      for (PeerNodeStatus peerNodeStatus : peerNodeStatuses) {
+        if (location == peerNodeStatus.getLocation()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private PeerStatusCounts computePeerStatusCounts(PeerNodeStatus[] peerNodeStatuses) {
+      return new PeerStatusCounts(
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONNECTED),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF),
+          PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_NEW),
+          PeerNodeStatus.getPeerStatusCount(peerNodeStatuses, PeerManager.PEER_NODE_STATUS_TOO_OLD),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTED),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISABLED),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_BURSTING),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTENING),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_LISTEN_ONLY),
+          0,
+          0,
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_ROUTING_DISABLED),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CLOCK_PROBLEM),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_CONN_ERROR),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_DISCONNECTING),
+          PeerNodeStatus.getPeerStatusCount(
+              peerNodeStatuses, PeerManager.PEER_NODE_STATUS_NO_LOAD_STATS));
+    }
+
+    private String buildTitleCountString(PeerStatusCounts counts) {
+      if (!node.isAdvancedModeEnabled()) {
+        int numberOfSimpleConnected = counts.connected() + counts.routingBackedOff();
+        int numberOfNotConnected = counts.notConnected();
+        return (numberOfNotConnected + numberOfSimpleConnected) > 0
+            ? String.valueOf(numberOfSimpleConnected)
+            : "";
+      }
+
+      return "("
+          + counts.connected()
+          + '/'
+          + counts.routingBackedOff()
+          + '/'
+          + counts.tooNew()
+          + '/'
+          + counts.tooOld()
+          + '/'
+          + counts.noLoadStats()
+          + '/'
+          + counts.routingDisabled()
+          + '/'
+          + counts.notConnected()
+          + ')';
+    }
+
+    private HTMLNode drawActivity(HTMLNode activityInfoboxContent) {
+      RequestTracker tracker = node.routing().tracker();
+      int numLocalChkInserts = tracker.getNumLocalCHKInserts();
+      int numRemoteChkInserts = tracker.getNumRemoteCHKInserts();
+      int numLocalSskInserts = tracker.getNumLocalSSKInserts();
+      int numRemoteSskInserts = tracker.getNumRemoteSSKInserts();
+      int numLocalChkRequests = tracker.getNumLocalCHKRequests();
+      int numRemoteChkRequests = tracker.getNumRemoteCHKRequests();
+      int numLocalSskRequests = tracker.getNumLocalSSKRequests();
+      int numRemoteSskRequests = tracker.getNumRemoteSSKRequests();
+      int numTransferringRequests = tracker.getNumTransferringRequestSenders();
+      int numTransferringRequestHandlers = tracker.getNumTransferringRequestHandlers();
+      int numChkOfferReplys = tracker.getNumCHKOfferReplies();
+      int numSskOfferReplys = tracker.getNumSSKOfferReplies();
+      int numChkRequests = numLocalChkRequests + numRemoteChkRequests;
+      int numSskRequests = numLocalSskRequests + numRemoteSskRequests;
+      int numChkInserts = numLocalChkInserts + numRemoteChkInserts;
+      int numSskInserts = numLocalSskInserts + numRemoteSskInserts;
+      if ((numTransferringRequests == 0)
+          && (numChkRequests == 0)
+          && (numSskRequests == 0)
+          && (numChkInserts == 0)
+          && (numSskInserts == 0)
+          && (numTransferringRequestHandlers == 0)
+          && (numChkOfferReplys == 0)
+          && (numSskOfferReplys == 0)) {
+        activityInfoboxContent.addChild("#", statisticsL10n("noRequests"));
+        return null;
+      }
+
+      HTMLNode activityList = activityInfoboxContent.addChild("ul");
+      if (numChkInserts > 0 || numSskInserts > 0) {
+        activityList.addChild(
+            "li",
+            NodeL10n.getBase()
+                .getString(
+                    "StatisticsToadlet.activityInserts",
+                    new String[] {"CHKhandlers", "SSKhandlers", "local"},
+                    new String[] {
+                      Integer.toString(numChkInserts),
+                      Integer.toString(numSskInserts),
+                      numLocalChkInserts + "/" + numLocalSskInserts
+                    }));
+      }
+      if (numChkRequests > 0 || numSskRequests > 0) {
+        activityList.addChild(
+            "li",
+            NodeL10n.getBase()
+                .getString(
+                    "StatisticsToadlet.activityRequests",
+                    new String[] {"CHKhandlers", "SSKhandlers", "local"},
+                    new String[] {
+                      Integer.toString(numChkRequests),
+                      Integer.toString(numSskRequests),
+                      numLocalChkRequests + "/" + numLocalSskRequests
+                    }));
+      }
+      if (numTransferringRequests > 0 || numTransferringRequestHandlers > 0) {
+        activityList.addChild(
+            "li",
+            NodeL10n.getBase()
+                .getString(
+                    "StatisticsToadlet.transferringRequests",
+                    new String[] {"senders", "receivers", "turtles"},
+                    new String[] {
+                      Integer.toString(numTransferringRequests),
+                      Integer.toString(numTransferringRequestHandlers),
+                      "0"
+                    }));
+      }
+      if (numChkOfferReplys > 0 || numSskOfferReplys > 0) {
+        activityList.addChild(
+            "li",
+            NodeL10n.getBase()
+                .getString(
+                    "StatisticsToadlet.offerReplys",
+                    new String[] {"chk", "ssk"},
+                    new String[] {
+                      Integer.toString(numChkOfferReplys), Integer.toString(numSskOfferReplys)
+                    }));
+      }
+      activityList.addChild(
+          "li",
+          NodeL10n.getBase()
+              .getString(
+                  "StatisticsToadlet.runningBlockTransfers",
+                  new String[] {"sends", "receives"},
+                  new String[] {
+                    Integer.toString(BlockTransmitter.getRunningSends()),
+                    Integer.toString(BlockReceiver.getRunningReceives())
+                  }));
+      return activityList;
+    }
+
+    private void drawBandwidth(HTMLNode activityList, long nodeUptimeSeconds) {
+      long[] total = node.network().collector().getTotalIO();
+      if (total[0] == 0 || total[1] == 0) {
+        return;
+      }
+      long totalOutputRate = total[0] / nodeUptimeSeconds;
+      long totalInputRate = total[1] / nodeUptimeSeconds;
+      long totalPayload = node.getTotalPayloadSent();
+      long totalPayloadRate = totalPayload / nodeUptimeSeconds;
+      BandwidthStatsContainer bandwidthStats =
+          node.services()
+              .clientCore()
+              .getClientLayerPersister()
+              .getBandwidthStatsPutter()
+              .getLatestBWData();
+      if (bandwidthStats == null) {
+        throw new NullPointerException();
+      }
+      long overallTotalOut = bandwidthStats.getTotalBytesOut();
+      long overallTotalIn = bandwidthStats.getTotalBytesIn();
+      int percent = (int) (100 * totalPayload / total[0]);
+      long[] rate = node.network().stats().getNodeIOStats();
+      long delta = (rate[5] - rate[2]) / 1000;
+      if (delta > 0) {
+        long outputRate = (rate[3] - rate[0]) / delta;
+        long inputRate = (rate[4] - rate[1]) / delta;
+        SubConfig nodeConfig = node.getConfig().get("node");
+        int outputBandwidthLimit = nodeConfig.getInt("outputBandwidthLimit");
+        int inputBandwidthLimit = nodeConfig.getInt("inputBandwidthLimit");
+        if (inputBandwidthLimit == -1) {
+          inputBandwidthLimit = outputBandwidthLimit * 4;
+        }
+        activityList.addChild(
+            "li",
+            statisticsL10n(
+                "inputRate",
+                new String[] {"rate", "max"},
+                new String[] {
+                  SizeUtil.formatSize(inputRate, true),
+                  SizeUtil.formatSize(inputBandwidthLimit, true)
+                }));
+        activityList.addChild(
+            "li",
+            statisticsL10n(
+                "outputRate",
+                new String[] {"rate", "max"},
+                new String[] {
+                  SizeUtil.formatSize(outputRate, true),
+                  SizeUtil.formatSize(outputBandwidthLimit, true)
+                }));
+      }
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "totalInputSession",
+              new String[] {TOTAL_KEY, "rate"},
+              new String[] {
+                SizeUtil.formatSize(total[1], true), SizeUtil.formatSize(totalInputRate, true)
+              }));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "totalOutputSession",
+              new String[] {TOTAL_KEY, "rate"},
+              new String[] {
+                SizeUtil.formatSize(total[0], true), SizeUtil.formatSize(totalOutputRate, true)
+              }));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "payloadOutput",
+              new String[] {TOTAL_KEY, "rate", PERCENT_KEY},
+              new String[] {
+                SizeUtil.formatSize(totalPayload, true),
+                SizeUtil.formatSize(totalPayloadRate, true),
+                Integer.toString(percent)
+              }));
+      activityList.addChild(
+          "li", statisticsL10n("totalInput", SizeUtil.formatSize(overallTotalIn, true)));
+      activityList.addChild(
+          "li", statisticsL10n("totalOutput", SizeUtil.formatSize(overallTotalOut, true)));
+      long totalBytesSentChkRequests = stats.getCHKRequestTotalBytesSent();
+      long totalBytesSentSskRequests = stats.getSSKRequestTotalBytesSent();
+      long totalBytesSentChkInserts = stats.getCHKInsertTotalBytesSent();
+      long totalBytesSentSskInserts = stats.getSSKInsertTotalBytesSent();
+      long totalBytesSentOfferedKeys = stats.getOfferedKeysTotalBytesSent();
+      long totalBytesSentOffers = stats.getOffersSentBytesSent();
+      long totalBytesSentSwapOutput = stats.getSwappingTotalBytesSent();
+      long totalBytesSentAuth = stats.getTotalAuthBytesSent();
+      long totalBytesSentAckOnly = stats.getNotificationOnlyPacketsSentBytes();
+      long totalBytesSentResends = stats.getResendBytesSent();
+      long totalBytesSentUom = stats.getUOMBytesSent();
+      long totalBytesSentAnnounce = stats.getAnnounceBytesSent();
+      long totalBytesSentAnnouncePayload = stats.getAnnounceBytesPayloadSent();
+      long totalBytesSentRoutingStatus = stats.getRoutingStatusBytes();
+      long totalBytesSentNetworkColoring = stats.getNetworkColoringSentBytes();
+      long totalBytesSentPing = stats.getPingSentBytes();
+      long totalBytesSentProbeRequest = stats.getProbeRequestSentBytes();
+      long totalBytesSentRouted = stats.getRoutedMessageSentBytes();
+      long totalBytesSentDisconn = stats.getDisconnBytesSent();
+      long totalBytesSentInitial = stats.getInitialMessagesBytesSent();
+      long totalBytesSentChangedIp = stats.getChangedIPBytesSent();
+      long totalBytesSentNodeToNode = stats.getNodeToNodeBytesSent();
+      long totalBytesSentAllocationNotices = stats.getAllocationNoticesBytesSent();
+      long totalBytesSentFoaf = stats.getFOAFBytesSent();
+      long totalBytesSentRemaining =
+          total[0]
+              - (totalPayload
+                  + totalBytesSentChkRequests
+                  + totalBytesSentSskRequests
+                  + totalBytesSentChkInserts
+                  + totalBytesSentSskInserts
+                  + totalBytesSentOfferedKeys
+                  + totalBytesSentOffers
+                  + totalBytesSentSwapOutput
+                  + totalBytesSentAuth
+                  + totalBytesSentAckOnly
+                  + totalBytesSentResends
+                  + totalBytesSentUom
+                  + totalBytesSentAnnounce
+                  + totalBytesSentRoutingStatus
+                  + totalBytesSentNetworkColoring
+                  + totalBytesSentPing
+                  + totalBytesSentProbeRequest
+                  + totalBytesSentRouted
+                  + totalBytesSentDisconn
+                  + totalBytesSentInitial
+                  + totalBytesSentChangedIp
+                  + totalBytesSentNodeToNode
+                  + totalBytesSentAllocationNotices
+                  + totalBytesSentFoaf);
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "requestOutput",
+              new String[] {"chk", "ssk"},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentChkRequests, true),
+                SizeUtil.formatSize(totalBytesSentSskRequests, true)
+              }));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "insertOutput",
+              new String[] {"chk", "ssk"},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentChkInserts, true),
+                SizeUtil.formatSize(totalBytesSentSskInserts, true)
+              }));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "offeredKeyOutput",
+              new String[] {TOTAL_KEY, "offered"},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentOfferedKeys, true),
+                SizeUtil.formatSize(totalBytesSentOffers, true)
+              }));
+      activityList.addChild(
+          "li", statisticsL10n("swapOutput", SizeUtil.formatSize(totalBytesSentSwapOutput, true)));
+      activityList.addChild(
+          "li", statisticsL10n("authBytes", SizeUtil.formatSize(totalBytesSentAuth, true)));
+      activityList.addChild(
+          "li", statisticsL10n("ackOnlyBytes", SizeUtil.formatSize(totalBytesSentAckOnly, true)));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "resendBytes",
+              new String[] {TOTAL_KEY, PERCENT_KEY},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentResends, true),
+                Long.toString((100 * totalBytesSentResends) / Math.max(1, total[0]))
+              }));
+      activityList.addChild(
+          "li", statisticsL10n("uomBytes", SizeUtil.formatSize(totalBytesSentUom, true)));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "announceBytes",
+              new String[] {TOTAL_KEY, "payload"},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentAnnounce, true),
+                SizeUtil.formatSize(totalBytesSentAnnouncePayload, true)
+              }));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "adminBytes",
+              new String[] {"routingStatus", "disconn", "initial", "changedIP"},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentRoutingStatus, true),
+                SizeUtil.formatSize(totalBytesSentDisconn, true),
+                SizeUtil.formatSize(totalBytesSentInitial, true),
+                SizeUtil.formatSize(totalBytesSentChangedIp, true)
+              }));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "debuggingBytes",
+              new String[] {"netColoring", "ping", "probe", "routed"},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentNetworkColoring, true),
+                SizeUtil.formatSize(totalBytesSentPing, true),
+                SizeUtil.formatSize(totalBytesSentProbeRequest, true),
+                SizeUtil.formatSize(totalBytesSentRouted, true)
+              }));
+      activityList.addChild(
+          "li",
+          statisticsL10n("nodeToNodeBytes", SizeUtil.formatSize(totalBytesSentNodeToNode, true)));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "loadAllocationNoticesBytes",
+              SizeUtil.formatSize(totalBytesSentAllocationNotices, true)));
+      activityList.addChild(
+          "li", statisticsL10n("foafBytes", SizeUtil.formatSize(totalBytesSentFoaf, true)));
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "unaccountedBytes",
+              new String[] {TOTAL_KEY, PERCENT_KEY},
+              new String[] {
+                SizeUtil.formatSize(totalBytesSentRemaining, true),
+                Integer.toString((int) (totalBytesSentRemaining * 100 / total[0]))
+              }));
+      double sentOverheadPerSecond = stats.getSentOverheadPerSecond();
+      activityList.addChild(
+          "li",
+          statisticsL10n(
+              "totalOverhead",
+              new String[] {"rate", PERCENT_KEY},
+              new String[] {
+                SizeUtil.formatSize((long) sentOverheadPerSecond),
+                Integer.toString((int) ((100 * sentOverheadPerSecond) / totalOutputRate))
+              }));
+    }
+
+    private void drawPeerStatsBox(HTMLNode peerStatsInfobox, PeerStatusCounts counts) {
+      peerStatsInfobox.addChild(
+          "div", ATTR_CLASS, INFOBOX_HEADER_CLASS, statisticsL10n("peerStatsTitle"));
+      HTMLNode peerStatsContent =
+          peerStatsInfobox.addChild("div", ATTR_CLASS, INFOBOX_CONTENT_CLASS);
+      HTMLNode peerStatsList = peerStatsContent.addChild("ul");
+      addPeerStat(
+          peerStatsList, counts.connected(), "peer_connected", CLASS_CONNECTED, "connectedShort");
+      addPeerStat(
+          peerStatsList,
+          counts.routingBackedOff(),
+          "peer_backed_off",
+          "backedOff",
+          "backedOffShort");
+      addPeerStat(peerStatsList, counts.tooNew(), "peer_too_new", "tooNew", "tooNewShort");
+      addPeerStat(peerStatsList, counts.tooOld(), "peer_too_old", "tooOld", "tooOldShort");
+      addPeerStat(
+          peerStatsList,
+          counts.disconnected(),
+          "peer_disconnected",
+          "notConnected",
+          "notConnectedShort");
+      addPeerStat(
+          peerStatsList,
+          counts.neverConnected(),
+          "peer_never_connected",
+          "neverConnected",
+          "neverConnectedShort");
+      addPeerStat(peerStatsList, counts.disabled(), "peer_disabled", "disabled", "disabledShort");
+      addPeerStat(peerStatsList, counts.bursting(), "peer_bursting", "bursting", "burstingShort");
+      addPeerStat(
+          peerStatsList, counts.listening(), PEER_LISTENING_CLASS, "listening", "listeningShort");
+      addPeerStat(
+          peerStatsList,
+          counts.listenOnly(),
+          PEER_LISTEN_ONLY_CLASS,
+          "listenOnly",
+          "listenOnlyShort");
+      addPeerStat(
+          peerStatsList,
+          counts.seedServers(),
+          PEER_LISTENING_CLASS,
+          "seedServers",
+          "seedServersShort");
+      addPeerStat(
+          peerStatsList,
+          counts.seedClients(),
+          PEER_LISTENING_CLASS,
+          "seedClients",
+          "seedClientsShort");
+      addPeerStat(
+          peerStatsList,
+          counts.routingDisabled(),
+          "peer_routing_disabled",
+          "routingDisabled",
+          "routingDisabledShort");
+      addPeerStat(
+          peerStatsList,
+          counts.clockProblem(),
+          "peer_clock_problem",
+          "clockProblem",
+          "clockProblemShort");
+      addPeerStat(
+          peerStatsList, counts.connError(), "peer_conn_error", "connError", "connErrorShort");
+      addPeerStat(
+          peerStatsList,
+          counts.disconnecting(),
+          "peer_disconnecting",
+          "disconnecting",
+          "disconnectingShort");
+      addPeerStat(
+          peerStatsList,
+          counts.noLoadStats(),
+          "peer_no_load_stats",
+          "noLoadStats",
+          "noLoadStatsShort");
+      OpennetManager opennetManager = node.network().opennet();
+      if (opennetManager != null) {
+        peerStatsList.addChild(
+            "li",
+            statisticsL10n("maxTotalPeers")
+                + ": "
+                + opennetManager.getNumberOfConnectedPeersToAimIncludingDarknet());
+        peerStatsList.addChild(
+            "li",
+            statisticsL10n("maxOpennetPeers")
+                + ": "
+                + opennetManager.getNumberOfConnectedPeersToAim());
+      }
+    }
+
+    private void addPeerStat(
+        HTMLNode list, int count, String cssClass, String titleKey, String labelKey) {
+      if (count <= 0) {
+        return;
+      }
+      HTMLNode item = list.addChild("li").addChild("span");
+      item.addChild(
+          "span",
+          new String[] {ATTR_CLASS, ATTR_TITLE, ATTR_STYLE},
+          new String[] {cssClass, connectionsL10n(titleKey), HELP_STYLE},
+          connectionsL10n(labelKey));
+      item.addChild("span", COLON_NBSP + count);
+    }
+
+    private String idleToString(long now, long idle) {
+      if (idle <= 0) {
+        return " ";
+      }
+      return TimeUtil.formatTime(now - idle);
+    }
+
+    private String sortString(boolean reversed, String type) {
+      return reversed ? ("?sortBy=" + type) : ("?sortBy=" + type + "&reversed");
+    }
+
+    protected static class ComparatorByStatus implements Comparator<PeerNodeStatus> {
+      protected final String sortBy;
+      protected final boolean reversed;
+
+      ComparatorByStatus(String sortBy, boolean reversed) {
+        this.sortBy = sortBy;
+        this.reversed = reversed;
+      }
+
+      @Override
+      public int compare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        int result = compareWithSort(firstNode, secondNode);
+        if (result == 0) {
+          result = compareByStatus(firstNode, secondNode);
+        }
+        return reversed ? -Integer.signum(result) : Integer.signum(result);
+      }
+
+      protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        if (sortBy == null) {
+          return 0;
+        }
+        return switch (sortBy) {
+          case "address" ->
+              firstNode.getPeerAddress().compareToIgnoreCase(secondNode.getPeerAddress());
+          case "location" -> compareLocations(firstNode, secondNode);
+          case "version" ->
+              Version.compareBuildNumbers(
+                  Version.parseNodeNameFromVersionStr(firstNode.getVersion()),
+                  Version.parseBuildNumberFromVersionStr(firstNode.getVersion(), -1),
+                  Version.parseNodeNameFromVersionStr(secondNode.getVersion()),
+                  Version.parseBuildNumberFromVersionStr(secondNode.getVersion(), -1));
+          case "backoffRT" ->
+              Double.compare(
+                  firstNode.getBackedOffPercent(true), secondNode.getBackedOffPercent(true));
+          case "backoffBulk" ->
+              Double.compare(
+                  firstNode.getBackedOffPercent(false), secondNode.getBackedOffPercent(false));
+          case "overload_p" -> Double.compare(firstNode.getPReject(), secondNode.getPReject());
+          case "idle" ->
+              compareLongs(
+                  firstNode.getTimeLastConnectionCompleted(),
+                  secondNode.getTimeLastConnectionCompleted());
+          case "time_routable" ->
+              Double.compare(
+                  firstNode.getPercentTimeRoutableConnection(),
+                  secondNode.getPercentTimeRoutableConnection());
+          case "total_traffic" -> {
+            long total1 = firstNode.getTotalInputBytes() + firstNode.getTotalOutputBytes();
+            long total2 = secondNode.getTotalInputBytes() + secondNode.getTotalOutputBytes();
+            yield compareLongs(total1, total2);
+          }
+          case "total_traffic_since_startup" -> {
+            long total1 =
+                firstNode.getTotalInputSinceStartup() + firstNode.getTotalOutputSinceStartup();
+            long total2 =
+                secondNode.getTotalInputSinceStartup() + secondNode.getTotalOutputSinceStartup();
+            yield compareLongs(total1, total2);
+          }
+          case "selection_percentage" ->
+              Double.compare(firstNode.getSelectionRate(), secondNode.getSelectionRate());
+          case "time_delta" -> compareLongs(firstNode.getClockDelta(), secondNode.getClockDelta());
+          case "uptime" ->
+              compareInts(
+                  firstNode.getReportedUptimePercentage(),
+                  secondNode.getReportedUptimePercentage());
+          default -> 0;
+        };
+      }
+
+      protected int lastResortCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        return compareLocations(firstNode, secondNode);
+      }
+
+      private int compareWithSort(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        if (sortBy == null) {
+          return 0;
+        }
+        return customCompare(firstNode, secondNode);
+      }
+
+      private int compareByStatus(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        int statusDifference =
+            Integer.compare(firstNode.getStatusValue(), secondNode.getStatusValue());
+        if (statusDifference != 0) {
+          return statusDifference;
+        }
+        return lastResortCompare(firstNode, secondNode);
+      }
+
+      private int compareLocations(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        double diff = firstNode.getLocation() - secondNode.getLocation();
+        if (Double.MIN_VALUE * 2 > Math.abs(diff)) {
+          return 0;
+        }
+        return diff > 0 ? 1 : -1;
+      }
+
+      private int compareLongs(long long1, long long2) {
+        int diff = Long.compare(long1, long2);
+        if (diff == 0) {
+          return 0;
+        }
+        return diff > 0 ? 1 : -1;
+      }
+
+      private int compareInts(int int1, int int2) {
+        int diff = Integer.compare(int1, int2);
+        if (diff == 0) {
+          return 0;
+        }
+        return diff > 0 ? 1 : -1;
+      }
+    }
+  }
+
+  /** Renders the legacy darknet friends page, including editable peer-action affordances. */
+  private final class DarknetRenderer extends ConnectionsRenderer {
+    @Override
+    protected String getPageTitle(String titleCountString) {
+      return NodeL10n.getBase()
+          .getString(
+              "DarknetConnectionsToadlet.fullTitle",
+              new String[] {"counts"},
+              new String[] {titleCountString});
+    }
+
+    @Override
+    protected String getPeerListTitle() {
+      return connectionsL10n("myFriends");
+    }
+
+    @Override
+    protected boolean isOpennet() {
+      return false;
+    }
+
+    @Override
+    protected boolean peerActionsEnabled() {
+      return true;
+    }
+
+    @Override
+    protected boolean hasTrustColumn() {
+      return true;
+    }
+
+    @Override
+    protected void drawTrustColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+      peerRow
+          .addChild("td", ATTR_CLASS, "peer-trust")
+          .addChild("#", ((DarknetPeerNodeStatus) peerNodeStatus).getTrustLevel().name());
+    }
+
+    @Override
+    protected boolean hasVisibilityColumn() {
+      return true;
+    }
+
+    @Override
+    protected void drawVisibilityColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
+      String content = ((DarknetPeerNodeStatus) peerNodeStatus).getOurVisibility().name();
+      if (advancedModeEnabled) {
+        content +=
+            " (" + ((DarknetPeerNodeStatus) peerNodeStatus).getTheirVisibility().name() + ")";
+      }
+      peerRow.addChild("td", ATTR_CLASS, "peer-trust").addChild("#", content);
+    }
+
+    @Override
+    protected boolean hasNameColumn() {
+      return true;
+    }
+
+    @Override
+    protected void drawNameColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
+      HTMLNode cell = peerRow.addChild("td", ATTR_CLASS, "peer-name");
+      cell.addChild(
+          "a",
+          "href",
+          "/send_n2ntm/?peernode_hashcode=" + peerNodeStatus.hashCode(),
+          ((DarknetPeerNodeStatus) peerNodeStatus).getName());
+      if (advancedModeEnabled && peerNodeStatus.hasFullNoderef) {
+        cell.addChild("#", " (");
+        cell.addChild(
+            "a",
+            "href",
+            FRIENDS_PATH + FRIEND_PREFIX + peerNodeStatus.hashCode() + FREF_SUFFIX,
+            connectionsL10n("noderefLink"));
+        cell.addChild("#", ")");
+      }
+    }
+
+    @Override
+    protected boolean hasPrivateNoteColumn() {
+      return true;
+    }
+
+    @Override
+    protected void drawPrivateNoteColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled) {
+      DarknetPeerNodeStatus status = (DarknetPeerNodeStatus) peerNodeStatus;
+      if (fProxyJavascriptEnabled) {
+        peerRow
+            .addChild("td", ATTR_CLASS, "peer-private-darknet-comment-note")
+            .addChild(
+                ELEMENT_INPUT,
+                new String[] {"type", "name", "size", "maxlength", "onChange", ATTR_VALUE},
+                new String[] {
+                  "text",
+                  PEER_PRIVATE_NOTE_PREFIX + peerNodeStatus.hashCode(),
+                  "16",
+                  "250",
+                  "peerNoteChange();",
+                  status.getPrivateDarknetCommentNote()
+                });
+      } else {
+        peerRow
+            .addChild("td", ATTR_CLASS, "peer-private-darknet-comment-note")
+            .addChild(
+                ELEMENT_INPUT,
+                new String[] {"type", "name", "size", "maxlength", ATTR_VALUE},
+                new String[] {
+                  "text",
+                  PEER_PRIVATE_NOTE_PREFIX + peerNodeStatus.hashCode(),
+                  "16",
+                  "250",
+                  status.getPrivateDarknetCommentNote()
+                });
+      }
+    }
+
+    @Override
+    protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
+      return peers.statusBook().getDarknetPeerNodeStatuses(noHeavy);
+    }
+
+    @Override
+    protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
+      return new DarknetComparator(sortBy, reversed);
+    }
+
+    @Override
+    protected void drawPeerActionSelectBox(HTMLNode peerForm, boolean advancedModeEnabled) {
+      peerForm.addChild(
+          ELEMENT_INPUT,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {
+            SUBMIT, "doSendMessageToPeers", connectionsL10n("sendConfidentialMessage")
+          });
+      peerForm.addChild("br");
+
+      HTMLNode actionSelect =
+          peerForm.addChild(
+              ELEMENT_SELECT, new String[] {"id", "name"}, new String[] {ACTION, ACTION});
+      actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, "", connectionsL10n("selectAction"));
+      actionSelect.addChild(
+          ELEMENT_OPTION, ATTR_VALUE, "update_notes", connectionsL10n("updateChangedPrivnotes"));
+      if (advancedModeEnabled) {
+        actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, "enable", connectionsL10n("peersEnable"));
+        actionSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, "disable", connectionsL10n("peersDisable"));
+        actionSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, "set_burst_only", connectionsL10n("peersSetBurstOnly"));
+        actionSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, "clear_burst_only", connectionsL10n("peersClearBurstOnly"));
+        actionSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, "set_listen_only", connectionsL10n("peersSetListenOnly"));
+        actionSelect.addChild(
+            ELEMENT_OPTION,
+            ATTR_VALUE,
+            "clear_listen_only",
+            connectionsL10n("peersClearListenOnly"));
+        actionSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, "set_allow_local", connectionsL10n("peersSetAllowLocal"));
+        actionSelect.addChild(
+            ELEMENT_OPTION,
+            ATTR_VALUE,
+            "clear_allow_local",
+            connectionsL10n("peersClearAllowLocal"));
+        actionSelect.addChild(
+            ELEMENT_OPTION,
+            ATTR_VALUE,
+            "set_ignore_source_port",
+            connectionsL10n("peersSetIgnoreSourcePort"));
+        actionSelect.addChild(
+            ELEMENT_OPTION,
+            ATTR_VALUE,
+            "clear_ignore_source_port",
+            connectionsL10n("peersClearIgnoreSourcePort"));
+        actionSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, "set_dont_route", connectionsL10n("peersSetDontRoute"));
+        actionSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, "clear_dont_route", connectionsL10n("peersClearDontRoute"));
+      }
+      actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, "", connectionsL10n("separator"));
+      actionSelect.addChild(ELEMENT_OPTION, ATTR_VALUE, REMOVE, connectionsL10n("removePeers"));
+      peerForm.addChild(
+          ELEMENT_INPUT,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {SUBMIT, DO_ACTION, connectionsL10n("go")});
+      peerForm.addChild("br");
+      peerForm.addChild(
+          ELEMENT_INPUT,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {SUBMIT, "doChangeTrust", connectionsL10n("changeTrustButton")});
+      HTMLNode changeTrustLevelSelect =
+          peerForm.addChild(
+              ELEMENT_SELECT,
+              new String[] {"id", "name"},
+              new String[] {CHANGE_TRUST, CHANGE_TRUST});
+      for (FRIEND_TRUST trust : FRIEND_TRUST.valuesBackwards()) {
+        changeTrustLevelSelect.addChild(
+            ELEMENT_OPTION, ATTR_VALUE, trust.name(), connectionsL10n("peerTrust." + trust.name()));
+      }
+      peerForm.addChild("br");
+      peerForm.addChild(
+          ELEMENT_INPUT,
+          new String[] {"type", "name", ATTR_VALUE},
+          new String[] {SUBMIT, "doChangeVisibility", connectionsL10n("changeVisibilityButton")});
+      HTMLNode changeVisibilitySelect =
+          peerForm.addChild(
+              ELEMENT_SELECT,
+              new String[] {"id", "name"},
+              new String[] {CHANGE_VISIBILITY, CHANGE_VISIBILITY});
+      for (FRIEND_VISIBILITY visibility : FRIEND_VISIBILITY.values()) {
+        changeVisibilitySelect.addChild(
+            ELEMENT_OPTION,
+            ATTR_VALUE,
+            visibility.name(),
+            connectionsL10n("peerVisibility." + visibility.name()));
+      }
+    }
+
+    private static final class DarknetComparator extends ComparatorByStatus {
+      private DarknetComparator(String sortBy, boolean reversed) {
+        super(sortBy, reversed);
+      }
+
+      @Override
+      protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        if (sortBy == null) {
+          return 0;
+        }
+        return switch (sortBy) {
+          case "name" ->
+              ((DarknetPeerNodeStatus) firstNode)
+                  .getName()
+                  .compareToIgnoreCase(((DarknetPeerNodeStatus) secondNode).getName());
+          case "privnote" ->
+              ((DarknetPeerNodeStatus) firstNode)
+                  .getPrivateDarknetCommentNote()
+                  .compareToIgnoreCase(
+                      ((DarknetPeerNodeStatus) secondNode).getPrivateDarknetCommentNote());
+          case TRUST ->
+              ((DarknetPeerNodeStatus) firstNode)
+                  .getTrustLevel()
+                  .compareTo(((DarknetPeerNodeStatus) secondNode).getTrustLevel());
+          case "visibility" -> {
+            int ret =
+                ((DarknetPeerNodeStatus) firstNode)
+                    .getOurVisibility()
+                    .compareTo(((DarknetPeerNodeStatus) secondNode).getOurVisibility());
+            if (ret != 0) {
+              yield ret;
+            }
+            yield ((DarknetPeerNodeStatus) firstNode)
+                .getTheirVisibility()
+                .compareTo(((DarknetPeerNodeStatus) secondNode).getTheirVisibility());
+          }
+          default -> super.customCompare(firstNode, secondNode);
+        };
+      }
+
+      @Override
+      protected int lastResortCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        return ((DarknetPeerNodeStatus) firstNode)
+            .getName()
+            .compareToIgnoreCase(((DarknetPeerNodeStatus) secondNode).getName());
+      }
+    }
+  }
+
+  /** Renders the legacy opennet strangers page, which remains read-only in this transition step. */
+  private final class OpennetRenderer extends ConnectionsRenderer {
+    @Override
+    protected String getPageTitle(String titleCountString) {
+      return NodeL10n.getBase()
+          .getString(
+              "OpennetConnectionsToadlet.fullTitle",
+              new String[] {"counts"},
+              new String[] {titleCountString});
+    }
+
+    @Override
+    protected String getPeerListTitle() {
+      return NodeL10n.getBase().getString("OpennetConnectionsToadlet.peersListTitle");
+    }
+
+    @Override
+    protected boolean isOpennet() {
+      return true;
+    }
+
+    @Override
+    protected boolean hasNameColumn() {
+      return false;
+    }
+
+    @Override
+    protected void drawNameColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean advancedModeEnabled) {
+      // No-op: opennet peers do not expose names.
+    }
+
+    @Override
+    protected boolean hasPrivateNoteColumn() {
+      return false;
+    }
+
+    @Override
+    protected void drawPrivateNoteColumn(
+        HTMLNode peerRow, PeerNodeStatus peerNodeStatus, boolean fProxyJavascriptEnabled) {
+      // No-op: opennet peers do not expose private notes.
+    }
+
+    @Override
+    protected PeerNodeStatus[] getPeerNodeStatuses(boolean noHeavy) {
+      return peers.statusBook().getOpennetPeerNodeStatuses(noHeavy);
+    }
+
+    @Override
+    protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
+      return new OpennetComparator(sortBy, reversed);
+    }
+
+    @Override
+    protected List<SimpleColumn> endColumnHeaders(boolean advancedMode) {
+      if (!advancedMode) {
+        return List.of();
+      }
+      return List.of(
+          new SimpleColumn() {
+            @Override
+            protected void drawColumn(HTMLNode peerRow, PeerNodeStatus peerNodeStatus) {
+              OpennetPeerNodeStatus status = (OpennetPeerNodeStatus) peerNodeStatus;
+              long timeLastSuccess = status.timeLastSuccess;
+              peerRow.addChild(
+                  "td",
+                  ATTR_CLASS,
+                  "peer-last-success",
+                  timeLastSuccess > 0
+                      ? TimeUtil.formatTime(System.currentTimeMillis() - timeLastSuccess)
+                      : "NEVER");
+            }
+
+            @Override
+            String getSortString() {
+              return "successTime";
+            }
+
+            @Override
+            String getTitleKey() {
+              return "OpennetConnectionsToadlet.successTimeTitle";
+            }
+
+            @Override
+            String getExplanationKey() {
+              return "OpennetConnectionsToadlet.successTime";
+            }
+          });
+    }
+
+    private static final class OpennetComparator extends ComparatorByStatus {
+      private OpennetComparator(String sortBy, boolean reversed) {
+        super(sortBy, reversed);
+      }
+
+      @Override
+      protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
+        if ("successTime".equals(sortBy)) {
+          long t1 = ((OpennetPeerNodeStatus) firstNode).timeLastSuccess;
+          long t2 = ((OpennetPeerNodeStatus) secondNode).timeLastSuccess;
+          if (t1 > t2) {
+            return reversed ? 1 : -1;
+          } else if (t2 > t1) {
+            return reversed ? -1 : 1;
+          }
+        }
+        return super.customCompare(firstNode, secondNode);
+      }
+    }
+  }
+
+  /**
+   * Groups friend-of-a-friend peer locations with the peer-status rows that fall into each bucket.
+   */
+  private record FoafGrouping(List<Double> locations, List<List<PeerNodeStatus>> peerGroups) {
+    int trivialCount() {
+      return (int) peerGroups.stream().filter(list -> list.size() == 1).count();
+    }
+  }
+
+  /** Carries per-request row-render state so each peer row does not need a long argument list. */
+  private record RowRenderContext(
+      List<SimpleColumn> endCols,
+      ConnectionsPageRequest request,
+      boolean fProxyJavascriptEnabled,
+      boolean enablePeerActions,
+      DecimalFormat percentageFormat,
+      long now,
+      double totalSelectionRate) {}
+
+  /**
+   * Resolves one localized string from the legacy darknet-connections bundle namespace.
+   *
+   * @param key unqualified localization key under {@code DarknetConnectionsToadlet}
+   * @return localized text for the current node locale
+   */
+  private static String connectionsL10n(String key) {
+    return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + key);
+  }
+
+  /**
+   * Resolves one count-oriented localized string from the darknet-connections bundle namespace.
+   *
+   * @param key unqualified localization key under {@code DarknetConnectionsToadlet}
+   * @param value replacement value for the {@value #COUNT} token
+   * @return localized text with the count token substituted
+   */
+  private static String connectionsL10nCount(String key, String value) {
+    return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + key, COUNT, value);
+  }
+
+  /**
+   * Resolves one localized string from the shared statistics bundle namespace.
+   *
+   * @param key unqualified localization key under {@code StatisticsToadlet}
+   * @return localized text for the current node locale
+   */
+  private static String statisticsL10n(String key) {
+    return NodeL10n.getBase().getString(STATS_PREFIX + key);
+  }
+
+  /**
+   * Resolves one statistics string that expects a single {@value #TOTAL_KEY} token replacement.
+   *
+   * @param key unqualified localization key under {@code StatisticsToadlet}
+   * @param total formatted total value to insert into the localized text
+   * @return localized text with the total token substituted
+   */
+  private static String statisticsL10n(String key, String total) {
+    return NodeL10n.getBase()
+        .getString(STATS_PREFIX + key, new String[] {TOTAL_KEY}, new String[] {total});
+  }
+
+  /**
+   * Resolves one statistics string with multiple token replacements.
+   *
+   * @param key unqualified localization key under {@code StatisticsToadlet}
+   * @param patterns replacement token names expected by the bundle entry
+   * @param values formatted values aligned with {@code patterns}
+   * @return localized text with all provided tokens substituted
+   */
+  private static String statisticsL10n(String key, String[] patterns, String[] values) {
+    return NodeL10n.getBase().getString(STATS_PREFIX + key, patterns, values);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectivityPort;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.ExecutionPort;
@@ -40,6 +41,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final LifecyclePort lifecyclePort;
   private final ConfigPort configPort;
   private final ConnectivityPort connectivityPort;
+  private final ConnectionsPagePort connectionsPagePort;
   private final DiagnosticPort diagnosticPort;
   private final StatisticsPort statisticsPort;
   private final RequestQueuePort requestQueuePort;
@@ -126,6 +128,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
         };
     this.configPort = new LegacyConfigPort(node, core);
     this.connectivityPort = new LegacyConnectivityPort(node);
+    this.connectionsPagePort = new LegacyConnectionsPagePort(node, core);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
@@ -196,6 +199,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public ConnectivityPort connectivity() {
     return connectivityPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the legacy connections-page traversal, peer sorting, and detached
+   * HTML fragment rendering inside the daemon root module while exposing only SPI-local snapshots
+   * upstream.
+   */
+  @Override
+  public ConnectionsPagePort connectionsPage() {
+    return connectionsPagePort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http;
 
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -12,6 +13,10 @@ import network.crypta.node.DarknetPeerNodeStatus;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerTooOldException;
+import network.crypta.runtime.spi.ConnectionsPageKind;
+import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.ConnectionsPageRequest;
+import network.crypta.runtime.spi.ConnectionsPageSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
@@ -26,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -33,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -42,12 +49,14 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class DarknetConnectionsToadletTest {
+  private static final String TEST_FORM_PASSWORD = "test-form-password";
 
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
 
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
+  @Mock private ConnectionsPagePort connectionsPage;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
 
@@ -55,8 +64,71 @@ class DarknetConnectionsToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new DarknetConnectionsToadlet(node, core, client);
+    toadlet = new DarknetConnectionsToadlet(node, core, client, connectionsPage);
     Mockito.lenient().when(request.isPartSet(anyString())).thenReturn(false);
+  }
+
+  @Test
+  void handleMethodGET_whenUsingDisplayMessageTypes_buildsDarknetRequestAndRedirectsOnZeroPeers()
+      throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(true);
+    when(request.getParam("sortBy", null)).thenReturn("name");
+    when(request.isParameterSet("reversed")).thenReturn(true);
+    when(connectionsPage.render(any()))
+        .thenReturn(new ConnectionsPageSnapshot("friends", 0, true, "", "", ""));
+
+    ArgumentCaptor<ConnectionsPageRequest> requestCaptor =
+        ArgumentCaptor.forClass(ConnectionsPageRequest.class);
+
+    RedirectException redirect =
+        assertThrows(
+            RedirectException.class,
+            () ->
+                toadlet.handleMethodGET(
+                    URI.create("http://localhost/friends/displaymessagetypes.html"), request, ctx));
+
+    assertEquals(URI.create("/addfriend/"), redirect.getTarget());
+    verify(connectionsPage).render(requestCaptor.capture());
+    ConnectionsPageRequest pageRequest = requestCaptor.getValue();
+    assertEquals(ConnectionsPageKind.DARKNET, pageRequest.kind());
+    assertTrue(pageRequest.advancedMode());
+    assertTrue(pageRequest.drawMessageTypes());
+    assertEquals("name", pageRequest.sortBy());
+    assertTrue(pageRequest.reversed());
+  }
+
+  @Test
+  void handleMethodGET_whenPeerActionsEnabled_wrapsPeerTableInPeersForm() throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(false);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(connectionsPage.render(any()))
+        .thenReturn(
+            new ConnectionsPageSnapshot(
+                "friends",
+                1,
+                true,
+                "<div id=\"before\">before</div>",
+                "<table id=\"peer-table\"></table><div id=\"actions\">actions</div>",
+                "<div id=\"after\">after</div>"));
+    stubFormChild(ctx);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/friends/"), request, ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertTrue(html.contains("before"));
+    assertTrue(html.contains("peer-table"));
+    assertTrue(html.contains("id=\"peersForm\""));
+    assertTrue(html.contains("formPassword"));
+    assertTrue(html.contains(TEST_FORM_PASSWORD));
+    assertTrue(html.contains("actions"));
+    assertTrue(html.contains("after"));
+    verify(ctx).addFormChild(any(HTMLNode.class), eq("."), eq("peersForm"));
   }
 
   @Test
@@ -92,34 +164,6 @@ class DarknetConnectionsToadletTest {
     int result = comparator.customCompare(first, second);
 
     assertTrue(result < 0, "NAME_ONLY should sort before NO when our visibility matches");
-  }
-
-  @Test
-  void drawPrivateNoteColumn_whenJavascriptEnabled_includesChangeHandler() {
-    HTMLNode row = new HTMLNode("tr");
-    DarknetPeerNodeStatus status = mock(DarknetPeerNodeStatus.class);
-    when(status.getPrivateDarknetCommentNote()).thenReturn("note");
-    int statusHash = System.identityHashCode(status);
-
-    toadlet.drawPrivateNoteColumn(row, status, true);
-
-    String rendered = row.generate();
-    assertTrue(rendered.contains("peerPrivateNote_" + statusHash));
-    assertTrue(rendered.contains("onChange=\"peerNoteChange();\""));
-  }
-
-  @Test
-  void drawPrivateNoteColumn_whenJavascriptDisabled_omitsChangeHandler() {
-    HTMLNode row = new HTMLNode("tr");
-    DarknetPeerNodeStatus status = mock(DarknetPeerNodeStatus.class);
-    when(status.getPrivateDarknetCommentNote()).thenReturn("note");
-    int statusHash = System.identityHashCode(status);
-
-    toadlet.drawPrivateNoteColumn(row, status, false);
-
-    String rendered = row.generate();
-    assertTrue(rendered.contains("peerPrivateNote_" + statusHash));
-    assertFalse(rendered.contains("onChange=\"peerNoteChange();\""));
   }
 
   @Test
@@ -280,5 +324,57 @@ class DarknetConnectionsToadletTest {
         ArgumentCaptor.forClass(MultiValueTable.class);
     verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
     assertEquals("/friends/", headersCaptor.getValue().getFirst("Location"));
+  }
+
+  private PageMaker stubPageMaker(HTMLNode content) {
+    HTMLNode root = new HTMLNode("html");
+    HTMLNode head = root.addChild("head");
+    root.addChild(content);
+    PageNode page = new PageNode(root, head, content);
+
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(pageMaker.getPageNode(anyString(), any(ToadletContext.class))).thenReturn(page);
+    return pageMaker;
+  }
+
+  private void stubFormChild(ToadletContext context) {
+    doAnswer(
+            invocation -> {
+              HTMLNode parentNode = invocation.getArgument(0);
+              String target = invocation.getArgument(1);
+              String id = invocation.getArgument(2);
+              HTMLNode formNode =
+                  parentNode
+                      .addChild("div")
+                      .addChild(
+                          "form",
+                          new String[] {"action", "method", "enctype", "id", "accept-charset"},
+                          new String[] {target, "post", "multipart/form-data", id, "utf-8"});
+              formNode.addChild(
+                  "input",
+                  new String[] {"type", "name", "value"},
+                  new String[] {"hidden", "formPassword", TEST_FORM_PASSWORD});
+              return formNode;
+            })
+        .when(context)
+        .addFormChild(any(HTMLNode.class), anyString(), anyString());
+  }
+
+  private ByteArrayOutputStream captureBody(ToadletContext context) throws Exception {
+    ByteArrayOutputStream body = new ByteArrayOutputStream();
+    doAnswer(_ -> null)
+        .when(context)
+        .sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
+    doAnswer(
+            invocation -> {
+              byte[] data = invocation.getArgument(0);
+              int offset = invocation.getArgument(1);
+              int length = invocation.getArgument(2);
+              body.write(data, offset, length);
+              return null;
+            })
+        .when(context)
+        .writeData(any(byte[].class), anyInt(), anyInt());
+    return body;
   }
 }

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -1,40 +1,40 @@
 package network.crypta.clients.http;
 
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.Comparator;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.l10n.BaseL10n;
-import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
-import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
-import network.crypta.node.PeerStatusBook;
+import network.crypta.runtime.spi.ConnectionsPageKind;
+import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.ConnectionsPageRequest;
+import network.crypta.runtime.spi.ConnectionsPageSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,21 +47,16 @@ class OpennetConnectionsToadletTest {
 
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
-  @Mock private PeerManager peerManager;
-  @Mock private PeerStatusBook statusBook;
+  @Mock private ConnectionsPagePort connectionsPage;
   @Mock private SimpleFieldSet noderef;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
 
   private OpennetConnectionsToadlet toadlet;
 
   @BeforeEach
   void setUp() {
-    toadlet = new TestOpennetConnectionsToadlet(node, core, client);
-  }
-
-  @Test
-  void hasNameAndPrivateNoteColumns_disabledForOpennet() {
-    assertFalse(toadlet.hasNameColumn());
-    assertFalse(toadlet.hasPrivateNoteColumn());
+    toadlet = new OpennetConnectionsToadlet(node, core, client, connectionsPage);
   }
 
   @Test
@@ -75,25 +70,6 @@ class OpennetConnectionsToadletTest {
 
     assertSame(noderef, result);
     verify(network).exportOpennetPublicFieldSet();
-  }
-
-  @Test
-  void getPeerNodeStatuses_fetchesFromPeerManager() {
-    OpennetPeerNodeStatus[] statuses =
-        new OpennetPeerNodeStatus[] {mock(OpennetPeerNodeStatus.class)};
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.peers()).thenReturn(peerManager);
-    when(peerManager.statusBook()).thenReturn(statusBook);
-    when(statusBook.getOpennetPeerNodeStatuses(false)).thenReturn(statuses);
-
-    PeerNodeStatus[] result = toadlet.getPeerNodeStatuses(false);
-
-    assertSame(statuses, result);
-    verify(network, atLeastOnce()).peers();
-    verify(peerManager).statusBook();
-    verify(statusBook).getOpennetPeerNodeStatuses(false);
   }
 
   @Test
@@ -150,68 +126,71 @@ class OpennetConnectionsToadletTest {
   }
 
   @Test
-  void endColumnHeaders_returnsNullWhenNotAdvanced() {
-    assertEquals(0, toadlet.endColumnHeaders(false).length);
+  void handleMethodGET_whenCalled_usesConnectionsPagePortAndSkipsPeerActionsForm()
+      throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(false);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(request.getParam("sortBy", null)).thenReturn("address");
+    when(request.isParameterSet("reversed")).thenReturn(false);
+    when(connectionsPage.render(any()))
+        .thenReturn(
+            new ConnectionsPageSnapshot(
+                "strangers",
+                1,
+                false,
+                "<div id=\"before\">before</div>",
+                "<table id=\"peer-table\"></table>",
+                "<div id=\"after\">after</div>"));
+
+    ArgumentCaptor<ConnectionsPageRequest> requestCaptor =
+        ArgumentCaptor.forClass(ConnectionsPageRequest.class);
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(
+        URI.create("http://localhost/strangers/displaymessagetypes.html"), request, ctx);
+
+    String html = body.toString(java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(html.contains("before"));
+    assertTrue(html.contains("peer-table"));
+    assertTrue(html.contains("after"));
+    verify(ctx, never()).addFormChild(any(HTMLNode.class), anyString(), anyString());
+    verify(connectionsPage).render(requestCaptor.capture());
+    ConnectionsPageRequest pageRequest = requestCaptor.getValue();
+    assertEquals(ConnectionsPageKind.OPENNET, pageRequest.kind());
+    assertFalse(pageRequest.advancedMode());
+    assertTrue(pageRequest.drawMessageTypes());
+    assertEquals("address", pageRequest.sortBy());
+    assertFalse(pageRequest.reversed());
   }
 
   @Test
-  void endColumnHeaders_rendersNeverWhenNoSuccess() {
-    OpennetPeerNodeStatus status = statusWithLastSuccess(-1);
-    HTMLNode row = new HTMLNode("tr");
+  void handleMethodGET_whenSnapshotHasNoPeers_doesNotRedirectLikeDarknet() throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(false);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(connectionsPage.render(any()))
+        .thenReturn(
+            new ConnectionsPageSnapshot(
+                "strangers",
+                0,
+                false,
+                "<div id=\"before\">before</div>",
+                "<div id=\"no-peers\">none</div>",
+                "<div id=\"after\">after</div>"));
 
-    ConnectionsToadlet.SimpleColumn[] columns = toadlet.endColumnHeaders(true);
-    assertNotNull(columns);
-    columns[0].drawColumn(row, status);
+    ByteArrayOutputStream body = captureBody(ctx);
 
-    HTMLNode td = row.getChildren().getFirst();
-    assertEquals("td", td.getName());
-    assertEquals("peer-last-success", td.getAttribute("class"));
-    assertEquals("NEVER", td.getChildren().getFirst().getContent());
-  }
+    assertDoesNotThrow(
+        () -> toadlet.handleMethodGET(URI.create("http://localhost/strangers/"), request, ctx));
 
-  @Test
-  void endColumnHeaders_rendersFormattedDurationWhenSuccessKnown() {
-    long now = System.currentTimeMillis();
-    OpennetPeerNodeStatus status = statusWithLastSuccess(now - 5000);
-    HTMLNode row = new HTMLNode("tr");
-
-    ConnectionsToadlet.SimpleColumn[] columns = toadlet.endColumnHeaders(true);
-    columns[0].drawColumn(row, status);
-
-    String rendered = row.getChildren().getFirst().getChildren().getFirst().getContent();
-    assertNotNull(rendered);
-    assertNotEquals("NEVER", rendered);
-    assertFalse(rendered.isEmpty());
-  }
-
-  @Test
-  void getPageTitle_usesLocalizationKey() {
-    try (MockedStatic<NodeL10n> mockedStatic = mockStatic(NodeL10n.class)) {
-      BaseL10n l10n = mock(BaseL10n.class);
-      mockedStatic.when(NodeL10n::getBase).thenReturn(l10n);
-      when(l10n.getString(
-              eq("OpennetConnectionsToadlet.fullTitle"),
-              any(String[].class),
-              argThat(values -> Arrays.equals(values, new String[] {"3"}))))
-          .thenReturn("localized");
-
-      String title = toadlet.getPageTitle("3");
-
-      assertEquals("localized", title);
-      mockedStatic.verify(NodeL10n::getBase);
-    }
-  }
-
-  @Test
-  void getPeerListTitle_usesLocalizationKey() {
-    try (MockedStatic<NodeL10n> mockedStatic = mockStatic(NodeL10n.class)) {
-      BaseL10n l10n = mock(BaseL10n.class);
-      mockedStatic.when(NodeL10n::getBase).thenReturn(l10n);
-      when(l10n.getString("OpennetConnectionsToadlet.peersListTitle")).thenReturn("peers");
-
-      assertEquals("peers", toadlet.getPeerListTitle());
-      mockedStatic.verify(NodeL10n::getBase);
-    }
+    String html = body.toString(java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(html.contains("no-peers"));
+    verify(ctx, never()).addFormChild(any(HTMLNode.class), anyString(), anyString());
   }
 
   private OpennetPeerNodeStatus statusWithLastSuccess(long timestamp) {
@@ -226,30 +205,40 @@ class OpennetConnectionsToadletTest {
       field.setAccessible(true);
       field.setLong(status, timestamp);
     } catch (ReflectiveOperationException e) {
-      throw linkageError("Unable to set timeLastSuccess on mock", e);
+      throw linkageError(e);
     }
   }
 
-  private static LinkageError linkageError(String message, ReflectiveOperationException e) {
-    LinkageError error = new LinkageError(message);
-    error.initCause(e);
-    return error;
+  private static LinkageError linkageError(ReflectiveOperationException e) {
+    return new LinkageError("Unable to set timeLastSuccess on mock", e);
   }
 
-  /** Minimal concrete subclass to expose the protected constructor for testing. */
-  private static final class TestOpennetConnectionsToadlet extends OpennetConnectionsToadlet {
-    TestOpennetConnectionsToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
-      super(n, core, client);
-    }
+  private PageMaker stubPageMaker(HTMLNode content) {
+    HTMLNode root = new HTMLNode("html");
+    HTMLNode head = root.addChild("head");
+    root.addChild(content);
+    PageNode page = new PageNode(root, head, content);
 
-    @Override
-    public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx) {
-      // Avoid invoking heavy superclass logic during unit tests.
-    }
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(pageMaker.getPageNode(anyString(), any(ToadletContext.class))).thenReturn(page);
+    return pageMaker;
+  }
 
-    @Override
-    public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx) {
-      // Avoid invoking heavy superclass logic during unit tests.
-    }
+  private ByteArrayOutputStream captureBody(ToadletContext context) throws Exception {
+    ByteArrayOutputStream body = new ByteArrayOutputStream();
+    doAnswer(_ -> null)
+        .when(context)
+        .sendReplyHeaders(anyInt(), anyString(), any(), anyString(), anyLong());
+    doAnswer(
+            invocation -> {
+              byte[] data = invocation.getArgument(0);
+              int offset = invocation.getArgument(1);
+              int length = invocation.getArgument(2);
+              body.write(data, offset, length);
+              return null;
+            })
+        .when(context)
+        .writeData(any(byte[].class), anyInt(), anyInt());
+    return body;
   }
 }

--- a/src/test/java/network/crypta/node/runtime/LegacyConnectionsPagePortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyConnectionsPagePortTest.java
@@ -1,0 +1,284 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Map;
+import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
+import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
+import network.crypta.node.DarknetPeerNodeStatus;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeStats;
+import network.crypta.node.OpennetPeerNodeStatus;
+import network.crypta.node.PeerManager;
+import network.crypta.node.PeerNodeStatus;
+import network.crypta.node.PeerStatusBook;
+import network.crypta.node.RequestTracker;
+import network.crypta.runtime.spi.ConnectionsPageKind;
+import network.crypta.runtime.spi.ConnectionsPageRequest;
+import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.support.BandwidthStatsContainer;
+import network.crypta.support.math.RunningAverage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class LegacyConnectionsPagePortTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private NodeClientCore core;
+
+  @Mock private NodeStats stats;
+  @Mock private PeerManager peers;
+  @Mock private PeerStatusBook statusBook;
+  @Mock private RequestTracker tracker;
+  @Mock private BandwidthStatsContainer bandwidthStats;
+
+  private LegacyConnectionsPagePort port;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    when(node.network().stats()).thenReturn(stats);
+    when(node.network().peers()).thenReturn(peers);
+    when(node.routing().tracker()).thenReturn(tracker);
+    when(peers.statusBook()).thenReturn(statusBook);
+    when(node.network().opennet()).thenReturn(null);
+    when(node.getStartupTime()).thenReturn(System.currentTimeMillis() - 60_000L);
+    when(node.getMyName()).thenReturn("LocalNode");
+    when(node.isAdvancedModeEnabled()).thenReturn(false);
+    when(node.isFProxyJavascriptEnabled()).thenReturn(false);
+    when(node.runDir().file("IpToCountry.dat")).thenReturn(new File("build/tmp/IpToCountry.dat"));
+    when(node.services()
+            .clientCore()
+            .getClientLayerPersister()
+            .getBandwidthStatsPutter()
+            .getLatestBWData())
+        .thenReturn(bandwidthStats);
+    when(peers.getPeerNodeRoutingBackoffReasons(false)).thenReturn(new String[0]);
+    when(peers.getPeerNodeRoutingBackoffReasons(true)).thenReturn(new String[0]);
+    when(statusBook.getDarknetPeerNodeStatuses(true)).thenReturn(new DarknetPeerNodeStatus[0]);
+    when(statusBook.getDarknetPeerNodeStatuses(false)).thenReturn(new DarknetPeerNodeStatus[0]);
+    when(statusBook.getOpennetPeerNodeStatuses(true)).thenReturn(new OpennetPeerNodeStatus[0]);
+    when(statusBook.getOpennetPeerNodeStatuses(false)).thenReturn(new OpennetPeerNodeStatus[0]);
+    when(statusBook.getPeerNodeStatuses(true)).thenReturn(new PeerNodeStatus[0]);
+
+    setRunningAverage("routingMissDistanceLocal");
+    setRunningAverage("routingMissDistanceRemote");
+    setRunningAverage("routingMissDistanceOverall");
+    setRunningAverage("routingMissDistanceBulk");
+    setRunningAverage("routingMissDistanceRT");
+    setRunningAverage("backedOffPercent");
+
+    port = new LegacyConnectionsPagePort(node, core);
+  }
+
+  @Test
+  void render_whenZeroPeers_returnsDetachedSnapshotsForDarknetAndOpennet() {
+    ConnectionsPageSnapshot darknet =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, false, false, null, false));
+    ConnectionsPageSnapshot opennet =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.OPENNET, false, false, null, false));
+
+    assertEquals(0, darknet.peerCount());
+    assertTrue(darknet.peerActionsEnabled());
+    assertEquals(0, opennet.peerCount());
+    assertFalse(opennet.peerActionsEnabled());
+  }
+
+  @Test
+  void render_whenAdvancedEnabled_includesOverviewMarkerAbsentFromBasicSnapshot() {
+    ConnectionsPageSnapshot basic =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, false, false, null, false));
+    ConnectionsPageSnapshot advanced =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, true, false, null, false));
+
+    assertFalse(basic.contentHtmlBeforePeerTable().contains("Node status overview"));
+    assertTrue(advanced.contentHtmlBeforePeerTable().contains("Node status overview"));
+  }
+
+  @Test
+  void render_whenAdvancedBandwidthRendered_usesLocalizedPayloadKeyAndIncludesDetailRows() {
+    when(tracker.getNumLocalCHKRequests()).thenReturn(1);
+    when(node.network().collector().getTotalIO()).thenReturn(new long[] {6_000L, 3_000L});
+    when(stats.getNodeIOStats()).thenReturn(new long[] {0L, 0L, 0L, 600L, 300L, 6_000L});
+    when(bandwidthStats.getTotalBytesOut()).thenReturn(12_000L);
+    when(bandwidthStats.getTotalBytesIn()).thenReturn(9_000L);
+
+    ConnectionsPageSnapshot snapshot =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, true, false, null, false));
+
+    assertTrue(snapshot.contentHtmlBeforePeerTable().contains("Payload Output"));
+    assertFalse(
+        snapshot.contentHtmlBeforePeerTable().contains("StatisticsToadlet.payloadOutputSession"));
+    assertTrue(
+        snapshot.contentHtmlBeforePeerTable().contains("Request output (excluding payload)"));
+    assertTrue(snapshot.contentHtmlBeforePeerTable().contains("Total non-request overhead"));
+  }
+
+  @Test
+  void render_whenMessageTypesEnabled_addsMessageCountMarkup() {
+    DarknetPeerNodeStatus peerStatus = mockDarknetStatus("Alpha", "10.0.0.1:1234", 0.25);
+    when(peerStatus.getLocalMessagesReceived()).thenReturn(Map.of("CHKData", 2L));
+    when(peerStatus.getLocalMessagesSent()).thenReturn(Map.of("CHKData", 1L));
+    when(statusBook.getDarknetPeerNodeStatuses(true))
+        .thenReturn(new DarknetPeerNodeStatus[] {peerStatus});
+    when(statusBook.getDarknetPeerNodeStatuses(false))
+        .thenReturn(new DarknetPeerNodeStatus[] {peerStatus});
+    when(statusBook.getPeerNodeStatuses(true)).thenReturn(new PeerNodeStatus[] {peerStatus});
+
+    ConnectionsPageSnapshot basic =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, false, false, null, false));
+    ConnectionsPageSnapshot detailed =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, false, true, null, false));
+
+    assertFalse(basic.peerTableHtml().contains("message-count"));
+    assertTrue(detailed.peerTableHtml().contains("message-count"));
+    assertTrue(detailed.peerTableHtml().contains("CHKData"));
+  }
+
+  @Test
+  void render_whenDarknetSortedByName_ordersRowsByRequestedColumn() {
+    DarknetPeerNodeStatus bravo = mockDarknetStatus("Bravo", "10.0.0.2:1234", 0.50);
+    DarknetPeerNodeStatus alpha = mockDarknetStatus("Alpha", "10.0.0.1:1234", 0.25);
+    when(statusBook.getDarknetPeerNodeStatuses(true))
+        .thenReturn(new DarknetPeerNodeStatus[] {bravo, alpha});
+    when(statusBook.getDarknetPeerNodeStatuses(false))
+        .thenReturn(new DarknetPeerNodeStatus[] {bravo, alpha});
+    when(statusBook.getPeerNodeStatuses(true)).thenReturn(new PeerNodeStatus[] {bravo, alpha});
+
+    ConnectionsPageSnapshot snapshot =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, false, false, "name", false));
+
+    assertTrue(
+        snapshot.peerTableHtml().indexOf("Alpha") < snapshot.peerTableHtml().indexOf("Bravo"));
+  }
+
+  @Test
+  void render_whenOpennetSortedBySuccessTime_ordersRowsByLastSuccess() throws Exception {
+    OpennetPeerNodeStatus older = mockOpennetStatus("10.0.0.5:1234", 1.00, 1_000L);
+    OpennetPeerNodeStatus newer = mockOpennetStatus("10.0.0.9:1234", 2.00, 2_000L);
+    when(statusBook.getOpennetPeerNodeStatuses(true))
+        .thenReturn(new OpennetPeerNodeStatus[] {older, newer});
+    when(statusBook.getOpennetPeerNodeStatuses(false))
+        .thenReturn(new OpennetPeerNodeStatus[] {older, newer});
+    when(statusBook.getPeerNodeStatuses(true)).thenReturn(new PeerNodeStatus[] {older, newer});
+
+    ConnectionsPageSnapshot snapshot =
+        port.render(
+            new ConnectionsPageRequest(
+                ConnectionsPageKind.OPENNET, false, false, "successTime", false));
+
+    assertTrue(
+        snapshot.peerTableHtml().indexOf("10.0.0.9:1234")
+            < snapshot.peerTableHtml().indexOf("10.0.0.5:1234"));
+  }
+
+  private DarknetPeerNodeStatus mockDarknetStatus(
+      String name, String address, double selectionRate) {
+    DarknetPeerNodeStatus status = mock(DarknetPeerNodeStatus.class);
+    stubCommonPeerStatus(status, address, selectionRate, selectionRate);
+    when(status.getName()).thenReturn(name);
+    when(status.getPrivateDarknetCommentNote()).thenReturn("note");
+    when(status.getTrustLevel()).thenReturn(FRIEND_TRUST.NORMAL);
+    when(status.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(status.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
+    when(status.getLocalMessagesReceived()).thenReturn(Map.of());
+    when(status.getLocalMessagesSent()).thenReturn(Map.of());
+    return status;
+  }
+
+  private OpennetPeerNodeStatus mockOpennetStatus(
+      String address, double selectionRate, long timeLastSuccess) throws Exception {
+    OpennetPeerNodeStatus status = mock(OpennetPeerNodeStatus.class);
+    stubCommonPeerStatus(status, address, selectionRate, selectionRate);
+    when(status.getLocalMessagesReceived()).thenReturn(Map.of());
+    when(status.getLocalMessagesSent()).thenReturn(Map.of());
+    setTimeLastSuccess(status, timeLastSuccess);
+    return status;
+  }
+
+  private void stubCommonPeerStatus(
+      PeerNodeStatus status, String address, double selectionRate, double location) {
+    long now = System.currentTimeMillis();
+    when(status.getSelectionRate()).thenReturn(selectionRate);
+    when(status.getStatusName()).thenReturn("CONNECTED");
+    when(status.getStatusCSSName()).thenReturn("connected");
+    when(status.getStatusValue()).thenReturn(PeerManager.PEER_NODE_STATUS_CONNECTED);
+    when(status.isFetchingARK()).thenReturn(false);
+    when(status.getPeerAddress()).thenReturn(address);
+    when(status.getPeerAddressAndPort()).thenReturn(address);
+    when(status.getPeerAddressBytes()).thenReturn(null);
+    when(status.isConnected()).thenReturn(true);
+    when(status.getAveragePingTime()).thenReturn(5.0);
+    when(status.getAveragePingTimeCorrected()).thenReturn(5.0);
+    when(status.isPublicInvalidVersion()).thenReturn(false);
+    when(status.isPublicReverseInvalidVersion()).thenReturn(false);
+    when(status.getSimpleVersion()).thenReturn(1);
+    when(status.isRoutable()).thenReturn(true);
+    when(status.getTimeLastRoutable()).thenReturn(now - 1_000L);
+    when(status.getTimeLastConnectionCompleted()).thenReturn(now - 1_000L);
+    when(status.getPeerAddedTime()).thenReturn(now - 10_000L);
+    when(status.getLocation()).thenReturn(location);
+    when(status.getPeersLocation()).thenReturn(null);
+    when(status.getVersion()).thenReturn("Crypta,1");
+    when(status.getBackedOffPercent(true)).thenReturn(0.0);
+    when(status.getBackedOffPercent(false)).thenReturn(0.0);
+    when(status.getPReject()).thenReturn(0.0);
+    when(status.getPercentTimeRoutableConnection()).thenReturn(1.0);
+    when(status.getTotalInputBytes()).thenReturn(10L);
+    when(status.getTotalOutputBytes()).thenReturn(20L);
+    when(status.getTotalInputSinceStartup()).thenReturn(30L);
+    when(status.getTotalOutputSinceStartup()).thenReturn(40L);
+    when(status.getResendBytesSent()).thenReturn(1L);
+    when(status.getClockDelta()).thenReturn(0L);
+    when(status.getReportedUptimePercentage()).thenReturn(100);
+    when(status.getMessageQueueLengthBytes()).thenReturn(0L);
+    when(status.getMessageQueueLengthTime()).thenReturn(0L);
+    when(status.getThrottle()).thenReturn(null);
+    when(status.getRoutingBackedOffUntil(true)).thenReturn(0L);
+    when(status.getRoutingBackedOffUntil(false)).thenReturn(0L);
+    when(status.getRoutingBackoffLength(true)).thenReturn(0L);
+    when(status.getRoutingBackoffLength(false)).thenReturn(0L);
+    when(status.getLastBackoffReason(true)).thenReturn(null);
+    when(status.getLastBackoffReason(false)).thenReturn(null);
+  }
+
+  private void setTimeLastSuccess(OpennetPeerNodeStatus status, long timestamp) throws Exception {
+    Field field = OpennetPeerNodeStatus.class.getField("timeLastSuccess");
+    field.setAccessible(true);
+    field.setLong(status, timestamp);
+  }
+
+  private void setRunningAverage(String fieldName) throws Exception {
+    RunningAverage runningAverage = mock(RunningAverage.class);
+    when(runningAverage.currentValue()).thenReturn(0.0);
+    Field field = NodeStats.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(stats, runningAverage);
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow page-oriented runtime SPI for the legacy connections GET/read path, including detached request and snapshot DTOs and `RuntimePorts` wiring
- move the heavy friends/strangers page traversal and detached HTML rendering into `LegacyConnectionsPagePort`, while keeping POST, peer mutation, noderef ingestion, and reference download behavior in the existing toadlets
- update the darknet and opennet connections toadlets plus registrar wiring to use the new port, and add focused toadlet/adapter tests for the migrated read path and follow-up regressions

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --tests 'network.crypta.clients.http.DarknetConnectionsToadletTest' --tests 'network.crypta.clients.http.OpennetConnectionsToadletTest' --tests 'network.crypta.node.runtime.LegacyConnectionsPagePortTest'`