### PR TITLE
refactor(wizard): Route legacy security flow through runtime port

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardPort.java
@@ -1,12 +1,15 @@
 package network.crypta.runtime.spi;
 
+import java.io.IOException;
+
 /**
- * Exposes the detached runtime surface that the JavaScript first-time wizard still needs.
+ * Exposes the detached runtime surface that the first-time wizard flows still need.
  *
  * <p>This SPI is intentionally page-shaped instead of domain-pure. The HTTP layer already owns the
  * wizard route, template model, localization keys, and request-local validation flow. What remains
  * here is the smallest stable boundary that keeps live daemon types out of the page code while
- * still preserving the existing onboarding behavior.
+ * still preserving the existing onboarding behavior for both the JavaScript wizard and the legacy
+ * multipage security path.
  *
  * <p>Implementations are responsible for:
  *
@@ -32,6 +35,64 @@ public interface FirstTimeWizardPort {
    *     current wizard page render
    */
   FirstTimeWizardSnapshot snapshot();
+
+  /**
+   * Returns whether the live node currently has Opennet enabled.
+   *
+   * @return {@code true} when the running node currently participates in Opennet
+   */
+  boolean isOpennetEnabled();
+
+  /**
+   * Returns the detached security snapshot needed by the legacy multipage wizard security steps.
+   *
+   * @return immutable snapshot of current threat levels, database status, and password-file
+   *     metadata
+   */
+  SecurityLevelsSnapshot securitySnapshot();
+
+  /**
+   * Applies a new detached network threat level using the legacy first-time-wizard semantics.
+   *
+   * @param level new detached network threat level
+   */
+  void setNetworkThreatLevel(SecurityNetworkThreatLevel level);
+
+  /**
+   * Applies a new detached physical threat level using the legacy first-time-wizard semantics.
+   *
+   * @param level new detached physical threat level
+   */
+  void setPhysicalThreatLevel(SecurityPhysicalThreatLevel level);
+
+  /**
+   * Changes the master password protecting client material using the first-time-wizard storage
+   * path.
+   *
+   * @param oldPassword previous password, possibly empty
+   * @param newPassword new password to set, possibly empty
+   * @return detached mutation outcome preserving the legacy wizard distinctions
+   * @throws IOException if a filesystem error occurs while reading or writing password material
+   */
+  MasterPasswordMutationStatus changeMasterPassword(String oldPassword, String newPassword)
+      throws IOException;
+
+  /**
+   * Sets or unlocks the master password protecting client material using the first-time-wizard
+   * storage path.
+   *
+   * @param password password to set or use for unlocking
+   * @return detached mutation outcome preserving the legacy wizard distinctions
+   * @throws IOException if a filesystem error occurs while reading or writing password material
+   */
+  MasterPasswordMutationStatus setMasterPassword(String password) throws IOException;
+
+  /**
+   * Deletes the master-password file using the first-time-wizard deletion path.
+   *
+   * @throws IOException if the file cannot be deleted
+   */
+  void deleteMasterPasswordFile() throws IOException;
 
   /**
    * Applies one detached first-time-wizard form submission to the live daemon.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -392,7 +392,6 @@ final class FProxyRegistrar {
         new FirstTimeWizardToadlet(
             client,
             config,
-            core,
             new FirstTimeWizardToadletRuntimePorts(
                 runtimePorts.firstTimeWizard(),
                 () -> DatastoreSize.maxDatastoreSize(node),

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -26,8 +26,9 @@ import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.HTTPRequest;
 import org.slf4j.Logger;
@@ -43,8 +44,9 @@ import org.slf4j.LoggerFactory;
  * <p>The toadlet coordinates several step handlers, each responsible for rendering and validating a
  * portion of the workflow. Requests are stateless; the wizard rebuilds its flow from submitted form
  * parameters and redirects between steps instead of maintaining a server-side session state. The
- * remaining live daemon writes flow through the injected {@link NodeClientCore}, while the
- * bandwidth/datastore slice reads detached runtime state through the wizard runtime SPI.
+ * remaining live daemon reads and writes flow through the injected {@link FirstTimeWizardPort},
+ * while a small HTTP-local runtime bundle still carries the legacy datastore and bandwidth
+ * collaborators that have not been folded into the shared wizard snapshot.
  *
  * <p>Concurrency: requests for the same user are serialized by the HTTP layer, but the class does
  * not assume single-threaded execution. All I/O and state changes are delegated to the injected
@@ -55,7 +57,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FirstTimeWizardToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(FirstTimeWizardToadlet.class);
-  private final NodeClientCore core;
+  private final FirstTimeWizardPort wizardPort;
   private final EnumMap<WIZARD_STEP, Step> steps;
   private final Misc stepMISC;
   private final SecurityNetwork stepSecurityNetwork;
@@ -153,12 +155,11 @@ public class FirstTimeWizardToadlet extends Toadlet {
   FirstTimeWizardToadlet(
       HighLevelSimpleClient client,
       Config config,
-      NodeClientCore core,
       FirstTimeWizardToadletRuntimePorts runtimePorts) {
     // Generic Toadlet-related initialization.
     super(client);
-    this.core = core;
     FirstTimeWizardToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts, "runtimePorts");
+    wizardPort = ports.firstTimeWizardPort();
 
     addWizardConfiguration(config);
 
@@ -184,10 +185,10 @@ public class FirstTimeWizardToadlet extends Toadlet {
     stepMISC = new Misc(config);
     steps.put(WIZARD_STEP.MISC, stepMISC);
 
-    stepSecurityNetwork = new SecurityNetwork(core);
+    stepSecurityNetwork = new SecurityNetwork(wizardPort);
     steps.put(WIZARD_STEP.SECURITY_NETWORK, stepSecurityNetwork);
 
-    stepSecurityPhysical = new SecurityPhysical(core);
+    stepSecurityPhysical = new SecurityPhysical(wizardPort);
     steps.put(WIZARD_STEP.SECURITY_PHYSICAL, stepSecurityPhysical);
   }
 
@@ -285,8 +286,7 @@ public class FirstTimeWizardToadlet extends Toadlet {
       super.writeTemporaryRedirect(
           ctx, "Need opennet choice", persistFields.appendTo(TOADLET_URL + "?step=OPENNET"));
       return;
-    } else if (currentStep == WIZARD_STEP.NAME_SELECTION
-        && core.getNode().network().isOpennetEnabled()) {
+    } else if (currentStep == WIZARD_STEP.NAME_SELECTION && wizardPort.isOpennetEnabled()) {
       // Skip node name selection if not in darknet mode.
       super.writeTemporaryRedirect(
           ctx,
@@ -387,8 +387,8 @@ public class FirstTimeWizardToadlet extends Toadlet {
 
     if (presetLow) {
       stepMISC.setAutoUpdate(enableAutoUpdater);
-      stepSecurityNetwork.setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.LOW);
-      stepSecurityPhysical.setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+      stepSecurityNetwork.setThreatLevel(SecurityNetworkThreatLevel.LOW);
+      stepSecurityPhysical.setThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
       redirectTo.append("&preset=LOW&opennet=true");
     } else if (presetHigh) {
       stepMISC.setAutoUpdate(enableAutoUpdater);

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadletRuntimePorts.java
@@ -10,13 +10,12 @@ import network.crypta.runtime.spi.FirstTimeWizardPort;
  * Shared runtime-port bundle used by the legacy first-time wizard toadlet.
  *
  * <p>The legacy multipage wizard still owns its HTTP routing, redirects, and most config writes,
- * but the bandwidth/datastore slice now reads detached runtime state through the existing
- * first-time-wizard SPI. It also needs the legacy datastore dropdown cap, which still comes from
- * the live store-directory heuristic rather than the shared JavaScript wizard snapshot. Grouping
- * those collaborators keeps the toadlet constructor narrow without threading the full runtime
- * aggregate through the HTTP layer.
+ * but the remaining live daemon interactions now route through the existing first-time-wizard SPI.
+ * It also needs the legacy datastore dropdown cap, which still comes from the live store-directory
+ * heuristic rather than the shared wizard snapshot. Grouping those collaborators keeps the toadlet
+ * constructor narrow without threading the full runtime aggregate through the HTTP layer.
  *
- * @param firstTimeWizardPort detached wizard runtime used by the bandwidth and datastore steps
+ * @param firstTimeWizardPort detached wizard runtime used by the legacy multipage wizard
  * @param legacyDatastoreMaxStorageLimitBytes store-dir-aware cap supplier used by the legacy
  *     datastore dropdown to preserve its historical thresholds
  * @param legacyCurrentBandwidthLimits supplier for the legacy rate-page “current settings” row,

--- a/src/main/java/network/crypta/clients/http/wizardsteps/SecurityNetwork.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/SecurityNetwork.java
@@ -2,8 +2,8 @@ package network.crypta.clients.http.wizardsteps;
 
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
@@ -11,12 +11,12 @@ import network.crypta.support.api.HTTPRequest;
 /**
  * Renders and processes the First Time Wizard step that configures the node's network threat level.
  *
- * <p>This step presents a small, curated set of {@link SecurityLevels.NETWORK_THREAT_LEVEL network
- * threat levels} based on whether the user is configuring an opennet or a darknet style connection.
- * The UI is intentionally constrained: when opennet is selected, only the lower threat levels are
- * offered; when opennet is not selected, only the higher threat levels are offered. This mirrors
- * the typical setup guidance for those network modes without requiring the user to understand all
- * internal security knobs.
+ * <p>This step presents a small, curated set of {@link SecurityNetworkThreatLevel network threat
+ * levels} based on whether the user is configuring an opennet or a darknet style connection. The UI
+ * is intentionally constrained: when opennet is selected, only the lower threat levels are offered;
+ * when opennet is not selected, only the higher threat levels are offered. This mirrors the typical
+ * setup guidance for those network modes without requiring the user to understand all internal
+ * security knobs.
  *
  * <p>Selection is a two-phase flow for the highest-impact choices. If the user chooses {@code HIGH}
  * or {@code MAXIMUM}, the wizard redirects back to the same step with a confirmation prompt that
@@ -27,11 +27,11 @@ import network.crypta.support.api.HTTPRequest;
  * <ul>
  *   <li>Reads the request parameter {@code opennet} to decide which options to display.
  *   <li>Uses the {@code confirm} flag to display a confirmation page for high-impact selections.
- *   <li>Persists the selection via {@link #setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL)}.
+ *   <li>Persists the selection via {@link #setThreatLevel(SecurityNetworkThreatLevel)}.
  * </ul>
  *
  * @see Step
- * @see SecurityLevels
+ * @see SecurityNetworkThreatLevel
  */
 public class SecurityNetwork implements Step {
 
@@ -44,21 +44,21 @@ public class SecurityNetwork implements Step {
   private static final String PARAM_NETWORK_THREAT_LEVEL_TRY_CONFIRM =
       "security-levels.networkThreatLevel.tryConfirm";
 
-  private final NodeClientCore core;
+  private final FirstTimeWizardPort wizardPort;
 
   /**
-   * Creates a wizard step instance bound to a specific {@link NodeClientCore}.
+   * Creates a wizard step instance bound to the detached first-time-wizard runtime port.
    *
-   * <p>The step is stateful only in that it holds a reference to the core; all user selections and
+   * <p>The step is stateful only in that it holds a reference to the port; all user selections and
    * navigation state are transported via the {@link HTTPRequest} and the wizard redirect mechanism.
-   * The provided core is used to apply the selected {@link SecurityLevels.NETWORK_THREAT_LEVEL} and
-   * persist the updated configuration.
+   * The provided port is used to apply the selected {@link SecurityNetworkThreatLevel} and persist
+   * the updated configuration using the legacy wizard semantics.
    *
-   * @param core the node core used to apply and persist the selected security level; must be
-   *     non-null
+   * @param wizardPort detached runtime used to apply and persist the selected security level; must
+   *     be non-null
    */
-  public SecurityNetwork(NodeClientCore core) {
-    this.core = core;
+  public SecurityNetwork(FirstTimeWizardPort wizardPort) {
+    this.wizardPort = wizardPort;
   }
 
   /**
@@ -66,9 +66,9 @@ public class SecurityNetwork implements Step {
    *
    * <p>This method renders the HTML content for the step. It selects between the opennet and
    * darknet variants based on the {@code opennet} request parameter and generates one radio-button
-   * row per eligible {@link SecurityLevels.NETWORK_THREAT_LEVEL}. When the {@code confirm}
-   * parameter is set, it renders a confirmation page for {@code HIGH} and {@code MAXIMUM}
-   * selections instead of the normal choice page.
+   * row per eligible {@link SecurityNetworkThreatLevel}. When the {@code confirm} parameter is set,
+   * it renders a confirmation page for {@code HIGH} and {@code MAXIMUM} selections instead of the
+   * normal choice page.
    *
    * @param request the current HTTP request carrying wizard parameters and posted form parts
    * @param helper the page helper used to create forms, infoboxes, and page content nodes
@@ -81,8 +81,8 @@ public class SecurityNetwork implements Step {
 
     if (request.isParameterSet("confirm")) {
       String networkThreatLevel = request.getParam(PARAM_NETWORK_THREAT_LEVEL);
-      SecurityLevels.NETWORK_THREAT_LEVEL newThreatLevel =
-          SecurityLevels.parseNetworkThreatLevel(networkThreatLevel);
+      SecurityNetworkThreatLevel newThreatLevel =
+          SecurityNetworkThreatLevel.parse(networkThreatLevel);
 
       HTMLNode infoboxContent =
           helper.getInfobox(
@@ -98,7 +98,7 @@ public class SecurityNetwork implements Step {
           new String[] {"type", "name", ATTR_VALUE},
           new String[] {"hidden", PARAM_NETWORK_THREAT_LEVEL, networkThreatLevel});
       HTMLNode p = formNode.addChild("p");
-      if (newThreatLevel == SecurityLevels.NETWORK_THREAT_LEVEL.MAXIMUM) {
+      if (newThreatLevel == SecurityNetworkThreatLevel.MAXIMUM) {
         NodeL10n.getBase()
             .addL10nSubstitution(
                 p,
@@ -178,8 +178,7 @@ public class SecurityNetwork implements Step {
 
       form = helper.addFormChild(infoboxContent, ".", "networkSecurityForm");
       HTMLNode div = form.addChild("div", "class", "opennetDiv");
-      for (SecurityLevels.NETWORK_THREAT_LEVEL level :
-          SecurityLevels.NETWORK_THREAT_LEVEL.getOpennetValues()) {
+      for (SecurityNetworkThreatLevel level : SecurityNetworkThreatLevel.opennetValues()) {
         securityLevelChoice(div, level);
       }
     } else {
@@ -194,8 +193,7 @@ public class SecurityNetwork implements Step {
 
       form = helper.addFormChild(infoboxContent, ".", "networkSecurityForm");
       HTMLNode div = form.addChild("div", "class", "darknetDiv");
-      for (SecurityLevels.NETWORK_THREAT_LEVEL level :
-          SecurityLevels.NETWORK_THREAT_LEVEL.getDarknetValues()) {
+      for (SecurityNetworkThreatLevel level : SecurityNetworkThreatLevel.darknetValues()) {
         securityLevelChoice(div, level);
       }
       form.addChild("p")
@@ -217,7 +215,7 @@ public class SecurityNetwork implements Step {
    * @param parent to add content to.
    * @param level to add content about.
    */
-  private void securityLevelChoice(HTMLNode parent, SecurityLevels.NETWORK_THREAT_LEVEL level) {
+  private void securityLevelChoice(HTMLNode parent, SecurityNetworkThreatLevel level) {
     HTMLNode input =
         parent
             .addChild("p")
@@ -260,8 +258,8 @@ public class SecurityNetwork implements Step {
    * display (or re-display) the confirmation prompt.
    *
    * <p>On successful completion, the new level is persisted by calling {@link
-   * #setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL)} and the wizard proceeds to the physical
-   * security step.
+   * #setThreatLevel(SecurityNetworkThreatLevel)} and the wizard proceeds to the physical security
+   * step.
    *
    * @param request the current HTTP request carrying the selected level and navigation controls
    * @return the next wizard step name to display, suitable for use as a redirect target
@@ -269,8 +267,8 @@ public class SecurityNetwork implements Step {
   @Override
   public String postStep(HTTPRequest request) {
     String networkThreatLevel = request.getPartAsStringFailsafe(PARAM_NETWORK_THREAT_LEVEL, 128);
-    SecurityLevels.NETWORK_THREAT_LEVEL newThreatLevel =
-        SecurityLevels.parseNetworkThreatLevel(networkThreatLevel);
+    SecurityNetworkThreatLevel newThreatLevel =
+        SecurityNetworkThreatLevel.parse(networkThreatLevel);
 
     // Used in case of redirect either for retry or confirmation.
     StringBuilder redirectTo =
@@ -296,8 +294,8 @@ public class SecurityNetwork implements Step {
       // Not in a preset, redisplay level choice.
       return FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_NETWORK.name();
     }
-    if ((newThreatLevel == SecurityLevels.NETWORK_THREAT_LEVEL.MAXIMUM
-        || newThreatLevel == SecurityLevels.NETWORK_THREAT_LEVEL.HIGH)) {
+    if ((newThreatLevel == SecurityNetworkThreatLevel.MAXIMUM
+        || newThreatLevel == SecurityNetworkThreatLevel.HIGH)) {
       // Make the user aware of the effects of high or maximum network threat if selected.
       // They must check a box acknowledging its effects to proceed.
       boolean confirmationChecked = request.isPartSet(PARAM_NETWORK_THREAT_LEVEL_CONFIRM);
@@ -332,12 +330,11 @@ public class SecurityNetwork implements Step {
    *
    * <p>This is the side-effectful operation for this wizard step: it updates the node's security
    * level and then stores the updated configuration. Callers should only invoke this after the user
-   * has made a valid selection and (when required) has completed any confirmation prompts.
+   * has made a valid choice and (when required) has completed any confirmation prompts.
    *
    * @param level the new network threat level to set; must be a valid enum value
    */
-  public void setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL level) {
-    core.getNode().services().securityLevels().setThreatLevel(level);
-    core.storeConfig();
+  public void setThreatLevel(SecurityNetworkThreatLevel level) {
+    wizardPort.setNetworkThreatLevel(level);
   }
 }

--- a/src/main/java/network/crypta/clients/http/wizardsteps/SecurityPhysical.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/SecurityPhysical.java
@@ -6,11 +6,10 @@ import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.clients.http.PasswordFormOptions;
 import network.crypta.clients.http.SecurityLevelsToadlet;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.MasterKeysFileSizeException;
-import network.crypta.node.MasterKeysWrongPasswordException;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.io.FileUtil.OperatingSystem;
@@ -23,11 +22,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This step renders the “physical security” page in the first-time setup wizard and processes
  * the corresponding form submission. The UI presents the available {@link
- * network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL physical threat levels}, and for the
- * “high” level it additionally collects and validates a master password. On POST, it may prompt
- * again for a password (for example, when upgrading to high with an empty password, when the
- * confirmation does not match, or when downgrading from high requires decrypting existing master
- * keys).
+ * SecurityPhysicalThreatLevel physical threat levels}, and for the “high” level it additionally
+ * collects and validates a master password. On POST, it may prompt again for a password (for
+ * example, when upgrading to high with an empty password, when the confirmation does not match, or
+ * when downgrading from high requires decrypting existing master keys).
  *
  * <p>Notable behaviors:
  *
@@ -55,7 +53,7 @@ public class SecurityPhysical implements Step {
   private static final String INPUT_TYPE_SUBMIT = "submit";
   private static final String PASSWORD_FOR_DECRYPT_TITLE_KEY = "passwordForDecryptTitle";
 
-  private final NodeClientCore core;
+  private final FirstTimeWizardPort wizardPort;
 
   private enum PASSWORD_PROMPT {
     SET_BLANK, // Requested new password was blank
@@ -65,17 +63,17 @@ public class SecurityPhysical implements Step {
   }
 
   /**
-   * Creates a new wizard step handler backed by the provided node client core.
+   * Creates a new wizard step handler backed by the detached first-time-wizard runtime port.
    *
-   * <p>The step reads and mutates security-related node state via {@link NodeClientCore} and the
-   * associated {@link Node}. The instance retains the reference for the lifetime of a single HTTP
-   * request/response cycle; callers typically construct a new step instance per request.
+   * <p>The step reads and mutates security-related runtime state via {@link FirstTimeWizardPort}.
+   * The instance retains the reference for the lifetime of a single HTTP request/response cycle;
+   * callers typically construct a new step instance per request.
    *
-   * @param core core services used to read/write security levels and password state; must be
-   *     non-null and already initialized.
+   * @param wizardPort runtime services used to read/write security levels and password state; must
+   *     be non-null and already initialized.
    */
-  public SecurityPhysical(NodeClientCore core) {
-    this.core = core;
+  public SecurityPhysical(FirstTimeWizardPort wizardPort) {
+    this.wizardPort = wizardPort;
   }
 
   /**
@@ -84,11 +82,11 @@ public class SecurityPhysical implements Step {
    * <p>If the request carries {@code error=} parameters, this method attempts to render a dedicated
    * error or password prompt page via {@link #errorHandler(HTTPRequest, PageHelper)}. Otherwise, it
    * renders the standard selection form, including the swap-file warning text and the available
-   * {@link SecurityLevels.PHYSICAL_THREAT_LEVEL} radio options.
+   * {@link SecurityPhysicalThreatLevel} radio options.
    *
-   * <p>When the user selects the {@link SecurityLevels.PHYSICAL_THREAT_LEVEL#HIGH} option and the
-   * node is not yet at high physical security, the form includes password and confirmation inputs
-   * for setting the master password.
+   * <p>When the user selects the {@link SecurityPhysicalThreatLevel#HIGH} option and the node is
+   * not yet at high physical security, the form includes password and confirmation inputs for
+   * setting the master password.
    *
    * @param request HTTP request providing query parameters that influence rendering (for example
    *     {@code error}, {@code type}, and the requested threat level).
@@ -101,6 +99,7 @@ public class SecurityPhysical implements Step {
       // Error page generated successfully.
       return;
     }
+    SecurityLevelsSnapshot snapshot = wizardPort.securitySnapshot();
 
     HTMLNode contentNode = helper.getPageContent(WizardL10n.l10n("physicalSecurityPageTitle"));
     HTMLNode infoboxContent =
@@ -136,8 +135,7 @@ public class SecurityPhysical implements Step {
     if (os == FileUtil.OperatingSystem.WINDOWS) {
       swapWarning.addChild("#", " " + WizardL10n.l10nSec("physicalThreatLevelSwapfileWindows"));
     }
-    for (SecurityLevels.PHYSICAL_THREAT_LEVEL level :
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.values()) {
+    for (SecurityPhysicalThreatLevel level : SecurityPhysicalThreatLevel.values()) {
       HTMLNode input;
       input =
           div.addChild("p")
@@ -155,8 +153,7 @@ public class SecurityPhysical implements Step {
               "SecurityLevels.physicalThreatLevel.choice." + level,
               new String[] {"bold"},
               new HTMLNode[] {HTMLNode.STRONG});
-      if (level == SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH
-          && core.getNode().services().securityLevels().getPhysicalThreatLevel() != level) {
+      if (level == SecurityPhysicalThreatLevel.HIGH && snapshot.physicalThreatLevel() != level) {
         // Add a password form on high security if not already at high security.
         HTMLNode p = div.addChild("p");
         p.addChild(TAG_LABEL, "for", "passwordBox", WizardL10n.l10nSec("setPasswordLabel") + ":");
@@ -196,8 +193,8 @@ public class SecurityPhysical implements Step {
    */
   private boolean errorHandler(HTTPRequest request, PageHelper helper) {
     String physicalThreatLevel = request.getParam("newThreatLevel");
-    SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel =
-        SecurityLevels.parsePhysicalThreatLevel(physicalThreatLevel);
+    SecurityPhysicalThreatLevel newThreatLevel =
+        SecurityPhysicalThreatLevel.parse(physicalThreatLevel);
     String error = request.getParam("error");
     if (newThreatLevel == null && ("pass".equals(error) || "delete".equals(error))) {
       // Render the default page if the threat level is missing/invalid.
@@ -271,12 +268,12 @@ public class SecurityPhysical implements Step {
       case "corrupt" -> {
         // Password file corrupts
         SecurityLevelsToadlet.sendPasswordFileCorruptedPageInner(
-            helper, core.getNode().storage().getMasterKeysFile().getPath());
+            helper, wizardPort.securitySnapshot().masterPasswordFilePath());
         return true;
       }
       case "delete" -> {
         SecurityLevelsToadlet.sendCantDeleteMasterKeysFileInner(
-            helper, core.getNode().storage().getMasterKeysFile().getPath(), newThreatLevel.name());
+            helper, wizardPort.securitySnapshot().masterPasswordFilePath(), newThreatLevel.name());
         return true;
       }
       default -> {
@@ -290,22 +287,22 @@ public class SecurityPhysical implements Step {
    * Returns the currently configured physical threat level for the node.
    *
    * <p>This is a convenience accessor used by wizard templates and other steps that need to reflect
-   * the current state. The returned value is read from {@link SecurityLevels} at call time and
-   * therefore reflects any changes applied earlier in the request.
+   * the current state. The returned value is read from the detached runtime snapshot at call time
+   * and therefore reflects any changes applied earlier in the request.
    *
-   * @return the node's current {@link SecurityLevels.PHYSICAL_THREAT_LEVEL}, never {@code null} in
+   * @return the node's current detached {@link SecurityPhysicalThreatLevel}, never {@code null} in
    *     a correctly initialized node.
    */
-  public SecurityLevels.PHYSICAL_THREAT_LEVEL getCurrentLevel() {
-    return core.getNode().services().securityLevels().getPhysicalThreatLevel();
+  public SecurityPhysicalThreatLevel getCurrentLevel() {
+    return wizardPort.securitySnapshot().physicalThreatLevel();
   }
 
   /**
    * Handles a physical security wizard form submission (HTTP POST).
    *
-   * <p>This method interprets the selected {@link SecurityLevels.PHYSICAL_THREAT_LEVEL} and, when
-   * necessary, validates or prompts for the master password. Depending on the transition requested
-   * by the user, it may:
+   * <p>This method interprets the selected {@link SecurityPhysicalThreatLevel} and, when necessary,
+   * validates or prompts for the master password. Depending on the transition requested by the
+   * user, it may:
    *
    * <ul>
    *   <li>prompt for a non-blank password or a matching confirmation when upgrading to high,
@@ -337,10 +334,10 @@ public class SecurityPhysical implements Step {
     final boolean passwordsDoNotMatch = !pass.equals(confirmPass);
 
     String physicalThreatLevel = request.getPartAsStringFailsafe(PARAM_PHYSICAL_THREAT_LEVEL, 128);
-    SecurityLevels.PHYSICAL_THREAT_LEVEL oldThreatLevel =
-        core.getNode().services().securityLevels().getPhysicalThreatLevel();
-    SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel =
-        SecurityLevels.parsePhysicalThreatLevel(physicalThreatLevel);
+    SecurityPhysicalThreatLevel oldThreatLevel =
+        wizardPort.securitySnapshot().physicalThreatLevel();
+    SecurityPhysicalThreatLevel newThreatLevel =
+        SecurityPhysicalThreatLevel.parse(physicalThreatLevel);
     if (FirstTimeWizardToadlet.shouldLogMinor()) {
       LOG.debug("Old threat level: {} new threat level: {}", oldThreatLevel, newThreatLevel);
     }
@@ -381,22 +378,21 @@ public class SecurityPhysical implements Step {
   }
 
   private static boolean shouldReturnToPhysicalSecurity(
-      HTTPRequest request, SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel) {
+      HTTPRequest request, SecurityPhysicalThreatLevel newThreatLevel) {
     return newThreatLevel == null
         || !request.isPartSet(PARAM_PHYSICAL_THREAT_LEVEL)
         || request.isPartSet("backToMain");
   }
 
   private String handleUpgradeToHigh(
-      SecurityLevels.PHYSICAL_THREAT_LEVEL oldThreatLevel,
-      SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel,
+      SecurityPhysicalThreatLevel oldThreatLevel,
+      SecurityPhysicalThreatLevel newThreatLevel,
       boolean passwordIsBlank,
       boolean passwordsDoNotMatch,
       String pass,
       String errorCorrupt)
       throws IOException {
-    if (newThreatLevel != SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH
-        || oldThreatLevel == newThreatLevel) {
+    if (newThreatLevel != SecurityPhysicalThreatLevel.HIGH || oldThreatLevel == newThreatLevel) {
       return null;
     }
     if (passwordIsBlank) {
@@ -407,72 +403,77 @@ public class SecurityPhysical implements Step {
       // Must Confirm the password before setting it
       return promptPassword(newThreatLevel, PASSWORD_PROMPT.SET_NO_MATCH);
     }
-    try {
-      if (oldThreatLevel == SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL
-          || oldThreatLevel == SecurityLevels.PHYSICAL_THREAT_LEVEL.LOW) {
-        core.getNode().storage().changeMasterPassword("", pass, true);
-      } else {
-        core.getNode().storage().setMasterPassword(pass, true);
-      }
-    } catch (Node.AlreadySetPasswordException _) {
-      // Do nothing, already set a password.
-    } catch (MasterKeysWrongPasswordException e) {
-      throw new IOException("Incorrect password when changing from another level to high", e);
-    } catch (MasterKeysFileSizeException _) {
-      return errorCorrupt;
+    MasterPasswordMutationStatus status;
+    if (oldThreatLevel == SecurityPhysicalThreatLevel.NORMAL
+        || oldThreatLevel == SecurityPhysicalThreatLevel.LOW) {
+      status = wizardPort.changeMasterPassword("", pass);
+    } else {
+      status = wizardPort.setMasterPassword(pass);
     }
-    return null;
+    switch (status) {
+      case SUCCESS, ALREADY_SET -> {
+        return null;
+      }
+      case WRONG_PASSWORD ->
+          throw new IOException("Incorrect password when changing from another level to high");
+      case CORRUPTED_FILE -> {
+        return errorCorrupt;
+      }
+    }
+    throw new IllegalStateException("Unhandled master password mutation status: " + status);
   }
 
   private String handleDowngradeFromHigh(
-      SecurityLevels.PHYSICAL_THREAT_LEVEL oldThreatLevel,
-      SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel,
+      SecurityPhysicalThreatLevel oldThreatLevel,
+      SecurityPhysicalThreatLevel newThreatLevel,
       boolean passwordIsBlank,
       String pass,
       String errorCorrupt)
       throws IOException {
     boolean isLowOrNormal =
-        newThreatLevel == SecurityLevels.PHYSICAL_THREAT_LEVEL.LOW
-            || newThreatLevel == SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL;
-    if (!isLowOrNormal || oldThreatLevel != SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH) {
+        newThreatLevel == SecurityPhysicalThreatLevel.LOW
+            || newThreatLevel == SecurityPhysicalThreatLevel.NORMAL;
+    if (!isLowOrNormal || oldThreatLevel != SecurityPhysicalThreatLevel.HIGH) {
       return null;
     }
     if (passwordIsBlank) {
       // Prompt for the old password, which is needed to decrypt
       return promptPassword(newThreatLevel, PASSWORD_PROMPT.DECRYPT_BLANK);
     }
-    if (!core.getNode().storage().getMasterKeysFile().exists()) {
+    if (!wizardPort.securitySnapshot().masterPasswordFileExists()) {
       return null;
     }
     try {
-      core.getNode().storage().changeMasterPassword(pass, "", true);
+      MasterPasswordMutationStatus status = wizardPort.changeMasterPassword(pass, "");
+      return switch (status) {
+        case SUCCESS -> null;
+        case WRONG_PASSWORD -> promptPassword(newThreatLevel, PASSWORD_PROMPT.DECRYPT_WRONG);
+        case CORRUPTED_FILE -> errorCorrupt;
+        case ALREADY_SET -> {
+          LOG.warn(
+              "Already set a password when changing it - maybe master.keys copied in at the wrong"
+                  + " moment???");
+          yield null;
+        }
+      };
     } catch (IOException e) {
-      if (!core.getNode().storage().getMasterKeysFile().exists()) {
+      if (!wizardPort.securitySnapshot().masterPasswordFileExists()) {
         // Ok.
         LOG.info("Master password file no longer exists, assuming this is deliberate");
       } else {
         LOG.error("Cannot change password as cannot write new passwords file", e);
         throw new IOException("cantWriteNewMasterKeysFile", e);
       }
-    } catch (MasterKeysWrongPasswordException _) {
-      return promptPassword(newThreatLevel, PASSWORD_PROMPT.DECRYPT_WRONG);
-    } catch (MasterKeysFileSizeException _) {
-      return errorCorrupt;
-    } catch (Node.AlreadySetPasswordException e) {
-      LOG.warn(
-          "Already set a password when changing it - maybe master.keys copied in at the wrong"
-              + " moment???",
-          e);
     }
     return null;
   }
 
-  private String handleMaximumThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel) {
-    if (newThreatLevel != SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM) {
+  private String handleMaximumThreatLevel(SecurityPhysicalThreatLevel newThreatLevel) {
+    if (newThreatLevel != SecurityPhysicalThreatLevel.MAXIMUM) {
       return null;
     }
     try {
-      core.getNode().storage().killMasterKeysFile();
+      wizardPort.deleteMasterPasswordFile();
     } catch (IOException _) {
       return FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL
           + "&error=delete&newThreatLevel="
@@ -488,8 +489,7 @@ public class SecurityPhysical implements Step {
    * @param type what type of prompt needed
    * @return URL to display the requested page
    */
-  private String promptPassword(
-      SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel, PASSWORD_PROMPT type) {
+  private String promptPassword(SecurityPhysicalThreatLevel newThreatLevel, PASSWORD_PROMPT type) {
     if (type == PASSWORD_PROMPT.DECRYPT_WRONG) {
       LOG.warn("Master password verification failed; prompting for password again");
     }
@@ -503,19 +503,17 @@ public class SecurityPhysical implements Step {
   /**
    * Applies the selected physical threat level and persists the change.
    *
-   * <p>This method updates {@link SecurityLevels} in-memory, stores the configuration to disk via
-   * {@link NodeClientCore#storeConfig()}, and triggers late database setup on the node. Callers are
-   * expected to have already validated that {@code newThreatLevel} is a supported choice and, when
-   * moving to or from {@link SecurityLevels.PHYSICAL_THREAT_LEVEL#HIGH}, to have handled any master
-   * password requirements.
+   * <p>This method applies the detached physical threat level through {@link FirstTimeWizardPort},
+   * which preserves the legacy wizard behavior of persisting the config and triggering late
+   * database setup. Callers are expected to have already validated that {@code newThreatLevel} is a
+   * supported choice and, when moving to or from {@link SecurityPhysicalThreatLevel#HIGH}, to have
+   * handled any master password requirements.
    *
    * @param newThreatLevel the threat level to set on the node; must be non-null and represent a
-   *     valid {@link SecurityLevels.PHYSICAL_THREAT_LEVEL} constant.
+   *     valid {@link SecurityPhysicalThreatLevel} constant.
    */
-  public void setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel) {
-    core.getNode().services().securityLevels().setThreatLevel(newThreatLevel);
-    core.storeConfig();
-    core.getNode().storage().lateSetupDatabase(null);
+  public void setThreatLevel(SecurityPhysicalThreatLevel newThreatLevel) {
+    wizardPort.setPhysicalThreatLevel(newThreatLevel);
   }
 
   private void addBackToPhysicalSeclevelsButton(HTMLNode form) {

--- a/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
@@ -1,5 +1,6 @@
 package network.crypta.node.runtime;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
@@ -20,6 +21,10 @@ import network.crypta.node.subsystem.NodeStorageSubsystem;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.Fields;
 import network.crypta.support.IllegalValueException;
 import network.crypta.support.io.DatastoreUtil;
@@ -31,10 +36,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * Implements the page-oriented first-time-wizard SPI on top of the legacy daemon runtime.
  *
- * <p>This adapter stays in the root module because the JavaScript wizard still depends on several
- * daemon-only behaviors that should not leak across the runtime SPI boundary. It reads the current
- * security state, datastore sizing defaults, storage caps, and bandwidth hints directly from the
- * live node, then exposes those values as detached records for the HTTP layer.
+ * <p>This adapter stays in the root module because the first-time wizard flows still depend on
+ * several daemon-only behaviors that should not leak across the runtime SPI boundary. It reads the
+ * current security state, datastore sizing defaults, storage caps, and bandwidth hints directly
+ * from the live node, then exposes those values as detached records for the HTTP layer.
  *
  * <p>The writing path preserves the existing wizard completion semantics rather than redesigning
  * them. Config writes and password-related failures that historically stayed daemon-local are still
@@ -53,6 +58,9 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
   /** Logger for daemon-local wizard failures that should remain in the root module. */
   private static final Logger LOG = LoggerFactory.getLogger(LegacyFirstTimeWizardPort.class);
 
+  /** Shared argument name used when validating detached threat-level setters. */
+  private static final String LEVEL_ARGUMENT = "level";
+
   /** Minimum datastore size exposed by this wizard flow, including the required cache overhead. */
   private static final long MIN_STORAGE_LIMIT = NodeStorageSubsystem.MIN_STORE_SIZE * 5 / 4;
 
@@ -69,7 +77,7 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
   private final NodeClientCore core;
 
   /**
-   * Creates a daemon-backed adapter for the JavaScript first-time wizard.
+   * Creates a daemon-backed adapter for the first-time wizard runtime SPI.
    *
    * <p>The adapter keeps stable references to the live {@link Node} and {@link NodeClientCore} so
    * each request can read current runtime values and persist changes through the existing daemon
@@ -105,6 +113,84 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
         detectedBandwidthLimits[0],
         detectedBandwidthLimits[1],
         autodetectedStorageLimitBytes);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isOpennetEnabled() {
+    return node.network().isOpennetEnabled();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SecurityLevelsSnapshot securitySnapshot() {
+    File masterKeysFile = node.storage().getMasterKeysFile();
+    return new SecurityLevelsSnapshot(
+        mapNetworkThreatLevel(node.services().securityLevels().getNetworkThreatLevel()),
+        mapPhysicalThreatLevel(node.services().securityLevels().getPhysicalThreatLevel()),
+        node.hasDatabase(),
+        masterKeysFile != null && masterKeysFile.exists(),
+        masterKeysFile == null ? "" : masterKeysFile.getPath());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setNetworkThreatLevel(SecurityNetworkThreatLevel level) {
+    node.services()
+        .securityLevels()
+        .setThreatLevel(mapNetworkThreatLevel(Objects.requireNonNull(level, LEVEL_ARGUMENT)));
+    core.storeConfig();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setPhysicalThreatLevel(SecurityPhysicalThreatLevel level) {
+    node.services()
+        .securityLevels()
+        .setThreatLevel(mapPhysicalThreatLevel(Objects.requireNonNull(level, LEVEL_ARGUMENT)));
+    core.storeConfig();
+    node.storage().lateSetupDatabase(null);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public MasterPasswordMutationStatus changeMasterPassword(String oldPassword, String newPassword)
+      throws IOException {
+    try {
+      node.storage()
+          .changeMasterPassword(
+              Objects.requireNonNull(oldPassword, "oldPassword"),
+              Objects.requireNonNull(newPassword, "newPassword"),
+              true);
+      return MasterPasswordMutationStatus.SUCCESS;
+    } catch (MasterKeysWrongPasswordException _) {
+      return MasterPasswordMutationStatus.WRONG_PASSWORD;
+    } catch (Node.AlreadySetPasswordException _) {
+      return MasterPasswordMutationStatus.ALREADY_SET;
+    } catch (MasterKeysFileSizeException _) {
+      return MasterPasswordMutationStatus.CORRUPTED_FILE;
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public MasterPasswordMutationStatus setMasterPassword(String password) throws IOException {
+    try {
+      node.storage().setMasterPassword(Objects.requireNonNull(password, "password"), true);
+      return MasterPasswordMutationStatus.SUCCESS;
+    } catch (MasterKeysWrongPasswordException _) {
+      return MasterPasswordMutationStatus.WRONG_PASSWORD;
+    } catch (Node.AlreadySetPasswordException _) {
+      return MasterPasswordMutationStatus.ALREADY_SET;
+    } catch (MasterKeysFileSizeException _) {
+      return MasterPasswordMutationStatus.CORRUPTED_FILE;
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteMasterPasswordFile() throws IOException {
+    node.storage().killMasterKeysFile();
   }
 
   /** {@inheritDoc} */
@@ -299,5 +385,41 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
    */
   private static String formatGiB(long sizeBytes) {
     return String.format(Locale.ENGLISH, "%.2f", (float) sizeBytes / DatastoreUtil.ONE_GIB);
+  }
+
+  private static SecurityNetworkThreatLevel mapNetworkThreatLevel(NETWORK_THREAT_LEVEL level) {
+    return switch (level) {
+      case LOW -> SecurityNetworkThreatLevel.LOW;
+      case NORMAL -> SecurityNetworkThreatLevel.NORMAL;
+      case HIGH -> SecurityNetworkThreatLevel.HIGH;
+      case MAXIMUM -> SecurityNetworkThreatLevel.MAXIMUM;
+    };
+  }
+
+  private static NETWORK_THREAT_LEVEL mapNetworkThreatLevel(SecurityNetworkThreatLevel level) {
+    return switch (level) {
+      case LOW -> NETWORK_THREAT_LEVEL.LOW;
+      case NORMAL -> NETWORK_THREAT_LEVEL.NORMAL;
+      case HIGH -> NETWORK_THREAT_LEVEL.HIGH;
+      case MAXIMUM -> NETWORK_THREAT_LEVEL.MAXIMUM;
+    };
+  }
+
+  private static SecurityPhysicalThreatLevel mapPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL level) {
+    return switch (level) {
+      case LOW -> SecurityPhysicalThreatLevel.LOW;
+      case NORMAL -> SecurityPhysicalThreatLevel.NORMAL;
+      case HIGH -> SecurityPhysicalThreatLevel.HIGH;
+      case MAXIMUM -> SecurityPhysicalThreatLevel.MAXIMUM;
+    };
+  }
+
+  private static PHYSICAL_THREAT_LEVEL mapPhysicalThreatLevel(SecurityPhysicalThreatLevel level) {
+    return switch (level) {
+      case LOW -> PHYSICAL_THREAT_LEVEL.LOW;
+      case NORMAL -> PHYSICAL_THREAT_LEVEL.NORMAL;
+      case HIGH -> PHYSICAL_THREAT_LEVEL.HIGH;
+      case MAXIMUM -> PHYSICAL_THREAT_LEVEL.MAXIMUM;
+    };
   }
 }

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
@@ -13,10 +13,9 @@ import network.crypta.clients.http.wizardsteps.SecurityNetwork;
 import network.crypta.clients.http.wizardsteps.SecurityPhysical;
 import network.crypta.clients.http.wizardsteps.Step;
 import network.crypta.config.PersistentConfig;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,10 +45,6 @@ class FirstTimeWizardToadletTest {
 
   @Mock private HighLevelSimpleClient client;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore core;
   @Mock private FirstTimeWizardPort firstTimeWizardPort;
   @Mock private ToadletContext ctx;
 
@@ -58,8 +53,8 @@ class FirstTimeWizardToadletTest {
   @BeforeEach
   void setUp() throws Exception {
     config = new PersistentConfig(null);
-    when(core.getNode()).thenReturn(node);
     when(ctx.checkFullAccess(any())).thenReturn(true);
+    when(firstTimeWizardPort.isOpennetEnabled()).thenReturn(false);
   }
 
   @Test
@@ -77,7 +72,6 @@ class FirstTimeWizardToadletTest {
             new FirstTimeWizardToadlet(
                 client,
                 config,
-                core,
                 new FirstTimeWizardToadletRuntimePorts(
                     firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);
@@ -109,7 +103,6 @@ class FirstTimeWizardToadletTest {
             new FirstTimeWizardToadlet(
                 client,
                 config,
-                core,
                 new FirstTimeWizardToadletRuntimePorts(
                     firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);
@@ -134,13 +127,41 @@ class FirstTimeWizardToadletTest {
   }
 
   @Test
+  void handleMethodGET_nameSelectionWhenOpennetEnabled_redirectsToDatastoreSize() throws Exception {
+    when(firstTimeWizardPort.isOpennetEnabled()).thenReturn(true);
+    FirstTimeWizardToadlet toadlet =
+        spy(
+            new FirstTimeWizardToadlet(
+                client,
+                config,
+                new FirstTimeWizardToadletRuntimePorts(
+                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.hasParameters()).thenReturn(true);
+    when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
+        .thenReturn("NAME_SELECTION");
+    when(request.getParam("opennet", "false")).thenReturn("false");
+    when(request.getParam("singlestep", "false")).thenReturn("false");
+    when(request.getParam("preset")).thenReturn("");
+
+    ArgumentCaptor<String> locationCaptor = ArgumentCaptor.forClass(String.class);
+    doNothing()
+        .when(toadlet)
+        .writeTemporaryRedirect(eq(ctx), anyString(), locationCaptor.capture());
+
+    toadlet.handleMethodGET(new URI(FirstTimeWizardToadlet.TOADLET_URL), request, ctx);
+
+    verify(toadlet).writeTemporaryRedirect(eq(ctx), eq("Skip name selection"), anyString());
+    assertEquals("/wizard/?step=DATASTORE_SIZE&opennet=false", locationCaptor.getValue());
+  }
+
+  @Test
   void handleMethodPOST_presetLow_setsThreatLevelsAndRedirects() throws Exception {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
                 client,
                 config,
-                core,
                 new FirstTimeWizardToadletRuntimePorts(
                     firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);
@@ -172,8 +193,8 @@ class FirstTimeWizardToadletTest {
     toadlet.handleMethodPOST(new URI(FirstTimeWizardToadlet.TOADLET_URL), request, ctx);
 
     verify(misc).setAutoUpdate(true);
-    verify(securityNetwork).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.LOW);
-    verify(securityPhysical).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    verify(securityNetwork).setThreatLevel(SecurityNetworkThreatLevel.LOW);
+    verify(securityPhysical).setThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
     assertEquals(
         "/wizard/?step=BROWSER_WARNING&incognito=0&preset=LOW&opennet=true",
         locationCaptor.getValue());
@@ -186,7 +207,6 @@ class FirstTimeWizardToadletTest {
             new FirstTimeWizardToadlet(
                 client,
                 config,
-                core,
                 new FirstTimeWizardToadletRuntimePorts(
                     firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
     HTTPRequest request = mock(HTTPRequest.class);

--- a/src/test/java/network/crypta/clients/http/wizardsteps/SecurityNetworkTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/SecurityNetworkTest.java
@@ -12,10 +12,8 @@ import java.util.stream.Collectors;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels;
-import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.Test;
@@ -34,8 +32,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,29 +68,19 @@ class SecurityNetworkTest {
       "SecurityLevels.networkThreatLevel.opennetFriendsWarning";
 
   @Test
-  void setThreatLevel_whenCalled_updatesSecurityLevelsAndStoresConfig() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    SecurityLevels securityLevels = mock(SecurityLevels.class);
-    when(core.getNode()).thenReturn(node);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.securityLevels()).thenReturn(securityLevels);
+  void setThreatLevel_whenCalled_updatesWizardPort() {
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
 
-    SecurityNetwork step = new SecurityNetwork(core);
+    step.setThreatLevel(SecurityNetworkThreatLevel.NORMAL);
 
-    step.setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
-
-    verify(core, times(1)).getNode();
-    verify(node, times(1)).services();
-    verify(securityLevels, times(1)).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
-    verify(core, times(1)).storeConfig();
+    verify(wizardPort).setNetworkThreatLevel(SecurityNetworkThreatLevel.NORMAL);
   }
 
   @Test
   void postStep_whenThreatLevelPartMissing_expectRedirectToSecurityNetwork() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
 
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn("LOW");
@@ -103,13 +89,13 @@ class SecurityNetworkTest {
     String redirect = step.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_NETWORK.name(), redirect);
-    verify(step, never()).setThreatLevel(any(SecurityLevels.NETWORK_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setNetworkThreatLevel(any(SecurityNetworkThreatLevel.class));
   }
 
   @Test
   void postStep_whenThreatLevelIsInvalid_expectRedirectToSecurityNetwork() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
 
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn("not-a-level");
@@ -117,53 +103,51 @@ class SecurityNetworkTest {
     String redirect = step.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_NETWORK.name(), redirect);
-    verify(step, never()).setThreatLevel(any(SecurityLevels.NETWORK_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setNetworkThreatLevel(any(SecurityNetworkThreatLevel.class));
   }
 
   @Test
   void postStep_whenReturnFromConfirmWithoutPreset_expectRedisplaySecurityNetwork() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
 
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn("HIGH");
     when(request.isPartSet(anyString())).thenReturn(false);
     when(request.isPartSet(PART_NETWORK_THREAT_LEVEL)).thenReturn(true);
     when(request.isPartSet(PART_RETURN_FROM_CONFIRM)).thenReturn(true);
-
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe(PART_PRESET, 4)).thenReturn("");
 
     String redirect = step.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_NETWORK.name(), redirect);
-    verify(step, never()).setThreatLevel(any(SecurityLevels.NETWORK_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setNetworkThreatLevel(any(SecurityNetworkThreatLevel.class));
   }
 
   @Test
   void postStep_whenReturnFromConfirmWithPreset_expectRedirectToPreviousStep() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
 
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn("HIGH");
     when(request.isPartSet(anyString())).thenReturn(false);
     when(request.isPartSet(PART_NETWORK_THREAT_LEVEL)).thenReturn(true);
     when(request.isPartSet(PART_RETURN_FROM_CONFIRM)).thenReturn(true);
-
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe(PART_PRESET, 4)).thenReturn("HIGH");
 
     String redirect = step.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.name(), redirect);
-    verify(step, never()).setThreatLevel(any(SecurityLevels.NETWORK_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setNetworkThreatLevel(any(SecurityNetworkThreatLevel.class));
   }
 
   @Test
   void postStep_whenHighWithoutConfirm_expectRedirectToConfirmationPage() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
 
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn("HIGH");
@@ -178,13 +162,13 @@ class SecurityNetworkTest {
         FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_NETWORK.name()
             + "&confirm=true&security-levels.networkThreatLevel=HIGH",
         redirect);
-    verify(step, never()).setThreatLevel(any(SecurityLevels.NETWORK_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setNetworkThreatLevel(any(SecurityNetworkThreatLevel.class));
   }
 
   @Test
   void postStep_whenHighTryConfirmWithoutConfirm_expectRedirectToConfirmationPage() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
 
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn("HIGH");
@@ -200,20 +184,13 @@ class SecurityNetworkTest {
         FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_NETWORK.name()
             + "&confirm=true&security-levels.networkThreatLevel=HIGH",
         redirect);
-    verify(step, never()).setThreatLevel(any(SecurityLevels.NETWORK_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setNetworkThreatLevel(any(SecurityNetworkThreatLevel.class));
   }
 
   @Test
   void postStep_whenHighConfirmed_expectSetThreatLevelAndRedirectPhysical() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    SecurityLevels securityLevels = mock(SecurityLevels.class);
-    when(core.getNode()).thenReturn(node);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.securityLevels()).thenReturn(securityLevels);
-
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
 
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn("HIGH");
@@ -226,26 +203,19 @@ class SecurityNetworkTest {
     String redirect = step.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL.name(), redirect);
-    verify(securityLevels, times(1)).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.HIGH);
-    verify(core, times(1)).storeConfig();
+    verify(wizardPort).setNetworkThreatLevel(SecurityNetworkThreatLevel.HIGH);
   }
 
   @ParameterizedTest
   @EnumSource(
-      value = SecurityLevels.NETWORK_THREAT_LEVEL.class,
+      value = SecurityNetworkThreatLevel.class,
       names = {"LOW", "NORMAL"})
   void postStep_whenThreatLevelDoesNotRequireConfirmation_expectSetThreatLevelAndRedirectPhysical(
-      SecurityLevels.NETWORK_THREAT_LEVEL level) {
-    NodeClientCore core = mock(NodeClientCore.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    SecurityLevels securityLevels = mock(SecurityLevels.class);
-    when(core.getNode()).thenReturn(node);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.securityLevels()).thenReturn(securityLevels);
-
-    SecurityNetwork step = spy(new SecurityNetwork(core));
+      SecurityNetworkThreatLevel level) {
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
     HTTPRequest request = mock(HTTPRequest.class);
+
     when(request.getPartAsStringFailsafe(PART_NETWORK_THREAT_LEVEL, 128)).thenReturn(level.name());
     when(request.isPartSet(anyString())).thenReturn(false);
     when(request.isPartSet(PART_NETWORK_THREAT_LEVEL)).thenReturn(true);
@@ -255,14 +225,13 @@ class SecurityNetworkTest {
     String redirect = step.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL.name(), redirect);
-    verify(securityLevels, times(1)).setThreatLevel(level);
-    verify(core, times(1)).storeConfig();
+    verify(wizardPort).setNetworkThreatLevel(level);
   }
 
   @Test
   void getStep_whenOpennetTrue_buildsRadioOptionsForOpennetThreatLevels() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = new SecurityNetwork(core);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
 
     HTTPRequest request = mock(HTTPRequest.class);
     PageHelper helper = mock(PageHelper.class);
@@ -315,8 +284,7 @@ class SecurityNetworkTest {
                     && "radio".equals(node.getAttribute(ATTR_TYPE))
                     && PART_NETWORK_THREAT_LEVEL.equals(node.getAttribute(ATTR_NAME)));
 
-    SecurityLevels.NETWORK_THREAT_LEVEL[] expectedLevels =
-        SecurityLevels.NETWORK_THREAT_LEVEL.getOpennetValues();
+    SecurityNetworkThreatLevel[] expectedLevels = SecurityNetworkThreatLevel.opennetValues();
     assertEquals(expectedLevels.length, radios.size());
     assertTrue(
         radios.stream()
@@ -337,8 +305,8 @@ class SecurityNetworkTest {
 
   @Test
   void getStep_whenOpennetFalse_buildsRadioOptionsForDarknetThreatLevelsAndWarning() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = new SecurityNetwork(core);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
 
     HTTPRequest request = mock(HTTPRequest.class);
     PageHelper helper = mock(PageHelper.class);
@@ -391,8 +359,7 @@ class SecurityNetworkTest {
                     && "radio".equals(node.getAttribute(ATTR_TYPE))
                     && PART_NETWORK_THREAT_LEVEL.equals(node.getAttribute(ATTR_NAME)));
 
-    SecurityLevels.NETWORK_THREAT_LEVEL[] expectedLevels =
-        SecurityLevels.NETWORK_THREAT_LEVEL.getDarknetValues();
+    SecurityNetworkThreatLevel[] expectedLevels = SecurityNetworkThreatLevel.darknetValues();
     assertEquals(expectedLevels.length, radios.size());
     assertTrue(
         radios.stream()
@@ -408,8 +375,8 @@ class SecurityNetworkTest {
 
   @Test
   void getStep_whenConfirmHigh_buildsConfirmationFormWithExpectedInputs() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = new SecurityNetwork(core);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
 
     HTTPRequest request = mock(HTTPRequest.class);
     PageHelper helper = mock(PageHelper.class);
@@ -482,8 +449,8 @@ class SecurityNetworkTest {
 
   @Test
   void getStep_whenCalled_usesExpectedPageHelperWiring() {
-    NodeClientCore core = mock(NodeClientCore.class);
-    SecurityNetwork step = new SecurityNetwork(core);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    SecurityNetwork step = new SecurityNetwork(wizardPort);
 
     HTTPRequest request = mock(HTTPRequest.class);
     PageHelper helper = mock(PageHelper.class);
@@ -548,17 +515,17 @@ class SecurityNetworkTest {
     return false;
   }
 
-  private static Set<String> enumNames(SecurityLevels.NETWORK_THREAT_LEVEL[] values) {
+  private static Set<String> enumNames(SecurityNetworkThreatLevel[] values) {
     Set<String> names = new HashSet<>();
-    for (SecurityLevels.NETWORK_THREAT_LEVEL value : values) {
+    for (SecurityNetworkThreatLevel value : values) {
       names.add(value.name());
     }
     return names;
   }
 
-  private static Set<String> enumIds(SecurityLevels.NETWORK_THREAT_LEVEL[] values) {
+  private static Set<String> enumIds(SecurityNetworkThreatLevel[] values) {
     Set<String> ids = new HashSet<>();
-    for (SecurityLevels.NETWORK_THREAT_LEVEL value : values) {
+    for (SecurityNetworkThreatLevel value : values) {
       ids.add(PART_NETWORK_THREAT_LEVEL + value.name());
     }
     return ids;

--- a/src/test/java/network/crypta/clients/http/wizardsteps/SecurityPhysicalTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/SecurityPhysicalTest.java
@@ -4,12 +4,11 @@ import java.io.File;
 import java.io.IOException;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.clients.http.SecurityLevelsToadlet;
-import network.crypta.node.MasterKeysFileSizeException;
-import network.crypta.node.MasterKeysWrongPasswordException;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels;
-import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,15 +19,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
@@ -45,39 +41,31 @@ class SecurityPhysicalTest {
   private static final String NEW_SECRET = "newPass";
   private static final String OLD_SECRET = "oldPass";
 
-  @Mock private NodeClientCore core;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeStorageSubsystem storage;
-  @Mock private SecurityLevels securityLevels;
+  @Mock private FirstTimeWizardPort wizardPort;
   @Mock private HTTPRequest request;
 
   @TempDir File tempDir;
 
   @Test
-  void getCurrentLevel_whenCalled_returnsLevelFromNodeSecurityLevels() {
-    when(core.getNode()).thenReturn(node);
-    when(node.services().securityLevels()).thenReturn(securityLevels);
-    when(securityLevels.getPhysicalThreatLevel())
-        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+  void getCurrentLevel_whenCalled_returnsLevelFromSnapshot() {
+    when(wizardPort.securitySnapshot())
+        .thenReturn(snapshot(SecurityPhysicalThreatLevel.NORMAL, false, ""));
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
-    SecurityLevels.PHYSICAL_THREAT_LEVEL current = subject.getCurrentLevel();
+    SecurityPhysicalThreatLevel current = subject.getCurrentLevel();
 
-    assertEquals(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, current);
+    assertEquals(SecurityPhysicalThreatLevel.NORMAL, current);
   }
 
   @Test
   void postStep_whenThreatLevelMissing_returnsPhysicalStepName() throws Exception {
-    stubOldThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    stubOldThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
     stubPasswordParts("pw", "pw");
     when(request.getPartAsStringFailsafe(PHYSICAL_THREAT_LEVEL_PART, 128)).thenReturn("HIGH");
     when(request.isPartSet(PHYSICAL_THREAT_LEVEL_PART)).thenReturn(false);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
@@ -86,42 +74,40 @@ class SecurityPhysicalTest {
 
   @Test
   void postStep_whenBackToMainSet_returnsPhysicalStepName() throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts("pw", "pw");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(true);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL.name(), next);
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
   void postStep_whenThreatLevelUnparseable_returnsPhysicalStepName() throws Exception {
-    stubOldThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    stubOldThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
     stubPasswordParts("pw", "pw");
     when(request.getPartAsStringFailsafe(PHYSICAL_THREAT_LEVEL_PART, 128))
         .thenReturn("NOT_A_LEVEL");
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL.name(), next);
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
   void postStep_whenUpgradeToHighWithBlankPassword_promptsSetBlank() throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts("", "");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
@@ -129,19 +115,18 @@ class SecurityPhysicalTest {
         FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL
             + "&error=pass&newThreatLevel=HIGH&type=SET_BLANK",
         next);
-    verify(storage, never()).changeMasterPassword(anyString(), anyString(), anyBoolean());
-    verify(storage, never()).setMasterPassword(anyString(), anyBoolean());
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).changeMasterPassword(anyString(), anyString());
+    verify(wizardPort, never()).setMasterPassword(anyString());
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
   void postStep_whenUpgradeToHighWithMismatchPassword_promptsSetNoMatch() throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts("pw1", "pw2");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
@@ -149,118 +134,105 @@ class SecurityPhysicalTest {
         FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL
             + "&error=pass&newThreatLevel=HIGH&type=SET_NO_MATCH",
         next);
-    verify(storage, never()).changeMasterPassword(anyString(), anyString(), anyBoolean());
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).changeMasterPassword(anyString(), anyString());
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
   void postStep_whenUpgradeToHighFromNormal_changesFromBlankPasswordThenAdvances()
       throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts(NEW_SECRET, NEW_SECRET);
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    when(node.storage()).thenReturn(storage);
-    doNothing().when(storage).changeMasterPassword("", NEW_SECRET, true);
+    when(wizardPort.changeMasterPassword("", NEW_SECRET))
+        .thenReturn(MasterPasswordMutationStatus.SUCCESS);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.NAME_SELECTION.name(), next);
-
-    InOrder inOrder = inOrder(storage, securityLevels, core);
-    inOrder.verify(storage).changeMasterPassword("", NEW_SECRET, true);
-    inOrder.verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
-    inOrder.verify(core).storeConfig();
-    inOrder.verify(storage).lateSetupDatabase(null);
+    InOrder inOrder = inOrder(wizardPort);
+    inOrder.verify(wizardPort).changeMasterPassword("", NEW_SECRET);
+    inOrder.verify(wizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.HIGH);
     inOrder.verifyNoMoreInteractions();
   }
 
   @Test
   void postStep_whenUpgradeToHighFromMaximum_setsMasterPasswordThenAdvances() throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    stubThreatLevels(SecurityPhysicalThreatLevel.MAXIMUM, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts(NEW_SECRET, NEW_SECRET);
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    when(node.storage()).thenReturn(storage);
-    doNothing().when(storage).setMasterPassword(NEW_SECRET, true);
+    when(wizardPort.setMasterPassword(NEW_SECRET)).thenReturn(MasterPasswordMutationStatus.SUCCESS);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.NAME_SELECTION.name(), next);
-    verify(storage).setMasterPassword(NEW_SECRET, true);
-    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
-    verify(core).storeConfig();
-    verify(storage).lateSetupDatabase(null);
+    InOrder inOrder = inOrder(wizardPort);
+    inOrder.verify(wizardPort).setMasterPassword(NEW_SECRET);
+    inOrder.verify(wizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.HIGH);
+    inOrder.verifyNoMoreInteractions();
   }
 
   @Test
-  void postStep_whenUpgradeToHighAlreadyHasPassword_ignoresAlreadySetExceptionAndAdvances()
+  void postStep_whenUpgradeToHighAlreadyHasPassword_ignoresAlreadySetAndAdvances()
       throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts(NEW_SECRET, NEW_SECRET);
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    doThrow(new Node.AlreadySetPasswordException())
-        .when(storage)
-        .changeMasterPassword("", NEW_SECRET, true);
+    when(wizardPort.changeMasterPassword("", NEW_SECRET))
+        .thenReturn(MasterPasswordMutationStatus.ALREADY_SET);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.NAME_SELECTION.name(), next);
-    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    verify(wizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.HIGH);
   }
 
   @Test
   void postStep_whenUpgradeToHighWrongPassword_throwsIOException() throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts(NEW_SECRET, NEW_SECRET);
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    doThrow(new MasterKeysWrongPasswordException())
-        .when(storage)
-        .changeMasterPassword("", NEW_SECRET, true);
+    when(wizardPort.changeMasterPassword("", NEW_SECRET))
+        .thenReturn(MasterPasswordMutationStatus.WRONG_PASSWORD);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     IOException thrown = assertThrows(IOException.class, () -> subject.postStep(request));
 
-    assertInstanceOf(MasterKeysWrongPasswordException.class, thrown.getCause());
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    assertEquals(
+        "Incorrect password when changing from another level to high", thrown.getMessage());
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
-  void postStep_whenUpgradeToHighMasterKeysFileSizeException_returnsCorruptError()
-      throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+  void postStep_whenUpgradeToHighCorruptedFile_returnsCorruptError() throws Exception {
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.HIGH);
     stubPasswordParts(NEW_SECRET, NEW_SECRET);
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    doThrow(new MasterKeysFileSizeException(false))
-        .when(storage)
-        .changeMasterPassword("", NEW_SECRET, true);
+    when(wizardPort.changeMasterPassword("", NEW_SECRET))
+        .thenReturn(MasterPasswordMutationStatus.CORRUPTED_FILE);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL + "&error=corrupt", next);
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
   void postStep_whenDowngradeFromHighBlankPassword_promptsDecryptBlank() throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH, SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    stubThreatLevels(SecurityPhysicalThreatLevel.HIGH, SecurityPhysicalThreatLevel.NORMAL);
     stubPasswordParts("", "");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
@@ -268,8 +240,8 @@ class SecurityPhysicalTest {
         FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL
             + "&error=pass&newThreatLevel=NORMAL&type=DECRYPT_BLANK",
         next);
-    verify(storage, never()).changeMasterPassword(anyString(), anyString(), anyBoolean());
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).changeMasterPassword(anyString(), anyString());
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
@@ -278,16 +250,13 @@ class SecurityPhysicalTest {
     assertFalse(masterKeys.exists());
     assertTrue(masterKeys.createNewFile());
 
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH, SecurityLevels.PHYSICAL_THREAT_LEVEL.LOW);
+    stubThreatLevelsFromHigh(SecurityPhysicalThreatLevel.LOW, masterKeys);
     stubPasswordParts(OLD_SECRET, "");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    when(storage.getMasterKeysFile()).thenReturn(masterKeys);
-    doThrow(new MasterKeysWrongPasswordException())
-        .when(storage)
-        .changeMasterPassword(OLD_SECRET, "", true);
+    when(wizardPort.changeMasterPassword(OLD_SECRET, ""))
+        .thenReturn(MasterPasswordMutationStatus.WRONG_PASSWORD);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
@@ -295,29 +264,26 @@ class SecurityPhysicalTest {
         FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL
             + "&error=pass&newThreatLevel=LOW&type=DECRYPT_WRONG",
         next);
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
-  void postStep_whenDowngradeFromHighFileSizeException_returnsCorruptError() throws Exception {
+  void postStep_whenDowngradeFromHighCorruptedFile_returnsCorruptError() throws Exception {
     File masterKeys = new File(tempDir, MASTER_KEYS_FILENAME);
     assertTrue(masterKeys.createNewFile());
 
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH, SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    stubThreatLevelsFromHigh(SecurityPhysicalThreatLevel.NORMAL, masterKeys);
     stubPasswordParts(OLD_SECRET, "");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    when(storage.getMasterKeysFile()).thenReturn(masterKeys);
-    doThrow(new MasterKeysFileSizeException(true))
-        .when(storage)
-        .changeMasterPassword(OLD_SECRET, "", true);
+    when(wizardPort.changeMasterPassword(OLD_SECRET, ""))
+        .thenReturn(MasterPasswordMutationStatus.CORRUPTED_FILE);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL + "&error=corrupt", next);
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
@@ -325,22 +291,20 @@ class SecurityPhysicalTest {
     File masterKeys = new File(tempDir, MASTER_KEYS_FILENAME);
     assertTrue(masterKeys.createNewFile());
 
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH, SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    stubThreatLevelsFromHigh(SecurityPhysicalThreatLevel.NORMAL, masterKeys);
     stubPasswordParts(OLD_SECRET, "");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    when(storage.getMasterKeysFile()).thenReturn(masterKeys);
 
     IOException lowLevel = new IOException("disk full");
-    doThrow(lowLevel).when(storage).changeMasterPassword(OLD_SECRET, "", true);
+    when(wizardPort.changeMasterPassword(OLD_SECRET, "")).thenThrow(lowLevel);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     IOException thrown = assertThrows(IOException.class, () -> subject.postStep(request));
 
     assertEquals("cantWriteNewMasterKeysFile", thrown.getMessage());
     assertSame(lowLevel, thrown.getCause());
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
@@ -348,26 +312,30 @@ class SecurityPhysicalTest {
     File masterKeys = new File(tempDir, MASTER_KEYS_FILENAME);
     assertTrue(masterKeys.createNewFile());
 
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH, SecurityLevels.PHYSICAL_THREAT_LEVEL.LOW);
+    when(wizardPort.securitySnapshot())
+        .thenAnswer(
+            _ ->
+                snapshot(
+                    SecurityPhysicalThreatLevel.HIGH, masterKeys.exists(), masterKeys.getPath()));
+    when(request.getPartAsStringFailsafe(PHYSICAL_THREAT_LEVEL_PART, 128)).thenReturn("LOW");
+    when(request.isPartSet(PHYSICAL_THREAT_LEVEL_PART)).thenReturn(true);
     stubPasswordParts(OLD_SECRET, "");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    when(storage.getMasterKeysFile()).thenReturn(masterKeys);
 
     doAnswer(
-            invocation -> {
+            _ -> {
               assertTrue(masterKeys.delete());
               throw new IOException("write failed");
             })
-        .when(storage)
-        .changeMasterPassword(OLD_SECRET, "", true);
+        .when(wizardPort)
+        .changeMasterPassword(OLD_SECRET, "");
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.NAME_SELECTION.name(), next);
-    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.LOW);
+    verify(wizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.LOW);
   }
 
   @Test
@@ -375,30 +343,27 @@ class SecurityPhysicalTest {
     File masterKeys = new File(tempDir, MASTER_KEYS_FILENAME);
     assertFalse(masterKeys.exists());
 
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH, SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    stubThreatLevelsFromHigh(SecurityPhysicalThreatLevel.NORMAL, masterKeys);
     stubPasswordParts(OLD_SECRET, "");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    when(storage.getMasterKeysFile()).thenReturn(masterKeys);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.NAME_SELECTION.name(), next);
-    verify(storage, never()).changeMasterPassword(anyString(), anyString(), anyBoolean());
-    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    verify(wizardPort, never()).changeMasterPassword(anyString(), anyString());
+    verify(wizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
   }
 
   @Test
   void postStep_whenMaximumThreatLevelDeleteFails_returnsDeleteError() throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.MAXIMUM);
     stubPasswordParts("pw", "pw");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    doThrow(new IOException("no permission")).when(storage).killMasterKeysFile();
+    doThrow(new IOException("no permission")).when(wizardPort).deleteMasterPasswordFile();
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
@@ -406,61 +371,44 @@ class SecurityPhysicalTest {
         FirstTimeWizardToadlet.WIZARD_STEP.SECURITY_PHYSICAL
             + "&error=delete&newThreatLevel=MAXIMUM",
         next);
-    verify(securityLevels, never()).setThreatLevel(any(SecurityLevels.PHYSICAL_THREAT_LEVEL.class));
+    verify(wizardPort, never()).setPhysicalThreatLevel(any(SecurityPhysicalThreatLevel.class));
   }
 
   @Test
   void postStep_whenMaximumThreatLevelDeleteSucceeds_advancesAndStoresThreatLevel()
       throws Exception {
-    stubThreatLevels(
-        SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL, SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM);
+    stubThreatLevels(SecurityPhysicalThreatLevel.NORMAL, SecurityPhysicalThreatLevel.MAXIMUM);
     stubPasswordParts("pw", "pw");
     when(request.isPartSet(BACK_TO_MAIN_PART)).thenReturn(false);
-    doNothing().when(storage).killMasterKeysFile();
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     String next = subject.postStep(request);
 
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.NAME_SELECTION.name(), next);
-    verify(storage).killMasterKeysFile();
-    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM);
-    verify(core).storeConfig();
-    verify(storage).lateSetupDatabase(null);
+    InOrder inOrder = inOrder(wizardPort);
+    inOrder.verify(wizardPort).deleteMasterPasswordFile();
+    inOrder.verify(wizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.MAXIMUM);
+    inOrder.verifyNoMoreInteractions();
   }
 
   @Test
   void setThreatLevel_whenNullThreatLevel_throwsNullPointerException() {
-    when(core.getNode()).thenReturn(node);
-    when(node.services().securityLevels()).thenReturn(securityLevels);
-    when(node.storage()).thenReturn(storage);
-    doThrow(new NullPointerException())
-        .when(securityLevels)
-        .setThreatLevel((SecurityLevels.PHYSICAL_THREAT_LEVEL) null);
-    SecurityPhysical subject = new SecurityPhysical(core);
+    doThrow(new NullPointerException()).when(wizardPort).setPhysicalThreatLevel(null);
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
     assertThrows(NullPointerException.class, () -> subject.setThreatLevel(null));
 
-    verify(securityLevels).setThreatLevel((SecurityLevels.PHYSICAL_THREAT_LEVEL) null);
-    verify(core, never()).storeConfig();
-    verify(storage, never()).lateSetupDatabase(any());
+    verify(wizardPort).setPhysicalThreatLevel(null);
   }
 
   @Test
-  void setThreatLevel_whenValidThreatLevel_updatesSecurityLevelsStoresConfigAndLateInitsDatabase() {
-    when(core.getNode()).thenReturn(node);
-    when(node.services().securityLevels()).thenReturn(securityLevels);
-    when(node.storage()).thenReturn(storage);
+  void setThreatLevel_whenValidThreatLevel_delegatesToWizardPort() {
+    SecurityPhysical subject = new SecurityPhysical(wizardPort);
 
-    SecurityPhysical subject = new SecurityPhysical(core);
+    subject.setThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
 
-    subject.setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
-
-    InOrder inOrder = inOrder(securityLevels, core, storage);
-    inOrder.verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
-    inOrder.verify(core).storeConfig();
-    inOrder.verify(storage).lateSetupDatabase(null);
-    inOrder.verifyNoMoreInteractions();
+    verify(wizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
   }
 
   private void stubPasswordParts(String masterPassword, String confirmPassword) {
@@ -473,18 +421,39 @@ class SecurityPhysicalTest {
   }
 
   private void stubThreatLevels(
-      SecurityLevels.PHYSICAL_THREAT_LEVEL oldThreatLevel,
-      SecurityLevels.PHYSICAL_THREAT_LEVEL newThreatLevel) {
+      SecurityPhysicalThreatLevel oldThreatLevel, SecurityPhysicalThreatLevel newThreatLevel) {
     when(request.getPartAsStringFailsafe(PHYSICAL_THREAT_LEVEL_PART, 128))
         .thenReturn(newThreatLevel.name());
     when(request.isPartSet(PHYSICAL_THREAT_LEVEL_PART)).thenReturn(true);
     stubOldThreatLevel(oldThreatLevel);
   }
 
-  private void stubOldThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL oldThreatLevel) {
-    when(core.getNode()).thenReturn(node);
-    when(node.services().securityLevels()).thenReturn(securityLevels);
-    when(node.storage()).thenReturn(storage);
-    when(securityLevels.getPhysicalThreatLevel()).thenReturn(oldThreatLevel);
+  private void stubThreatLevelsFromHigh(
+      SecurityPhysicalThreatLevel newThreatLevel, File masterKeysFile) {
+    when(request.getPartAsStringFailsafe(PHYSICAL_THREAT_LEVEL_PART, 128))
+        .thenReturn(newThreatLevel.name());
+    when(request.isPartSet(PHYSICAL_THREAT_LEVEL_PART)).thenReturn(true);
+    when(wizardPort.securitySnapshot())
+        .thenReturn(
+            snapshot(
+                SecurityPhysicalThreatLevel.HIGH,
+                masterKeysFile.exists(),
+                masterKeysFile.getPath()));
+  }
+
+  private void stubOldThreatLevel(SecurityPhysicalThreatLevel oldThreatLevel) {
+    when(wizardPort.securitySnapshot()).thenReturn(snapshot(oldThreatLevel, false, ""));
+  }
+
+  private SecurityLevelsSnapshot snapshot(
+      SecurityPhysicalThreatLevel physicalThreatLevel,
+      boolean masterPasswordFileExists,
+      String masterPasswordFilePath) {
+    return new SecurityLevelsSnapshot(
+        SecurityNetworkThreatLevel.NORMAL,
+        physicalThreatLevel,
+        true,
+        masterPasswordFileExists,
+        masterPasswordFilePath);
   }
 }

--- a/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
@@ -1,5 +1,6 @@
 package network.crypta.node.runtime;
 
+import java.io.File;
 import java.util.Locale;
 import network.crypta.clients.http.wizardsteps.BandwidthDetectionUnavailableException;
 import network.crypta.clients.http.wizardsteps.BandwidthLimit;
@@ -10,6 +11,8 @@ import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
+import network.crypta.node.MasterKeysFileSizeException;
+import network.crypta.node.MasterKeysWrongPasswordException;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeIPDetector;
@@ -18,10 +21,15 @@ import network.crypta.node.subsystem.NodeServicesSubsystem;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.Fields;
 import network.crypta.support.io.DatastoreUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -31,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -51,6 +60,8 @@ class LegacyFirstTimeWizardPortTest {
   @Mock private SubConfig fproxySubConfig;
   @Mock private SecurityLevels securityLevels;
   @Mock private NodeStorageSubsystem storage;
+
+  @TempDir File tempDir;
 
   @Test
   void snapshot_whenDaemonStateAvailable_returnsDetachedDefaultsAndSuggestions() {
@@ -227,6 +238,124 @@ class LegacyFirstTimeWizardPortTest {
       assertEquals("1.24", snapshot.maxStorageLimitGiB());
       assertEquals(roundedUpMaxStorageLimitBytes, snapshot.maxStorageLimitBytes());
     }
+  }
+
+  @Test
+  void isOpennetEnabled_whenRuntimeReportsEnabled_returnsTrue() {
+    network.crypta.node.subsystem.NodeNetworkSubsystem networkSubsystem =
+        mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
+    when(node.network()).thenReturn(networkSubsystem);
+    when(networkSubsystem.isOpennetEnabled()).thenReturn(true);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    assertTrue(port.isOpennetEnabled());
+  }
+
+  @Test
+  void securitySnapshot_whenDaemonStateAvailable_returnsDetachedSecurityState() throws Exception {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    File masterKeysFile = new File(tempDir, "master.keys");
+    assertTrue(masterKeysFile.createNewFile());
+
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getNetworkThreatLevel())
+        .thenReturn(SecurityLevels.NETWORK_THREAT_LEVEL.HIGH);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM);
+    when(node.storage()).thenReturn(storage);
+    when(storage.getMasterKeysFile()).thenReturn(masterKeysFile);
+    when(node.hasDatabase()).thenReturn(true);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    SecurityLevelsSnapshot snapshot = port.securitySnapshot();
+
+    assertEquals(SecurityNetworkThreatLevel.HIGH, snapshot.networkThreatLevel());
+    assertEquals(SecurityPhysicalThreatLevel.MAXIMUM, snapshot.physicalThreatLevel());
+    assertTrue(snapshot.hasDatabase());
+    assertTrue(snapshot.masterPasswordFileExists());
+    assertEquals(masterKeysFile.getPath(), snapshot.masterPasswordFilePath());
+  }
+
+  @Test
+  void setNetworkThreatLevel_whenCalled_updatesSecurityLevelsAndPersistsConfig() {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    port.setNetworkThreatLevel(SecurityNetworkThreatLevel.LOW);
+
+    verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.LOW);
+    verify(core).storeConfig();
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenCalled_updatesSecurityLevelsPersistsAndInitializesDatabase() {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(node.storage()).thenReturn(storage);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    port.setPhysicalThreatLevel(SecurityPhysicalThreatLevel.MAXIMUM);
+
+    verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM);
+    verify(core).storeConfig();
+    verify(storage).lateSetupDatabase(null);
+  }
+
+  @Test
+  void changeMasterPassword_whenSuccessful_usesFirstTimeWizardStoragePath() throws Exception {
+    when(node.storage()).thenReturn(storage);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    MasterPasswordMutationStatus status = port.changeMasterPassword("old", "new");
+
+    assertEquals(MasterPasswordMutationStatus.SUCCESS, status);
+    verify(storage).changeMasterPassword("old", "new", true);
+  }
+
+  @Test
+  void changeMasterPassword_whenWrongPassword_returnsWrongPassword() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    doThrow(new MasterKeysWrongPasswordException())
+        .when(storage)
+        .changeMasterPassword("old", "new", true);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    MasterPasswordMutationStatus status = port.changeMasterPassword("old", "new");
+
+    assertEquals(MasterPasswordMutationStatus.WRONG_PASSWORD, status);
+  }
+
+  @Test
+  void setMasterPassword_whenCorruptedFile_returnsCorruptedFile() throws Exception {
+    when(node.storage()).thenReturn(storage);
+    doThrow(new MasterKeysFileSizeException(false)).when(storage).setMasterPassword("secret", true);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    MasterPasswordMutationStatus status = port.setMasterPassword("secret");
+
+    assertEquals(MasterPasswordMutationStatus.CORRUPTED_FILE, status);
+  }
+
+  @Test
+  void deleteMasterPasswordFile_whenCalled_delegatesToStorage() throws Exception {
+    when(node.storage()).thenReturn(storage);
+
+    LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+    port.deleteMasterPasswordFile();
+
+    verify(storage).killMasterKeysFile();
   }
 
   @Test


### PR DESCRIPTION
## Summary
- extend `FirstTimeWizardPort` with the minimal security/runtime surface needed by the legacy multipage wizard security path
- implement the new security methods in `LegacyFirstTimeWizardPort` while preserving the legacy wizard semantics for opennet state, threat-level persistence, late database setup, and master-password file handling
- migrate `FirstTimeWizardToadlet`, `SecurityNetwork`, and `SecurityPhysical` off direct `NodeClientCore` / `Node` access, update `FProxyRegistrar`, and keep the newer JS wizard path intact with focused test updates

## Testing
- `./gradlew test --tests 'network.crypta.clients.http.FirstTimeWizardToadletTest' --tests 'network.crypta.clients.http.wizardsteps.SecurityNetworkTest' --tests 'network.crypta.clients.http.wizardsteps.SecurityPhysicalTest' --tests 'network.crypta.node.runtime.LegacyFirstTimeWizardPortTest'`
- `./gradlew test --tests 'network.crypta.clients.http.FirstTimeWizardNewToadletTest'`
- `./gradlew test`
