### PR TITLE
feat(queue): Extract queue download SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueDownloadPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueDownloadPort.java
@@ -1,0 +1,63 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+
+/**
+ * Runtime capability for creating new persistent download requests from the queue UI.
+ *
+ * <p>This port isolates the remaining live-daemon work involved in registering new persistent
+ * downloads while keeping HTTP request parsing, URI validation, path selection, and user-facing
+ * response mapping outside the runtime boundary. Callers submit one detached {@link
+ * QueueDownloadRequest} at a time after they have already decided whether the request should go to
+ * disk or return directly to the browser.
+ *
+ * <p>The contract is intentionally narrow. It does not expose daemon-only URI types, queue page
+ * models, or any bulk helper. Higher layers keep those concerns so queue toadlets can preserve
+ * their current success and failure rendering while still moving the actual enqueue operation
+ * behind a JDK-only runtime SPI.
+ *
+ * <ul>
+ *   <li>Creates only new persistent downloads; it does not mutate existing requests.
+ *   <li>Uses JDK-only request data so the SPI stays independent of daemon-only URI types.
+ *   <li>Surfaces policy rejections separately from queue-unavailable failures.
+ * </ul>
+ *
+ * @see QueueDownloadRequest
+ * @see QueueDownloadRejectedException
+ * @see RequestQueueUnavailableException
+ */
+public interface QueueDownloadPort {
+  /**
+   * Returns whether runtime policy currently disables disk-backed downloads.
+   *
+   * <p>Callers use this flag to preserve the existing queue-page behavior that falls back to
+   * direct-return downloads when disk targets are not permitted. The result reports the current
+   * runtime policy only; callers still keep HTTP-layer access checks such as public-gateway
+   * restrictions and any per-request path validation. The value is a point-in-time snapshot, so
+   * callers should use it only to choose the immediate handling path for the current request.
+   *
+   * @return {@code true} when disk downloads are disabled by the runtime; otherwise {@code false}
+   */
+  boolean isDiskDownloadDisabled();
+
+  /**
+   * Registers one new persistent download request with the runtime.
+   *
+   * <p>The runtime adapter is responsible only for bridging the detached request into the legacy
+   * queueing implementation. Callers retain any URI parsing, bulk text splitting, path creation,
+   * redirects, and user-facing error-page selection in their own layer. Each invocation handles
+   * exactly one request, so bulk callers should loop explicitly and decide for themselves whether
+   * to stop on the first failure or accumulate partial results.
+   *
+   * @param request detached download request describing the fetch, return mode, and optional disk
+   *     target chosen by the caller
+   * @throws QueueDownloadRejectedException if runtime policy rejects the requested download target
+   *     or other not-allowed queue operation
+   * @throws RequestQueueUnavailableException if the persistent queue is unavailable for new
+   *     requests, such as when persistence support is disabled
+   * @throws IOException if request creation fails for another I/O reason while bridging to the
+   *     legacy queueing implementation
+   */
+  void enqueueDownload(QueueDownloadRequest request)
+      throws QueueDownloadRejectedException, RequestQueueUnavailableException, IOException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueDownloadRejectedException.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueDownloadRejectedException.java
@@ -1,0 +1,43 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Signals that runtime policy rejected creation of a new queue download.
+ *
+ * <p>This checked exception separates access-control-style rejections from broader queue
+ * availability failures. Typical callers keep user-facing mapping in the HTTP layer, where single
+ * downloads and bulk downloads may render the rejection differently while still treating the cause
+ * as a non-retriable policy failure.
+ *
+ * <p>Use this exception when the runtime decided that the requested operation is not allowed, not
+ * when the queue subsystem is missing or temporarily unavailable. That distinction lets callers
+ * preserve existing queue-page behavior such as rendering a disk-configuration error for a single
+ * download while still recording per-key failures during bulk submission.
+ */
+public class QueueDownloadRejectedException extends Exception {
+  /**
+   * Creates an exception with the supplied detail message.
+   *
+   * <p>The message should describe the policy rejection at a level suitable for logs and debugging.
+   * Callers typically map this exception type to a user-facing page or aggregate failure list
+   * rather than exposing the raw message directly.
+   *
+   * @param message human-readable explanation of the rejection
+   */
+  public QueueDownloadRejectedException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception with the supplied detail message and cause.
+   *
+   * <p>Use this constructor when adapting a runtime-specific exception into the detached SPI so the
+   * original failure remains available for diagnostics without leaking daemon-only exception types
+   * across the boundary.
+   *
+   * @param message human-readable explanation of the rejection
+   * @param cause underlying runtime-specific rejection cause retained for diagnostics
+   */
+  public QueueDownloadRejectedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueDownloadRequest.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueDownloadRequest.java
@@ -1,0 +1,33 @@
+package network.crypta.runtime.spi;
+
+import java.io.File;
+
+/**
+ * Detached request data for creating one new persistent queue download.
+ *
+ * <p>The record carries only the small set of values the legacy queue-download adapter needs to
+ * recreate the existing persistent-download call. The HTTP layer owns all user-input parsings and
+ * validation; this DTO simply preserves the chosen fetch URI string, filter flag, persistence mode,
+ * return mode, and optional disk target directory.
+ *
+ * <p>The record is deliberately transport-like rather than behavior-rich. It does not normalize
+ * legacy strings, create directories, or validate that a URI can be fetched. Callers should treat
+ * instances as immutable request snapshots that are ready to hand to {@link QueueDownloadPort}
+ * after the user-facing layer has finished all parsing and policy checks.
+ *
+ * @param fetchUri fetch URI string supplied by the caller; already validated by the HTTP layer in
+ *     normal flows
+ * @param filterData whether fetched data should be filtered before delivery
+ * @param expectedMimeType optional MIME hint for download naming; may be {@code null}
+ * @param persistenceType legacy persistence mode string such as {@code forever}
+ * @param returnType legacy return mode string such as {@code disk} or {@code direct}
+ * @param downloadsDir target directory for disk-backed downloads; {@code null} for direct-return
+ *     requests
+ */
+public record QueueDownloadRequest(
+    String fetchUri,
+    boolean filterData,
+    String expectedMimeType,
+    String persistenceType,
+    String returnType,
+    File downloadsDir) {}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -26,6 +26,7 @@ package network.crypta.runtime.spi;
  * @see DarknetMessagingPort
  * @see DiagnosticPort
  * @see QueuePagePort
+ * @see QueueDownloadPort
  * @see QueueMutationPort
  * @see StatisticsPort
  * @see NodeInfoPort
@@ -179,6 +180,17 @@ public interface RuntimePorts {
    * @return queue-page runtime port for detached legacy queue snapshots and text exports
    */
   QueuePagePort queuePage();
+
+  /**
+   * Returns the legacy queue-download capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining live creation of new persistent downloads inside the daemon
+   * root module while exposing only a narrow JDK-only request shape upstream. Callers retain HTTP
+   * request parsing, per-key bulk aggregation, redirects, and user-facing error mapping.
+   *
+   * @return queue-download runtime port for creating new persistent downloads
+   */
+  QueueDownloadPort queueDownload();
 
   /**
    * Returns the legacy queue-mutation capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -145,7 +145,11 @@ final class FProxyRegistrar {
             core.getEndpoints().getFCPServer(),
             client,
             false,
-            new QueueToadletRuntimePorts(runtimePorts.queuePage(), runtimePorts.queueMutation()));
+            new QueueToadletRuntimePorts(
+                runtimePorts.queuePage(),
+                runtimePorts.transferAccess(),
+                runtimePorts.queueDownload(),
+                runtimePorts.queueMutation()));
     server.register(
         downloadToadlet,
         ToadletRegistration.menuLink(
@@ -167,7 +171,11 @@ final class FProxyRegistrar {
             core.getEndpoints().getFCPServer(),
             client,
             true,
-            new QueueToadletRuntimePorts(runtimePorts.queuePage(), runtimePorts.queueMutation()));
+            new QueueToadletRuntimePorts(
+                runtimePorts.queuePage(),
+                runtimePorts.transferAccess(),
+                runtimePorts.queueDownload(),
+                runtimePorts.queueMutation()));
     server.register(
         uploadToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -48,7 +48,6 @@ import network.crypta.clients.fcp.FcpInsertRequest;
 import network.crypta.clients.fcp.FcpInsertTuningOptions;
 import network.crypta.clients.fcp.IdentifierCollisionException;
 import network.crypta.clients.fcp.NotAllowedException;
-import network.crypta.clients.fcp.PersistentGlobalRequestParams;
 import network.crypta.clients.fcp.RequestCompletionCallback;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
@@ -58,11 +57,15 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.useralerts.StoringUserEvent;
 import network.crypta.node.useralerts.UserAlert;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueDownloadRejectedException;
+import network.crypta.runtime.spi.QueueDownloadRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SizeUtil;
@@ -138,6 +141,8 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private final NodeClientCore core;
   final FCPServer fcp;
   private final QueuePagePort queuePagePort;
+  private final TransferAccessPort transferAccessPort;
+  private final QueueDownloadPort queueDownloadPort;
   private final QueueMutationPort queueMutationPort;
   private FileInsertWizardToadlet fiw;
   private final QueuePostHandler postHandler;
@@ -213,8 +218,11 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     super(client);
     this.core = core;
     this.fcp = fcp;
-    this.queuePagePort = Objects.requireNonNull(runtimePorts).queuePagePort();
-    this.queueMutationPort = runtimePorts.queueMutationPort();
+    QueueToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts);
+    this.queuePagePort = ports.queuePagePort();
+    this.transferAccessPort = ports.transferAccessPort();
+    this.queueDownloadPort = ports.queueDownloadPort();
+    this.queueMutationPort = ports.queueMutationPort();
     this.uploads = uploads;
     this.postHandler = new QueuePostHandler();
     QueueCompletionTracker completionTracker = new QueueCompletionTracker();
@@ -593,9 +601,9 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       if (request.isPartSet("type")) {
         expectedMIMEType = request.getPartAsStringFailsafe("type", MAX_TYPE_LENGTH);
       }
-      FreenetURI fetchURI;
+      String fetchUri = request.getPartAsStringFailsafe("key", MAX_KEY_LENGTH);
       try {
-        fetchURI = new FreenetURI(request.getPartAsStringFailsafe("key", MAX_KEY_LENGTH));
+        new FreenetURI(fetchUri);
       } catch (MalformedURLException _) {
         writeError(l10n(ERROR_INVALID_URI), l10n(ERROR_INVALID_URI_TO_D), ctx);
         return true;
@@ -605,7 +613,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       boolean filterData = request.isPartSet(FILTER_DATA);
       String downloadPath;
       File downloadsDir = null;
-      if (request.isPartSet("path") && !FProxyToadlet.isDownloadDisabledOrUnsafe(ctx, core)) {
+      if (request.isPartSet("path") && !isDiskDownloadDisabledOrUnsafe(ctx)) {
         downloadPath = request.getPartAsStringFailsafe("path", MAX_FILENAME_LENGTH);
         try {
           downloadsDir = getDownloadsDir(downloadPath);
@@ -617,19 +625,13 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         returnType = RETURN_TYPE_DIRECT;
       }
       try {
-        fcp.makePersistentGlobalRequestBlocking(
-            new PersistentGlobalRequestParams(
-                fetchURI,
-                filterData,
-                expectedMIMEType,
-                persistence,
-                returnType,
-                false,
-                downloadsDir));
-      } catch (NotAllowedException _) {
+        queueDownloadPort.enqueueDownload(
+            new QueueDownloadRequest(
+                fetchUri, filterData, expectedMIMEType, persistence, returnType, downloadsDir));
+      } catch (QueueDownloadRejectedException _) {
         writeError(l10n("errorDToDisk"), l10n("errorDToDiskConfig"), ctx);
         return true;
-      } catch (PersistenceDisabledException _) {
+      } catch (RequestQueueUnavailableException _) {
         sendPersistenceDisabledError(ctx);
         return true;
       }
@@ -655,7 +657,6 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
       BulkDownloadResult result =
           enqueueBulkDownloads(keys, request.isPartSet(FILTER_DATA), downloadTarget);
-
       renderBulkDownloadResult(ctx, result);
       return true;
     }
@@ -674,10 +675,13 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     private DownloadTarget resolveDownloadTarget(HTTPRequest request, ToadletContext ctx)
         throws ToadletContextClosedException, IOException {
       String target = request.getPartAsStringFailsafe(TARGET, 128);
-      if (target == null) target = RETURN_TYPE_DIRECT;
+      if (target == null || target.isEmpty()) target = RETURN_TYPE_DIRECT;
 
-      if (!request.isPartSet("path") || FProxyToadlet.isDownloadDisabledOrUnsafe(ctx, core)) {
+      if (!request.isPartSet("path")) {
         return new DownloadTarget(target, null);
+      }
+      if (isDiskDownloadDisabledOrUnsafe(ctx)) {
+        return new DownloadTarget(RETURN_TYPE_DIRECT, null);
       }
 
       String downloadPath = request.getPartAsStringFailsafe("path", MAX_FILENAME_LENGTH);
@@ -702,14 +706,13 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
         try {
           FreenetURI fetchURI = new FreenetURI(currentKey);
-          fcp.makePersistentGlobalRequestBlocking(
-              new PersistentGlobalRequestParams(
-                  fetchURI,
+          queueDownloadPort.enqueueDownload(
+              new QueueDownloadRequest(
+                  currentKey,
                   filterData,
                   null,
                   "forever",
                   downloadTarget.target(),
-                  false,
                   downloadTarget.downloadsDir()));
           success.add(fetchURI.toString(true, false));
         } catch (Exception e) {
@@ -1884,10 +1887,15 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       writeHTMLReply(ctx, 200, "OK", page.generate());
     }
 
+    private boolean isDiskDownloadDisabledOrUnsafe(ToadletContext ctx) {
+      return queueDownloadPort.isDiskDownloadDisabled()
+          || (ctx.getContainer().publicGatewayMode() && !ctx.isAllowedFullAccess());
+    }
+
     private File getDownloadsDir(String downloadPath) throws NotAllowedException {
       File downloadsDir = new File(downloadPath);
       // Invalid if it's disallowed, doesn't exist, isn't a directory, or can't be created.
-      if (!core.allowDownloadTo(downloadsDir)
+      if (!transferAccessPort.allowDownloadTo(downloadsDir)
           || !((downloadsDir.exists() && downloadsDir.isDirectory()) || !downloadsDir.mkdirs())) {
         throw new NotAllowedException();
       }

--- a/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
@@ -1,36 +1,49 @@
 package network.crypta.clients.http;
 
 import java.util.Objects;
+import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.TransferAccessPort;
 
 /**
  * Shared runtime-port bundle used by the legacy queue toadlets.
  *
- * <p>The download and upload queue pages share the same detached read-path and mutation runtime
- * ports. Grouping them in one small record keeps constructor signatures stable while preserving the
- * option to add other queue-specific ports later without widening the main toadlet constructor
- * again.
+ * <p>The download and upload queue pages share the same detached read-path, mutation, and
+ * transfer-policy runtime ports, and the download side also uses the queue-download creation port.
+ * Grouping them in one small record keeps constructor signatures stable while preserving the option
+ * to add other queue-specific ports later without widening the main toadlet constructor again.
  *
  * <p>This record lives in the HTTP layer because it models HTTP wiring rather than a daemon-side
  * runtime capability. The queue toadlets can accept one stable parameter today and still grow to
  * include additional queue-related ports in later migrations without repeating constructor churn.
  *
  * @param queuePagePort detached queue-page read port
+ * @param transferAccessPort detached transfer-policy port used by queue-local path checks
+ * @param queueDownloadPort detached queue-download port used for new persistent downloads
  * @param queueMutationPort detached queue-mutation port
  */
 public record QueueToadletRuntimePorts(
-    QueuePagePort queuePagePort, QueueMutationPort queueMutationPort) {
+    QueuePagePort queuePagePort,
+    TransferAccessPort transferAccessPort,
+    QueueDownloadPort queueDownloadPort,
+    QueueMutationPort queueMutationPort) {
   /**
    * Creates one validated queue-toadlet port bundle.
    *
    * @param queuePagePort detached queue-page read port shared by the download and upload toadlets
+   * @param transferAccessPort detached transfer-policy port shared by the download and upload
+   *     toadlets
+   * @param queueDownloadPort detached queue-download port shared by the download and upload
+   *     toadlets
    * @param queueMutationPort detached queue-mutation port shared by the download and upload
    *     toadlets
-   * @throws NullPointerException if either port is {@code null}
+   * @throws NullPointerException if any port is {@code null}
    */
   public QueueToadletRuntimePorts {
     Objects.requireNonNull(queuePagePort);
+    Objects.requireNonNull(transferAccessPort);
+    Objects.requireNonNull(queueDownloadPort);
     Objects.requireNonNull(queueMutationPort);
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyQueueDownloadPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyQueueDownloadPort.java
@@ -1,0 +1,92 @@
+package network.crypta.node.runtime;
+
+import java.io.IOException;
+import java.util.Objects;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.NotAllowedException;
+import network.crypta.clients.fcp.PersistentGlobalRequestParams;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueDownloadRejectedException;
+import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+
+/**
+ * Legacy daemon-backed implementation of the queue-download runtime SPI.
+ *
+ * <p>This adapter keeps the remaining creation of new persistent downloads inside the daemon root
+ * module while exposing only a small JDK-only request shape upstream. It resolves the live {@link
+ * FCPServer} lazily through {@link NodeClientCore#getEndpoints()} so runtime-port construction does
+ * not force early endpoint initialization during startup.
+ *
+ * <p>The adapter preserves the current queue-download behavior exactly: each request is bridged to
+ * the legacy blocking persistent-global-request call, disk-download disablement is delegated to the
+ * client core, and policy rejections and persistence failures are mapped to the SPI-specific
+ * checked exceptions expected by higher layers.
+ *
+ * <ul>
+ *   <li>Startup wiring stays safe because {@link FCPServer} lookup happens only inside methods.
+ *   <li>The adapter performs the minimal translation from detached SPI data to legacy daemon
+ *       arguments.
+ *   <li>Higher layers still own request parsing, path validation, and HTTP response selection.
+ * </ul>
+ *
+ * @see QueueDownloadPort
+ * @see QueueDownloadRequest
+ */
+public final class LegacyQueueDownloadPort implements QueueDownloadPort {
+  private final NodeClientCore core;
+
+  /**
+   * Creates a queue-download adapter backed by the supplied client core.
+   *
+   * <p>The adapter stores only the core reference and resolves the live {@link FCPServer} lazily
+   * for each enqueue call. This constructor is therefore safe to use during early runtime-port
+   * assembly, before client endpoints and the FCP subsystem are fully initialized.
+   *
+   * @param core live daemon client core that provides queue access, download policy, and deferred
+   *     endpoint lookup
+   */
+  public LegacyQueueDownloadPort(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isDiskDownloadDisabled() {
+    return core.isDownloadDisabled();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void enqueueDownload(QueueDownloadRequest request)
+      throws QueueDownloadRejectedException, RequestQueueUnavailableException, IOException {
+    Objects.requireNonNull(request);
+    try {
+      fcpServer()
+          .makePersistentGlobalRequestBlocking(
+              new PersistentGlobalRequestParams(
+                  new FreenetURI(request.fetchUri()),
+                  request.filterData(),
+                  request.expectedMimeType(),
+                  request.persistenceType(),
+                  request.returnType(),
+                  false,
+                  request.downloadsDir()));
+    } catch (NotAllowedException e) {
+      throw new QueueDownloadRejectedException("Queue download rejected", e);
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
+    }
+  }
+
+  private FCPServer fcpServer() {
+    FCPServer fcpServer = core.getEndpoints().getFCPServer();
+    if (fcpServer == null) {
+      throw new IllegalStateException("FCP server unavailable");
+    }
+    return fcpServer;
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -16,6 +16,7 @@ import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.RandomnessPort;
@@ -54,6 +55,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
   private final QueuePagePort queuePagePort;
+  private final QueueDownloadPort queueDownloadPort;
   private final QueueMutationPort queueMutationPort;
   private final StatisticsPort statisticsPort;
   private final SecurityLevelsPort securityLevelsPort;
@@ -153,6 +155,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.darknetMessagingPort = new LegacyDarknetMessagingPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.queuePagePort = new LegacyQueuePagePort(core);
+    this.queueDownloadPort = new LegacyQueueDownloadPort(core);
     this.queueMutationPort = new LegacyQueueMutationPort(core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.securityLevelsPort = new LegacySecurityLevelsPort(node);
@@ -295,6 +298,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public QueuePagePort queuePage() {
     return queuePagePort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining new-download queue registration inside the daemon root
+   * module while exposing only a narrow JDK-only request surface upstream.
+   */
+  @Override
+  public QueueDownloadPort queueDownload() {
+    return queueDownloadPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
@@ -1,9 +1,12 @@
 package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import network.crypta.client.ArchiveManager;
@@ -36,6 +39,8 @@ import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueDownloadRejectedException;
+import network.crypta.runtime.spi.QueueDownloadRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -64,6 +69,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -72,14 +79,17 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @SuppressWarnings("java:S100")
-class QueueToadletPostMutationTest {
+class QueueToadletPostDownloadTest {
 
   @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
@@ -105,118 +115,188 @@ class QueueToadletPostMutationTest {
     when(ctx.getContainer()).thenReturn(container);
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
+    when(queueDownloadPort.isDiskDownloadDisabled()).thenReturn(false);
   }
 
   @Test
-  void handleMethodPOST_whenRemoveRequestSelected_callsQueueMutationPort() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
+  void handleMethodPOST_whenSingleDownloadRequested_callsQueueDownloadPort() throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    Path downloadsDir = Files.createDirectories(tempDir.resolve("downloads"));
+    String downloadPath = downloadsDir.toString();
+    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(true);
     HTTPRequest request =
         createRequest(
             Map.of(
-                "remove_request", "yes",
-                "identifier-a", "download-1",
-                "identifier-b", "download-2"));
+                "download", "yes",
+                "key", "CHK@",
+                "type", "text/plain",
+                "persistence", "forever",
+                "return-type", "disk",
+                "path", downloadPath,
+                "filterData", "on"));
 
     toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
 
-    String location = captureRedirectLocation(ctx);
-    verify(queueMutationPort).removeRequests(java.util.List.of("download-1", "download-2"));
-    assertEquals(QueueToadlet.PATH_DOWNLOADS, location);
+    assertEquals(QueueToadlet.PATH_DOWNLOADS, captureRedirectLocation(ctx));
+    ArgumentCaptor<QueueDownloadRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueDownloadRequest.class);
+    verify(queueDownloadPort).enqueueDownload(requestCaptor.capture());
+    QueueDownloadRequest queueRequest = requestCaptor.getValue();
+    assertEquals("CHK@", queueRequest.fetchUri());
+    assertTrue(queueRequest.filterData());
+    assertEquals("text/plain", queueRequest.expectedMimeType());
+    assertEquals("forever", queueRequest.persistenceType());
+    assertEquals("disk", queueRequest.returnType());
+    assertEquals(new File(downloadPath), queueRequest.downloadsDir());
   }
 
   @Test
-  void handleMethodPOST_whenRestartRequestSelected_callsQueueMutationPortWithDisableFilterData()
+  void handleMethodPOST_whenBulkDownloadsRequested_callsQueueDownloadPortOncePerValidKey()
       throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
+    QueueToadlet toadlet = createQueueToadlet();
+    Path downloadsDir = Files.createDirectories(tempDir.resolve("bulk-downloads"));
+    String downloadPath = downloadsDir.toString();
+    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(true);
+    ByteArrayOutputStream body = captureBody(ctx);
     HTTPRequest request =
         createRequest(
             Map.of(
-                "restart_request", "yes",
-                "disableFilterData", "on",
-                "identifier-a", "download-1"));
+                "bulkDownloads", "CHK@\nnot-a-uri\n\nSSK@\n",
+                "target", "disk",
+                "path", downloadPath,
+                "filterData", "on"));
 
     toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
 
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).restartRequests(java.util.List.of("download-1"), true);
+    ArgumentCaptor<QueueDownloadRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueDownloadRequest.class);
+    verify(queueDownloadPort, times(2)).enqueueDownload(requestCaptor.capture());
+    List<QueueDownloadRequest> requests = requestCaptor.getAllValues();
+    assertEquals("CHK@", requests.getFirst().fetchUri());
+    assertEquals("SSK@", requests.get(1).fetchUri());
+    assertEquals("disk", requests.getFirst().returnType());
+    assertEquals(new File(downloadPath), requests.getFirst().downloadsDir());
+    assertTrue(body.toString(StandardCharsets.UTF_8).contains("not-a-uri"));
   }
 
   @Test
-  void handleMethodPOST_whenChangePriorityTopSelected_callsQueueMutationPort() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
+  void handleMethodPOST_whenSingleDownloadRejected_returnsDiskConfigErrorPage() throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    Path downloadsDir = Files.createDirectories(tempDir.resolve("downloads"));
+    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(true);
+    doThrow(new QueueDownloadRejectedException("rejected"))
+        .when(queueDownloadPort)
+        .enqueueDownload(any(QueueDownloadRequest.class));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
         createRequest(
             Map.of(
-                "change_priority_top", "yes",
-                "priority_top", "4",
-                "identifier-a", "download-1"));
+                "download", "yes",
+                "key", "CHK@",
+                "persistence", "forever",
+                "return-type", "disk",
+                "path", downloadsDir.toString())),
+        ctx);
 
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).changePriority(java.util.List.of("download-1"), (short) 4);
+    verify(queueDownloadPort).enqueueDownload(any(QueueDownloadRequest.class));
+    verify(ctx).sendReplyHeaders(eq(400), eq("Bad request"), any(), anyString(), anyLong());
   }
 
   @Test
-  void handleMethodPOST_whenChangePriorityBottomSelected_callsQueueMutationPort() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
-        createRequest(
-            Map.of(
-                "change_priority_bottom", "yes",
-                "priority_bottom", "2",
-                "identifier-a", "download-1"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).changePriority(java.util.List.of("download-1"), (short) 2);
-  }
-
-  @Test
-  void handleMethodPOST_whenRemoveFinishedUploadsSelected_callsQueueMutationPort()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(true);
-    HTTPRequest request = createRequest(Map.of("remove_finished_uploads_request", "yes"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/uploads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).removeFinishedUploads();
-  }
-
-  @Test
-  void handleMethodPOST_whenRemoveFinishedDownloadsSelected_callsQueueMutationPort()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request = createRequest(Map.of("remove_finished_downloads_request", "yes"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).removeFinishedDownloads();
-  }
-
-  @Test
-  void handleMethodPOST_whenQueueMutationUnavailable_returnsPersistenceDisabledErrorPage()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
-        createRequest(Map.of("remove_request", "yes", "identifier-a", "download-1"));
+  void handleMethodPOST_whenBulkQueueUnavailable_rendersBulkFailureResultPage() throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
     doThrow(new RequestQueueUnavailableException("queue unavailable"))
-        .when(queueMutationPort)
-        .removeRequests(java.util.List.of("download-1"));
-
+        .when(queueDownloadPort)
+        .enqueueDownload(any(QueueDownloadRequest.class));
     ByteArrayOutputStream body = captureBody(ctx);
 
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
+        createRequest(Map.of("bulkDownloads", "CHK@\n", "target", "direct")),
+        ctx);
 
     String html = body.toString(StandardCharsets.UTF_8);
-    assertTrue(html.contains(tempDir.toString()));
-    assertTrue(html.contains("queue.db"));
+    assertTrue(html.contains("CHK@"));
+    assertFalse(html.contains("queue.db"));
+    verify(ctx).sendReplyHeaders(eq(200), eq("OK"), any(), anyString(), anyLong());
   }
 
-  private QueueToadlet createQueueToadlet(boolean uploads) throws Exception {
+  @Test
+  void handleMethodPOST_whenBulkQueueUnavailableAfterPartialSuccess_preservesAcceptedKeys()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    doNothing()
+        .doThrow(new RequestQueueUnavailableException("queue unavailable"))
+        .when(queueDownloadPort)
+        .enqueueDownload(any(QueueDownloadRequest.class));
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
+        createRequest(Map.of("bulkDownloads", "CHK@\nSSK@\n", "target", "direct")),
+        ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertTrue(html.contains("CHK@"));
+    assertTrue(html.contains("SSK@"));
+    assertFalse(html.contains("queue.db"));
+    verify(queueDownloadPort, times(2)).enqueueDownload(any(QueueDownloadRequest.class));
+    verify(ctx).sendReplyHeaders(eq(200), eq("OK"), any(), anyString(), anyLong());
+  }
+
+  @Test
+  void handleMethodPOST_whenDownloadPathDisallowed_returnsDisallowedPageWithoutQueueDownloadCall()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    String downloadPath = tempDir.resolve("blocked").toString();
+    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(false);
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
+        createRequest(
+            Map.of(
+                "download", "yes",
+                "key", "CHK@",
+                "persistence", "forever",
+                "return-type", "disk",
+                "path", downloadPath)),
+        ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertTrue(html.contains(downloadPath));
+    assertTrue(html.contains("disallowed"));
+    verify(queueDownloadPort, never()).enqueueDownload(any(QueueDownloadRequest.class));
+  }
+
+  @Test
+  void handleMethodPOST_whenDiskDownloadsDisabled_fallsBackToDirectReturnWithoutPathCheck()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    when(queueDownloadPort.isDiskDownloadDisabled()).thenReturn(true);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
+        createRequest(
+            Map.of(
+                "download", "yes",
+                "key", "CHK@",
+                "persistence", "forever",
+                "return-type", "disk",
+                "path", tempDir.resolve("downloads").toString())),
+        ctx);
+
+    ArgumentCaptor<QueueDownloadRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueDownloadRequest.class);
+    verify(queueDownloadPort).enqueueDownload(requestCaptor.capture());
+    QueueDownloadRequest queueRequest = requestCaptor.getValue();
+    assertEquals("direct", queueRequest.returnType());
+    assertNull(queueRequest.downloadsDir());
+    verify(transferAccessPort, never()).allowDownloadTo(any(File.class));
+  }
+
+  private QueueToadlet createQueueToadlet() throws Exception {
     ProgramDirectory userDir = new ProgramDirectory();
     userDir.move(tempDir.toString());
 
@@ -276,7 +356,7 @@ class QueueToadletPostMutationTest {
             core,
             fcp,
             client,
-            uploads,
+            false,
             new QueueToadletRuntimePorts(
                 queuePagePort, transferAccessPort, queueDownloadPort, queueMutationPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -42,11 +42,13 @@ import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.node.useralerts.UserEvent;
+import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
@@ -96,6 +98,8 @@ class QueueToadletTest {
   @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
   @Mock private QueuePagePort queuePagePort;
+  @Mock private TransferAccessPort transferAccessPort;
+  @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private UserAlertManager alerts;
   @Mock private PriorityAwareExecutor executor;
@@ -116,6 +120,7 @@ class QueueToadletTest {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     when(ctx.getFormPassword()).thenReturn(TEST_FORM_PASSWORD);
     when(ctx.getAlertManager()).thenReturn(alerts);
+    when(ctx.getContainer()).thenReturn(container);
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
     when(fcp.isEnabled()).thenReturn(true);
@@ -464,7 +469,8 @@ class QueueToadletTest {
             fcp,
             client,
             uploads,
-            new QueueToadletRuntimePorts(queuePagePort, queueMutationPort));
+            new QueueToadletRuntimePorts(
+                queuePagePort, transferAccessPort, queueDownloadPort, queueMutationPort));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/node/runtime/LegacyQueueDownloadPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyQueueDownloadPortTest.java
@@ -1,0 +1,133 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.NotAllowedException;
+import network.crypta.clients.fcp.PersistentGlobalRequestParams;
+import network.crypta.node.ClientEndpoints;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.QueueDownloadRejectedException;
+import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyQueueDownloadPortTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientEndpoints endpoints;
+  @Mock private FCPServer fcp;
+
+  private LegacyQueueDownloadPort port;
+
+  @BeforeEach
+  void setUp() {
+    port = new LegacyQueueDownloadPort(core);
+  }
+
+  @Test
+  void isDiskDownloadDisabled_whenCoreReportsDisabled_returnsTrue() {
+    when(core.isDownloadDisabled()).thenReturn(true);
+
+    boolean disabled = port.isDiskDownloadDisabled();
+
+    assertTrue(disabled);
+    verify(core).isDownloadDisabled();
+    verifyNoInteractions(endpoints, fcp);
+  }
+
+  @Test
+  void isDiskDownloadDisabled_whenCoreReportsEnabled_returnsFalse() {
+    when(core.isDownloadDisabled()).thenReturn(false);
+
+    boolean disabled = port.isDiskDownloadDisabled();
+
+    assertFalse(disabled);
+    verify(core).isDownloadDisabled();
+    verifyNoInteractions(endpoints, fcp);
+  }
+
+  @Test
+  void enqueueDownload_whenCalled_resolvesFcpLazilyAndForwardsExpectedValues() throws Exception {
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(fcp);
+    QueueDownloadRequest request =
+        new QueueDownloadRequest(
+            "CHK@", true, "text/plain", "forever", "disk", new File("/tmp/downloads"));
+
+    verifyNoInteractions(endpoints, fcp);
+
+    port.enqueueDownload(request);
+
+    ArgumentCaptor<PersistentGlobalRequestParams> paramsCaptor =
+        ArgumentCaptor.forClass(PersistentGlobalRequestParams.class);
+    verify(endpoints).getFCPServer();
+    verify(fcp).makePersistentGlobalRequestBlocking(paramsCaptor.capture());
+    PersistentGlobalRequestParams params = paramsCaptor.getValue();
+    assertEquals("CHK@", params.fetchURI().toString());
+    assertTrue(params.filterData());
+    assertEquals("text/plain", params.expectedMimeType());
+    assertEquals("forever", params.persistenceType());
+    assertEquals("disk", params.returnType());
+    assertFalse(params.realTimeFlag());
+    assertSame(request.downloadsDir(), params.downloadsDir());
+  }
+
+  @Test
+  void enqueueDownload_whenNotAllowed_translatesToQueueDownloadRejectedException()
+      throws Exception {
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(fcp);
+    NotAllowedException cause = new NotAllowedException();
+    doThrow(cause)
+        .when(fcp)
+        .makePersistentGlobalRequestBlocking(any(PersistentGlobalRequestParams.class));
+
+    QueueDownloadRejectedException thrown =
+        assertThrows(
+            QueueDownloadRejectedException.class,
+            () ->
+                port.enqueueDownload(
+                    new QueueDownloadRequest("CHK@", false, null, "forever", "disk", null)));
+
+    assertSame(cause, thrown.getCause());
+  }
+
+  @Test
+  void enqueueDownload_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
+      throws Exception {
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(fcp);
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    doThrow(cause)
+        .when(fcp)
+        .makePersistentGlobalRequestBlocking(any(PersistentGlobalRequestParams.class));
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(
+            RequestQueueUnavailableException.class,
+            () ->
+                port.enqueueDownload(
+                    new QueueDownloadRequest("CHK@", false, null, "forever", "disk", null)));
+
+    assertSame(cause, thrown.getCause());
+  }
+}


### PR DESCRIPTION
## Summary
- add a detached queue-download runtime SPI with a legacy daemon-backed adapter and runtime wiring
- route `QueueToadlet` single-download and bulk-download POST creation paths through the new SPI and use `TransferAccessPort` for targeted download-path checks
- preserve grouped bulk-download partial results when the queue becomes unavailable mid-submission, and add focused tests plus Javadoc for the new production types

## How to test
- `./gradlew test --tests '*LegacyQueueDownloadPortTest' --tests '*QueueToadletPostDownloadTest' --tests '*QueueToadletPostMutationTest' --tests '*QueueToadletTest'`