### PR TITLE
refactor(n2ntm): SPI-ize compose/send flow

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessageSendStatus.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessageSendStatus.java
@@ -1,0 +1,34 @@
+package network.crypta.runtime.spi;
+
+/**
+ * UI-level delivery categories for legacy node-to-node message sends.
+ *
+ * <p>The N2NTM compose/send page does not expose the daemon's full peer-state matrix. It collapses
+ * the underlying sending result into three buckets that are stable enough for HTTP rendering and
+ * localization: sent now, delayed because the peer is backed off, or queued for later delivery.
+ * This enum is that detached contract.
+ *
+ * <p>Keeping the contract at this level lets the HTTP layer render the existing page without
+ * depending on {@code PeerManager} status constants or live daemon objects. Callers should treat
+ * these values as presentation categories, not as a complete audit trail of low-level transport
+ * behavior.
+ */
+public enum DarknetMessageSendStatus {
+  /**
+   * The daemon reported a currently connected peer, so the UI renders the message as sent
+   * immediately.
+   */
+  SENT,
+
+  /**
+   * The daemon reported routing backoff for the selected peer, so the UI keeps the existing delayed
+   * bucket wording.
+   */
+  DELAYED,
+
+  /**
+   * Any legacy outcome outside the sent and delayed buckets is rendered in the existing queued UI
+   * category.
+   */
+  QUEUED
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessagingPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessagingPort.java
@@ -1,0 +1,109 @@
+package network.crypta.runtime.spi;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Exposes the legacy node-to-node message compose/send capability.
+ *
+ * <p>This port is the detached boundary used by the HTTP compose/send page. It lets the web layer
+ * identify target peers by stable runtime snapshots, offer optional attachments, and render the
+ * existing sent or delayed or queued result buckets without reaching into live daemon objects.
+ * Implementations are responsible for resolving detached peer identities on demand and delegating
+ * to the daemon's current sending APIs.
+ *
+ * <p>The interface is intentionally small. It models only the behaviors that the N2NTM UI currently
+ * needs, preserves the legacy selection-token flow, and avoids bringing HTTP request abstractions
+ * into {@code runtime-spi}. Callers should assume that peer identity resolution is request-scoped
+ * and may fail if the peer roster changes before the sending occurs.
+ */
+public interface DarknetMessagingPort {
+  /**
+   * Sends one text message to the selected detached darknet peer.
+   *
+   * <p>The implementation resolves the supplied detached identity against the current runtime peer
+   * roster, sends the text through the daemon's existing N2NTM path, and maps the daemon result to
+   * a UI-level delivery category. Callers typically pass the full message body shown on the
+   * "compose" page; this method implies no truncation.
+   *
+   * @param nodeIdentifier detached peer identity selected from the legacy friends page and used for
+   *     request-scoped peer lookup
+   * @param message UTF-8 text to send to the resolved darknet peer without additional UI formatting
+   * @return UI-level delivery category that the compose/send page can render directly
+   * @throws UnknownPeerException if the detached peer identity no longer resolves at sending time
+   * @throws DarknetPeerRequiredException if the resolved peer exists but is not a darknet peer
+   */
+  DarknetMessageSendStatus sendText(String nodeIdentifier, String message)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+
+  /**
+   * Sends one local-file offer to the selected detached darknet peer.
+   *
+   * <p>This is the detached equivalent of the legacy file-offer path for files that already exist
+   * on the node's local filesystem. The implementation resolves the target peer on demand and
+   * delegates to the daemon's existing file-offer API without changing the caller-provided note.
+   *
+   * @param nodeIdentifier detached peer identity selected from the legacy friends page and used for
+   *     request-scoped peer lookup
+   * @param file local file on disk that the daemon should offer to the selected peer
+   * @param messageHead optional short human-readable note that comes with the file offer
+   * @throws UnknownPeerException if the detached peer identity no longer resolves at sending time
+   * @throws DarknetPeerRequiredException if the resolved peer exists but is not a darknet peer
+   * @throws IOException if the local file cannot be opened or read by the daemon adapter
+   */
+  void sendFileOffer(String nodeIdentifier, File file, String messageHead)
+      throws UnknownPeerException, DarknetPeerRequiredException, IOException;
+
+  /**
+   * Sends one uploaded-file offer to the selected detached darknet peer.
+   *
+   * <p>This variant handles uploads that arrived through the HTTP request rather than through a
+   * local filesystem path. The detached payload must be adaptable to the daemon's file-offer API
+   * without depending on HTTP-layer bucket types inside the SPI surface.
+   *
+   * @param nodeIdentifier detached peer identity selected from the legacy friends page and used for
+   *     request-scoped peer lookup
+   * @param upload detached uploaded-file payload, including metadata and a reopenable content
+   *     stream
+   * @param messageHead optional short human-readable note that comes with the file offer
+   * @throws UnknownPeerException if the detached peer identity no longer resolves at sending time
+   * @throws DarknetPeerRequiredException if the resolved peer exists but is not a darknet peer
+   * @throws IOException if the detached upload cannot be adapted or reopened for sending
+   */
+  void sendUploadedFileOffer(String nodeIdentifier, DarknetUploadedFile upload, String messageHead)
+      throws UnknownPeerException, DarknetPeerRequiredException, IOException;
+
+  /**
+   * Sends one composed N2NTM to the selected detached darknet peer.
+   *
+   * <p>Implementations must resolve the peer once for the whole operation, then send the optional
+   * file offer and text message through that same bound peer instance. At most one of {@code file}
+   * or {@code upload} should be non-{@code null}; when both are {@code null}, this behaves like a
+   * plain text sending.
+   *
+   * <p>This method preserves the original page semantics where one selected peer maps to one
+   * logical send operation. The implementation must keep the whole sequence bound to one peer
+   * resolution so that the optional file-offer step and the text-send step succeed or fail against
+   * the same peer object. Callers should pass either {@code file} or {@code upload}; supplying both
+   * is invalid caller behavior and is not normalized here.
+   *
+   * @param nodeIdentifier detached peer identity selected from the legacy friends page and used for
+   *     request-scoped peer lookup
+   * @param message UTF-8 text to send after any requested file-offer step has completed
+   * @param file local file on disk to offer before sending the text message; may be {@code null}
+   * @param upload detached uploaded-file payload to offer before sending the text message; may be
+   *     {@code null}
+   * @param messageHead optional short human-readable note that comes with the file offer
+   * @return UI-level delivery category for the text-send result that follows any file-offer step
+   * @throws UnknownPeerException if the detached peer identity no longer resolves at sending time
+   * @throws DarknetPeerRequiredException if the resolved peer exists but is not a darknet peer
+   * @throws IOException if the requested file or detached, upload cannot be opened or read
+   */
+  DarknetMessageSendStatus sendComposedMessage(
+      String nodeIdentifier,
+      String message,
+      File file,
+      DarknetUploadedFile upload,
+      String messageHead)
+      throws UnknownPeerException, DarknetPeerRequiredException, IOException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetUploadedFile.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetUploadedFile.java
@@ -1,0 +1,135 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Detached upload payload for darknet file offers.
+ *
+ * <p>This value carries only the metadata and stream-opening behavior that the runtime bridge needs
+ * to replay an HTTP upload into the daemon's existing file-offer APIs. It intentionally avoids HTTP
+ * request objects, bucket implementations, and daemon-specific types so that {@code runtime-spi}
+ * stays JDK-only while still representing uploaded content without an additional byte-array or
+ * temp-file hop.
+ *
+ * <p>Instances are immutable after construction. The contained {@link StreamSource} must reopen the
+ * upload from the beginning on every call because one compose/send request may offer the same
+ * uploaded file to more than one peer.
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+public final class DarknetUploadedFile {
+  /**
+   * JDK-only stream source for detached uploaded-file contents.
+   *
+   * <p>Implementations must return a new readable stream positioned at the beginning of the upload
+   * every time this method is called. Callers may invoke it more than once during one HTTP request
+   * when the same upload is offered to multiple peers.
+   */
+  @FunctionalInterface
+  public interface StreamSource {
+    /**
+     * Opens a fresh stream for reading the upload contents.
+     *
+     * <p>The returned stream should expose the exact uploaded bytes from offset {@code 0}. The
+     * caller is responsible for closing it after each sending attempt.
+     *
+     * @return new readable stream positioned at the first byte of the detached upload
+     * @throws IOException if the upload contents cannot be reopened for reading
+     */
+    InputStream openStream() throws IOException;
+  }
+
+  private final String filename;
+  private final String contentType;
+  private final long size;
+  private final StreamSource streamSource;
+
+  /**
+   * Creates a detached uploaded-file payload.
+   *
+   * <p>The constructor records the caller-supplied metadata and validates only the detached shape
+   * of the object. It does not read from the underlying upload stream, sniff content types, or
+   * verify that the declared size matches the number of bytes later returned by the stream source.
+   *
+   * @param filename client-supplied filename that comes with the detached upload and may be empty
+   *     but never {@code null}
+   * @param contentType client-supplied MIME type, or {@code null} when the request did not supply
+   *     one
+   * @param size declared upload size in bytes; must be zero or greater
+   * @param streamSource source that can reopen the upload contents from the beginning on demand
+   * @throws NullPointerException if {@code filename} or {@code streamSource} is {@code null}
+   * @throws IllegalArgumentException if {@code size} is negative
+   */
+  public DarknetUploadedFile(
+      String filename, String contentType, long size, StreamSource streamSource) {
+    if (size < 0) {
+      throw new IllegalArgumentException("size");
+    }
+    this.filename = Objects.requireNonNull(filename, "filename");
+    this.contentType = contentType;
+    this.size = size;
+    this.streamSource = Objects.requireNonNull(streamSource, "streamSource");
+  }
+
+  /**
+   * Returns the client-supplied filename.
+   *
+   * <p>This is opaque metadata preserved from the original HTTP upload. Callers should treat it as
+   * presentation data, not as a trusted filesystem path.
+   *
+   * @return detached filename string; never {@code null}
+   */
+  public String filename() {
+    return filename;
+  }
+
+  /**
+   * Returns the client-supplied MIME type.
+   *
+   * <p>The value is passed through unchanged from the original upload metadata and may be absent or
+   * inaccurate.
+   *
+   * @return detached MIME type, or {@code null} when the upload had no declared content type
+   */
+  public String contentType() {
+    return contentType;
+  }
+
+  /**
+   * Returns the declared upload size.
+   *
+   * <p>The size is the detached byte count captured by the HTTP layer before the upload enters the
+   * runtime SPI boundary.
+   *
+   * @return upload size in bytes; guaranteed to be zero or greater
+   */
+  public long size() {
+    return size;
+  }
+
+  /**
+   * Opens a fresh stream for reading the detached upload contents.
+   *
+   * <p>Each call delegates to the stored {@link StreamSource}. Repeated calls are expected to yield
+   * independent streams, so callers can retry or send the same upload to multiple peers without
+   * caching the content in memory.
+   *
+   * @return readable stream positioned at the first byte of the detached upload
+   * @throws IOException if the detached upload contents cannot be reopened for reading
+   */
+  public InputStream openStream() throws IOException {
+    return streamSource.openStream();
+  }
+
+  @Override
+  public String toString() {
+    return "DarknetUploadedFile[filename="
+        + filename
+        + ", contentType="
+        + contentType
+        + ", size="
+        + size
+        + ']';
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -22,6 +22,7 @@ package network.crypta.runtime.spi;
  * @see ConnectivityPort
  * @see ConnectionsPagePort
  * @see DarknetConnectionsPort
+ * @see DarknetMessagingPort
  * @see DiagnosticPort
  * @see StatisticsPort
  * @see NodeInfoPort
@@ -125,6 +126,18 @@ public interface RuntimePorts {
    * @return darknet friends-page companion port for detached peer selection and noderef export
    */
   DarknetConnectionsPort darknetConnections();
+
+  /**
+   * Returns the legacy darknet message-compose capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port lets higher layers send node-to-node text messages and file offers to detached
+   * peer identities without depending on daemon-only peer classes, upload wrappers, or peer-status
+   * constants. The returned object should be treated as a live runtime view that resolves detached
+   * peer identifiers on demand and preserves the current UI-level delivery categorization.
+   *
+   * @return darknet messaging runtime port for detached compose/send actions
+   */
+  DarknetMessagingPort darknetMessaging();
 
   /**
    * Returns the diagnostic-report capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -313,9 +313,9 @@ final class FProxyRegistrar {
             true,
             chatForumsToadlet));
 
-    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(node, core, client);
-    server.register(n2ntmToadlet, ToadletRegistration.basic(null, "/send_n2ntm/", true, true));
     LocalFileN2NMToadlet localFileN2NMToadlet = new LocalFileN2NMToadlet(core, client);
+    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(runtimePorts, localFileN2NMToadlet, client);
+    server.register(n2ntmToadlet, ToadletRegistration.basic(null, "/send_n2ntm/", true, true));
     server.register(
         localFileN2NMToadlet,
         ToadletRegistration.basic(null, LocalFileN2NMToadlet.BROWSE_PATH, true, false));

--- a/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
+++ b/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
@@ -4,18 +4,26 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeStarter;
-import network.crypta.node.PeerManager;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessageSendStatus;
+import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetUploadedFile;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SizeUtil;
+import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.api.HTTPUploadedFile;
 import org.slf4j.Logger;
@@ -30,8 +38,8 @@ import org.slf4j.LoggerFactory;
  * redirected back to the friends page when the flow is not recognized or when permission checks
  * fail. Error responses are rendered as infoboxes so the user can retry without losing context.
  *
- * <p>The class delegates file browsing to {@link LocalFileN2NMToadlet} and uses {@link Node} and
- * {@link DarknetPeerNode} APIs for delivery. It relies on the toadlet framework for request
+ * <p>The class delegates file browsing to {@link LocalFileN2NMToadlet} and routes peer lookup and
+ * delivery through detached runtime SPI ports. It relies on the toadlet framework for request
  * threading and performs no additional synchronization. Message size and upload size are bounded,
  * and UI feedback is localized through {@link NodeL10n}.
  *
@@ -60,26 +68,30 @@ public class N2NTMToadlet extends Toadlet {
   private static final int MESSAGE_HEAD_LIMIT = 1024;
   private static final int MESSAGE_LIMIT = 1024 * 128;
 
-  private final Node node;
+  private final DarknetConnectionsPort darknetConnections;
+  private final DarknetMessagingPort darknetMessaging;
   private final LocalFileN2NMToadlet browser;
 
   /**
    * Creates the toadlet with access to node state and HTTP utilities.
    *
-   * <p>The instance keeps references to the node and its browser toadlet so it can resolve peers,
-   * open the local file browser, and emit localized responses. Callers should provide the same
-   * {@link HighLevelSimpleClient} used by other toadlets to keep configuration and permissions
-   * consistent. The constructor performs no I/O and does not register itself; registration is
-   * managed elsewhere by the HTTP subsystem.
+   * <p>The instance keeps references to the detached runtime ports and its browser toadlet so it
+   * can resolve peers, send messages, open the local file browser, and emit localized responses.
+   * Callers should provide the same {@link HighLevelSimpleClient} used by other toadlets to keep
+   * configuration and permissions consistent. The constructor performs no I/O and does not register
+   * itself; registration is managed elsewhere by the HTTP subsystem.
    *
-   * @param n node instance that provides darknet peer connections and status.
-   * @param core node client core used by the file browser toadlet.
+   * @param runtimePorts runtime aggregate that exposes detached peer lookup and messaging ports.
+   * @param browser browser toadlet used for local file selection.
    * @param client HTTP client wrapper used by the base {@link Toadlet}.
    */
-  protected N2NTMToadlet(Node n, NodeClientCore core, HighLevelSimpleClient client) {
+  protected N2NTMToadlet(
+      RuntimePorts runtimePorts, LocalFileN2NMToadlet browser, HighLevelSimpleClient client) {
     super(client);
-    browser = new LocalFileN2NMToadlet(core, client);
-    this.node = n;
+    RuntimePorts ports = Objects.requireNonNull(runtimePorts, "runtimePorts");
+    this.darknetConnections = Objects.requireNonNull(ports.darknetConnections());
+    this.darknetMessaging = Objects.requireNonNull(ports.darknetMessaging());
+    this.browser = Objects.requireNonNull(browser, "browser");
   }
 
   /**
@@ -100,9 +112,9 @@ public class N2NTMToadlet extends Toadlet {
    * Handles GET requests for the N2NTM send page.
    *
    * <p>The handler first enforces full-access permissions. If the request includes a peer hashcode
-   * parameter, it renders a pre-targeted send form or a peer-not-found error when the hash does not
-   * resolve. Otherwise, it redirects to the friends page so the normal N2N navigation remains
-   * consistent. This method does not mutate persistent state; it only renders HTML responses or
+   * parameter, it renders a pre-targeted sending form or a peer-not-found error when the hash does
+   * not resolve. Otherwise, it redirects to the friends page so the normal N2N navigation remains
+   * consistent. This method does not mutate a persistent state; it only renders HTML responses or
    * performs a redirect.
    *
    * @param uri request URI used for trace logging and path introspection.
@@ -133,7 +145,6 @@ public class N2NTMToadlet extends Toadlet {
     PageNode page = ctx.getPageMaker().getPageNode(l10n("sendMessage"), ctx);
     HTMLNode contentNode = page.getContentNode();
 
-    String peerNodeName = null;
     String inputHashcodeString = request.getParam("peernode_hashcode");
     int inputHashcode = -1;
     try {
@@ -141,27 +152,28 @@ public class N2NTMToadlet extends Toadlet {
     } catch (NumberFormatException _) {
       // ignore here, handle below
     }
-    if (inputHashcode != -1) {
-      DarknetPeerNode[] peerNodes = node.network().darknetConnections();
-      for (DarknetPeerNode pn : peerNodes) {
-        int peerHashcode = pn.hashCode();
-        if (peerHashcode == inputHashcode) {
-          peerNodeName = pn.getName();
-          break;
-        }
-      }
-    }
-    if (peerNodeName == null) {
+    DarknetConnectionPeerSnapshot peer =
+        inputHashcode == -1 ? null : findPeerBySelectionToken(inputHashcode);
+    if (peer == null) {
       contentNode.addChild(
           createPeerErrorInfobox(
               l10n("peerNotFoundTitle"), l10nPeerNotFoundWithHash(inputHashcodeString)));
       this.writeHTMLReply(ctx, 200, "OK", page.generate());
       return;
     }
-    HashMap<String, String> peers = new HashMap<>();
-    peers.put(inputHashcodeString, peerNodeName);
+    Map<String, String> peers = new LinkedHashMap<>();
+    peers.put(inputHashcodeString, peer.displayName());
     createN2NTMSendForm(ctx.isAdvancedModeEnabled(), contentNode, ctx, peers);
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
+  }
+
+  private DarknetConnectionPeerSnapshot findPeerBySelectionToken(int selectionToken) {
+    for (DarknetConnectionPeerSnapshot peer : darknetConnections.listPeers()) {
+      if (peer.selectionToken() == selectionToken) {
+        return peer;
+      }
+    }
+    return null;
   }
 
   private static String l10n(String key) {
@@ -233,7 +245,7 @@ public class N2NTMToadlet extends Toadlet {
     }
     if (!ctx.checkFullAccess(this)) return;
 
-    // Browse button clicked. Redirect.
+    // The browse button clicked. Redirect.
     if (request.isPartSet("n2nm-browse")) {
       handleBrowseRedirect();
       return;
@@ -254,7 +266,7 @@ public class N2NTMToadlet extends Toadlet {
 
   private void handleBrowseRedirect() throws RedirectException {
     try {
-      throw new RedirectException(LocalFileN2NMToadlet.BROWSE_PATH);
+      throw new RedirectException(browser.path());
     } catch (URISyntaxException _) {
       // Should be impossible because the browser is registered with .PATH.
     }
@@ -271,7 +283,7 @@ public class N2NTMToadlet extends Toadlet {
     HTMLNode peerTableInfobox = contentNode.addChild("div", ATTR_CLASS, "infobox infobox-normal");
     SendRequestContext sendRequestContext =
         new SendRequestContext(request, peerTableInfobox, page, ctx, message);
-    DarknetPeerNode[] peerNodes = node.network().darknetConnections();
+    List<DarknetConnectionPeerSnapshot> selectedPeers = listSelectedPeers(request);
     FileSelection selectedFile =
         resolveSelectedFile(
             sendRequestContext.request(),
@@ -281,20 +293,43 @@ public class N2NTMToadlet extends Toadlet {
     if (selectedFile.handled()) {
       return;
     }
-
+    UploadSelection uploadSelection =
+        resolveUploadedFile(sendRequestContext, selectedFile.file(), selectedPeers.isEmpty());
+    if (uploadSelection.handled()) {
+      return;
+    }
     HTMLNode peerTable = buildPeerStatusTable(peerTableInfobox);
-    for (DarknetPeerNode pn : peerNodes) {
-      if (!request.isPartSet("node_" + pn.hashCode())) {
-        continue;
+    for (DarknetConnectionPeerSnapshot peer : selectedPeers) {
+      try {
+        DarknetMessageSendStatus status =
+            sendComposedMessageOrWriteFailureResponse(
+                sendRequestContext,
+                peer,
+                message,
+                selectedFile.file(),
+                uploadSelection.upload(),
+                messageHead);
+        if (status == null) {
+          return;
+        }
+        addPeerStatusRow(peerTable, peer.displayName(), status, message);
+      } catch (UnknownPeerException | DarknetPeerRequiredException e) {
+        LOG.warn("Rendering queued N2NTM status for unresolved peer {}", peer.nodeIdentifier(), e);
+        addPeerStatusRow(peerTable, peer.displayName(), DarknetMessageSendStatus.QUEUED, message);
       }
-      if (!sendFileOfferIfNeeded(sendRequestContext, pn, selectedFile.file(), messageHead)) {
-        return;
-      }
-      int status = pn.sendTextFeed(message);
-      addPeerStatusRow(peerTable, pn, status, message);
     }
     addMessageAndReturnLinks(peerTableInfobox, message);
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
+  }
+
+  private List<DarknetConnectionPeerSnapshot> listSelectedPeers(HTTPRequest request) {
+    List<DarknetConnectionPeerSnapshot> selectedPeers = new ArrayList<>();
+    for (DarknetConnectionPeerSnapshot peer : darknetConnections.listPeers()) {
+      if (request.isPartSet("node_" + peer.selectionToken())) {
+        selectedPeers.add(peer);
+      }
+    }
+    return List.copyOf(selectedPeers);
   }
 
   private String getMessageOrReply(HTTPRequest request, ToadletContext ctx)
@@ -327,50 +362,80 @@ public class N2NTMToadlet extends Toadlet {
     return new FileSelection(null, false);
   }
 
-  private boolean sendFileOfferIfNeeded(
-      SendRequestContext requestContext, DarknetPeerNode pn, File filename, String messageHead)
+  private UploadSelection resolveUploadedFile(
+      SendRequestContext requestContext, File selectedFile, boolean noSelectedPeers)
       throws ToadletContextClosedException, IOException {
-    if (filename != null) {
-      try {
-        pn.sendFileOffer(filename, messageHead);
-        return true;
-      } catch (IOException _) {
-        requestContext.peerTableInfobox().addChild("#", l10n("noSuchFileOrCannotRead"));
-        Toadlet.addHomepageLink(requestContext.peerTableInfobox());
-        addUnsentMessageTextInfo(requestContext.peerTableInfobox(), requestContext.message());
-        this.writeHTMLReply(requestContext.ctx(), 200, "OK", requestContext.page().generate());
-        return false;
-      }
-    }
-    if (!requestContext.request().isPartSet(UPLOAD_PART)) {
-      return true;
+    if (selectedFile != null
+        || noSelectedPeers
+        || !requestContext.request().isPartSet(UPLOAD_PART)) {
+      return new UploadSelection(null, false);
     }
     try {
       HTTPUploadedFile file = requestContext.request().getUploadedFile(UPLOAD_PART);
-      if (!file.getFilename().isEmpty()) {
-        long size = requestContext.request().getUploadedFile(UPLOAD_PART).getData().size();
-        if (size > 0) {
-          long limit = maxSize();
-          if (size > limit) {
-            addTooLargeUploadResponse(
-                requestContext.peerTableInfobox(),
-                size,
-                limit,
-                requestContext.message(),
-                requestContext.ctx(),
-                requestContext.page());
-            return false;
-          }
-          pn.sendFileOffer(requestContext.request().getUploadedFile(UPLOAD_PART), messageHead);
-        }
+      if (file == null || file.getFilename().isEmpty()) {
+        return new UploadSelection(null, false);
       }
+      Bucket uploadData = file.getData();
+      long size = uploadData.size();
+      if (size <= 0) {
+        return new UploadSelection(null, false);
+      }
+      long limit = maxSize();
+      if (size > limit) {
+        addTooLargeUploadResponse(
+            requestContext.peerTableInfobox(),
+            size,
+            limit,
+            requestContext.message(),
+            requestContext.ctx(),
+            requestContext.page());
+        return new UploadSelection(null, true);
+      }
+      return new UploadSelection(
+          new DarknetUploadedFile(
+              file.getFilename(),
+              file.getContentType(),
+              size,
+              uploadData::getInputStreamUnbuffered),
+          false);
     } catch (IOException _) {
-      requestContext.peerTableInfobox().addChild("#", l10n("uploadFailed"));
-      Toadlet.addHomepageLink(requestContext.peerTableInfobox());
-      addUnsentMessageTextInfo(requestContext.peerTableInfobox(), requestContext.message());
-      this.writeHTMLReply(requestContext.ctx(), 200, "OK", requestContext.page().generate());
-      return false;
+      return new UploadSelection(null, writeSendFailureResponse(requestContext, "uploadFailed"));
     }
+  }
+
+  private DarknetMessageSendStatus sendComposedMessageOrWriteFailureResponse(
+      SendRequestContext requestContext,
+      DarknetConnectionPeerSnapshot peer,
+      String message,
+      File filename,
+      DarknetUploadedFile upload,
+      String messageHead)
+      throws ToadletContextClosedException,
+          IOException,
+          UnknownPeerException,
+          DarknetPeerRequiredException {
+    try {
+      return darknetMessaging.sendComposedMessage(
+          peer.nodeIdentifier(), message, filename, upload, messageHead);
+    } catch (IOException e) {
+      if (filename != null) {
+        writeSendFailureResponse(requestContext, "noSuchFileOrCannotRead");
+        return null;
+      }
+      if (upload != null) {
+        writeSendFailureResponse(requestContext, "uploadFailed");
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  private boolean writeSendFailureResponse(SendRequestContext requestContext, String l10nKey)
+      throws ToadletContextClosedException, IOException {
+    requestContext.peerTableInfobox().addChild("#", l10n(l10nKey));
+    Toadlet.addHomepageLink(requestContext.peerTableInfobox());
+    addUnsentMessageTextInfo(requestContext.peerTableInfobox(), requestContext.message());
+    this.writeHTMLReply(requestContext.ctx(), 200, "OK", requestContext.page().generate());
     return true;
   }
 
@@ -404,21 +469,21 @@ public class N2NTMToadlet extends Toadlet {
   }
 
   private void addPeerStatusRow(
-      HTMLNode peerTable, DarknetPeerNode pn, int status, String message) {
+      HTMLNode peerTable, String peerDisplayName, DarknetMessageSendStatus status, String message) {
     SendStatusInfo statusInfo =
         switch (status) {
-          case PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF ->
+          case DELAYED ->
               new SendStatusInfo(
                   l10n("delayedTitle"), l10n("delayed"), "n2ntm-send-delayed", "Sent");
-          case PeerManager.PEER_NODE_STATUS_CONNECTED ->
+          case SENT ->
               new SendStatusInfo(l10n("sentTitle"), l10n("sent"), "n2ntm-send-sent", "Sent");
           default ->
               new SendStatusInfo(
                   l10n("queuedTitle"), l10n("queued"), "n2ntm-send-queued", "Queued");
         };
-    LOG.info("{} N2NTM to '{}': {}", statusInfo.logAction(), pn.getName(), message);
+    LOG.info("{} N2NTM to '{}': {}", statusInfo.logAction(), peerDisplayName, message);
     HTMLNode peerRow = peerTable.addChild("tr");
-    peerRow.addChild("td", ATTR_CLASS, "peer-name").addChild("#", pn.getName());
+    peerRow.addChild("td", ATTR_CLASS, "peer-name").addChild("#", peerDisplayName);
     peerRow
         .addChild("td", ATTR_CLASS, statusInfo.cssClass())
         .addChild(
@@ -452,9 +517,9 @@ public class N2NTMToadlet extends Toadlet {
    * Appends explanatory text and the unsent message to the given node.
    *
    * <p>This helper renders a short localized explanation followed by the raw message body so the
-   * user can copy or edit the content after a failed send. The message is inserted as plain text,
-   * not HTML, so any markup-like characters are treated as content. The caller owns the container
-   * node and decides where the paragraphs appear within the page layout.
+   * user can copy or edit the content after a failed sending. The message is inserted as plain
+   * text, not HTML, so any markup-like characters are treated as content. The caller owns the
+   * container node and decides where the paragraphs appear within the page layout.
    *
    * @param node HTML container that receives the explanatory paragraphs.
    * @param message original message content to re-display verbatim.
@@ -465,6 +530,8 @@ public class N2NTMToadlet extends Toadlet {
   }
 
   private record FileSelection(File file, boolean handled) {}
+
+  private record UploadSelection(DarknetUploadedFile upload, boolean handled) {}
 
   private record SendRequestContext(
       HTTPRequest request,
@@ -481,8 +548,8 @@ public class N2NTMToadlet extends Toadlet {
    *
    * <p>The form lists target peers, collects the message body, and optionally exposes file
    * attachment controls when advanced mode is enabled. Hidden fields encode the selected peers so
-   * the subsequent POST can map each checkbox to a peer hashcode. In advanced mode, the form shows
-   * both a local file browser button and a file upload input, plus a size warning derived from the
+   * the later POST can map each checkbox to a peer hashcode. In advanced mode, the form shows both
+   * a local file browser button and a file upload input, plus a size warning derived from the
    * runtime memory limit. The caller supplies the content node and toadlet context used to create a
    * correctly scoped form action.
    *
@@ -563,7 +630,7 @@ public class N2NTMToadlet extends Toadlet {
    * a stable routing key and avoid constructing variants with trailing segments, since those are
    * handled by separate toadlets or redirects.
    *
-   * @return the URL path segment for the send N2NTM endpoint.
+   * @return the URL path segment for the sending N2NTM endpoint.
    */
   @Override
   public String path() {

--- a/src/main/java/network/crypta/node/runtime/LegacyDarknetConnectionsPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyDarknetConnectionsPort.java
@@ -10,7 +10,6 @@ import java.util.concurrent.TimeUnit;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.PeerManager;
-import network.crypta.node.PeerNode;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
@@ -42,6 +41,8 @@ final class LegacyDarknetConnectionsPort implements DarknetConnectionsPort {
   /** Live daemon node whose darknet peer inventory backs this adapter. */
   private final Node node;
 
+  private final LegacyDarknetPeerResolver peerResolver;
+
   /**
    * Creates a legacy-backed companion port for the darknet friends page.
    *
@@ -49,6 +50,7 @@ final class LegacyDarknetConnectionsPort implements DarknetConnectionsPort {
    */
   LegacyDarknetConnectionsPort(Node node) {
     this.node = Objects.requireNonNull(node);
+    this.peerResolver = new LegacyDarknetPeerResolver(node);
   }
 
   /** {@inheritDoc} */
@@ -90,35 +92,20 @@ final class LegacyDarknetConnectionsPort implements DarknetConnectionsPort {
   @Override
   public void acceptTransfer(String nodeIdentifier, long transferId)
       throws UnknownPeerException, DarknetPeerRequiredException {
-    resolveDarknetPeerByIdentity(nodeIdentifier).acceptTransfer(transferId);
+    peerResolver.resolveByIdentity(nodeIdentifier).acceptTransfer(transferId);
   }
 
   /** {@inheritDoc} */
   @Override
   public void rejectTransfer(String nodeIdentifier, long transferId)
       throws UnknownPeerException, DarknetPeerRequiredException {
-    resolveDarknetPeerByIdentity(nodeIdentifier).rejectTransfer(transferId);
+    peerResolver.resolveByIdentity(nodeIdentifier).rejectTransfer(transferId);
   }
 
   private static boolean removableWithoutForce(
       DarknetPeerNode peer, long removableWithoutForceCutoff) {
     return peer.timeLastConnectionCompleted() < removableWithoutForceCutoff
         || peer.getPeerNodeStatus() == PeerManager.PEER_NODE_STATUS_NEVER_CONNECTED;
-  }
-
-  private DarknetPeerNode resolveDarknetPeerByIdentity(String nodeIdentifier)
-      throws UnknownPeerException, DarknetPeerRequiredException {
-    Objects.requireNonNull(nodeIdentifier, "nodeIdentifier");
-    for (PeerNode peer : node.network().peerNodes()) {
-      if (!nodeIdentifier.equals(peer.getIdentityString())) {
-        continue;
-      }
-      if (peer instanceof DarknetPeerNode darknetPeer) {
-        return darknetPeer;
-      }
-      throw new DarknetPeerRequiredException(nodeIdentifier);
-    }
-    throw new UnknownPeerException(nodeIdentifier);
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyDarknetMessagingPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyDarknetMessagingPort.java
@@ -1,0 +1,225 @@
+package network.crypta.node.runtime;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Objects;
+import network.crypta.client.async.ClientContext;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.PeerManager;
+import network.crypta.runtime.spi.DarknetMessageSendStatus;
+import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetUploadedFile;
+import network.crypta.runtime.spi.UnknownPeerException;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.HTTPUploadedFile;
+
+/**
+ * Adapts the legacy node-to-node message compose/send flow to the runtime SPI.
+ *
+ * <p>This bridge keeps the remaining live daemon peer lookup and send delegation inside the daemon
+ * root module while exposing only detached identities, detached upload content, and detached
+ * UI-level send statuses to the HTTP layer. It performs no policy changes of its own.
+ *
+ * <p>The adapter is intentionally thin. It resolves the detached peer identifier at the last
+ * responsible moment, forwards attachment offers and text sends to the existing {@link
+ * DarknetPeerNode} APIs, and maps daemon status integers into the compact {@link
+ * DarknetMessageSendStatus} contract used by the HTTP page. Attachment adaptation is kept
+ * request-scoped and read-only so the runtime SPI can stay detached from HTTP bucket
+ * implementations.
+ */
+final class LegacyDarknetMessagingPort implements DarknetMessagingPort {
+  /** Null-check label used for detached upload arguments and wrappers. */
+  private static final String ARG_UPLOAD = "upload";
+
+  /** Resolver that maps detached node identifiers to live darknet peers when a send begins. */
+  private final LegacyDarknetPeerResolver peerResolver;
+
+  /**
+   * Creates a runtime-port bridge rooted at the current daemon instance.
+   *
+   * @param node live daemon root used only for request-scoped peer resolution
+   */
+  LegacyDarknetMessagingPort(Node node) {
+    this.peerResolver = new LegacyDarknetPeerResolver(node);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public DarknetMessageSendStatus sendText(String nodeIdentifier, String message)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    Objects.requireNonNull(message, "message");
+    return mapSendStatus(peerResolver.resolveByIdentity(nodeIdentifier).sendTextFeed(message));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void sendFileOffer(String nodeIdentifier, File file, String messageHead)
+      throws UnknownPeerException, DarknetPeerRequiredException, IOException {
+    Objects.requireNonNull(file, "file");
+    peerResolver.resolveByIdentity(nodeIdentifier).sendFileOffer(file, messageHead);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void sendUploadedFileOffer(
+      String nodeIdentifier, DarknetUploadedFile upload, String messageHead)
+      throws UnknownPeerException, DarknetPeerRequiredException, IOException {
+    Objects.requireNonNull(upload, ARG_UPLOAD);
+    DarknetPeerNode peer = peerResolver.resolveByIdentity(nodeIdentifier);
+    peer.sendFileOffer(new StagedUploadedFile(upload), messageHead);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public DarknetMessageSendStatus sendComposedMessage(
+      String nodeIdentifier,
+      String message,
+      File file,
+      DarknetUploadedFile upload,
+      String messageHead)
+      throws UnknownPeerException, DarknetPeerRequiredException, IOException {
+    Objects.requireNonNull(message, "message");
+    DarknetPeerNode peer = peerResolver.resolveByIdentity(nodeIdentifier);
+    if (file != null) {
+      peer.sendFileOffer(file, messageHead);
+    } else if (upload != null) {
+      peer.sendFileOffer(new StagedUploadedFile(upload), messageHead);
+    }
+    return mapSendStatus(peer.sendTextFeed(message));
+  }
+
+  /**
+   * Maps legacy daemon sends statuses into the smaller UI-facing delivery categories.
+   *
+   * @param legacyStatus daemon status constant returned by the legacy send path
+   * @return detached delivery category that preserves the existing compose/send page buckets
+   */
+  private static DarknetMessageSendStatus mapSendStatus(int legacyStatus) {
+    return switch (legacyStatus) {
+      case PeerManager.PEER_NODE_STATUS_CONNECTED -> DarknetMessageSendStatus.SENT;
+      case PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF -> DarknetMessageSendStatus.DELAYED;
+      default -> DarknetMessageSendStatus.QUEUED;
+    };
+  }
+
+  /**
+   * Minimal uploaded-file view that lets the daemon reuse its existing HTTP-upload send path.
+   *
+   * <p>The wrapper is metadata-only apart from the detached upload reference. Each call to {@link
+   * #getData()} returns a fresh read-only {@link Bucket} backed by the detached stream source.
+   *
+   * @param upload detached uploaded-file payload supplied through the runtime SPI
+   */
+  private record StagedUploadedFile(DarknetUploadedFile upload) implements HTTPUploadedFile {
+    /**
+     * Validates the detached upload wrapper.
+     *
+     * <p>The compact constructor stores no additional state beyond the record component.
+     */
+    private StagedUploadedFile {
+      Objects.requireNonNull(upload, ARG_UPLOAD);
+    }
+
+    @Override
+    public String getContentType() {
+      return upload.contentType();
+    }
+
+    @Override
+    public Bucket getData() {
+      return new UploadStreamBucket(upload);
+    }
+
+    @Override
+    public String getFilename() {
+      return upload.filename();
+    }
+  }
+
+  /**
+   * Read-only bucket adapter that reopens a detached upload stream on demand.
+   *
+   * <p>The daemon's legacy file-offer path expects an {@link HTTPUploadedFile} backed by a {@link
+   * Bucket}. This adapter satisfies that contract without reintroducing HTTP-layer bucket types
+   * into the SPI or holding on to a single mutable stream instance between reads.
+   */
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class UploadStreamBucket implements Bucket {
+    /** Detached upload payload whose bytes are exposed through reopened input streams. */
+    private final DarknetUploadedFile upload;
+
+    /**
+     * Creates one read-only bucket view for a detached upload payload.
+     *
+     * @param upload detached upload that can reopen its stream contents on demand
+     */
+    private UploadStreamBucket(DarknetUploadedFile upload) {
+      this.upload = Objects.requireNonNull(upload, ARG_UPLOAD);
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+      throw new IOException("UploadStreamBucket is read-only");
+    }
+
+    @Override
+    public OutputStream getOutputStreamUnbuffered() throws IOException {
+      throw new IOException("UploadStreamBucket is read-only");
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+      return upload.openStream();
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() throws IOException {
+      return upload.openStream();
+    }
+
+    @Override
+    public String getName() {
+      return "Uploaded N2NTM file: " + upload.filename();
+    }
+
+    @Override
+    public long size() {
+      return upload.size();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+
+    @Override
+    public void setReadOnly() {
+      // Always read-only.
+    }
+
+    @Override
+    public void free() {
+      // No resources are retained between stream openings.
+    }
+
+    @Override
+    public Bucket createShadow() {
+      return new UploadStreamBucket(upload);
+    }
+
+    @Override
+    public void onResume(ClientContext context) {
+      // Request-scoped upload streams do not participate in resume.
+    }
+
+    @Override
+    public void storeTo(DataOutputStream dos) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyDarknetPeerResolver.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyDarknetPeerResolver.java
@@ -1,0 +1,61 @@
+package network.crypta.node.runtime;
+
+import java.util.Objects;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.UnknownPeerException;
+
+/**
+ * Resolves detached darknet peer identities against the live daemon peer list.
+ *
+ * <p>This helper keeps the legacy identity-to-peer lookup used by the friends-page companion
+ * adapters in one place without widening the runtime SPI surface or introducing a broader daemon
+ * refactor. It resolves by exact peer identity string and preserves the daemon's distinction
+ * between a missing peer and a resolved non-darknet peer.
+ *
+ * <p>The resolver is intentionally request-scoped and stateless apart from the daemon root
+ * reference. It does not cache peers between calls, so callers see the current roster at the time
+ * they attempt the operation rather than a stale snapshot.
+ */
+final class LegacyDarknetPeerResolver {
+  /** Live daemon root whose current peer roster is searched for detached identities. */
+  private final Node node;
+
+  /**
+   * Creates a resolver rooted at the current daemon instance.
+   *
+   * @param node live daemon root used for peer-list lookup
+   */
+  LegacyDarknetPeerResolver(Node node) {
+    this.node = Objects.requireNonNull(node, "node");
+  }
+
+  /**
+   * Resolves one detached peer identity to a live darknet peer.
+   *
+   * <p>The lookup walks the current daemon peer list and matches on the exact identity string used
+   * in detached runtime snapshots. If the identity resolves to a non-darknet peer, the caller gets
+   * a distinct exception so higher layers can preserve the daemon's existing error semantics.
+   *
+   * @param nodeIdentifier detached peer identity captured from the runtime snapshot
+   * @return live darknet peer instance that corresponds to the supplied detached identity
+   * @throws UnknownPeerException if no current peer matches the supplied detached identity
+   * @throws DarknetPeerRequiredException if the identity resolves to a non-darknet peer
+   */
+  DarknetPeerNode resolveByIdentity(String nodeIdentifier)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    Objects.requireNonNull(nodeIdentifier, "nodeIdentifier");
+    for (PeerNode peer : node.network().peerNodes()) {
+      if (!nodeIdentifier.equals(peer.getIdentityString())) {
+        continue;
+      }
+      if (peer instanceof DarknetPeerNode darknetPeer) {
+        return darknetPeer;
+      }
+      throw new DarknetPeerRequiredException(nodeIdentifier);
+    }
+    throw new UnknownPeerException(nodeIdentifier);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -8,6 +8,7 @@ import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectivityPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.LifecyclePort;
@@ -44,6 +45,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final ConnectivityPort connectivityPort;
   private final ConnectionsPagePort connectionsPagePort;
   private final DarknetConnectionsPort darknetConnectionsPort;
+  private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
   private final StatisticsPort statisticsPort;
   private final RequestQueuePort requestQueuePort;
@@ -132,6 +134,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.connectivityPort = new LegacyConnectivityPort(node);
     this.connectionsPagePort = new LegacyConnectionsPagePort(node, core);
     this.darknetConnectionsPort = new LegacyDarknetConnectionsPort(node);
+    this.darknetMessagingPort = new LegacyDarknetMessagingPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
@@ -226,6 +229,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public DarknetConnectionsPort darknetConnections() {
     return darknetConnectionsPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps legacy N2NTM peer resolution, file-offer adaptation, and sends
+   * status mapping inside the daemon root module while exposing only detached SPI-local values
+   * upstream.
+   */
+  @Override
+  public DarknetMessagingPort darknetMessaging() {
+    return darknetMessagingPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
@@ -1,26 +1,40 @@
 package network.crypta.clients.http;
 
+import java.io.IOException;
 import java.net.URI;
-import java.util.HashMap;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessageSendStatus;
+import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.DarknetUploadedFile;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.api.HTTPUploadedFile;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -28,10 +42,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -39,10 +53,10 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class N2NTMToadletTest {
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore core;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private DarknetMessagingPort darknetMessagingPort;
+  @Mock private LocalFileN2NMToadlet browser;
   @Mock private HighLevelSimpleClient client;
   @Mock private HTTPRequest request;
   @Mock private ToadletContext ctx;
@@ -51,13 +65,18 @@ class N2NTMToadletTest {
 
   @BeforeAll
   static void initL10n() {
-    // Ensure the localization bundle is initialized once for predictable strings.
     new NodeL10n();
   }
 
   @BeforeEach
   void setUp() {
-    toadlet = new N2NTMToadlet(node, core, client);
+    org.mockito.Mockito.lenient()
+        .when(runtimePorts.darknetConnections())
+        .thenReturn(darknetConnectionsPort);
+    org.mockito.Mockito.lenient()
+        .when(runtimePorts.darknetMessaging())
+        .thenReturn(darknetMessagingPort);
+    toadlet = new N2NTMToadlet(runtimePorts, browser, client);
   }
 
   @Test
@@ -66,8 +85,8 @@ class N2NTMToadletTest {
   }
 
   @Test
-  void getBrowser_returnsLocalFileToadlet() {
-    assertInstanceOf(LocalFileN2NMToadlet.class, toadlet.getBrowser());
+  void getBrowser_returnsInjectedBrowser() {
+    assertSame(browser, toadlet.getBrowser());
   }
 
   @Test
@@ -99,18 +118,10 @@ class N2NTMToadletTest {
   void handleMethodGET_whenPeerMissing_showsErrorBox() throws Exception {
     when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
     when(request.isParameterSet("peernode_hashcode")).thenReturn(true);
-    DarknetPeerNode peer = mock(DarknetPeerNode.class);
-    int peerHash = peer.hashCode();
-    String missingHash = String.valueOf(peerHash + 1);
-    when(request.getParam("peernode_hashcode")).thenReturn(missingHash);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+    when(request.getParam("peernode_hashcode")).thenReturn("99");
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeerSnapshot()));
 
-    PageMaker pageMaker = mock(PageMaker.class);
-    PageNode page = createPageNode();
-    doReturn(page).when(pageMaker).getPageNode(anyString(), any(ToadletContext.class));
+    PageMaker pageMaker = pageMaker();
     when(ctx.getPageMaker()).thenReturn(pageMaker);
     AtomicReference<String> html = new AtomicReference<>("");
     N2NTMToadlet spyToadlet = spy(toadlet);
@@ -123,29 +134,21 @@ class N2NTMToadletTest {
         .writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
 
     spyToadlet.handleMethodGET(
-        new URI("http://localhost/send_n2ntm/?peernode_hashcode=1234"), request, ctx);
+        new URI("http://localhost/send_n2ntm/?peernode_hashcode=99"), request, ctx);
 
     String generated = html.get();
     assertTrue(generated.contains("infobox-error"));
-    assertTrue(generated.contains(missingHash));
+    assertTrue(generated.contains("99"));
   }
 
   @Test
-  void handleMethodGET_whenPeerFound_rendersSendForm() throws Exception {
+  void handleMethodGET_whenPeerFound_rendersSendFormFromDetachedSnapshot() throws Exception {
     when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
     when(request.isParameterSet("peernode_hashcode")).thenReturn(true);
-    DarknetPeerNode peer = mock(DarknetPeerNode.class);
-    int peerHash = peer.hashCode();
-    when(request.getParam("peernode_hashcode")).thenReturn(String.valueOf(peerHash));
-    when(peer.getName()).thenReturn("Alice");
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[] {peer});
+    when(request.getParam("peernode_hashcode")).thenReturn("42");
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeerSnapshot()));
 
-    PageMaker pageMaker = mock(PageMaker.class);
-    PageNode page = createPageNode();
-    doReturn(page).when(pageMaker).getPageNode(anyString(), any(ToadletContext.class));
+    PageMaker pageMaker = pageMaker();
     when(ctx.getPageMaker()).thenReturn(pageMaker);
     when(ctx.isAdvancedModeEnabled()).thenReturn(true);
     when(ctx.isAllowedFullAccess()).thenReturn(true);
@@ -173,18 +176,17 @@ class N2NTMToadletTest {
 
     String generated = html.get();
     assertTrue(generated.contains("Alice"));
-    assertTrue(generated.contains("node_" + peerHash));
+    assertTrue(generated.contains("node_42"));
     assertTrue(generated.contains("n2ntmtext"));
   }
 
   @Test
   void handleMethodPOST_whenMessageTooLong_returnsBadRequest() throws Exception {
     when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
-    when(request.isPartSet(anyString())).thenReturn(false);
-    when(request.isPartSet("send")).thenReturn(true);
-
-    String oversizedMessage = "x".repeat(130 * 1024 + 1);
-    when(request.getPartAsStringFailsafe("message", 1024 * 1024)).thenReturn(oversizedMessage);
+    doReturn(false).when(request).isPartSet(anyString());
+    doReturn(true).when(request).isPartSet("send");
+    when(request.getPartAsStringFailsafe("message", 1024 * 1024))
+        .thenReturn("x".repeat(130 * 1024 + 1));
 
     N2NTMToadlet spyToadlet = spy(toadlet);
     AtomicReference<Integer> status = new AtomicReference<>(0);
@@ -203,6 +205,167 @@ class N2NTMToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenSelectedPeerPresent_sendsTextThroughMessagingPort() throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    doReturn(false).when(request).isPartSet(anyString());
+    doReturn(true).when(request).isPartSet("send");
+    when(request.getPartAsStringFailsafe("message", 1024 * 1024)).thenReturn("hello");
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeerSnapshot()));
+    doReturn(true).when(request).isPartSet("node_42");
+    when(darknetMessagingPort.sendComposedMessage("peer-1", "hello", null, null, "hello"))
+        .thenReturn(DarknetMessageSendStatus.SENT);
+
+    PageMaker pageMaker = pageMaker();
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    AtomicReference<String> html = new AtomicReference<>("");
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    doAnswer(
+            invocation -> {
+              html.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodPOST(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    verify(darknetMessagingPort).sendComposedMessage("peer-1", "hello", null, null, "hello");
+    assertTrue(html.get().contains("Alice"));
+    assertTrue(html.get().contains("n2ntm-send-sent"));
+  }
+
+  @Test
+  void handleMethodPOST_whenLocalFileSelected_sendsFileOfferThroughMessagingPort(
+      @TempDir Path tempDir) throws Exception {
+    Path filePath = Files.writeString(tempDir.resolve("offer.txt"), "payload");
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    doReturn(false).when(request).isPartSet(anyString());
+    doReturn(true).when(request).isPartSet(LocalFileBrowserToadlet.SELECT_FILE);
+    when(request.getPartAsStringFailsafe("message", 1024 * 1024)).thenReturn("hello");
+    when(request.getPartAsStringFailsafe("filename", 1024)).thenReturn(filePath.toString());
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeerSnapshot()));
+    doReturn(true).when(request).isPartSet("node_42");
+    when(darknetMessagingPort.sendComposedMessage(
+            "peer-1", "hello", filePath.toFile(), null, "hello"))
+        .thenReturn(DarknetMessageSendStatus.SENT);
+
+    PageMaker pageMaker = pageMaker();
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    doAnswer(_ -> null).when(spyToadlet).writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodPOST(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    verify(darknetMessagingPort)
+        .sendComposedMessage("peer-1", "hello", filePath.toFile(), null, "hello");
+  }
+
+  @Test
+  void handleMethodPOST_whenUploadSelected_streamsUploadThroughMessagingPort() throws Exception {
+    byte[] bytes = "payload".getBytes(StandardCharsets.UTF_8);
+    HTTPUploadedFile uploadedFile = org.mockito.Mockito.mock(HTTPUploadedFile.class);
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    doReturn(false).when(request).isPartSet(anyString());
+    doReturn(true).when(request).isPartSet("n2nm-upload");
+    when(request.getPartAsStringFailsafe("message", 1024 * 1024)).thenReturn("hello");
+    when(request.getUploadedFile("n2nm-upload")).thenReturn(uploadedFile);
+    when(uploadedFile.getFilename()).thenReturn("upload.txt");
+    when(uploadedFile.getContentType()).thenReturn("text/plain");
+    when(uploadedFile.getData()).thenReturn(new SimpleReadOnlyArrayBucket(bytes));
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeerSnapshot()));
+    doReturn(true).when(request).isPartSet("node_42");
+
+    doAnswer(
+            invocation -> {
+              DarknetUploadedFile upload = invocation.getArgument(3);
+              assertEquals("upload.txt", upload.filename());
+              assertEquals("text/plain", upload.contentType());
+              assertEquals(bytes.length, upload.size());
+              try (var inputStream = upload.openStream()) {
+                assertArrayEquals(bytes, inputStream.readAllBytes());
+              }
+              return DarknetMessageSendStatus.SENT;
+            })
+        .when(darknetMessagingPort)
+        .sendComposedMessage(
+            eq("peer-1"), eq("hello"), eq(null), any(DarknetUploadedFile.class), eq("hello"));
+
+    PageMaker pageMaker = pageMaker();
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    doAnswer(_ -> null).when(spyToadlet).writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodPOST(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    verify(darknetMessagingPort)
+        .sendComposedMessage(
+            eq("peer-1"), eq("hello"), eq(null), any(DarknetUploadedFile.class), eq("hello"));
+  }
+
+  @Test
+  void handleMethodPOST_whenUploadResolutionFails_writesFailureAndStops() throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    doReturn(false).when(request).isPartSet(anyString());
+    doReturn(true).when(request).isPartSet("n2nm-upload");
+    when(request.getPartAsStringFailsafe("message", 1024 * 1024)).thenReturn("hello");
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeerSnapshot()));
+    doReturn(true).when(request).isPartSet("node_42");
+    doAnswer(
+            _ -> {
+              throw new IOException("boom");
+            })
+        .when(request)
+        .getUploadedFile("n2nm-upload");
+
+    PageMaker pageMaker = pageMaker();
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    AtomicReference<String> html = new AtomicReference<>("");
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    doAnswer(
+            invocation -> {
+              html.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodPOST(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    verify(spyToadlet, times(1)).writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+    verifyNoInteractions(darknetMessagingPort);
+    assertTrue(html.get().contains("hello"));
+  }
+
+  @Test
+  void handleMethodPOST_whenPeerCannotBeResolved_rendersQueuedStatusRow() throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    doReturn(false).when(request).isPartSet(anyString());
+    doReturn(true).when(request).isPartSet("send");
+    when(request.getPartAsStringFailsafe("message", 1024 * 1024)).thenReturn("hello");
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeerSnapshot()));
+    doReturn(true).when(request).isPartSet("node_42");
+    when(darknetMessagingPort.sendComposedMessage("peer-1", "hello", null, null, "hello"))
+        .thenThrow(new UnknownPeerException("peer-1"));
+
+    PageMaker pageMaker = pageMaker();
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    AtomicReference<String> html = new AtomicReference<>("");
+    N2NTMToadlet spyToadlet = spy(toadlet);
+    doAnswer(
+            invocation -> {
+              html.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeHTMLReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodPOST(new URI("http://localhost/send_n2ntm/"), request, ctx);
+
+    assertTrue(html.get().contains("Alice"));
+    assertTrue(html.get().contains("n2ntm-send-queued"));
+  }
+
+  @Test
   void addUnsentMessageTextInfo_appendsMessage() {
     HTMLNode root = new HTMLNode("div");
     String message = "Pending message body";
@@ -217,7 +380,7 @@ class N2NTMToadletTest {
   @Test
   void createN2NTMSendForm_whenAdvanced_addsFileControls() {
     HTMLNode contentNode = new HTMLNode("div");
-    HashMap<String, String> peers = new HashMap<>();
+    Map<String, String> peers = new LinkedHashMap<>();
     peers.put("7", "Bob");
 
     when(ctx.addFormChild(any(HTMLNode.class), eq("/send_n2ntm/"), eq("sendN2NTMForm")))
@@ -237,6 +400,16 @@ class N2NTMToadletTest {
     assertTrue(html.contains("node_7"));
     assertTrue(html.contains("n2nm-upload"));
     assertTrue(html.contains("n2ntmtext"));
+  }
+
+  private PageMaker pageMaker() {
+    PageMaker pageMaker = org.mockito.Mockito.mock(PageMaker.class);
+    doReturn(createPageNode()).when(pageMaker).getPageNode(anyString(), any(ToadletContext.class));
+    return pageMaker;
+  }
+
+  private static DarknetConnectionPeerSnapshot alicePeerSnapshot() {
+    return new DarknetConnectionPeerSnapshot(42, "peer-1", "Alice", "", false);
   }
 
   private PageNode createPageNode() {

--- a/src/test/java/network/crypta/node/runtime/LegacyDarknetMessagingPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyDarknetMessagingPortTest.java
@@ -1,0 +1,152 @@
+package network.crypta.node.runtime;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.PeerManager;
+import network.crypta.node.PeerNode;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.DarknetMessageSendStatus;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetUploadedFile;
+import network.crypta.runtime.spi.UnknownPeerException;
+import network.crypta.support.api.HTTPUploadedFile;
+import network.crypta.support.io.BucketTools;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyDarknetMessagingPortTest {
+
+  @Mock private Node node;
+
+  @Mock private NodeNetworkSubsystem network;
+
+  @Mock private DarknetPeerNode darknetPeer;
+
+  @Mock private PeerNode nonDarknetPeer;
+
+  @Test
+  void sendText_whenLegacyStatusConnected_returnsSent() throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+    when(darknetPeer.sendTextFeed("hello")).thenReturn(PeerManager.PEER_NODE_STATUS_CONNECTED);
+
+    DarknetMessageSendStatus result = port.sendText("peer-1", "hello");
+
+    assertEquals(DarknetMessageSendStatus.SENT, result);
+  }
+
+  @Test
+  void sendText_whenLegacyStatusRoutingBackedOff_returnsDelayed() throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+    when(darknetPeer.sendTextFeed("hello"))
+        .thenReturn(PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF);
+
+    DarknetMessageSendStatus result = port.sendText("peer-1", "hello");
+
+    assertEquals(DarknetMessageSendStatus.DELAYED, result);
+  }
+
+  @Test
+  void sendText_whenLegacyStatusIsOther_returnsQueued() throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+    when(darknetPeer.sendTextFeed("hello")).thenReturn(PeerManager.PEER_NODE_STATUS_DISCONNECTED);
+
+    DarknetMessageSendStatus result = port.sendText("peer-1", "hello");
+
+    assertEquals(DarknetMessageSendStatus.QUEUED, result);
+  }
+
+  @Test
+  void sendFileOffer_whenIdentityResolves_delegatesToPeer() throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    File file = new File("shared/path/example.txt");
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    port.sendFileOffer("peer-1", file, "message-head");
+
+    verify(darknetPeer).sendFileOffer(file, "message-head");
+  }
+
+  @Test
+  void sendUploadedFileOffer_whenIdentityResolves_adaptsDetachedUpload() throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    byte[] bytes = "hello".getBytes(StandardCharsets.UTF_8);
+    DarknetUploadedFile upload =
+        new DarknetUploadedFile(
+            "hello.txt", "text/plain", bytes.length, () -> new ByteArrayInputStream(bytes));
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+    ArgumentCaptor<HTTPUploadedFile> uploadCaptor = ArgumentCaptor.forClass(HTTPUploadedFile.class);
+
+    port.sendUploadedFileOffer("peer-1", upload, "message-head");
+
+    verify(darknetPeer).sendFileOffer(uploadCaptor.capture(), eq("message-head"));
+    HTTPUploadedFile delegatedUpload = uploadCaptor.getValue();
+    assertEquals("hello.txt", delegatedUpload.getFilename());
+    assertEquals("text/plain", delegatedUpload.getContentType());
+    assertArrayEquals(bytes, BucketTools.toByteArray(delegatedUpload.getData()));
+  }
+
+  @Test
+  void sendComposedMessage_whenLocalFilePresent_usesOnePeerResolutionForOfferAndText()
+      throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    File file = new File("shared/path/example.txt");
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+    when(darknetPeer.sendTextFeed("hello")).thenReturn(PeerManager.PEER_NODE_STATUS_CONNECTED);
+
+    DarknetMessageSendStatus result =
+        port.sendComposedMessage("peer-1", "hello", file, null, "message-head");
+
+    assertEquals(DarknetMessageSendStatus.SENT, result);
+    InOrder sendOrder = inOrder(darknetPeer);
+    sendOrder.verify(darknetPeer).sendFileOffer(file, "message-head");
+    sendOrder.verify(darknetPeer).sendTextFeed("hello");
+  }
+
+  @Test
+  void sendText_whenPeerIdentityIsUnknown_throwsUnknownPeerException() {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[0]);
+
+    assertThrows(UnknownPeerException.class, () -> port.sendText("missing-peer", "hello"));
+  }
+
+  @Test
+  void sendText_whenResolvedPeerIsNotDarknet_throwsDarknetPeerRequiredException() {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {nonDarknetPeer});
+    when(nonDarknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    assertThrows(DarknetPeerRequiredException.class, () -> port.sendText("peer-1", "hello"));
+  }
+
+  private LegacyDarknetMessagingPort newPort() {
+    when(node.network()).thenReturn(network);
+    return new LegacyDarknetMessagingPort(node);
+  }
+}

--- a/src/test/java/network/crypta/node/runtime/LegacyDarknetPeerResolverTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyDarknetPeerResolverTest.java
@@ -1,0 +1,92 @@
+package network.crypta.node.runtime;
+
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.PeerNode;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.UnknownPeerException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyDarknetPeerResolverTest {
+
+  @Mock private Node node;
+
+  @Mock private NodeNetworkSubsystem network;
+
+  @Mock private PeerNode otherPeer;
+
+  @Mock private PeerNode nonDarknetPeer;
+
+  @Mock private DarknetPeerNode darknetPeer;
+
+  @Test
+  void constructor_whenNodeIsNull_throwsNullPointerException() {
+    NullPointerException exception =
+        assertThrows(NullPointerException.class, () -> new LegacyDarknetPeerResolver(null));
+
+    assertEquals("node", exception.getMessage());
+  }
+
+  @Test
+  void resolveByIdentity_whenIdentifierIsNull_throwsNullPointerException() {
+    LegacyDarknetPeerResolver resolver = new LegacyDarknetPeerResolver(node);
+
+    NullPointerException exception =
+        assertThrows(NullPointerException.class, () -> resolver.resolveByIdentity(null));
+
+    assertEquals("nodeIdentifier", exception.getMessage());
+  }
+
+  @Test
+  void resolveByIdentity_whenDarknetPeerMatches_returnsDarknetPeer() throws Exception {
+    LegacyDarknetPeerResolver resolver = newResolver();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {otherPeer, darknetPeer});
+    when(otherPeer.getIdentityString()).thenReturn("peer-0");
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    DarknetPeerNode resolvedPeer = resolver.resolveByIdentity("peer-1");
+
+    assertSame(darknetPeer, resolvedPeer);
+  }
+
+  @Test
+  void resolveByIdentity_whenMatchingPeerIsNotDarknet_throwsDarknetPeerRequiredException() {
+    LegacyDarknetPeerResolver resolver = newResolver();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {nonDarknetPeer});
+    when(nonDarknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    DarknetPeerRequiredException exception =
+        assertThrows(
+            DarknetPeerRequiredException.class, () -> resolver.resolveByIdentity("peer-1"));
+
+    assertEquals("peer-1", exception.nodeIdentifier());
+  }
+
+  @Test
+  void resolveByIdentity_whenNoPeerMatches_throwsUnknownPeerException() {
+    LegacyDarknetPeerResolver resolver = newResolver();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {otherPeer});
+    when(otherPeer.getIdentityString()).thenReturn("peer-0");
+
+    UnknownPeerException exception =
+        assertThrows(UnknownPeerException.class, () -> resolver.resolveByIdentity("peer-1"));
+
+    assertEquals("peer-1", exception.nodeIdentifier());
+  }
+
+  private LegacyDarknetPeerResolver newResolver() {
+    when(node.network()).thenReturn(network);
+    return new LegacyDarknetPeerResolver(node);
+  }
+}

--- a/src/test/java/network/crypta/runtime/spi/DarknetUploadedFileTest.java
+++ b/src/test/java/network/crypta/runtime/spi/DarknetUploadedFileTest.java
@@ -1,0 +1,123 @@
+package network.crypta.runtime.spi;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class DarknetUploadedFileTest {
+
+  @Test
+  void constructor_whenFilenameIsNull_throwsNullPointerException() {
+    DarknetUploadedFile.StreamSource streamSource =
+        () -> new ByteArrayInputStream(new byte[] {1, 2, 3});
+
+    NullPointerException exception =
+        assertThrows(
+            NullPointerException.class,
+            () -> new DarknetUploadedFile(null, "text/plain", 3, streamSource));
+
+    assertEquals("filename", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenStreamSourceIsNull_throwsNullPointerException() {
+    NullPointerException exception =
+        assertThrows(
+            NullPointerException.class,
+            () -> new DarknetUploadedFile("upload.txt", "text/plain", 3, null));
+
+    assertEquals("streamSource", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenSizeIsNegative_throwsIllegalArgumentException() {
+    DarknetUploadedFile.StreamSource streamSource =
+        () -> new ByteArrayInputStream(new byte[] {1, 2, 3});
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new DarknetUploadedFile("upload.txt", "text/plain", -1, streamSource));
+
+    assertEquals("size", exception.getMessage());
+  }
+
+  @Test
+  void accessors_whenContentTypeMissing_returnDetachedMetadata() {
+    byte[] data = "payload".getBytes(StandardCharsets.UTF_8);
+    DarknetUploadedFile upload =
+        new DarknetUploadedFile(
+            "upload.txt", null, data.length, () -> new ByteArrayInputStream(data));
+
+    assertAll(
+        () -> assertEquals("upload.txt", upload.filename()),
+        () -> assertNull(upload.contentType()),
+        () -> assertEquals(data.length, upload.size()));
+  }
+
+  @Test
+  void openStream_whenCalledRepeatedly_reopensFreshStreams() throws Exception {
+    byte[] data = "payload".getBytes(StandardCharsets.UTF_8);
+    AtomicInteger openCount = new AtomicInteger();
+    DarknetUploadedFile upload =
+        new DarknetUploadedFile(
+            "upload.txt",
+            "text/plain",
+            data.length,
+            () -> {
+              openCount.incrementAndGet();
+              return new ByteArrayInputStream(data);
+            });
+
+    byte[] firstRead;
+    byte[] secondRead;
+    try (var firstStream = upload.openStream();
+        var secondStream = upload.openStream()) {
+      firstRead = firstStream.readAllBytes();
+      secondRead = secondStream.readAllBytes();
+    }
+
+    assertAll(
+        () -> assertEquals(2, openCount.get()),
+        () -> assertArrayEquals(data, firstRead),
+        () -> assertArrayEquals(data, secondRead));
+  }
+
+  @Test
+  void openStream_whenSourceThrows_propagatesIOException() {
+    IOException failure = new IOException("boom");
+    DarknetUploadedFile upload =
+        new DarknetUploadedFile(
+            "upload.txt",
+            "text/plain",
+            7,
+            () -> {
+              throw failure;
+            });
+
+    IOException thrown = assertThrows(IOException.class, upload::openStream);
+
+    assertSame(failure, thrown);
+  }
+
+  @Test
+  void toString_whenCalled_includesDetachedMetadata() {
+    DarknetUploadedFile upload =
+        new DarknetUploadedFile(
+            "upload.txt", "text/plain", 7, () -> new ByteArrayInputStream(new byte[] {1}));
+
+    assertEquals(
+        "DarknetUploadedFile[filename=upload.txt, contentType=text/plain, size=7]",
+        upload.toString());
+  }
+}


### PR DESCRIPTION
## Summary
- add a detached `DarknetMessagingPort` plus `DarknetMessageSendStatus` and stream-backed `DarknetUploadedFile` types in `runtime-spi`
- refactor `N2NTMToadlet` and `FProxyRegistrar` to resolve peers and send through runtime ports while preserving the legacy `node_<hashcode>` selection flow and the existing sent/delayed/queued UI behavior
- add daemon-root adapters and focused tests for the messaging port, peer resolver, upload handling, and the compose/send page

## How to test
- `./gradlew test --tests "network.crypta.node.runtime.LegacyDarknetMessagingPortTest"`
- `./gradlew test --tests "network.crypta.clients.http.N2NTMToadletTest"`
- `./gradlew test --tests "network.crypta.runtime.spi.DarknetUploadedFileTest"`
- `./gradlew test --tests "network.crypta.node.runtime.LegacyDarknetPeerResolverTest"`
- `./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/runtime/spi/DarknetUploadedFileTest.java`
- `./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/node/runtime/LegacyDarknetPeerResolverTest.java`
- `./gradlew test`
