### PR TITLE
refactor(security-levels): Migrate SecurityLevelsToadlet to runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/MasterPasswordMutationStatus.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/MasterPasswordMutationStatus.java
@@ -1,0 +1,22 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Outcome categories for legacy master-password mutations exposed through the runtime SPI.
+ *
+ * <p>The legacy admin page needs only a small set of user-facing results from daemon-side password
+ * operations. This enum keeps those outcomes detached from daemon exception types while leaving
+ * {@link java.io.IOException} as the transport for underlying filesystem failures.
+ */
+public enum MasterPasswordMutationStatus {
+  /** The requested operation completed successfully. */
+  SUCCESS,
+
+  /** The supplied current password did not match the existing master-keys file. */
+  WRONG_PASSWORD,
+
+  /** The requested mutation cannot proceed because a password is already configured. */
+  ALREADY_SET,
+
+  /** The master-keys file appears structurally invalid or corrupted. */
+  CORRUPTED_FILE
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -29,6 +29,7 @@ package network.crypta.runtime.spi;
  * @see NodeInfoPort
  * @see PeerPort
  * @see RequestQueuePort
+ * @see SecurityLevelsPort
  */
 public interface RuntimePorts {
   /**
@@ -176,6 +177,17 @@ public interface RuntimePorts {
    * @return statistics-page runtime port for detached overview and requester snapshots
    */
   StatisticsPort statistics();
+
+  /**
+   * Returns the legacy security-levels-page capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining live security-level reads, confirmation-warning generation,
+   * and master-password-file mutations behind the runtime boundary while exposing only SPI-local
+   * enums, snapshots, status values, and plain rendered HTML fragments upstream.
+   *
+   * @return security-levels runtime port for detached page state and mutations
+   */
+  SecurityLevelsPort securityLevels();
 
   /**
    * Returns the persistent-request queue-control capability exposed to infrastructure code.

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityLevelsPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityLevelsPort.java
@@ -1,0 +1,75 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+
+/**
+ * Exposes the small legacy security-levels admin-page runtime surface without daemon-only types.
+ *
+ * <p>This port is intentionally page-oriented rather than a general security domain model. It keeps
+ * the remaining live daemon interactions for the `/seclevels/` admin page behind one narrow SPI:
+ * current threat-level reads, the existing network-level confirmation-warning builder, threat-level
+ * mutations, and master-password-file operations.
+ */
+public interface SecurityLevelsPort {
+  /**
+   * Returns a detached snapshot of the current legacy security-levels page state.
+   *
+   * @return immutable snapshot of current threat levels, database status, and password-file
+   *     metadata
+   */
+  SecurityLevelsSnapshot snapshot();
+
+  /**
+   * Returns the legacy confirmation warning HTML for a prospective network-level change.
+   *
+   * <p>Implementations may return {@code null} when no confirmation UI is required for the
+   * requested transition.
+   *
+   * @param newLevel requested detached network threat level
+   * @param checkboxName checkbox name that the rendered HTML should use for confirmation
+   * @return rendered warning HTML, or {@code null} when no warning is required
+   */
+  String networkThreatLevelConfirmWarningHtml(
+      SecurityNetworkThreatLevel newLevel, String checkboxName);
+
+  /**
+   * Applies a new detached network threat level.
+   *
+   * @param newLevel new detached network threat level
+   */
+  void setNetworkThreatLevel(SecurityNetworkThreatLevel newLevel);
+
+  /**
+   * Applies a new detached physical threat level.
+   *
+   * @param newLevel new detached physical threat level
+   */
+  void setPhysicalThreatLevel(SecurityPhysicalThreatLevel newLevel);
+
+  /**
+   * Changes the master password protecting client material.
+   *
+   * @param oldPassword previous password, possibly empty
+   * @param newPassword new password to set, possibly empty
+   * @return detached mutation outcome preserving the legacy admin-page distinctions
+   * @throws IOException if a filesystem error occurs while reading or writing password material
+   */
+  MasterPasswordMutationStatus changeMasterPassword(String oldPassword, String newPassword)
+      throws IOException;
+
+  /**
+   * Sets or unlocks the master password protecting client material.
+   *
+   * @param password password to set or use for unlocking
+   * @return detached mutation outcome preserving the legacy admin-page distinctions
+   * @throws IOException if a filesystem error occurs while reading or writing password material
+   */
+  MasterPasswordMutationStatus setMasterPassword(String password) throws IOException;
+
+  /**
+   * Deletes the master-password file using the runtime's existing deletion path.
+   *
+   * @throws IOException if the file cannot be deleted
+   */
+  void deleteMasterPasswordFile() throws IOException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityLevelsSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityLevelsSnapshot.java
@@ -1,0 +1,35 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * A detached snapshot of the legacy security-levels page state.
+ *
+ * <p>This record carries only the small set of runtime values that the legacy `/seclevels/` page
+ * still needs to render forms and error pages: current network and physical threat levels, whether
+ * the client database is active, and the current master-password file metadata.
+ *
+ * @param networkThreatLevel current detached network threat level
+ * @param physicalThreatLevel current detached physical threat level
+ * @param hasDatabase whether the node currently has an active client database
+ * @param masterPasswordFileExists whether the master-password file currently exists on disk
+ * @param masterPasswordFilePath path to the master-password file, or an empty string when
+ *     unavailable
+ */
+public record SecurityLevelsSnapshot(
+    SecurityNetworkThreatLevel networkThreatLevel,
+    SecurityPhysicalThreatLevel physicalThreatLevel,
+    boolean hasDatabase,
+    boolean masterPasswordFileExists,
+    String masterPasswordFilePath) {
+  /**
+   * Creates an immutable security-levels snapshot.
+   *
+   * @throws NullPointerException if a required enum or path value is {@code null}
+   */
+  public SecurityLevelsSnapshot {
+    Objects.requireNonNull(networkThreatLevel, "networkThreatLevel");
+    Objects.requireNonNull(physicalThreatLevel, "physicalThreatLevel");
+    Objects.requireNonNull(masterPasswordFilePath, "masterPasswordFilePath");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityNetworkThreatLevel.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityNetworkThreatLevel.java
@@ -1,0 +1,54 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached network threat levels exposed through the runtime SPI.
+ *
+ * <p>The values intentionally match the legacy daemon enum names exactly so existing HTTP form
+ * payloads and localization key derivation can continue to use {@link #name()} without another
+ * mapping layer in callers.
+ */
+public enum SecurityNetworkThreatLevel {
+  /** Favor performance and permit opennet participation. */
+  LOW,
+
+  /** Default mixed posture with both opennet and darknet available. */
+  NORMAL,
+
+  /** Darknet-only posture with standard hardening. */
+  HIGH,
+
+  /** Most restrictive darknet-only posture. */
+  MAXIMUM;
+
+  /**
+   * Parses a threat level from its exact enum name.
+   *
+   * @param value exact enum name, case-sensitive
+   * @return parsed level or {@code null} when the value is invalid
+   */
+  public static SecurityNetworkThreatLevel parse(String value) {
+    try {
+      return SecurityNetworkThreatLevel.valueOf(value);
+    } catch (IllegalArgumentException _) {
+      return null;
+    }
+  }
+
+  /**
+   * Returns the levels that still permit Opennet participation.
+   *
+   * @return detached opennet-capable threat levels
+   */
+  public static SecurityNetworkThreatLevel[] opennetValues() {
+    return new SecurityNetworkThreatLevel[] {LOW, NORMAL};
+  }
+
+  /**
+   * Returns the levels that require darknet-only operation.
+   *
+   * @return detached darknet-only threat levels
+   */
+  public static SecurityNetworkThreatLevel[] darknetValues() {
+    return new SecurityNetworkThreatLevel[] {HIGH, MAXIMUM};
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityPhysicalThreatLevel.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/SecurityPhysicalThreatLevel.java
@@ -1,0 +1,36 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached physical threat levels exposed through the runtime SPI.
+ *
+ * <p>The values intentionally match the legacy daemon enum names exactly so existing HTTP form
+ * payloads and localization key derivation can continue to use {@link #name()} without another
+ * mapping layer in callers.
+ */
+public enum SecurityPhysicalThreatLevel {
+  /** Do not encrypt local transient artifacts. */
+  LOW,
+
+  /** Encrypt temporary artifacts and centralize client-cache keys in {@code master.keys}. */
+  NORMAL,
+
+  /** Require a password to unlock {@code master.keys}. */
+  HIGH,
+
+  /** Use transient encryption and disable persistence-dependent features. */
+  MAXIMUM;
+
+  /**
+   * Parses a threat level from its exact enum name.
+   *
+   * @param value exact enum name, case-sensitive
+   * @return parsed level or {@code null} when the value is invalid
+   */
+  public static SecurityPhysicalThreatLevel parse(String value) {
+    try {
+      return SecurityPhysicalThreatLevel.valueOf(value);
+    } catch (IllegalArgumentException _) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -205,7 +205,10 @@ final class FProxyRegistrar {
     SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, node);
     server.register(symlinkToadlet, ToadletRegistration.basic(null, "/sl/", true, false));
 
-    SecurityLevelsToadlet seclevels = new SecurityLevelsToadlet(client, node, core);
+    SecurityLevelsToadletRuntimePorts securityLevelsToadletRuntimePorts =
+        new SecurityLevelsToadletRuntimePorts(runtimePorts.securityLevels(), runtimePorts.config());
+    SecurityLevelsToadlet seclevels =
+        new SecurityLevelsToadlet(client, securityLevelsToadletRuntimePorts);
     server.register(
         seclevels,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
@@ -9,14 +9,11 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.wizardsteps.PageHelper;
 import network.crypta.clients.http.wizardsteps.WizardL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.MasterKeysFileSizeException;
-import network.crypta.node.MasterKeysWrongPasswordException;
-import network.crypta.node.Node.AlreadySetPasswordException;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
-import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
-import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
@@ -30,9 +27,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This toadlet orchestrates the full workflow for selecting network and physical threat levels,
  * prompting for master passwords when high-security modes require them, and rendering
- * confirmation/rollback screens before persisting changes. It collaborates with {@link
- * SecurityLevels} to translate user choices into durable node settings, and delegates HTML
- * construction to the surrounding {@code ToadletContext}. The class assumes callers gate access
+ * confirmation/rollback screens before persisting changes. It keeps the HTTP request branching,
+ * HTML construction, and localization logic in the toadlet, while delegating live runtime state and
+ * mutations to the detached security-levels and config ports. The class assumes callers gate access
  * through {@link ToadletContext#checkFullAccess(Toadlet)} so it can operate on administrative data.
  *
  * <p>Lifecycle highlights:
@@ -41,19 +38,18 @@ import org.slf4j.LoggerFactory;
  *   <li>Reads form submissions and routes between threat-level updates and password management.
  *   <li>Generates confirmation pages when sensitive changes occur, preserving user-provided form
  *       values so the follow-up submission remains deterministic.
- *   <li>Persists configuration changes via {@link NodeClientCore#storeConfig()} only after
- *       successful validation.
+ *   <li>Persists configuration changes via the detached config runtime port only after successful
+ *       validation.
  *   <li>Surfaces localized guidance and warnings to steer users away from insecure downgrades.
  * </ul>
  *
  * <p>Thread safety: instances are created per toadlet and rely on the servlet-style dispatching of
  * the surrounding framework; no internal synchronization is performed. Mutability is limited to
- * request-scoped helpers and stored {@link Node} references. Use a distinct instance per request
+ * request-scoped helpers and stored runtime-port references. Use a distinct instance per request
  * handler or ensure external serialization if reused.
  *
  * @author Matthew Toseland {@literal <}toad@amphibian.dyndns.org{@literal >} (0xE43DA450)
- * @see SecurityLevels
- * @see NodeClientCore
+ * @see SecurityLevelsPort
  */
 public class SecurityLevelsToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(SecurityLevelsToadlet.class);
@@ -106,15 +102,14 @@ public class SecurityLevelsToadlet extends Toadlet {
   private static final String SET_PASSWORD_TITLE_KEY = "setPasswordTitle";
   private static final String CONFIRM_PASSWORD_BOX_ID = "confirmPasswordBox";
   private static final String PASSWORD_FILE_CORRUPTED_TITLE_KEY = "passwordFileCorruptedTitle";
-  private final NodeClientCore core;
-  private final Node node;
+  private final SecurityLevelsToadletRuntimePorts runtimePorts;
 
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly.
 
-  SecurityLevelsToadlet(HighLevelSimpleClient client, Node node, NodeClientCore core) {
+  SecurityLevelsToadlet(
+      HighLevelSimpleClient client, SecurityLevelsToadletRuntimePorts runtimePorts) {
     super(client);
-    this.core = core;
-    this.node = node;
+    this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
   }
 
   private static final class SecurityChangeState {
@@ -125,6 +120,14 @@ public class SecurityLevelsToadlet extends Toadlet {
     boolean hasConfirmPage() {
       return pageNode != null;
     }
+  }
+
+  private SecurityLevelsPort securityLevelsPort() {
+    return runtimePorts.securityLevelsPort();
+  }
+
+  private SecurityLevelsSnapshot securitySnapshot() {
+    return securityLevelsPort().snapshot();
   }
 
   /**
@@ -168,7 +171,7 @@ public class SecurityLevelsToadlet extends Toadlet {
     }
 
     if (state.changedAnything) {
-      core.storeConfig();
+      runtimePorts.configPort().persist();
     }
 
     if (state.hasConfirmPage()) {
@@ -181,39 +184,39 @@ public class SecurityLevelsToadlet extends Toadlet {
   private void processNetworkThreatLevel(
       HTTPRequest request, ToadletContext ctx, SecurityChangeState state) {
     String networkThreatLevel = request.getPartAsStringFailsafe(PARAM_NETWORK_THREAT_LEVEL, 128);
-    NETWORK_THREAT_LEVEL newThreatLevel =
-        SecurityLevels.parseNetworkThreatLevel(networkThreatLevel);
-    NETWORK_THREAT_LEVEL currentLevel = node.services().securityLevels().getNetworkThreatLevel();
+    SecurityNetworkThreatLevel newThreatLevel =
+        SecurityNetworkThreatLevel.parse(networkThreatLevel);
+    SecurityNetworkThreatLevel currentLevel = securitySnapshot().networkThreatLevel();
 
     if (newThreatLevel == null || newThreatLevel == currentLevel) {
       return;
     }
 
     if (request.isPartSet(PARAM_NETWORK_THREAT_LEVEL_CONFIRM)) {
-      node.services().securityLevels().setThreatLevel(newThreatLevel);
+      securityLevelsPort().setNetworkThreatLevel(newThreatLevel);
       state.changedAnything = true;
       return;
     }
 
-    HTMLNode warning =
-        node.services()
-            .securityLevels()
-            .getConfirmWarning(newThreatLevel, PARAM_NETWORK_THREAT_LEVEL_CONFIRM);
-    if (warning == null) {
-      node.services().securityLevels().setThreatLevel(newThreatLevel);
+    String warningHtml =
+        securityLevelsPort()
+            .networkThreatLevelConfirmWarningHtml(
+                newThreatLevel, PARAM_NETWORK_THREAT_LEVEL_CONFIRM);
+    if (warningHtml == null) {
+      securityLevelsPort().setNetworkThreatLevel(newThreatLevel);
       state.changedAnything = true;
       return;
     }
 
-    buildNetworkConfirmPage(networkThreatLevel, newThreatLevel, ctx, state, warning);
+    buildNetworkConfirmPage(networkThreatLevel, newThreatLevel, ctx, state, warningHtml);
   }
 
   private void buildNetworkConfirmPage(
       String networkThreatLevel,
-      NETWORK_THREAT_LEVEL newThreatLevel,
+      SecurityNetworkThreatLevel newThreatLevel,
       ToadletContext ctx,
       SecurityChangeState state,
-      HTMLNode warning) {
+      String warningHtml) {
     PageNode page =
         ctx.getPageMaker()
             .getPageNode(NodeL10n.getBase().getString("ConfigToadlet.fullTitle"), ctx);
@@ -235,9 +238,9 @@ public class SecurityLevelsToadlet extends Toadlet {
         l10nSec(
             "networkThreatLevelConfirmTitle",
             "mode",
-            SecurityLevels.localisedName(newThreatLevel)));
+            l10nSec("networkThreatLevel.name." + newThreatLevel.name())));
     HTMLNode infoboxContent = infobox.addChild(TAG_DIV, ATTR_CLASS, CLASS_INFOBOX_CONTENT);
-    infoboxContent.addChild(warning);
+    infoboxContent.addChild("%", warningHtml);
     infoboxContent.addChild(
         TAG_INPUT,
         new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
@@ -248,15 +251,11 @@ public class SecurityLevelsToadlet extends Toadlet {
       HTTPRequest request, ToadletContext ctx, SecurityChangeState state)
       throws ToadletContextClosedException, IOException {
     String physicalThreatLevel = request.getPartAsStringFailsafe(PARAM_PHYSICAL_THREAT_LEVEL, 128);
-    PHYSICAL_THREAT_LEVEL newPhysicalLevel =
-        SecurityLevels.parsePhysicalThreatLevel(physicalThreatLevel);
-    PHYSICAL_THREAT_LEVEL oldPhysicalLevel =
-        core.getNode().services().securityLevels().getPhysicalThreatLevel();
+    SecurityPhysicalThreatLevel newPhysicalLevel =
+        SecurityPhysicalThreatLevel.parse(physicalThreatLevel);
+    SecurityPhysicalThreatLevel oldPhysicalLevel = securitySnapshot().physicalThreatLevel();
     if (LOG.isDebugEnabled()) {
-      LOG.debug(
-          "New physical threat level: {} old = {}",
-          newPhysicalLevel,
-          node.services().securityLevels().getPhysicalThreatLevel());
+      LOG.debug("New physical threat level: {} old = {}", newPhysicalLevel, oldPhysicalLevel);
     }
 
     if (newPhysicalLevel == null) {
@@ -271,7 +270,7 @@ public class SecurityLevelsToadlet extends Toadlet {
       return false;
     }
 
-    if (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH
+    if (newPhysicalLevel == SecurityPhysicalThreatLevel.HIGH
         && handleUpgradeToHigh(request, ctx, state, oldPhysicalLevel, newPhysicalLevel)) {
       return true;
     }
@@ -281,12 +280,12 @@ public class SecurityLevelsToadlet extends Toadlet {
       return true;
     }
 
-    if (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM
+    if (newPhysicalLevel == SecurityPhysicalThreatLevel.MAXIMUM
         && handleMaximumLevel(ctx, newPhysicalLevel)) {
       return true;
     }
 
-    node.services().securityLevels().setThreatLevel(newPhysicalLevel);
+    securityLevelsPort().setPhysicalThreatLevel(newPhysicalLevel);
     state.changedAnything = true;
     return false;
   }
@@ -295,7 +294,7 @@ public class SecurityLevelsToadlet extends Toadlet {
       HTTPRequest request,
       ToadletContext ctx,
       SecurityChangeState state,
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      SecurityPhysicalThreatLevel newPhysicalLevel)
       throws ToadletContextClosedException, IOException {
 
     String password = request.getPartAsStringFailsafe(PARAM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
@@ -306,20 +305,27 @@ public class SecurityLevelsToadlet extends Toadlet {
         && !confirmPassword.isEmpty()
         && !password.isEmpty()
         && password.equals(confirmPassword)) {
-      try {
-        core.getNode().storage().changeMasterPassword(oldPassword, password, false);
-      } catch (MasterKeysWrongPasswordException _) {
-        sendChangePasswordForm(ctx, true, false, newPhysicalLevel.name());
-        storeConfigIfChanged(state);
-        return true;
-      } catch (MasterKeysFileSizeException _) {
-        sendPasswordFileCorruptedPage(ctx);
-        storeConfigIfChanged(state);
-        return true;
-      } catch (AlreadySetPasswordException _) {
-        sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
-        storeConfigIfChanged(state);
-        return true;
+      MasterPasswordMutationStatus status =
+          securityLevelsPort().changeMasterPassword(oldPassword, password);
+      switch (status) {
+        case SUCCESS -> {
+          return false;
+        }
+        case WRONG_PASSWORD -> {
+          sendChangePasswordForm(ctx, true, false, newPhysicalLevel.name());
+          storeConfigIfChanged(state);
+          return true;
+        }
+        case CORRUPTED_FILE -> {
+          sendPasswordFileCorruptedPage(ctx);
+          storeConfigIfChanged(state);
+          return true;
+        }
+        case ALREADY_SET -> {
+          sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
+          storeConfigIfChanged(state);
+          return true;
+        }
       }
     } else if (!password.isEmpty() || !oldPassword.isEmpty() || !confirmPassword.isEmpty()) {
       sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
@@ -333,12 +339,34 @@ public class SecurityLevelsToadlet extends Toadlet {
       String password,
       ToadletContext ctx,
       SecurityChangeState state,
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      SecurityPhysicalThreatLevel newPhysicalLevel)
       throws ToadletContextClosedException, IOException {
     try {
-      core.getNode().storage().changeMasterPassword(password, "", false);
+      MasterPasswordMutationStatus status = securityLevelsPort().changeMasterPassword(password, "");
+      switch (status) {
+        case SUCCESS -> {
+          return false;
+        }
+        case WRONG_PASSWORD -> {
+          LOG.warn("Wrong password supplied when downgrading from HIGH");
+          sendWrongPasswordResponse(
+              ctx, PASSWORD_FOR_DECRYPT_TITLE_KEY, true, false, newPhysicalLevel.name());
+          storeConfigIfChanged(state);
+          return true;
+        }
+        case CORRUPTED_FILE -> {
+          sendPasswordFileCorruptedPage(ctx);
+          storeConfigIfChanged(state);
+          return true;
+        }
+        case ALREADY_SET -> {
+          sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
+          storeConfigIfChanged(state);
+          return true;
+        }
+      }
     } catch (IOException e) {
-      if (!core.getNode().storage().getMasterKeysFile().exists()) {
+      if (!securitySnapshot().masterPasswordFileExists()) {
         LOG.info("Master password file no longer exists, assuming this is deliberate");
       } else {
         LOG.error("Cannot change password as cannot write new passwords file", e);
@@ -359,20 +387,6 @@ public class SecurityLevelsToadlet extends Toadlet {
         storeConfigIfChanged(state);
         return true;
       }
-    } catch (MasterKeysWrongPasswordException e) {
-      LOG.warn("Wrong password supplied when downgrading from HIGH", e);
-      sendWrongPasswordResponse(
-          ctx, PASSWORD_FOR_DECRYPT_TITLE_KEY, true, false, newPhysicalLevel.name());
-      storeConfigIfChanged(state);
-      return true;
-    } catch (MasterKeysFileSizeException _) {
-      sendPasswordFileCorruptedPage(ctx);
-      storeConfigIfChanged(state);
-      return true;
-    } catch (AlreadySetPasswordException _) {
-      sendChangePasswordForm(ctx, false, true, newPhysicalLevel.name());
-      storeConfigIfChanged(state);
-      return true;
     }
     return false;
   }
@@ -381,8 +395,8 @@ public class SecurityLevelsToadlet extends Toadlet {
       HTTPRequest request,
       ToadletContext ctx,
       SecurityChangeState state,
-      PHYSICAL_THREAT_LEVEL oldPhysicalLevel,
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      SecurityPhysicalThreatLevel oldPhysicalLevel,
+      SecurityPhysicalThreatLevel newPhysicalLevel)
       throws ToadletContextClosedException, IOException {
     String password = request.getPartAsStringFailsafe(PARAM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
     String confirmPassword =
@@ -400,7 +414,7 @@ public class SecurityLevelsToadlet extends Toadlet {
   private boolean handleUpgradePasswordMismatch(
       ToadletContext ctx,
       SecurityChangeState state,
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel,
+      SecurityPhysicalThreatLevel newPhysicalLevel,
       String password,
       String confirmPassword)
       throws ToadletContextClosedException, IOException {
@@ -414,46 +428,54 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   private boolean applyUpgradePassword(
-      PHYSICAL_THREAT_LEVEL oldPhysicalLevel,
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel,
+      SecurityPhysicalThreatLevel oldPhysicalLevel,
+      SecurityPhysicalThreatLevel newPhysicalLevel,
       String password,
       ToadletContext ctx,
       SecurityChangeState state)
       throws ToadletContextClosedException, IOException {
-    try {
-      if (oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.NORMAL
-          || oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.LOW) {
-        core.getNode().storage().changeMasterPassword("", password, false);
-      } else {
-        core.getNode().storage().setMasterPassword(password, false);
-      }
-    } catch (AlreadySetPasswordException _) {
-      sendChangePasswordForm(ctx, false, false, newPhysicalLevel.name());
-      storeConfigIfChanged(state);
-      return true;
-    } catch (MasterKeysWrongPasswordException e) {
-      LOG.warn("Wrong password supplied when upgrading to HIGH", e);
-      sendWrongPasswordResponse(ctx, PASSWORD_PAGE_TITLE_KEY, false, true, newPhysicalLevel.name());
-      storeConfigIfChanged(state);
-      return true;
-    } catch (MasterKeysFileSizeException _) {
-      sendPasswordFileCorruptedPage(ctx);
-      storeConfigIfChanged(state);
-      return true;
+    MasterPasswordMutationStatus status;
+    if (oldPhysicalLevel == SecurityPhysicalThreatLevel.NORMAL
+        || oldPhysicalLevel == SecurityPhysicalThreatLevel.LOW) {
+      status = securityLevelsPort().changeMasterPassword("", password);
+    } else {
+      status = securityLevelsPort().setMasterPassword(password);
     }
-    return false;
+    switch (status) {
+      case SUCCESS -> {
+        return false;
+      }
+      case ALREADY_SET -> {
+        sendChangePasswordForm(ctx, false, false, newPhysicalLevel.name());
+        storeConfigIfChanged(state);
+        return true;
+      }
+      case WRONG_PASSWORD -> {
+        LOG.warn("Wrong password supplied when upgrading to HIGH");
+        sendWrongPasswordResponse(
+            ctx, PASSWORD_PAGE_TITLE_KEY, false, true, newPhysicalLevel.name());
+        storeConfigIfChanged(state);
+        return true;
+      }
+      case CORRUPTED_FILE -> {
+        sendPasswordFileCorruptedPage(ctx);
+        storeConfigIfChanged(state);
+        return true;
+      }
+    }
+    throw new IllegalStateException("Unhandled master password mutation status: " + status);
   }
 
   private boolean handleDowngradeFromHigh(
       HTTPRequest request,
       ToadletContext ctx,
       SecurityChangeState state,
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+      SecurityPhysicalThreatLevel newPhysicalLevel)
       throws ToadletContextClosedException, IOException {
     String password = request.getPartAsStringFailsafe(PARAM_MASTER_PASSWORD, MAX_PASSWORD_LENGTH);
     if (!password.isEmpty()) {
       return applyDowngradePasswordChange(password, ctx, state, newPhysicalLevel);
-    } else if (core.getNode().storage().getMasterKeysFile().exists()) {
+    } else if (securitySnapshot().masterPasswordFileExists()) {
       PageNode page = ctx.getPageMaker().getPageNode(l10nSec(PASSWORD_FOR_DECRYPT_TITLE_KEY), ctx);
       HTMLNode contentNode = page.getContentNode();
 
@@ -509,10 +531,11 @@ public class SecurityLevelsToadlet extends Toadlet {
     writeHTMLReply(ctx, 200, "OK", page.generate());
   }
 
-  private boolean handleMaximumLevel(ToadletContext ctx, PHYSICAL_THREAT_LEVEL newPhysicalLevel)
+  private boolean handleMaximumLevel(
+      ToadletContext ctx, SecurityPhysicalThreatLevel newPhysicalLevel)
       throws ToadletContextClosedException, IOException {
     try {
-      core.getNode().storage().killMasterKeysFile();
+      securityLevelsPort().deleteMasterPasswordFile();
     } catch (IOException _) {
       sendCantDeleteMasterKeysFile(ctx, newPhysicalLevel.name());
       return true;
@@ -529,18 +552,24 @@ public class SecurityLevelsToadlet extends Toadlet {
       return;
     }
     LOG.info("Setting master password");
-    try {
-      node.storage().setMasterPassword(masterPassword, false);
-    } catch (AlreadySetPasswordException _) {
-      LOG.error("Already set master password");
-      redirectToRoot(ctx);
-      return;
-    } catch (MasterKeysWrongPasswordException _) {
-      sendPasswordFormPage(ctx);
-      return;
-    } catch (MasterKeysFileSizeException _) {
-      sendPasswordFileCorruptedPage(ctx);
-      return;
+    MasterPasswordMutationStatus status = securityLevelsPort().setMasterPassword(masterPassword);
+    switch (status) {
+      case SUCCESS -> {
+        // Continue with the redirect handling below.
+      }
+      case ALREADY_SET -> {
+        LOG.error("Already set master password");
+        redirectToRoot(ctx);
+        return;
+      }
+      case WRONG_PASSWORD -> {
+        sendPasswordFormPage(ctx);
+        return;
+      }
+      case CORRUPTED_FILE -> {
+        sendPasswordFileCorruptedPage(ctx);
+        return;
+      }
     }
     MultiValueTable<String, String> headers = new MultiValueTable<>();
     if (request.isPartSet(PARAM_REDIRECT)) {
@@ -583,27 +612,28 @@ public class SecurityLevelsToadlet extends Toadlet {
 
   private void storeConfigIfChanged(SecurityChangeState state) {
     if (state.changedAnything) {
-      core.storeConfig();
+      runtimePorts.configPort().persist();
     }
   }
 
   private boolean isDowngradeFromHigh(
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel, PHYSICAL_THREAT_LEVEL oldPhysicalLevel) {
-    return (newPhysicalLevel == PHYSICAL_THREAT_LEVEL.LOW
-            || newPhysicalLevel == PHYSICAL_THREAT_LEVEL.NORMAL)
-        && oldPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH;
+      SecurityPhysicalThreatLevel newPhysicalLevel, SecurityPhysicalThreatLevel oldPhysicalLevel) {
+    return (newPhysicalLevel == SecurityPhysicalThreatLevel.LOW
+            || newPhysicalLevel == SecurityPhysicalThreatLevel.NORMAL)
+        && oldPhysicalLevel == SecurityPhysicalThreatLevel.HIGH;
   }
 
   private boolean isSameHighThreatLevel(
-      PHYSICAL_THREAT_LEVEL newPhysicalLevel, PHYSICAL_THREAT_LEVEL oldPhysicalLevel) {
-    return newPhysicalLevel == oldPhysicalLevel && newPhysicalLevel == PHYSICAL_THREAT_LEVEL.HIGH;
+      SecurityPhysicalThreatLevel newPhysicalLevel, SecurityPhysicalThreatLevel oldPhysicalLevel) {
+    return newPhysicalLevel == oldPhysicalLevel
+        && newPhysicalLevel == SecurityPhysicalThreatLevel.HIGH;
   }
 
   private void sendCantDeleteMasterKeysFile(ToadletContext ctx, String physicalSecurityLevel)
       throws ToadletContextClosedException, IOException {
     HTMLNode pageNode =
         sendCantDeleteMasterKeysFileInner(
-            ctx, node.storage().getMasterKeysFile().getPath(), false, physicalSecurityLevel);
+            ctx, securitySnapshot().masterPasswordFilePath(), false, physicalSecurityLevel);
     writeHTMLReply(ctx, 200, "OK", pageNode.generate());
   }
 
@@ -821,12 +851,9 @@ public class SecurityLevelsToadlet extends Toadlet {
 
   private void drawSecurityLevelsPage(HTMLNode contentNode, ToadletContext ctx) {
     HTMLNode formNode = createSeclevelsForm(contentNode, ctx);
-
-    NETWORK_THREAT_LEVEL networkLevel = node.services().securityLevels().getNetworkThreatLevel();
-    addNetworkThreatSection(formNode, networkLevel);
-
-    PHYSICAL_THREAT_LEVEL physicalLevel = node.services().securityLevels().getPhysicalThreatLevel();
-    addPhysicalThreatSection(formNode, physicalLevel);
+    SecurityLevelsSnapshot snapshot = securitySnapshot();
+    addNetworkThreatSection(formNode, snapshot.networkThreatLevel());
+    addPhysicalThreatSection(formNode, snapshot.physicalThreatLevel(), snapshot.hasDatabase());
 
     addFormButtons(formNode);
   }
@@ -839,7 +866,7 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   private void addNetworkThreatSection(
-      HTMLNode formNode, NETWORK_THREAT_LEVEL currentNetworkLevel) {
+      HTMLNode formNode, SecurityNetworkThreatLevel currentNetworkLevel) {
     formNode.addChild(TAG_DIV, ATTR_CLASS, "configprefix", l10nSec("networkThreatLevelShort"));
     HTMLNode ul = formNode.addChild("ul", ATTR_CLASS, CLASS_CONFIG);
     HTMLNode seclevelGroup = ul.addChild("li");
@@ -849,7 +876,7 @@ public class SecurityLevelsToadlet extends Toadlet {
         seclevelGroup,
         "networkThreatLevel.opennetLabel",
         "networkThreatLevel.opennetExplain",
-        NETWORK_THREAT_LEVEL.getOpennetValues(),
+        SecurityNetworkThreatLevel.opennetValues(),
         currentNetworkLevel,
         "opennetDiv",
         false);
@@ -858,7 +885,7 @@ public class SecurityLevelsToadlet extends Toadlet {
         seclevelGroup,
         "networkThreatLevel.darknetLabel",
         "networkThreatLevel.darknetExplain",
-        NETWORK_THREAT_LEVEL.getDarknetValues(),
+        SecurityNetworkThreatLevel.darknetValues(),
         currentNetworkLevel,
         "darknetDiv",
         true);
@@ -870,8 +897,8 @@ public class SecurityLevelsToadlet extends Toadlet {
       HTMLNode seclevelGroup,
       String labelKey,
       String explainKey,
-      NETWORK_THREAT_LEVEL[] levels,
-      NETWORK_THREAT_LEVEL currentNetworkLevel,
+      SecurityNetworkThreatLevel[] levels,
+      SecurityNetworkThreatLevel currentNetworkLevel,
       String cssClass,
       boolean includeLink) {
     HTMLNode paragraph = seclevelGroup.addChild("p");
@@ -879,15 +906,15 @@ public class SecurityLevelsToadlet extends Toadlet {
     paragraph.addChild("#", ": " + l10nSec(explainKey));
     HTMLNode container = seclevelGroup.addChild(TAG_DIV, ATTR_CLASS, cssClass);
 
-    for (NETWORK_THREAT_LEVEL level : levels) {
+    for (SecurityNetworkThreatLevel level : levels) {
       addNetworkLevelOption(container, currentNetworkLevel, level, includeLink);
     }
   }
 
   private void addNetworkLevelOption(
       HTMLNode container,
-      NETWORK_THREAT_LEVEL currentNetworkLevel,
-      NETWORK_THREAT_LEVEL level,
+      SecurityNetworkThreatLevel currentNetworkLevel,
+      SecurityNetworkThreatLevel level,
       boolean includeLink) {
     String inputId = PARAM_NETWORK_THREAT_LEVEL + level.name();
     HTMLNode input =
@@ -905,7 +932,7 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   private void addNetworkDescriptions(
-      HTMLNode input, NETWORK_THREAT_LEVEL level, boolean includeLink) {
+      HTMLNode input, SecurityNetworkThreatLevel level, boolean includeLink) {
     NodeL10n.getBase()
         .addL10nSubstitution(
             input,
@@ -931,7 +958,7 @@ public class SecurityLevelsToadlet extends Toadlet {
   }
 
   private void addPhysicalThreatSection(
-      HTMLNode formNode, PHYSICAL_THREAT_LEVEL currentPhysicalLevel) {
+      HTMLNode formNode, SecurityPhysicalThreatLevel currentPhysicalLevel, boolean hasDatabase) {
     formNode.addChild(TAG_DIV, ATTR_CLASS, "configprefix", l10nSec("physicalThreatLevelShort"));
     HTMLNode ul = formNode.addChild("ul", ATTR_CLASS, CLASS_CONFIG);
     HTMLNode seclevelGroup = ul.addChild("li");
@@ -960,15 +987,16 @@ public class SecurityLevelsToadlet extends Toadlet {
       swapWarning.addChild("#", " " + WizardL10n.l10nSec("physicalThreatLevelSwapfileWindows"));
     }
 
-    for (PHYSICAL_THREAT_LEVEL level : PHYSICAL_THREAT_LEVEL.values()) {
-      addPhysicalLevelOption(seclevelGroup, currentPhysicalLevel, level);
+    for (SecurityPhysicalThreatLevel level : SecurityPhysicalThreatLevel.values()) {
+      addPhysicalLevelOption(seclevelGroup, currentPhysicalLevel, level, hasDatabase);
     }
   }
 
   private void addPhysicalLevelOption(
       HTMLNode seclevelGroup,
-      PHYSICAL_THREAT_LEVEL currentPhysicalLevel,
-      PHYSICAL_THREAT_LEVEL level) {
+      SecurityPhysicalThreatLevel currentPhysicalLevel,
+      SecurityPhysicalThreatLevel level,
+      boolean hasDatabase) {
     String inputId = PARAM_PHYSICAL_THREAT_LEVEL + level.name();
     HTMLNode input =
         addRadioInput(
@@ -994,10 +1022,10 @@ public class SecurityLevelsToadlet extends Toadlet {
             "SecurityLevels.physicalThreatLevel.desc." + level,
             new String[] {"bold"},
             new HTMLNode[] {HTMLNode.STRONG});
-    if (level == PHYSICAL_THREAT_LEVEL.MAXIMUM && node.hasDatabase()) {
+    if (level == SecurityPhysicalThreatLevel.MAXIMUM && hasDatabase) {
       inner.addChild("b", " " + l10nSec("warningMaximumWillDeleteQueue"));
     }
-    if (level == PHYSICAL_THREAT_LEVEL.HIGH) {
+    if (level == SecurityPhysicalThreatLevel.HIGH) {
       if (currentPhysicalLevel == level) {
         addPasswordChangeForm(inner);
       } else {
@@ -1100,7 +1128,7 @@ public class SecurityLevelsToadlet extends Toadlet {
   void sendPasswordFileCorruptedPage(ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     HTMLNode page =
-        sendPasswordFileCorruptedPageInner(ctx, node.storage().getMasterKeysFile().getPath());
+        sendPasswordFileCorruptedPageInner(ctx, securitySnapshot().masterPasswordFilePath());
     writeHTMLReply(ctx, 500, "Internal Server Error", page.generate());
   }
 

--- a/src/main/java/network/crypta/clients/http/SecurityLevelsToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/SecurityLevelsToadletRuntimePorts.java
@@ -1,0 +1,33 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+
+/**
+ * Shared runtime-port bundle used by the legacy security-levels toadlet.
+ *
+ * <p>The `/seclevels/` page still owns its HTTP branching and HTML generation, but its remaining
+ * live daemon touches are now limited to detached runtime collaborators for security-level state
+ * and config persistence. Grouping those two ports keeps the constructor narrow without threading
+ * the full runtime aggregate into the HTTP layer.
+ *
+ * @param securityLevelsPort detached security-levels runtime used for threat-level reads, warning
+ *     rendering, and master-password mutations
+ * @param configPort detached config runtime used to persist the page's existing configuration
+ *     writes
+ */
+record SecurityLevelsToadletRuntimePorts(
+    SecurityLevelsPort securityLevelsPort, ConfigPort configPort) {
+  /**
+   * Creates a runtime-port bundle for the legacy security-levels page.
+   *
+   * @param securityLevelsPort detached security-levels runtime required by the toadlet
+   * @param configPort detached config runtime used after successful mutations
+   * @throws NullPointerException if either runtime port reference is {@code null}
+   */
+  SecurityLevelsToadletRuntimePorts {
+    Objects.requireNonNull(securityLevelsPort);
+    Objects.requireNonNull(configPort);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -18,6 +18,7 @@ import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.StatisticsPort;
 import network.crypta.runtime.spi.TransferAccessPort;
 
@@ -50,6 +51,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
   private final StatisticsPort statisticsPort;
+  private final SecurityLevelsPort securityLevelsPort;
   private final RequestQueuePort requestQueuePort;
   private final NodeInfoPort nodeInfoPort;
   private final PeerPort peerPort;
@@ -145,6 +147,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.darknetMessagingPort = new LegacyDarknetMessagingPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
+    this.securityLevelsPort = new LegacySecurityLevelsPort(node);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
@@ -282,6 +285,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public StatisticsPort statistics() {
     return statisticsPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps legacy security-level reads, confirmation-warning rendering, and
+   * master-password-file mutation handling inside the daemon root module while exposing only
+   * detached SPI-local values upstream.
+   */
+  @Override
+  public SecurityLevelsPort securityLevels() {
+    return securityLevelsPort;
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacySecurityLevelsPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacySecurityLevelsPort.java
@@ -1,0 +1,181 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import network.crypta.node.MasterKeysFileSizeException;
+import network.crypta.node.MasterKeysWrongPasswordException;
+import network.crypta.node.Node;
+import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
+import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+import network.crypta.support.HTMLNode;
+
+/**
+ * Bridges legacy daemon security-levels behavior into the detached runtime SPI.
+ *
+ * <p>This adapter keeps all daemon-only threat-level enums, password-mutation exceptions, storage
+ * calls, and HTML warning generation inside the root module while exposing only SPI-local enums,
+ * snapshots, and status values to higher layers.
+ */
+public final class LegacySecurityLevelsPort implements SecurityLevelsPort {
+  /** Parameter name used when validating detached threat-level arguments. */
+  private static final String NEW_LEVEL_ARGUMENT = "newLevel";
+
+  /**
+   * Live daemon node that still owns security-level state, warning rendering, and master-password
+   * storage operations.
+   */
+  private final Node node;
+
+  /**
+   * Creates a security-levels runtime adapter backed by the current daemon node.
+   *
+   * @param node live daemon node that owns security-level and storage state
+   */
+  public LegacySecurityLevelsPort(Node node) {
+    this.node = Objects.requireNonNull(node, "node");
+  }
+
+  @Override
+  public SecurityLevelsSnapshot snapshot() {
+    File masterKeysFile = node.storage().getMasterKeysFile();
+    return new SecurityLevelsSnapshot(
+        mapNetworkThreatLevel(node.services().securityLevels().getNetworkThreatLevel()),
+        mapPhysicalThreatLevel(node.services().securityLevels().getPhysicalThreatLevel()),
+        node.hasDatabase(),
+        masterKeysFile != null && masterKeysFile.exists(),
+        masterKeysFile == null ? "" : masterKeysFile.getPath());
+  }
+
+  @Override
+  public String networkThreatLevelConfirmWarningHtml(
+      SecurityNetworkThreatLevel newLevel, String checkboxName) {
+    Objects.requireNonNull(checkboxName, "checkboxName");
+    HTMLNode warning =
+        node.services()
+            .securityLevels()
+            .getConfirmWarning(
+                mapNetworkThreatLevel(Objects.requireNonNull(newLevel, NEW_LEVEL_ARGUMENT)),
+                checkboxName);
+    return warning == null ? null : warning.generate();
+  }
+
+  @Override
+  public void setNetworkThreatLevel(SecurityNetworkThreatLevel newLevel) {
+    node.services()
+        .securityLevels()
+        .setThreatLevel(
+            mapNetworkThreatLevel(Objects.requireNonNull(newLevel, NEW_LEVEL_ARGUMENT)));
+  }
+
+  @Override
+  public void setPhysicalThreatLevel(SecurityPhysicalThreatLevel newLevel) {
+    node.services()
+        .securityLevels()
+        .setThreatLevel(
+            mapPhysicalThreatLevel(Objects.requireNonNull(newLevel, NEW_LEVEL_ARGUMENT)));
+  }
+
+  @Override
+  public MasterPasswordMutationStatus changeMasterPassword(String oldPassword, String newPassword)
+      throws IOException {
+    try {
+      node.storage()
+          .changeMasterPassword(
+              Objects.requireNonNull(oldPassword, "oldPassword"),
+              Objects.requireNonNull(newPassword, "newPassword"),
+              false);
+      return MasterPasswordMutationStatus.SUCCESS;
+    } catch (MasterKeysWrongPasswordException _) {
+      return MasterPasswordMutationStatus.WRONG_PASSWORD;
+    } catch (Node.AlreadySetPasswordException _) {
+      return MasterPasswordMutationStatus.ALREADY_SET;
+    } catch (MasterKeysFileSizeException _) {
+      return MasterPasswordMutationStatus.CORRUPTED_FILE;
+    }
+  }
+
+  @Override
+  public MasterPasswordMutationStatus setMasterPassword(String password) throws IOException {
+    try {
+      node.storage().setMasterPassword(Objects.requireNonNull(password, "password"), false);
+      return MasterPasswordMutationStatus.SUCCESS;
+    } catch (MasterKeysWrongPasswordException _) {
+      return MasterPasswordMutationStatus.WRONG_PASSWORD;
+    } catch (Node.AlreadySetPasswordException _) {
+      return MasterPasswordMutationStatus.ALREADY_SET;
+    } catch (MasterKeysFileSizeException _) {
+      return MasterPasswordMutationStatus.CORRUPTED_FILE;
+    }
+  }
+
+  @Override
+  public void deleteMasterPasswordFile() throws IOException {
+    node.storage().killMasterKeysFile();
+  }
+
+  /**
+   * Converts a daemon network threat level into the detached SPI enum used by HTTP callers.
+   *
+   * @param level daemon network threat level read from the live security-levels service
+   * @return detached network threat level with the same legacy enum name
+   */
+  private static SecurityNetworkThreatLevel mapNetworkThreatLevel(NETWORK_THREAT_LEVEL level) {
+    return switch (level) {
+      case LOW -> SecurityNetworkThreatLevel.LOW;
+      case NORMAL -> SecurityNetworkThreatLevel.NORMAL;
+      case HIGH -> SecurityNetworkThreatLevel.HIGH;
+      case MAXIMUM -> SecurityNetworkThreatLevel.MAXIMUM;
+    };
+  }
+
+  /**
+   * Converts a detached network threat level back into the daemon enum expected by the node.
+   *
+   * @param level detached network threat level supplied through the runtime SPI
+   * @return daemon network threat level with the same legacy enum name
+   */
+  private static NETWORK_THREAT_LEVEL mapNetworkThreatLevel(SecurityNetworkThreatLevel level) {
+    return switch (level) {
+      case LOW -> NETWORK_THREAT_LEVEL.LOW;
+      case NORMAL -> NETWORK_THREAT_LEVEL.NORMAL;
+      case HIGH -> NETWORK_THREAT_LEVEL.HIGH;
+      case MAXIMUM -> NETWORK_THREAT_LEVEL.MAXIMUM;
+    };
+  }
+
+  /**
+   * Converts a daemon physical threat level into the detached SPI enum used by HTTP callers.
+   *
+   * @param level daemon physical threat level read from the live security-levels service
+   * @return detached physical threat level with the same legacy enum name
+   */
+  private static SecurityPhysicalThreatLevel mapPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL level) {
+    return switch (level) {
+      case LOW -> SecurityPhysicalThreatLevel.LOW;
+      case NORMAL -> SecurityPhysicalThreatLevel.NORMAL;
+      case HIGH -> SecurityPhysicalThreatLevel.HIGH;
+      case MAXIMUM -> SecurityPhysicalThreatLevel.MAXIMUM;
+    };
+  }
+
+  /**
+   * Converts a detached physical threat level back into the daemon enum expected by the node.
+   *
+   * @param level detached physical threat level supplied through the runtime SPI
+   * @return daemon physical threat level with the same legacy enum name
+   */
+  private static PHYSICAL_THREAT_LEVEL mapPhysicalThreatLevel(SecurityPhysicalThreatLevel level) {
+    return switch (level) {
+      case LOW -> PHYSICAL_THREAT_LEVEL.LOW;
+      case NORMAL -> PHYSICAL_THREAT_LEVEL.NORMAL;
+      case HIGH -> PHYSICAL_THREAT_LEVEL.HIGH;
+      case MAXIMUM -> PHYSICAL_THREAT_LEVEL.MAXIMUM;
+    };
+  }
+}

--- a/src/test/java/network/crypta/clients/http/SecurityLevelsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SecurityLevelsToadletTest.java
@@ -1,11 +1,16 @@
 package network.crypta.clients.http;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.HTMLNode;
+import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -16,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -27,15 +33,53 @@ class SecurityLevelsToadletTest {
 
   @Test
   void path_whenCalled_returnsSecurityLevelsPath() {
+    SecurityLevelsPort securityLevelsPort = mock(SecurityLevelsPort.class);
+    ConfigPort configPort = mock(ConfigPort.class);
     SecurityLevelsToadlet toadlet =
         new SecurityLevelsToadlet(
             mock(HighLevelSimpleClient.class),
-            mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS),
-            mock(NodeClientCore.class));
+            new SecurityLevelsToadletRuntimePorts(securityLevelsPort, configPort));
 
     String result = toadlet.path();
 
     assertEquals(SecurityLevelsToadlet.PATH, result);
+  }
+
+  @Test
+  void handleMethodPost_whenNetworkLevelChanges_persistsThroughConfigPort() throws Exception {
+    SecurityLevelsPort securityLevelsPort = mock(SecurityLevelsPort.class);
+    ConfigPort configPort = mock(ConfigPort.class);
+    SecurityLevelsToadlet toadlet =
+        new SecurityLevelsToadlet(
+            mock(HighLevelSimpleClient.class),
+            new SecurityLevelsToadletRuntimePorts(securityLevelsPort, configPort));
+    HTTPRequest request = mock(HTTPRequest.class);
+    ToadletContext ctx = mock(ToadletContext.class);
+
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isPartSet("seclevels")).thenReturn(true);
+    when(request.isPartSet("security-levels.networkThreatLevel.confirm")).thenReturn(false);
+    when(request.getPartAsStringFailsafe("security-levels.networkThreatLevel", 128))
+        .thenReturn("HIGH");
+    when(request.getPartAsStringFailsafe("security-levels.physicalThreatLevel", 128))
+        .thenReturn("");
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                false,
+                false,
+                "/tmp/master.keys"));
+    when(securityLevelsPort.networkThreatLevelConfirmWarningHtml(
+            SecurityNetworkThreatLevel.HIGH, "security-levels.networkThreatLevel.confirm"))
+        .thenReturn(null);
+
+    toadlet.handleMethodPOST(URI.create(SecurityLevelsToadlet.PATH), request, ctx);
+
+    verify(securityLevelsPort).setNetworkThreatLevel(SecurityNetworkThreatLevel.HIGH);
+    verify(configPort).persist();
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), eq(null), eq(0L));
   }
 
   @Test

--- a/src/test/java/network/crypta/node/runtime/LegacySecurityLevelsPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacySecurityLevelsPortTest.java
@@ -1,0 +1,206 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import network.crypta.node.MasterKeysFileSizeException;
+import network.crypta.node.MasterKeysWrongPasswordException;
+import network.crypta.node.Node;
+import network.crypta.node.SecurityLevels;
+import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacySecurityLevelsPortTest {
+
+  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock private SecurityLevels securityLevels;
+  @Mock private NodeStorageSubsystem storage;
+
+  @TempDir File tempDir;
+
+  @Test
+  void snapshot_whenCalled_mapsDetachedThreatLevelsAndPasswordFileMetadata() throws Exception {
+    File masterKeysFile = new File(tempDir, "master.keys");
+    assertTrue(masterKeysFile.createNewFile());
+    when(node.services().securityLevels()).thenReturn(securityLevels);
+    when(node.storage()).thenReturn(storage);
+    when(node.hasDatabase()).thenReturn(true);
+    when(storage.getMasterKeysFile()).thenReturn(masterKeysFile);
+    when(securityLevels.getNetworkThreatLevel())
+        .thenReturn(SecurityLevels.NETWORK_THREAT_LEVEL.MAXIMUM);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    SecurityLevelsSnapshot snapshot = port.snapshot();
+
+    assertEquals(SecurityNetworkThreatLevel.MAXIMUM, snapshot.networkThreatLevel());
+    assertEquals(SecurityPhysicalThreatLevel.HIGH, snapshot.physicalThreatLevel());
+    assertTrue(snapshot.hasDatabase());
+    assertTrue(snapshot.masterPasswordFileExists());
+    assertEquals(masterKeysFile.getPath(), snapshot.masterPasswordFilePath());
+  }
+
+  @Test
+  void networkThreatLevelConfirmWarningHtml_whenWarningExists_returnsRenderedHtml() {
+    HTMLNode warning = new HTMLNode("div");
+    warning.addChild("p", "Need confirmation");
+    when(node.services().securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getConfirmWarning(
+            SecurityLevels.NETWORK_THREAT_LEVEL.HIGH, "confirmNetworkThreatLevel"))
+        .thenReturn(warning);
+
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    String warningHtml =
+        port.networkThreatLevelConfirmWarningHtml(
+            SecurityNetworkThreatLevel.HIGH, "confirmNetworkThreatLevel");
+
+    assertNotNull(warningHtml);
+    assertTrue(warningHtml.contains("Need confirmation"));
+  }
+
+  @Test
+  void setNetworkThreatLevel_whenCalled_delegatesWithMappedEnum() {
+    when(node.services().securityLevels()).thenReturn(securityLevels);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    port.setNetworkThreatLevel(SecurityNetworkThreatLevel.LOW);
+
+    verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.LOW);
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenCalled_delegatesWithMappedEnum() {
+    when(node.services().securityLevels()).thenReturn(securityLevels);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    port.setPhysicalThreatLevel(SecurityPhysicalThreatLevel.MAXIMUM);
+
+    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM);
+  }
+
+  @Test
+  void changeMasterPassword_whenSuccessful_returnsSuccess() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    doNothing().when(storage).changeMasterPassword("old", "new", false);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    MasterPasswordMutationStatus status = port.changeMasterPassword("old", "new");
+
+    assertEquals(MasterPasswordMutationStatus.SUCCESS, status);
+  }
+
+  @Test
+  void changeMasterPassword_whenWrongPassword_returnsWrongPassword() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    doThrow(new MasterKeysWrongPasswordException())
+        .when(storage)
+        .changeMasterPassword("old", "new", false);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    MasterPasswordMutationStatus status = port.changeMasterPassword("old", "new");
+
+    assertEquals(MasterPasswordMutationStatus.WRONG_PASSWORD, status);
+  }
+
+  @Test
+  void changeMasterPassword_whenAlreadySet_returnsAlreadySet() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    doThrow(new Node.AlreadySetPasswordException())
+        .when(storage)
+        .changeMasterPassword("old", "new", false);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    MasterPasswordMutationStatus status = port.changeMasterPassword("old", "new");
+
+    assertEquals(MasterPasswordMutationStatus.ALREADY_SET, status);
+  }
+
+  @Test
+  void changeMasterPassword_whenCorruptedFile_returnsCorruptedFile() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    doThrow(new MasterKeysFileSizeException(false))
+        .when(storage)
+        .changeMasterPassword("old", "new", false);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    MasterPasswordMutationStatus status = port.changeMasterPassword("old", "new");
+
+    assertEquals(MasterPasswordMutationStatus.CORRUPTED_FILE, status);
+  }
+
+  @Test
+  void changeMasterPassword_whenIoFails_propagatesIOException() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    IOException failure = new IOException("boom");
+    doThrow(failure).when(storage).changeMasterPassword("old", "new", false);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    IOException thrown =
+        assertThrows(IOException.class, () -> port.changeMasterPassword("old", "new"));
+
+    assertEquals(failure, thrown);
+  }
+
+  @Test
+  void setMasterPassword_whenWrongPassword_returnsWrongPassword() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    doThrow(new MasterKeysWrongPasswordException())
+        .when(storage)
+        .setMasterPassword("secret", false);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    MasterPasswordMutationStatus status = port.setMasterPassword("secret");
+
+    assertEquals(MasterPasswordMutationStatus.WRONG_PASSWORD, status);
+  }
+
+  @Test
+  void deleteMasterPasswordFile_whenCalled_delegatesToStorage() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    port.deleteMasterPasswordFile();
+
+    verify(storage).killMasterKeysFile();
+  }
+
+  @Test
+  void networkThreatLevelConfirmWarningHtml_whenNoWarning_returnsNull() {
+    when(node.services().securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getConfirmWarning(
+            SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL, "confirmNetworkThreatLevel"))
+        .thenReturn(null);
+    LegacySecurityLevelsPort port = new LegacySecurityLevelsPort(node);
+
+    String warningHtml =
+        port.networkThreatLevelConfirmWarningHtml(
+            SecurityNetworkThreatLevel.NORMAL, "confirmNetworkThreatLevel");
+
+    assertNull(warningHtml);
+  }
+}


### PR DESCRIPTION
## Summary

- add a detached `SecurityLevelsPort` and the SPI-local snapshot, threat-level, and password-mutation types needed by the legacy `/seclevels/` page
- implement `LegacySecurityLevelsPort`, wire it through `RuntimePorts` and `LegacyRuntimePorts`, and pass a narrow `SecurityLevelsToadletRuntimePorts` bundle from `FProxyRegistrar`
- refactor `SecurityLevelsToadlet` to use the new runtime ports and `ConfigPort.persist()`, then add focused adapter/toadlet coverage and Javadoc cleanup for the new production types

## Testing

- `./gradlew test --tests 'network.crypta.node.runtime.LegacySecurityLevelsPortTest' --tests 'network.crypta.clients.http.SecurityLevelsToadletTest' --tests 'network.crypta.clients.http.wizardsteps.SecurityPhysicalTest'`
- `./gradlew compileJava compileTestJava`

## Scope

- keeps the change narrowly scoped to the legacy security-levels admin page runtime extraction
- does not refactor wizard toadlets, page-shell/platform code, or the daemon security subsystem design
