### PR TITLE
fix(friends): Finish detached admin migration

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionPeerSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionPeerSnapshot.java
@@ -15,18 +15,25 @@ import java.util.Objects;
  * keep them only for the duration of one render or form submission without holding a reference to a
  * live {@code DarknetPeerNode}. The snapshot carries only the data the legacy friends page still
  * needs in this migration stage: the current selection token, the peer identity used for exact
- * updates, the display name shown in the UI, and the private note text needed to preserve the old
- * "write only when changed" behavior.
+ * updates, the display name shown in the UI, the private note text needed to preserve the old
+ * "write only when changed" behavior, and the detached remove-policy decision used by the legacy
+ * confirmation flow.
  *
  * @param selectionToken legacy hash-based token used in friends-page form field names
  * @param nodeIdentifier detached peer identity string suitable for exact-identity friends-page
- *     updates through {@link PeerPort}
+ *     updates and removal through {@link PeerPort}
  * @param displayName detached friend display name used in the legacy UI and downloads
  * @param privateNoteText detached private darknet comment note currently shown on the page
+ * @param removableWithoutForce whether the legacy friends page may remove this peer immediately
+ *     without rendering the force-remove confirmation form
  * @see DarknetConnectionsPort
  */
 public record DarknetConnectionPeerSnapshot(
-    int selectionToken, String nodeIdentifier, String displayName, String privateNoteText) {
+    int selectionToken,
+    String nodeIdentifier,
+    String displayName,
+    String privateNoteText,
+    boolean removableWithoutForce) {
   /**
    * Creates an immutable friends-page peer snapshot.
    *

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionsPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetConnectionsPort.java
@@ -9,8 +9,9 @@ import java.util.Optional;
  * <p>This port exists specifically to support the remaining legacy friends-page POST actions and
  * per-peer noderef download path while keeping the current hash-based selection-token scheme out of
  * the generic {@link PeerPort}. It provides detached peer identity, display-name, and private-note
- * data for the current page selection model plus one optional full noderef export for a selected
- * peer.
+ * data for the current page selection model, one detached remove-policy decision, one optional full
+ * noderef export for a selected peer, and transfer confirmation actions resolved by exact detached
+ * peer identity.
  *
  * <p>The port is intentionally conservative and page-oriented. It does not attempt to model all
  * darknet peer behavior, and it does not expose live daemon peer objects or field-set transport
@@ -45,4 +46,34 @@ public interface DarknetConnectionsPort {
    * @return optional detached noderef export for the selected peer
    */
   Optional<NodeReferenceSnapshot> exportPeerReference(int selectionToken);
+
+  /**
+   * Accepts one incoming transfer for the detached peer identity selected on the friends page.
+   *
+   * <p>The peer identity is expected to come from {@link #listPeers()} rather than directly from
+   * the legacy hash token. Implementations should preserve the daemon's current distinction between
+   * a missing peer and a resolved non-darknet peer.
+   *
+   * @param nodeIdentifier detached peer identity selected on the friends page
+   * @param transferId transfer identifier submitted by the legacy confirmation form
+   * @throws UnknownPeerException if the peer cannot be resolved
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  void acceptTransfer(String nodeIdentifier, long transferId)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+
+  /**
+   * Rejects one incoming transfer for the detached peer identity selected on the friends page.
+   *
+   * <p>The peer identity is expected to come from {@link #listPeers()} rather than directly from
+   * the legacy hash token. Implementations should preserve the daemon's current distinction between
+   * a missing peer and a resolved non-darknet peer.
+   *
+   * @param nodeIdentifier detached peer identity selected on the friends page
+   * @param transferId transfer identifier submitted by the legacy confirmation form
+   * @throws UnknownPeerException if the peer cannot be resolved
+   * @throws DarknetPeerRequiredException if the resolved peer is not a darknet peer
+   */
+  void rejectTransfer(String nodeIdentifier, long transferId)
+      throws UnknownPeerException, DarknetPeerRequiredException;
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerPort.java
@@ -110,6 +110,19 @@ public interface PeerPort {
   RemovedPeerSnapshot remove(String nodeIdentifier) throws UnknownPeerException;
 
   /**
+   * Removes one peer from the runtime using an exact peer identity match.
+   *
+   * <p>This method exists for detached callers that already know the selected peer's unique
+   * identity string and must avoid the legacy nickname or address fallback used by {@link
+   * #remove(String)}.
+   *
+   * @param peerIdentity exact peer identity string used for lookup
+   * @return detached removal result describing the removed peer
+   * @throws UnknownPeerException if the peer cannot be resolved
+   */
+  RemovedPeerSnapshot removeByIdentity(String peerIdentity) throws UnknownPeerException;
+
+  /**
    * Reads the existing private darknet comment note for one peer.
    *
    * <p>This method intentionally exposes only the currently supported private darknet comment note.

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -3,18 +3,15 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.DarknetPeerNodeStatus;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -45,9 +42,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Typical callers route HTTP GET and POST traffic from the node's web interface to this class.
  * The toadlet builds HTML structures with {@link network.crypta.support.HTMLNode} helpers. It
- * delegates non-destructive peer updates through runtime SPI ports. It still relies on the live
- * {@link network.crypta.node.Node} for the legacy destructive and messaging paths that remain in
- * scope for later migration.
+ * delegates friends-page peer lookup, updates, removal, noderef export, and transfer decisions
+ * through runtime SPI ports. The node-to-node message workflow itself remains in {@link
+ * N2NTMToadlet}; this class only builds the detached target map that the legacy compose form still
+ * expects.
  *
  * <ul>
  *   <li>Renders friend metadata, noderef download links, and private notes.
@@ -103,18 +101,15 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
           Map.entry(
               "clear_allow_local",
               peerSettingsUpdate(null, null, null, null, Boolean.FALSE, null)));
-  private final Node node;
   private final DarknetConnectionsPort darknetConnectionsPort;
   private final PeerPort peerPort;
 
   DarknetConnectionsToadlet(
-      Node n,
       NodeClientCore core,
       HighLevelSimpleClient client,
       ConnectionsToadletRuntimePorts runtimePorts,
       DarknetConnectionsPort darknetConnectionsPort) {
     super(core, client, runtimePorts);
-    this.node = n;
     this.darknetConnectionsPort = darknetConnectionsPort;
     this.peerPort = runtimePorts.peerPort();
   }
@@ -447,14 +442,23 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     if (transferId == null) {
       return;
     }
-    DarknetPeerNode peer = findFirstSelectedPeer(request);
+    DarknetConnectionPeerSnapshot peer = findFirstSelectedPeer(request);
     if (peer == null) {
       return;
     }
-    if (acceptTransfer) {
-      peer.acceptTransfer(transferId);
-    } else {
-      peer.rejectTransfer(transferId);
+    try {
+      if (acceptTransfer) {
+        darknetConnectionsPort.acceptTransfer(peer.nodeIdentifier(), transferId);
+      } else {
+        darknetConnectionsPort.rejectTransfer(peer.nodeIdentifier(), transferId);
+      }
+    } catch (UnknownPeerException | DarknetPeerRequiredException e) {
+      LOG.warn(
+          "Failed to {} transfer {} for darknet peer {}",
+          acceptTransfer ? "accept" : "reject",
+          transferId,
+          peer.nodeIdentifier(),
+          e);
     }
   }
 
@@ -470,10 +474,10 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     }
   }
 
-  private DarknetPeerNode findFirstSelectedPeer(HTTPRequest request) {
-    for (DarknetPeerNode pn : node.network().darknetConnections()) {
-      if (request.isPartSet(NODE_PREFIX + pn.hashCode())) {
-        return pn;
+  private DarknetConnectionPeerSnapshot findFirstSelectedPeer(HTTPRequest request) {
+    for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
+      if (request.isPartSet(NODE_PREFIX + peer.selectionToken())) {
+        return peer;
       }
     }
     return null;
@@ -523,21 +527,34 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       throws ToadletContextClosedException, IOException {
     if (LOG.isDebugEnabled()) LOG.debug("Remove node");
 
-    for (DarknetPeerNode pn : node.network().darknetConnections()) {
-      if (!request.isPartSet(NODE_PREFIX + pn.hashCode())) {
-        if (LOG.isDebugEnabled()) LOG.debug("Part not set: node_{}", pn.hashCode());
-      } else if (shouldRemovePeer(pn, request)) {
-        node.network().removePeerConnection(pn);
-        if (LOG.isDebugEnabled()) LOG.debug("Removed node: node_{}", pn.hashCode());
+    boolean forceRemoval = request.isPartSet("forceit");
+    for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
+      if (!request.isPartSet(NODE_PREFIX + peer.selectionToken())) {
+        logUnselectedPeer(peer);
+      } else if (forceRemoval || peer.removableWithoutForce()) {
+        removePeer(peer);
       } else {
-        showRemovalConfirmation(ctx, pn);
+        showRemovalConfirmation(ctx, peer);
         return;
       }
     }
     redirectHere(ctx);
   }
 
-  private void showRemovalConfirmation(ToadletContext ctx, DarknetPeerNode pn)
+  private void logUnselectedPeer(DarknetConnectionPeerSnapshot peer) {
+    if (LOG.isDebugEnabled()) LOG.debug("Part not set: node_{}", peer.selectionToken());
+  }
+
+  private void removePeer(DarknetConnectionPeerSnapshot peer) {
+    try {
+      peerPort.removeByIdentity(peer.nodeIdentifier());
+      if (LOG.isDebugEnabled()) LOG.debug("Removed node: node_{}", peer.selectionToken());
+    } catch (UnknownPeerException e) {
+      LOG.warn("Failed to remove darknet peer {}", peer.nodeIdentifier(), e);
+    }
+  }
+
+  private void showRemovalConfirmation(ToadletContext ctx, DarknetConnectionPeerSnapshot peer)
       throws ToadletContextClosedException, IOException {
     PageNode page = ctx.getPageMaker().getPageNode(l10n("confirmRemoveNodeTitle"), ctx);
     HTMLNode contentNode = page.getContentNode();
@@ -557,12 +574,12 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
                 .getString(
                     "DarknetConnectionsToadlet.confirmRemoveNode",
                     new String[] {"name"},
-                    new String[] {pn.getName()}));
+                    new String[] {peer.displayName()}));
     HTMLNode removeForm = ctx.addFormChild(content, path(), "removeConfirmForm");
     removeForm.addChild(
         ELEMENT_INPUT,
         new String[] {"type", "name", ATTR_VALUE},
-        new String[] {"hidden", NODE_PREFIX + pn.hashCode(), REMOVE});
+        new String[] {"hidden", NODE_PREFIX + peer.selectionToken(), REMOVE});
     removeForm.addChild(
         ELEMENT_INPUT,
         new String[] {"type", "name", ATTR_VALUE},
@@ -577,13 +594,6 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
         new String[] {"hidden", "forceit", l10n("forceRemove")});
 
     writeHTMLReply(ctx, 200, "OK", page.generate());
-  }
-
-  private boolean shouldRemovePeer(DarknetPeerNode pn, HTTPRequest request) {
-    long oneWeekAgo = System.currentTimeMillis() - 1000L * 60 * 60 * 24 * 7;
-    return pn.timeLastConnectionCompleted() < oneWeekAgo
-        || (pn.getPeerNodeStatus() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED)
-        || request.isPartSet("forceit");
   }
 
   private void handleUpdateNotes(HTTPRequest request) {
@@ -635,12 +645,12 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       throws ToadletContextClosedException, IOException {
     PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessageTitle"), ctx);
     HTMLNode contentNode = page.getContentNode();
-    HashMap<String, String> peers = new HashMap<>();
-    for (DarknetPeerNode pn : node.network().darknetConnections()) {
-      String nodePart = NODE_PREFIX + pn.hashCode();
+    Map<String, String> peers = new LinkedHashMap<>();
+    for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
+      String nodePart = NODE_PREFIX + peer.selectionToken();
       if (request.isPartSet(nodePart)) {
-        String peerHash = String.valueOf(pn.hashCode());
-        peers.putIfAbsent(peerHash, pn.getName());
+        String peerHash = String.valueOf(peer.selectionToken());
+        peers.putIfAbsent(peerHash, peer.displayName());
       }
     }
     N2NTMToadlet.createN2NTMSendForm(ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -264,7 +264,7 @@ final class FProxyRegistrar {
 
     DarknetConnectionsToadlet friendsToadlet =
         new DarknetConnectionsToadlet(
-            node, core, client, connectionsToadletRuntimePorts, runtimePorts.darknetConnections());
+            core, client, connectionsToadletRuntimePorts, runtimePorts.darknetConnections());
     server.register(
         friendsToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/node/runtime/LegacyDarknetConnectionsPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyDarknetConnectionsPort.java
@@ -6,21 +6,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
+import network.crypta.node.PeerManager;
+import network.crypta.node.PeerNode;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 
 /**
  * Adapts the legacy darknet friends-page peer traversal to the runtime SPI companion port.
  *
  * <p>This bridge preserves the current friends-page hash-token scheme inside the daemon root module
- * while exposing only detached peer identity, display-name, private-note, and noderef data to the
- * HTTP layer. It is intentionally narrow and exists only to migrate the remaining non-destructive
- * darknet friends-page actions away from direct live-daemon peer access.
+ * while exposing only detached peer identity, display-name, private-note, remove-policy, noderef,
+ * and transfer-decision data to the HTTP layer. It is intentionally narrow and exists only to
+ * migrate the remaining legacy darknet friends-page actions away from direct live-daemon peer
+ * access.
  *
  * <p>The adapter reads the live peer list on demand and immediately converts it into detached
  * values. That means it does not cache peer objects between requests and does not try to hide
@@ -30,6 +36,9 @@ import network.crypta.support.SimpleFieldSet;
  * directly.
  */
 final class LegacyDarknetConnectionsPort implements DarknetConnectionsPort {
+  /** Age threshold after which the legacy friends page skips the force-remove confirmation. */
+  private static final long REMOVE_WITHOUT_FORCE_AGE_MILLIS = TimeUnit.DAYS.toMillis(7);
+
   /** Live daemon node whose darknet peer inventory backs this adapter. */
   private final Node node;
 
@@ -47,13 +56,15 @@ final class LegacyDarknetConnectionsPort implements DarknetConnectionsPort {
   public List<DarknetConnectionPeerSnapshot> listPeers() {
     DarknetPeerNode[] peers = node.network().darknetConnections();
     List<DarknetConnectionPeerSnapshot> snapshots = new ArrayList<>(peers.length);
+    long removableWithoutForceCutoff = System.currentTimeMillis() - REMOVE_WITHOUT_FORCE_AGE_MILLIS;
     for (DarknetPeerNode peer : peers) {
       snapshots.add(
           new DarknetConnectionPeerSnapshot(
               peer.hashCode(),
               peer.getIdentityString(),
               Objects.requireNonNullElse(peer.getName(), ""),
-              Objects.requireNonNullElse(peer.getPrivateDarknetCommentNote(), "")));
+              Objects.requireNonNullElse(peer.getPrivateDarknetCommentNote(), ""),
+              removableWithoutForce(peer, removableWithoutForceCutoff)));
     }
     return List.copyOf(snapshots);
   }
@@ -73,6 +84,41 @@ final class LegacyDarknetConnectionsPort implements DarknetConnectionsPort {
       return Optional.of(new NodeReferenceSnapshot(toNodeFieldSet(fieldSet)));
     }
     return Optional.empty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void acceptTransfer(String nodeIdentifier, long transferId)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    resolveDarknetPeerByIdentity(nodeIdentifier).acceptTransfer(transferId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void rejectTransfer(String nodeIdentifier, long transferId)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    resolveDarknetPeerByIdentity(nodeIdentifier).rejectTransfer(transferId);
+  }
+
+  private static boolean removableWithoutForce(
+      DarknetPeerNode peer, long removableWithoutForceCutoff) {
+    return peer.timeLastConnectionCompleted() < removableWithoutForceCutoff
+        || peer.getPeerNodeStatus() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED;
+  }
+
+  private DarknetPeerNode resolveDarknetPeerByIdentity(String nodeIdentifier)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    Objects.requireNonNull(nodeIdentifier, "nodeIdentifier");
+    for (PeerNode peer : node.network().peerNodes()) {
+      if (!nodeIdentifier.equals(peer.getIdentityString())) {
+        continue;
+      }
+      if (peer instanceof DarknetPeerNode darknetPeer) {
+        return darknetPeer;
+      }
+      throw new DarknetPeerRequiredException(nodeIdentifier);
+    }
+    throw new UnknownPeerException(nodeIdentifier);
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyPeerPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyPeerPort.java
@@ -153,6 +153,18 @@ final class LegacyPeerPort implements PeerPort {
 
   /** {@inheritDoc} */
   @Override
+  public RemovedPeerSnapshot removeByIdentity(String peerIdentity) throws UnknownPeerException {
+    PeerNode peer = resolvePeerByIdentity(peerIdentity);
+    if (peer == null) {
+      throw new UnknownPeerException(peerIdentity);
+    }
+    String identity = peer.getIdentityString();
+    node.network().removePeerConnection(peer);
+    return new RemovedPeerSnapshot(identity, peerIdentity);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public String readPrivateDarknetComment(String nodeIdentifier)
       throws UnknownPeerException, DarknetPeerRequiredException {
     return resolveDarknetPeer(nodeIdentifier).getPrivateDarknetCommentNote();

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.DarknetPeerNodeStatus;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -103,8 +102,7 @@ class DarknetConnectionsToadletTest {
   void setUp() {
     ConnectionsToadletRuntimePorts runtimePorts =
         new ConnectionsToadletRuntimePorts(connectionsPage, peerPort, nodeInfoPort, configPort);
-    toadlet =
-        new DarknetConnectionsToadlet(node, core, client, runtimePorts, darknetConnectionsPort);
+    toadlet = new DarknetConnectionsToadlet(core, client, runtimePorts, darknetConnectionsPort);
     Mockito.lenient().when(request.isPartSet(anyString())).thenReturn(false);
   }
 
@@ -298,15 +296,9 @@ class DarknetConnectionsToadletTest {
 
   @Test
   void handleAltPost_removeWithForce_removesPeerAndRedirects() throws Exception {
-    DarknetPeerNode peer = mock(DarknetPeerNode.class);
-    when(peer.timeLastConnectionCompleted()).thenReturn(System.currentTimeMillis());
-    when(peer.getPeerNodeStatus()).thenReturn(0);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
-
-    int peerHash = peer.hashCode();
+    int peerHash = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(peerHash, "Alice", "")));
     when(request.isPartSet("remove")).thenReturn(true);
     when(request.isPartSet("node_" + peerHash)).thenReturn(true);
     when(request.isPartSet("forceit")).thenReturn(true);
@@ -315,8 +307,91 @@ class DarknetConnectionsToadletTest {
 
     toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
 
-    verify(network).removePeerConnection(peer);
+    verify(peerPort).removeByIdentity(TEST_NODE_IDENTIFIER);
     assertRedirectIssued();
+  }
+
+  @Test
+  void handleAltPost_removeWithoutForceForNonRemovablePeer_rendersConfirmationAndDoesNotRemove()
+      throws Exception {
+    int selectionToken = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(selectionToken, "Alice", "")));
+    when(request.isPartSet("remove")).thenReturn(true);
+    when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    stubFormChild(ctx);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertTrue(html.contains("Alice"));
+    assertTrue(html.contains("name=\"node_" + selectionToken + '"'));
+    verify(peerPort, Mockito.never()).removeByIdentity(anyString());
+  }
+
+  @Test
+  void handleAltPost_acceptTransfer_usesDarknetConnectionsPortAndRedirects() throws Exception {
+    int selectionToken = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(selectionToken, "Alice", "")));
+    when(request.isPartSet("acceptTransfer")).thenReturn(true);
+    when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
+    when(request.getPartAsStringFailsafe("id", 32)).thenReturn("77");
+
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    verify(darknetConnectionsPort).acceptTransfer(TEST_NODE_IDENTIFIER, 77L);
+    assertRedirectIssued();
+  }
+
+  @Test
+  void handleAltPost_rejectTransfer_usesDarknetConnectionsPortAndRedirects() throws Exception {
+    int selectionToken = 101;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(darknetPeerSnapshot(selectionToken, "Alice", "")));
+    when(request.isPartSet("rejectTransfer")).thenReturn(true);
+    when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
+    when(request.getPartAsStringFailsafe("id", 32)).thenReturn("88");
+
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    verify(darknetConnectionsPort).rejectTransfer(TEST_NODE_IDENTIFIER, 88L);
+    assertRedirectIssued();
+  }
+
+  @Test
+  void handleAltPost_sendMessageToPeers_buildsComposeFormFromDetachedSnapshots() throws Exception {
+    int aliceToken = 101;
+    int bobToken = 202;
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(
+            List.of(
+                darknetPeerSnapshot(aliceToken, "Alice", ""),
+                darknetPeerSnapshot(bobToken, "Bob", "")));
+    when(request.isPartSet("doSendMessageToPeers")).thenReturn(true);
+    when(request.isPartSet("node_" + aliceToken)).thenReturn(true);
+    when(request.isPartSet("node_" + bobToken)).thenReturn(true);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    stubFormChild(ctx);
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertTrue(html.contains("Alice"));
+    assertTrue(html.contains("Bob"));
+    assertTrue(html.contains("name=\"node_" + aliceToken + '"'));
+    assertTrue(html.contains("name=\"node_" + bobToken + '"'));
   }
 
   @Test
@@ -549,7 +624,11 @@ class DarknetConnectionsToadletTest {
         .when(
             pageMaker.getInfobox(
                 anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
-        .thenAnswer(_ -> new HTMLNode("div"));
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parentNode = invocation.getArgument(2);
+              return parentNode.addChild("div");
+            });
     return pageMaker;
   }
 
@@ -601,7 +680,7 @@ class DarknetConnectionsToadletTest {
   private static DarknetConnectionPeerSnapshot darknetPeerSnapshot(
       int selectionToken, String displayName, String privateNoteText) {
     return new DarknetConnectionPeerSnapshot(
-        selectionToken, TEST_NODE_IDENTIFIER, displayName, privateNoteText);
+        selectionToken, TEST_NODE_IDENTIFIER, displayName, privateNoteText, false);
   }
 
   private static NodeReferenceSnapshot ownNodeReferenceSnapshot() {

--- a/src/test/java/network/crypta/node/runtime/LegacyDarknetConnectionsPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyDarknetConnectionsPortTest.java
@@ -3,12 +3,16 @@ package network.crypta.node.runtime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +20,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +37,8 @@ class LegacyDarknetConnectionsPortTest {
 
   @Mock private DarknetPeerNode peerTwo;
 
+  @Mock private PeerNode nonDarknetPeer;
+
   @Test
   void listPeers_whenDarknetPeersPresent_returnsDetachedSnapshotsInEncounterOrder() {
     LegacyDarknetConnectionsPort port = newPort();
@@ -38,17 +46,62 @@ class LegacyDarknetConnectionsPortTest {
     when(peerOne.getIdentityString()).thenReturn("peer-1");
     when(peerOne.getName()).thenReturn("Alice");
     when(peerOne.getPrivateDarknetCommentNote()).thenReturn("note-one");
+    when(peerOne.timeLastConnectionCompleted()).thenReturn(System.currentTimeMillis());
+    when(peerOne.getPeerNodeStatus()).thenReturn(0);
     when(peerTwo.getIdentityString()).thenReturn("peer-2");
     when(peerTwo.getName()).thenReturn("Bob");
     when(peerTwo.getPrivateDarknetCommentNote()).thenReturn("note-two");
+    when(peerTwo.timeLastConnectionCompleted())
+        .thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8));
 
     List<DarknetConnectionPeerSnapshot> snapshots = port.listPeers();
 
     assertEquals(
         List.of(
-            new DarknetConnectionPeerSnapshot(peerOne.hashCode(), "peer-1", "Alice", "note-one"),
-            new DarknetConnectionPeerSnapshot(peerTwo.hashCode(), "peer-2", "Bob", "note-two")),
+            new DarknetConnectionPeerSnapshot(
+                peerOne.hashCode(), "peer-1", "Alice", "note-one", false),
+            new DarknetConnectionPeerSnapshot(
+                peerTwo.hashCode(), "peer-2", "Bob", "note-two", true)),
         snapshots);
+  }
+
+  @Test
+  void acceptTransfer_whenIdentityResolvesToDarknetPeer_delegatesToPeer() throws Exception {
+    LegacyDarknetConnectionsPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {peerOne});
+    when(peerOne.getIdentityString()).thenReturn("peer-1");
+
+    port.acceptTransfer("peer-1", 42L);
+
+    verify(peerOne).acceptTransfer(42L);
+  }
+
+  @Test
+  void rejectTransfer_whenIdentityResolvesToDarknetPeer_delegatesToPeer() throws Exception {
+    LegacyDarknetConnectionsPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {peerOne});
+    when(peerOne.getIdentityString()).thenReturn("peer-1");
+
+    port.rejectTransfer("peer-1", 84L);
+
+    verify(peerOne).rejectTransfer(84L);
+  }
+
+  @Test
+  void acceptTransfer_whenPeerIdentityIsUnknown_throwsUnknownPeerException() {
+    LegacyDarknetConnectionsPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[0]);
+
+    assertThrows(UnknownPeerException.class, () -> port.acceptTransfer("missing-peer", 42L));
+  }
+
+  @Test
+  void rejectTransfer_whenResolvedPeerIsNotDarknet_throwsDarknetPeerRequiredException() {
+    LegacyDarknetConnectionsPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {nonDarknetPeer});
+    when(nonDarknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    assertThrows(DarknetPeerRequiredException.class, () -> port.rejectTransfer("peer-1", 84L));
   }
 
   @Test

--- a/src/test/java/network/crypta/node/runtime/LegacyPeerPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyPeerPortTest.java
@@ -337,6 +337,32 @@ class LegacyPeerPortTest {
   }
 
   @Test
+  void removeByIdentity_whenIdentityMatchesPeer_resolvesByIdentityOnly()
+      throws UnknownPeerException {
+    LegacyPeerPort port = newPort();
+    DarknetPeerNode collidingNamePeer = org.mockito.Mockito.mock(DarknetPeerNode.class);
+    when(network.peerNodes()).thenReturn(new PeerNode[] {collidingNamePeer, peerOne});
+    when(collidingNamePeer.getIdentityString()).thenReturn("other-peer");
+    when(peerOne.getIdentityString()).thenReturn("peer-123");
+
+    RemovedPeerSnapshot removedPeer = port.removeByIdentity("peer-123");
+
+    assertEquals("peer-123", removedPeer.identity());
+    assertEquals("peer-123", removedPeer.nodeIdentifier());
+    verify(network).removePeerConnection(peerOne);
+    verify(network, never()).getPeerNode(any());
+  }
+
+  @Test
+  void removeByIdentity_whenPeerMissing_throwsUnknownPeerException() {
+    LegacyPeerPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {peerOne});
+    when(peerOne.getIdentityString()).thenReturn("other-peer");
+
+    assertThrows(UnknownPeerException.class, () -> port.removeByIdentity("peer-123"));
+  }
+
+  @Test
   void remove_whenPeerMissing_throwsUnknownPeerException() {
     LegacyPeerPort port = newPort();
     when(network.getPeerNode("missing-peer")).thenReturn(null);


### PR DESCRIPTION
## Summary
- extend the friends-page runtime SPI with detached removal policy data plus detached transfer accept/reject actions
- remove the remaining live `Node` dependency from `DarknetConnectionsToadlet` for remove, transfer, and send-message target selection
- preserve exact peer identity during detached removals via `PeerPort.removeByIdentity(...)` so nickname/address fallback cannot delete the wrong friend
- keep `N2NTMToadlet` unchanged while updating the legacy runtime adapters and focused tests for the migrated paths

## How to test
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyDarknetConnectionsPortTest'`
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyPeerPortTest'`
- `./gradlew test --tests 'network.crypta.clients.http.DarknetConnectionsToadletTest'`
- `./gradlew test`
