### PR TITLE
refactor(http): Port legacy wizard bandwidth/datastore

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
@@ -35,6 +35,8 @@ import java.util.Objects;
  *     string when automatic detection is unavailable
  * @param detectedUploadLimitKiB recommended direct upload limit in KiB/s text or an empty string
  *     when automatic detection is unavailable
+ * @param autodetectedStorageLimitBytes autodetected datastore suggestion in exact bytes, or {@code
+ *     -1} when the legacy datastore page should fall back to its fixed-size defaults
  */
 public record FirstTimeWizardSnapshot(
     boolean passwordAlreadySet,
@@ -47,7 +49,8 @@ public record FirstTimeWizardSnapshot(
     long maxUploadLimitKiB,
     String minBandwidthMonthlyLimitGiB,
     String detectedDownloadLimitKiB,
-    String detectedUploadLimitKiB) {
+    String detectedUploadLimitKiB,
+    long autodetectedStorageLimitBytes) {
   /**
    * Creates an immutable first-time-wizard snapshot.
    *

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -10,6 +10,8 @@ import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
 import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
 import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
 import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
+import network.crypta.clients.http.wizardsteps.BandwidthLimit;
+import network.crypta.clients.http.wizardsteps.DatastoreSize;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
@@ -386,7 +388,15 @@ final class FProxyRegistrar {
             true,
             null));
 
-    FirstTimeWizardToadlet firstTimeWizardToadlet = new FirstTimeWizardToadlet(client, node, core);
+    FirstTimeWizardToadlet firstTimeWizardToadlet =
+        new FirstTimeWizardToadlet(
+            client,
+            config,
+            core,
+            new FirstTimeWizardToadletRuntimePorts(
+                runtimePorts.firstTimeWizard(),
+                () -> DatastoreSize.maxDatastoreSize(node),
+                () -> legacyCurrentBandwidthLimits(config, node)));
     server.register(
         firstTimeWizardToadlet,
         ToadletRegistration.basic(null, FirstTimeWizardToadlet.TOADLET_URL, true, false));
@@ -442,5 +452,17 @@ final class FProxyRegistrar {
     server.register(
         dismissAlertToadlet,
         ToadletRegistration.basic(null, dismissAlertToadlet.path(), true, false));
+  }
+
+  private static BandwidthLimit legacyCurrentBandwidthLimits(Config config, Node node) {
+    if (config.get("node").getOption("outputBandwidthLimit").isDefault()) {
+      return null;
+    }
+
+    return new BandwidthLimit(
+        node.network().inputBandwidthLimit(),
+        node.network().outputBandwidthLimit(),
+        "bandwidthCurrent",
+        false);
   }
 }

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -26,7 +26,6 @@ import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.SecurityLevels;
 import network.crypta.support.api.BooleanCallback;
@@ -43,16 +42,16 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The toadlet coordinates several step handlers, each responsible for rendering and validating a
  * portion of the workflow. Requests are stateless; the wizard rebuilds its flow from submitted form
- * parameters and redirects between steps instead of maintaining a server-side session state. All
- * mutations funnel through the injected {@link NodeClientCore} instance, so external callers can
- * rely on consistent authorization and threading policies enforced by the core.
+ * parameters and redirects between steps instead of maintaining a server-side session state. The
+ * remaining live daemon writes flow through the injected {@link NodeClientCore}, while the
+ * bandwidth/datastore slice reads detached runtime state through the wizard runtime SPI.
  *
  * <p>Concurrency: requests for the same user are serialized by the HTTP layer, but the class does
- * not assume single-threaded execution. All I/O and state changes are delegated to {@link
- * NodeClientCore#getNode()} executors or configuration APIs, preserving thread safety. Callers
- * should treat instances as request-safe but not share mutable wizard state beyond the persisted
- * form parameters. Typical usage is to register this toadlet at {@link #TOADLET_URL} so the user is
- * redirected there after first launch.
+ * not assume single-threaded execution. All I/O and state changes are delegated to the injected
+ * collaborators or configuration APIs, preserving thread safety. Callers should treat instances as
+ * request-safe but not share mutable wizard state beyond the persisted form parameters. Typical
+ * usage is to register this toadlet at {@link #TOADLET_URL} so the user is redirected there after
+ * first launch.
  */
 public class FirstTimeWizardToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(FirstTimeWizardToadlet.class);
@@ -151,11 +150,15 @@ public class FirstTimeWizardToadlet extends Toadlet {
     HIGH
   }
 
-  FirstTimeWizardToadlet(HighLevelSimpleClient client, Node node, NodeClientCore core) {
+  FirstTimeWizardToadlet(
+      HighLevelSimpleClient client,
+      Config config,
+      NodeClientCore core,
+      FirstTimeWizardToadletRuntimePorts runtimePorts) {
     // Generic Toadlet-related initialization.
     super(client);
     this.core = core;
-    Config config = node.getConfig();
+    FirstTimeWizardToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts, "runtimePorts");
 
     addWizardConfiguration(config);
 
@@ -164,11 +167,18 @@ public class FirstTimeWizardToadlet extends Toadlet {
     steps.put(WIZARD_STEP.WELCOME, new Welcome(config));
     steps.put(WIZARD_STEP.BROWSER_WARNING, new BrowserWarning());
     steps.put(WIZARD_STEP.NAME_SELECTION, new NameSelection(config));
-    steps.put(WIZARD_STEP.DATASTORE_SIZE, new DatastoreSize(core, config));
+    steps.put(
+        WIZARD_STEP.DATASTORE_SIZE,
+        new DatastoreSize(
+            ports.firstTimeWizardPort(), config, ports.legacyDatastoreMaxStorageLimitBytes()));
     steps.put(WIZARD_STEP.OPENNET, new Opennet());
     steps.put(WIZARD_STEP.BANDWIDTH, new Bandwidth());
-    steps.put(WIZARD_STEP.BANDWIDTH_MONTHLY, new BandwidthMonthly(core, config));
-    steps.put(WIZARD_STEP.BANDWIDTH_RATE, new BandwidthRate(core, config));
+    steps.put(
+        WIZARD_STEP.BANDWIDTH_MONTHLY, new BandwidthMonthly(ports.firstTimeWizardPort(), config));
+    steps.put(
+        WIZARD_STEP.BANDWIDTH_RATE,
+        new BandwidthRate(
+            ports.firstTimeWizardPort(), config, ports.legacyCurrentBandwidthLimits()));
 
     // Add step handlers that presets set
     stepMISC = new Misc(config);

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadletRuntimePorts.java
@@ -1,0 +1,44 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import network.crypta.clients.http.wizardsteps.BandwidthLimit;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+
+/**
+ * Shared runtime-port bundle used by the legacy first-time wizard toadlet.
+ *
+ * <p>The legacy multipage wizard still owns its HTTP routing, redirects, and most config writes,
+ * but the bandwidth/datastore slice now reads detached runtime state through the existing
+ * first-time-wizard SPI. It also needs the legacy datastore dropdown cap, which still comes from
+ * the live store-directory heuristic rather than the shared JavaScript wizard snapshot. Grouping
+ * those collaborators keeps the toadlet constructor narrow without threading the full runtime
+ * aggregate through the HTTP layer.
+ *
+ * @param firstTimeWizardPort detached wizard runtime used by the bandwidth and datastore steps
+ * @param legacyDatastoreMaxStorageLimitBytes store-dir-aware cap supplier used by the legacy
+ *     datastore dropdown to preserve its historical thresholds
+ * @param legacyCurrentBandwidthLimits supplier for the legacy rate-page “current settings” row,
+ *     backed by the live network subsystem instead of config-derived defaults
+ */
+record FirstTimeWizardToadletRuntimePorts(
+    FirstTimeWizardPort firstTimeWizardPort,
+    LongSupplier legacyDatastoreMaxStorageLimitBytes,
+    Supplier<BandwidthLimit> legacyCurrentBandwidthLimits) {
+  /**
+   * Creates the legacy wizard's HTTP-local runtime bundle.
+   *
+   * <p>The compact constructor enforces the invariant that every collaborator needed by the legacy
+   * multipage wizard is present up front. That keeps later request handling code simple: the
+   * toadlet and step helpers can dereference the record components without repeating null checks or
+   * partially constructing fallback behavior.
+   *
+   * @throws NullPointerException if any supplied runtime collaborator is {@code null}
+   */
+  FirstTimeWizardToadletRuntimePorts {
+    Objects.requireNonNull(firstTimeWizardPort);
+    Objects.requireNonNull(legacyDatastoreMaxStorageLimitBytes);
+    Objects.requireNonNull(legacyCurrentBandwidthLimits);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthManipulator.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthManipulator.java
@@ -1,11 +1,11 @@
 package network.crypta.clients.http.wizardsteps;
 
+import java.util.Objects;
+import java.util.function.Supplier;
 import network.crypta.compat.BandwidthIndicator;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigException;
 import network.crypta.config.InvalidConfigValueException;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.IllegalValueException;
 import org.slf4j.Logger;
@@ -20,10 +20,10 @@ import org.slf4j.LoggerFactory;
  * contains a static helper for turning raw indicator-reported bit rates into the {@link
  * BandwidthLimit} value object used by the wizard UI.
  *
- * <p>Instances are lightweight and hold references to a {@link NodeClientCore} and {@link Config}
- * supplied by the surrounding HTTP wizard implementation. This class does not own those objects and
- * does not perform any synchronization; callers are expected to invoke it from the same execution
- * context used to render and handle wizard requests.
+ * <p>Instances are lightweight and hold a reference to the shared {@link Config} supplied by the
+ * surrounding HTTP wizard implementation. This class does not own that object and does not perform
+ * any synchronization; callers are expected to invoke it from the same execution context used to
+ * render and handle wizard requests.
  *
  * <ul>
  *   <li>Applies an input or output limit string to the {@code node.*BandwidthLimit} option.
@@ -34,15 +34,8 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class BandwidthManipulator {
   private static final Logger LOG = LoggerFactory.getLogger(BandwidthManipulator.class);
-
-  /**
-   * Node core used to access the current {@link Node} instance and its configured bandwidth state.
-   *
-   * <p>This reference is provided by the caller and is treated as non-null. The reference itself is
-   * immutable, but the underlying core and node may have state that changes over time as the node
-   * runs and configuration is applied.
-   */
-  protected final NodeClientCore core;
+  private static final String OUTPUT_BANDWIDTH_LIMIT = "outputBandwidthLimit";
+  private static final String INPUT_BANDWIDTH_LIMIT = "inputBandwidthLimit";
 
   /**
    * Node configuration used to read and update wizard-related options.
@@ -53,21 +46,39 @@ public abstract class BandwidthManipulator {
    */
   protected final Config config;
 
+  private final Supplier<BandwidthLimit> currentBandwidthLimitsSupplier;
+
   /**
-   * Creates a new helper bound to the given core and configuration.
+   * Creates a new helper bound to the given configuration.
    *
    * <p>Subclasses typically call this from their constructors and then use the protected helpers
    * during request handling (rendering pages, validating user input, and persisting wizard state).
    * This constructor performs no I/O and does not persist configuration changes.
    *
-   * @param core Node core used to access the current node and its bandwidth limits; must be
-   *     non-null for subclasses to function correctly.
    * @param config Configuration handle used to read and update wizard options; must be non-null and
    *     should refer to the node's live configuration.
    */
-  protected BandwidthManipulator(NodeClientCore core, Config config) {
+  protected BandwidthManipulator(Config config) {
+    this(config, () -> null);
+  }
+
+  /**
+   * Creates a new helper bound to the given configuration and current-bandwidth supplier.
+   *
+   * <p>The supplier is used only for rendering the legacy “current settings” preset on the
+   * rate-based bandwidth page. Callers should return {@code null} when no current preset row should
+   * be shown.
+   *
+   * @param config Configuration handle used to read and update wizard options; must be non-null and
+   *     should refer to the node's live configuration.
+   * @param currentBandwidthLimitsSupplier supplier for the live current bandwidth limits used by
+   *     the “current settings” row; must be non-null but may return {@code null}
+   */
+  protected BandwidthManipulator(
+      Config config, Supplier<BandwidthLimit> currentBandwidthLimitsSupplier) {
     this.config = config;
-    this.core = core;
+    this.currentBandwidthLimitsSupplier =
+        Objects.requireNonNull(currentBandwidthLimitsSupplier, "currentBandwidthLimitsSupplier");
   }
 
   /**
@@ -86,11 +97,10 @@ public abstract class BandwidthManipulator {
    * @param setOutputLimit Whether to apply the limit to output (true) or input (false) bandwidth.
    * @throws InvalidConfigValueException If the value is rejected by configuration parsing, such as
    *     being negative, unparsable, or too low to be usable for a running node.
-   * @see Node#getMinimumBandwidth()
    */
   protected void setBandwidthLimit(String limit, boolean setOutputLimit)
       throws InvalidConfigValueException {
-    String limitType = setOutputLimit ? "outputBandwidthLimit" : "inputBandwidthLimit";
+    String limitType = setOutputLimit ? OUTPUT_BANDWIDTH_LIMIT : INPUT_BANDWIDTH_LIMIT;
     try {
       config.get("node").set(limitType, limit);
       LOG.info("The {} has been set to {}", limitType, limit);
@@ -129,28 +139,19 @@ public abstract class BandwidthManipulator {
   }
 
   /**
-   * Returns the node's currently effective bandwidth limits when they are explicitly configured.
+   * Returns the node's currently effective bandwidth limits for the legacy “current settings” row.
    *
-   * <p>This helper is used to populate the wizard UI with a “current settings” row when the node is
-   * not using the default bandwidth configuration. If the relevant option is still at its default
-   * value, this method returns {@code null} so callers can omit the “current” section.
+   * <p>This helper delegates to the supplier provided by the surrounding HTTP wiring. Callers
+   * should return {@code null} when the wizard should omit the “current” row.
    *
-   * <p>The returned {@link BandwidthLimit} is constructed from the node's current input/output
-   * values and is intended for display only; it does not imply that the wizard has validated or
-   * re-applied these settings during the current request.
+   * <p>The returned {@link BandwidthLimit} is intended for display only; it does not imply that the
+   * wizard has validated or re-applied these settings during the current request.
    *
    * @return A {@link BandwidthLimit} describing the node's current limits, or {@code null} when the
    *     wizard should treat the node as using defaults.
    */
   protected BandwidthLimit getCurrentBandwidthLimitsOrNull() {
-    if (!config.get("node").getOption("outputBandwidthLimit").isDefault()) {
-      return new BandwidthLimit(
-          core.getNode().network().inputBandwidthLimit(),
-          core.getNode().network().outputBandwidthLimit(),
-          "bandwidthCurrent",
-          false);
-    }
-    return null;
+    return currentBandwidthLimitsSupplier.get();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthMonthly.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthMonthly.java
@@ -1,10 +1,12 @@
 package network.crypta.clients.http.wizardsteps;
 
+import java.util.Objects;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.URLEncoder;
 import network.crypta.support.api.HTTPRequest;
@@ -16,9 +18,9 @@ import network.crypta.support.io.DatastoreUtil;
  * <p>This step presents a small set of common monthly transfer caps (plus a free-form input) and
  * translates the user’s selection into the node’s underlying up/down bandwidth limits. The UI is
  * intentionally phrased in terms of a monthly total because many ISPs describe limits that way,
- * while the underlying configuration is expressed as sustained rates. On submit, the handler parses
- * the requested cap, converts it to bytes, and delegates to {@link BandwidthManipulator} to persist
- * the computed limits in {@link Config}.
+ * while the underlying configuration is expressed as sustained rates. On submitting, the handler
+ * parses the requested cap, converts it to bytes, and delegates to {@link BandwidthManipulator} to
+ * persist the computed limits in {@link Config}.
  *
  * <p>Notable behaviors:
  *
@@ -30,7 +32,7 @@ import network.crypta.support.io.DatastoreUtil;
  * </ul>
  *
  * <p>Thread-safety: instances are intended to be used on the request-handling thread for the wizard
- * UI. This class does not maintain mutable shared state beyond delegating to the configuration
+ * UI. This class does not maintain a mutable shared state beyond delegating to the configuration
  * layer.
  *
  * @see BandwidthManipulator
@@ -45,23 +47,23 @@ public class BandwidthMonthly extends BandwidthManipulator implements Step {
   private static final String PARAM_CAP_TO = "capTo";
   private static final String TYPE_SUBMIT = "submit";
 
-  private static final long[] caps = {
-    (long) Math.ceil(BandwidthLimit.MIN_MONTHLY_LIMIT), 100, 150, 250, 500
-  };
+  private final FirstTimeWizardPort wizardPort;
 
   /**
-   * Creates a wizard step instance bound to a specific node core and configuration.
+   * Creates a wizard step instance bound to a detached wizard runtime and configuration.
    *
    * <p>The created instance is used to render the HTML form for the step and to apply the submitted
    * selection back into the persistent configuration via {@link BandwidthManipulator}. Callers
-   * typically construct this once during wizard initialization and reuse it for subsequent HTTP
-   * requests for the same node instance.
+   * typically construct this once during wizard initialization and reuse it for later HTTP requests
+   * for the same node instance.
    *
-   * @param core node core used to access services required by the wizard, must be non-null
+   * @param wizardPort detached wizard runtime used for minimum monthly-bandwidth reads must be
+   *     non-null
    * @param config persistent configuration object updated by this step, must be non-null
    */
-  public BandwidthMonthly(NodeClientCore core, Config config) {
-    super(core, config);
+  public BandwidthMonthly(FirstTimeWizardPort wizardPort, Config config) {
+    super(config);
+    this.wizardPort = Objects.requireNonNull(wizardPort, "wizardPort");
   }
 
   /**
@@ -79,6 +81,10 @@ public class BandwidthMonthly extends BandwidthManipulator implements Step {
    */
   @Override
   public void getStep(HTTPRequest request, PageHelper helper) {
+    FirstTimeWizardSnapshot snapshot = wizardPort.snapshot();
+    double minMonthlyLimitGiB = minimumMonthlyLimitGiB(snapshot);
+    long[] caps = {(long) Math.ceil(minMonthlyLimitGiB), 100, 150, 250, 500};
+
     HTMLNode contentNode = helper.getPageContent(WizardL10n.l10n("bandwidthLimit"));
 
     // Check for and display any errors.
@@ -96,7 +102,7 @@ public class BandwidthMonthly extends BandwidthManipulator implements Step {
                   new String[] {"requested", "minimum", "useMinimum"},
                   new String[] {
                     parseTarget,
-                    String.valueOf(Math.round(BandwidthLimit.MIN_MONTHLY_LIMIT)),
+                    String.valueOf(Math.round(minMonthlyLimitGiB)),
                     WizardL10n.l10n("bandwidthMonthlyUseMinimum")
                   }));
 
@@ -104,7 +110,7 @@ public class BandwidthMonthly extends BandwidthManipulator implements Step {
       minimumForm.addChild(
           TAG_INPUT,
           new String[] {"type", "name", ATTR_VALUE},
-          new String[] {"hidden", PARAM_CAP_TO, String.valueOf(BandwidthLimit.MIN_MONTHLY_LIMIT)});
+          new String[] {"hidden", PARAM_CAP_TO, snapshot.minBandwidthMonthlyLimitGiB()});
       minimumForm.addChild(
           TAG_INPUT,
           new String[] {"type", ATTR_VALUE},
@@ -223,5 +229,13 @@ public class BandwidthMonthly extends BandwidthManipulator implements Step {
     setWizardComplete();
 
     return FirstTimeWizardToadlet.WIZARD_STEP.COMPLETE.name();
+  }
+
+  private static double minimumMonthlyLimitGiB(FirstTimeWizardSnapshot snapshot) {
+    try {
+      return Double.parseDouble(snapshot.minBandwidthMonthlyLimitGiB());
+    } catch (NumberFormatException _) {
+      return BandwidthLimit.MIN_MONTHLY_LIMIT;
+    }
   }
 }

--- a/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthRate.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthRate.java
@@ -1,13 +1,15 @@
 package network.crypta.clients.http.wizardsteps;
 
 import java.text.DecimalFormat;
+import java.util.Objects;
+import java.util.function.Supplier;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.IllegalValueException;
 import network.crypta.support.SizeUtil;
 import network.crypta.support.URLEncoder;
 import network.crypta.support.api.HTTPRequest;
@@ -42,6 +44,7 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
   private static final String ATTR_VALUE = "value";
 
   private final BandwidthLimit[] limits;
+  private final FirstTimeWizardPort wizardPort;
 
   /**
    * Creates a new bandwidth-rate wizard step with a fixed set of preset profiles.
@@ -50,11 +53,30 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
    * PageHelper)}. Construction does not apply configuration changes; persistence occurs only after
    * a successful {@link #postStep(HTTPRequest)} submission.
    *
-   * @param core node core used to access runtime services such as bandwidth indicators
+   * @param wizardPort detached wizard runtime used for detected-bandwidth suggestions
    * @param config node configuration instance that receives the selected bandwidth limits
    */
-  public BandwidthRate(NodeClientCore core, Config config) {
-    super(core, config);
+  public BandwidthRate(FirstTimeWizardPort wizardPort, Config config) {
+    this(wizardPort, config, () -> null);
+  }
+
+  /**
+   * Creates a new bandwidth-rate wizard step with a fixed set of preset profiles.
+   *
+   * <p>The extra supplier is used only for the legacy “current settings” row, so the page can
+   * render the node's live effective limits instead of reconstructing them from config defaults.
+   *
+   * @param wizardPort detached wizard runtime used for detected-bandwidth suggestions
+   * @param config node configuration instance that receives the selected bandwidth limits
+   * @param currentBandwidthLimitsSupplier supplier for the live current-bandwidth row; must be
+   *     non-null but may return {@code null}
+   */
+  public BandwidthRate(
+      FirstTimeWizardPort wizardPort,
+      Config config,
+      Supplier<BandwidthLimit> currentBandwidthLimitsSupplier) {
+    super(config, currentBandwidthLimitsSupplier);
+    this.wizardPort = Objects.requireNonNull(wizardPort, "wizardPort");
     final long KiB = 1024L;
     limits =
         new BandwidthLimit[] {
@@ -92,6 +114,7 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
    */
   @Override
   public void getStep(HTTPRequest request, PageHelper helper) {
+    FirstTimeWizardSnapshot snapshot = wizardPort.snapshot();
     HTMLNode contentNode = helper.getPageContent(WizardL10n.l10n("bandwidthLimit"));
 
     HTMLNode formNode = helper.addFormChild(contentNode, ".", "limit");
@@ -122,18 +145,10 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
 
     boolean addedDefault = false;
 
-    try {
-      BandwidthLimit detected =
-          detectBandwidthLimits(core.getNode().network().ipDetector().getBandwidthIndicator());
-
-      // Detected limits reasonable; add half of both as a recommended option.
-      BandwidthLimit usable =
-          new BandwidthLimit(
-              detected.downBytes / 2, detected.upBytes / 2, "bandwidthDetected", true);
-      addLimitRow(table, usable, true, true);
+    BandwidthLimit detected = detectedBandwidthLimitOrNull(snapshot);
+    if (detected != null) {
+      addLimitRow(table, detected, true, true);
       addedDefault = true;
-    } catch (BandwidthDetectionUnavailableException | IllegalValueException e) {
-      LOG.info(e.getMessage(), e);
     }
 
     BandwidthLimit current = getCurrentBandwidthLimitsOrNull();
@@ -229,6 +244,26 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
 
     setWizardComplete();
     return FirstTimeWizardToadlet.WIZARD_STEP.COMPLETE.name();
+  }
+
+  private BandwidthLimit detectedBandwidthLimitOrNull(FirstTimeWizardSnapshot snapshot) {
+    String detectedDownload = snapshot.detectedDownloadLimitKiB();
+    String detectedUpload = snapshot.detectedUploadLimitKiB();
+    if (detectedDownload.isEmpty() || detectedUpload.isEmpty()) {
+      return null;
+    }
+
+    try {
+      final long kib = 1024L;
+      return new BandwidthLimit(
+          Long.parseLong(detectedDownload) * kib,
+          Long.parseLong(detectedUpload) * kib,
+          "bandwidthDetected",
+          true);
+    } catch (NumberFormatException e) {
+      LOG.info("Ignoring malformed detected bandwidth suggestion.", e);
+      return null;
+    }
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.http.wizardsteps;
 
 import java.io.File;
+import java.util.Objects;
+import java.util.function.LongSupplier;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigException;
@@ -8,8 +10,9 @@ import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.Option;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeStarter;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SizeUtil;
@@ -50,23 +53,32 @@ public class DatastoreSize implements Step {
   private static final String ATTR_VALUE = "value";
   private static final String TAG_OPTION = "option";
 
-  private final NodeClientCore core;
+  private final FirstTimeWizardPort wizardPort;
+  private final LongSupplier legacyDatastoreMaxStorageLimitBytes;
   private final Config config;
 
   /**
-   * Creates a wizard step bound to a specific node core and configuration.
+   * Creates a wizard step bound to the detached wizard runtime and legacy datastore cap.
    *
    * <p>The instance is lightweight and holds references to the provided objects; it does not
    * perform any environment detection until {@link #getStep(HTTPRequest, PageHelper)} is called.
    * Callers typically construct this step as part of the wizard flow and reuse it for the lifetime
    * of a single request.
    *
-   * @param core node core used for environment-aware sizing heuristics and store directory access
+   * @param wizardPort detached wizard runtime used for datastore suggestions and size bounds
    * @param config mutable configuration that receives the selected datastore and cache settings
+   * @param legacyDatastoreMaxStorageLimitBytes store-dir-aware cap supplier used to preserve the
+   *     legacy dropdown thresholds
    */
-  public DatastoreSize(NodeClientCore core, Config config) {
+  public DatastoreSize(
+      FirstTimeWizardPort wizardPort,
+      Config config,
+      LongSupplier legacyDatastoreMaxStorageLimitBytes) {
     this.config = config;
-    this.core = core;
+    this.wizardPort = Objects.requireNonNull(wizardPort, "wizardPort");
+    this.legacyDatastoreMaxStorageLimitBytes =
+        Objects.requireNonNull(
+            legacyDatastoreMaxStorageLimitBytes, "legacyDatastoreMaxStorageLimitBytes");
   }
 
   /**
@@ -81,11 +93,12 @@ public class DatastoreSize implements Step {
    * <p>This method does not mutate {@link Config}; it only constructs the HTML content for the
    * current request.
    *
-   * @param request current HTTP request, used only for step context and localization behavior
+   * @param request the current HTTP request, used only for step context and localization behavior
    * @param helper helper responsible for creating page structure and form elements for the wizard
    */
   @Override
   public void getStep(HTTPRequest request, PageHelper helper) {
+    FirstTimeWizardSnapshot snapshot = wizardPort.snapshot();
     HTMLNode contentNode = helper.getPageContent(WizardL10n.l10n("step4Title"));
     HTMLNode bandwidthInfoboxContent =
         helper.getInfobox(
@@ -95,9 +108,8 @@ public class DatastoreSize implements Step {
     HTMLNode bandwidthForm = helper.addFormChild(bandwidthInfoboxContent, ".", "dsForm");
     HTMLNode result = bandwidthForm.addChild("select", "name", "ds");
 
-    long maxSize = maxDatastoreSize(core.getNode());
-
-    long autodetectedSize = canAutoconfigureDatastoreSize();
+    long maxSize = legacyDatastoreMaxStorageLimitBytes.getAsLong();
+    long autodetectedSize = snapshot.autodetectedStorageLimitBytes();
     if (maxSize < autodetectedSize) autodetectedSize = maxSize;
 
     Option<Long> sizeOption = Config.longOption(config.get("node"), "storeSize");
@@ -137,7 +149,7 @@ public class DatastoreSize implements Step {
    */
   @Override
   public String postStep(HTTPRequest request) {
-    // drop down options may be 6 chars or fewer, but formatted ones e.g. old value if re-running
+    // drop down options may be 6 chars or fewer, but formatted ones e.g., old value if re-running
     // can
     // be more
     boolean firsttime = !request.isPartSet("singlestep");
@@ -190,10 +202,10 @@ public class DatastoreSize implements Step {
       int limit;
       if (downstreamLimit <= 0) limit = upstreamLimit;
       else limit = Math.min(downstreamLimit, upstreamLimit);
-      // 35KB/sec limit has been seen to have 0.5 store writes per second.
-      // So saying we want to have space to cache everything is only doubling that ...
-      // OTOH most stuff is at low enough HTL to go to the datastore and thus not to
-      // the slashdot cache, so we could probably cut this significantly...
+      // A 35 KiB/sec limit has been seen to have 0.5 store writes per second.
+      // Reserving enough room to cache everything only doubles that rate.
+      // Most traffic is at a low enough HTL to go to the datastore instead.
+      // That means this slashdot cache estimate could probably be smaller.
       long lifetime = config.get("node").getLong("slashdotCacheLifetime");
       long maxSlashdotCacheSize = (lifetime / 1000) * limit;
       long slashdotCacheSize = Math.min(size / 10, maxSlashdotCacheSize);
@@ -328,16 +340,12 @@ public class DatastoreSize implements Step {
     available = available / 2;
     // Slot filters are 4 bytes per slot.
     long slots = available / 4;
-    // There are 3 types of keys. We want the number of { SSK, CHK, pubkey } i.e. the number of
+    // There are 3 types of keys. We want the number of { SSK, CHK, pubkey } i.e., the number of
     // slots in each store.
     slots /= 3;
-    // We return the total size, so we don't need to worry about cache vs store or even client
+    // We return the total size, so we don't need to worry about cache vs. store or even client
     // cache.
     // One key of all 3 types combined uses NodeStorageSubsystem.SIZE_PER_KEY bytes on disk.
     return slots * network.crypta.node.subsystem.NodeStorageSubsystem.SIZE_PER_KEY;
-  }
-
-  private long canAutoconfigureDatastoreSize() {
-    return DatastoreUtil.autodetectDatastoreSize(core, config);
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
@@ -90,10 +90,11 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
     Config config = node.getConfig();
     long minStorageLimitBytes = MIN_STORAGE_LIMIT;
     long maxStorageLimitBytes = DatastoreUtil.maxDatastoreSize();
+    long autodetectedStorageLimitBytes = autodetectedStorageLimitBytes(config);
     String[] detectedBandwidthLimits = detectedBandwidthLimits();
     return new FirstTimeWizardSnapshot(
         passwordAlreadySet(),
-        initialStorageLimitGiB(config),
+        initialStorageLimitGiB(config, autodetectedStorageLimitBytes),
         formatGiB(minStorageLimitBytes),
         minStorageLimitBytes,
         formatGiB(maxStorageLimitBytes),
@@ -102,7 +103,8 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
         SECONDS.toNanos(1) / KIB,
         String.format(Locale.ENGLISH, "%.2f", BandwidthLimit.MIN_MONTHLY_LIMIT),
         detectedBandwidthLimits[0],
-        detectedBandwidthLimits[1]);
+        detectedBandwidthLimits[1],
+        autodetectedStorageLimitBytes);
   }
 
   /** {@inheritDoc} */
@@ -143,7 +145,7 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
    * @param config live daemon config used to read existing datastore-related options
    * @return initial datastore size formatted as English-locale GiB text for the form field
    */
-  private String initialStorageLimitGiB(Config config) {
+  private String initialStorageLimitGiB(Config config, long autodetectedStorageLimitBytes) {
     float storage = 100;
     Option<Long> sizeOption = Config.longOption(config.get("node"), "storeSize");
     if (!sizeOption.isDefault()) {
@@ -155,13 +157,29 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
               + clientCacheSizeOption.getValue()
               + slashdotCacheSizeOption.getValue();
       storage = (float) totalSize / DatastoreUtil.ONE_GIB;
-    } else {
-      long autodetectedDatastoreSize = DatastoreUtil.autodetectDatastoreSize(core, config);
-      if (autodetectedDatastoreSize > 0) {
-        storage = (float) autodetectedDatastoreSize / DatastoreUtil.ONE_GIB;
-      }
+    } else if (autodetectedStorageLimitBytes > 0) {
+      storage = (float) autodetectedStorageLimitBytes / DatastoreUtil.ONE_GIB;
     }
     return String.format(Locale.ENGLISH, "%.2f", storage);
+  }
+
+  /**
+   * Returns the exact datastore suggestion used by the legacy datastore-size dropdown.
+   *
+   * <p>A negative value preserves the legacy “no suggestion available” flow so the HTTP layer can
+   * keep its existing fixed-size fallback selection behavior.
+   *
+   * @param config live daemon config used to decide whether datastore size is already configured
+   * @return autodetected datastore suggestion in bytes, or {@code -1} when unavailable
+   */
+  private long autodetectedStorageLimitBytes(Config config) {
+    Option<Long> sizeOption = Config.longOption(config.get("node"), "storeSize");
+    if (!sizeOption.isDefault()) {
+      return -1;
+    }
+
+    long autodetectedStorageLimitBytes = DatastoreUtil.autodetectDatastoreSize(core, config);
+    return autodetectedStorageLimitBytes > 0 ? autodetectedStorageLimitBytes : -1;
   }
 
   /**
@@ -174,9 +192,10 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
    */
   private String[] detectedBandwidthLimits() {
     try {
+      var ipDetector = node.network().ipDetector();
       BandwidthLimit detected =
           BandwidthManipulator.detectBandwidthLimits(
-              node.network().ipDetector().getBandwidthIndicator());
+              ipDetector == null ? null : ipDetector.getBandwidthIndicator());
       return new String[] {
         Long.toString(detected.downBytes / 2 / KIB), Long.toString(detected.upBytes / 2 / KIB)
       };

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
@@ -52,7 +52,8 @@ class FirstTimeWizardNewToadletTest {
           976562,
           "49.44",
           "",
-          "");
+          "",
+          -1L);
 
   @Mock private HighLevelSimpleClient client;
   @Mock private FirstTimeWizardPort wizardPort;
@@ -115,7 +116,8 @@ class FirstTimeWizardNewToadletTest {
                 976562,
                 "49.44",
                 "1024",
-                "512"));
+                "512",
+                -1L));
 
     withMockedNodeL10n(
         () ->
@@ -252,7 +254,8 @@ class FirstTimeWizardNewToadletTest {
                 976562,
                 "49.44",
                 "",
-                ""));
+                "",
+                -1L));
 
     Map<String, String> parts = new HashMap<>();
     parts.put("haveMonthlyLimit", "");

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
@@ -16,6 +16,7 @@ import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,12 +50,14 @@ class FirstTimeWizardToadletTest {
   private Node node;
 
   @Mock private NodeClientCore core;
+  @Mock private FirstTimeWizardPort firstTimeWizardPort;
   @Mock private ToadletContext ctx;
+
+  private PersistentConfig config;
 
   @BeforeEach
   void setUp() throws Exception {
-    PersistentConfig config = new PersistentConfig(null);
-    when(node.getConfig()).thenReturn(config);
+    config = new PersistentConfig(null);
     when(core.getNode()).thenReturn(node);
     when(ctx.checkFullAccess(any())).thenReturn(true);
   }
@@ -69,7 +72,14 @@ class FirstTimeWizardToadletTest {
 
   @Test
   void handleMethodGET_browserWarningWithIncognitoChrome_redirectsToMisc() throws Exception {
-    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    FirstTimeWizardToadlet toadlet =
+        spy(
+            new FirstTimeWizardToadlet(
+                client,
+                config,
+                core,
+                new FirstTimeWizardToadletRuntimePorts(
+                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -94,7 +104,14 @@ class FirstTimeWizardToadletTest {
 
   @Test
   void handleMethodGET_securityNetworkWithoutOpennet_redirectsToOpenNet() throws Exception {
-    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    FirstTimeWizardToadlet toadlet =
+        spy(
+            new FirstTimeWizardToadlet(
+                client,
+                config,
+                core,
+                new FirstTimeWizardToadletRuntimePorts(
+                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -118,7 +135,14 @@ class FirstTimeWizardToadletTest {
 
   @Test
   void handleMethodPOST_presetLow_setsThreatLevelsAndRedirects() throws Exception {
-    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    FirstTimeWizardToadlet toadlet =
+        spy(
+            new FirstTimeWizardToadlet(
+                client,
+                config,
+                core,
+                new FirstTimeWizardToadletRuntimePorts(
+                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe("step", 20)).thenReturn("WELCOME");
@@ -157,7 +181,14 @@ class FirstTimeWizardToadletTest {
 
   @Test
   void handleMethodPOST_whenStepThrowsIOException_returnsInternalErrorPage() throws Exception {
-    FirstTimeWizardToadlet toadlet = spy(new FirstTimeWizardToadlet(client, node, core));
+    FirstTimeWizardToadlet toadlet =
+        spy(
+            new FirstTimeWizardToadlet(
+                client,
+                config,
+                core,
+                new FirstTimeWizardToadletRuntimePorts(
+                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe("step", 20)).thenReturn("MISC");

--- a/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthMonthlyTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthMonthlyTest.java
@@ -7,7 +7,8 @@ import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.URLEncoder;
@@ -39,6 +40,20 @@ class BandwidthMonthlyTest {
   private static final String PARAM_PARSE_ERROR = "parseError";
   private static final String PARAM_TOO_LOW = "tooLow";
   private static final String FRAGMENT_PARSE_TARGET = "&parseTarget=";
+  private static final FirstTimeWizardSnapshot DEFAULT_SNAPSHOT =
+      new FirstTimeWizardSnapshot(
+          false,
+          "2.00",
+          "1.25",
+          1L,
+          "10.00",
+          10L,
+          10L,
+          976562L,
+          String.valueOf(BandwidthLimit.MIN_MONTHLY_LIMIT),
+          "",
+          "",
+          -1L);
 
   @Mock HTTPRequest request;
   @Mock PageHelper helper;
@@ -132,7 +147,9 @@ class BandwidthMonthlyTest {
 
   @Test
   void getStep_whenNoErrorParams_rendersCapsCustomInputAndBackButton() {
-    BandwidthMonthly step = new BandwidthMonthly(mock(NodeClientCore.class), mock(Config.class));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
+    BandwidthMonthly step = new BandwidthMonthly(wizardPort, mock(Config.class));
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
 
@@ -174,7 +191,9 @@ class BandwidthMonthlyTest {
 
   @Test
   void getStep_whenParseErrorParamSet_showsCouldNotParseMessage() {
-    BandwidthMonthly step = new BandwidthMonthly(mock(NodeClientCore.class), mock(Config.class));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
+    BandwidthMonthly step = new BandwidthMonthly(wizardPort, mock(Config.class));
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
 
@@ -209,7 +228,9 @@ class BandwidthMonthlyTest {
 
   @Test
   void getStep_whenTooLowParamSet_includesUseMinimumFormWithMinimumValue() {
-    BandwidthMonthly step = new BandwidthMonthly(mock(NodeClientCore.class), mock(Config.class));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
+    BandwidthMonthly step = new BandwidthMonthly(wizardPort, mock(Config.class));
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
 
@@ -294,7 +315,7 @@ class BandwidthMonthlyTest {
     boolean throwInvalidConfigOnNextSet;
 
     TestableBandwidthMonthly() {
-      super(mock(NodeClientCore.class), mock(Config.class));
+      super(mock(FirstTimeWizardPort.class), mock(Config.class));
     }
 
     @Override

--- a/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthRateTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthRateTest.java
@@ -5,12 +5,10 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
-import network.crypta.compat.BandwidthIndicator;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.NodeIPDetector;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.URLEncoder;
@@ -44,6 +42,9 @@ class BandwidthRateTest {
   private static final String MSG_DOWN_BAD = "down bad";
   private static final String MSG_UP_BAD = "up bad";
   private static final String ATTR_CHECKED = "checked=\"checked\"";
+  private static final FirstTimeWizardSnapshot DEFAULT_SNAPSHOT =
+      new FirstTimeWizardSnapshot(
+          false, "2.00", "1.25", 1L, "10.00", 10L, 10L, 976562L, "49.44", "", "", -1L);
 
   @Mock HTTPRequest request;
   @Mock PageHelper helper;
@@ -213,19 +214,11 @@ class BandwidthRateTest {
 
   @Test
   void getStep_whenParseErrorParamSet_includesParseTargetInHtml() {
-    NodeClientCore core = mock(NodeClientCore.class);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
     Config config = mock(Config.class);
+    when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
 
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
-    when(core.getNode()).thenReturn(node);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.ipDetector()).thenReturn(ipDetector);
-    when(ipDetector.getBandwidthIndicator()).thenReturn(null);
-
-    BandwidthRate step = new TestableBandwidthRate(core, config, null);
+    BandwidthRate step = new TestableBandwidthRate(wizardPort, config, null);
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
     stubHelperToAttachInfoboxesAndForms();
@@ -244,19 +237,11 @@ class BandwidthRateTest {
 
   @Test
   void getStep_whenNoDetectedOrCurrentLimit_expectMaybeDefaultOptionChecked() {
-    NodeClientCore core = mock(NodeClientCore.class);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
     Config config = mock(Config.class);
+    when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
 
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
-    when(core.getNode()).thenReturn(node);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.ipDetector()).thenReturn(ipDetector);
-    when(ipDetector.getBandwidthIndicator()).thenReturn(null);
-
-    BandwidthRate step = new TestableBandwidthRate(core, config, null);
+    BandwidthRate step = new TestableBandwidthRate(wizardPort, config, null);
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
     stubHelperToAttachInfoboxesAndForms();
@@ -275,24 +260,53 @@ class BandwidthRateTest {
   }
 
   @Test
-  void getStep_whenDetectedBandwidthAvailable_expectDetectedRecommendedOptionChecked() {
-    NodeClientCore core = mock(NodeClientCore.class);
+  void getStep_whenLiveCurrentLimitAvailable_expectCurrentOptionRendered() {
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
     Config config = mock(Config.class);
+    when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
 
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeIPDetector ipDetector = mock(NodeIPDetector.class);
-    when(core.getNode()).thenReturn(node);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.ipDetector()).thenReturn(ipDetector);
+    BandwidthRate step =
+        new BandwidthRate(
+            wizardPort, config, () -> new BandwidthLimit(4096L, 1024L, "bandwidthCurrent", false));
 
-    BandwidthIndicator indicator = mock(BandwidthIndicator.class);
-    when(ipDetector.getBandwidthIndicator()).thenReturn(indicator);
-    when(indicator.getDownstreamMaxBitRate()).thenReturn(8_000_000);
-    when(indicator.getUpstreamMaxBitRate()).thenReturn(1_000_000);
+    when(helper.getPageContent(anyString())).thenReturn(pageContent);
+    stubHelperToAttachInfoboxesAndForms();
+    when(request.isParameterSet(anyString())).thenReturn(false);
 
-    BandwidthRate step = new TestableBandwidthRate(core, config, null);
+    step.getStep(request, helper);
+
+    String html = pageContent.generate();
+    String expectedCurrentValue = "4096/1024";
+    Pattern currentPattern =
+        Pattern.compile(
+            "(?s)<input\\b"
+                + "(?=[^>]*\\btype=\"radio\")"
+                + "(?=[^>]*\\bname=\""
+                + Pattern.quote(PARAM_BANDWIDTH)
+                + "\")"
+                + "(?=[^>]*\\bvalue=\""
+                + Pattern.quote(HTMLEncoder.encode(expectedCurrentValue))
+                + "\")"
+                + "[^>]*>");
+    assertTrue(
+        currentPattern.matcher(html).find(),
+        "Missing radio input name=bandwidth value=" + expectedCurrentValue);
+    assertTrue(
+        html.contains(HTMLEncoder.encode(WizardL10n.l10n("bandwidthCurrent"))),
+        "Expected current-bandwidth label to be present");
+  }
+
+  @Test
+  void getStep_whenDetectedBandwidthAvailable_expectDetectedRecommendedOptionChecked() {
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    Config config = mock(Config.class);
+    when(wizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                false, "2.00", "1.25", 1L, "10.00", 10L, 10L, 976562L, "49.44", "1024", "512",
+                -1L));
+
+    BandwidthRate step = new TestableBandwidthRate(wizardPort, config, null);
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
     stubHelperToAttachInfoboxesAndForms();
@@ -302,9 +316,7 @@ class BandwidthRateTest {
 
     String html = pageContent.generate();
 
-    long downBytesPerSecond = 8_000_000L / 8;
-    long upBytesPerSecond = 1_000_000L / 8;
-    String expectedSelectedValue = (downBytesPerSecond / 2) + "/" + (upBytesPerSecond / 2);
+    String expectedSelectedValue = (1024L * 1024L) + "/" + (512L * 1024L);
     assertHtmlHasCheckedBandwidthRadio(html, expectedSelectedValue);
 
     String suggestedLabel = WizardL10n.l10n("autodetectedSuggestedLimit");
@@ -403,11 +415,11 @@ class BandwidthRateTest {
     private final BandwidthLimit current;
 
     TestableBandwidthRate() {
-      this(mock(NodeClientCore.class), mock(Config.class), null);
+      this(mock(FirstTimeWizardPort.class), mock(Config.class), null);
     }
 
-    TestableBandwidthRate(NodeClientCore core, Config config, BandwidthLimit current) {
-      super(core, config);
+    TestableBandwidthRate(FirstTimeWizardPort wizardPort, Config config, BandwidthLimit current) {
+      super(wizardPort, config);
       this.current = current;
     }
 

--- a/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
@@ -7,8 +7,9 @@ import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeStarter;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SizeUtil;
@@ -47,6 +48,7 @@ class DatastoreSizeTest {
   private static final String KEY_SLASHDOT_CACHE_SIZE = "slashdotCacheSize";
   private static final String KEY_STORE_SIZE = "storeSize";
   private static final String KEY_STORE_TYPE = "storeType";
+  private static final long MAX_STORAGE_LIMIT_BYTES = 5L * 1024 * 1024 * 1024;
   private static final String TAG_OPTION = "option";
   private static final String TAG_SELECT = "select";
   private static final String VALUE_DEFAULT = "default";
@@ -174,8 +176,8 @@ class DatastoreSizeTest {
   @Test
   void postStep_whenFirstTime_expectNextStepBandwidthAndUsesSelected() {
     Config config = newConfigWithNodeDefaults(10, 0, 1000L);
-    NodeClientCore core = mock(NodeClientCore.class);
-    DatastoreSize step = new DatastoreSize(core, config);
+    DatastoreSize step =
+        new DatastoreSize(mock(FirstTimeWizardPort.class), config, () -> MAX_STORAGE_LIMIT_BYTES);
 
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.isPartSet("singlestep")).thenReturn(false);
@@ -203,8 +205,8 @@ class DatastoreSizeTest {
     assertEquals(VALUE_DEFAULT, node.getString(KEY_STORE_TYPE));
     assertEquals(VALUE_DEFAULT, node.getString(KEY_CLIENT_CACHE_TYPE));
 
-    NodeClientCore core = mock(NodeClientCore.class);
-    DatastoreSize step = new DatastoreSize(core, config);
+    DatastoreSize step =
+        new DatastoreSize(mock(FirstTimeWizardPort.class), config, () -> MAX_STORAGE_LIMIT_BYTES);
 
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.isPartSet("singlestep")).thenReturn(true);
@@ -248,11 +250,10 @@ class DatastoreSizeTest {
   @Test
   void getStep_whenAutodetectedIs512MiB_expectNo512MOption() {
     Config config = newConfigWithNodeDefaults(10, 10, 1000L);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getNode()).thenReturn(node);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(512L * 1024 * 1024));
 
-    DatastoreSize step = new DatastoreSize(core, config);
+    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> MAX_STORAGE_LIMIT_BYTES);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -263,18 +264,7 @@ class DatastoreSizeTest {
         .thenReturn(infoboxNode);
     when(helper.addFormChild(eq(infoboxNode), anyString(), anyString())).thenReturn(formNode);
 
-    try (MockedStatic<DatastoreSize> datastoreSizeStatic =
-            mockStatic(DatastoreSize.class, org.mockito.Mockito.CALLS_REAL_METHODS);
-        MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreSizeStatic
-          .when(() -> DatastoreSize.maxDatastoreSize(any(Node.class)))
-          .thenReturn(5L * 1024 * 1024 * 1024);
-      datastoreUtil
-          .when(() -> DatastoreUtil.autodetectDatastoreSize(eq(core), eq(config)))
-          .thenReturn(512L * 1024 * 1024);
-
-      step.getStep(mock(HTTPRequest.class), helper);
-    }
+    step.getStep(mock(HTTPRequest.class), helper);
 
     HTMLNode selectNode = findDatastoreSelect(formNode);
     assertNo512MOption(selectNode);
@@ -284,11 +274,10 @@ class DatastoreSizeTest {
   @Test
   void getStep_whenAutodetectedIsNot512MiB_expect512MOptionPresent() {
     Config config = newConfigWithNodeDefaults(10, 10, 1000L);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getNode()).thenReturn(node);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(2L * 1024 * 1024 * 1024));
 
-    DatastoreSize step = new DatastoreSize(core, config);
+    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> MAX_STORAGE_LIMIT_BYTES);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -299,18 +288,7 @@ class DatastoreSizeTest {
         .thenReturn(infoboxNode);
     when(helper.addFormChild(eq(infoboxNode), anyString(), anyString())).thenReturn(formNode);
 
-    try (MockedStatic<DatastoreSize> datastoreSizeStatic =
-            mockStatic(DatastoreSize.class, org.mockito.Mockito.CALLS_REAL_METHODS);
-        MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreSizeStatic
-          .when(() -> DatastoreSize.maxDatastoreSize(any(Node.class)))
-          .thenReturn(5L * 1024 * 1024 * 1024);
-      datastoreUtil
-          .when(() -> DatastoreUtil.autodetectDatastoreSize(eq(core), eq(config)))
-          .thenReturn(2L * 1024 * 1024 * 1024);
-
-      step.getStep(mock(HTTPRequest.class), helper);
-    }
+    step.getStep(mock(HTTPRequest.class), helper);
 
     HTMLNode selectNode = findDatastoreSelect(formNode);
     assertOptionValuePresent(selectNode, "512M");
@@ -326,11 +304,10 @@ class DatastoreSizeTest {
     nodeConfig.set(KEY_CLIENT_CACHE_SIZE, "512MiB");
     nodeConfig.set(KEY_SLASHDOT_CACHE_SIZE, "256MiB");
 
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getNode()).thenReturn(node);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(-1L));
 
-    DatastoreSize step = new DatastoreSize(core, config);
+    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> MAX_STORAGE_LIMIT_BYTES);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -347,18 +324,7 @@ class DatastoreSizeTest {
             + Config.longOption(nodeConfig, KEY_SLASHDOT_CACHE_SIZE).getValue();
     String expectedValue = SizeUtil.formatSize(expectedTotal);
 
-    try (MockedStatic<DatastoreSize> datastoreSizeStatic =
-            mockStatic(DatastoreSize.class, org.mockito.Mockito.CALLS_REAL_METHODS);
-        MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreSizeStatic
-          .when(() -> DatastoreSize.maxDatastoreSize(any(Node.class)))
-          .thenReturn(5L * 1024 * 1024 * 1024);
-      datastoreUtil
-          .when(() -> DatastoreUtil.autodetectDatastoreSize(eq(core), eq(config)))
-          .thenReturn(-1L);
-
-      step.getStep(mock(HTTPRequest.class), helper);
-    }
+    step.getStep(mock(HTTPRequest.class), helper);
 
     HTMLNode selectNode = findDatastoreSelect(formNode);
     HTMLNode selectedOption =
@@ -371,6 +337,55 @@ class DatastoreSizeTest {
     assertEquals(expectedValue, selectedOption.getAttribute(ATTR_VALUE));
     assertTrue(selectedOption.generateChildren().contains(expectedValue));
     assertTrue(selectedOption.generateChildren().contains(WizardL10n.l10n("currentPrefix")));
+  }
+
+  @Test
+  void getStep_whenLegacyCapIsBelowSnapshotMax_expectLegacyThresholdsPreserved() {
+    Config config = newConfigWithNodeDefaults(10, 10, 1000L);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(-1L));
+
+    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> 4L * 1024 * 1024 * 1024);
+
+    PageHelper helper = mock(PageHelper.class);
+    HTMLNode contentNode = new HTMLNode("div");
+    HTMLNode infoboxNode = new HTMLNode("div");
+    HTMLNode formNode = new HTMLNode("form");
+    when(helper.getPageContent(anyString())).thenReturn(contentNode);
+    when(helper.getInfobox(anyString(), anyString(), eq(contentNode), any(), anyBoolean()))
+        .thenReturn(infoboxNode);
+    when(helper.addFormChild(eq(infoboxNode), anyString(), anyString())).thenReturn(formNode);
+
+    step.getStep(mock(HTTPRequest.class), helper);
+
+    HTMLNode selectNode = findDatastoreSelect(formNode);
+    assertOptionValuePresent(selectNode, "3G");
+    assertOptionValueAbsent(selectNode, "5G");
+  }
+
+  @Test
+  void getStep_whenLegacyCapIsAboveSnapshotMax_expectLegacyThresholdsPreserved() {
+    Config config = newConfigWithNodeDefaults(10, 10, 1000L);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(-1L));
+
+    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> 50L * 1024 * 1024 * 1024);
+
+    PageHelper helper = mock(PageHelper.class);
+    HTMLNode contentNode = new HTMLNode("div");
+    HTMLNode infoboxNode = new HTMLNode("div");
+    HTMLNode formNode = new HTMLNode("form");
+    when(helper.getPageContent(anyString())).thenReturn(contentNode);
+    when(helper.getInfobox(anyString(), anyString(), eq(contentNode), any(), anyBoolean()))
+        .thenReturn(infoboxNode);
+    when(helper.addFormChild(eq(infoboxNode), anyString(), anyString())).thenReturn(formNode);
+
+    step.getStep(mock(HTTPRequest.class), helper);
+
+    HTMLNode selectNode = findDatastoreSelect(formNode);
+    assertOptionValuePresent(selectNode, "20G");
+    assertOptionValuePresent(selectNode, "50G");
+    assertOptionValueAbsent(selectNode, "200G");
   }
 
   private static Config newConfigWithNodeDefaults(
@@ -416,6 +431,22 @@ class DatastoreSizeTest {
     return config;
   }
 
+  private static FirstTimeWizardSnapshot snapshot(long autodetectedSize) {
+    return new FirstTimeWizardSnapshot(
+        false,
+        "2.00",
+        "1.25",
+        1L,
+        SizeUtil.formatSize(MAX_STORAGE_LIMIT_BYTES),
+        MAX_STORAGE_LIMIT_BYTES,
+        10L,
+        976562L,
+        "49.44",
+        "",
+        "",
+        autodetectedSize);
+  }
+
   private static HTMLNode findDatastoreSelect(HTMLNode formNode) {
     List<HTMLNode> selects =
         formNode.getChildren().stream()
@@ -435,7 +466,10 @@ class DatastoreSizeTest {
   }
 
   private static void assertNo512MOption(HTMLNode selectNode) {
-    String forbiddenValue = "512M";
+    assertOptionValueAbsent(selectNode, "512M");
+  }
+
+  private static void assertOptionValueAbsent(HTMLNode selectNode, String forbiddenValue) {
     assertTrue(
         selectNode.getChildren().stream()
             .filter(child -> TAG_OPTION.equals(child.getName()))

--- a/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
@@ -114,6 +114,7 @@ class LegacyFirstTimeWizardPortTest {
           snapshot.minBandwidthMonthlyLimitGiB());
       assertEquals("1024", snapshot.detectedDownloadLimitKiB());
       assertEquals("512", snapshot.detectedUploadLimitKiB());
+      assertEquals(-1L, snapshot.autodetectedStorageLimitBytes());
     }
   }
 
@@ -151,6 +152,44 @@ class LegacyFirstTimeWizardPortTest {
       assertEquals("100.00", snapshot.initialStorageLimitGiB());
       assertEquals("", snapshot.detectedDownloadLimitKiB());
       assertEquals("", snapshot.detectedUploadLimitKiB());
+      assertEquals(-1L, snapshot.autodetectedStorageLimitBytes());
+    }
+  }
+
+  @Test
+  void snapshot_whenIpDetectorNotInitialized_returnsStorageSuggestionAndEmptyBandwidthHints() {
+    Option<Long> storeSize = mockLongOption();
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    network.crypta.node.subsystem.NodeNetworkSubsystem networkSubsystem =
+        mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
+    long autodetectedStorageLimitBytes = 3L * DatastoreUtil.ONE_GIB;
+
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    when(node.network()).thenReturn(networkSubsystem);
+    when(networkSubsystem.ipDetector()).thenReturn(null);
+
+    try (MockedStatic<Config> configStatic = mockStatic(Config.class);
+        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class)) {
+      configStatic.when(() -> Config.longOption(nodeSubConfig, "storeSize")).thenReturn(storeSize);
+      when(storeSize.isDefault()).thenReturn(true);
+      datastore
+          .when(() -> DatastoreUtil.autodetectDatastoreSize(core, config))
+          .thenReturn(autodetectedStorageLimitBytes);
+      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      FirstTimeWizardSnapshot snapshot = port.snapshot();
+
+      assertEquals("3.00", snapshot.initialStorageLimitGiB());
+      assertEquals("", snapshot.detectedDownloadLimitKiB());
+      assertEquals("", snapshot.detectedUploadLimitKiB());
+      assertEquals(autodetectedStorageLimitBytes, snapshot.autodetectedStorageLimitBytes());
     }
   }
 


### PR DESCRIPTION
## Summary
- move the legacy multipage first-time wizard bandwidth/datastore slice onto `FirstTimeWizardPort` through a small HTTP-local runtime bundle
- remove the legacy wizard toadlet's direct `Node` dependency and migrate the bandwidth/datastore helpers to detached runtime reads
- preserve legacy datastore and current-bandwidth behavior, including startup-safe fallback when the IP detector is not initialized, and update the affected tests

## How to test
- `./gradlew test --tests 'network.crypta.clients.http.FirstTimeWizardToadletTest'`
- `./gradlew test --tests 'network.crypta.clients.http.wizardsteps.BandwidthMonthlyTest'`
- `./gradlew test --tests 'network.crypta.clients.http.wizardsteps.BandwidthRateTest'`
- `./gradlew test --tests 'network.crypta.clients.http.wizardsteps.DatastoreSizeTest'`
- `./gradlew test --tests '*LegacyFirstTimeWizardPortTest'`
- `./gradlew test`