### PR TITLE
refactor(wizard): Extract first-time wizard port

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardPort.java
@@ -1,0 +1,50 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Exposes the detached runtime surface that the JavaScript first-time wizard still needs.
+ *
+ * <p>This SPI is intentionally page-shaped instead of domain-pure. The HTTP layer already owns the
+ * wizard route, template model, localization keys, and request-local validation flow. What remains
+ * here is the smallest stable boundary that keeps live daemon types out of the page code while
+ * still preserving the existing onboarding behavior.
+ *
+ * <p>Implementations are responsible for:
+ *
+ * <ul>
+ *   <li>reading current defaults and limits from the live node,
+ *   <li>formatting detached values so the legacy form can round-trip them unchanged, and
+ *   <li>applying a validated submission to the daemon using the existing save semantics.
+ * </ul>
+ *
+ * @see FirstTimeWizardSnapshot
+ * @see FirstTimeWizardSubmission
+ */
+public interface FirstTimeWizardPort {
+  /**
+   * Returns a detached snapshot of the current first-time-wizard page state.
+   *
+   * <p>Callers typically request a fresh snapshot for each HTTP render so the page reflects the
+   * current datastore bounds, password state, and bandwidth suggestions. The returned record is
+   * immutable and contains only detached values that can be safely passed into templates and form
+   * validation logic.
+   *
+   * @return immutable snapshot containing the defaults, bounds, and suggested values used by the
+   *     current wizard page render
+   */
+  FirstTimeWizardSnapshot snapshot();
+
+  /**
+   * Applies one detached first-time-wizard form submission to the live daemon.
+   *
+   * <p>Implementations preserve the current legacy page behavior: threat-level changes, bandwidth
+   * and datastore configuration writes, optional master-password mutation, wizard completion, and
+   * config persistence all remain inside the daemon root module. The submission is expected to have
+   * passed the HTTP layer's request validation already, but implementations may still reject it if
+   * live daemon constraints changed between rendering and submission.
+   *
+   * @param submission detached form submission reflecting the legacy wizard page semantics and raw
+   *     form field values
+   * @throws NullPointerException if {@code submission} is {@code null}
+   */
+  void applySubmission(FirstTimeWizardSubmission submission);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
@@ -1,0 +1,68 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Captures one detached view of the legacy JavaScript first-time wizard page state.
+ *
+ * <p>The HTTP wizard uses this record to populate the initial form, re-render invalid submissions,
+ * and validate user input without reaching back into live daemon objects. All string values are
+ * expected to be ready for direct reuse in HTML form fields, including locale-stable decimal
+ * formatting for GiB values and empty strings when a bandwidth suggestion is unavailable.
+ *
+ * <p>The record carries both rounded display strings and exact byte bounds for datastore size. That
+ * split preserves the existing UI while letting the HTTP layer validate submissions against the
+ * live daemon's true limits instead of reparsing rounded text. Instances are immutable and safe to
+ * pass across request-handling layers.
+ *
+ * @param passwordAlreadySet whether the current physical-threat policy already implies that a
+ *     startup password is configured
+ * @param initialStorageLimitGiB initial datastore size suggestion, formatted as GiB text for the
+ *     storage form field
+ * @param minStorageLimitGiB minimum datastore size accepted by the page, formatted as GiB text for
+ *     display and error messages
+ * @param minStorageLimitBytes minimum datastore size accepted by the page, expressed in exact bytes
+ *     for validation
+ * @param maxStorageLimitGiB maximum datastore size accepted by the page, formatted as GiB text for
+ *     display and error messages
+ * @param maxStorageLimitBytes maximum datastore size accepted by the page, expressed in exact bytes
+ *     for validation
+ * @param minBandwidthKiB minimum direct download or upload limit accepted by the page, in KiB/s
+ * @param maxUploadLimitKiB maximum direct upload limit accepted by the page, in KiB/s
+ * @param minBandwidthMonthlyLimitGiB minimum monthly transfer budget accepted by the page,
+ *     formatted as GiB text
+ * @param detectedDownloadLimitKiB recommended direct download limit in KiB/s text or an empty
+ *     string when automatic detection is unavailable
+ * @param detectedUploadLimitKiB recommended direct upload limit in KiB/s text or an empty string
+ *     when automatic detection is unavailable
+ */
+public record FirstTimeWizardSnapshot(
+    boolean passwordAlreadySet,
+    String initialStorageLimitGiB,
+    String minStorageLimitGiB,
+    long minStorageLimitBytes,
+    String maxStorageLimitGiB,
+    long maxStorageLimitBytes,
+    long minBandwidthKiB,
+    long maxUploadLimitKiB,
+    String minBandwidthMonthlyLimitGiB,
+    String detectedDownloadLimitKiB,
+    String detectedUploadLimitKiB) {
+  /**
+   * Creates an immutable first-time-wizard snapshot.
+   *
+   * <p>The constructor preserves the detached values exactly as supplied. It enforces only the
+   * nullability contract for string-backed form values and display bounds; it does not normalize
+   * units, trim whitespace, or reinterpret empty strings.
+   *
+   * @throws NullPointerException if any string-backed field is {@code null}
+   */
+  public FirstTimeWizardSnapshot {
+    Objects.requireNonNull(initialStorageLimitGiB, "initialStorageLimitGiB");
+    Objects.requireNonNull(minStorageLimitGiB, "minStorageLimitGiB");
+    Objects.requireNonNull(maxStorageLimitGiB, "maxStorageLimitGiB");
+    Objects.requireNonNull(minBandwidthMonthlyLimitGiB, "minBandwidthMonthlyLimitGiB");
+    Objects.requireNonNull(detectedDownloadLimitKiB, "detectedDownloadLimitKiB");
+    Objects.requireNonNull(detectedUploadLimitKiB, "detectedUploadLimitKiB");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSubmission.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSubmission.java
@@ -1,0 +1,56 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Represents one detached submission from the legacy JavaScript first-time wizard page.
+ *
+ * <p>This record intentionally mirrors the existing page model instead of introducing a broader
+ * onboarding domain type. The HTTP layer still performs request parsing, checkbox handling, and
+ * user-facing validation. The runtime adapter receives the detached result and maps it onto the
+ * legacy daemon writes that complete wizard setup.
+ *
+ * <p>String fields preserve the raw form values after HTTP extraction. That lets the page
+ * round-trip user input unchanged when validation fails, while still allowing the runtime adapter
+ * to apply the same units and parsing rules used by the legacy wizard flow.
+ *
+ * @param knowSomeone whether the user reports knowing an existing trusted Crypta operator
+ * @param connectToStrangers whether the user still opts into connecting to untrusted peers
+ * @param haveMonthlyLimit whether the submission uses a monthly transfer budget instead of direct
+ *     per-second limits
+ * @param downloadLimitKiB requested direct download limit, preserved as KiB/s text from the form
+ * @param uploadLimitKiB requested direct upload limit, preserved as KiB/s text from the form
+ * @param bandwidthMonthlyLimitGiB requested monthly transfer budget, preserved as GiB text from the
+ *     form
+ * @param storageLimitGiB requested datastore size, preserved as GiB text from the form
+ * @param setPassword whether the user chose to configure a startup password during wizard
+ *     completion
+ * @param password requested password text, which may be empty when password setup is disabled
+ */
+public record FirstTimeWizardSubmission(
+    boolean knowSomeone,
+    boolean connectToStrangers,
+    boolean haveMonthlyLimit,
+    String downloadLimitKiB,
+    String uploadLimitKiB,
+    String bandwidthMonthlyLimitGiB,
+    String storageLimitGiB,
+    boolean setPassword,
+    String password) {
+  /**
+   * Creates an immutable first-time-wizard submission.
+   *
+   * <p>The constructor preserves the HTTP layer's detached values exactly as provided. It validates
+   * only that string-backed fields are non-null, leaving parsing, range checking, and empty-string
+   * semantics to the surrounding wizard workflow.
+   *
+   * @throws NullPointerException if any string-backed field is {@code null}
+   */
+  public FirstTimeWizardSubmission {
+    Objects.requireNonNull(downloadLimitKiB, "downloadLimitKiB");
+    Objects.requireNonNull(uploadLimitKiB, "uploadLimitKiB");
+    Objects.requireNonNull(bandwidthMonthlyLimitGiB, "bandwidthMonthlyLimitGiB");
+    Objects.requireNonNull(storageLimitGiB, "storageLimitGiB");
+    Objects.requireNonNull(password, "password");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -30,6 +30,7 @@ package network.crypta.runtime.spi;
  * @see PeerPort
  * @see RequestQueuePort
  * @see SecurityLevelsPort
+ * @see FirstTimeWizardPort
  */
 public interface RuntimePorts {
   /**
@@ -188,6 +189,17 @@ public interface RuntimePorts {
    * @return security-levels runtime port for detached page state and mutations
    */
   SecurityLevelsPort securityLevels();
+
+  /**
+   * Returns the legacy JavaScript first-time-wizard capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining live wizard reads, validation bounds, bandwidth suggestions,
+   * security-level changes, master-password mutations, and config writes inside the daemon root
+   * module while exposing only detached SPI-local snapshot and submission values upstream.
+   *
+   * @return first-time-wizard runtime port for detached page state and submission application
+   */
+  FirstTimeWizardPort firstTimeWizard();
 
   /**
    * Returns the persistent-request queue-control capability exposed to infrastructure code.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -392,7 +392,7 @@ final class FProxyRegistrar {
         ToadletRegistration.basic(null, FirstTimeWizardToadlet.TOADLET_URL, true, false));
 
     FirstTimeWizardNewToadlet firstTimeWizardNewToadlet =
-        new FirstTimeWizardNewToadlet(client, core, config);
+        new FirstTimeWizardNewToadlet(client, runtimePorts.firstTimeWizard());
     server.register(
         firstTimeWizardNewToadlet,
         ToadletRegistration.basic(null, FirstTimeWizardNewToadlet.TOADLET_URL, true, false));

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
@@ -3,55 +3,37 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.clients.http.wizardsteps.BandwidthDetectionUnavailableException;
-import network.crypta.clients.http.wizardsteps.BandwidthLimit;
-import network.crypta.clients.http.wizardsteps.BandwidthManipulator;
-import network.crypta.clients.http.wizardsteps.DatastoreSize;
-import network.crypta.config.Config;
-import network.crypta.config.ConfigException;
-import network.crypta.config.Option;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.MasterKeysFileSizeException;
-import network.crypta.node.MasterKeysWrongPasswordException;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
 import network.crypta.support.Fields;
-import network.crypta.support.IllegalValueException;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.DatastoreUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * JavaScript-based First-Time-Wizard toadlet that guides new nodes through the minimum secure setup
  * steps. The regular wizard redirects here when both FProxy and the user's browser have JavaScript
  * enabled so that the richer, single-page flow can be used.
  *
- * <p>This toadlet orchestrates the entire first-run experience: it detects recommended bandwidth
- * limits, proposes datastore sizes, optionally enforces a master password based on the configured
- * physical threat level, and persists the resulting configuration. All rendering is delegated to
- * the shared web template system, with localized strings loaded via {@link NodeL10n} and per-page
- * state stored in a simple model map.
- *
- * <p>Instances are tied to a {@link NodeClientCore} and {@link Config}. They are not thread-safe on
- * their own but are typically created once and invoked by the toadlet container on request threads.
- * Error handling is intentionally defensive: invalid input re-renders the form with contextual
- * messages, while unexpected failures are surfaced through structured logging.
+ * <p>This toadlet orchestrates the entire first-run experience using one detached runtime port: it
+ * renders the shared template, validates request-local input, and delegates the remaining daemon
+ * reads and writes to {@link FirstTimeWizardPort}. Instances are not thread-safe on their own but
+ * are typically created once and invoked by the toadlet container on request threads.
  *
  * <ul>
- *   <li>Collects threat-level choices and optionally enforces a master password.
- *   <li>Suggests datastore and bandwidth limits based on detected capabilities.
+ *   <li>Collects threat-level and bandwidth choices through the shared HTML template system.
+ *   <li>Validates submitted values against detached runtime bounds and suggested defaults.
  *   <li>Redirects to {@link WelcomeToadlet#ROOT_PATH} after successful completion.
  * </ul>
  *
  * @see WebTemplateToadlet
  * @see WelcomeToadlet
+ * @see FirstTimeWizardPort
  */
 public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(FirstTimeWizardNewToadlet.class);
@@ -63,18 +45,12 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
    */
   public static final String TOADLET_URL = "/wiz/";
 
-  private static final long MIN_STORAGE_LIMIT =
-      network.crypta.node.subsystem.NodeStorageSubsystem.MIN_STORE_SIZE
-          * 5
-          / 4; // min store size + 10% for client cache + 10% for slashdot cache
-
-  private final NodeClientCore core;
-
-  private final Config config;
+  private final FirstTimeWizardPort wizardPort;
 
   private static final String L10N_PREFIX = "FirstTimeWizardToadlet.";
 
-  private static final int KIB = 1024;
+  private static final long KIB = 1024L;
+  private static final long MAX_INT_BACKED_BANDWIDTH_LIMIT_BYTES = Integer.MAX_VALUE;
 
   private static final String DOWNLOAD_LIMIT_ERROR_KEY = "downloadLimitError";
 
@@ -86,12 +62,9 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
   private static final String CHECKED_VALUE = "checked";
 
-  private static final String UNEXPECTED_ERROR_MESSAGE = "Should not happen, please report! {}";
-
-  FirstTimeWizardNewToadlet(HighLevelSimpleClient client, NodeClientCore core, Config config) {
+  FirstTimeWizardNewToadlet(HighLevelSimpleClient client, FirstTimeWizardPort wizardPort) {
     super(client);
-    this.core = core;
-    this.config = config;
+    this.wizardPort = Objects.requireNonNull(wizardPort, "wizardPort");
   }
 
   /**
@@ -121,7 +94,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
       return;
     }
 
-    showForm(ctx, new FormModel(isPasswordAlreadySet()).toModel());
+    showForm(ctx, new FormModel(wizardPort.snapshot()).toModel());
   }
 
   /**
@@ -151,10 +124,11 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
       return;
     }
 
-    FormModel formModel = new FormModel(request, isPasswordAlreadySet());
+    FirstTimeWizardSnapshot snapshot = wizardPort.snapshot();
+    FormModel formModel = new FormModel(request, snapshot);
 
     if (formModel.isValid()) {
-      formModel.save();
+      wizardPort.applySubmission(formModel.toSubmission());
       super.writeTemporaryRedirect(ctx, "Wizard complete", WelcomeToadlet.ROOT_PATH);
       return;
     }
@@ -165,7 +139,7 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
   private void showForm(ToadletContext ctx, Map<String, Object> model)
       throws IOException, ToadletContextClosedException {
-    model.put("formPassword", core.getEndpoints().getToadletContainer().getFormPassword());
+    model.put("formPassword", ctx.getFormPassword());
     PageNode page =
         ctx.getPageMaker()
             .getPageNode(
@@ -195,23 +169,17 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
     return NodeL10n.getBase().getString(L10N_PREFIX + key);
   }
 
-  private static String l10n(String key, String value) {
-    return NodeL10n.getBase().getString(L10N_PREFIX + key, value);
-  }
-
-  /**
-   * Returns whether physical security policy currently indicates an already-configured password.
-   *
-   * <p>In the wizard flow, HIGH physical threat implies the user has already completed password
-   * setup and should not be prompted to set it again.
-   */
-  private boolean isPasswordAlreadySet() {
-    return core.getNode().services().securityLevels().getPhysicalThreatLevel()
-        == SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH;
-  }
-
-  private final class FormModel {
+  private static final class FormModel {
     private final boolean passwordAlreadySet;
+    private final String minStorageLimit;
+    private final long minStorageLimitBytes;
+    private final String maxStorageLimit;
+    private final long maxStorageLimitBytes;
+    private final long minBandwidthKiB;
+    private final long maxUploadLimitKiB;
+    private final String minBandwidthMonthlyLimit;
+    private final String downloadLimitDetected;
+    private final String uploadLimitDetected;
 
     private String knowSomeone = "";
 
@@ -227,55 +195,43 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
     private final String storageLimit;
 
-    private final String minStorageLimit =
-        String.format(Locale.ENGLISH, "%.2f", (float) MIN_STORAGE_LIMIT / DatastoreUtil.ONE_GIB);
-
     private String setPassword = "";
 
     private String password = "";
 
-    private String downloadLimitDetected;
-
-    private String uploadLimitDetected;
-
     private final Map<String, String> errors = new HashMap<>();
 
-    FormModel(boolean passwordAlreadySet) {
-      this.passwordAlreadySet = passwordAlreadySet;
-      float storage = 100;
-      Option<Long> sizeOption =
-          network.crypta.config.Config.longOption(config.get("node"), "storeSize");
-      if (!sizeOption.isDefault()) {
-        Option<Long> clientCacheSizeOption =
-            network.crypta.config.Config.longOption(config.get("node"), "clientCacheSize");
-        Option<Long> slashdotCacheSizeOption =
-            network.crypta.config.Config.longOption(config.get("node"), "slashdotCacheSize");
-        long totalSize =
-            sizeOption.getValue()
-                + clientCacheSizeOption.getValue()
-                + slashdotCacheSizeOption.getValue();
-        storage = (float) totalSize / DatastoreUtil.ONE_GIB;
-      } else {
-        long autodetectedDatastoreSize = DatastoreUtil.autodetectDatastoreSize(core, config);
-        if (autodetectedDatastoreSize > 0) {
-          storage = (float) autodetectedDatastoreSize / DatastoreUtil.ONE_GIB;
-        }
-      }
-      // format with English locale to ensure that the decimal point is "." as required for the form
-      // value
-      storageLimit = String.format(Locale.ENGLISH, "%.2f", storage);
-
-      detectBandwidthLimit();
-      if (downloadLimitDetected != null) {
+    FormModel(FirstTimeWizardSnapshot snapshot) {
+      this.passwordAlreadySet = snapshot.passwordAlreadySet();
+      this.storageLimit = snapshot.initialStorageLimitGiB();
+      this.minStorageLimit = snapshot.minStorageLimitGiB();
+      this.minStorageLimitBytes = snapshot.minStorageLimitBytes();
+      this.maxStorageLimit = snapshot.maxStorageLimitGiB();
+      this.maxStorageLimitBytes = snapshot.maxStorageLimitBytes();
+      this.minBandwidthKiB = snapshot.minBandwidthKiB();
+      this.maxUploadLimitKiB = snapshot.maxUploadLimitKiB();
+      this.minBandwidthMonthlyLimit = snapshot.minBandwidthMonthlyLimitGiB();
+      this.downloadLimitDetected = snapshot.detectedDownloadLimitKiB();
+      this.uploadLimitDetected = snapshot.detectedUploadLimitKiB();
+      if (!downloadLimitDetected.isEmpty()) {
         downloadLimit = downloadLimitDetected;
       }
-      if (uploadLimitDetected != null) {
+      if (!uploadLimitDetected.isEmpty()) {
         uploadLimit = uploadLimitDetected;
       }
     }
 
-    FormModel(HTTPRequest request, boolean passwordAlreadySet) {
-      this.passwordAlreadySet = passwordAlreadySet;
+    FormModel(HTTPRequest request, FirstTimeWizardSnapshot snapshot) {
+      this.passwordAlreadySet = snapshot.passwordAlreadySet();
+      this.minStorageLimit = snapshot.minStorageLimitGiB();
+      this.minStorageLimitBytes = snapshot.minStorageLimitBytes();
+      this.maxStorageLimit = snapshot.maxStorageLimitGiB();
+      this.maxStorageLimitBytes = snapshot.maxStorageLimitBytes();
+      this.minBandwidthKiB = snapshot.minBandwidthKiB();
+      this.maxUploadLimitKiB = snapshot.maxUploadLimitKiB();
+      this.minBandwidthMonthlyLimit = snapshot.minBandwidthMonthlyLimitGiB();
+      this.downloadLimitDetected = snapshot.detectedDownloadLimitKiB();
+      this.uploadLimitDetected = snapshot.detectedUploadLimitKiB();
       knowSomeone = request.getPartAsStringFailsafe("knowSomeone", 20);
       connectToStrangers = request.getPartAsStringFailsafe("connectToStrangers", 20);
       haveMonthlyLimit = request.getPartAsStringFailsafe("haveMonthlyLimit", 20);
@@ -312,56 +268,61 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
     private void validateDownloadLimit() {
       try {
         long parsedDownloadLimit =
-            downloadLimit.isEmpty() ? 0 : Fields.parseInt(downloadLimit + "KiB");
-        if (parsedDownloadLimit < Node.getMinimumBandwidth()) {
+            downloadLimit.isEmpty() ? 0 : Fields.parseLong(downloadLimit + "KiB");
+        if (parsedDownloadLimit > MAX_INT_BACKED_BANDWIDTH_LIMIT_BYTES) {
+          throw new NumberFormatException("value exceeds the maximum supported bandwidth limit");
+        }
+        if (parsedDownloadLimit < minBandwidthKiB * KIB) {
           errors.put(
               DOWNLOAD_LIMIT_ERROR_KEY,
-              l10n("valid.downloadLimit", Integer.toString(Node.getMinimumBandwidth() / KIB)));
+              l10n("valid.downloadLimit", Long.toString(minBandwidthKiB)));
         }
       } catch (NumberFormatException e) {
         errors.put(
             DOWNLOAD_LIMIT_ERROR_KEY,
-            l10n("valid.number.prefix.downloadLimit") + " " + e.getMessage());
+            FirstTimeWizardNewToadlet.l10n("valid.number.prefix.downloadLimit")
+                + " "
+                + e.getMessage());
       }
     }
 
     private void validateUploadLimit() {
       try {
-        long parsedUploadLimit = uploadLimit.isEmpty() ? 0 : Fields.parseInt(uploadLimit + "KiB");
-        if (parsedUploadLimit < Node.getMinimumBandwidth()) {
+        long parsedUploadLimit = uploadLimit.isEmpty() ? 0 : Fields.parseLong(uploadLimit + "KiB");
+        if (parsedUploadLimit < minBandwidthKiB * KIB) {
           errors.put(
-              UPLOAD_LIMIT_ERROR_KEY,
-              l10n("valid.uploadLimit", Integer.toString(Node.getMinimumBandwidth() / KIB)));
+              UPLOAD_LIMIT_ERROR_KEY, l10n("valid.uploadLimit", Long.toString(minBandwidthKiB)));
         }
-        int nanosInSecond = (int) SECONDS.toNanos(1);
-        if (nanosInSecond < parsedUploadLimit) { // see the Node set outputBandwidthLimit
+        if (maxUploadLimitKiB * KIB < parsedUploadLimit) {
           errors.put(
               UPLOAD_LIMIT_ERROR_KEY,
-              l10n("valid.uploadLimitMax", Integer.toString(nanosInSecond / KIB)));
+              l10n("valid.uploadLimitMax", Long.toString(maxUploadLimitKiB)));
         }
       } catch (NumberFormatException e) {
         errors.put(
-            UPLOAD_LIMIT_ERROR_KEY, l10n("valid.number.prefix.uploadLimit") + " " + e.getMessage());
+            UPLOAD_LIMIT_ERROR_KEY,
+            FirstTimeWizardNewToadlet.l10n("valid.number.prefix.uploadLimit")
+                + " "
+                + e.getMessage());
       }
     }
 
     private void validateMonthlyLimit() {
       try {
-        double monthlyLimitValue = 0;
-        if (!bandwidthMonthlyLimit.isEmpty()) {
-          monthlyLimitValue = Double.parseDouble(bandwidthMonthlyLimit);
-        }
-        if (monthlyLimitValue < BandwidthLimit.MIN_MONTHLY_LIMIT) {
+        long monthlyLimitValue =
+            bandwidthMonthlyLimit.isEmpty() ? 0 : Fields.parseLong(bandwidthMonthlyLimit + "GiB");
+        long minMonthlyLimitValue = Fields.parseLong(minBandwidthMonthlyLimit + "GiB");
+        if (monthlyLimitValue < minMonthlyLimitValue) {
           errors.put(
               "bandwidthMonthlyLimitError",
-              l10n(
-                  "valid.bandwidthMonthlyLimit",
-                  "%.2f".formatted(BandwidthLimit.MIN_MONTHLY_LIMIT)));
+              l10n("valid.bandwidthMonthlyLimit", minBandwidthMonthlyLimit));
         }
       } catch (NumberFormatException e) {
         errors.put(
             "bandwidthMonthlyLimitError",
-            l10n("valid.number.prefix.bandwidthMonthlyLimit") + " " + e.getMessage());
+            FirstTimeWizardNewToadlet.l10n("valid.number.prefix.bandwidthMonthlyLimit")
+                + " "
+                + e.getMessage());
       }
     }
 
@@ -369,26 +330,21 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
       try {
         long storageLimitValue =
             storageLimit.isEmpty() ? 0 : Fields.parseLong(storageLimit + "GiB");
-        if (storageLimitValue
-            < MIN_STORAGE_LIMIT) { // min store size + 10% for client cache + 10% for slashdot cache
+        if (storageLimitValue < minStorageLimitBytes) {
           errors.put(
               STORAGE_LIMIT_ERROR_KEY,
               NodeL10n.getBase().getString("Node.invalidMinStoreSizeWithCaches"));
-        } else {
-          long maxDatastoreSize = DatastoreUtil.maxDatastoreSize();
-          if (storageLimitValue > maxDatastoreSize) {
-            errors.put(
-                STORAGE_LIMIT_ERROR_KEY,
-                NodeL10n.getBase()
-                    .getString(
-                        "Node.invalidMaxStoreSize",
-                        "%.2f".formatted((float) maxDatastoreSize / DatastoreUtil.ONE_GIB)));
-          }
+        } else if (storageLimitValue > maxStorageLimitBytes) {
+          errors.put(
+              STORAGE_LIMIT_ERROR_KEY,
+              NodeL10n.getBase().getString("Node.invalidMaxStoreSize", maxStorageLimit));
         }
       } catch (NumberFormatException e) {
         errors.put(
             STORAGE_LIMIT_ERROR_KEY,
-            l10n("valid.number.prefix.storageLimit") + " " + e.getMessage());
+            FirstTimeWizardNewToadlet.l10n("valid.number.prefix.storageLimit")
+                + " "
+                + e.getMessage());
       }
     }
 
@@ -415,20 +371,6 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
       return errors.isEmpty();
     }
 
-    private void detectBandwidthLimit() {
-      try {
-        BandwidthLimit detected =
-            BandwidthManipulator.detectBandwidthLimits(
-                core.getNode().network().ipDetector().getBandwidthIndicator());
-
-        // Detected limits reasonable; add half of both as a recommended option.
-        downloadLimitDetected = Long.toString(detected.downBytes / 2 / KIB);
-        uploadLimitDetected = Long.toString(detected.upBytes / 2 / KIB);
-      } catch (BandwidthDetectionUnavailableException | IllegalValueException e) {
-        LOG.info(e.getMessage(), e);
-      }
-    }
-
     private Map<String, Object> toModel() {
       HashMap<String, Object> model = new HashMap<>();
       model.put("knowSomeone", !knowSomeone.isEmpty() ? CHECKED_VALUE : "");
@@ -437,103 +379,46 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
       model.put("downloadLimit", downloadLimit);
       model.put("uploadLimit", uploadLimit);
       model.put("bandwidthMonthlyLimit", bandwidthMonthlyLimit);
-      model.put("minBandwidthMonthlyLimit", "%.2f".formatted(BandwidthLimit.MIN_MONTHLY_LIMIT));
+      model.put("minBandwidthMonthlyLimit", minBandwidthMonthlyLimit);
       model.put("storageLimit", storageLimit);
       model.put("minStorageLimit", minStorageLimit);
       if (!passwordAlreadySet) {
         model.put("setPassword", !setPassword.isEmpty() ? CHECKED_VALUE : "");
       }
       model.put("isPasswordAlreadySet", passwordAlreadySet);
-
-      if (downloadLimitDetected == null || uploadLimitDetected == null) {
-        detectBandwidthLimit();
-      }
       model.put(
           "downloadLimitDetected",
-          downloadLimitDetected != null
+          !downloadLimitDetected.isEmpty()
               ? downloadLimitDetected
-              : l10n("bandwidthCommonInternetConnectionSpeedsDetectedUnavailable"));
+              : FirstTimeWizardNewToadlet.l10n(
+                  "bandwidthCommonInternetConnectionSpeedsDetectedUnavailable"));
       model.put(
           "uploadLimitDetected",
-          uploadLimitDetected != null
+          !uploadLimitDetected.isEmpty()
               ? uploadLimitDetected
-              : l10n("bandwidthCommonInternetConnectionSpeedsDetectedUnavailable"));
+              : FirstTimeWizardNewToadlet.l10n(
+                  "bandwidthCommonInternetConnectionSpeedsDetectedUnavailable"));
 
       model.put("errors", errors);
 
       return model;
     }
 
-    private void save() {
-      if (knowSomeone.isEmpty()) {
-        // Opennet + Darknet (possible)
-        core.getNode()
-            .services()
-            .securityLevels()
-            .setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
-      } else {
-        if (connectToStrangers.isEmpty()) {
-          // Darknet
-          core.getNode()
-              .services()
-              .securityLevels()
-              .setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.HIGH);
-        } else {
-          // Opennet + Darknet
-          core.getNode()
-              .services()
-              .securityLevels()
-              .setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
-        }
-      }
+    private FirstTimeWizardSubmission toSubmission() {
+      return new FirstTimeWizardSubmission(
+          !knowSomeone.isEmpty(),
+          !connectToStrangers.isEmpty(),
+          !haveMonthlyLimit.isEmpty(),
+          downloadLimit,
+          uploadLimit,
+          bandwidthMonthlyLimit,
+          storageLimit,
+          !setPassword.isEmpty(),
+          password);
+    }
 
-      try {
-        if (haveMonthlyLimit.isEmpty()) { // save download & uploadLimit
-          config.get("node").set("inputBandwidthLimit", downloadLimit + "KiB");
-          config.get("node").set("outputBandwidthLimit", uploadLimit + "KiB");
-        } else { // save bandwidthMonthlyLimit
-          BandwidthLimit bandwidth =
-              new BandwidthLimit(Fields.parseLong(bandwidthMonthlyLimit + "GiB"));
-          config.get("node").set("inputBandwidthLimit", Long.toString(bandwidth.downBytes));
-          config.get("node").set("outputBandwidthLimit", Long.toString(bandwidth.upBytes));
-        }
-      } catch (ConfigException e) {
-        LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
-      }
-
-      DatastoreSize.setDatastoreSize(storageLimit + "GiB", config);
-
-      if (!passwordAlreadySet) {
-        try {
-          String newPassword;
-          if (setPassword.isEmpty()) { // no password protection requested
-            core.getNode()
-                .services()
-                .securityLevels()
-                .setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
-            newPassword = "";
-          } else {
-            core.getNode()
-                .services()
-                .securityLevels()
-                .setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
-            newPassword = password;
-          }
-          core.getNode().storage().changeMasterPassword("", newPassword, true);
-        } catch (Node.AlreadySetPasswordException
-            | MasterKeysWrongPasswordException
-            | MasterKeysFileSizeException
-            | IOException e) {
-          LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
-        }
-      }
-
-      try {
-        config.get("fproxy").set("hasCompletedWizard", true);
-      } catch (ConfigException e) {
-        LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
-      }
-      core.storeConfig();
+    private static String l10n(String key, String value) {
+      return NodeL10n.getBase().getString(L10N_PREFIX + key, value);
     }
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
@@ -1,0 +1,284 @@
+package network.crypta.node.runtime;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+import network.crypta.clients.http.wizardsteps.BandwidthDetectionUnavailableException;
+import network.crypta.clients.http.wizardsteps.BandwidthLimit;
+import network.crypta.clients.http.wizardsteps.BandwidthManipulator;
+import network.crypta.clients.http.wizardsteps.DatastoreSize;
+import network.crypta.config.Config;
+import network.crypta.config.ConfigException;
+import network.crypta.config.Option;
+import network.crypta.node.MasterKeysFileSizeException;
+import network.crypta.node.MasterKeysWrongPasswordException;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
+import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.support.Fields;
+import network.crypta.support.IllegalValueException;
+import network.crypta.support.io.DatastoreUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Implements the page-oriented first-time-wizard SPI on top of the legacy daemon runtime.
+ *
+ * <p>This adapter stays in the root module because the JavaScript wizard still depends on several
+ * daemon-only behaviors that should not leak across the runtime SPI boundary. It reads the current
+ * security state, datastore sizing defaults, storage caps, and bandwidth hints directly from the
+ * live node, then exposes those values as detached records for the HTTP layer.
+ *
+ * <p>The writing path preserves the existing wizard completion semantics rather than redesigning
+ * them. Config writes and password-related failures that historically stayed daemon-local are still
+ * logged here, while runtime validation failures that would make the request report a false success
+ * are allowed to abort the submission before the wizard is marked complete.
+ *
+ * <p>Responsibilities in this adapter are intentionally narrow:
+ *
+ * <ul>
+ *   <li>translate live node state into {@link FirstTimeWizardSnapshot} values,
+ *   <li>apply a {@link FirstTimeWizardSubmission} using the legacy ordering of writes, and
+ *   <li>keep daemon exceptions, enums, and config internals out of {@code runtime-spi}.
+ * </ul>
+ */
+final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
+  /** Logger for daemon-local wizard failures that should remain in the root module. */
+  private static final Logger LOG = LoggerFactory.getLogger(LegacyFirstTimeWizardPort.class);
+
+  /** Minimum datastore size exposed by this wizard flow, including the required cache overhead. */
+  private static final long MIN_STORAGE_LIMIT = NodeStorageSubsystem.MIN_STORE_SIZE * 5 / 4;
+
+  /** Binary kibibyte unit used when converting between daemon byte values and form units. */
+  private static final long KIB = 1024L;
+
+  /** Shared message text for unexpected legacy failures that are logged and kept daemon-local. */
+  private static final String UNEXPECTED_ERROR_MESSAGE = "Should not happen, please report! {}";
+
+  /** Live node backing the wizard's security, network, storage, and config reads. */
+  private final Node node;
+
+  /** Live client core used for autodetection helpers and final config persistence. */
+  private final NodeClientCore core;
+
+  /**
+   * Creates a daemon-backed adapter for the JavaScript first-time wizard.
+   *
+   * <p>The adapter keeps stable references to the live {@link Node} and {@link NodeClientCore} so
+   * each request can read current runtime values and persist changes through the existing daemon
+   * pathways.
+   *
+   * @param node live daemon node that provides config, security, storage, and network state
+   * @param core live node client core used for autodetection and config persistence
+   * @throws NullPointerException if either argument is {@code null}
+   */
+  LegacyFirstTimeWizardPort(Node node, NodeClientCore core) {
+    this.node = Objects.requireNonNull(node, "node");
+    this.core = Objects.requireNonNull(core, "core");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public FirstTimeWizardSnapshot snapshot() {
+    Config config = node.getConfig();
+    long minStorageLimitBytes = MIN_STORAGE_LIMIT;
+    long maxStorageLimitBytes = DatastoreUtil.maxDatastoreSize();
+    String[] detectedBandwidthLimits = detectedBandwidthLimits();
+    return new FirstTimeWizardSnapshot(
+        passwordAlreadySet(),
+        initialStorageLimitGiB(config),
+        formatGiB(minStorageLimitBytes),
+        minStorageLimitBytes,
+        formatGiB(maxStorageLimitBytes),
+        maxStorageLimitBytes,
+        Node.getMinimumBandwidth() / KIB,
+        SECONDS.toNanos(1) / KIB,
+        String.format(Locale.ENGLISH, "%.2f", BandwidthLimit.MIN_MONTHLY_LIMIT),
+        detectedBandwidthLimits[0],
+        detectedBandwidthLimits[1]);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void applySubmission(FirstTimeWizardSubmission submission) {
+    Objects.requireNonNull(submission, "submission");
+
+    node.services()
+        .securityLevels()
+        .setThreatLevel(
+            submission.knowSomeone() && !submission.connectToStrangers()
+                ? NETWORK_THREAT_LEVEL.HIGH
+                : NETWORK_THREAT_LEVEL.NORMAL);
+
+    Config config = node.getConfig();
+    applyBandwidth(config, submission);
+    applyDatastore(config, submission.storageLimitGiB());
+    applyPasswordIfRequired(submission);
+    markWizardComplete(config);
+    core.storeConfig();
+  }
+
+  /**
+   * Returns whether the live physical-threat policy already implies a configured password.
+   *
+   * @return {@code true} when the live node currently requires a startup password
+   */
+  private boolean passwordAlreadySet() {
+    return node.services().securityLevels().getPhysicalThreatLevel() == PHYSICAL_THREAT_LEVEL.HIGH;
+  }
+
+  /**
+   * Computes the initial datastore size shown in the wizard form.
+   *
+   * <p>The method preserves the legacy precedence order: explicit configured sizes win, otherwise
+   * the adapter falls back to datastore autodetection and finally to the historical fixed default.
+   *
+   * @param config live daemon config used to read existing datastore-related options
+   * @return initial datastore size formatted as English-locale GiB text for the form field
+   */
+  private String initialStorageLimitGiB(Config config) {
+    float storage = 100;
+    Option<Long> sizeOption = Config.longOption(config.get("node"), "storeSize");
+    if (!sizeOption.isDefault()) {
+      Option<Long> clientCacheSizeOption = Config.longOption(config.get("node"), "clientCacheSize");
+      Option<Long> slashdotCacheSizeOption =
+          Config.longOption(config.get("node"), "slashdotCacheSize");
+      long totalSize =
+          sizeOption.getValue()
+              + clientCacheSizeOption.getValue()
+              + slashdotCacheSizeOption.getValue();
+      storage = (float) totalSize / DatastoreUtil.ONE_GIB;
+    } else {
+      long autodetectedDatastoreSize = DatastoreUtil.autodetectDatastoreSize(core, config);
+      if (autodetectedDatastoreSize > 0) {
+        storage = (float) autodetectedDatastoreSize / DatastoreUtil.ONE_GIB;
+      }
+    }
+    return String.format(Locale.ENGLISH, "%.2f", storage);
+  }
+
+  /**
+   * Detects recommended bandwidth limits for display in the wizard form.
+   *
+   * <p>Detection failures are expected on some systems. In that case the adapter logs the daemon
+   * detail and returns empty strings so the HTTP layer can render the existing unavailable message.
+   *
+   * @return two-element array containing download then upload suggestions in KiB/s text
+   */
+  private String[] detectedBandwidthLimits() {
+    try {
+      BandwidthLimit detected =
+          BandwidthManipulator.detectBandwidthLimits(
+              node.network().ipDetector().getBandwidthIndicator());
+      return new String[] {
+        Long.toString(detected.downBytes / 2 / KIB), Long.toString(detected.upBytes / 2 / KIB)
+      };
+    } catch (BandwidthDetectionUnavailableException | IllegalValueException e) {
+      LOG.info(e.getMessage(), e);
+      return new String[] {"", ""};
+    }
+  }
+
+  /**
+   * Applies the submission's bandwidth settings through the legacy config keys.
+   *
+   * <p>Direct per-second limits are written back as KiB-formatted strings. Monthly transfer budgets
+   * are converted to the daemon's byte-based bandwidth model first, then stored through the same
+   * config pathway. Legacy {@link ConfigException} failures remain daemon-local and are logged.
+   *
+   * @param config live daemon config receiving the bandwidth writes
+   * @param submission detached wizard submission whose bandwidth fields were already validated by
+   *     the HTTP layer
+   */
+  private void applyBandwidth(Config config, FirstTimeWizardSubmission submission) {
+    try {
+      if (!submission.haveMonthlyLimit()) {
+        config.get("node").set("inputBandwidthLimit", submission.downloadLimitKiB() + "KiB");
+        config.get("node").set("outputBandwidthLimit", submission.uploadLimitKiB() + "KiB");
+        return;
+      }
+
+      BandwidthLimit bandwidth =
+          new BandwidthLimit(Fields.parseLong(submission.bandwidthMonthlyLimitGiB() + "GiB"));
+      config.get("node").set("inputBandwidthLimit", Long.toString(bandwidth.downBytes));
+      config.get("node").set("outputBandwidthLimit", Long.toString(bandwidth.upBytes));
+    } catch (ConfigException e) {
+      LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
+    }
+  }
+
+  /**
+   * Applies the requested datastore size through the existing datastore-sizing helper.
+   *
+   * <p>Runtime validation failures are allowed to propagate, so the wizard request aborts instead
+   * of reporting success after the datastore size was rejected.
+   *
+   * @param config live daemon config passed into the datastore sizing helper
+   * @param storageLimitGiB requested datastore size in GiB text from the wizard form
+   */
+  private void applyDatastore(Config config, String storageLimitGiB) {
+    DatastoreSize.setDatastoreSize(storageLimitGiB + "GiB", config);
+  }
+
+  /**
+   * Applies the optional startup-password step when the node does not already require one.
+   *
+   * <p>The method preserves the legacy order of operations: update the physical threat level first,
+   * then invoke the master-password change path. Checked daemon failures stay local to this adapter
+   * and are logged rather than surfacing new checked exceptions through the SPI.
+   *
+   * @param submission detached wizard submission containing the password-related choices
+   */
+  private void applyPasswordIfRequired(FirstTimeWizardSubmission submission) {
+    if (passwordAlreadySet()) {
+      return;
+    }
+
+    try {
+      String newPassword;
+      if (!submission.setPassword()) {
+        node.services().securityLevels().setThreatLevel(PHYSICAL_THREAT_LEVEL.NORMAL);
+        newPassword = "";
+      } else {
+        node.services().securityLevels().setThreatLevel(PHYSICAL_THREAT_LEVEL.HIGH);
+        newPassword = submission.password();
+      }
+      node.storage().changeMasterPassword("", newPassword, true);
+    } catch (Node.AlreadySetPasswordException
+        | MasterKeysWrongPasswordException
+        | MasterKeysFileSizeException
+        | IOException e) {
+      LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
+    }
+  }
+
+  /**
+   * Marks the JavaScript wizard as completed in FProxy config state.
+   *
+   * @param config live daemon config receiving the completion marker
+   */
+  private void markWizardComplete(Config config) {
+    try {
+      config.get("fproxy").set("hasCompletedWizard", true);
+    } catch (ConfigException e) {
+      LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
+    }
+  }
+
+  /**
+   * Formats a byte value as the English-locale GiB text used by the wizard form.
+   *
+   * @param sizeBytes datastore-related byte value to render
+   * @return GiB string rounded to two decimal places for direct display in the page
+   */
+  private static String formatGiB(long sizeBytes) {
+    return String.format(Locale.ENGLISH, "%.2f", (float) sizeBytes / DatastoreUtil.ONE_GIB);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -12,6 +12,7 @@ import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.ExecutionPort;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.PeerPort;
@@ -52,6 +53,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DiagnosticPort diagnosticPort;
   private final StatisticsPort statisticsPort;
   private final SecurityLevelsPort securityLevelsPort;
+  private final FirstTimeWizardPort firstTimeWizardPort;
   private final RequestQueuePort requestQueuePort;
   private final NodeInfoPort nodeInfoPort;
   private final PeerPort peerPort;
@@ -148,6 +150,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.securityLevelsPort = new LegacySecurityLevelsPort(node);
+    this.firstTimeWizardPort = new LegacyFirstTimeWizardPort(node, core);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
@@ -297,6 +300,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public SecurityLevelsPort securityLevels() {
     return securityLevelsPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the legacy JavaScript first-time wizard defaults, validation bounds,
+   * and submission-side daemon writes inside the root module while exposing only detached SPI-local
+   * values upstream.
+   */
+  @Override
+  public FirstTimeWizardPort firstTimeWizard() {
+    return firstTimeWizardPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
@@ -4,25 +4,14 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.clients.http.wizardsteps.BandwidthDetectionUnavailableException;
-import network.crypta.clients.http.wizardsteps.BandwidthLimit;
-import network.crypta.clients.http.wizardsteps.BandwidthManipulator;
-import network.crypta.clients.http.wizardsteps.DatastoreSize;
-import network.crypta.compat.BandwidthIndicator;
-import network.crypta.config.Config;
-import network.crypta.config.Option;
-import network.crypta.config.SubConfig;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.ClientEndpoints;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.NodeIPDetector;
-import network.crypta.node.SecurityLevels;
-import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.DatastoreUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,8 +19,6 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -39,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,29 +33,31 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class FirstTimeWizardNewToadletTest {
 
+  private static final FirstTimeWizardSnapshot DEFAULT_SNAPSHOT =
+      new FirstTimeWizardSnapshot(
+          false,
+          "2.00",
+          "1.25",
+          Fields.parseLong("1.25GiB"),
+          "10.00",
+          Fields.parseLong("10GiB"),
+          10,
+          976562,
+          "49.44",
+          "",
+          "");
+
   @Mock private HighLevelSimpleClient client;
-  @Mock private NodeClientCore core;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private SecurityLevels securityLevels;
+  @Mock private FirstTimeWizardPort wizardPort;
   @Mock private ToadletContext ctx;
   @Mock private PageMaker pageMaker;
-  @Mock private SimpleToadletServer toadletContainer;
-  @Mock private Config config;
-  @Mock private SubConfig nodeSubConfig;
-  @Mock private SubConfig fproxySubConfig;
 
   @BeforeEach
   void setUp() {
@@ -78,24 +66,17 @@ class FirstTimeWizardNewToadletTest {
     HTMLNode content = outer.addChild("div");
     PageNode pageNode = new PageNode(outer, head, content);
 
-    when(core.getNode()).thenReturn(node);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.securityLevels()).thenReturn(securityLevels);
-    when(ctx.getPageMaker()).thenReturn(pageMaker);
-    when(pageMaker.getPageNode(anyString(), eq(ctx), any(PageMaker.RenderParameters.class)))
+    lenient().when(ctx.getPageMaker()).thenReturn(pageMaker);
+    lenient().when(ctx.getFormPassword()).thenReturn("form-pass");
+    lenient()
+        .when(pageMaker.getPageNode(anyString(), eq(ctx), any(PageMaker.RenderParameters.class)))
         .thenReturn(pageNode);
-    ClientEndpoints endpoints = mock(ClientEndpoints.class);
-    when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getToadletContainer()).thenReturn(toadletContainer);
-    when(toadletContainer.getFormPassword()).thenReturn("form-pass");
-    lenient().when(config.get("node")).thenReturn(nodeSubConfig);
-    lenient().when(config.get("fproxy")).thenReturn(fproxySubConfig);
+    lenient().when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
   }
 
   @Test
   void path_returnsWizardUrl() {
-    FirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(client, core, config);
+    FirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(client, wizardPort);
 
     assertEquals(FirstTimeWizardNewToadlet.TOADLET_URL, toadlet.path());
   }
@@ -103,137 +84,85 @@ class FirstTimeWizardNewToadletTest {
   @Test
   void handleMethodGET_whenAccessDenied_returnsEarly() throws Exception {
     TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, core, config);
+        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(false);
 
     toadlet.handleMethodGET(
         new URI(FirstTimeWizardNewToadlet.TOADLET_URL), mock(HTTPRequest.class), ctx);
 
-    verify(ctx, times(1)).checkFullAccess(toadlet);
+    verify(ctx).checkFullAccess(toadlet);
+    verify(wizardPort, never()).snapshot();
     assertFalse(toadlet.htmlWritten);
     assertNull(toadlet.lastModel);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
-  void handleMethodGET_whenPhysicalThreatHigh_setsPasswordAlreadySetAndUsesDetectedLimits()
+  void handleMethodGET_whenSnapshotHasSuggestedValues_populatesModelFromSnapshot()
       throws Exception {
     TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, core, config);
+        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
-    when(securityLevels.getPhysicalThreatLevel())
-        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    when(wizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                true,
+                "2.50",
+                "1.25",
+                Fields.parseLong("1.25GiB"),
+                "10.00",
+                Fields.parseLong("10GiB"),
+                10,
+                976562,
+                "49.44",
+                "1024",
+                "512"));
 
-    BandwidthIndicator bandwidthIndicator = mock(BandwidthIndicator.class);
-    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.ipDetector()).thenReturn(ipDetector);
-    lenient().when(ipDetector.getBandwidthIndicator()).thenReturn(bandwidthIndicator);
-
-    Option<Long> storeSize = mock(Option.class);
-    Option<Long> clientCache = mock(Option.class);
-    Option<Long> slashdotCache = mock(Option.class);
-    when(storeSize.isDefault()).thenReturn(false);
-    when(storeSize.getValue()).thenReturn(2L * DatastoreUtil.ONE_GIB);
-    when(clientCache.getValue()).thenReturn(0L);
-    when(slashdotCache.getValue()).thenReturn(0L);
-
-    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
-        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class);
-        MockedStatic<Config> configStatic = mockStatic(Config.class)) {
-
-      BaseL10n base = mock(BaseL10n.class);
-      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
-      when(base.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
-      when(base.getString(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(0));
-      when(base.getString(anyString(), any(String[].class), any(String[].class)))
-          .thenAnswer(inv -> inv.getArgument(0));
-
-      configStatic.when(() -> Config.longOption(nodeSubConfig, "storeSize")).thenReturn(storeSize);
-      configStatic
-          .when(() -> Config.longOption(nodeSubConfig, "clientCacheSize"))
-          .thenReturn(clientCache);
-      configStatic
-          .when(() -> Config.longOption(nodeSubConfig, "slashdotCacheSize"))
-          .thenReturn(slashdotCache);
-
-      bandwidth
-          .when(() -> BandwidthManipulator.detectBandwidthLimits(bandwidthIndicator))
-          .thenReturn(new BandwidthLimit(2097152L, 1048576L, "desc", false));
-
-      toadlet.handleMethodGET(
-          new URI(FirstTimeWizardNewToadlet.TOADLET_URL), mock(HTTPRequest.class), ctx);
-    }
+    withMockedNodeL10n(
+        () ->
+            toadlet.handleMethodGET(
+                new URI(FirstTimeWizardNewToadlet.TOADLET_URL), mock(HTTPRequest.class), ctx));
 
     assertTrue(toadlet.htmlWritten);
     assertNotNull(toadlet.lastModel);
     assertEquals(Boolean.TRUE, toadlet.lastModel.get("isPasswordAlreadySet"));
     assertFalse(toadlet.lastModel.containsKey("setPassword"));
+    assertEquals("2.50", toadlet.lastModel.get("storageLimit"));
+    assertEquals("1.25", toadlet.lastModel.get("minStorageLimit"));
+    assertEquals("49.44", toadlet.lastModel.get("minBandwidthMonthlyLimit"));
+    assertEquals("1024", toadlet.lastModel.get("downloadLimit"));
+    assertEquals("512", toadlet.lastModel.get("uploadLimit"));
     assertEquals("1024", toadlet.lastModel.get("downloadLimitDetected"));
     assertEquals("512", toadlet.lastModel.get("uploadLimitDetected"));
     assertEquals("form-pass", toadlet.lastModel.get("formPassword"));
   }
 
   @Test
-  void handleMethodPOST_whenValidInput_savesConfigAndRedirects() throws Exception {
+  void handleMethodPOST_whenValidInput_appliesDetachedSubmissionAndRedirects() throws Exception {
     TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, core, config);
+        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
     Map<String, String> parts = new HashMap<>();
-    parts.put("knowSomeone", "");
-    parts.put("connectToStrangers", "on");
+    parts.put("knowSomeone", "on");
+    parts.put("connectToStrangers", "");
     parts.put("haveMonthlyLimit", "");
     parts.put("downLimit", "20000");
     parts.put("upLimit", "20000");
     parts.put("monthlyLimit", "");
     parts.put("storage", "2");
-    parts.put("setPassword", "");
-    parts.put("password", "");
-    parts.put("confirmPassword", "");
+    parts.put("setPassword", "on");
+    parts.put("password", "secret");
+    parts.put("confirmPassword", "secret");
     HTTPRequest request = buildRequest(parts);
 
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.ipDetector()).thenReturn(mock(NodeIPDetector.class));
+    withMockedNodeL10n(
+        () ->
+            toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx));
 
-    network.crypta.node.subsystem.NodeStorageSubsystem storage =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeStorageSubsystem.class);
-    when(node.storage()).thenReturn(storage);
-
-    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
-        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
-        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class);
-        MockedStatic<DatastoreSize> datastoreSize = mockStatic(DatastoreSize.class)) {
-
-      BaseL10n base = mock(BaseL10n.class);
-      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
-      when(base.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
-      when(base.getString(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(0));
-      when(base.getString(anyString(), any(String[].class), any(String[].class)))
-          .thenAnswer(inv -> inv.getArgument(0));
-
-      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
-      datastore.when(() -> DatastoreUtil.autodetectDatastoreSize(core, config)).thenReturn(0L);
-      bandwidth
-          .when(() -> BandwidthManipulator.detectBandwidthLimits(any()))
-          .thenThrow(new BandwidthDetectionUnavailableException("none"));
-
-      toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx);
-
-      datastoreSize.verify(() -> DatastoreSize.setDatastoreSize(eq("2GiB"), eq(config)), times(1));
-    }
-
-    verify(nodeSubConfig).set("inputBandwidthLimit", "20000KiB");
-    verify(nodeSubConfig).set("outputBandwidthLimit", "20000KiB");
-    verify(fproxySubConfig).set("hasCompletedWizard", true);
-    verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
-    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
-    verify(storage).changeMasterPassword("", "", true);
-    verify(core).storeConfig();
+    verify(wizardPort)
+        .applySubmission(
+            new FirstTimeWizardSubmission(
+                true, false, false, "20000", "20000", "", "2", true, "secret"));
     verify(ctx)
         .sendReplyHeaders(
             eq(302),
@@ -248,7 +177,7 @@ class FirstTimeWizardNewToadletTest {
   @Test
   void handleMethodPOST_whenDownloadBelowMinimum_rendersErrorsInsteadOfRedirect() throws Exception {
     TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, core, config);
+        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
     Map<String, String> parts = new HashMap<>();
@@ -262,42 +191,145 @@ class FirstTimeWizardNewToadletTest {
     parts.put("confirmPassword", "");
     HTTPRequest request = buildRequest(parts);
 
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.ipDetector()).thenReturn(mock(NodeIPDetector.class));
-
-    try (MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
-        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
-        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class)) {
-
-      BaseL10n base = mock(BaseL10n.class);
-      nodeL10n.when(NodeL10n::getBase).thenReturn(base);
-      when(base.getString(anyString())).thenAnswer(inv -> inv.getArgument(0));
-      when(base.getString(anyString(), anyString())).thenAnswer(inv -> inv.getArgument(0));
-      when(base.getString(anyString(), any(String[].class), any(String[].class)))
-          .thenAnswer(inv -> inv.getArgument(0));
-
-      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
-      bandwidth
-          .when(() -> BandwidthManipulator.detectBandwidthLimits(any()))
-          .thenThrow(new BandwidthDetectionUnavailableException("none"));
-
-      toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx);
-    }
+    withMockedNodeL10n(
+        () ->
+            toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx));
 
     assertTrue(toadlet.htmlWritten);
     verify(ctx, never()).sendReplyHeaders(eq(302), anyString(), any(), anyString(), anyLong());
+    verify(wizardPort, never()).applySubmission(any(FirstTimeWizardSubmission.class));
     assertNotNull(toadlet.lastModel);
     @SuppressWarnings("unchecked")
     Map<String, String> errors = (Map<String, String>) toadlet.lastModel.get("errors");
     assertTrue(errors.containsKey("downloadLimitError"));
-    verifyNoInteractions(nodeSubConfig, fproxySubConfig);
+  }
+
+  @Test
+  void handleMethodPOST_whenDownloadExceedsIntBackedConfigRange_rendersErrors() throws Exception {
+    TestableFirstTimeWizardNewToadlet toadlet =
+        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+
+    Map<String, String> parts = new HashMap<>();
+    parts.put("haveMonthlyLimit", "");
+    parts.put("downLimit", Integer.toString(Integer.MAX_VALUE / 1024 + 1));
+    parts.put("upLimit", "20000");
+    parts.put("monthlyLimit", "");
+    parts.put("storage", "2");
+    parts.put("setPassword", "");
+    parts.put("password", "");
+    parts.put("confirmPassword", "");
+    HTTPRequest request = buildRequest(parts);
+
+    withMockedNodeL10n(
+        () ->
+            toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx));
+
+    assertTrue(toadlet.htmlWritten);
+    verify(ctx, never()).sendReplyHeaders(eq(302), anyString(), any(), anyString(), anyLong());
+    verify(wizardPort, never()).applySubmission(any(FirstTimeWizardSubmission.class));
+    assertNotNull(toadlet.lastModel);
+    @SuppressWarnings("unchecked")
+    Map<String, String> errors = (Map<String, String>) toadlet.lastModel.get("errors");
+    assertTrue(errors.containsKey("downloadLimitError"));
+  }
+
+  @Test
+  void handleMethodPOST_whenStorageExceedsExactRoundedCap_rendersErrors() throws Exception {
+    TestableFirstTimeWizardNewToadlet toadlet =
+        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(wizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                false,
+                "1.00",
+                "1.00",
+                Fields.parseLong("1GiB"),
+                "1.24",
+                Fields.parseLong("1.235GiB"),
+                10,
+                976562,
+                "49.44",
+                "",
+                ""));
+
+    Map<String, String> parts = new HashMap<>();
+    parts.put("haveMonthlyLimit", "");
+    parts.put("downLimit", "20000");
+    parts.put("upLimit", "20000");
+    parts.put("monthlyLimit", "");
+    parts.put("storage", "1.24");
+    parts.put("setPassword", "");
+    parts.put("password", "");
+    parts.put("confirmPassword", "");
+    HTTPRequest request = buildRequest(parts);
+
+    withMockedNodeL10n(
+        () ->
+            toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx));
+
+    assertTrue(toadlet.htmlWritten);
+    verify(ctx, never()).sendReplyHeaders(eq(302), anyString(), any(), anyString(), anyLong());
+    verify(wizardPort, never()).applySubmission(any(FirstTimeWizardSubmission.class));
+    assertNotNull(toadlet.lastModel);
+    @SuppressWarnings("unchecked")
+    Map<String, String> errors = (Map<String, String>) toadlet.lastModel.get("errors");
+    assertTrue(errors.containsKey("storageLimitError"));
+  }
+
+  @Test
+  void handleMethodPOST_whenMonthlyLimitUsesUnsupportedExponentFormat_rendersErrors()
+      throws Exception {
+    TestableFirstTimeWizardNewToadlet toadlet =
+        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+
+    Map<String, String> parts = new HashMap<>();
+    parts.put("haveMonthlyLimit", "on");
+    parts.put("monthlyLimit", "1e8");
+    parts.put("storage", "2");
+    parts.put("setPassword", "");
+    parts.put("password", "");
+    parts.put("confirmPassword", "");
+    HTTPRequest request = buildRequest(parts);
+
+    withMockedNodeL10n(
+        () ->
+            toadlet.handleMethodPOST(new URI(FirstTimeWizardNewToadlet.TOADLET_URL), request, ctx));
+
+    assertTrue(toadlet.htmlWritten);
+    verify(ctx, never()).sendReplyHeaders(eq(302), anyString(), any(), anyString(), anyLong());
+    verify(wizardPort, never()).applySubmission(any(FirstTimeWizardSubmission.class));
+    assertNotNull(toadlet.lastModel);
+    @SuppressWarnings("unchecked")
+    Map<String, String> errors = (Map<String, String>) toadlet.lastModel.get("errors");
+    assertTrue(errors.containsKey("bandwidthMonthlyLimitError"));
+  }
+
+  private MockedStatic<NodeL10n> mockNodeL10n() {
+    MockedStatic<NodeL10n> nodeL10n = mockStatic(NodeL10n.class);
+    BaseL10n base = mock(BaseL10n.class);
+    nodeL10n.when(NodeL10n::getBase).thenReturn(base);
+    lenient().when(base.getString(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+    lenient()
+        .when(base.getString(anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+    lenient()
+        .when(base.getString(anyString(), any(String[].class), any(String[].class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    return nodeL10n;
+  }
+
+  private void withMockedNodeL10n(ThrowingAction action) throws Exception {
+    try (var _ = mockNodeL10n()) {
+      action.run();
+    }
   }
 
   private HTTPRequest buildRequest(Map<String, String> parts) {
     HTTPRequest request = mock(HTTPRequest.class);
-    when(request.getPartAsStringFailsafe(anyString(), anyInt()))
+    when(request.getPartAsStringFailsafe(anyString(), ArgumentMatchers.anyInt()))
         .thenAnswer(
             invocation -> {
               String key = invocation.getArgument(0, String.class);
@@ -306,13 +338,18 @@ class FirstTimeWizardNewToadletTest {
     return request;
   }
 
+  @FunctionalInterface
+  private interface ThrowingAction {
+    void run() throws Exception;
+  }
+
   private static final class TestableFirstTimeWizardNewToadlet extends FirstTimeWizardNewToadlet {
     Map<String, Object> lastModel;
     boolean htmlWritten;
 
     TestableFirstTimeWizardNewToadlet(
-        HighLevelSimpleClient client, NodeClientCore core, Config config) {
-      super(client, core, config);
+        HighLevelSimpleClient client, FirstTimeWizardPort wizardPort) {
+      super(client, wizardPort);
     }
 
     @Override
@@ -329,7 +366,7 @@ class FirstTimeWizardNewToadletTest {
 
     @Override
     protected void writeTemporaryRedirect(ToadletContext ctx, String msg, String location) {
-      // Intentionally no-op in tests; we only assert that redirects were requested.
+      // Intentionally no-op in tests; redirects are asserted via the underlying reply headers.
     }
   }
 }

--- a/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
@@ -1,0 +1,337 @@
+package network.crypta.node.runtime;
+
+import java.util.Locale;
+import network.crypta.clients.http.wizardsteps.BandwidthDetectionUnavailableException;
+import network.crypta.clients.http.wizardsteps.BandwidthLimit;
+import network.crypta.clients.http.wizardsteps.BandwidthManipulator;
+import network.crypta.clients.http.wizardsteps.DatastoreSize;
+import network.crypta.compat.BandwidthIndicator;
+import network.crypta.config.Config;
+import network.crypta.config.Option;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeIPDetector;
+import network.crypta.node.SecurityLevels;
+import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.support.Fields;
+import network.crypta.support.io.DatastoreUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class LegacyFirstTimeWizardPortTest {
+
+  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock private NodeClientCore core;
+  @Mock private PersistentConfig config;
+  @Mock private SubConfig nodeSubConfig;
+  @Mock private SubConfig fproxySubConfig;
+  @Mock private SecurityLevels securityLevels;
+  @Mock private NodeStorageSubsystem storage;
+
+  @Test
+  void snapshot_whenDaemonStateAvailable_returnsDetachedDefaultsAndSuggestions() {
+    Option<Long> storeSize = mockLongOption();
+    Option<Long> clientCache = mockLongOption();
+    Option<Long> slashdotCache = mockLongOption();
+    BandwidthIndicator bandwidthIndicator = mock(BandwidthIndicator.class);
+    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    network.crypta.node.subsystem.NodeNetworkSubsystem networkSubsystem =
+        mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
+
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(node.network()).thenReturn(networkSubsystem);
+    when(networkSubsystem.ipDetector()).thenReturn(ipDetector);
+    when(ipDetector.getBandwidthIndicator()).thenReturn(bandwidthIndicator);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    when(storeSize.isDefault()).thenReturn(false);
+    when(storeSize.getValue()).thenReturn(2L * DatastoreUtil.ONE_GIB);
+    when(clientCache.getValue()).thenReturn(0L);
+    when(slashdotCache.getValue()).thenReturn(0L);
+
+    try (MockedStatic<Config> configStatic = mockStatic(Config.class);
+        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
+        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class)) {
+      configStatic.when(() -> Config.longOption(nodeSubConfig, "storeSize")).thenReturn(storeSize);
+      configStatic
+          .when(() -> Config.longOption(nodeSubConfig, "clientCacheSize"))
+          .thenReturn(clientCache);
+      configStatic
+          .when(() -> Config.longOption(nodeSubConfig, "slashdotCacheSize"))
+          .thenReturn(slashdotCache);
+      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      bandwidth
+          .when(() -> BandwidthManipulator.detectBandwidthLimits(bandwidthIndicator))
+          .thenReturn(new BandwidthLimit(2097152L, 1048576L, "desc", false));
+
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      FirstTimeWizardSnapshot snapshot = port.snapshot();
+
+      assertTrue(snapshot.passwordAlreadySet());
+      assertEquals("2.00", snapshot.initialStorageLimitGiB());
+      assertEquals(
+          String.format(
+              Locale.ENGLISH,
+              "%.2f",
+              (float) (NodeStorageSubsystem.MIN_STORE_SIZE * 5 / 4) / DatastoreUtil.ONE_GIB),
+          snapshot.minStorageLimitGiB());
+      assertEquals(NodeStorageSubsystem.MIN_STORE_SIZE * 5 / 4, snapshot.minStorageLimitBytes());
+      assertEquals("10.00", snapshot.maxStorageLimitGiB());
+      assertEquals(10L * DatastoreUtil.ONE_GIB, snapshot.maxStorageLimitBytes());
+      assertEquals(Node.getMinimumBandwidth() / 1024L, snapshot.minBandwidthKiB());
+      assertEquals(SECONDS.toNanos(1) / 1024L, snapshot.maxUploadLimitKiB());
+      assertEquals(
+          String.format(Locale.ENGLISH, "%.2f", BandwidthLimit.MIN_MONTHLY_LIMIT),
+          snapshot.minBandwidthMonthlyLimitGiB());
+      assertEquals("1024", snapshot.detectedDownloadLimitKiB());
+      assertEquals("512", snapshot.detectedUploadLimitKiB());
+    }
+  }
+
+  @Test
+  void snapshot_whenAutodetectAndDetectionUnavailable_returnsFallbackAndEmptySuggestions() {
+    Option<Long> storeSize = mockLongOption();
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+
+    try (MockedStatic<Config> configStatic = mockStatic(Config.class);
+        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
+        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class)) {
+      configStatic.when(() -> Config.longOption(nodeSubConfig, "storeSize")).thenReturn(storeSize);
+      when(storeSize.isDefault()).thenReturn(true);
+      datastore.when(() -> DatastoreUtil.autodetectDatastoreSize(core, config)).thenReturn(0L);
+      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      bandwidth
+          .when(
+              () ->
+                  BandwidthManipulator.detectBandwidthLimits(
+                      node.network().ipDetector().getBandwidthIndicator()))
+          .thenThrow(new BandwidthDetectionUnavailableException("none"));
+
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      FirstTimeWizardSnapshot snapshot = port.snapshot();
+
+      assertFalse(snapshot.passwordAlreadySet());
+      assertEquals("100.00", snapshot.initialStorageLimitGiB());
+      assertEquals("", snapshot.detectedDownloadLimitKiB());
+      assertEquals("", snapshot.detectedUploadLimitKiB());
+    }
+  }
+
+  @Test
+  void snapshot_whenStorageCapNeedsRounding_preservesExactStorageBytes() {
+    Option<Long> storeSize = mockLongOption();
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    long roundedUpMaxStorageLimitBytes = Fields.parseLong("1.235GiB");
+
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+
+    try (MockedStatic<Config> configStatic = mockStatic(Config.class);
+        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
+        MockedStatic<BandwidthManipulator> bandwidth = mockStatic(BandwidthManipulator.class)) {
+      configStatic.when(() -> Config.longOption(nodeSubConfig, "storeSize")).thenReturn(storeSize);
+      when(storeSize.isDefault()).thenReturn(true);
+      datastore.when(() -> DatastoreUtil.autodetectDatastoreSize(core, config)).thenReturn(0L);
+      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(roundedUpMaxStorageLimitBytes);
+      bandwidth
+          .when(
+              () ->
+                  BandwidthManipulator.detectBandwidthLimits(
+                      node.network().ipDetector().getBandwidthIndicator()))
+          .thenThrow(new BandwidthDetectionUnavailableException("none"));
+
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      FirstTimeWizardSnapshot snapshot = port.snapshot();
+
+      assertEquals("1.24", snapshot.maxStorageLimitGiB());
+      assertEquals(roundedUpMaxStorageLimitBytes, snapshot.maxStorageLimitBytes());
+    }
+  }
+
+  @Test
+  void applySubmission_whenDirectLimitsWithoutPassword_writesDaemonStateAndPersists()
+      throws Exception {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(config.get("fproxy")).thenReturn(fproxySubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(node.storage()).thenReturn(storage);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+
+    try (MockedStatic<DatastoreSize> datastoreSize = mockStatic(DatastoreSize.class)) {
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      port.applySubmission(
+          new FirstTimeWizardSubmission(true, false, false, "20000", "10000", "", "2", false, ""));
+
+      verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.HIGH);
+      verify(nodeSubConfig).set("inputBandwidthLimit", "20000KiB");
+      verify(nodeSubConfig).set("outputBandwidthLimit", "10000KiB");
+      datastoreSize.verify(() -> DatastoreSize.setDatastoreSize("2GiB", config), times(1));
+      verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+      verify(storage).changeMasterPassword("", "", true);
+      verify(fproxySubConfig).set("hasCompletedWizard", true);
+      verify(core).storeConfig();
+    }
+  }
+
+  @Test
+  void applySubmission_whenMonthlyLimitAndPasswordRequested_derivesBandwidthAndSetsPassword()
+      throws Exception {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(config.get("fproxy")).thenReturn(fproxySubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(node.storage()).thenReturn(storage);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+
+    try (MockedStatic<DatastoreSize> datastoreSize = mockStatic(DatastoreSize.class)) {
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      port.applySubmission(
+          new FirstTimeWizardSubmission(false, true, true, "", "", "500", "3", true, "secret"));
+
+      BandwidthLimit bandwidth = new BandwidthLimit(Fields.parseLong("500GiB"));
+      verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
+      verify(nodeSubConfig).set("inputBandwidthLimit", Long.toString(bandwidth.downBytes));
+      verify(nodeSubConfig).set("outputBandwidthLimit", Long.toString(bandwidth.upBytes));
+      datastoreSize.verify(() -> DatastoreSize.setDatastoreSize("3GiB", config), times(1));
+      verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+      verify(storage).changeMasterPassword("", "secret", true);
+      verify(fproxySubConfig).set("hasCompletedWizard", true);
+      verify(core).storeConfig();
+    }
+  }
+
+  @Test
+  void applySubmission_whenMonthlyLimitCannotBeParsed_throwsAndDoesNotCompleteWizard()
+      throws Exception {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.getConfig()).thenReturn(config);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+
+    try (MockedStatic<DatastoreSize> datastoreSize = mockStatic(DatastoreSize.class)) {
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+      FirstTimeWizardSubmission invalidSubmission =
+          new FirstTimeWizardSubmission(false, true, true, "", "", "1e8", "3", true, "secret");
+
+      assertThrows(NumberFormatException.class, () -> port.applySubmission(invalidSubmission));
+
+      verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
+      verify(fproxySubConfig, never()).set("hasCompletedWizard", true);
+      verify(core, never()).storeConfig();
+      verify(storage, never()).changeMasterPassword("", "secret", true);
+      datastoreSize.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void applySubmission_whenDatastoreSizingFails_throwsAndDoesNotCompleteWizard() throws Exception {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+
+    try (MockedStatic<DatastoreSize> datastoreSize = mockStatic(DatastoreSize.class)) {
+      datastoreSize
+          .when(() -> DatastoreSize.setDatastoreSize("3GiB", config))
+          .thenThrow(new IllegalArgumentException("too big"));
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+      FirstTimeWizardSubmission invalidSubmission =
+          new FirstTimeWizardSubmission(
+              false, true, false, "20000", "10000", "", "3", true, "secret");
+
+      assertThrows(IllegalArgumentException.class, () -> port.applySubmission(invalidSubmission));
+
+      verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
+      verify(nodeSubConfig).set("inputBandwidthLimit", "20000KiB");
+      verify(nodeSubConfig).set("outputBandwidthLimit", "10000KiB");
+      verify(fproxySubConfig, never()).set("hasCompletedWizard", true);
+      verify(core, never()).storeConfig();
+      verify(storage, never()).changeMasterPassword("", "secret", true);
+    }
+  }
+
+  @Test
+  void applySubmission_whenPasswordAlreadySet_skipsPasswordMutation() throws Exception {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(config.get("fproxy")).thenReturn(fproxySubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+
+    try (MockedStatic<DatastoreSize> datastoreSize = mockStatic(DatastoreSize.class)) {
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      port.applySubmission(
+          new FirstTimeWizardSubmission(
+              false, false, false, "20000", "10000", "", "2", true, "secret"));
+
+      verify(nodeSubConfig).set("inputBandwidthLimit", "20000KiB");
+      verify(nodeSubConfig).set("outputBandwidthLimit", "10000KiB");
+      datastoreSize.verify(() -> DatastoreSize.setDatastoreSize("2GiB", config), times(1));
+      verify(securityLevels, never()).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+      verify(node, never()).storage();
+      verify(core).storeConfig();
+    }
+  }
+
+  private static Option<Long> mockLongOption() {
+    @SuppressWarnings("unchecked")
+    Option<Long> option = (Option<Long>) mock(Option.class);
+    return option;
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow `FirstTimeWizardPort` runtime SPI with detached snapshot and submission records for the JavaScript first-time wizard
- move `FirstTimeWizardNewToadlet` off direct `Node`, `NodeClientCore`, and `Config` dependencies by routing wizard reads and writes through `LegacyFirstTimeWizardPort`
- preserve and tighten wizard validation around storage and bandwidth edge cases, and add focused adapter/toadlet regression coverage plus Javadoc for the new non-test Java files

## How to test
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyFirstTimeWizardPortTest' --tests 'network.crypta.clients.http.FirstTimeWizardNewToadletTest'`
- `./gradlew compileJava compileTestJava`