### PR TITLE
refactor(http): SPI-ify DarknetAddRefToadlet

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -29,7 +29,9 @@ Use this skill when you need to:
 - The runtime boundary is split intentionally:
   - `:runtime-spi` exposes small JDK-only ports and immutable config DTOs.
   - The root project implements those ports in `network.crypta.node.runtime.LegacyRuntimePorts`
-    and `LegacyConfigPort`.
+    plus per-slice adapters such as `LegacyConfigPort`, `LegacyNodeInfoPort`, `LegacyPeerPort`,
+    `LegacyConnectionsPagePort`, `LegacyConnectionsSupportPort`,
+    `LegacyDarknetConnectionsPort`, and `LegacyDarknetMessagingPort`.
 - The large cyclic daemon core still lives in the root project:
   `network.crypta.node`, `network.crypta.io`, `network.crypta.client`,
   `network.crypta.clients`, `network.crypta.support`, `network.crypta.config`,
@@ -67,15 +69,34 @@ Use this skill when you need to:
     through `RuntimePorts`.
   - `FcpRuntimeAdapters` preserves legacy FCP-local shapes such as `PriorityAwareExecutor` and
     `RandomSource` on top of the SPI.
+  - Detached peer-management operations such as `ModifyPeer` now go through `RuntimePorts#peer()`.
 - HTTP interface: `network.crypta.clients.http`
+  - The migrated management slices no longer depend directly on live daemon peers or node-info
+    exports for their core data flow.
+  - `ConnectionsToadlet`, `DarknetConnectionsToadlet`, `OpennetConnectionsToadlet`, and
+    `DarknetAddRefToadlet` use detached ports such as `ConnectionsPagePort`,
+    `ConnectionsSupportPort`, `PeerPort`, and `NodeInfoPort`.
+  - `N2NTMToadlet` uses `DarknetConnectionsPort` and `DarknetMessagingPort` for selected-peer
+    lookup, transfer confirmations, and compose/send actions.
 
 ### Runtime SPI (`network.crypta.runtime.spi`)
 - Aggregate boundary: `RuntimePorts`
-- Small ports: `ExecutionPort`, `RandomnessPort`, `TransferAccessPort`, `LifecyclePort`,
-  `ConfigPort`
-- Immutable config DTOs: `ConfigSnapshot`, `ConfigFieldSet`, `ConfigSection`
+- Small ports include: `ExecutionPort`, `RandomnessPort`, `TransferAccessPort`, `LifecyclePort`,
+  `ConfigPort`, `ConnectivityPort`, `ConnectionsPagePort`, `ConnectionsSupportPort`,
+  `DarknetConnectionsPort`, `DarknetMessagingPort`, `DiagnosticPort`, `StatisticsPort`,
+  `RequestQueuePort`, `NodeInfoPort`, and `PeerPort`
+- Detached DTOs include config, connectivity, peer, darknet-friends, node-reference, and
+  statistics/report snapshot types such as `ConfigSnapshot`, `ConfigFieldSet`, `ConfigSection`,
+  `PeerSnapshot`, `DarknetConnectionPeerSnapshot`, `DarknetUploadedFile`, and
+  `NodeReferenceSnapshot`
 - Root adapters: `network.crypta.node.runtime.LegacyRuntimePorts`,
-  `network.crypta.node.runtime.LegacyConfigPort`
+  `network.crypta.node.runtime.LegacyConfigPort`,
+  `network.crypta.node.runtime.LegacyNodeInfoPort`,
+  `network.crypta.node.runtime.LegacyPeerPort`,
+  `network.crypta.node.runtime.LegacyConnectionsPagePort`,
+  `network.crypta.node.runtime.LegacyConnectionsSupportPort`,
+  `network.crypta.node.runtime.LegacyDarknetConnectionsPort`,
+  `network.crypta.node.runtime.LegacyDarknetMessagingPort`
 
 ### Plugin system (`network.crypta.pluginmanager`)
 - Management: `PluginManager`
@@ -84,8 +105,10 @@ Use this skill when you need to:
 
 ### Configuration (`network.crypta.config`)
 - Type-safe configuration with persistence
-- Higher layers should prefer `RuntimePorts#config()` over traversing daemon config internals
-  directly when the SPI already covers the needed operation
+- Higher layers should prefer the narrow `RuntimePorts` sub-port that already covers the needed
+  operation (`config()`, `peer()`, `nodeInfo()`, `connectionsPage()`, `connectionsSupport()`,
+  `darknetConnections()`, `darknetMessaging()`, etc.) instead of traversing daemon internals
+  directly
 
 ### Supporting infrastructure (`network.crypta.support`)
 - Logging, data structures, threading, helpers

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Cryptad now uses a partial multi-project Gradle build.
 - `:foundation-fs` owns `network.crypta.fs`.
 - `:foundation-compat` owns `network.crypta.compat`.
 - `:runtime-spi` owns `network.crypta.runtime.spi` and the JDK-only runtime/config boundary used
-  by higher layers.
+  by higher layers, including the migrated FCP peer-management and admin-HTTP connections-family
+  slices.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
@@ -178,7 +179,8 @@ Cryptad now uses a partial multi-project Gradle build.
 - The large cyclic daemon core remains in the root project for now, and all tests still live there.
 - Higher-level infrastructure now crosses a narrower boundary through
   `network.crypta.runtime.spi.RuntimePorts`, implemented in the root project by
-  `network.crypta.node.runtime.LegacyRuntimePorts`.
+  `network.crypta.node.runtime.LegacyRuntimePorts`, plus a few HTTP-local wiring records such as
+  `network.crypta.clients.http.ConnectionsToadletRuntimePorts`.
 
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
 `gradle/wrapper/gradle-wrapper.properties`). To also verify the download by checksum, add
@@ -503,10 +505,15 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 - Keys (`network.crypta.keys`): `ClientCHK`, `ClientSSK`, `FreenetURI`, USK.
 - Clients: `network.crypta.client`, FCP (`network.crypta.clients.fcp`), HTTP
   (`network.crypta.clients.http`). FCP now consumes execution, randomness, transfer policy,
-  lifecycle, and config access through `RuntimePorts` and FCP-local adapters instead of reaching
-  directly into daemon internals for those concerns.
-- Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and immutable config DTOs such as
-  `RuntimePorts`, `ConfigPort`, `ConfigSnapshot`, and `ConfigFieldSet`.
+  lifecycle, config access, and detached peer mutations through `RuntimePorts` and FCP-local
+  adapters instead of reaching directly into daemon internals for those concerns. The migrated HTTP
+  management slices now also consume detached runtime ports for connectivity, friends/strangers
+  page snapshots, add-friend installer metadata, local noderef export, selected-peer actions, and
+  N2NTM compose/send flows.
+- Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and detached DTOs such as
+  `RuntimePorts`, `ConfigPort`, `NodeInfoPort`, `PeerPort`, `ConnectionsPagePort`,
+  `ConnectionsSupportPort`, `DarknetConnectionsPort`, `DarknetMessagingPort`, `ConfigSnapshot`,
+  and `ConfigFieldSet`.
 - Config (`network.crypta.config`): type‑safe persisted configuration retained in the root daemon
   and exposed upstream through `network.crypta.node.runtime.LegacyConfigPort` via
   `RuntimePorts#config()`.

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsInstallerSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsInstallerSnapshot.java
@@ -1,0 +1,30 @@
+package network.crypta.runtime.spi;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * Detached metadata for one add-friend installer download target.
+ *
+ * <p>This snapshot preserves the legacy installer behavior used by the add-friend HTTP page while
+ * keeping daemon-only updater types out of the runtime SPI. Callers receive the short download
+ * filename, an optional already-downloaded local file, and the legacy fallback source text used to
+ * build a freenet-relative link such as {@code "/" + sourceUriText}.
+ *
+ * @param filename short installer filename served from {@code /addfriend/}
+ * @param localFile existing readable local installer file, or {@code null} when the installer is
+ *     not currently cached on disk
+ * @param sourceUriText legacy fallback source text used to build the installer link when no local
+ *     file is available
+ */
+public record ConnectionsInstallerSnapshot(String filename, File localFile, String sourceUriText) {
+  /**
+   * Creates an immutable installer snapshot.
+   *
+   * @throws NullPointerException if {@code filename} or {@code sourceUriText} is {@code null}
+   */
+  public ConnectionsInstallerSnapshot {
+    Objects.requireNonNull(filename, "filename");
+    Objects.requireNonNull(sourceUriText, "sourceUriText");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsSupportPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsSupportPort.java
@@ -6,15 +6,38 @@ import java.io.IOException;
  * Exposes the narrow legacy connections-page support capability still needed by the HTTP layer.
  *
  * <p>This port is intentionally transitional and page-oriented. The legacy friends and strangers
- * pages still need one feature-flag check and one file-backed noderef import source, but those
- * concerns do not justify widening broader runtime SPI surfaces such as {@link ConnectionsPagePort}
- * or {@link NodeInfoPort}. Implementations may delegate to live daemon state internally while
- * exposing only JDK-only types here.
+ * pages still need a small set of support helpers that do not justify widening broader runtime SPI
+ * surfaces such as {@link ConnectionsPagePort} or {@link NodeInfoPort}: installer download metadata
+ * for the add-friend page, one feature-flag check, and one file-backed noderef import source.
+ * Implementations may delegate to live daemon state internally while exposing only JDK-only types
+ * here.
  *
  * <p>The port is not a general node API. It exists only to finish removing direct daemon-root
  * dependencies from the legacy connections-family HTTP toadlets.
  */
 public interface ConnectionsSupportPort {
+  /**
+   * Returns the detached metadata for the Windows installer offered by the add-friend page.
+   *
+   * <p>The returned snapshot must preserve the current legacy semantics: when the local file is
+   * present, callers can stream it directly from the add-friend endpoint; otherwise they can build
+   * the fallback link from {@code "/" + sourceUriText}.
+   *
+   * @return current Windows installer snapshot for add-friend download handling
+   */
+  ConnectionsInstallerSnapshot windowsInstaller();
+
+  /**
+   * Returns the detached metadata for the non-Windows installer offered by the add-friend page.
+   *
+   * <p>The returned snapshot must preserve the current legacy semantics: when the local file is
+   * present, callers can stream it directly from the add-friend endpoint; otherwise they can build
+   * the fallback link from {@code "/" + sourceUriText}.
+   *
+   * @return current non-Windows installer snapshot for add-friend download handling
+   */
+  ConnectionsInstallerSnapshot nonWindowsInstaller();
+
   /**
    * Returns whether opennet support is currently enabled.
    *

--- a/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
@@ -3,11 +3,15 @@ package network.crypta.clients.http;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
-import network.crypta.node.NodeFile;
-import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.spi.ConnectionsInstallerSnapshot;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
@@ -25,11 +29,11 @@ import network.crypta.support.io.FileBucket;
  * ToadletContext)} builds the page via {@link PageMaker}, and {@link #getNoderef()} supplies the
  * serialized public fields.
  *
- * <p>Thread safety: the class is stateless beyond references to {@link Node} and the companion
- * toadlet; it relies on the surrounding HTTP framework for synchronization. Instances are usually
- * constructed once at node startup and reused for many requests. It assumes the {@link Node}
- * provides up-to-date installers and noderefs and that callers perform access checks via the
- * provided {@link ToadletContext}.
+ * <p>Thread safety: the class is stateless beyond references to runtime SPI collaborators and the
+ * companion toadlet; it relies on the surrounding HTTP framework for synchronization. Instances are
+ * usually constructed once at node startup and reused for many requests. It assumes those
+ * collaborators provide up-to-date installers and noderefs and that callers perform access checks
+ * via the provided {@link ToadletContext}.
  *
  * <ul>
  *   <li>Renders localized explanations and guidance for adding a friend.
@@ -38,34 +42,41 @@ import network.crypta.support.io.FileBucket;
  * </ul>
  *
  * @see DarknetConnectionsToadlet
- * @see NodeNetworkSubsystem#exportDarknetPublicFieldSet()
+ * @see NodeInfoPort
  */
 public class DarknetAddRefToadlet extends Toadlet {
 
-  private final Node node;
+  private final ConnectionsSupportPort connectionsSupportPort;
+  private final NodeInfoPort nodeInfoPort;
   private final DarknetConnectionsToadlet friendsToadlet;
 
   /**
    * Creates the toadlet with the dependencies required to generate darknet onboarding pages.
    *
-   * <p>The constructor wires the owning {@link Node} for state such as installer paths and noderef
-   * export, the high-level client for inherited toadlet functionality, and the companion
-   * connections toadlet used to draw peer-related UI sections. Callers typically instantiate this
-   * once during HTTP handler setup and keep it alive for the lifetime of the node so that cached
-   * installers remain accessible and localization resources stay loaded.
+   * <p>The constructor wires the runtime SPI collaborators that provide installer metadata and
+   * darknet noderef export, plus the companion connections toadlet used to draw peer-related UI
+   * sections. Callers typically instantiate this once during HTTP handler setup and keep it alive
+   * for the lifetime of the node so that cached installers remain accessible and localization
+   * resources stay loaded.
    *
-   * @param n node instance supplying installer access and noderef export; must not be {@code null}
-   *     and should outlive the toadlet.
+   * @param connectionsSupportPort support port supplying installer metadata; must not be {@code
+   *     null}
+   * @param nodeInfoPort node-info port supplying the public darknet noderef export; must not be
+   *     {@code null}
    * @param client high-level HTTP client the superclass relies on for responses and redirects; may
    *     share the lifecycle of the enclosing HTTP server.
    * @param friendsToadlet companion toadlet used to render friend lists and noderef boxes within
    *     this page; should correspond to the same node instance.
    */
   protected DarknetAddRefToadlet(
-      Node n, HighLevelSimpleClient client, DarknetConnectionsToadlet friendsToadlet) {
+      ConnectionsSupportPort connectionsSupportPort,
+      NodeInfoPort nodeInfoPort,
+      HighLevelSimpleClient client,
+      DarknetConnectionsToadlet friendsToadlet) {
     super(client);
-    this.node = n;
-    this.friendsToadlet = friendsToadlet;
+    this.connectionsSupportPort = Objects.requireNonNull(connectionsSupportPort);
+    this.nodeInfoPort = Objects.requireNonNull(nodeInfoPort);
+    this.friendsToadlet = Objects.requireNonNull(friendsToadlet);
   }
 
   /**
@@ -102,22 +113,19 @@ public class DarknetAddRefToadlet extends Toadlet {
     if (!ctx.checkFullAccess(this)) return;
 
     String path = uri.getPath();
-    if (path.endsWith(NodeFile.INSTALLER_WINDOWS.getFilename())) {
-      File installer = node.services().nodeUpdater().getInstallerWindows();
-      if (installer != null) {
-        FileBucket bucket = new FileBucket(installer, true, false, false, false);
-        this.writeReply(ctx, ReplyHeaders.of(200, "OK", "application/x-msdownload"), bucket);
-        return;
-      }
+    ConnectionsInstallerSnapshot windowsInstaller = connectionsSupportPort.windowsInstaller();
+    if (path.endsWith(windowsInstaller.filename()) && windowsInstaller.localFile() != null) {
+      FileBucket bucket = new FileBucket(windowsInstaller.localFile(), true, false, false, false);
+      this.writeReply(ctx, ReplyHeaders.of(200, "OK", "application/x-msdownload"), bucket);
+      return;
     }
 
-    if (path.endsWith(NodeFile.INSTALLER_NON_WINDOWS.getFilename())) {
-      File installer = node.services().nodeUpdater().getInstallerNonWindows();
-      if (installer != null) {
-        FileBucket bucket = new FileBucket(installer, true, false, false, false);
-        this.writeReply(ctx, ReplyHeaders.of(200, "OK", "application/x-java-archive"), bucket);
-        return;
-      }
+    ConnectionsInstallerSnapshot nonWindowsInstaller = connectionsSupportPort.nonWindowsInstaller();
+    if (path.endsWith(nonWindowsInstaller.filename()) && nonWindowsInstaller.localFile() != null) {
+      FileBucket bucket =
+          new FileBucket(nonWindowsInstaller.localFile(), true, false, false, false);
+      this.writeReply(ctx, ReplyHeaders.of(200, "OK", "application/x-java-archive"), bucket);
+      return;
     }
 
     PageMaker pageMaker = ctx.getPageMaker();
@@ -137,8 +145,8 @@ public class DarknetAddRefToadlet extends Toadlet {
     boxContent.addChild("p", l10n("explainBox1"));
     boxContent.addChild("p", l10n("explainBox2"));
 
-    File installer = node.services().nodeUpdater().getInstallerWindows();
-    String shortFilename = NodeFile.INSTALLER_WINDOWS.getFilename();
+    File installer = windowsInstaller.localFile();
+    String shortFilename = windowsInstaller.filename();
 
     HTMLNode p = boxContent.addChild("p");
 
@@ -157,13 +165,10 @@ public class DarknetAddRefToadlet extends Toadlet {
               p,
               "DarknetAddRefToadlet.explainInstallerWindowsNotYet",
               new String[] {"link"},
-              new HTMLNode[] {
-                HTMLNode.link(
-                    "/" + node.services().nodeUpdater().getInstallerWindowsURI().toString())
-              });
+              new HTMLNode[] {HTMLNode.link("/" + windowsInstaller.sourceUriText())});
 
-    installer = node.services().nodeUpdater().getInstallerNonWindows();
-    shortFilename = NodeFile.INSTALLER_NON_WINDOWS.getFilename();
+    installer = nonWindowsInstaller.localFile();
+    shortFilename = nonWindowsInstaller.filename();
 
     boxContent.addChild("#", " ");
 
@@ -187,8 +192,7 @@ public class DarknetAddRefToadlet extends Toadlet {
               "DarknetAddRefToadlet.explainInstallerNonWindowsNotYet",
               new String[] {"link", "shortfilename"},
               new HTMLNode[] {
-                HTMLNode.link(
-                    "/" + node.services().nodeUpdater().getInstallerNonWindowsURI().toString()),
+                HTMLNode.link("/" + nonWindowsInstaller.sourceUriText()),
                 HTMLNode.text(shortFilename)
               });
 
@@ -203,17 +207,29 @@ public class DarknetAddRefToadlet extends Toadlet {
    * Exposes the public darknet noderef for this node as a field set suitable for embedding in
    * responses.
    *
-   * <p>The returned {@link SimpleFieldSet} contains only public fields and is constructed by the
-   * underlying {@link Node} at call time, ensuring that peers receive up-to-date routing and key
-   * material. Callers should treat the object as read-only and avoid persisting it beyond the
-   * immediate HTTP response, because it reflects the node’s current configuration and may change
-   * when peers or keys are rotated.
+   * <p>The returned {@link SimpleFieldSet} contains only public fields and is rebuilt from the
+   * detached runtime noderef export at call time, ensuring that peers receive up-to-date routing
+   * and key material. Callers should treat the object as read-only and avoid persisting it beyond
+   * the immediate HTTP response, because it reflects the node’s current configuration and may
+   * change when peers or keys are rotated.
    *
-   * @return immutable view of the node’s exported darknet reference fields; ownership remains with
-   *     the caller for serialization but should not be mutated.
+   * @return field set view of the current exported darknet reference; ownership remains with the
+   *     caller for serialization but should not be mutated.
    */
   protected SimpleFieldSet getNoderef() {
-    return node.network().exportDarknetPublicFieldSet();
+    return toSimpleFieldSet(
+        nodeInfoPort.exportReference(NodeReferenceView.DARKNET_PUBLIC, false).root());
+  }
+
+  private static SimpleFieldSet toSimpleFieldSet(NodeFieldSet source) {
+    SimpleFieldSet target = new SimpleFieldSet(true);
+    for (Map.Entry<String, String> entry : source.directValues().entrySet()) {
+      target.putSingle(entry.getKey(), entry.getValue());
+    }
+    for (Map.Entry<String, NodeFieldSet> entry : source.directSubsets().entrySet()) {
+      target.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
+    }
+    return target;
   }
 
   private static String l10n(String string) {

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -277,7 +277,9 @@ final class FProxyRegistrar {
             true,
             null));
 
-    DarknetAddRefToadlet addRefToadlet = new DarknetAddRefToadlet(node, client, friendsToadlet);
+    DarknetAddRefToadlet addRefToadlet =
+        new DarknetAddRefToadlet(
+            runtimePorts.connectionsSupport(), runtimePorts.nodeInfo(), client, friendsToadlet);
     server.register(
         addRefToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/node/runtime/LegacyConnectionsSupportPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyConnectionsSupportPort.java
@@ -4,21 +4,42 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
 import network.crypta.node.Node;
+import network.crypta.node.NodeFile;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.runtime.spi.ConnectionsInstallerSnapshot;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.support.io.FileUtil;
 
 /**
  * Adapts the remaining connections-page support helpers behind the runtime SPI.
  *
- * <p>This bridge is intentionally narrow and transitional. It keeps the legacy opennet-enabled
- * check and peer-offer file traversal inside the daemon root module while exposing only JDK-only
- * values to the HTTP connections-family toadlets.
+ * <p>This bridge is intentionally narrow and transitional. It keeps the legacy add-friend installer
+ * lookups, opennet-enabled check, and peer-offer file traversal inside the daemon root module while
+ * exposing only JDK-only values to the HTTP connections-family toadlets.
  */
 final class LegacyConnectionsSupportPort implements ConnectionsSupportPort {
   private final Node node;
 
   LegacyConnectionsSupportPort(Node node) {
     this.node = Objects.requireNonNull(node);
+  }
+
+  @Override
+  public ConnectionsInstallerSnapshot windowsInstaller() {
+    NodeUpdateManager nodeUpdater = node.services().nodeUpdater();
+    return new ConnectionsInstallerSnapshot(
+        NodeFile.INSTALLER_WINDOWS.getFilename(),
+        nodeUpdater.getInstallerWindows(),
+        nodeUpdater.getInstallerWindowsURI().toString());
+  }
+
+  @Override
+  public ConnectionsInstallerSnapshot nonWindowsInstaller() {
+    NodeUpdateManager nodeUpdater = node.services().nodeUpdater();
+    return new ConnectionsInstallerSnapshot(
+        NodeFile.INSTALLER_NON_WINDOWS.getFilename(),
+        nodeUpdater.getInstallerNonWindows(),
+        nodeUpdater.getInstallerNonWindowsURI().toString());
   }
 
   @Override

--- a/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
@@ -5,13 +5,17 @@ import java.io.File;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
 import network.crypta.node.NodeFile;
-import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.runtime.spi.ConnectionsInstallerSnapshot;
+import network.crypta.runtime.spi.ConnectionsSupportPort;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
@@ -27,13 +31,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -46,10 +50,8 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 class DarknetAddRefToadletTest {
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeUpdateManager nodeUpdater;
+  @Mock private ConnectionsSupportPort connectionsSupportPort;
+  @Mock private NodeInfoPort nodeInfoPort;
   @Mock private HighLevelSimpleClient client;
   @Mock private DarknetConnectionsToadlet friendsToadlet;
   @Mock private ToadletContext ctx;
@@ -59,11 +61,22 @@ class DarknetAddRefToadletTest {
 
   @BeforeEach
   void setUp() {
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    lenient().when(services.nodeUpdater()).thenReturn(nodeUpdater);
-    toadlet = new TestableDarknetAddRefToadlet(node, client, friendsToadlet);
+    lenient()
+        .when(connectionsSupportPort.windowsInstaller())
+        .thenReturn(
+            new ConnectionsInstallerSnapshot(
+                NodeFile.INSTALLER_WINDOWS.getFilename(), null, "CHK@windows-installer"));
+    lenient()
+        .when(connectionsSupportPort.nonWindowsInstaller())
+        .thenReturn(
+            new ConnectionsInstallerSnapshot(
+                NodeFile.INSTALLER_NON_WINDOWS.getFilename(), null, "CHK@nonwindows-installer"));
+    lenient()
+        .when(nodeInfoPort.exportReference(NodeReferenceView.DARKNET_PUBLIC, false))
+        .thenReturn(sampleNoderefSnapshot());
+    toadlet =
+        new TestableDarknetAddRefToadlet(
+            connectionsSupportPort, nodeInfoPort, client, friendsToadlet);
   }
 
   @Test
@@ -76,7 +89,10 @@ class DarknetAddRefToadletTest {
     }
 
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
-    when(nodeUpdater.getInstallerWindows()).thenReturn(installer);
+    when(connectionsSupportPort.windowsInstaller())
+        .thenReturn(
+            new ConnectionsInstallerSnapshot(
+                NodeFile.INSTALLER_WINDOWS.getFilename(), installer, "CHK@windows-installer"));
 
     URI path = new URI(toadlet.path() + NodeFile.INSTALLER_WINDOWS.getFilename());
     toadlet.handleMethodGET(path, request, ctx);
@@ -99,7 +115,12 @@ class DarknetAddRefToadletTest {
     }
 
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
-    when(nodeUpdater.getInstallerNonWindows()).thenReturn(installer);
+    when(connectionsSupportPort.nonWindowsInstaller())
+        .thenReturn(
+            new ConnectionsInstallerSnapshot(
+                NodeFile.INSTALLER_NON_WINDOWS.getFilename(),
+                installer,
+                "CHK@nonwindows-installer"));
 
     URI path = new URI(toadlet.path() + NodeFile.INSTALLER_NON_WINDOWS.getFilename());
     toadlet.handleMethodGET(path, request, ctx);
@@ -113,7 +134,7 @@ class DarknetAddRefToadletTest {
   }
 
   @Test
-  void handleMethodGET_whenAccessDenied_doesNotTouchNode() throws Exception {
+  void handleMethodGET_whenAccessDenied_doesNotTouchRuntimePorts() throws Exception {
     when(ctx.checkFullAccess(toadlet)).thenReturn(false);
 
     URI path = new URI(toadlet.path() + NodeFile.INSTALLER_WINDOWS.getFilename());
@@ -121,16 +142,12 @@ class DarknetAddRefToadletTest {
 
     assertFalse(toadlet.writeReplyCalled);
     verify(ctx, times(1)).checkFullAccess(toadlet);
-    verifyNoMoreInteractions(nodeUpdater);
+    verifyNoMoreInteractions(connectionsSupportPort, nodeInfoPort);
   }
 
   @Test
   void handleMethodGET_whenInstallersMissing_rendersHtmlPage() throws Exception {
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
-    when(nodeUpdater.getInstallerWindows()).thenReturn(null);
-    when(nodeUpdater.getInstallerNonWindows()).thenReturn(null);
-    when(nodeUpdater.getInstallerWindowsURI()).thenReturn(new FreenetURI("CHK", "win"));
-    when(nodeUpdater.getInstallerNonWindowsURI()).thenReturn(new FreenetURI("CHK", "unix"));
 
     HTMLNode content = new HTMLNode("div");
     HTMLNode pageOuter = new HTMLNode("div");
@@ -157,14 +174,8 @@ class DarknetAddRefToadletTest {
               return boxContent;
             });
 
-    SimpleFieldSet noderef = new SimpleFieldSet(false);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.exportDarknetPublicFieldSet()).thenReturn(noderef);
     String friendsPath = "/friends/";
     when(friendsToadlet.path()).thenReturn(friendsPath);
-    doNothing().when(friendsToadlet).drawNoderefBox(content, noderef);
 
     try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
         MockedStatic<ConnectionsToadlet> connections = mockStatic(ConnectionsToadlet.class)) {
@@ -172,9 +183,7 @@ class DarknetAddRefToadletTest {
       BaseL10n baseL10n = mock(BaseL10n.class);
       nodeL10n.when(NodeL10n::getBase).thenReturn(baseL10n);
       when(baseL10n.getString(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
-      doAnswer(invocation -> null)
-          .when(baseL10n)
-          .addL10nSubstitution(any(), anyString(), any(), any());
+      doAnswer(_ -> null).when(baseL10n).addL10nSubstitution(any(), anyString(), any(), any());
 
       toadlet.handleMethodGET(new URI(toadlet.path()), request, ctx);
 
@@ -184,19 +193,47 @@ class DarknetAddRefToadletTest {
 
       connections.verify(
           () -> ConnectionsToadlet.drawAddPeerBox(content, ctx, false, friendsPath), times(1));
-      verify(friendsToadlet, times(1)).drawNoderefBox(content, noderef);
+      verify(nodeInfoPort).exportReference(NodeReferenceView.DARKNET_PUBLIC, false);
+      verify(friendsToadlet, times(1))
+          .drawNoderefBox(eq(content), argThat(DarknetAddRefToadletTest::isExpectedNoderef));
     }
   }
 
   @Test
-  void getNoderef_returnsNodeExport() {
-    SimpleFieldSet expected = new SimpleFieldSet(false);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.exportDarknetPublicFieldSet()).thenReturn(expected);
+  void handleMethodGET_whenInstallerPathRequestedWithoutLocalFile_rendersHtmlPageFallback()
+      throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
-    assertSame(expected, toadlet.getNoderef());
+    HTMLNode content = new HTMLNode("div");
+    stubPageRendering(content);
+    when(friendsToadlet.path()).thenReturn("/friends/");
+
+    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
+        MockedStatic<ConnectionsToadlet> connections = mockStatic(ConnectionsToadlet.class)) {
+      BaseL10n baseL10n = mock(BaseL10n.class);
+      nodeL10n.when(NodeL10n::getBase).thenReturn(baseL10n);
+      when(baseL10n.getString(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+      doAnswer(_ -> null).when(baseL10n).addL10nSubstitution(any(), anyString(), any(), any());
+
+      URI path = new URI(toadlet.path() + NodeFile.INSTALLER_WINDOWS.getFilename());
+      toadlet.handleMethodGET(path, request, ctx);
+
+      assertFalse(toadlet.writeReplyCalled);
+      assertTrue(toadlet.writeHtmlCalled);
+      connections.verify(
+          () -> ConnectionsToadlet.drawAddPeerBox(content, ctx, false, "/friends/"), times(1));
+    }
+  }
+
+  @Test
+  void getNoderef_returnsSimpleFieldSetConvertedFromRuntimeExport() {
+    SimpleFieldSet actual = toadlet.getNoderef();
+    SimpleFieldSet physical = actual.subset("physical");
+
+    assertEquals("alice", actual.get("myName"));
+    assertNotNull(physical);
+    assertEquals("127.0.0.1", physical.get("udp"));
+    verify(nodeInfoPort).exportReference(NodeReferenceView.DARKNET_PUBLIC, false);
   }
 
   @Test
@@ -214,8 +251,11 @@ class DarknetAddRefToadletTest {
     String lastHtml;
 
     TestableDarknetAddRefToadlet(
-        Node node, HighLevelSimpleClient client, DarknetConnectionsToadlet friendsToadlet) {
-      super(node, client, friendsToadlet);
+        ConnectionsSupportPort connectionsSupportPort,
+        NodeInfoPort nodeInfoPort,
+        HighLevelSimpleClient client,
+        DarknetConnectionsToadlet friendsToadlet) {
+      super(connectionsSupportPort, nodeInfoPort, client, friendsToadlet);
     }
 
     @Override
@@ -234,5 +274,47 @@ class DarknetAddRefToadletTest {
       this.lastDescription = desc;
       this.lastHtml = reply;
     }
+  }
+
+  private void stubPageRendering(HTMLNode content) {
+    HTMLNode pageOuter = new HTMLNode("div");
+    HTMLNode head = pageOuter.addChild("head");
+    pageOuter.addChild(content);
+    PageNode page = new PageNode(pageOuter, head, content);
+
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(pageMaker.getPageNode(anyString(), eq(ctx))).thenReturn(page);
+    network.crypta.node.useralerts.UserAlertManager alertManager =
+        mock(network.crypta.node.useralerts.UserAlertManager.class);
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("#", "summary"));
+
+    when(pageMaker.getInfobox(anyString(), anyString(), eq(content), anyString(), eq(true)))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(2);
+              HTMLNode infobox = new HTMLNode("div", "id", "infobox");
+              parent.addChild(infobox);
+              HTMLNode boxContent = new HTMLNode("div", "class", "content");
+              infobox.addChild(boxContent);
+              return boxContent;
+            });
+  }
+
+  private static NodeReferenceSnapshot sampleNoderefSnapshot() {
+    return new NodeReferenceSnapshot(
+        new NodeFieldSet(
+            Map.of("myName", "alice"),
+            Map.of("physical", new NodeFieldSet(Map.of("udp", "127.0.0.1"), Map.of()))));
+  }
+
+  private static boolean isExpectedNoderef(SimpleFieldSet fieldSet) {
+    if (!"alice".equals(fieldSet.get("myName"))) {
+      return false;
+    }
+
+    SimpleFieldSet physical = fieldSet.subset("physical");
+    return physical != null && "127.0.0.1".equals(physical.get("udp"));
   }
 }

--- a/src/test/java/network/crypta/node/runtime/LegacyConnectionsSupportPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyConnectionsSupportPortTest.java
@@ -4,9 +4,14 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
+import network.crypta.node.NodeFile;
 import network.crypta.node.ProgramDirectory;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.runtime.spi.ConnectionsInstallerSnapshot;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +22,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +33,8 @@ import static org.mockito.Mockito.when;
 class LegacyConnectionsSupportPortTest {
 
   @Mock private Node node;
+  @Mock private NodeServicesSubsystem services;
+  @Mock private NodeUpdateManager nodeUpdater;
 
   @TempDir private Path tempDir;
 
@@ -32,7 +42,38 @@ class LegacyConnectionsSupportPortTest {
 
   @BeforeEach
   void setUp() {
+    lenient().when(node.services()).thenReturn(services);
+    lenient().when(services.nodeUpdater()).thenReturn(nodeUpdater);
     port = new LegacyConnectionsSupportPort(node);
+  }
+
+  @Test
+  void windowsInstaller_whenQueried_returnsFilenameLocalFileAndFallbackSourceText()
+      throws Exception {
+    File installer =
+        Files.createFile(tempDir.resolve("freenet-latest-installer-windows.exe")).toFile();
+    FreenetURI installerUri = new FreenetURI("CHK", "win");
+    when(nodeUpdater.getInstallerWindows()).thenReturn(installer);
+    when(nodeUpdater.getInstallerWindowsURI()).thenReturn(installerUri);
+
+    ConnectionsInstallerSnapshot snapshot = port.windowsInstaller();
+
+    assertEquals(NodeFile.INSTALLER_WINDOWS.getFilename(), snapshot.filename());
+    assertSame(installer, snapshot.localFile());
+    assertEquals(installerUri.toString(), snapshot.sourceUriText());
+  }
+
+  @Test
+  void nonWindowsInstaller_whenLocalFileMissing_returnsFallbackSnapshot() {
+    FreenetURI installerUri = new FreenetURI("CHK", "unix");
+    when(nodeUpdater.getInstallerNonWindows()).thenReturn(null);
+    when(nodeUpdater.getInstallerNonWindowsURI()).thenReturn(installerUri);
+
+    ConnectionsInstallerSnapshot snapshot = port.nonWindowsInstaller();
+
+    assertEquals(NodeFile.INSTALLER_NON_WINDOWS.getFilename(), snapshot.filename());
+    assertNull(snapshot.localFile());
+    assertEquals(installerUri.toString(), snapshot.sourceUriText());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- remove the live `Node` dependency from `DarknetAddRefToadlet` and route add-friend installer metadata through runtime SPI support ports
- add `ConnectionsInstallerSnapshot` plus narrow `ConnectionsSupportPort` installer accessors, implemented by `LegacyConnectionsSupportPort`, while keeping installer download and fallback-link semantics unchanged
- export the local public darknet noderef through `NodeInfoPort`, update `FProxyRegistrar` wiring, extend focused tests, and refresh the architecture docs for the expanded runtime SPI boundary

## Testing
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyConnectionsSupportPortTest' --tests 'network.crypta.clients.http.DarknetAddRefToadletTest'`
- `./gradlew testClasses`
