### PR TITLE
refactor(connections): Move write path behind runtime SPI

### DIFF
--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringTokenizer;
@@ -17,25 +18,30 @@ import network.crypta.clients.fcp.AddPeer;
 import network.crypta.clients.http.complexhtmlnodes.PeerTrustInputForAddPeerBoxNode;
 import network.crypta.clients.http.complexhtmlnodes.PeerVisibilityInputForAddPeerBoxNode;
 import network.crypta.config.ConfigException;
-import network.crypta.io.comm.PeerParseException;
-import network.crypta.io.comm.ReferenceSignatureVerificationException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.FSParseException;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.PeerManager;
-import network.crypta.node.PeerNode;
 import network.crypta.node.PeerNodeStatus;
-import network.crypta.node.PeerTooOldException;
 import network.crypta.node.Version;
+import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.PeerAddFailureReason;
+import network.crypta.runtime.spi.PeerAddRejectedException;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
@@ -52,21 +58,21 @@ import org.slf4j.LoggerFactory;
  * for subclasses that tailor per-network presentation. It centralizes sorting, pagination,
  * validation, and noderef ingestion so downstream pages can focus on the specifics of each
  * topology. Instances are long-lived and reused across requests; state comes from the injected
- * {@link Node} and {@link NodeClientCore} rather than per-request mutability.
+ * runtime ports and {@link NodeClientCore} rather than per-request mutability.
  *
  * <p>Responsibilities include:
  *
  * <ul>
  *   <li>Rendering peer summaries, trust/visibility columns, and message-type breakdowns.
- *   <li>Parsing noderefs from form uploads, pasted text, or URLs, then delegating to {@link Node}
- *       for peer creation.
+ *   <li>Parsing noderefs from form uploads, pasted text, or URLs, then delegating to the runtime
+ *       SPI for peer creation.
  *   <li>Handling redirects and guidance when no peers exist or when access checks fail.
  * </ul>
  *
- * <p>Thread-safety: instances rely on externally synchronized {@link Node}/{@link PeerManager}
- * methods. The toadlet itself holds no mutable request-scoped state except transient flags on the
- * stack, so it can service concurrent requests when the surrounding HTTP server invokes it in
- * parallel. Subclasses should preserve this behavior when adding fields or caching.
+ * <p>Thread-safety: instances hold only long-lived collaborators and no mutable request-scoped
+ * state except transient flags on the stack, so they can service concurrent requests when the
+ * surrounding HTTP server invokes them in parallel. Subclasses should preserve this behavior when
+ * adding fields or caching.
  */
 public abstract class ConnectionsToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionsToadlet.class);
@@ -240,17 +246,20 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
   }
 
-  /** Reference to the running node that backs all connection states and operations. */
-  protected final Node node;
-
   /** Core services used for filesystem paths, configuration, and network integration. */
   protected final NodeClientCore core;
 
-  /** Peer manager providing live peer state and addition helpers. */
-  protected final PeerManager peers;
-
   /** Page-oriented runtime port used for detached GET-only connections page rendering. */
   private final ConnectionsPagePort connectionsPage;
+
+  /** Runtime peer-management port used for peer additions and darknet note writes. */
+  private final PeerPort peerPort;
+
+  /** Runtime node-info port used to export this node's own noderef for the UI. */
+  private final NodeInfoPort nodeInfoPort;
+
+  /** Runtime config port used for add-peer flow overrides that previously hit daemon config. */
+  private final ConfigPort configPort;
 
   /**
    * Outcomes returned when attempting to add a peer from a supplied noderef.
@@ -278,23 +287,28 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /**
    * Creates a toadlet bound to shared node infrastructure used by connection pages.
    *
-   * @param n live {@link Node} supplying peer state and creation helpers; must not be {@code null}.
    * @param core {@link NodeClientCore} providing filesystem access and runtime paths used for
    *     noderef files.
    * @param client high-level client used to retrieve noderefs via Freenet or HTTP when users submit
    *     URLs instead of pasted references.
    * @param connectionsPage read-only runtime page port backing the detached GET render path.
+   * @param peerPort runtime peer-management port used for peer additions and related mutations.
+   * @param nodeInfoPort runtime node-info port used to export this node's own noderef.
+   * @param configPort runtime config port used for add-peer flow overrides.
    */
   protected ConnectionsToadlet(
-      Node n,
       NodeClientCore core,
       HighLevelSimpleClient client,
-      ConnectionsPagePort connectionsPage) {
+      ConnectionsPagePort connectionsPage,
+      PeerPort peerPort,
+      NodeInfoPort nodeInfoPort,
+      ConfigPort configPort) {
     super(client);
-    this.node = n;
-    this.core = core;
-    this.peers = n.network().peers();
+    this.core = Objects.requireNonNull(core);
     this.connectionsPage = Objects.requireNonNull(connectionsPage);
+    this.peerPort = Objects.requireNonNull(peerPort);
+    this.nodeInfoPort = Objects.requireNonNull(nodeInfoPort);
+    this.configPort = Objects.requireNonNull(configPort);
     refLink = HTMLNode.link(path() + "myref.fref").setReadOnly();
     reftextLink = HTMLNode.link(path() + "myref.txt").setReadOnly();
   }
@@ -360,7 +374,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 
     if (shouldDrawNoderefBox(advancedMode)) {
       drawAddPeerBox(contentNode, ctx);
-      drawNoderefBox(contentNode, getNoderef());
+      drawNoderefBox(contentNode, exportOwnNoderef());
     }
 
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
@@ -369,7 +383,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   private boolean serveReferenceDownload(String path, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     if (path.endsWith("myref.fref")) {
-      SimpleFieldSet fs = getNoderef();
+      SimpleFieldSet fs = exportOwnNoderef();
       String noderefString = fs.toOrderedStringWithBase64();
       MultiValueTable<String, String> extraHeaders =
           MultiValueTable.from("Content-Disposition", "attachment; filename=myref.fref");
@@ -381,7 +395,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
 
     if (path.endsWith("myref.txt")) {
-      SimpleFieldSet fs = getNoderef();
+      SimpleFieldSet fs = exportOwnNoderef();
       String noderefString = fs.toOrderedStringWithBase64();
       writeTextReply(ctx, 200, "OK", noderefString);
       return true;
@@ -450,7 +464,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   private void handleAddPeer(HTTPRequest request, ToadletContext ctx)
-      throws IOException, ToadletContextClosedException, ConfigException {
+      throws IOException, ToadletContextClosedException {
     AddPeerRequestData data = extractAddPeerRequestData(request);
     if (!validateTrustAndVisibility(ctx, data)) {
       return;
@@ -465,8 +479,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
     processReferences(data, ref, ctx);
   }
 
-  private AddPeerRequestData extractAddPeerRequestData(HTTPRequest request)
-      throws IOException, ConfigException {
+  private AddPeerRequestData extractAddPeerRequestData(HTTPRequest request) throws IOException {
     String urltext = request.getPartAsStringFailsafe("url", 200).trim();
     String reftext = request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE).trim();
     if (reftext.length() < 200) {
@@ -482,7 +495,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
       if (!peersOffersRefs.isBlank()) {
         reftext = peersOffersRefs;
       }
-      node.getConfig().get("node").set("peersOffersDismissed", true);
+      configPort.applyOverrides(Map.of("node.peersOffersDismissed", "true"));
     }
 
     FRIEND_TRUST trust = parseTrust(request);
@@ -711,29 +724,26 @@ public abstract class ConnectionsToadlet extends Toadlet {
       LOG.error("Internal error adding reference :{}", e.getMessage(), e);
       return PeerAdditionReturnCodes.INTERNAL_ERROR;
     }
-    PeerNode pn;
-    try {
-      if (isOpennet()) {
-        pn = node.network().createNewOpennetNode(fs);
-      } else {
-        pn = node.network().createNewDarknetNode(fs, trust, visibility);
-        ((DarknetPeerNode) pn).setPrivateDarknetCommentNote(privateComment);
-      }
-    } catch (FSParseException | PeerParseException | PeerTooOldException _) {
+
+    if (!matchesExpectedPeerType(fs)) {
+      LOG.warn(
+          "Rejecting {} noderef on {} connections page",
+          fs.getBoolean("opennet", false) ? "opennet" : "darknet",
+          isOpennet() ? "opennet" : "darknet");
       return PeerAdditionReturnCodes.CANT_PARSE;
-    } catch (ReferenceSignatureVerificationException _) {
-      return PeerAdditionReturnCodes.INVALID_SIGNATURE;
+    }
+
+    try {
+      PeerSnapshot addedPeer =
+          peerPort.add(toPeerFieldSet(fs), toPeerTrust(trust), toPeerVisibility(visibility));
+      maybeWritePrivateDarknetComment(addedPeer, privateComment);
+      return PeerAdditionReturnCodes.OK;
+    } catch (PeerAddRejectedException e) {
+      return mapPeerAddFailure(e.reason());
     } catch (Exception e) {
       LOG.error("Internal error adding reference :{}", e.getMessage(), e);
       return PeerAdditionReturnCodes.INTERNAL_ERROR;
     }
-    if (Arrays.equals(pn.peerECDSAPubKeyHash, node.network().darknetPubKeyHash())) {
-      return PeerAdditionReturnCodes.TRY_TO_ADD_SELF;
-    }
-    if (!this.node.network().addPeerConnection(pn)) {
-      return PeerAdditionReturnCodes.ALREADY_IN_REFERENCE;
-    }
-    return PeerAdditionReturnCodes.OK;
   }
 
   private String cleanReferenceText(String reftext) {
@@ -980,11 +990,99 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   /**
-   * Returns the node's own reference for download or display.
+   * Selects which runtime noderef view should back the local-reference UI for this page.
    *
-   * @return immutable {@link SimpleFieldSet} representing this node's noderef.
+   * @return runtime noderef view to export for this toadlet.
    */
-  protected abstract SimpleFieldSet getNoderef();
+  protected abstract NodeReferenceView noderefView();
+
+  private SimpleFieldSet exportOwnNoderef() {
+    return toSimpleFieldSet(nodeInfoPort.exportReference(noderefView(), false).root());
+  }
+
+  private static SimpleFieldSet toSimpleFieldSet(NodeFieldSet source) {
+    SimpleFieldSet target = new SimpleFieldSet(true);
+    for (Map.Entry<String, String> entry : source.directValues().entrySet()) {
+      target.putSingle(entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, NodeFieldSet> entry : source.directSubsets().entrySet()) {
+      target.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
+    }
+    return target;
+  }
+
+  private static PeerFieldSet toPeerFieldSet(SimpleFieldSet source) {
+    if (source.isEmpty()) {
+      return PeerFieldSet.empty();
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(source.directKeyValues());
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleFieldSet> entry : source.directSubsets().entrySet()) {
+      PeerFieldSet subset = toPeerFieldSet(entry.getValue());
+      if (!subset.isEmpty()) {
+        directSubsets.put(entry.getKey(), subset);
+      }
+    }
+    return new PeerFieldSet(directValues, directSubsets);
+  }
+
+  private boolean matchesExpectedPeerType(SimpleFieldSet fieldSet) {
+    return fieldSet.getBoolean("opennet", false) == isOpennet();
+  }
+
+  private static PeerTrust toPeerTrust(FRIEND_TRUST trust) {
+    if (trust == null) {
+      return PeerTrust.NORMAL;
+    }
+    return switch (trust) {
+      case LOW -> PeerTrust.LOW;
+      case NORMAL -> PeerTrust.NORMAL;
+      case HIGH -> PeerTrust.HIGH;
+    };
+  }
+
+  private static PeerVisibility toPeerVisibility(FRIEND_VISIBILITY visibility) {
+    if (visibility == null) {
+      return PeerVisibility.YES;
+    }
+    return switch (visibility) {
+      case YES -> PeerVisibility.YES;
+      case NAME_ONLY -> PeerVisibility.NAME_ONLY;
+      case NO -> PeerVisibility.NO;
+    };
+  }
+
+  private static PeerAdditionReturnCodes mapPeerAddFailure(PeerAddFailureReason reason) {
+    return switch (reason) {
+      case REF_PARSE_ERROR -> PeerAdditionReturnCodes.CANT_PARSE;
+      case REF_SIGNATURE_INVALID -> PeerAdditionReturnCodes.INVALID_SIGNATURE;
+      case CANNOT_PEER_WITH_SELF -> PeerAdditionReturnCodes.TRY_TO_ADD_SELF;
+      case DUPLICATE_PEER_REF -> PeerAdditionReturnCodes.ALREADY_IN_REFERENCE;
+      case OPENNET_DISABLED -> PeerAdditionReturnCodes.INTERNAL_ERROR;
+    };
+  }
+
+  private void maybeWritePrivateDarknetComment(PeerSnapshot addedPeer, String privateComment) {
+    if (isOpennet() || privateComment == null || privateComment.isBlank()) {
+      return;
+    }
+
+    String identity = addedPeer.root().directValues().get("identity");
+    if (identity == null || identity.isBlank()) {
+      LOG.warn("Added darknet peer without identity in snapshot; skipping private note write");
+      return;
+    }
+
+    try {
+      peerPort.writePrivateDarknetComment(identity, privateComment);
+    } catch (UnknownPeerException | DarknetPeerRequiredException | RuntimeException e) {
+      LOG.warn(
+          "Added darknet peer {} but failed to write private note; keeping peer addition",
+          identity,
+          e);
+    }
+  }
 
   private static String l10n(String string) {
     return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + string);

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -16,7 +16,11 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.PeerPort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
@@ -80,13 +84,18 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
           Map.entry("clear_listen_only", pn -> pn.setListenOnly(false)),
           Map.entry("set_allow_local", pn -> pn.setAllowLocalAddresses(true)),
           Map.entry("clear_allow_local", pn -> pn.setAllowLocalAddresses(false)));
+  private final Node node;
 
   DarknetConnectionsToadlet(
       Node n,
       NodeClientCore core,
       HighLevelSimpleClient client,
-      ConnectionsPagePort connectionsPage) {
-    super(n, core, client, connectionsPage);
+      ConnectionsPagePort connectionsPage,
+      PeerPort peerPort,
+      NodeInfoPort nodeInfoPort,
+      ConfigPort configPort) {
+    super(core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
+    this.node = n;
   }
 
   private static String l10n(String string) {
@@ -169,17 +178,16 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   /**
-   * Export the local node's public darknet reference for distribution.
+   * Select the local node's public darknet reference view for distribution.
    *
-   * <p>The exported field set omits private data and contains only the values needed for a remote
-   * peer to add this node as a friend. Callers typically embed the returned structure in the
-   * noderef download box so users can save or transmit it securely.
+   * <p>The shared base class uses this selector to export a detached noderef snapshot through the
+   * runtime SPI before rendering the noderef box or serving `myref.*` downloads.
    *
-   * @return a {@link SimpleFieldSet} containing the sanitized public darknet reference.
+   * @return public darknet noderef view used by the connections page.
    */
   @Override
-  protected SimpleFieldSet getNoderef() {
-    return node.network().exportDarknetPublicFieldSet();
+  protected NodeReferenceView noderefView() {
+    return NodeReferenceView.DARKNET_PUBLIC;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -17,6 +17,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClientBuilder;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.updater.CoreActionToadlet;
+import network.crypta.runtime.spi.RuntimePorts;
 
 import static network.crypta.node.updater.UpdaterPaths.CORE_UPDATE_PATH;
 
@@ -68,6 +69,7 @@ final class FProxyRegistrar {
 
     HighLevelSimpleClient client =
         core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+    RuntimePorts runtimePorts = core.getRuntimePorts();
 
     FProxyToadlet.random = new byte[32];
     core.getRandom().nextBytes(FProxyToadlet.random);
@@ -254,7 +256,14 @@ final class FProxyRegistrar {
         coreActionToadlet, ToadletRegistration.basic(null, CORE_UPDATE_PATH, true, false));
 
     DarknetConnectionsToadlet friendsToadlet =
-        new DarknetConnectionsToadlet(node, core, client, core.getRuntimePorts().connectionsPage());
+        new DarknetConnectionsToadlet(
+            node,
+            core,
+            client,
+            runtimePorts.connectionsPage(),
+            runtimePorts.peer(),
+            runtimePorts.nodeInfo(),
+            runtimePorts.config());
     server.register(
         friendsToadlet,
         ToadletRegistration.menuLink(
@@ -279,7 +288,14 @@ final class FProxyRegistrar {
             null));
 
     OpennetConnectionsToadlet opennetToadlet =
-        new OpennetConnectionsToadlet(node, core, client, core.getRuntimePorts().connectionsPage());
+        new OpennetConnectionsToadlet(
+            node,
+            core,
+            client,
+            runtimePorts.connectionsPage(),
+            runtimePorts.peer(),
+            runtimePorts.nodeInfo(),
+            runtimePorts.config());
     server.register(
         opennetToadlet,
         ToadletRegistration.menuLink(
@@ -317,8 +333,7 @@ final class FProxyRegistrar {
     BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(client);
     server.register(browserTestToadlet, ToadletRegistration.basic(null, "/test/", true, false));
 
-    StatisticsToadlet statisticsToadlet =
-        new StatisticsToadlet(client, core.getRuntimePorts().statistics());
+    StatisticsToadlet statisticsToadlet = new StatisticsToadlet(client, runtimePorts.statistics());
     server.register(
         statisticsToadlet,
         ToadletRegistration.menuLink(
@@ -330,8 +345,7 @@ final class FProxyRegistrar {
             true,
             null));
 
-    DiagnosticToadlet diagnosticToadlet =
-        new DiagnosticToadlet(client, core.getRuntimePorts().diagnostic());
+    DiagnosticToadlet diagnosticToadlet = new DiagnosticToadlet(client, runtimePorts.diagnostic());
     server.register(
         diagnosticToadlet,
         ToadletRegistration.menuLink(
@@ -344,7 +358,7 @@ final class FProxyRegistrar {
             null));
 
     ConnectivityToadlet connectivityToadlet =
-        new ConnectivityToadlet(client, core.getRuntimePorts().connectivity());
+        new ConnectivityToadlet(client, runtimePorts.connectivity());
     server.register(
         connectivityToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -6,9 +6,12 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.PeerPort;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 
 /**
  * Toadlet that renders the opennet peer list for the FProxy UI, focusing on anonymous stranger
@@ -30,6 +33,7 @@ import network.crypta.support.SimpleFieldSet;
  * collaborators are themselves thread-safe.
  */
 public class OpennetConnectionsToadlet extends ConnectionsToadlet implements LinkEnabledCallback {
+  private final Node node;
 
   /**
    * Builds an opennet-specific toadlet using the shared node components required to render peer
@@ -49,27 +53,28 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
       Node n,
       NodeClientCore core,
       HighLevelSimpleClient client,
-      ConnectionsPagePort connectionsPage) {
-    super(n, core, client, connectionsPage);
+      ConnectionsPagePort connectionsPage,
+      PeerPort peerPort,
+      NodeInfoPort nodeInfoPort,
+      ConfigPort configPort) {
+    super(core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
+    this.node = n;
   }
 
   /**
-   * Exports the public opennet noderef from the hosting node so that advanced users can copy it.
-   * The returned field set reflects the node's current opennet identity and is fetched fresh for
-   * each request to avoid stale values.
+   * Selects the public opennet noderef view used by the shared base-class export flow.
    *
-   * @return field set containing the opennet noderef, ready for serialization into the response
-   *     page.
+   * @return public opennet noderef view used by the connections page.
    */
   @Override
-  protected SimpleFieldSet getNoderef() {
-    return node.network().exportOpennetPublicFieldSet();
+  protected NodeReferenceView noderefView() {
+    return NodeReferenceView.OPENNET_PUBLIC;
   }
 
   /**
    * Checks whether opennet support is currently enabled on the hosting node before serving the
-   * toadlet. Requests are only allowed when opennet is active, preventing exposure of partial UI
-   * state while the feature is disabled or unavailable.
+   * toadlet. Requests are only allowed when opennet is active, preventing exposure of the partial
+   * UI state while the feature is disabled or unavailable.
    *
    * @param ctx HTTP context passed by the caller; used by the base class for permission checks and
    *     locale selection.
@@ -102,7 +107,7 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    */
   @Override
   protected boolean showPeerActionsBox() {
-    // No per-peer actions supported on opennet - there's no point, they'll only reconnect,
+    // No per-peer actions supported on opennet - there's no point; they'll only reconnect,
     // possibly as a different identity. And we don't want to be able to send N2NTM spam either.
     return false;
   }
@@ -137,12 +142,12 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
 
   /**
    * Provides the redirect target used when the toadlet needs to bounce the user after processing a
-   * form or encountering an error. It always returns the opennet landing path to keep navigation
+   * form or encountering an error. It always returns the Opennet landing path to keep navigation
    * consistent.
    *
    * <p>Using a fixed location avoids leaking intermediate URLs and reduces the chance of confusing
    * users with partial states after submitting a noderef. The target matches the canonical entry
-   * point of this page so refreshed state is immediately visible after the redirect completes.
+   * point of this page, so the refreshed state is immediately visible after the redirect completes.
    *
    * @return fixed redirect path {@code "/opennet/"} for opennet UI flows.
    */
@@ -173,7 +178,7 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    * metrics while preserving support for reversed ordering when requested by the caller.
    *
    * <p>The comparator is created per request to encapsulate the active sort key and direction,
-   * ensuring thread-safety and allowing multiple concurrent sorts without shared mutable state.
+   * ensuring thread-safety and allowing multiple concurrent sorts without a shared mutable state.
    */
   protected static class OpennetComparator extends ComparatorByStatus {
 
@@ -190,7 +195,7 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
      *     {@link OpennetPeerNodeStatus} instance.
      * @param secondNode second peer node considered by the comparison routine; expected to be an
      *     {@link OpennetPeerNodeStatus} instance.
-     * @return negative, zero, or positive according to the configured ordering and reversal flag,
+     * @return negative, zero, or positive, according to the configured ordering and reversal flag,
      *     using last-success timestamps when available.
      */
     @Override

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -4,7 +4,10 @@ import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
@@ -12,11 +15,23 @@ import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.DarknetPeerNodeStatus;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.PeerTooOldException;
+import network.crypta.node.ProgramDirectory;
+import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.PeerAddFailureReason;
+import network.crypta.runtime.spi.PeerAddRejectedException;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
@@ -24,6 +39,7 @@ import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -34,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -50,6 +67,14 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 class DarknetConnectionsToadletTest {
   private static final String TEST_FORM_PASSWORD = "test-form-password";
+  private static final String VALID_PEER_REFERENCE =
+      "identity=peer-identity\nlastGoodVersion=1\nEnd\n";
+  private static final String VALID_OPENNET_REFERENCE =
+      "opennet=true\nidentity=peer-identity\nlastGoodVersion=1\nEnd\n";
+  private static final String OWN_NODE_NAME = "Alice";
+  private static final String OWN_NODE_IDENTITY = "peer-identity";
+  private static final String OWN_NODE_LAST_GOOD_VERSION = "1";
+  private static final String OWN_NODE_PHYSICAL_UDP = "127.0.0.1:1234";
 
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
@@ -57,14 +82,20 @@ class DarknetConnectionsToadletTest {
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
   @Mock private ConnectionsPagePort connectionsPage;
+  @Mock private PeerPort peerPort;
+  @Mock private NodeInfoPort nodeInfoPort;
+  @Mock private ConfigPort configPort;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
+  @TempDir Path tempDir;
 
   private DarknetConnectionsToadlet toadlet;
 
   @BeforeEach
   void setUp() {
-    toadlet = new DarknetConnectionsToadlet(node, core, client, connectionsPage);
+    toadlet =
+        new DarknetConnectionsToadlet(
+            node, core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
     Mockito.lenient().when(request.isPartSet(anyString())).thenReturn(false);
   }
 
@@ -234,16 +265,124 @@ class DarknetConnectionsToadletTest {
   }
 
   @Test
-  void addNewNode_whenDarknetPeerTooOld_returnsCantParse() throws Exception {
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.createNewDarknetNode(any(), any(), any()))
-        .thenThrow(new PeerTooOldException("old build", 1, Instant.EPOCH));
+  void addNewNode_whenPeerPortAcceptsDarknetRef_addsPeerAndWritesPrivateNote() throws Exception {
+    when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot("peer-added"));
 
-    ConnectionsToadlet.PeerAdditionReturnCodes result = invokeAddNewNode();
+    ConnectionsToadlet.PeerAdditionReturnCodes result =
+        invokeAddNewNode("private-note", FRIEND_TRUST.HIGH, FRIEND_VISIBILITY.NAME_ONLY);
+
+    assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.OK, result);
+
+    ArgumentCaptor<PeerFieldSet> fieldSetCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
+    ArgumentCaptor<PeerTrust> trustCaptor = ArgumentCaptor.forClass(PeerTrust.class);
+    ArgumentCaptor<PeerVisibility> visibilityCaptor = ArgumentCaptor.forClass(PeerVisibility.class);
+    verify(peerPort)
+        .add(fieldSetCaptor.capture(), trustCaptor.capture(), visibilityCaptor.capture());
+    verify(peerPort).writePrivateDarknetComment("peer-added", "private-note");
+
+    assertEquals("peer-identity", fieldSetCaptor.getValue().directValues().get("identity"));
+    assertEquals("1", fieldSetCaptor.getValue().directValues().get("lastGoodVersion"));
+    assertEquals(PeerTrust.HIGH, trustCaptor.getValue());
+    assertEquals(PeerVisibility.NAME_ONLY, visibilityCaptor.getValue());
+  }
+
+  @Test
+  void addNewNode_whenPeerPortRejects_mapsLegacyFailureReasons() throws Exception {
+    assertAddRejectedMaps(
+        PeerAddFailureReason.REF_PARSE_ERROR,
+        ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE);
+    assertAddRejectedMaps(
+        PeerAddFailureReason.REF_SIGNATURE_INVALID,
+        ConnectionsToadlet.PeerAdditionReturnCodes.INVALID_SIGNATURE);
+    assertAddRejectedMaps(
+        PeerAddFailureReason.CANNOT_PEER_WITH_SELF,
+        ConnectionsToadlet.PeerAdditionReturnCodes.TRY_TO_ADD_SELF);
+    assertAddRejectedMaps(
+        PeerAddFailureReason.DUPLICATE_PEER_REF,
+        ConnectionsToadlet.PeerAdditionReturnCodes.ALREADY_IN_REFERENCE);
+    assertAddRejectedMaps(
+        PeerAddFailureReason.OPENNET_DISABLED,
+        ConnectionsToadlet.PeerAdditionReturnCodes.INTERNAL_ERROR);
+  }
+
+  @Test
+  void addNewNode_whenOpennetReferenceSubmittedOnDarknetPage_rejectsWithoutCallingPeerPort()
+      throws Exception {
+    ConnectionsToadlet.PeerAdditionReturnCodes result =
+        invokeAddNewNode(
+            VALID_OPENNET_REFERENCE,
+            "private-note",
+            FRIEND_TRUST.HIGH,
+            FRIEND_VISIBILITY.NAME_ONLY);
 
     assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE, result);
+    verify(peerPort, Mockito.never()).add(any(), any(), any());
+    verify(peerPort, Mockito.never()).writePrivateDarknetComment(anyString(), anyString());
+  }
+
+  @Test
+  void handleMethodPOST_whenUsingPeersOfferFiles_appliesDismissedOverrideAndAddsPeer()
+      throws Exception {
+    Path peersOffersDir = Files.createDirectories(tempDir.resolve("peers-offers"));
+    Files.writeString(
+        peersOffersDir.resolve("offer.fref"),
+        "identity=offer-peer\nlastGoodVersion=1\nEnd\n",
+        StandardCharsets.UTF_8);
+
+    ProgramDirectory runDir = new ProgramDirectory();
+    runDir.move(tempDir.toString());
+    when(core.getNode()).thenReturn(node);
+    when(node.runDir()).thenReturn(runDir);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isPartSet("add")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("url", 200)).thenReturn("");
+    when(request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("peerPrivateNote", 250)).thenReturn("");
+    when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("true");
+    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn(FRIEND_TRUST.NORMAL.name());
+    when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn(FRIEND_VISIBILITY.NO.name());
+    when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot("offer-peer"));
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    captureBody(ctx);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/friends/"), request, ctx);
+
+    verify(configPort).applyOverrides(Map.of("node.peersOffersDismissed", "true"));
+    ArgumentCaptor<PeerFieldSet> fieldSetCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
+    verify(peerPort).add(fieldSetCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.NO));
+    assertEquals("offer-peer", fieldSetCaptor.getValue().directValues().get("identity"));
+    assertEquals("1", fieldSetCaptor.getValue().directValues().get("lastGoodVersion"));
+  }
+
+  @Test
+  void handleMethodGET_whenDownloadingOwnReference_usesNodeInfoPort() throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(nodeInfoPort.exportReference(NodeReferenceView.DARKNET_PUBLIC, false))
+        .thenReturn(ownNodeReferenceSnapshot());
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/friends/myref.fref"), request, ctx);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(nodeInfoPort).exportReference(NodeReferenceView.DARKNET_PUBLIC, false);
+    verify(ctx)
+        .sendReplyHeaders(
+            eq(200),
+            eq("OK"),
+            headersCaptor.capture(),
+            eq("application/x-freenet-reference"),
+            anyLong());
+    assertEquals(
+        "attachment; filename=myref.fref",
+        headersCaptor.getValue().getFirst("Content-Disposition"));
+    assertEquals(
+        ownNodeReferenceFieldSet().toOrderedStringWithBase64(),
+        body.toString(StandardCharsets.UTF_8));
   }
 
   @Test
@@ -309,13 +448,32 @@ class DarknetConnectionsToadletTest {
     return (boolean) method.invoke(toadlet, uri, request, ctx);
   }
 
-  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode() throws Exception {
+  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode(
+      String nodeReference, String privateComment, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility)
+      throws Exception {
     Method method =
         ConnectionsToadlet.class.getDeclaredMethod(
             "addNewNode", String.class, String.class, FRIEND_TRUST.class, FRIEND_VISIBILITY.class);
     method.setAccessible(true);
     return (ConnectionsToadlet.PeerAdditionReturnCodes)
-        method.invoke(toadlet, "foo=bar\nEnd\n", "", FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.NO);
+        method.invoke(toadlet, nodeReference, privateComment, trust, visibility);
+  }
+
+  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode(
+      String privateComment, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility) throws Exception {
+    return invokeAddNewNode(VALID_PEER_REFERENCE, privateComment, trust, visibility);
+  }
+
+  private void assertAddRejectedMaps(
+      PeerAddFailureReason reason, ConnectionsToadlet.PeerAdditionReturnCodes expected)
+      throws Exception {
+    Mockito.reset(peerPort);
+    when(peerPort.add(any(), any(), any())).thenThrow(new PeerAddRejectedException(reason, "bad"));
+
+    ConnectionsToadlet.PeerAdditionReturnCodes result =
+        invokeAddNewNode("", FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.NO);
+
+    assertEquals(expected, result);
   }
 
   private void assertRedirectIssued() throws Exception {
@@ -334,6 +492,11 @@ class DarknetConnectionsToadletTest {
 
     PageMaker pageMaker = mock(PageMaker.class);
     when(pageMaker.getPageNode(anyString(), any(ToadletContext.class))).thenReturn(page);
+    Mockito.lenient()
+        .when(
+            pageMaker.getInfobox(
+                anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
+        .thenAnswer(_ -> new HTMLNode("div"));
     return pageMaker;
   }
 
@@ -376,5 +539,31 @@ class DarknetConnectionsToadletTest {
         .when(context)
         .writeData(any(byte[].class), anyInt(), anyInt());
     return body;
+  }
+
+  private static PeerSnapshot peerSnapshot(String identity) {
+    return new PeerSnapshot(new PeerFieldSet(Map.of("identity", identity), Map.of()));
+  }
+
+  private static NodeReferenceSnapshot ownNodeReferenceSnapshot() {
+    return new NodeReferenceSnapshot(new NodeFieldSet(ownNodeReferenceValues(), Map.of()));
+  }
+
+  private static Map<String, String> ownNodeReferenceValues() {
+    LinkedHashMap<String, String> values = new LinkedHashMap<>();
+    values.put("myName", OWN_NODE_NAME);
+    values.put("identity", OWN_NODE_IDENTITY);
+    values.put("lastGoodVersion", OWN_NODE_LAST_GOOD_VERSION);
+    values.put("physical.udp", OWN_NODE_PHYSICAL_UDP);
+    return values;
+  }
+
+  private static SimpleFieldSet ownNodeReferenceFieldSet() {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("myName", OWN_NODE_NAME);
+    fieldSet.putSingle("identity", OWN_NODE_IDENTITY);
+    fieldSet.putSingle("lastGoodVersion", OWN_NODE_LAST_GOOD_VERSION);
+    fieldSet.putSingle("physical.udp", OWN_NODE_PHYSICAL_UDP);
+    return fieldSet;
   }
 }

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -2,19 +2,27 @@ package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.PeerPort;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +34,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -41,6 +48,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class OpennetConnectionsToadletTest {
+  private static final String VALID_DARKNET_REFERENCE =
+      "identity=darknet-peer\nlastGoodVersion=1\nEnd\n";
+  private static final String OWN_NODE_IDENTITY = "peer-1";
+  private static final String OWN_NODE_LAST_GOOD_VERSION = "1";
 
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
@@ -48,7 +59,9 @@ class OpennetConnectionsToadletTest {
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
   @Mock private ConnectionsPagePort connectionsPage;
-  @Mock private SimpleFieldSet noderef;
+  @Mock private PeerPort peerPort;
+  @Mock private NodeInfoPort nodeInfoPort;
+  @Mock private ConfigPort configPort;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
 
@@ -56,20 +69,14 @@ class OpennetConnectionsToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new OpennetConnectionsToadlet(node, core, client, connectionsPage);
+    toadlet =
+        new OpennetConnectionsToadlet(
+            node, core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
   }
 
   @Test
-  void getNoderef_delegatesToNodeExport() {
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.exportOpennetPublicFieldSet()).thenReturn(noderef);
-
-    SimpleFieldSet result = toadlet.getNoderef();
-
-    assertSame(noderef, result);
-    verify(network).exportOpennetPublicFieldSet();
+  void noderefView_returnsPublicOpennetReferenceView() {
+    assertEquals(NodeReferenceView.OPENNET_PUBLIC, toadlet.noderefView());
   }
 
   @Test
@@ -193,6 +200,48 @@ class OpennetConnectionsToadletTest {
     verify(ctx, never()).addFormChild(any(HTMLNode.class), anyString(), anyString());
   }
 
+  @Test
+  void handleMethodGET_whenAdvancedModeEnabled_rendersOwnNoderefFromNodeInfoPort()
+      throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(true);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    when(request.getParam("sortBy", null)).thenReturn(null);
+    when(request.isParameterSet("reversed")).thenReturn(false);
+    when(connectionsPage.render(any()))
+        .thenReturn(
+            new ConnectionsPageSnapshot(
+                "strangers",
+                1,
+                false,
+                "<div id=\"before\">before</div>",
+                "<div>peer-table</div>",
+                ""));
+    when(nodeInfoPort.exportReference(NodeReferenceView.OPENNET_PUBLIC, false))
+        .thenReturn(ownNodeReferenceSnapshot());
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    stubFormChild(ctx);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/strangers/"), request, ctx);
+
+    String html = body.toString(java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(html.contains("identity=" + OWN_NODE_IDENTITY));
+    assertTrue(html.contains("lastGoodVersion=" + OWN_NODE_LAST_GOOD_VERSION));
+    verify(nodeInfoPort).exportReference(NodeReferenceView.OPENNET_PUBLIC, false);
+  }
+
+  @Test
+  void addNewNode_whenDarknetReferenceSubmittedOnOpennetPage_rejectsWithoutCallingPeerPort()
+      throws Exception {
+    ConnectionsToadlet.PeerAdditionReturnCodes result = invokeAddNewNodeWithDarknetReference();
+
+    assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE, result);
+    verify(peerPort, never()).add(any(), any(), any());
+  }
+
   private OpennetPeerNodeStatus statusWithLastSuccess(long timestamp) {
     OpennetPeerNodeStatus status = mock(OpennetPeerNodeStatus.class);
     setTimeLastSuccess(status, timestamp);
@@ -211,6 +260,20 @@ class OpennetConnectionsToadletTest {
 
   private static LinkageError linkageError(ReflectiveOperationException e) {
     return new LinkageError("Unable to set timeLastSuccess on mock", e);
+  }
+
+  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNodeWithDarknetReference()
+      throws Exception {
+    Method method =
+        ConnectionsToadlet.class.getDeclaredMethod(
+            "addNewNode",
+            String.class,
+            String.class,
+            network.crypta.node.DarknetPeerNode.FRIEND_TRUST.class,
+            network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY.class);
+    method.setAccessible(true);
+    return (ConnectionsToadlet.PeerAdditionReturnCodes)
+        method.invoke(toadlet, VALID_DARKNET_REFERENCE, "", null, null);
   }
 
   private PageMaker stubPageMaker(HTMLNode content) {
@@ -240,5 +303,33 @@ class OpennetConnectionsToadletTest {
         .when(context)
         .writeData(any(byte[].class), anyInt(), anyInt());
     return body;
+  }
+
+  private void stubFormChild(ToadletContext context) {
+    doAnswer(
+            invocation -> {
+              HTMLNode parentNode = invocation.getArgument(0);
+              String target = invocation.getArgument(1);
+              String id = invocation.getArgument(2);
+              return parentNode
+                  .addChild("div")
+                  .addChild(
+                      "form",
+                      new String[] {"action", "method", "enctype", "id", "accept-charset"},
+                      new String[] {target, "post", "multipart/form-data", id, "utf-8"});
+            })
+        .when(context)
+        .addFormChild(any(HTMLNode.class), anyString(), anyString());
+  }
+
+  private static NodeReferenceSnapshot ownNodeReferenceSnapshot() {
+    return new NodeReferenceSnapshot(new NodeFieldSet(ownNodeReferenceValues(), Map.of()));
+  }
+
+  private static Map<String, String> ownNodeReferenceValues() {
+    LinkedHashMap<String, String> values = new LinkedHashMap<>();
+    values.put("identity", OWN_NODE_IDENTITY);
+    values.put("lastGoodVersion", OWN_NODE_LAST_GOOD_VERSION);
+    return values;
   }
 }


### PR DESCRIPTION
## Summary
- move shared `ConnectionsToadlet` own-noderef export, download, and noderef-box rendering behind `NodeInfoPort` using page-specific `NodeReferenceView` selectors
- route the shared add-peer POST flow through `PeerPort` and `ConfigPort`, while preserving legacy return-code mapping, darknet private-note writes, and page-bound opennet/darknet rejection
- update `FProxyRegistrar` wiring and refresh the darknet/opennet HTTP tests for the new constructor shape and runtime-port behavior

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --tests '*DarknetConnectionsToadletTest' --tests '*OpennetConnectionsToadletTest' --tests '*LegacyPeerPortTest' --tests '*LegacyNodeInfoPortTest'`