### PR TITLE
refactor(http): Remove ConfigToadlet live runtime deps

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/LifecyclePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/LifecyclePort.java
@@ -44,6 +44,19 @@ public interface LifecyclePort {
   boolean isStopping();
 
   /**
+   * Reports whether the runtime was launched under the Tanuki wrapper.
+   *
+   * <p>This exposes the daemon's existing wrapper-detection flag without changing its meaning.
+   * Management and HTTP code use it only as runtime metadata when deciding whether wrapper-backed
+   * restart affordances should be shown. A return value of {@code false} therefore means callers
+   * must not assume wrapper restart support is available.
+   *
+   * @return {@code true} when the runtime is using the wrapper according to existing daemon
+   *     semantics, otherwise {@code false}
+   */
+  boolean isUsingWrapper();
+
+  /**
    * Returns the startup timestamp recorded by the runtime in milliseconds.
    *
    * <p>The value is the daemon's own startup time metadata, exposed without reinterpretation. It is

--- a/src/main/java/network/crypta/clients/http/ConfigToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConfigToadlet.java
@@ -12,8 +12,6 @@ import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.config.WrapperConfig;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.ProgramDirectory;
 import network.crypta.node.useralerts.AbstractUserAlert;
 import network.crypta.node.useralerts.UserAlert;
@@ -30,9 +28,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This toadlet renders and processes the node configuration UI that lives under the {@code
  * /config/<subconfig>} path. It translates {@link Option} metadata into HTML controls, handles form
- * submissions, persists updates to {@link Config}, and surfaces restart requirements through both
- * inline notices and {@link UserAlert} instances. The handler also wires the optional directory
- * chooser loop so users can browse for filesystem paths without manually editing text fields.
+ * submissions, persists updates through runtime config services, and surfaces restart requirements
+ * through both inline notices and {@link UserAlert} instances. The handler also wires the optional
+ * directory chooser loop so users can browse for filesystem paths without manually editing text
+ * fields.
  *
  * <p>Typical call flow is a GET request to display grouped options followed by a POST that either
  * applies changes, redirects to the directory selector, or confirms a reset to defaults. The class
@@ -82,8 +81,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
   private String directoryBrowserPath;
   private final SubConfig subConfig;
   private final Config config;
-  private final NodeClientCore core;
-  private final Node node;
+  private final ConfigToadletRuntimePorts runtimePorts;
 
   private boolean needRestart = false;
   private NeedRestartUserAlert needRestartUserAlert;
@@ -116,7 +114,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
       HTMLNode alertNode = new HTMLNode("div");
       alertNode.addChild("#", l10n("needRestart"));
 
-      if (node.isUsingWrapper()) {
+      if (isUsingWrapper()) {
         alertNode.addChild("br");
         HTMLNode restartForm =
             alertNode
@@ -192,19 +190,18 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
    * @param directoryBrowserPath path segment for directory browsing, with or without slashes; never
    *     {@code null} after normalization.
    * @param client HTTP client used for outbound helper requests initiated by the parent toadlet.
-   * @param conf configuration root that persists option values once form submission succeeds.
+   * @param conf configuration root used to traverse and update legacy option metadata.
    * @param subConfig logical configuration group that provides the options to render and update.
-   * @param node running node instance required for restart checks and wrapper awareness.
-   * @param core node client core used to locate directories such as the default downloads path.
+   * @param runtimePorts detached runtime services used for persistence, wrapper-state checks, and
+   *     directory-browser defaults.
    */
-  public ConfigToadlet(
+  ConfigToadlet(
       String directoryBrowserPath,
       HighLevelSimpleClient client,
       Config conf,
       SubConfig subConfig,
-      Node node,
-      NodeClientCore core) {
-    this(client, conf, subConfig, node, core);
+      ConfigToadletRuntimePorts runtimePorts) {
+    this(client, conf, subConfig, runtimePorts);
     this.directoryBrowserPath = normalizeDirectoryBrowserPath(directoryBrowserPath);
   }
 
@@ -216,21 +213,19 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
    * supplies a real location via the alternate constructor.
    *
    * @param client HTTP client used for outbound helper requests initiated by the parent toadlet.
-   * @param conf configuration root that persists option values once form submission succeeds.
+   * @param conf configuration root used to traverse and update legacy option metadata.
    * @param subConfig logical configuration group that provides the options to render and update.
-   * @param node running node instance required for restart checks and wrapper awareness.
-   * @param core node client core used to locate directories such as the default downloads path.
+   * @param runtimePorts detached runtime services used for persistence, wrapper-state checks, and
+   *     directory-browser defaults.
    */
-  public ConfigToadlet(
+  ConfigToadlet(
       HighLevelSimpleClient client,
       Config conf,
       SubConfig subConfig,
-      Node node,
-      NodeClientCore core) {
+      ConfigToadletRuntimePorts runtimePorts) {
     super(client);
     config = conf;
-    this.core = core;
-    this.node = node;
+    this.runtimePorts = runtimePorts;
     this.subConfig = subConfig;
     this.directoryBrowserPath = normalizeDirectoryBrowserPath(null);
   }
@@ -370,7 +365,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
             directoryBrowserPath
                 + paramsBuilder
                 + "path="
-                + core.getDownloadsDir().getAbsolutePath());
+                + runtimePorts.transferAccessPort().downloadsDir().getAbsolutePath());
     ctx.sendReplyHeaders(302, "Found", headers, null, 0);
     return true;
   }
@@ -391,7 +386,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
     applyOptionChanges(request, errbuf, prefix, resetToDefault);
     applyWrapperConfig(request);
 
-    config.store();
+    runtimePorts.configPort().persist();
     writeApplyResult(ctx, errbuf);
   }
 
@@ -528,7 +523,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
     content.addChild("br");
     content.addChild("#", l10n("needRestart"));
 
-    if (node.isUsingWrapper()) {
+    if (isUsingWrapper()) {
       content.addChild("br");
       HTMLNode restartForm = ctx.addFormChild(content, "/", "restartForm");
       restartForm.addChild(
@@ -547,6 +542,10 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 
   private static String l10n(String string) {
     return NodeL10n.getBase().getString("ConfigToadlet." + string);
+  }
+
+  private boolean isUsingWrapper() {
+    return runtimePorts.lifecyclePort().isUsingWrapper();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/ConfigToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/ConfigToadletRuntimePorts.java
@@ -1,0 +1,29 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.TransferAccessPort;
+
+/**
+ * Shared runtime-port bundle used by HTTP configuration toadlets.
+ *
+ * <p>{@link ConfigToadlet} still renders and edits the legacy daemon configuration model directly,
+ * but its remaining runtime touches now flow through detached SPI ports. Grouping those three
+ * collaborators keeps the constructor narrow without passing the full {@code RuntimePorts}
+ * aggregate into the HTTP layer.
+ *
+ * @param configPort config persistence port used after option changes are applied.
+ * @param transferAccessPort transfer-policy port used for the default downloads directory during
+ *     directory-browser redirects.
+ * @param lifecyclePort lifecycle port used to decide whether wrapper-backed restart affordances
+ *     should be shown.
+ */
+record ConfigToadletRuntimePorts(
+    ConfigPort configPort, TransferAccessPort transferAccessPort, LifecyclePort lifecyclePort) {
+  ConfigToadletRuntimePorts {
+    Objects.requireNonNull(configPort);
+    Objects.requireNonNull(transferAccessPort);
+    Objects.requireNonNull(lifecyclePort);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -217,6 +217,9 @@ final class FProxyRegistrar {
             true,
             null));
 
+    ConfigToadletRuntimePorts configToadletRuntimePorts =
+        new ConfigToadletRuntimePorts(
+            runtimePorts.config(), runtimePorts.transferAccess(), runtimePorts.lifecycle());
     SubConfig[] sc = config.getConfigs();
     Arrays.sort(sc);
 
@@ -226,7 +229,8 @@ final class FProxyRegistrar {
       LocalDirectoryConfigToadlet localDirectoryConfigToadlet =
           new LocalDirectoryConfigToadlet(core, client, FProxyToadlet.CONFIG_PATH + prefix);
       ConfigToadlet configtoadlet =
-          new ConfigToadlet(localDirectoryConfigToadlet.path(), client, config, cfg, node, core);
+          new ConfigToadlet(
+              localDirectoryConfigToadlet.path(), client, config, cfg, configToadletRuntimePorts);
       server.register(
           configtoadlet,
           ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -128,6 +128,11 @@ public final class LegacyRuntimePorts implements RuntimePorts {
           }
 
           @Override
+          public boolean isUsingWrapper() {
+            return LegacyRuntimePorts.this.node.isUsingWrapper();
+          }
+
+          @Override
           public long startupTimeMillis() {
             return LegacyRuntimePorts.this.node.getStartupTime();
           }

--- a/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
@@ -6,8 +6,9 @@ import network.crypta.config.Config;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,12 +26,18 @@ class ConfigToadletTest {
   @Mock private SubConfig subConfig;
   @Mock private Config config;
   @Mock private HighLevelSimpleClient client;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore core;
+  @Mock private ConfigPort configPort;
+  @Mock private TransferAccessPort transferAccessPort;
+  @Mock private LifecyclePort lifecyclePort;
   @Mock private ToadletContext ctx;
+
+  private ConfigToadlet createToadlet() {
+    return new ConfigToadlet(
+        client,
+        config,
+        subConfig,
+        new ConfigToadletRuntimePorts(configPort, transferAccessPort, lifecyclePort));
+  }
 
   @Test
   void addTextBox_whenEnabled_setsExpectedAttributes() {
@@ -110,7 +117,7 @@ class ConfigToadletTest {
   void path_returnsPrefixFromSubConfig() {
     when(subConfig.getPrefix()).thenReturn("fproxy");
 
-    ConfigToadlet toadlet = new ConfigToadlet(client, config, subConfig, node, core);
+    ConfigToadlet toadlet = createToadlet();
 
     assertEquals("/config/fproxy", toadlet.path());
   }
@@ -120,7 +127,7 @@ class ConfigToadletTest {
     when(ctx.isAdvancedModeEnabled()).thenReturn(true);
     when(subConfig.getOptions()).thenReturn(new Option<?>[] {});
 
-    ConfigToadlet toadlet = new ConfigToadlet(client, config, subConfig, node, core);
+    ConfigToadlet toadlet = createToadlet();
 
     assertTrue(toadlet.isEnabled(ctx));
   }
@@ -135,7 +142,7 @@ class ConfigToadletTest {
     when(ctx.isAdvancedModeEnabled()).thenReturn(false);
     when(subConfig.getOptions()).thenReturn(new Option<?>[] {expertOption, normalOption});
 
-    ConfigToadlet toadlet = new ConfigToadlet(client, config, subConfig, node, core);
+    ConfigToadlet toadlet = createToadlet();
 
     assertTrue(toadlet.isEnabled(ctx));
   }
@@ -150,7 +157,7 @@ class ConfigToadletTest {
     when(ctx.isAdvancedModeEnabled()).thenReturn(false);
     when(subConfig.getOptions()).thenReturn(new Option<?>[] {expertOption1, expertOption2});
 
-    ConfigToadlet toadlet = new ConfigToadlet(client, config, subConfig, node, core);
+    ConfigToadlet toadlet = createToadlet();
 
     assertFalse(toadlet.isEnabled(ctx));
   }

--- a/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
@@ -1,27 +1,58 @@
 package network.crypta.clients.http;
 
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.config.EnumerableOptionCallback;
+import network.crypta.config.NodeNeedRestartException;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
+import network.crypta.config.WrapperConfig;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ConfigToadletTest {
+  private static final URI CONFIG_URI = URI.create("http://localhost/config/");
+  private static final String WRAPPER_MAX_MEMORY = "wrapper.java.maxmemory";
 
   @Mock private SubConfig subConfig;
   @Mock private Config config;
@@ -30,6 +61,13 @@ class ConfigToadletTest {
   @Mock private TransferAccessPort transferAccessPort;
   @Mock private LifecyclePort lifecyclePort;
   @Mock private ToadletContext ctx;
+  @Mock private PageMaker pageMaker;
+  @Mock private UserAlertManager alertManager;
+
+  @BeforeEach
+  void setUp() {
+    new NodeL10n();
+  }
 
   private ConfigToadlet createToadlet() {
     return new ConfigToadlet(
@@ -114,6 +152,13 @@ class ConfigToadletTest {
   }
 
   @Test
+  void addBooleanComboBox_whenDisabled_setsDisabledOnSelect() {
+    HTMLNode combo = ConfigToadlet.addBooleanComboBox(true, "bool.option", true);
+
+    assertEquals("disabled", combo.getAttribute("disabled"));
+  }
+
+  @Test
   void path_returnsPrefixFromSubConfig() {
     when(subConfig.getPrefix()).thenReturn("fproxy");
 
@@ -160,5 +205,284 @@ class ConfigToadletTest {
     ConfigToadlet toadlet = createToadlet();
 
     assertFalse(toadlet.isEnabled(ctx));
+  }
+
+  @Test
+  void handleMethodPOST_whenConfirmResetRequested_rendersConfirmationPageWithMatchingParts()
+      throws Exception {
+    when(subConfig.getPrefix()).thenReturn("node");
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    stubPageMaker();
+    stubInfoboxCreation();
+    stubFormChildCreation();
+
+    HTTPRequest request =
+        createRequest(
+            Map.ofEntries(
+                Map.entry("confirm-reset-to-defaults", "true"),
+                Map.entry("subconfig", "node"),
+                Map.entry("node.option", "value"),
+                Map.entry("other.option", "ignored")));
+
+    ConfigToadlet toadlet = createToadlet();
+
+    toadlet.handleMethodPOST(CONFIG_URI, request, ctx);
+
+    String body = captureWrittenBody();
+
+    assertTrue(body.contains("name=\"subconfig\""));
+    assertTrue(body.contains("value=\"node\""));
+    assertTrue(body.contains("name=\"node.option\""));
+    assertTrue(body.contains("value=\"value\""));
+    assertFalse(body.contains("name=\"other.option\""));
+    assertTrue(body.contains("name=\"reset-to-defaults\""));
+    assertTrue(body.contains("name=\"decline-default-reset\""));
+  }
+
+  @Test
+  void handleMethodPOST_whenDirectorySelectorRequested_redirectsUsingDownloadsDir()
+      throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+
+    File downloadsDir = new File("build/test-downloads").getAbsoluteFile();
+    when(transferAccessPort.downloadsDir()).thenReturn(downloadsDir);
+
+    LinkedHashMap<String, String> parts = new LinkedHashMap<>();
+    parts.put("subconfig", "node");
+    parts.put("node.other", "with spaces");
+    parts.put("select-directory.node.downloadsDir", "browse");
+
+    ConfigToadlet toadlet =
+        new ConfigToadlet(
+            "directory-browser",
+            client,
+            config,
+            subConfig,
+            new ConfigToadletRuntimePorts(configPort, transferAccessPort, lifecyclePort));
+
+    toadlet.handleMethodPOST(CONFIG_URI, createRequest(parts), ctx);
+
+    assertEquals(
+        "/directory-browser/?subconfig=node&node.other=with%20spaces&select-for=node.downloadsDir&path="
+            + downloadsDir.getAbsolutePath(),
+        captureRedirectLocation());
+    verify(configPort, never()).persist();
+    verify(ctx, never()).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void handleMethodPOST_whenOptionChanges_persistsConfigAndAppliesValue() throws Exception {
+    when(subConfig.getPrefix()).thenReturn("node");
+    when(subConfig.getOptions()).thenReturn(new Option<?>[] {});
+    when(config.get("node")).thenReturn(subConfig);
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    stubPageMaker();
+    stubInfoboxCreation();
+
+    Option<?> option = mock(Option.class);
+    when(option.getName()).thenReturn("downloadsDir");
+    when(option.getValueDisplayString()).thenReturn("/old");
+    when(subConfig.getOptions()).thenReturn(new Option<?>[] {option});
+
+    HTTPRequest request =
+        createRequest(
+            Map.ofEntries(
+                Map.entry("subconfig", "node"), Map.entry("node.downloadsDir", "/new/path")));
+
+    ConfigToadlet toadlet = createToadlet();
+
+    toadlet.handleMethodPOST(CONFIG_URI, request, ctx);
+
+    verify(option).setValue("/new/path");
+    verify(configPort).persist();
+    assertTrue(captureWrittenBody().contains("href=\"/config/node\""));
+  }
+
+  @Test
+  void handleMethodPOST_whenRestartRequiredAndWrapperIsUsed_registersAlertAndShowsRestartForm()
+      throws Exception {
+    when(subConfig.getPrefix()).thenReturn("node");
+    when(config.get("node")).thenReturn(subConfig);
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.getFormPassword()).thenReturn("secret");
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(lifecyclePort.isUsingWrapper()).thenReturn(true);
+    stubPageMaker();
+    stubInfoboxCreation();
+    stubFormChildCreation();
+
+    Option<?> option = mock(Option.class);
+    when(option.getName()).thenReturn("cacheSize");
+    when(option.getValueDisplayString()).thenReturn("old");
+    doThrow(new NodeNeedRestartException("restart required")).when(option).setValue("new");
+    when(subConfig.getOptions()).thenReturn(new Option<?>[] {option});
+
+    HTTPRequest request =
+        createRequest(
+            Map.ofEntries(Map.entry("subconfig", "node"), Map.entry("node.cacheSize", "new")));
+
+    ConfigToadlet toadlet = createToadlet();
+
+    toadlet.handleMethodPOST(CONFIG_URI, request, ctx);
+
+    verify(configPort).persist();
+    ArgumentCaptor<UserAlert> alertCaptor = ArgumentCaptor.forClass(UserAlert.class);
+    verify(alertManager).register(alertCaptor.capture());
+
+    String alertHtml = alertCaptor.getValue().getHTMLText().generate();
+    String body = captureWrittenBody();
+
+    assertTrue(alertHtml.contains("name=\"restart2\""));
+    assertTrue(alertHtml.contains("value=\"secret\""));
+    assertTrue(body.contains("name=\"restart\""));
+    assertTrue(body.contains("name=\"restart2\""));
+  }
+
+  @Test
+  void handleMethodPOST_whenResettingFproxyPortToDefaults_keepsCurrentPortValue() throws Exception {
+    when(subConfig.getPrefix()).thenReturn("fproxy");
+    when(config.get("fproxy")).thenReturn(subConfig);
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    stubPageMaker();
+    stubInfoboxCreation();
+
+    Option<?> option = mock(Option.class);
+    when(option.getName()).thenReturn("port");
+    when(option.getValueDisplayString()).thenReturn("8888");
+    when(subConfig.getOptions()).thenReturn(new Option<?>[] {option});
+
+    HTTPRequest request =
+        createRequest(
+            Map.ofEntries(
+                Map.entry("subconfig", "fproxy"),
+                Map.entry("reset-to-defaults", "true"),
+                Map.entry("fproxy.port", "ignored")));
+
+    ConfigToadlet toadlet = createToadlet();
+
+    toadlet.handleMethodPOST(CONFIG_URI, request, ctx);
+
+    verify(option, never()).setValue(anyString());
+    verify(configPort).persist();
+  }
+
+  @Test
+  void handleMethodGET_whenWrapperMemorySubmitted_rendersSubmittedPseudoOptionValue()
+      throws Exception {
+    when(subConfig.getPrefix()).thenReturn("node");
+    when(subConfig.getOptions()).thenReturn(new Option<?>[] {});
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.isAdvancedModeEnabled()).thenReturn(false);
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("#", ""));
+    stubPageMaker();
+    stubFormChildCreation();
+
+    HTTPRequest request = createRequest(Map.ofEntries(Map.entry(WRAPPER_MAX_MEMORY, "768")));
+
+    try (MockedStatic<WrapperConfig> wrapperConfig = mockStatic(WrapperConfig.class)) {
+      wrapperConfig.when(WrapperConfig::canChangeProperties).thenReturn(true);
+      wrapperConfig
+          .when(() -> WrapperConfig.getWrapperProperty(WRAPPER_MAX_MEMORY))
+          .thenReturn("512");
+
+      ConfigToadlet toadlet = createToadlet();
+
+      toadlet.handleMethodGET(CONFIG_URI, request, ctx);
+    }
+
+    String body = captureWrittenBody();
+
+    assertTrue(body.contains("name=\"" + WRAPPER_MAX_MEMORY + "\""));
+    assertTrue(body.contains("value=\"768\""));
+  }
+
+  private HTTPRequest createRequest(Map<String, String> parts) {
+    HTTPRequest request = mock(HTTPRequest.class);
+    lenient().when(request.getParts()).thenReturn(parts.keySet().toArray(String[]::new));
+    when(request.isPartSet(anyString()))
+        .thenAnswer(invocation -> parts.containsKey(invocation.getArgument(0, String.class)));
+    when(request.getPartAsStringFailsafe(anyString(), anyInt()))
+        .thenAnswer(invocation -> parts.getOrDefault(invocation.getArgument(0, String.class), ""));
+    return request;
+  }
+
+  private void stubPageMaker() {
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(pageMaker.getPageNode(anyString(), eq(ctx))).thenAnswer(_ -> createPageNode());
+  }
+
+  private void stubInfoboxCreation() {
+    when(pageMaker.getInfobox(
+            anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
+        .thenAnswer(
+            invocation ->
+                createInfoboxContent(
+                    invocation.getArgument(0),
+                    invocation.getArgument(1),
+                    invocation.getArgument(2),
+                    invocation.getArgument(3),
+                    invocation.getArgument(4)));
+  }
+
+  private void stubFormChildCreation() {
+    when(ctx.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation ->
+                createFormNode(
+                    invocation.getArgument(0),
+                    invocation.getArgument(1),
+                    invocation.getArgument(2)));
+  }
+
+  private static PageNode createPageNode() {
+    HTMLNode outer = new HTMLNode("html");
+    HTMLNode head = outer.addChild("head");
+    HTMLNode body = outer.addChild("body");
+    HTMLNode content = body.addChild("div", "id", "content");
+    return new PageNode(outer, head, content);
+  }
+
+  private static HTMLNode createInfoboxContent(
+      String category, String header, HTMLNode parent, String title, boolean isUnique) {
+    String cssClass = (category == null) ? "infobox" : "infobox " + category;
+    HTMLNode infobox = new HTMLNode("div", "class", cssClass);
+    if (isUnique && title != null) {
+      infobox.addAttribute("id", title);
+    }
+    infobox.addChild("div", "class", "infobox-header").addChild("#", header);
+    HTMLNode contentNode = infobox.addChild("div", "class", "infobox-content");
+    parent.addChild(infobox);
+    return contentNode;
+  }
+
+  private static HTMLNode createFormNode(HTMLNode parent, String target, String id) {
+    HTMLNode form =
+        new HTMLNode(
+            "form",
+            new String[] {"action", "method", "enctype", "id", "name"},
+            new String[] {target, "post", "multipart/form-data", id, id});
+    parent.addChild(form);
+    return form;
+  }
+
+  private String captureWrittenBody() throws Exception {
+    ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> lengthCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(ctx).writeData(dataCaptor.capture(), offsetCaptor.capture(), lengthCaptor.capture());
+    return new String(
+        dataCaptor.getValue(),
+        offsetCaptor.getValue(),
+        lengthCaptor.getValue(),
+        StandardCharsets.UTF_8);
+  }
+
+  @SuppressWarnings("unchecked")
+  private String captureRedirectLocation() throws Exception {
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
+    return headersCaptor.getValue().getFirst("Location");
   }
 }


### PR DESCRIPTION
## Summary
- add `LifecyclePort.isUsingWrapper()` and delegate it in `LegacyRuntimePorts` so wrapper restart affordance checks stay behind the runtime SPI
- add a package-private `ConfigToadletRuntimePorts` bundle and refactor `ConfigToadlet` to use `ConfigPort`, `TransferAccessPort`, and `LifecyclePort` instead of direct `Node` / `NodeClientCore` references
- update `FProxyRegistrar` and `ConfigToadletTest` to use the new runtime-port wiring while keeping the legacy config edit loop and page behavior unchanged

## How to test
- `./gradlew test --tests 'network.crypta.clients.http.ConfigToadletTest' --tests 'network.crypta.clients.http.LocalDirectoryConfigToadletTest'`
- `./gradlew test --tests 'network.crypta.clients.fcp.FcpServerListenerTest'`
- `./gradlew testClasses`
