### PR TITLE
refactor(connections): Remove live-daemon dependencies from legacy pages

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsSupportPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsSupportPort.java
@@ -1,0 +1,39 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+
+/**
+ * Exposes the narrow legacy connections-page support capability still needed by the HTTP layer.
+ *
+ * <p>This port is intentionally transitional and page-oriented. The legacy friends and strangers
+ * pages still need one feature-flag check and one file-backed noderef import source, but those
+ * concerns do not justify widening broader runtime SPI surfaces such as {@link ConnectionsPagePort}
+ * or {@link NodeInfoPort}. Implementations may delegate to live daemon state internally while
+ * exposing only JDK-only types here.
+ *
+ * <p>The port is not a general node API. It exists only to finish removing direct daemon-root
+ * dependencies from the legacy connections-family HTTP toadlets.
+ */
+public interface ConnectionsSupportPort {
+  /**
+   * Returns whether opennet support is currently enabled.
+   *
+   * <p>Callers use this to decide whether to expose or route the legacy strangers page without
+   * depending on daemon-local network objects.
+   *
+   * @return {@code true} when opennet is enabled in the live runtime
+   */
+  boolean isOpennetEnabled();
+
+  /**
+   * Reads and concatenates peer-offer reference text for legacy add-peer import.
+   *
+   * <p>The returned text should preserve the current legacy behavior of scanning the node's
+   * peer-offer directory, reading matching reference files as UTF-8 text, and concatenating their
+   * contents in encountered iteration order.
+   *
+   * @return concatenated peer-offer noderef text, or an empty string when no matching files exist
+   * @throws IOException on I/O failure while reading the peer-offer reference files
+   */
+  String readPeerOfferReferencesText() throws IOException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -21,6 +21,7 @@ package network.crypta.runtime.spi;
  * @see ConfigPort
  * @see ConnectivityPort
  * @see ConnectionsPagePort
+ * @see ConnectionsSupportPort
  * @see DarknetConnectionsPort
  * @see DarknetMessagingPort
  * @see DiagnosticPort
@@ -114,6 +115,18 @@ public interface RuntimePorts {
    * @return connections-page runtime port for detached legacy friends and strangers snapshots
    */
   ConnectionsPagePort connectionsPage();
+
+  /**
+   * Returns the legacy connections-page support capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps a small set of remaining live-runtime helpers behind the runtime boundary:
+   * the opennet-enabled flag used to gate the strangers page and the peer-offer reference import
+   * text used by the legacy add-peer flow. It is intentionally page-support-oriented rather than a
+   * general node API.
+   *
+   * @return connections-page support port for opennet enablement and peer-offer reference text
+   */
+  ConnectionsSupportPort connectionsSupport();
 
   /**
    * Returns the legacy darknet friends-page companion capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.http;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -22,7 +21,6 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerNodeStatus;
 import network.crypta.node.Version;
 import network.crypta.runtime.spi.ConfigPort;
@@ -30,6 +28,7 @@ import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeInfoPort;
@@ -47,7 +46,6 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * for subclasses that tailor per-network presentation. It centralizes sorting, pagination,
  * validation, and noderef ingestion so downstream pages can focus on the specifics of each
  * topology. Instances are long-lived and reused across requests; state comes from the injected
- * runtime ports and {@link NodeClientCore} rather than per-request mutability.
+ * runtime ports rather than per-request mutability.
  *
  * <p>Responsibilities include:
  *
@@ -76,6 +74,8 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ConnectionsToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionsToadlet.class);
+  private static final String OPENNET = "opennet";
+  private static final String DARKNET = "darknet";
   private static final String ATTR_CLASS = "class";
   private static final String ELEMENT_TABLE = "table";
   private static final String INFOBOX_CLASS = "infobox";
@@ -246,9 +246,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
   }
 
-  /** Core services used for filesystem paths, configuration, and network integration. */
-  protected final NodeClientCore core;
-
   /** Page-oriented runtime port used for detached GET-only connections page rendering. */
   private final ConnectionsPagePort connectionsPage;
 
@@ -260,6 +257,9 @@ public abstract class ConnectionsToadlet extends Toadlet {
 
   /** Runtime config port used for add-peer flow overrides that previously hit daemon config. */
   private final ConfigPort configPort;
+
+  /** Runtime support port used for opennet enablement and peer-offer noderef imports. */
+  private final ConnectionsSupportPort connectionsSupportPort;
 
   /**
    * Outcomes returned when attempting to add a peer from a supplied noderef.
@@ -287,24 +287,19 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /**
    * Creates a toadlet bound to shared node infrastructure used by connection pages.
    *
-   * @param core {@link NodeClientCore} providing filesystem access and runtime paths used for
-   *     noderef files.
    * @param client high-level client used to retrieve noderefs via Freenet or HTTP when users submit
    *     URLs instead of pasted references.
    * @param runtimePorts shared detached runtime ports backing page rendering, peer changes, noderef
-   *     export, and config lookups.
+   *     export, config lookups, and legacy page-support helpers.
    */
-  protected ConnectionsToadlet(
-      NodeClientCore core,
-      HighLevelSimpleClient client,
-      ConnectionsToadletRuntimePorts runtimePorts) {
+  ConnectionsToadlet(HighLevelSimpleClient client, ConnectionsToadletRuntimePorts runtimePorts) {
     super(client);
     ConnectionsToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts);
-    this.core = Objects.requireNonNull(core);
     this.connectionsPage = ports.connectionsPage();
     this.peerPort = ports.peerPort();
     this.nodeInfoPort = ports.nodeInfoPort();
     this.configPort = ports.configPort();
+    this.connectionsSupportPort = ports.connectionsSupportPort();
     refLink = HTMLNode.link(path() + "myref.fref").setReadOnly();
     reftextLink = HTMLNode.link(path() + "myref.txt").setReadOnly();
   }
@@ -501,17 +496,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   private String readPeersOffersFiles() throws IOException {
-    File[] files = core.getNode().runDir().file("peers-offers").listFiles();
-    if (files == null || files.length == 0) {
-      return "";
-    }
-    StringBuilder peersOffersFilesContent = new StringBuilder();
-    for (final File file : files) {
-      if (file.isFile() && file.getName().endsWith(".fref")) {
-        peersOffersFilesContent.append(FileUtil.readUTF(file));
-      }
-    }
-    return peersOffersFilesContent.toString();
+    return connectionsSupportPort.readPeerOfferReferencesText();
   }
 
   private FRIEND_TRUST parseTrust(HTTPRequest request) {
@@ -724,8 +709,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
     if (!matchesExpectedPeerType(fs)) {
       LOG.warn(
           "Rejecting {} noderef on {} connections page",
-          fs.getBoolean("opennet", false) ? "opennet" : "darknet",
-          isOpennet() ? "opennet" : "darknet");
+          fs.getBoolean(OPENNET, false) ? OPENNET : DARKNET,
+          isOpennet() ? OPENNET : DARKNET);
       return PeerAdditionReturnCodes.CANT_PARSE;
     }
 
@@ -1024,7 +1009,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   private boolean matchesExpectedPeerType(SimpleFieldSet fieldSet) {
-    return fieldSet.getBoolean("opennet", false) == isOpennet();
+    return fieldSet.getBoolean(OPENNET, false) == isOpennet();
   }
 
   private static PeerTrust toPeerTrust(FRIEND_TRUST trust) {

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadletRuntimePorts.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http;
 import java.util.Objects;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.PeerPort;
 
@@ -24,12 +25,14 @@ import network.crypta.runtime.spi.PeerPort;
  * @param peerPort peer-management port used for additions and updates.
  * @param nodeInfoPort node-info port used for local noderef export.
  * @param configPort config port used for connections-page settings.
+ * @param connectionsSupportPort support port used for opennet enablement and peer-offer imports.
  */
 record ConnectionsToadletRuntimePorts(
     ConnectionsPagePort connectionsPage,
     PeerPort peerPort,
     NodeInfoPort nodeInfoPort,
-    ConfigPort configPort) {
+    ConfigPort configPort,
+    ConnectionsSupportPort connectionsSupportPort) {
   /**
    * Creates one shared runtime-port bundle for connections toadlets.
    *
@@ -43,5 +46,6 @@ record ConnectionsToadletRuntimePorts(
     Objects.requireNonNull(peerPort);
     Objects.requireNonNull(nodeInfoPort);
     Objects.requireNonNull(configPort);
+    Objects.requireNonNull(connectionsSupportPort);
   }
 }

--- a/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -11,7 +11,6 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
 import network.crypta.node.DarknetPeerNodeStatus;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerNodeStatus;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -105,11 +104,10 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   private final PeerPort peerPort;
 
   DarknetConnectionsToadlet(
-      NodeClientCore core,
       HighLevelSimpleClient client,
       ConnectionsToadletRuntimePorts runtimePorts,
       DarknetConnectionsPort darknetConnectionsPort) {
-    super(core, client, runtimePorts);
+    super(client, runtimePorts);
     this.darknetConnectionsPort = darknetConnectionsPort;
     this.peerPort = runtimePorts.peerPort();
   }

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -260,11 +260,12 @@ final class FProxyRegistrar {
             runtimePorts.connectionsPage(),
             runtimePorts.peer(),
             runtimePorts.nodeInfo(),
-            runtimePorts.config());
+            runtimePorts.config(),
+            runtimePorts.connectionsSupport());
 
     DarknetConnectionsToadlet friendsToadlet =
         new DarknetConnectionsToadlet(
-            core, client, connectionsToadletRuntimePorts, runtimePorts.darknetConnections());
+            client, connectionsToadletRuntimePorts, runtimePorts.darknetConnections());
     server.register(
         friendsToadlet,
         ToadletRegistration.menuLink(
@@ -289,7 +290,7 @@ final class FProxyRegistrar {
             null));
 
     OpennetConnectionsToadlet opennetToadlet =
-        new OpennetConnectionsToadlet(node, core, client, connectionsToadletRuntimePorts);
+        new OpennetConnectionsToadlet(client, connectionsToadletRuntimePorts);
     server.register(
         opennetToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -2,10 +2,9 @@ package network.crypta.clients.http;
 
 import java.util.Comparator;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerNodeStatus;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.support.HTMLNode;
 
@@ -25,33 +24,26 @@ import network.crypta.support.HTMLNode;
  *
  * <p>Thread-safety mirrors the base toadlet: instances are expected to be used on the request
  * thread managed by the HTTP layer, and no shared mutable state is introduced here. It is suitable
- * for multithreaded servlet environments as long as the injected {@link Node} and supporting
+ * for multithreaded servlet environments as long as the injected runtime ports and supporting
  * collaborators are themselves thread-safe.
  */
 public class OpennetConnectionsToadlet extends ConnectionsToadlet implements LinkEnabledCallback {
-  private final Node node;
+  private final ConnectionsSupportPort connectionsSupportPort;
 
   /**
-   * Builds an opennet-specific toadlet using the shared node components required to render peer
-   * state. Callers supply the node, client core, and a high-level client wrapper; the constructor
-   * merely stores them for the base class without adding additional side effects. The instance can
-   * be created eagerly during UI wiring because it defers all data retrieval to per-request
-   * handlers, avoiding heavy startup costs.
+   * Builds an opennet-specific toadlet using the shared runtime ports required to render peer
+   * state. The instance can be created eagerly during UI wiring because it defers all data
+   * retrieval to per-request handlers, avoiding heavy startup costs.
    *
-   * @param n node that owns the peer set and opennet configuration; must remain reachable
-   *     throughout the toadlet lifetime.
-   * @param core client core used by the base toadlet for noderef export and related helpers; not
-   *     null when opennet is enabled.
    * @param client high-level client for UI links and redirects; expected to be configured for
    *     opennet-safe operations.
+   * @param runtimePorts shared detached runtime ports backing page rendering, noderef export, and
+   *     legacy support helpers.
    */
   OpennetConnectionsToadlet(
-      Node n,
-      NodeClientCore core,
-      HighLevelSimpleClient client,
-      ConnectionsToadletRuntimePorts runtimePorts) {
-    super(core, client, runtimePorts);
-    this.node = n;
+      HighLevelSimpleClient client, ConnectionsToadletRuntimePorts runtimePorts) {
+    super(client, runtimePorts);
+    this.connectionsSupportPort = runtimePorts.connectionsSupportPort();
   }
 
   /**
@@ -75,7 +67,7 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    */
   @Override
   public boolean isEnabled(ToadletContext ctx) {
-    return node.network().isOpennetEnabled();
+    return connectionsSupportPort.isOpennetEnabled();
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyConnectionsSupportPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyConnectionsSupportPort.java
@@ -1,0 +1,44 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import network.crypta.node.Node;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
+import network.crypta.support.io.FileUtil;
+
+/**
+ * Adapts the remaining connections-page support helpers behind the runtime SPI.
+ *
+ * <p>This bridge is intentionally narrow and transitional. It keeps the legacy opennet-enabled
+ * check and peer-offer file traversal inside the daemon root module while exposing only JDK-only
+ * values to the HTTP connections-family toadlets.
+ */
+final class LegacyConnectionsSupportPort implements ConnectionsSupportPort {
+  private final Node node;
+
+  LegacyConnectionsSupportPort(Node node) {
+    this.node = Objects.requireNonNull(node);
+  }
+
+  @Override
+  public boolean isOpennetEnabled() {
+    return node.network().isOpennetEnabled();
+  }
+
+  @Override
+  public String readPeerOfferReferencesText() throws IOException {
+    File[] files = node.runDir().file("peers-offers").listFiles();
+    if (files == null || files.length == 0) {
+      return "";
+    }
+
+    StringBuilder peerOfferReferencesText = new StringBuilder();
+    for (File file : files) {
+      if (file.isFile() && file.getName().endsWith(".fref")) {
+        peerOfferReferencesText.append(FileUtil.readUTF(file));
+      }
+    }
+    return peerOfferReferencesText.toString();
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -6,6 +6,7 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.ConnectivityPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -44,6 +45,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final ConfigPort configPort;
   private final ConnectivityPort connectivityPort;
   private final ConnectionsPagePort connectionsPagePort;
+  private final ConnectionsSupportPort connectionsSupportPort;
   private final DarknetConnectionsPort darknetConnectionsPort;
   private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
@@ -133,6 +135,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.configPort = new LegacyConfigPort(node, core);
     this.connectivityPort = new LegacyConnectivityPort(node);
     this.connectionsPagePort = new LegacyConnectionsPagePort(node, core);
+    this.connectionsSupportPort = new LegacyConnectionsSupportPort(node);
     this.darknetConnectionsPort = new LegacyDarknetConnectionsPort(node);
     this.darknetMessagingPort = new LegacyDarknetMessagingPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
@@ -217,6 +220,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public ConnectionsPagePort connectionsPage() {
     return connectionsPagePort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining legacy opennet-enabled check and peer-offer file
+   * traversal inside the daemon root module while exposing only JDK-only support values upstream.
+   */
+  @Override
+  public ConnectionsSupportPort connectionsSupport() {
+    return connectionsSupportPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -4,8 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,14 +12,12 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
 import network.crypta.node.DarknetPeerNodeStatus;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.ProgramDirectory;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
@@ -43,12 +39,12 @@ import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -82,28 +78,35 @@ class DarknetConnectionsToadletTest {
   private static final String OWN_NODE_PHYSICAL_UDP = "127.0.0.1:1234";
   private static final String TEST_NODE_IDENTIFIER = "peer-1";
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
   @Mock private ConnectionsPagePort connectionsPage;
+  @Mock private ConnectionsSupportPort connectionsSupportPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private PeerPort peerPort;
   @Mock private NodeInfoPort nodeInfoPort;
   @Mock private ConfigPort configPort;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
-  @TempDir Path tempDir;
 
   private DarknetConnectionsToadlet toadlet;
 
   @BeforeEach
   void setUp() {
     ConnectionsToadletRuntimePorts runtimePorts =
-        new ConnectionsToadletRuntimePorts(connectionsPage, peerPort, nodeInfoPort, configPort);
-    toadlet = new DarknetConnectionsToadlet(core, client, runtimePorts, darknetConnectionsPort);
+        new ConnectionsToadletRuntimePorts(
+            connectionsPage, peerPort, nodeInfoPort, configPort, connectionsSupportPort);
+    toadlet = new DarknetConnectionsToadlet(client, runtimePorts, darknetConnectionsPort);
     Mockito.lenient().when(request.isPartSet(anyString())).thenReturn(false);
+  }
+
+  @Test
+  void constructor_withoutNodeClientCoreDependency_acceptsRuntimePortsOnly() {
+    ConnectionsToadletRuntimePorts runtimePorts =
+        new ConnectionsToadletRuntimePorts(
+            connectionsPage, peerPort, nodeInfoPort, configPort, connectionsSupportPort);
+
+    assertDoesNotThrow(
+        () -> new DarknetConnectionsToadlet(client, runtimePorts, darknetConnectionsPort));
   }
 
   @Test
@@ -220,7 +223,6 @@ class DarknetConnectionsToadletTest {
     toadlet.handleAltPost(new URI("http://localhost/friends/"), request, ctx, false);
 
     verify(peerPort).writePrivateDarknetCommentByIdentity(TEST_NODE_IDENTIFIER, "new");
-    verifyNoInteractions(node);
     assertRedirectIssued();
   }
 
@@ -243,7 +245,6 @@ class DarknetConnectionsToadletTest {
     verify(peerPort).updateDarknetPeerByIdentity(eq(TEST_NODE_IDENTIFIER), updateCaptor.capture());
     assertEquals(Boolean.FALSE, updateCaptor.getValue().disabled());
     assertNull(updateCaptor.getValue().routingEnabled());
-    verifyNoInteractions(node);
     assertRedirectIssued();
   }
 
@@ -266,7 +267,6 @@ class DarknetConnectionsToadletTest {
         ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
     verify(peerPort).updateDarknetPeerByIdentity(eq(TEST_NODE_IDENTIFIER), updateCaptor.capture());
     assertEquals(PeerTrust.HIGH, updateCaptor.getValue().trust());
-    verifyNoInteractions(node);
     assertRedirectIssued();
   }
 
@@ -290,7 +290,6 @@ class DarknetConnectionsToadletTest {
         ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
     verify(peerPort).updateDarknetPeerByIdentity(eq(TEST_NODE_IDENTIFIER), updateCaptor.capture());
     assertEquals(PeerVisibility.NAME_ONLY, updateCaptor.getValue().visibility());
-    verifyNoInteractions(node);
     assertRedirectIssued();
   }
 
@@ -453,16 +452,6 @@ class DarknetConnectionsToadletTest {
   @Test
   void handleMethodPOST_whenUsingPeersOfferFiles_appliesDismissedOverrideAndAddsPeer()
       throws Exception {
-    Path peersOffersDir = Files.createDirectories(tempDir.resolve("peers-offers"));
-    Files.writeString(
-        peersOffersDir.resolve("offer.fref"),
-        "identity=offer-peer\nlastGoodVersion=1\nEnd\n",
-        StandardCharsets.UTF_8);
-
-    ProgramDirectory runDir = new ProgramDirectory();
-    runDir.move(tempDir.toString());
-    when(core.getNode()).thenReturn(node);
-    when(node.runDir()).thenReturn(runDir);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     when(request.isPartSet("add")).thenReturn(true);
     when(request.getPartAsStringFailsafe("url", 200)).thenReturn("");
@@ -472,6 +461,8 @@ class DarknetConnectionsToadletTest {
     when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("true");
     when(request.getPartAsStringFailsafe("trust", 10)).thenReturn(FRIEND_TRUST.NORMAL.name());
     when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn(FRIEND_VISIBILITY.NO.name());
+    when(connectionsSupportPort.readPeerOfferReferencesText())
+        .thenReturn("identity=offer-peer\nlastGoodVersion=1\nEnd\n");
     when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot("offer-peer"));
     PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
     when(ctx.getPageMaker()).thenReturn(pageMaker);
@@ -479,6 +470,7 @@ class DarknetConnectionsToadletTest {
 
     toadlet.handleMethodPOST(URI.create("http://localhost/friends/"), request, ctx);
 
+    verify(connectionsSupportPort).readPeerOfferReferencesText();
     verify(configPort).applyOverrides(Map.of("node.peersOffersDismissed", "true"));
     ArgumentCaptor<PeerFieldSet> fieldSetCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
     verify(peerPort).add(fieldSetCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.NO));
@@ -555,7 +547,6 @@ class DarknetConnectionsToadletTest {
         peerNodeReferenceFieldSet().toString(),
         new String(bodyCaptor.getValue(), StandardCharsets.UTF_8));
     verify(darknetConnectionsPort).exportPeerReference(peerHash);
-    verifyNoInteractions(node);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -8,8 +8,6 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerNodeStatus;
 import network.crypta.runtime.spi.ConfigPort;
@@ -17,6 +15,7 @@ import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
@@ -42,6 +41,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,12 +53,9 @@ class OpennetConnectionsToadletTest {
   private static final String OWN_NODE_IDENTITY = "peer-1";
   private static final String OWN_NODE_LAST_GOOD_VERSION = "1";
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
   @Mock private ConnectionsPagePort connectionsPage;
+  @Mock private ConnectionsSupportPort connectionsSupportPort;
   @Mock private PeerPort peerPort;
   @Mock private NodeInfoPort nodeInfoPort;
   @Mock private ConfigPort configPort;
@@ -70,8 +67,18 @@ class OpennetConnectionsToadletTest {
   @BeforeEach
   void setUp() {
     ConnectionsToadletRuntimePorts runtimePorts =
-        new ConnectionsToadletRuntimePorts(connectionsPage, peerPort, nodeInfoPort, configPort);
-    toadlet = new OpennetConnectionsToadlet(node, core, client, runtimePorts);
+        new ConnectionsToadletRuntimePorts(
+            connectionsPage, peerPort, nodeInfoPort, configPort, connectionsSupportPort);
+    toadlet = new OpennetConnectionsToadlet(client, runtimePorts);
+  }
+
+  @Test
+  void constructor_withoutNodeOrNodeClientCoreDependency_acceptsRuntimePortsOnly() {
+    ConnectionsToadletRuntimePorts runtimePorts =
+        new ConnectionsToadletRuntimePorts(
+            connectionsPage, peerPort, nodeInfoPort, configPort, connectionsSupportPort);
+
+    assertDoesNotThrow(() -> new OpennetConnectionsToadlet(client, runtimePorts));
   }
 
   @Test
@@ -80,14 +87,12 @@ class OpennetConnectionsToadletTest {
   }
 
   @Test
-  void isEnabled_returnsNodeFlag() {
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.isOpennetEnabled()).thenReturn(true).thenReturn(false);
+  void isEnabled_whenQueried_usesConnectionsSupportPort() {
+    when(connectionsSupportPort.isOpennetEnabled()).thenReturn(true).thenReturn(false);
 
     assertTrue(toadlet.isEnabled(null));
     assertFalse(toadlet.isEnabled(null));
+    verify(connectionsSupportPort, times(2)).isOpennetEnabled();
   }
 
   @Test

--- a/src/test/java/network/crypta/node/runtime/LegacyConnectionsSupportPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyConnectionsSupportPortTest.java
@@ -1,0 +1,98 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.node.Node;
+import network.crypta.node.ProgramDirectory;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyConnectionsSupportPortTest {
+
+  @Mock private Node node;
+
+  @TempDir private Path tempDir;
+
+  private LegacyConnectionsSupportPort port;
+
+  @BeforeEach
+  void setUp() {
+    port = new LegacyConnectionsSupportPort(node);
+  }
+
+  @Test
+  void isOpennetEnabled_whenQueried_delegatesToNetworkSubsystem() {
+    NodeNetworkSubsystem network = org.mockito.Mockito.mock(NodeNetworkSubsystem.class);
+    when(node.network()).thenReturn(network);
+    when(network.isOpennetEnabled()).thenReturn(true).thenReturn(false);
+
+    assertTrue(port.isOpennetEnabled());
+    assertFalse(port.isOpennetEnabled());
+  }
+
+  @Test
+  void readPeerOfferReferencesText_whenPeersOffersDirectoryMissingOrEmpty_returnsEmptyString()
+      throws Exception {
+    stubRunDir();
+
+    assertEquals("", port.readPeerOfferReferencesText());
+
+    Files.createDirectories(tempDir.resolve("peers-offers"));
+
+    assertEquals("", port.readPeerOfferReferencesText());
+  }
+
+  @Test
+  void readPeerOfferReferencesText_whenFrefFilesPresent_readsAndConcatenatesMatchesOnly()
+      throws Exception {
+    stubRunDir();
+    Path peersOffersDir = Files.createDirectories(tempDir.resolve("peers-offers"));
+    Files.writeString(
+        peersOffersDir.resolve("offer-a.fref"),
+        "identity=alpha\nlastGoodVersion=1\nEnd\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        peersOffersDir.resolve("ignored.txt"),
+        "identity=ignored\nlastGoodVersion=9\nEnd\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        peersOffersDir.resolve("offer-b.fref"),
+        "identity=beta\nlastGoodVersion=2\nEnd\n",
+        StandardCharsets.UTF_8);
+
+    String actual = port.readPeerOfferReferencesText();
+
+    File[] encounteredFiles = peersOffersDir.toFile().listFiles();
+    assertNotNull(encounteredFiles);
+    StringBuilder expected = new StringBuilder();
+    for (File file : encounteredFiles) {
+      if (file.isFile() && file.getName().endsWith(".fref")) {
+        expected.append(Files.readString(file.toPath(), StandardCharsets.UTF_8));
+      }
+    }
+
+    assertEquals(expected.toString(), actual);
+    assertFalse(actual.contains("ignored"));
+  }
+
+  private void stubRunDir() throws Exception {
+    ProgramDirectory runDir = new ProgramDirectory();
+    runDir.move(tempDir.toString());
+    when(node.runDir()).thenReturn(runDir);
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow `ConnectionsSupportPort` runtime SPI for opennet enablement and peer-offer imports
- route `ConnectionsToadlet`, `DarknetConnectionsToadlet`, `OpennetConnectionsToadlet`, and `FProxyRegistrar` through detached runtime ports instead of direct `Node` / `NodeClientCore` dependencies
- add focused coverage for the new legacy adapter and the updated darknet/opennet toadlet wiring

## How to test
- `./gradlew test --tests "network.crypta.node.runtime.LegacyConnectionsSupportPortTest"`
- `./gradlew test --tests "network.crypta.clients.http.OpennetConnectionsToadletTest"`
- `./gradlew test --tests "network.crypta.clients.http.DarknetConnectionsToadletTest"`
- `./gradlew test`

## Notes
- preserves existing friends/strangers page behavior while keeping the support concerns out of `ConnectionsPagePort` and `NodeInfoPort`
- leaves `DarknetAddRefToadlet` for a follow-up PR
