### PR TITLE
feat(http): Migrate darknet friends updates to SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionPeerSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionPeerSnapshot.java
@@ -1,0 +1,43 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Represents one detached peer entry used by the legacy darknet friends-page actions.
+ *
+ * <p>This snapshot intentionally preserves the current hash-based selection token used by the
+ * legacy HTML form fields, but it keeps that token-specific concern isolated to the friends-page
+ * companion SPI rather than widening the generic peer-management API. Callers receive the detached
+ * identity and display data needed to map the submitted checkbox and note field names back to the
+ * selected peer.
+ *
+ * <p>Instances are immutable and detached from the live daemon state. The HTTP layer can therefore
+ * keep them only for the duration of one render or form submission without holding a reference to a
+ * live {@code DarknetPeerNode}. The snapshot carries only the data the legacy friends page still
+ * needs in this migration stage: the current selection token, the peer identity used for exact
+ * updates, the display name shown in the UI, and the private note text needed to preserve the old
+ * "write only when changed" behavior.
+ *
+ * @param selectionToken legacy hash-based token used in friends-page form field names
+ * @param nodeIdentifier detached peer identity string suitable for exact-identity friends-page
+ *     updates through {@link PeerPort}
+ * @param displayName detached friend display name used in the legacy UI and downloads
+ * @param privateNoteText detached private darknet comment note currently shown on the page
+ * @see DarknetConnectionsPort
+ */
+public record DarknetConnectionPeerSnapshot(
+    int selectionToken, String nodeIdentifier, String displayName, String privateNoteText) {
+  /**
+   * Creates an immutable friends-page peer snapshot.
+   *
+   * <p>The constructor rejects {@code null} string fields so callers can treat each component as a
+   * ready-to-render value without repeating null checks in the HTTP layer.
+   *
+   * @throws NullPointerException if any detached string field is {@code null}
+   */
+  public DarknetConnectionPeerSnapshot {
+    Objects.requireNonNull(nodeIdentifier, "nodeIdentifier");
+    Objects.requireNonNull(displayName, "displayName");
+    Objects.requireNonNull(privateNoteText, "privateNoteText");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionsPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionsPort.java
@@ -1,0 +1,48 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Exposes the narrow legacy darknet friends-page companion capability.
+ *
+ * <p>This port exists specifically to support the remaining legacy friends-page POST actions and
+ * per-peer noderef download path while keeping the current hash-based selection-token scheme out of
+ * the generic {@link PeerPort}. It provides detached peer identity, display-name, and private-note
+ * data for the current page selection model plus one optional full noderef export for a selected
+ * peer.
+ *
+ * <p>The port is intentionally conservative and page-oriented. It does not attempt to model all
+ * darknet peer behavior, and it does not expose live daemon peer objects or field-set transport
+ * types to the HTTP layer. Typical callers render the friends page, map submitted checkbox names
+ * back to the selected peers, and then route any non-destructive updates through {@link PeerPort}
+ * using the exact identity carried by each detached snapshot. That keeps the legacy selection-token
+ * behavior local to this bridge instead of turning it into a generic peer-management concern.
+ */
+public interface DarknetConnectionsPort {
+  /**
+   * Lists the current darknet peers in encounter order for the legacy friends page.
+   *
+   * <p>The returned snapshots preserve the existing selection-token semantics used by the legacy
+   * HTML form field names while also carrying the detached runtime peer identifier needed for later
+   * mutation through {@link PeerPort}. Implementations should return a fresh detached view for each
+   * call so the HTTP layer can compare form values against the page state it just rendered.
+   *
+   * @return detached friends-page peer snapshots in encounter order
+   */
+  List<DarknetConnectionPeerSnapshot> listPeers();
+
+  /**
+   * Exports one full noderef for the peer identified by the supplied legacy selection token.
+   *
+   * <p>The selection token follows the current hash-based friends-page scheme. Implementations
+   * should preserve the existing encounter-order resolution behavior and return {@link
+   * Optional#empty()} when no matching peer exists or when the peer has no full noderef export.
+   * Callers should treat an empty result as a normal miss rather than as an exceptional condition,
+   * because the legacy page already tolerates peers disappearing between render and download.
+   *
+   * @param selectionToken legacy hash-based friends-page peer token
+   * @return optional detached noderef export for the selected peer
+   */
+  Optional<NodeReferenceSnapshot> exportPeerReference(int selectionToken);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetPeerSettingsUpdate.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetPeerSettingsUpdate.java
@@ -22,13 +22,21 @@ package network.crypta.runtime.spi;
  *     setting unchanged
  * @param allowLocalAddresses optional local-address allowance update; {@code null} leaves the
  *     current setting unchanged
+ * @param routingEnabled optional routing status update; {@code null} leaves the current routing
+ *     state unchanged
+ * @param trust optional trust-level update; {@code null} leaves the current trust unchanged
+ * @param visibility optional visibility update; {@code null} leaves the current visibility
+ *     unchanged
  */
 public record DarknetPeerSettingsUpdate(
     Boolean disabled,
     Boolean listenOnly,
     Boolean burstOnly,
     Boolean ignoreSourcePort,
-    Boolean allowLocalAddresses) {
+    Boolean allowLocalAddresses,
+    Boolean routingEnabled,
+    PeerTrust trust,
+    PeerVisibility visibility) {
   /**
    * Returns whether this update carries no requested changes.
    *
@@ -42,6 +50,9 @@ public record DarknetPeerSettingsUpdate(
         && listenOnly == null
         && burstOnly == null
         && ignoreSourcePort == null
-        && allowLocalAddresses == null;
+        && allowLocalAddresses == null
+        && routingEnabled == null
+        && trust == null
+        && visibility == null;
   }
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerPort.java
@@ -82,6 +82,22 @@ public interface PeerPort {
       throws UnknownPeerException, DarknetPeerRequiredException;
 
   /**
+   * Applies one optional settings update to a darknet peer resolved by exact peer identity.
+   *
+   * <p>This method exists for detached callers that already know the selected peer's unique
+   * identity string and must avoid the legacy nickname or address fallback used by {@link
+   * #updateDarknetPeer(String, DarknetPeerSettingsUpdate)}.
+   *
+   * @param peerIdentity exact peer identity string used for lookup
+   * @param update optional darknet settings update
+   * @return detached snapshot of the updated peer, including metadata and volatile state
+   * @throws UnknownPeerException if the peer cannot be resolved
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  PeerSnapshot updateDarknetPeerByIdentity(String peerIdentity, DarknetPeerSettingsUpdate update)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+
+  /**
    * Removes one peer from the runtime.
    *
    * <p>The returned snapshot contains only the removal details needed by the current peer-removal
@@ -120,5 +136,21 @@ public interface PeerPort {
    * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
    */
   String writePrivateDarknetComment(String nodeIdentifier, String noteText)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+
+  /**
+   * Writes the private darknet comment note for one peer resolved by exact peer identity.
+   *
+   * <p>This method exists for detached callers that already know the selected peer's unique
+   * identity string and must avoid the legacy nickname or address fallback used by {@link
+   * #writePrivateDarknetComment(String, String)}.
+   *
+   * @param peerIdentity exact peer identity string used for lookup
+   * @param noteText note text to store
+   * @return stored private darknet comment note text
+   * @throws UnknownPeerException if the peer cannot be resolved
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  String writePrivateDarknetCommentByIdentity(String peerIdentity, String noteText)
       throws UnknownPeerException, DarknetPeerRequiredException;
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -21,6 +21,7 @@ package network.crypta.runtime.spi;
  * @see ConfigPort
  * @see ConnectivityPort
  * @see ConnectionsPagePort
+ * @see DarknetConnectionsPort
  * @see DiagnosticPort
  * @see StatisticsPort
  * @see NodeInfoPort
@@ -112,6 +113,18 @@ public interface RuntimePorts {
    * @return connections-page runtime port for detached legacy friends and strangers snapshots
    */
   ConnectionsPagePort connectionsPage();
+
+  /**
+   * Returns the legacy darknet friends-page companion capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port lets higher layers resolve the current hash-based friends-page selection tokens to
+   * detached peer identity, display-name, and private-note data, and export one peer-specific full
+   * noderef without traversing live daemon peers directly. It exists only for the remaining legacy
+   * friends-page POST and download paths that have not yet moved to a more general detached model.
+   *
+   * @return darknet friends-page companion port for detached peer selection and noderef export
+   */
+  DarknetConnectionsPort darknetConnections();
 
   /**
    * Returns the diagnostic-report capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeer.java
@@ -117,7 +117,10 @@ public class ModifyPeer extends FCPMessage {
             parseOptionalBoolean(fs.get("IsListenOnly")),
             parseOptionalBoolean(fs.get("IsBurstOnly")),
             parseOptionalBoolean(fs.get("IgnoreSourcePort")),
-            parseOptionalBoolean(fs.get("AllowLocalAddresses")));
+            parseOptionalBoolean(fs.get("AllowLocalAddresses")),
+            null,
+            null,
+            null);
     try {
       PeerSnapshot snapshot =
           handler.getServer().runtime().peer().updateDarknetPeer(nodeIdentifier, update);

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -291,24 +291,20 @@ public abstract class ConnectionsToadlet extends Toadlet {
    *     noderef files.
    * @param client high-level client used to retrieve noderefs via Freenet or HTTP when users submit
    *     URLs instead of pasted references.
-   * @param connectionsPage read-only runtime page port backing the detached GET render path.
-   * @param peerPort runtime peer-management port used for peer additions and related mutations.
-   * @param nodeInfoPort runtime node-info port used to export this node's own noderef.
-   * @param configPort runtime config port used for add-peer flow overrides.
+   * @param runtimePorts shared detached runtime ports backing page rendering, peer changes, noderef
+   *     export, and config lookups.
    */
   protected ConnectionsToadlet(
       NodeClientCore core,
       HighLevelSimpleClient client,
-      ConnectionsPagePort connectionsPage,
-      PeerPort peerPort,
-      NodeInfoPort nodeInfoPort,
-      ConfigPort configPort) {
+      ConnectionsToadletRuntimePorts runtimePorts) {
     super(client);
+    ConnectionsToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts);
     this.core = Objects.requireNonNull(core);
-    this.connectionsPage = Objects.requireNonNull(connectionsPage);
-    this.peerPort = Objects.requireNonNull(peerPort);
-    this.nodeInfoPort = Objects.requireNonNull(nodeInfoPort);
-    this.configPort = Objects.requireNonNull(configPort);
+    this.connectionsPage = ports.connectionsPage();
+    this.peerPort = ports.peerPort();
+    this.nodeInfoPort = ports.nodeInfoPort();
+    this.configPort = ports.configPort();
     refLink = HTMLNode.link(path() + "myref.fref").setReadOnly();
     reftextLink = HTMLNode.link(path() + "myref.txt").setReadOnly();
   }

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadletRuntimePorts.java
@@ -1,0 +1,47 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.PeerPort;
+
+/**
+ * Shared runtime-port bundle used by HTTP connections toadlets.
+ *
+ * <p>Darknet and opennet connections pages both require the same detached runtime services for page
+ * rendering, peer updates, noderef export, and config lookups. Grouping these collaborators keeps
+ * constructor signatures small while preserving the existing split between generic connections-page
+ * behavior and network-specific extensions.
+ *
+ * <p>This record is package-private because it is only a wiring convenience for the HTTP layer. It
+ * does not define a new cross-module abstraction, and it deliberately avoids pulling darknet-only
+ * helpers into the shared base toadlet constructor. Instances are immutable after construction and
+ * can be shared safely across long-lived toadlet instances because they contain only stable runtime
+ * service references.
+ *
+ * @param connectionsPage read-only page-rendering port for detached peer snapshots.
+ * @param peerPort peer-management port used for additions and updates.
+ * @param nodeInfoPort node-info port used for local noderef export.
+ * @param configPort config port used for connections-page settings.
+ */
+record ConnectionsToadletRuntimePorts(
+    ConnectionsPagePort connectionsPage,
+    PeerPort peerPort,
+    NodeInfoPort nodeInfoPort,
+    ConfigPort configPort) {
+  /**
+   * Creates one shared runtime-port bundle for connections toadlets.
+   *
+   * <p>All components are required because the base connections-page flow can exercise any of them
+   * during rendering, noderef export, add-peer handling, or follow-up configuration reads.
+   *
+   * @throws NullPointerException if any required runtime port reference is {@code null}
+   */
+  ConnectionsToadletRuntimePorts {
+    Objects.requireNonNull(connectionsPage);
+    Objects.requireNonNull(peerPort);
+    Objects.requireNonNull(nodeInfoPort);
+    Objects.requireNonNull(configPort);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -16,11 +16,17 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
-import network.crypta.runtime.spi.ConfigPort;
-import network.crypta.runtime.spi.ConnectionsPagePort;
-import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
@@ -32,16 +38,16 @@ import org.slf4j.LoggerFactory;
 /**
  * Toadlet that renders and manages the darknet "friends" page and its form actions.
  *
- * <p>This toadlet presents the list of trusted darknet peers, allows users to adjust trust and
- * visibility settings, and exposes bulk actions such as enabling, disabling, or removing peers. It
- * reuses the shared table rendering logic from {@link ConnectionsToadlet} but specializes it for
- * darknet-only concepts like private notes, friend references, and transfer confirmations. Typical
- * callers route HTTP GET and POST traffic from the node's web interface to this class, which then
- * populates HTML structures using {@link network.crypta.support.HTMLNode} builders and performs
- * side effects against {@link network.crypta.node.DarknetPeerNode} instances. The class is stateful
- * only through its reference to the owning {@link network.crypta.node.Node}, and operations are
- * expected to run on the single request-handling thread that invoked the toadlet; no internal
- * synchronization is performed.
+ * <p>This toadlet presents the list of trusted darknet peers. It lets users adjust trust and
+ * visibility settings and trigger bulk actions such as enabling, disabling, or removing peers. It
+ * reuses the shared table rendering logic from {@link ConnectionsToadlet}. It also specializes the
+ * page for darknet-only concepts like private notes, friend references, and transfer confirmations.
+ *
+ * <p>Typical callers route HTTP GET and POST traffic from the node's web interface to this class.
+ * The toadlet builds HTML structures with {@link network.crypta.support.HTMLNode} helpers. It
+ * delegates non-destructive peer updates through runtime SPI ports. It still relies on the live
+ * {@link network.crypta.node.Node} for the legacy destructive and messaging paths that remain in
+ * scope for later migration.
  *
  * <ul>
  *   <li>Renders friend metadata, noderef download links, and private notes.
@@ -70,32 +76,65 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   private static final char PATH_SEPARATOR = '/';
   private static final String FRIENDS_PATH = PATH_SEPARATOR + "friends" + PATH_SEPARATOR;
   private static final String NODE_PREFIX = "node_";
-  private static final Map<String, Consumer<DarknetPeerNode>> SIMPLE_ACTIONS =
+  private static final Map<String, DarknetPeerSettingsUpdate> SIMPLE_ACTIONS =
       Map.ofEntries(
-          Map.entry("enable", DarknetPeerNode::enablePeer),
-          Map.entry("disable", DarknetPeerNode::disablePeer),
-          Map.entry("set_burst_only", pn -> pn.setBurstOnly(true)),
-          Map.entry("clear_burst_only", pn -> pn.setBurstOnly(false)),
-          Map.entry("set_ignore_source_port", pn -> pn.setIgnoreSourcePort(true)),
-          Map.entry("clear_ignore_source_port", pn -> pn.setIgnoreSourcePort(false)),
-          Map.entry("set_dont_route", pn -> pn.setRoutingStatus(false, true)),
-          Map.entry("clear_dont_route", pn -> pn.setRoutingStatus(true, true)),
-          Map.entry("set_listen_only", pn -> pn.setListenOnly(true)),
-          Map.entry("clear_listen_only", pn -> pn.setListenOnly(false)),
-          Map.entry("set_allow_local", pn -> pn.setAllowLocalAddresses(true)),
-          Map.entry("clear_allow_local", pn -> pn.setAllowLocalAddresses(false)));
+          Map.entry("enable", peerSettingsUpdate(Boolean.FALSE, null, null, null, null, null)),
+          Map.entry("disable", peerSettingsUpdate(Boolean.TRUE, null, null, null, null, null)),
+          Map.entry(
+              "set_burst_only", peerSettingsUpdate(null, null, Boolean.TRUE, null, null, null)),
+          Map.entry(
+              "clear_burst_only", peerSettingsUpdate(null, null, Boolean.FALSE, null, null, null)),
+          Map.entry(
+              "set_ignore_source_port",
+              peerSettingsUpdate(null, null, null, Boolean.TRUE, null, null)),
+          Map.entry(
+              "clear_ignore_source_port",
+              peerSettingsUpdate(null, null, null, Boolean.FALSE, null, null)),
+          Map.entry(
+              "set_dont_route", peerSettingsUpdate(null, null, null, null, null, Boolean.FALSE)),
+          Map.entry(
+              "clear_dont_route", peerSettingsUpdate(null, null, null, null, null, Boolean.TRUE)),
+          Map.entry(
+              "set_listen_only", peerSettingsUpdate(null, Boolean.TRUE, null, null, null, null)),
+          Map.entry(
+              "clear_listen_only", peerSettingsUpdate(null, Boolean.FALSE, null, null, null, null)),
+          Map.entry(
+              "set_allow_local", peerSettingsUpdate(null, null, null, null, Boolean.TRUE, null)),
+          Map.entry(
+              "clear_allow_local",
+              peerSettingsUpdate(null, null, null, null, Boolean.FALSE, null)));
   private final Node node;
+  private final DarknetConnectionsPort darknetConnectionsPort;
+  private final PeerPort peerPort;
 
   DarknetConnectionsToadlet(
       Node n,
       NodeClientCore core,
       HighLevelSimpleClient client,
-      ConnectionsPagePort connectionsPage,
-      PeerPort peerPort,
-      NodeInfoPort nodeInfoPort,
-      ConfigPort configPort) {
-    super(core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
+      ConnectionsToadletRuntimePorts runtimePorts,
+      DarknetConnectionsPort darknetConnectionsPort) {
+    super(core, client, runtimePorts);
     this.node = n;
+    this.darknetConnectionsPort = darknetConnectionsPort;
+    this.peerPort = runtimePorts.peerPort();
+  }
+
+  private static DarknetPeerSettingsUpdate peerSettingsUpdate(
+      Boolean disabled,
+      Boolean listenOnly,
+      Boolean burstOnly,
+      Boolean ignoreSourcePort,
+      Boolean allowLocalAddresses,
+      Boolean routingEnabled) {
+    return new DarknetPeerSettingsUpdate(
+        disabled,
+        listenOnly,
+        burstOnly,
+        ignoreSourcePort,
+        allowLocalAddresses,
+        routingEnabled,
+        null,
+        null);
   }
 
   private static String l10n(String string) {
@@ -443,12 +482,18 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   private void handleChangeVisibility(HTTPRequest request) {
     FRIEND_VISIBILITY visibility =
         FRIEND_VISIBILITY.valueOf(request.getPartAsStringFailsafe(CHANGE_VISIBILITY, 10));
-    forSelectedPeers(request, pn -> pn.setVisibility(visibility));
+    applyUpdateToSelectedPeers(
+        request,
+        new DarknetPeerSettingsUpdate(
+            null, null, null, null, null, null, null, toPeerVisibility(visibility)));
   }
 
   private void handleChangeTrust(HTTPRequest request) {
     FRIEND_TRUST trust = FRIEND_TRUST.valueOf(request.getPartAsStringFailsafe(CHANGE_TRUST, 10));
-    forSelectedPeers(request, pn -> pn.setTrustLevel(trust));
+    applyUpdateToSelectedPeers(
+        request,
+        new DarknetPeerSettingsUpdate(
+            null, null, null, null, null, null, toPeerTrust(trust), null));
   }
 
   private boolean handleDoAction(String action, HTTPRequest request, ToadletContext ctx)
@@ -459,9 +504,9 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       return true;
     }
 
-    Consumer<DarknetPeerNode> peerAction = SIMPLE_ACTIONS.get(action);
+    DarknetPeerSettingsUpdate peerAction = SIMPLE_ACTIONS.get(action);
     if (peerAction != null) {
-      forSelectedPeers(request, peerAction);
+      applyUpdateToSelectedPeers(request, peerAction);
       redirectHere(ctx);
       return true;
     }
@@ -542,23 +587,47 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   private void handleUpdateNotes(HTTPRequest request) {
-    for (DarknetPeerNode pn : node.network().darknetConnections()) {
-      String partName = PEER_PRIVATE_NOTE_PREFIX + pn.hashCode();
+    for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
+      String partName = PEER_PRIVATE_NOTE_PREFIX + peer.selectionToken();
       if (!request.isPartSet(partName)) {
         continue;
       }
       String newNote = request.getPartAsStringFailsafe(partName, 250);
-      if (!newNote.equals(pn.getPrivateDarknetCommentNote())) {
-        pn.setPrivateDarknetCommentNote(newNote);
+      if (!newNote.equals(peer.privateNoteText())) {
+        writePrivateDarknetCommentByIdentity(peer.nodeIdentifier(), newNote);
       }
     }
   }
 
-  private void forSelectedPeers(HTTPRequest request, Consumer<DarknetPeerNode> action) {
-    for (DarknetPeerNode pn : node.network().darknetConnections()) {
-      if (request.isPartSet(NODE_PREFIX + pn.hashCode())) {
-        action.accept(pn);
+  private void forSelectedPeers(
+      HTTPRequest request, Consumer<DarknetConnectionPeerSnapshot> action) {
+    for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
+      if (request.isPartSet(NODE_PREFIX + peer.selectionToken())) {
+        action.accept(peer);
       }
+    }
+  }
+
+  private void applyUpdateToSelectedPeers(HTTPRequest request, DarknetPeerSettingsUpdate update) {
+    if (update.isEmpty()) {
+      return;
+    }
+    forSelectedPeers(request, peer -> updateDarknetPeerByIdentity(peer.nodeIdentifier(), update));
+  }
+
+  private void updateDarknetPeerByIdentity(String peerIdentity, DarknetPeerSettingsUpdate update) {
+    try {
+      peerPort.updateDarknetPeerByIdentity(peerIdentity, update);
+    } catch (UnknownPeerException | DarknetPeerRequiredException | RuntimeException e) {
+      LOG.warn("Failed to update darknet peer {}", peerIdentity, e);
+    }
+  }
+
+  private void writePrivateDarknetCommentByIdentity(String peerIdentity, String newNote) {
+    try {
+      peerPort.writePrivateDarknetCommentByIdentity(peerIdentity, newNote);
+    } catch (UnknownPeerException | DarknetPeerRequiredException | RuntimeException e) {
+      LOG.warn("Failed to update private note for darknet peer {}", peerIdentity, e);
     }
   }
 
@@ -658,14 +727,19 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       return false;
     }
 
-    DarknetPeerNode peerNode = findPeerByHashcode(inputHashcode);
-    if (peerNode == null) {
+    DarknetConnectionPeerSnapshot peer = findPeerByHashcode(inputHashcode);
+    if (peer == null) {
       return false;
     }
 
-    SimpleFieldSet fs = peerNode.getFullNoderef();
-    if (fs == null) return false;
-    String filename = FileUtil.sanitizeFileNameWithExtras(peerNode.getName() + FREF_SUFFIX, "\" ");
+    NodeReferenceSnapshot snapshot =
+        darknetConnectionsPort.exportPeerReference(inputHashcode).orElse(null);
+    if (snapshot == null) {
+      return false;
+    }
+
+    SimpleFieldSet fs = toSimpleFieldSet(snapshot.root());
+    String filename = FileUtil.sanitizeFileNameWithExtras(peer.displayName() + FREF_SUFFIX, "\" ");
     String content = fs.toString();
     MultiValueTable<String, String> extraHeaders =
         MultiValueTable.from(
@@ -684,12 +758,31 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     }
   }
 
-  private DarknetPeerNode findPeerByHashcode(int targetHashcode) {
-    for (DarknetPeerNode peerNode : node.network().darknetConnections()) {
-      if (peerNode.hashCode() == targetHashcode) {
-        return peerNode;
+  private DarknetConnectionPeerSnapshot findPeerByHashcode(int targetHashcode) {
+    for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
+      if (peer.selectionToken() == targetHashcode) {
+        return peer;
       }
     }
     return null;
+  }
+
+  private static SimpleFieldSet toSimpleFieldSet(NodeFieldSet source) {
+    SimpleFieldSet target = new SimpleFieldSet(true);
+    for (Map.Entry<String, String> entry : source.directValues().entrySet()) {
+      target.putSingle(entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, NodeFieldSet> entry : source.directSubsets().entrySet()) {
+      target.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
+    }
+    return target;
+  }
+
+  private static PeerTrust toPeerTrust(FRIEND_TRUST trust) {
+    return PeerTrust.valueOf(trust.name());
+  }
+
+  private static PeerVisibility toPeerVisibility(FRIEND_VISIBILITY visibility) {
+    return PeerVisibility.valueOf(visibility.name());
   }
 }

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -255,15 +255,16 @@ final class FProxyRegistrar {
     server.register(
         coreActionToadlet, ToadletRegistration.basic(null, CORE_UPDATE_PATH, true, false));
 
-    DarknetConnectionsToadlet friendsToadlet =
-        new DarknetConnectionsToadlet(
-            node,
-            core,
-            client,
+    ConnectionsToadletRuntimePorts connectionsToadletRuntimePorts =
+        new ConnectionsToadletRuntimePorts(
             runtimePorts.connectionsPage(),
             runtimePorts.peer(),
             runtimePorts.nodeInfo(),
             runtimePorts.config());
+
+    DarknetConnectionsToadlet friendsToadlet =
+        new DarknetConnectionsToadlet(
+            node, core, client, connectionsToadletRuntimePorts, runtimePorts.darknetConnections());
     server.register(
         friendsToadlet,
         ToadletRegistration.menuLink(
@@ -288,14 +289,7 @@ final class FProxyRegistrar {
             null));
 
     OpennetConnectionsToadlet opennetToadlet =
-        new OpennetConnectionsToadlet(
-            node,
-            core,
-            client,
-            runtimePorts.connectionsPage(),
-            runtimePorts.peer(),
-            runtimePorts.nodeInfo(),
-            runtimePorts.config());
+        new OpennetConnectionsToadlet(node, core, client, connectionsToadletRuntimePorts);
     server.register(
         opennetToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -6,11 +6,7 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerNodeStatus;
-import network.crypta.runtime.spi.ConfigPort;
-import network.crypta.runtime.spi.ConnectionsPagePort;
-import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.NodeReferenceView;
-import network.crypta.runtime.spi.PeerPort;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -49,15 +45,12 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    * @param client high-level client for UI links and redirects; expected to be configured for
    *     opennet-safe operations.
    */
-  protected OpennetConnectionsToadlet(
+  OpennetConnectionsToadlet(
       Node n,
       NodeClientCore core,
       HighLevelSimpleClient client,
-      ConnectionsPagePort connectionsPage,
-      PeerPort peerPort,
-      NodeInfoPort nodeInfoPort,
-      ConfigPort configPort) {
-    super(core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
+      ConnectionsToadletRuntimePorts runtimePorts) {
+    super(core, client, runtimePorts);
     this.node = n;
   }
 

--- a/src/main/java/network/crypta/node/runtime/LegacyDarknetConnectionsPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyDarknetConnectionsPort.java
@@ -1,0 +1,103 @@
+package network.crypta.node.runtime;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.support.SimpleFieldSet;
+
+/**
+ * Adapts the legacy darknet friends-page peer traversal to the runtime SPI companion port.
+ *
+ * <p>This bridge preserves the current friends-page hash-token scheme inside the daemon root module
+ * while exposing only detached peer identity, display-name, private-note, and noderef data to the
+ * HTTP layer. It is intentionally narrow and exists only to migrate the remaining non-destructive
+ * darknet friends-page actions away from direct live-daemon peer access.
+ *
+ * <p>The adapter reads the live peer list on demand and immediately converts it into detached
+ * values. That means it does not cache peer objects between requests and does not try to hide
+ * normal race conditions such as a peer disappearing after the page renders. Its job is narrower:
+ * preserve encounter order, preserve the legacy selection token behavior, and provide just enough
+ * data for the migrated HTTP paths to act on the intended peer without traversing daemon internals
+ * directly.
+ */
+final class LegacyDarknetConnectionsPort implements DarknetConnectionsPort {
+  /** Live daemon node whose darknet peer inventory backs this adapter. */
+  private final Node node;
+
+  /**
+   * Creates a legacy-backed companion port for the darknet friends page.
+   *
+   * @param node live daemon node that exposes the current darknet peers
+   */
+  LegacyDarknetConnectionsPort(Node node) {
+    this.node = Objects.requireNonNull(node);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public List<DarknetConnectionPeerSnapshot> listPeers() {
+    DarknetPeerNode[] peers = node.network().darknetConnections();
+    List<DarknetConnectionPeerSnapshot> snapshots = new ArrayList<>(peers.length);
+    for (DarknetPeerNode peer : peers) {
+      snapshots.add(
+          new DarknetConnectionPeerSnapshot(
+              peer.hashCode(),
+              peer.getIdentityString(),
+              Objects.requireNonNullElse(peer.getName(), ""),
+              Objects.requireNonNullElse(peer.getPrivateDarknetCommentNote(), "")));
+    }
+    return List.copyOf(snapshots);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<NodeReferenceSnapshot> exportPeerReference(int selectionToken) {
+    for (DarknetPeerNode peer : node.network().darknetConnections()) {
+      if (peer.hashCode() != selectionToken) {
+        continue;
+      }
+
+      SimpleFieldSet fieldSet = peer.getFullNoderef();
+      if (fieldSet == null) {
+        return Optional.empty();
+      }
+      return Optional.of(new NodeReferenceSnapshot(toNodeFieldSet(fieldSet)));
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Converts one legacy {@link SimpleFieldSet} noderef tree into the detached SPI field-set model.
+   *
+   * <p>The conversion keeps direct values and direct subsets in encounter order so later HTTP
+   * serialization produces stable output. Empty subsets are dropped because the detached
+   * representation does not need to retain placeholder branches that carry no values.
+   *
+   * @param fieldSet legacy noderef field-set tree exported by the daemon
+   * @return detached field-set tree with the same direct values and non-empty subsets
+   */
+  private static NodeFieldSet toNodeFieldSet(SimpleFieldSet fieldSet) {
+    if (fieldSet.isEmpty()) {
+      return NodeFieldSet.empty();
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(fieldSet.directKeyValues());
+    LinkedHashMap<String, NodeFieldSet> directSubsets = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleFieldSet> entry : fieldSet.directSubsets().entrySet()) {
+      NodeFieldSet subset = toNodeFieldSet(entry.getValue());
+      if (!subset.isEmpty()) {
+        directSubsets.put(entry.getKey(), subset);
+      }
+    }
+    return new NodeFieldSet(directValues, directSubsets);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyPeerPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyPeerPort.java
@@ -116,11 +116,29 @@ final class LegacyPeerPort implements PeerPort {
       throws UnknownPeerException, DarknetPeerRequiredException {
     Objects.requireNonNull(update, "update");
     DarknetPeerNode peer = resolveDarknetPeer(nodeIdentifier);
+    return applyDarknetPeerUpdate(peer, update);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PeerSnapshot updateDarknetPeerByIdentity(
+      String peerIdentity, DarknetPeerSettingsUpdate update)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    Objects.requireNonNull(update, "update");
+    DarknetPeerNode peer = resolveDarknetPeerByIdentity(peerIdentity);
+    return applyDarknetPeerUpdate(peer, update);
+  }
+
+  private PeerSnapshot applyDarknetPeerUpdate(
+      DarknetPeerNode peer, DarknetPeerSettingsUpdate update) {
     applyDisableFlag(peer, update.disabled());
     applyBooleanFlag(update.listenOnly(), peer::setListenOnly);
     applyBooleanFlag(update.burstOnly(), peer::setBurstOnly);
     applyBooleanFlag(update.ignoreSourcePort(), peer::setIgnoreSourcePort);
     applyBooleanFlag(update.allowLocalAddresses(), peer::setAllowLocalAddresses);
+    applyRoutingFlag(peer, update.routingEnabled());
+    applyTrust(peer, update.trust());
+    applyVisibility(peer, update.visibility());
     return toPeerSnapshot(peer, true, true);
   }
 
@@ -149,6 +167,15 @@ final class LegacyPeerPort implements PeerPort {
     return peer.getPrivateDarknetCommentNote();
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public String writePrivateDarknetCommentByIdentity(String peerIdentity, String noteText)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    DarknetPeerNode peer = resolveDarknetPeerByIdentity(peerIdentity);
+    peer.setPrivateDarknetCommentNote(noteText);
+    return peer.getPrivateDarknetCommentNote();
+  }
+
   /**
    * Resolves one peer by the daemon's existing node-identifier lookup path.
    *
@@ -165,6 +192,16 @@ final class LegacyPeerPort implements PeerPort {
     return peer;
   }
 
+  private PeerNode resolvePeerByIdentity(String identity) {
+    Objects.requireNonNull(identity, "identity");
+    for (PeerNode peer : node.network().peerNodes()) {
+      if (identity.equals(peer.getIdentityString())) {
+        return peer;
+      }
+    }
+    return null;
+  }
+
   /**
    * Resolves one peer and verifies that it is a darknet peer.
    *
@@ -178,6 +215,18 @@ final class LegacyPeerPort implements PeerPort {
     PeerNode peer = resolvePeer(nodeIdentifier);
     if (!(peer instanceof DarknetPeerNode darknetPeer)) {
       throw new DarknetPeerRequiredException(nodeIdentifier);
+    }
+    return darknetPeer;
+  }
+
+  private DarknetPeerNode resolveDarknetPeerByIdentity(String peerIdentity)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    PeerNode peer = resolvePeerByIdentity(peerIdentity);
+    if (peer == null) {
+      throw new UnknownPeerException(peerIdentity);
+    }
+    if (!(peer instanceof DarknetPeerNode darknetPeer)) {
+      throw new DarknetPeerRequiredException(peerIdentity);
     }
     return darknetPeer;
   }
@@ -300,6 +349,42 @@ final class LegacyPeerPort implements PeerPort {
       Boolean flagValue, java.util.function.Consumer<Boolean> setter) {
     if (flagValue != null) {
       setter.accept(flagValue);
+    }
+  }
+
+  /**
+   * Applies the nullable routing-enabled flag using the legacy routing-status setter.
+   *
+   * @param peer darknet peer to update
+   * @param routingEnabled nullable routing-enabled flag from the detached update DTO
+   */
+  private static void applyRoutingFlag(DarknetPeerNode peer, Boolean routingEnabled) {
+    if (routingEnabled != null) {
+      peer.setRoutingStatus(routingEnabled, true);
+    }
+  }
+
+  /**
+   * Applies the nullable trust update using the legacy darknet trust setter.
+   *
+   * @param peer darknet peer to update
+   * @param trust nullable runtime-spi trust value from the detached update DTO
+   */
+  private static void applyTrust(DarknetPeerNode peer, PeerTrust trust) {
+    if (trust != null) {
+      peer.setTrustLevel(toLegacyTrust(trust));
+    }
+  }
+
+  /**
+   * Applies the nullable visibility update using the legacy darknet visibility setter.
+   *
+   * @param peer darknet peer to update
+   * @param visibility nullable runtime-spi visibility value from the detached update DTO
+   */
+  private static void applyVisibility(DarknetPeerNode peer, PeerVisibility visibility) {
+    if (visibility != null) {
+      peer.setVisibility(toLegacyVisibility(visibility));
     }
   }
 

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -7,6 +7,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.LifecyclePort;
@@ -42,6 +43,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final ConfigPort configPort;
   private final ConnectivityPort connectivityPort;
   private final ConnectionsPagePort connectionsPagePort;
+  private final DarknetConnectionsPort darknetConnectionsPort;
   private final DiagnosticPort diagnosticPort;
   private final StatisticsPort statisticsPort;
   private final RequestQueuePort requestQueuePort;
@@ -129,6 +131,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.configPort = new LegacyConfigPort(node, core);
     this.connectivityPort = new LegacyConnectivityPort(node);
     this.connectionsPagePort = new LegacyConnectionsPagePort(node, core);
+    this.darknetConnectionsPort = new LegacyDarknetConnectionsPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
@@ -211,6 +214,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public ConnectionsPagePort connectionsPage() {
     return connectionsPagePort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the legacy darknet friends-page selection-token traversal and
+   * peer-specific noderef export inside the daemon root module while exposing only detached
+   * SPI-local snapshots upstream.
+   */
+  @Override
+  public DarknetConnectionsPort darknetConnections() {
+    return darknetConnectionsPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ModifyPeerTest.java
@@ -163,6 +163,9 @@ class ModifyPeerTest {
     assertEquals(Boolean.FALSE, update.burstOnly());
     assertEquals(Boolean.TRUE, update.ignoreSourcePort());
     assertEquals(Boolean.FALSE, update.allowLocalAddresses());
+    assertNull(update.routingEnabled());
+    assertNull(update.trust());
+    assertNull(update.visibility());
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler, times(1)).send(captor.capture());
@@ -232,6 +235,9 @@ class ModifyPeerTest {
     assertNull(update.burstOnly());
     assertNull(update.ignoreSourcePort());
     assertNull(update.allowLocalAddresses());
+    assertNull(update.routingEnabled());
+    assertNull(update.trust());
+    assertNull(update.visibility());
     verify(handler, times(1)).send(any(PeerMessage.class));
   }
 

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -7,7 +7,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
@@ -21,6 +23,9 @@ import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
@@ -47,6 +52,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,6 +81,7 @@ class DarknetConnectionsToadletTest {
   private static final String OWN_NODE_IDENTITY = "peer-identity";
   private static final String OWN_NODE_LAST_GOOD_VERSION = "1";
   private static final String OWN_NODE_PHYSICAL_UDP = "127.0.0.1:1234";
+  private static final String TEST_NODE_IDENTIFIER = "peer-1";
 
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
@@ -82,6 +89,7 @@ class DarknetConnectionsToadletTest {
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
   @Mock private ConnectionsPagePort connectionsPage;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private PeerPort peerPort;
   @Mock private NodeInfoPort nodeInfoPort;
   @Mock private ConfigPort configPort;
@@ -93,9 +101,10 @@ class DarknetConnectionsToadletTest {
 
   @BeforeEach
   void setUp() {
+    ConnectionsToadletRuntimePorts runtimePorts =
+        new ConnectionsToadletRuntimePorts(connectionsPage, peerPort, nodeInfoPort, configPort);
     toadlet =
-        new DarknetConnectionsToadlet(
-            node, core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
+        new DarknetConnectionsToadlet(node, core, client, runtimePorts, darknetConnectionsPort);
     Mockito.lenient().when(request.isPartSet(anyString())).thenReturn(false);
   }
 
@@ -199,45 +208,91 @@ class DarknetConnectionsToadletTest {
 
   @Test
   void handleAltPost_updateNotes_updatesChangedNotesAndRedirects() throws Exception {
-    DarknetPeerNode peer = mock(DarknetPeerNode.class);
-    when(peer.getPrivateDarknetCommentNote()).thenReturn("old");
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
-
-    int peerHash = peer.hashCode();
+    int selectionToken = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(selectionToken, "Alice", "old")));
     when(request.isPartSet("doAction")).thenReturn(true);
     when(request.getPartAsStringFailsafe("action", 25)).thenReturn("update_notes");
-    when(request.isPartSet("peerPrivateNote_" + peerHash)).thenReturn(true);
-    when(request.getPartAsStringFailsafe("peerPrivateNote_" + peerHash, 250)).thenReturn("new");
+    when(request.isPartSet("peerPrivateNote_" + selectionToken)).thenReturn(true);
+    when(request.getPartAsStringFailsafe("peerPrivateNote_" + selectionToken, 250))
+        .thenReturn("new");
 
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
     toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
 
-    verify(peer).setPrivateDarknetCommentNote("new");
+    verify(peerPort).writePrivateDarknetCommentByIdentity(TEST_NODE_IDENTIFIER, "new");
+    verifyNoInteractions(node);
     assertRedirectIssued();
   }
 
   @Test
-  void handleAltPost_enableAction_enablesSelectedPeersAndRedirects() throws Exception {
-    DarknetPeerNode peer = mock(DarknetPeerNode.class);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
-
-    int peerHash = peer.hashCode();
+  void handleAltPost_enableAction_updatesSelectedPeersThroughPeerPortAndRedirects()
+      throws Exception {
+    int selectionToken = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(selectionToken, "Alice", "")));
     when(request.isPartSet("doAction")).thenReturn(true);
     when(request.getPartAsStringFailsafe("action", 25)).thenReturn("enable");
-    when(request.isPartSet("node_" + peerHash)).thenReturn(true);
+    when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
 
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
     toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
 
-    verify(peer).enablePeer();
+    ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
+        ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
+    verify(peerPort).updateDarknetPeerByIdentity(eq(TEST_NODE_IDENTIFIER), updateCaptor.capture());
+    assertEquals(Boolean.FALSE, updateCaptor.getValue().disabled());
+    assertNull(updateCaptor.getValue().routingEnabled());
+    verifyNoInteractions(node);
+    assertRedirectIssued();
+  }
+
+  @Test
+  void handleAltPost_changeTrust_updatesSelectedPeersThroughPeerPortAndRedirects()
+      throws Exception {
+    int selectionToken = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(selectionToken, "Alice", "")));
+    when(request.isPartSet("changeTrust")).thenReturn(true);
+    when(request.isPartSet("doChangeTrust")).thenReturn(true);
+    when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
+    when(request.getPartAsStringFailsafe("changeTrust", 10)).thenReturn(FRIEND_TRUST.HIGH.name());
+
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
+        ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
+    verify(peerPort).updateDarknetPeerByIdentity(eq(TEST_NODE_IDENTIFIER), updateCaptor.capture());
+    assertEquals(PeerTrust.HIGH, updateCaptor.getValue().trust());
+    verifyNoInteractions(node);
+    assertRedirectIssued();
+  }
+
+  @Test
+  void handleAltPost_changeVisibility_updatesSelectedPeersThroughPeerPortAndRedirects()
+      throws Exception {
+    int selectionToken = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(selectionToken, "Alice", "")));
+    when(request.isPartSet("changeVisibility")).thenReturn(true);
+    when(request.isPartSet("doChangeVisibility")).thenReturn(true);
+    when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
+    when(request.getPartAsStringFailsafe("changeVisibility", 10))
+        .thenReturn(FRIEND_VISIBILITY.NAME_ONLY.name());
+
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
+        ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
+    verify(peerPort).updateDarknetPeerByIdentity(eq(TEST_NODE_IDENTIFIER), updateCaptor.capture());
+    assertEquals(PeerVisibility.NAME_ONLY, updateCaptor.getValue().visibility());
+    verifyNoInteractions(node);
     assertRedirectIssued();
   }
 
@@ -387,18 +442,11 @@ class DarknetConnectionsToadletTest {
 
   @Test
   void tryHandlePeerNoderef_withValidFriendHash_sendsAttachmentResponse() throws Exception {
-    SimpleFieldSet fieldSet = new SimpleFieldSet(false);
-    fieldSet.putSingle("key", "value");
-
-    DarknetPeerNode peer = mock(DarknetPeerNode.class);
-    when(peer.getName()).thenReturn("Friend");
-    when(peer.getFullNoderef()).thenReturn(fieldSet);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
-
-    int peerHash = peer.hashCode();
+    int peerHash = 1234;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(peerHash, "Friend", "")));
+    when(darknetConnectionsPort.exportPeerReference(peerHash))
+        .thenReturn(Optional.of(peerNodeReferenceSnapshot()));
     URI uri = URI.create("http://localhost/friends/friend-" + peerHash + ".fref");
 
     doNothing()
@@ -415,7 +463,8 @@ class DarknetConnectionsToadletTest {
         ArgumentCaptor.forClass(MultiValueTable.class);
     ArgumentCaptor<byte[]> bodyCaptor = ArgumentCaptor.forClass(byte[].class);
 
-    int expectedLength = fieldSet.toString().getBytes(StandardCharsets.UTF_8).length;
+    int expectedLength =
+        peerNodeReferenceFieldSet().toString().getBytes(StandardCharsets.UTF_8).length;
     verify(ctx)
         .sendReplyHeaders(
             eq(200),
@@ -427,7 +476,11 @@ class DarknetConnectionsToadletTest {
 
     String headerValue = headersCaptor.getValue().getFirst("Content-Disposition");
     assertEquals("attachment; filename=Friend.fref", headerValue);
-    assertEquals(fieldSet.toString(), new String(bodyCaptor.getValue(), StandardCharsets.UTF_8));
+    assertEquals(
+        peerNodeReferenceFieldSet().toString(),
+        new String(bodyCaptor.getValue(), StandardCharsets.UTF_8));
+    verify(darknetConnectionsPort).exportPeerReference(peerHash);
+    verifyNoInteractions(node);
   }
 
   @Test
@@ -545,8 +598,18 @@ class DarknetConnectionsToadletTest {
     return new PeerSnapshot(new PeerFieldSet(Map.of("identity", identity), Map.of()));
   }
 
+  private static DarknetConnectionPeerSnapshot darknetPeerSnapshot(
+      int selectionToken, String displayName, String privateNoteText) {
+    return new DarknetConnectionPeerSnapshot(
+        selectionToken, TEST_NODE_IDENTIFIER, displayName, privateNoteText);
+  }
+
   private static NodeReferenceSnapshot ownNodeReferenceSnapshot() {
     return new NodeReferenceSnapshot(new NodeFieldSet(ownNodeReferenceValues(), Map.of()));
+  }
+
+  private static NodeReferenceSnapshot peerNodeReferenceSnapshot() {
+    return new NodeReferenceSnapshot(new NodeFieldSet(Map.of("key", "value"), Map.of()));
   }
 
   private static Map<String, String> ownNodeReferenceValues() {
@@ -564,6 +627,12 @@ class DarknetConnectionsToadletTest {
     fieldSet.putSingle("identity", OWN_NODE_IDENTITY);
     fieldSet.putSingle("lastGoodVersion", OWN_NODE_LAST_GOOD_VERSION);
     fieldSet.putSingle("physical.udp", OWN_NODE_PHYSICAL_UDP);
+    return fieldSet;
+  }
+
+  private static SimpleFieldSet peerNodeReferenceFieldSet() {
+    SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+    fieldSet.putSingle("key", "value");
     return fieldSet;
   }
 }

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -69,9 +69,9 @@ class OpennetConnectionsToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet =
-        new OpennetConnectionsToadlet(
-            node, core, client, connectionsPage, peerPort, nodeInfoPort, configPort);
+    ConnectionsToadletRuntimePorts runtimePorts =
+        new ConnectionsToadletRuntimePorts(connectionsPage, peerPort, nodeInfoPort, configPort);
+    toadlet = new OpennetConnectionsToadlet(node, core, client, runtimePorts);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/runtime/LegacyDarknetConnectionsPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyDarknetConnectionsPortTest.java
@@ -1,0 +1,100 @@
+package network.crypta.node.runtime;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.support.SimpleFieldSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyDarknetConnectionsPortTest {
+
+  @Mock private Node node;
+
+  @Mock private NodeNetworkSubsystem network;
+
+  @Mock private DarknetPeerNode peerOne;
+
+  @Mock private DarknetPeerNode peerTwo;
+
+  @Test
+  void listPeers_whenDarknetPeersPresent_returnsDetachedSnapshotsInEncounterOrder() {
+    LegacyDarknetConnectionsPort port = newPort();
+    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peerOne, peerTwo});
+    when(peerOne.getIdentityString()).thenReturn("peer-1");
+    when(peerOne.getName()).thenReturn("Alice");
+    when(peerOne.getPrivateDarknetCommentNote()).thenReturn("note-one");
+    when(peerTwo.getIdentityString()).thenReturn("peer-2");
+    when(peerTwo.getName()).thenReturn("Bob");
+    when(peerTwo.getPrivateDarknetCommentNote()).thenReturn("note-two");
+
+    List<DarknetConnectionPeerSnapshot> snapshots = port.listPeers();
+
+    assertEquals(
+        List.of(
+            new DarknetConnectionPeerSnapshot(peerOne.hashCode(), "peer-1", "Alice", "note-one"),
+            new DarknetConnectionPeerSnapshot(peerTwo.hashCode(), "peer-2", "Bob", "note-two")),
+        snapshots);
+  }
+
+  @Test
+  void exportPeerReference_whenPeerHasFullNoderef_returnsDetachedSnapshot() {
+    LegacyDarknetConnectionsPort port = newPort();
+    SimpleFieldSet noderef = new SimpleFieldSet(true);
+    noderef.putSingle("identity", "peer-1");
+    SimpleFieldSet physical = new SimpleFieldSet(true);
+    physical.putSingle("host", "127.0.0.1");
+    noderef.put("physical", physical);
+    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peerOne});
+    when(peerOne.getFullNoderef()).thenReturn(noderef);
+
+    Optional<NodeReferenceSnapshot> snapshot = port.exportPeerReference(peerOne.hashCode());
+
+    assertEquals(
+        Optional.of(
+            new NodeReferenceSnapshot(
+                new NodeFieldSet(
+                    Map.of("identity", "peer-1"),
+                    Map.of("physical", new NodeFieldSet(Map.of("host", "127.0.0.1"), Map.of()))))),
+        snapshot);
+  }
+
+  @Test
+  void exportPeerReference_whenSelectionTokenDoesNotResolve_returnsEmptyOptional() {
+    LegacyDarknetConnectionsPort port = newPort();
+    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peerOne});
+
+    int missingToken =
+        peerOne.hashCode() == Integer.MAX_VALUE ? Integer.MIN_VALUE : peerOne.hashCode() + 1;
+
+    assertTrue(port.exportPeerReference(missingToken).isEmpty());
+  }
+
+  @Test
+  void exportPeerReference_whenPeerHasNoFullNoderef_returnsEmptyOptional() {
+    LegacyDarknetConnectionsPort port = newPort();
+    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peerOne});
+    when(peerOne.getFullNoderef()).thenReturn(null);
+
+    assertTrue(port.exportPeerReference(peerOne.hashCode()).isEmpty());
+  }
+
+  private LegacyDarknetConnectionsPort newPort() {
+    when(node.network()).thenReturn(network);
+    return new LegacyDarknetConnectionsPort(node);
+  }
+}

--- a/src/test/java/network/crypta/node/runtime/LegacyPeerPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyPeerPortTest.java
@@ -239,8 +239,9 @@ class LegacyPeerPortTest {
   }
 
   @Test
-  void updateDarknetPeer_whenFlagsPresent_appliesRequestedMutationsAndReturnsSnapshot()
-      throws Exception {
+  void
+      updateDarknetPeer_whenFlagsTrustAndVisibilityPresent_appliesRequestedMutationsAndReturnsSnapshot()
+          throws Exception {
     LegacyPeerPort port = newPort();
     when(network.getPeerNode("peer-123")).thenReturn(darknetPeer);
     stubPeerExports(darknetPeer, "peer-123", "trustLevel", "NORMAL", "CONNECTED");
@@ -249,14 +250,77 @@ class LegacyPeerPortTest {
         port.updateDarknetPeer(
             "peer-123",
             new DarknetPeerSettingsUpdate(
-                Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.FALSE, Boolean.TRUE));
+                Boolean.TRUE,
+                Boolean.FALSE,
+                Boolean.TRUE,
+                Boolean.FALSE,
+                Boolean.TRUE,
+                Boolean.TRUE,
+                PeerTrust.HIGH,
+                PeerVisibility.NO));
 
     verify(darknetPeer).disablePeer();
     verify(darknetPeer).setListenOnly(false);
     verify(darknetPeer).setBurstOnly(true);
     verify(darknetPeer).setIgnoreSourcePort(false);
     verify(darknetPeer).setAllowLocalAddresses(true);
+    verify(darknetPeer).setRoutingStatus(true, true);
+    verify(darknetPeer).setTrustLevel(FRIEND_TRUST.HIGH);
+    verify(darknetPeer).setVisibility(FRIEND_VISIBILITY.NO);
     assertEquals("peer-123", snapshot.root().directValues().get("identity"));
+  }
+
+  @Test
+  void updateDarknetPeer_whenIdentifierUsesIdentityPrefix_usesLegacyLookupSemantics()
+      throws Exception {
+    LegacyPeerPort port = newPort();
+    when(network.getPeerNode("identity:peer-123")).thenReturn(darknetPeer);
+    stubPeerExports(darknetPeer, "peer-123", "trustLevel", "NORMAL", "CONNECTED");
+
+    port.updateDarknetPeer(
+        "identity:peer-123",
+        new DarknetPeerSettingsUpdate(
+            Boolean.TRUE, null, null, null, null, null, null, PeerVisibility.NAME_ONLY));
+
+    verify(network).getPeerNode("identity:peer-123");
+    verify(darknetPeer).disablePeer();
+    verify(darknetPeer).setVisibility(FRIEND_VISIBILITY.NAME_ONLY);
+  }
+
+  @Test
+  void updateDarknetPeerByIdentity_whenIdentityMatchesPeer_resolvesByIdentityOnly()
+      throws Exception {
+    LegacyPeerPort port = newPort();
+    DarknetPeerNode collidingNamePeer = org.mockito.Mockito.mock(DarknetPeerNode.class);
+    when(network.peerNodes()).thenReturn(new PeerNode[] {collidingNamePeer, darknetPeer});
+    when(collidingNamePeer.getIdentityString()).thenReturn("other-peer");
+    when(darknetPeer.getIdentityString()).thenReturn("peer-123");
+    stubPeerExports(darknetPeer, "peer-123", "trustLevel", "NORMAL", "CONNECTED");
+
+    port.updateDarknetPeerByIdentity(
+        "peer-123",
+        new DarknetPeerSettingsUpdate(
+            Boolean.TRUE, null, null, null, null, null, null, PeerVisibility.NAME_ONLY));
+
+    verify(darknetPeer).disablePeer();
+    verify(darknetPeer).setVisibility(FRIEND_VISIBILITY.NAME_ONLY);
+    verify(collidingNamePeer, never()).disablePeer();
+    verify(network, never()).getPeerNode(any());
+  }
+
+  @Test
+  void updateDarknetPeerByIdentity_whenPeerMissing_throwsUnknownPeerException() {
+    LegacyPeerPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {peerOne});
+    when(peerOne.getIdentityString()).thenReturn("other-peer");
+
+    assertThrows(
+        UnknownPeerException.class,
+        () ->
+            port.updateDarknetPeerByIdentity(
+                "peer-123",
+                new DarknetPeerSettingsUpdate(
+                    Boolean.TRUE, null, null, null, null, null, null, null)));
   }
 
   @Test
@@ -300,6 +364,24 @@ class LegacyPeerPortTest {
     String storedNote = port.writePrivateDarknetComment("peer-123", "updated-note");
 
     verify(darknetPeer).setPrivateDarknetCommentNote("updated-note");
+    assertEquals("stored-note", storedNote);
+  }
+
+  @Test
+  void writePrivateDarknetCommentByIdentity_whenIdentityMatchesPeer_resolvesByIdentityOnly()
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    LegacyPeerPort port = newPort();
+    DarknetPeerNode collidingNamePeer = org.mockito.Mockito.mock(DarknetPeerNode.class);
+    when(network.peerNodes()).thenReturn(new PeerNode[] {collidingNamePeer, darknetPeer});
+    when(collidingNamePeer.getIdentityString()).thenReturn("other-peer");
+    when(darknetPeer.getIdentityString()).thenReturn("peer-123");
+    when(darknetPeer.getPrivateDarknetCommentNote()).thenReturn("stored-note");
+
+    String storedNote = port.writePrivateDarknetCommentByIdentity("peer-123", "updated-note");
+
+    verify(darknetPeer).setPrivateDarknetCommentNote("updated-note");
+    verify(collidingNamePeer, never()).setPrivateDarknetCommentNote(any());
+    verify(network, never()).getPeerNode(any());
     assertEquals("stored-note", storedNote);
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated `DarknetConnectionsPort` companion SPI for the legacy friends page plus detached peer snapshots and per-peer noderef export
- route `update_notes`, non-destructive bulk actions, trust/visibility updates, and peer-specific `.fref` downloads through runtime SPI instead of direct live-daemon darknet traversal
- preserve exact friends-page peer targeting with identity-based runtime updates while leaving generic `NodeIdentifier` lookup semantics unchanged for other admin/FCP callers
- add focused runtime and HTTP regression tests and enrich the new non-test Java APIs with doclint-clean Javadoc

## Out of scope
- `handleRemove(...)` and the remove confirmation / force-remove flow
- transfer accept/reject paths
- `doSendMessageToPeers`, `N2NTMToadlet`, and `DarknetAddRefToadlet`
- changing the legacy friends-page hash token scheme

## How to test
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyDarknetConnectionsPortTest'`
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyPeerPortTest'`
- `./gradlew test --tests 'network.crypta.clients.http.DarknetConnectionsToadletTest'`
- `./gradlew test`
- `./gradlew compileJava compileTestJava`

## Notes
- The friends-page bridge now resolves selected peers by exact identity only for the migrated detached HTTP flow, avoiding nickname-vs-identity collisions without reserving prefixes in shared `PeerPort` lookups.
