### PR TITLE
refactor(queue): Extract insert runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueBrowserUploadInsertRequest.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueBrowserUploadInsertRequest.java
@@ -1,0 +1,65 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Detached request data for creating a new persistent insert from browser-uploaded bytes.
+ *
+ * <p>Callers usually create this record after the queue UI has parsed a multipart upload and chosen
+ * the insert target. The record keeps only JDK-level values plus the detached {@link
+ * QueueUploadedFile} stream source that the daemon-side adapter needs to stage the upload into
+ * persistent storage. That lets the HTTP layer stay responsible for form handling and user-facing
+ * redirects while the runtime layer recreates the legacy insert request.
+ *
+ * <p>The record is immutable after construction, aside from caller-owned objects referenced by its
+ * components. {@code filenameForKey} is optional because not every insert URI needs a filename hint
+ * when the legacy daemon rebuilds the final key.
+ *
+ * @param insertUri validated insert URI string chosen by the caller
+ * @param identifier queue identifier that should remain stable for this insert attempt
+ * @param upload detached uploaded-file payload that can reopen the browser data
+ * @param options detached insert options mirrored from queue form controls
+ * @param filenameForKey optional filename hint for key types that embed one
+ */
+public record QueueBrowserUploadInsertRequest(
+    String insertUri,
+    String identifier,
+    QueueUploadedFile upload,
+    QueueInsertOptions options,
+    String filenameForKey) {
+
+  /** Validates the required detached values before the request crosses the runtime boundary. */
+  public QueueBrowserUploadInsertRequest {
+    Objects.requireNonNull(insertUri, "insertUri");
+    Objects.requireNonNull(identifier, "identifier");
+    Objects.requireNonNull(upload, "upload");
+    Objects.requireNonNull(options, "options");
+  }
+
+  /**
+   * Returns the detached compression preference for the insert.
+   *
+   * @return {@code true} when the legacy adapter should request compression
+   */
+  public boolean compress() {
+    return options.compress();
+  }
+
+  /**
+   * Returns the compatibility mode selected for the insert.
+   *
+   * @return compatibility-mode name understood by the legacy daemon adapter
+   */
+  public String compatibilityMode() {
+    return options.compatibilityMode();
+  }
+
+  /**
+   * Returns the optional override splitfile crypto key.
+   *
+   * @return caller-supplied splitfile key bytes, or {@code null} when no override was chosen
+   */
+  public byte[] overrideSplitfileCryptoKey() {
+    return options.overrideSplitfileCryptoKey();
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertFailureReason.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertFailureReason.java
@@ -1,0 +1,38 @@
+package network.crypta.runtime.spi;
+
+/**
+ * User-facing rejection categories for queue insert creation.
+ *
+ * <p>These values represent the small set of rejection cases that the queue UI already knows how to
+ * explain to the user. They keep caller-side response mapping stable while avoiding direct exposure
+ * to daemon-specific exception types and policy classes.
+ *
+ * <p>The enum is intentionally narrow. Outcomes such as identifier collisions and unresolved
+ * metadata stay on the normal {@link QueueInsertOutcome} path, while broader queue availability
+ * problems use {@link RequestQueueUnavailableException}.
+ */
+public enum QueueInsertFailureReason {
+  /**
+   * Runtime policy rejected the selected upload, file, or directory source.
+   *
+   * <p>Typical causes include access-control checks or local-security policies that refuse the
+   * source before a persistent insert is started.
+   */
+  ACCESS_DENIED,
+
+  /**
+   * The requested file or directory is missing or unreadable.
+   *
+   * <p>Callers usually map this reason to the existing "no file selected" or "cannot read" response
+   * path rather than treating it as an internal daemon failure.
+   */
+  SOURCE_NOT_FOUND,
+
+  /**
+   * The selected directory exceeds the legacy inserter's per-request file limit.
+   *
+   * <p>This reason is specific to the directory inserts and preserves the queue page's existing
+   * too-many-files error page.
+   */
+  TOO_MANY_FILES
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertOptions.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertOptions.java
@@ -1,0 +1,90 @@
+package network.crypta.runtime.spi;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Detached insert option values shared by queue insert creation requests.
+ *
+ * <p>This value object mirrors the subset of queue form controls that materially influence how the
+ * legacy daemon starts an insert. It keeps the SPI free of daemon-owned option classes while still
+ * giving the runtime adapter enough information to reconstruct the older {@code
+ * FcpInsertOptions}-based flow.
+ *
+ * <p>The instance is logically immutable. The optional override splitfile key is stored and
+ * returned as supplied, so callers that share the same array across components should treat that
+ * array as read-only after construction.
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+public final class QueueInsertOptions {
+  private final boolean compress;
+  private final String compatibilityMode;
+  private final byte[] overrideSplitfileCryptoKey;
+
+  /**
+   * Creates a detached option bundle for queue insert creation.
+   *
+   * @param compress {@code true} when the insert should request compression
+   * @param compatibilityMode compatibility-mode name expected by the legacy insert adapter
+   * @param overrideSplitfileCryptoKey optional caller-supplied splitfile key bytes, or {@code null}
+   *     when no override was selected
+   */
+  public QueueInsertOptions(
+      boolean compress, String compatibilityMode, byte[] overrideSplitfileCryptoKey) {
+    this.compress = compress;
+    this.compatibilityMode = Objects.requireNonNull(compatibilityMode, "compatibilityMode");
+    this.overrideSplitfileCryptoKey = overrideSplitfileCryptoKey;
+  }
+
+  /**
+   * Returns the detached compression preference.
+   *
+   * @return {@code true} when the insert should request compression
+   */
+  public boolean compress() {
+    return compress;
+  }
+
+  /**
+   * Returns the compatibility mode requested by the caller.
+   *
+   * @return compatibility-mode name understood by the legacy adapter
+   */
+  public String compatibilityMode() {
+    return compatibilityMode;
+  }
+
+  /**
+   * Returns the optional override splitfile crypto key.
+   *
+   * @return caller-supplied splitfile key bytes, or {@code null} when absent
+   */
+  public byte[] overrideSplitfileCryptoKey() {
+    return overrideSplitfileCryptoKey;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof QueueInsertOptions other)) {
+      return false;
+    }
+    return compress == other.compress
+        && Objects.equals(compatibilityMode, other.compatibilityMode)
+        && Arrays.equals(overrideSplitfileCryptoKey, other.overrideSplitfileCryptoKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * Objects.hash(compress, compatibilityMode)
+        + Arrays.hashCode(overrideSplitfileCryptoKey);
+  }
+
+  @Override
+  public String toString() {
+    return "QueueInsertOptions[compress="
+        + compress
+        + ", compatibilityMode="
+        + compatibilityMode
+        + ']';
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertOutcome.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertOutcome.java
@@ -1,0 +1,36 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Legacy completion states returned after creating a new persistent queue insert.
+ *
+ * <p>The queue insert SPI keeps a few legacy daemon completion states on the normal return path
+ * instead of turning them into exceptions. That preserves the queue page's established redirect and
+ * completion behavior after insert construction moved behind the runtime boundary.
+ *
+ * <p>These values therefore describe what happened while attempting to register the insert, not
+ * whether the eventual network insert will succeed later.
+ */
+public enum QueueInsertOutcome {
+  /**
+   * The insert request was registered with the persistent queue and started successfully.
+   *
+   * <p>Callers normally follow this outcome with the existing queue-page redirect.
+   */
+  STARTED,
+
+  /**
+   * The chosen identifier was already in use.
+   *
+   * <p>This matches the older queue behavior where identifier collisions were treated as a normal
+   * redirect-only outcome instead of a user-visible hard failure.
+   */
+  IDENTIFIER_COLLISION,
+
+  /**
+   * Redirect metadata could not be resolved while constructing the insert.
+   *
+   * <p>The queue UI historically handled this case the same way it handled successful enqueueing
+   * for redirect purposes, so the SPI preserves that distinction.
+   */
+  METADATA_UNRESOLVED
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertPort.java
@@ -1,0 +1,70 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+
+/**
+ * Runtime capability for creating new persistent queue inserts from the queue UI.
+ *
+ * <p>This port hides the remaining daemon-specific work needed to create persistent queue inserts.
+ * Callers are expected to parse form data, validate URIs, and choose the user-facing response path
+ * before invoking the port. The implementation then stages browser uploads, rebuilds the matching
+ * legacy insert objects, and starts the request through the daemon's persistent queue.
+ *
+ * <p>The port deliberately exposes one method per queue-toadlet flow instead of a single tagged
+ * union request. That keeps the boundary readable, makes caller intent explicit, and avoids leaking
+ * HTTP-only concepts into the runtime SPI.
+ */
+public interface QueueInsertPort {
+  /**
+   * Registers one new persistent insert backed by browser-uploaded bytes.
+   *
+   * <p>The caller remains responsible for multipart parsing, insert URI validation, and redirect
+   * handling. Implementations may perform temporary staging work before queue registration because
+   * browser uploads do not already exist as files on disk.
+   *
+   * @param request detached browser-upload insert request with staged form values
+   * @return legacy completion state describing how registration finished
+   * @throws QueueInsertRejectedException if runtime policy rejects the uploaded source
+   * @throws RequestQueueUnavailableException if the persistent request queue or FCP endpoint is
+   *     unavailable while starting the insert
+   * @throws IOException if I/O fails while staging, upload bytes, or rebuilding the legacy request
+   */
+  QueueInsertOutcome enqueueBrowserUploadInsert(QueueBrowserUploadInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException;
+
+  /**
+   * Registers one new persistent insert backed by a local file.
+   *
+   * <p>This method represents the queue flow where the user selected one local file from the file
+   * browser. The runtime adapter is responsible for access checks, legacy request reconstruction,
+   * and starting the insert on the persistent queue.
+   *
+   * @param request detached local-file insert request with the chosen source path
+   * @return legacy completion state describing how registration finished
+   * @throws QueueInsertRejectedException if runtime policy rejects the local source file
+   * @throws RequestQueueUnavailableException if the persistent request queue or FCP endpoint is
+   *     unavailable while starting the insert
+   * @throws IOException if I/O fails while reopening the local file or rebuilding the legacy
+   *     request
+   */
+  QueueInsertOutcome enqueueLocalFileInsert(QueueLocalFileInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException;
+
+  /**
+   * Registers one new persistent insert backed by a local directory tree.
+   *
+   * <p>This method covers the legacy directory-insert flow where the daemon scans a selected tree
+   * and reconstructs a persistent manifest-style request. Callers still own redirect and error-page
+   * mapping after the outcome or exception is returned.
+   *
+   * @param request detached local-directory insert request with the selected root directory
+   * @return legacy completion state describing how registration finished
+   * @throws QueueInsertRejectedException if runtime policy rejects the directory, or it exceeds the
+   *     supported per-insert file limit
+   * @throws RequestQueueUnavailableException if the persistent request queue or FCP endpoint is
+   *     unavailable while starting the insert
+   * @throws IOException if I/O fails while rebuilding the legacy directory insert request
+   */
+  QueueInsertOutcome enqueueLocalDirectoryInsert(QueueLocalDirectoryInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertRejectedException.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertRejectedException.java
@@ -1,0 +1,55 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Signals that queue insert creation was rejected for a user-facing reason.
+ *
+ * <p>This checked exception represents rejection cases that callers are expected to map directly to
+ * an existing queue error page. It deliberately separates policy-style failures such as
+ * access-control denials from broader queue-unavailable conditions and from normal redirect-style
+ * outcomes such as identifier collisions.
+ *
+ * <p>The exception carries a detached {@link QueueInsertFailureReason} so higher layers can keep
+ * their existing response mapping without depending on daemon-owned exception classes.
+ */
+public class QueueInsertRejectedException extends Exception {
+  /** Detached rejection category used for stable caller-side response mapping. */
+  private final QueueInsertFailureReason reason;
+
+  /**
+   * Creates an exception with the supplied detached rejection reason and detail message.
+   *
+   * @param reason detached rejection category for caller-side response mapping
+   * @param message human-readable explanation suitable for logs and debugging
+   */
+  public QueueInsertRejectedException(QueueInsertFailureReason reason, String message) {
+    super(message);
+    this.reason = Objects.requireNonNull(reason, "reason");
+  }
+
+  /**
+   * Creates an exception with the supplied detached rejection reason, detail message, and cause.
+   *
+   * @param reason detached rejection category for caller-side response mapping
+   * @param message human-readable explanation suitable for logs and debugging
+   * @param cause underlying daemon-specific cause retained for diagnostics
+   */
+  public QueueInsertRejectedException(
+      QueueInsertFailureReason reason, String message, Throwable cause) {
+    super(message, cause);
+    this.reason = Objects.requireNonNull(reason, "reason");
+  }
+
+  /**
+   * Returns the detached rejection category associated with this failure.
+   *
+   * <p>The returned value is stable across runtime implementations and is intended for
+   * caller-controlled response mapping rather than for end-user display text.
+   *
+   * @return rejection category used by higher layers for user-facing mapping
+   */
+  public QueueInsertFailureReason reason() {
+    return reason;
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueLocalDirectoryInsertRequest.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueLocalDirectoryInsertRequest.java
@@ -1,0 +1,134 @@
+package network.crypta.runtime.spi;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * Detached request data for creating a new persistent insert from a local directory tree.
+ *
+ * <p>This request represents the queue flow where the user chooses a local directory for a
+ * manifest-style insert. It keeps only the selected root directory, the caller-chosen insert
+ * metadata, and the detached option values the legacy adapter needs to rebuild the older
+ * directory-insert path.
+ *
+ * <p>The HTTP layer remains responsible for URI parsing, redirects, and user-facing error pages.
+ * The runtime adapter consumes this value to perform access checks, rebuild the legacy {@code
+ * ClientPutDir}, and start the request on the persistent queue.
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+public final class QueueLocalDirectoryInsertRequest {
+  private final File sourceDirectory;
+  private final String insertUri;
+  private final String identifier;
+  private final QueueInsertOptions options;
+
+  /**
+   * Creates a detached local-directory insert request.
+   *
+   * @param sourceDirectory selected local directory that should be inserted
+   * @param insertUri validated insert URI string chosen by the caller
+   * @param identifier queue identifier that should remain stable for this insert attempt
+   * @param options detached insert options mirrored from queue form controls
+   */
+  public QueueLocalDirectoryInsertRequest(
+      File sourceDirectory, String insertUri, String identifier, QueueInsertOptions options) {
+    this.sourceDirectory = Objects.requireNonNull(sourceDirectory, "sourceDirectory");
+    this.insertUri = Objects.requireNonNull(insertUri, "insertUri");
+    this.identifier = Objects.requireNonNull(identifier, "identifier");
+    this.options = Objects.requireNonNull(options, "options");
+  }
+
+  /**
+   * Returns the selected source directory.
+   *
+   * @return local directory that the runtime adapter should scan and enqueue
+   */
+  public File sourceDirectory() {
+    return sourceDirectory;
+  }
+
+  /**
+   * Returns the detached insert URI string.
+   *
+   * @return validated insert URI string chosen by the caller
+   */
+  public String insertUri() {
+    return insertUri;
+  }
+
+  /**
+   * Returns the caller-selected queue identifier.
+   *
+   * @return identifier that distinguishes this insert attempt in the persistent queue
+   */
+  public String identifier() {
+    return identifier;
+  }
+
+  /**
+   * Returns the detached insert-option bundle.
+   *
+   * @return shared option values used when rebuilding the legacy insert request
+   */
+  public QueueInsertOptions options() {
+    return options;
+  }
+
+  /**
+   * Returns the detached compression preference.
+   *
+   * @return {@code true} when the directory insert should request compression
+   */
+  public boolean compress() {
+    return options.compress();
+  }
+
+  /**
+   * Returns the requested compatibility mode.
+   *
+   * @return compatibility-mode name understood by the legacy adapter
+   */
+  public String compatibilityMode() {
+    return options.compatibilityMode();
+  }
+
+  /**
+   * Returns the optional override splitfile crypto key.
+   *
+   * @return caller-supplied splitfile key bytes, or {@code null} when absent
+   */
+  public byte[] overrideSplitfileCryptoKey() {
+    return options.overrideSplitfileCryptoKey();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof QueueLocalDirectoryInsertRequest other)) {
+      return false;
+    }
+    return Objects.equals(sourceDirectory, other.sourceDirectory)
+        && Objects.equals(insertUri, other.insertUri)
+        && Objects.equals(identifier, other.identifier)
+        && Objects.equals(options, other.options);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceDirectory, insertUri, identifier, options);
+  }
+
+  @Override
+  public String toString() {
+    return "QueueLocalDirectoryInsertRequest[sourceDirectory="
+        + sourceDirectory
+        + ", insertUri="
+        + insertUri
+        + ", identifier="
+        + identifier
+        + ", compress="
+        + options.compress()
+        + ", compatibilityMode="
+        + options.compatibilityMode()
+        + ']';
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueLocalFileInsertRequest.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueLocalFileInsertRequest.java
@@ -1,0 +1,168 @@
+package network.crypta.runtime.spi;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * Detached request data for creating a new persistent insert from a local file.
+ *
+ * <p>This request represents the queue flow where the user chooses one local file from the file
+ * browser. It carries the selected source file, the caller-chosen insert metadata, and the detached
+ * option values the daemon-side adapter needs to rebuild the existing persistent insert request.
+ *
+ * <p>The request intentionally avoids FCP and HTTP-owned types. The HTTP layer stays responsible
+ * for request parsing and user-facing mapping, while the runtime adapter consumes this value to
+ * perform access checks and start the insert.
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+public final class QueueLocalFileInsertRequest {
+  private final File sourceFile;
+  private final String insertUri;
+  private final String identifier;
+  private final String contentType;
+  private final QueueInsertOptions options;
+  private final String targetFilename;
+
+  /**
+   * Creates a detached local-file insert request.
+   *
+   * @param sourceFile selected local file that should be inserted
+   * @param insertUri validated insert URI string chosen by the caller
+   * @param identifier queue identifier that should remain stable for this insert attempt
+   * @param contentType optional MIME type to expose to the legacy insert path
+   * @param options detached insert options mirrored from queue form controls
+   * @param targetFilename optional filename hint stored with the legacy request
+   */
+  public QueueLocalFileInsertRequest(
+      File sourceFile,
+      String insertUri,
+      String identifier,
+      String contentType,
+      QueueInsertOptions options,
+      String targetFilename) {
+    this.sourceFile = Objects.requireNonNull(sourceFile, "sourceFile");
+    this.insertUri = Objects.requireNonNull(insertUri, "insertUri");
+    this.identifier = Objects.requireNonNull(identifier, "identifier");
+    this.contentType = contentType;
+    this.options = Objects.requireNonNull(options, "options");
+    this.targetFilename = targetFilename;
+  }
+
+  /**
+   * Returns the selected local source file.
+   *
+   * @return file that the runtime adapter should reopen for the insert
+   */
+  public File sourceFile() {
+    return sourceFile;
+  }
+
+  /**
+   * Returns the detached insert URI string.
+   *
+   * @return validated insert URI string chosen by the caller
+   */
+  public String insertUri() {
+    return insertUri;
+  }
+
+  /**
+   * Returns the caller-selected queue identifier.
+   *
+   * @return identifier that distinguishes this insert attempt in the persistent queue
+   */
+  public String identifier() {
+    return identifier;
+  }
+
+  /**
+   * Returns the optional MIME type for the file insert.
+   *
+   * @return caller-supplied MIME type, or {@code null} when no type was selected
+   */
+  public String contentType() {
+    return contentType;
+  }
+
+  /**
+   * Returns the detached insert-option bundle.
+   *
+   * @return shared option values used when rebuilding the legacy insert request
+   */
+  public QueueInsertOptions options() {
+    return options;
+  }
+
+  /**
+   * Returns the detached compression preference.
+   *
+   * @return {@code true} when the file insert should request compression
+   */
+  public boolean compress() {
+    return options.compress();
+  }
+
+  /**
+   * Returns the requested compatibility mode.
+   *
+   * @return compatibility-mode name understood by the legacy adapter
+   */
+  public String compatibilityMode() {
+    return options.compatibilityMode();
+  }
+
+  /**
+   * Returns the optional override splitfile crypto key.
+   *
+   * @return caller-supplied splitfile key bytes, or {@code null} when absent
+   */
+  public byte[] overrideSplitfileCryptoKey() {
+    return options.overrideSplitfileCryptoKey();
+  }
+
+  /**
+   * Returns the optional target filename for the insert.
+   *
+   * @return filename hint stored with the legacy request, or {@code null} when absent
+   */
+  public String targetFilename() {
+    return targetFilename;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof QueueLocalFileInsertRequest other)) {
+      return false;
+    }
+    return Objects.equals(sourceFile, other.sourceFile)
+        && Objects.equals(insertUri, other.insertUri)
+        && Objects.equals(identifier, other.identifier)
+        && Objects.equals(contentType, other.contentType)
+        && Objects.equals(options, other.options)
+        && Objects.equals(targetFilename, other.targetFilename);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceFile, insertUri, identifier, contentType, options, targetFilename);
+  }
+
+  @Override
+  public String toString() {
+    return "QueueLocalFileInsertRequest[sourceFile="
+        + sourceFile
+        + ", insertUri="
+        + insertUri
+        + ", identifier="
+        + identifier
+        + ", contentType="
+        + contentType
+        + ", compress="
+        + options.compress()
+        + ", compatibilityMode="
+        + options.compatibilityMode()
+        + ", targetFilename="
+        + targetFilename
+        + ']';
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueUploadedFile.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueUploadedFile.java
@@ -1,0 +1,112 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Detached uploaded-file payload for queue browser-upload inserts.
+ *
+ * <p>This value carries only the metadata and stream-opening behavior needed to replay a browser
+ * upload into the daemon's persistent insert path. It intentionally avoids HTTP request objects,
+ * bucket implementations, and daemon-specific insert types so {@code runtime-spi} remains JDK-only
+ * while still representing uploaded data without forcing an extra byte-array copy in the HTTP
+ * layer.
+ *
+ * <p>Callers provide a {@link StreamSource} that can reopen the uploaded bytes from the beginning.
+ * That lets the runtime adapter decide when to stage the upload into persistent storage without
+ * holding onto HTTP request objects or assuming the source is backed by one specific bucket type.
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+public final class QueueUploadedFile {
+  /**
+   * JDK-only source that reopens the uploaded bytes from the beginning on demand.
+   *
+   * <p>Implementations must return a fresh readable stream each time this method is called.
+   */
+  @FunctionalInterface
+  public interface StreamSource {
+    /**
+     * Opens a new readable stream for the detached upload contents.
+     *
+     * @return readable stream positioned at the first byte of the upload
+     * @throws IOException if the upload bytes cannot be reopened
+     */
+    InputStream openStream() throws IOException;
+  }
+
+  private final String filename;
+  private final String contentType;
+  private final long size;
+  private final StreamSource streamSource;
+
+  /**
+   * Creates a detached uploaded-file payload.
+   *
+   * @param filename client-supplied upload filename; never {@code null}
+   * @param contentType client-supplied MIME type, or {@code null} when absent
+   * @param size declared upload size in bytes; must be zero or greater
+   * @param streamSource source that can reopen the upload bytes from the beginning of each read
+   */
+  public QueueUploadedFile(
+      String filename, String contentType, long size, StreamSource streamSource) {
+    if (size < 0) {
+      throw new IllegalArgumentException("size");
+    }
+    this.filename = Objects.requireNonNull(filename, "filename");
+    this.contentType = contentType;
+    this.size = size;
+    this.streamSource = Objects.requireNonNull(streamSource, "streamSource");
+  }
+
+  /**
+   * Returns the client-supplied upload filename.
+   *
+   * @return detached filename string; never {@code null}
+   */
+  public String filename() {
+    return filename;
+  }
+
+  /**
+   * Returns the client-supplied MIME type.
+   *
+   * @return detached MIME type, or {@code null} when absent
+   */
+  public String contentType() {
+    return contentType;
+  }
+
+  /**
+   * Returns the declared upload size.
+   *
+   * @return upload size in bytes; guaranteed to be zero or greater
+   */
+  public long size() {
+    return size;
+  }
+
+  /**
+   * Opens a new readable stream for the detached upload contents.
+   *
+   * <p>Each invocation is expected to return a fresh stream positioned at the first byte. Callers
+   * should close the returned stream promptly after copying or inspection completes.
+   *
+   * @return readable stream positioned at the first byte of the upload
+   * @throws IOException if the upload bytes cannot be reopened
+   */
+  public InputStream openStream() throws IOException {
+    return streamSource.openStream();
+  }
+
+  @Override
+  public String toString() {
+    return "QueueUploadedFile[filename="
+        + filename
+        + ", contentType="
+        + contentType
+        + ", size="
+        + size
+        + ']';
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -193,6 +193,17 @@ public interface RuntimePorts {
   QueueDownloadPort queueDownload();
 
   /**
+   * Returns the legacy queue-insert capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining new-upload and local-insert queue registration inside the
+   * daemon root module while exposing only narrow JDK-only request shapes upstream. Callers retain
+   * HTTP request parsing, URI validation, redirects, and user-facing error mapping.
+   *
+   * @return queue-insert runtime port for creating new persistent uploads and local inserts
+   */
+  QueueInsertPort queueInsert();
+
+  /**
    * Returns the legacy queue-mutation capability exposed to admin-facing HTTP code.
    *
    * <p>This port keeps the remaining existing-request queue mutations inside the daemon root module

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -149,6 +149,7 @@ final class FProxyRegistrar {
                 runtimePorts.queuePage(),
                 runtimePorts.transferAccess(),
                 runtimePorts.queueDownload(),
+                runtimePorts.queueInsert(),
                 runtimePorts.queueMutation()));
     server.register(
         downloadToadlet,
@@ -175,6 +176,7 @@ final class FProxyRegistrar {
                 runtimePorts.queuePage(),
                 runtimePorts.transferAccess(),
                 runtimePorts.queueDownload(),
+                runtimePorts.queueInsert(),
                 runtimePorts.queueMutation()));
     server.register(
         uploadToadlet,

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -25,55 +25,49 @@ import java.util.Map;
 import java.util.Objects;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext.CompatibilityMode;
-import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.clients.fcp.ClientGet;
 import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
 import network.crypta.clients.fcp.ClientPut;
-import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
 import network.crypta.clients.fcp.ClientPutDir;
-import network.crypta.clients.fcp.ClientPutUpload;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.FcpInsertBehaviorOptions;
-import network.crypta.clients.fcp.FcpInsertOptions;
-import network.crypta.clients.fcp.FcpInsertRequest;
-import network.crypta.clients.fcp.FcpInsertTuningOptions;
-import network.crypta.clients.fcp.IdentifierCollisionException;
 import network.crypta.clients.fcp.NotAllowedException;
 import network.crypta.clients.fcp.RequestCompletionCallback;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.RequestStarter;
 import network.crypta.node.useralerts.StoringUserEvent;
 import network.crypta.node.useralerts.UserAlert;
+import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRejectedException;
 import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueInsertFailureReason;
+import network.crypta.runtime.spi.QueueInsertOptions;
+import network.crypta.runtime.spi.QueueInsertOutcome;
+import network.crypta.runtime.spi.QueueInsertPort;
+import network.crypta.runtime.spi.QueueInsertRejectedException;
+import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
+import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
+import network.crypta.runtime.spi.QueueUploadedFile;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SizeUtil;
+import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.api.HTTPUploadedFile;
-import network.crypta.support.api.RandomAccessBucket;
-import network.crypta.support.io.BucketTools;
-import network.crypta.support.io.FileBucket;
 import network.crypta.support.io.FileUtil;
 import network.crypta.support.io.NativeThread;
 import org.jetbrains.annotations.NotNull;
@@ -132,8 +126,10 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private static final String GROUPED_DOWNLOADS = "grouped-downloads";
   private static final String FILENAME = "filename";
   private static final String FRED_SUFFIX = "-fred-";
+  private static final String ERROR_ACCESS_DENIED = "errorAccessDenied";
   private static final String ERROR_ACCESS_DENIED_FILE_KEY = "errorAccessDeniedFile";
   private static final String ERROR_NO_FILE_OR_CANNOT_READ = "errorNoFileOrCannotRead";
+  private static final String TOO_MANY_FILES_IN_ONE_FOLDER = "tooManyFilesInOneFolder";
   private static final String COMPRESS_LABEL = ", compress=";
   private static final String CMODE_LABEL = ", cmode=";
   private static final String OVERRIDE_SPLITFILE_KEY_LABEL = ", overrideSplitfileKey=";
@@ -143,6 +139,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private final QueuePagePort queuePagePort;
   private final TransferAccessPort transferAccessPort;
   private final QueueDownloadPort queueDownloadPort;
+  private final QueueInsertPort queueInsertPort;
   private final QueueMutationPort queueMutationPort;
   private FileInsertWizardToadlet fiw;
   private final QueuePostHandler postHandler;
@@ -222,6 +219,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     this.queuePagePort = ports.queuePagePort();
     this.transferAccessPort = ports.transferAccessPort();
     this.queueDownloadPort = ports.queueDownloadPort();
+    this.queueInsertPort = ports.queueInsertPort();
     this.queueMutationPort = ports.queueMutationPort();
     this.uploads = uploads;
     this.postHandler = new QueuePostHandler();
@@ -772,36 +770,36 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
     @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
     private static final class InsertUploadContext {
-      private final FreenetURI insertURI;
-      private final HTTPUploadedFile file;
+      private final String insertUri;
+      private final QueueUploadedFile file;
       private final boolean compress;
       private final String identifier;
-      private final CompatibilityMode cmode;
+      private final String compatibilityMode;
       private final byte[] overrideSplitfileKey;
       private final String filenameForKey;
 
       private InsertUploadContext(
-          FreenetURI insertURI,
-          HTTPUploadedFile file,
+          String insertUri,
+          QueueUploadedFile file,
           boolean compress,
           String identifier,
-          CompatibilityMode cmode,
+          String compatibilityMode,
           byte[] overrideSplitfileKey,
           String filenameForKey) {
-        this.insertURI = insertURI;
+        this.insertUri = insertUri;
         this.file = file;
         this.compress = compress;
         this.identifier = identifier;
-        this.cmode = cmode;
+        this.compatibilityMode = compatibilityMode;
         this.overrideSplitfileKey = overrideSplitfileKey;
         this.filenameForKey = filenameForKey;
       }
 
-      FreenetURI insertURI() {
-        return insertURI;
+      String insertUri() {
+        return insertUri;
       }
 
-      HTTPUploadedFile file() {
+      QueueUploadedFile file() {
         return file;
       }
 
@@ -813,8 +811,8 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return identifier;
       }
 
-      CompatibilityMode cmode() {
-        return cmode;
+      String compatibilityMode() {
+        return compatibilityMode;
       }
 
       byte[] overrideSplitfileKey() {
@@ -831,25 +829,26 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           return false;
         }
         return compress == other.compress
-            && Objects.equals(insertURI, other.insertURI)
+            && Objects.equals(insertUri, other.insertUri)
             && Objects.equals(file, other.file)
             && Objects.equals(identifier, other.identifier)
-            && cmode == other.cmode
+            && Objects.equals(compatibilityMode, other.compatibilityMode)
             && Arrays.equals(overrideSplitfileKey, other.overrideSplitfileKey)
             && Objects.equals(filenameForKey, other.filenameForKey);
       }
 
       @Override
       public int hashCode() {
-        int result = Objects.hash(insertURI, file, compress, identifier, cmode, filenameForKey);
+        int result =
+            Objects.hash(insertUri, file, compress, identifier, compatibilityMode, filenameForKey);
         return 31 * result + Arrays.hashCode(overrideSplitfileKey);
       }
 
       @Override
       public @NotNull String toString() {
         return "InsertUploadContext{"
-            + "insertURI="
-            + insertURI
+            + "insertUri="
+            + insertUri
             + ", file="
             + file
             + COMPRESS_LABEL
@@ -858,7 +857,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             + identifier
             + '\''
             + CMODE_LABEL
-            + cmode
+            + compatibilityMode
             + OVERRIDE_SPLITFILE_KEY_LABEL
             + Arrays.toString(overrideSplitfileKey)
             + ", filenameForKey='"
@@ -871,14 +870,14 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
     private static final class InsertOptions {
       private final boolean compress;
-      private final CompatibilityMode cmode;
+      private final String compatibilityMode;
       private final byte[] overrideSplitfileKey;
       private final String target;
 
       private InsertOptions(
-          boolean compress, CompatibilityMode cmode, byte[] overrideSplitfileKey, String target) {
+          boolean compress, String compatibilityMode, byte[] overrideSplitfileKey, String target) {
         this.compress = compress;
-        this.cmode = cmode;
+        this.compatibilityMode = compatibilityMode;
         this.overrideSplitfileKey = overrideSplitfileKey;
         this.target = target;
       }
@@ -887,8 +886,8 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return compress;
       }
 
-      CompatibilityMode cmode() {
-        return cmode;
+      String compatibilityMode() {
+        return compatibilityMode;
       }
 
       byte[] overrideSplitfileKey() {
@@ -905,14 +904,14 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           return false;
         }
         return compress == other.compress
-            && cmode == other.cmode
+            && Objects.equals(compatibilityMode, other.compatibilityMode)
             && Arrays.equals(overrideSplitfileKey, other.overrideSplitfileKey)
             && Objects.equals(target, other.target);
       }
 
       @Override
       public int hashCode() {
-        int result = Objects.hash(compress, cmode, target);
+        int result = Objects.hash(compress, compatibilityMode, target);
         return 31 * result + Arrays.hashCode(overrideSplitfileKey);
       }
 
@@ -922,7 +921,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             + COMPRESS_LABEL
             + compress
             + CMODE_LABEL
-            + cmode
+            + compatibilityMode
             + OVERRIDE_SPLITFILE_KEY_LABEL
             + Arrays.toString(overrideSplitfileKey)
             + ", target='"
@@ -933,14 +932,14 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     }
 
     private record LocalFileInsertParams(
-        File file, String id, String contentType, FreenetURI uri, InsertOptions options) {
+        File file, String id, String contentType, String uri, InsertOptions options) {
 
       boolean compress() {
         return options.compress();
       }
 
-      CompatibilityMode cmode() {
-        return options.cmode();
+      String compatibilityMode() {
+        return options.compatibilityMode();
       }
 
       byte[] overrideSplitfileKey() {
@@ -996,23 +995,23 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     private static final class LocalDirInsertParams {
       private final File file;
       private final String identifier;
-      private final FreenetURI uri;
+      private final String uri;
       private final boolean compress;
-      private final CompatibilityMode cmode;
+      private final String compatibilityMode;
       private final byte[] overrideSplitfileKey;
 
       private LocalDirInsertParams(
           File file,
           String identifier,
-          FreenetURI uri,
+          String uri,
           boolean compress,
-          CompatibilityMode cmode,
+          String compatibilityMode,
           byte[] overrideSplitfileKey) {
         this.file = file;
         this.identifier = identifier;
         this.uri = uri;
         this.compress = compress;
-        this.cmode = cmode;
+        this.compatibilityMode = compatibilityMode;
         this.overrideSplitfileKey = overrideSplitfileKey;
       }
 
@@ -1024,7 +1023,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return identifier;
       }
 
-      FreenetURI uri() {
+      String uri() {
         return uri;
       }
 
@@ -1032,8 +1031,8 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return compress;
       }
 
-      CompatibilityMode cmode() {
-        return cmode;
+      String compatibilityMode() {
+        return compatibilityMode;
       }
 
       byte[] overrideSplitfileKey() {
@@ -1046,7 +1045,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           return false;
         }
         return compress == other.compress
-            && cmode == other.cmode
+            && Objects.equals(compatibilityMode, other.compatibilityMode)
             && Objects.equals(file, other.file)
             && Objects.equals(identifier, other.identifier)
             && Objects.equals(uri, other.uri)
@@ -1055,7 +1054,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
       @Override
       public int hashCode() {
-        int result = Objects.hash(file, identifier, uri, compress, cmode);
+        int result = Objects.hash(file, identifier, uri, compress, compatibilityMode);
         return 31 * result + Arrays.hashCode(overrideSplitfileKey);
       }
 
@@ -1072,7 +1071,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
             + COMPRESS_LABEL
             + compress
             + CMODE_LABEL
-            + cmode
+            + compatibilityMode
             + OVERRIDE_SPLITFILE_KEY_LABEL
             + Arrays.toString(overrideSplitfileKey)
             + '}';
@@ -1102,22 +1101,34 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return true;
       }
 
-      final RandomAccessBucket copiedBucket = copyUploadedFile(params.file());
-      final SimpleLatch done = new SimpleLatch(1);
-
-      if (!queueInsertUpload(params, copiedBucket, done, ctx)) {
-        return true;
+      try {
+        QueueInsertOutcome outcome =
+            queueInsertPort.enqueueBrowserUploadInsert(
+                new QueueBrowserUploadInsertRequest(
+                    params.insertUri(),
+                    params.identifier(),
+                    params.file(),
+                    new QueueInsertOptions(
+                        params.compress(),
+                        params.compatibilityMode(),
+                        params.overrideSplitfileKey()),
+                    params.filenameForKey()));
+        handleInsertOutcome(outcome, ctx);
+      } catch (QueueInsertRejectedException e) {
+        handleBrowserUploadInsertRejection(e.reason(), params, ctx);
+      } catch (RequestQueueUnavailableException _) {
+        sendPersistenceDisabledError(ctx);
+      } catch (IOException e) {
+        writeInternalError(e, ctx);
       }
-
-      awaitInsertCompletion(done);
       return true;
     }
 
     private InsertUploadContext parseInsertUploadRequest(HTTPRequest request, ToadletContext ctx)
         throws ToadletContextClosedException, IOException {
       String keyType = request.getPartAsStringFailsafe("keytype", 10);
-      FreenetURI insertURI = parseInsertURI(keyType, request, ctx);
-      if (insertURI == null) {
+      String insertUri = parseInsertURI(keyType, request, ctx);
+      if (insertUri == null) {
         return null;
       }
 
@@ -1129,33 +1140,39 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
       boolean compress = !request.getPartAsStringFailsafe(COMPRESS_FIELD, 128).isEmpty();
       String identifier = file.getFilename() + FRED_SUFFIX + System.currentTimeMillis();
-      CompatibilityMode cmode = parseCompatibilityMode(request);
+      String compatibilityMode = parseCompatibilityMode(request);
       byte[] overrideSplitfileKey =
           normalizeOverrideSplitfileKey(parseOverrideSplitfileKey(request));
       String filenameForKey =
-          "CHK".equals(insertURI.getKeyType()) || "SSK".equals(keyType) ? file.getFilename() : null;
+          insertUri.startsWith("CHK@") || "SSK".equals(keyType) ? file.getFilename() : null;
 
       return new InsertUploadContext(
-          insertURI, file, compress, identifier, cmode, overrideSplitfileKey, filenameForKey);
+          insertUri,
+          toQueueUploadedFile(file),
+          compress,
+          identifier,
+          compatibilityMode,
+          overrideSplitfileKey,
+          filenameForKey);
     }
 
-    private FreenetURI parseInsertURI(String keyType, HTTPRequest request, ToadletContext ctx)
+    private String parseInsertURI(String keyType, HTTPRequest request, ToadletContext ctx)
         throws ToadletContextClosedException, IOException {
       try {
         if ("CHK".equals(keyType)) {
           if (fiw != null) fiw.reportCanonicalInsert();
-          return new FreenetURI("CHK@");
+          return "CHK@";
         }
         if ("SSK".equals(keyType)) {
           if (fiw != null) fiw.reportRandomInsert();
-          return new FreenetURI("SSK@");
+          return "SSK@";
         }
         if ("specify".equals(keyType)) {
           String uri = request.getPartAsStringFailsafe("key", MAX_KEY_LENGTH);
           FreenetURI insertURI = new FreenetURI(uri);
           if (LOG.isDebugEnabled())
             LOG.debug("Insert upload key specified: {} ({})", insertURI, uri);
-          return insertURI;
+          return insertURI.toString();
         }
         writeInsertError(
             l10n("errorMustSpecifyKeyTypeTitle"), l10n("errorMustSpecifyKeyType"), ctx);
@@ -1166,12 +1183,21 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       }
     }
 
-    private CompatibilityMode parseCompatibilityMode(HTTPRequest request) {
+    private String parseCompatibilityMode(HTTPRequest request) {
       String compatibilityMode = request.getPartAsStringFailsafe(COMPATIBILITY_MODE_FIELD, 100);
       if (compatibilityMode.isEmpty()) {
-        return CompatibilityMode.COMPAT_DEFAULT.intern();
+        return CompatibilityMode.COMPAT_DEFAULT.intern().name();
       }
-      return CompatibilityMode.valueOf(compatibilityMode).intern();
+      return CompatibilityMode.valueOf(compatibilityMode).intern().name();
+    }
+
+    private QueueUploadedFile toQueueUploadedFile(HTTPUploadedFile file) {
+      Bucket uploadData = file.getData();
+      return new QueueUploadedFile(
+          file.getFilename(),
+          file.getContentType(),
+          uploadData.size(),
+          uploadData::getInputStreamUnbuffered);
     }
 
     private byte[] parseOverrideSplitfileKey(HTTPRequest request) {
@@ -1203,150 +1229,72 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       return out;
     }
 
-    private RandomAccessBucket copyUploadedFile(HTTPUploadedFile file) throws IOException {
-      RandomAccessBucket copiedBucket =
-          core.getPersistentTempBucketFactory().makeBucket(file.getData().size());
-      BucketTools.copy(file.getData(), copiedBucket);
-      return copiedBucket;
-    }
-
-    private boolean queueInsertUpload(
-        InsertUploadContext params,
-        RandomAccessBucket copiedBucket,
-        SimpleLatch done,
-        ToadletContext ctx)
+    private void handleInsertOutcome(QueueInsertOutcome outcome, ToadletContext ctx)
         throws ToadletContextClosedException, IOException {
-      try {
-        core.getClientLayerPersister()
-            .queue(
-                new PersistentJob() {
-
-                  @Override
-                  public String toString() {
-                    return "QueueToadlet StartInsert";
-                  }
-
-                  @Override
-                  public boolean run(ClientContext context) {
-                    try {
-                      return runInsertUploadJob(params, copiedBucket, ctx);
-                    } catch (IOException | ToadletContextClosedException _) {
-                      return false;
-                    } finally {
-                      done.countDown();
-                    }
-                  }
-                },
-                NativeThread.PriorityLevel.HIGH_PRIORITY.value + 1);
-        return true;
-      } catch (PersistenceDisabledException _) {
-        sendPersistenceDisabledError(ctx);
-        return false;
+      switch (outcome) {
+        case STARTED, IDENTIFIER_COLLISION, METADATA_UNRESOLVED ->
+            writePermanentRedirect(ctx, "Done", path());
       }
     }
 
-    private boolean runInsertUploadJob(
-        InsertUploadContext params, RandomAccessBucket copiedBucket, ToadletContext ctx)
-        throws IOException, ToadletContextClosedException {
-      try {
-        ClientPut clientPut = buildClientPut(params, copiedBucket);
-        if (!startClientPut(clientPut, ctx)) {
-          return false;
-        }
-        writePermanentRedirect(ctx, "Done", path());
-        return true;
-      } catch (IdentifierCollisionException _) {
-        LOG.error(
-            "Upload insert request collision: cannot put same file twice in same millisecond");
-        writePermanentRedirect(ctx, "Done", path());
-        return false;
-      } catch (NotAllowedException _) {
-        writeInsertError(
-            l10n("errorAccessDenied"),
-            l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.file().getFilename()),
-            ctx);
-        return false;
-      } catch (FileNotFoundException _) {
-        writeInsertError(
-            l10n(ERROR_NO_FILE_OR_CANNOT_READ),
-            l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.file().getFilename()),
-            ctx);
-        return false;
-      } catch (MalformedURLException _) {
-        writeInsertError(l10n(ERROR_INVALID_URI), l10n(ERROR_INVALID_URI_TO_U), ctx);
-        return false;
-      } catch (MetadataUnresolvedException e) {
-        LOG.error(
-            "Unresolved metadata in starting insert from data uploaded from browser: {}", e, e);
-        writePermanentRedirect(ctx, "Done", path());
-        return false;
-      } catch (Exception e) {
-        writeInternalError(e, ctx);
-        return false;
-      }
-    }
-
-    private ClientPut buildClientPut(InsertUploadContext params, RandomAccessBucket copiedBucket)
-        throws NotAllowedException,
-            MetadataUnresolvedException,
-            IdentifierCollisionException,
-            IOException {
-      return new ClientPut(
-          new FcpInsertRequest(
-              fcp.getGlobalForeverClient(),
-              params.insertURI(),
-              params.identifier(),
-              Integer.MAX_VALUE,
-              null,
-              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-              Persistence.FOREVER,
-              null,
-              true),
-          new FcpInsertOptions(
-              new FcpInsertBehaviorOptions(
-                  false, !params.compress(), false, -1, false, false, false),
-              new FcpInsertTuningOptions(
-                  false,
-                  Node.FORK_ON_CACHEABLE_DEFAULT,
-                  null,
-                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-                  params.cmode()),
-              params.overrideSplitfileKey()),
-          new ClientPutUpload(
-              UploadFrom.DIRECT,
-              null,
-              params.file().getContentType(),
-              copiedBucket,
-              null,
-              params.filenameForKey(),
-              false),
-          fcp.getCore());
-    }
-
-    private boolean startClientPut(ClientPut clientPut, ToadletContext ctx)
+    private void handleBrowserUploadInsertRejection(
+        QueueInsertFailureReason reason, InsertUploadContext params, ToadletContext ctx)
         throws ToadletContextClosedException, IOException {
-      try {
-        fcp.startBlocking(clientPut);
-        return true;
-      } catch (IdentifierCollisionException _) {
-        LOG.error("Upload insert start collision: cannot put same file twice in same millisecond");
-        writePermanentRedirect(ctx, "Done", path());
-        return false;
-      } catch (PersistenceDisabledException _) {
-        // Impossible???
-        return true;
+      switch (reason) {
+        case ACCESS_DENIED ->
+            writeInsertError(
+                l10n(ERROR_ACCESS_DENIED),
+                l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.file().filename()),
+                ctx);
+        case SOURCE_NOT_FOUND ->
+            writeInsertError(
+                l10n(ERROR_NO_FILE_OR_CANNOT_READ),
+                l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.file().filename()),
+                ctx);
+        case TOO_MANY_FILES ->
+            writeInsertError(
+                l10n(TOO_MANY_FILES_IN_ONE_FOLDER), l10n(TOO_MANY_FILES_IN_ONE_FOLDER), ctx);
       }
     }
 
-    private void awaitInsertCompletion(SimpleLatch done) {
-      while (done.getCount() > 0) {
-        try {
-          done.await();
-        } catch (InterruptedException _) {
-          Thread.currentThread().interrupt();
-          break;
-        }
+    private void handleLocalFileInsertRejection(
+        QueueInsertFailureReason reason, LocalFileInsertParams params, ToadletContext ctx)
+        throws ToadletContextClosedException, IOException {
+      switch (reason) {
+        case ACCESS_DENIED ->
+            writeError(
+                l10n(ERROR_ACCESS_DENIED),
+                l10n(
+                    ERROR_ACCESS_DENIED_FILE_KEY,
+                    new String[] {"file"},
+                    new String[] {params.file().getName()}),
+                ctx);
+        case SOURCE_NOT_FOUND ->
+            writeError(
+                l10n(ERROR_NO_FILE_OR_CANNOT_READ),
+                l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.target()),
+                ctx);
+        case TOO_MANY_FILES ->
+            writeError(l10n(TOO_MANY_FILES_IN_ONE_FOLDER), l10n(TOO_MANY_FILES_IN_ONE_FOLDER), ctx);
+      }
+    }
+
+    private void handleLocalDirectoryInsertRejection(
+        QueueInsertFailureReason reason, LocalDirInsertParams params, ToadletContext ctx)
+        throws ToadletContextClosedException, IOException {
+      switch (reason) {
+        case ACCESS_DENIED ->
+            writeError(
+                l10n(ERROR_ACCESS_DENIED),
+                l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.file().toString()),
+                ctx);
+        case SOURCE_NOT_FOUND ->
+            writeError(
+                l10n(ERROR_NO_FILE_OR_CANNOT_READ),
+                l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.file().toString()),
+                ctx);
+        case TOO_MANY_FILES ->
+            writeError(l10n(TOO_MANY_FILES_IN_ONE_FOLDER), l10n(TOO_MANY_FILES_IN_ONE_FOLDER), ctx);
       }
     }
 
@@ -1361,12 +1309,27 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return true;
       }
 
-      SimpleLatch done = new SimpleLatch(1);
-      if (!queueLocalFileInsert(params, done, ctx)) {
-        return true;
+      try {
+        QueueInsertOutcome outcome =
+            queueInsertPort.enqueueLocalFileInsert(
+                new QueueLocalFileInsertRequest(
+                    params.file(),
+                    params.uri(),
+                    params.id(),
+                    params.contentType(),
+                    new QueueInsertOptions(
+                        params.compress(),
+                        params.compatibilityMode(),
+                        params.overrideSplitfileKey()),
+                    params.target()));
+        handleInsertOutcome(outcome, ctx);
+      } catch (QueueInsertRejectedException e) {
+        handleLocalFileInsertRejection(e.reason(), params, ctx);
+      } catch (RequestQueueUnavailableException _) {
+        sendPersistenceDisabledError(ctx);
+      } catch (IOException e) {
+        writeInternalError(e, ctx);
       }
-
-      awaitInsertCompletion(done);
       return true;
     }
 
@@ -1380,7 +1343,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       String contentType = DefaultMIMETypes.guessMIMEType(filename, false);
       String key = request.getPartAsStringFailsafe("key", MAX_KEY_LENGTH);
       boolean compress = request.isPartSet(COMPRESS_FIELD);
-      CompatibilityMode cmode = parseCompatibilityMode(request);
+      String compatibilityMode = parseCompatibilityMode(request);
       byte[] overrideSplitfileKey =
           normalizeOverrideSplitfileKey(parseOverrideSplitfileKey(request));
       FreenetURI furi;
@@ -1396,133 +1359,9 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       }
 
       String target = (furi.getDocName() != null) ? null : file.getName();
-      InsertOptions options = new InsertOptions(compress, cmode, overrideSplitfileKey, target);
-      return new LocalFileInsertParams(file, identifier, contentType, furi, options);
-    }
-
-    private boolean queueLocalFileInsert(
-        LocalFileInsertParams params, SimpleLatch done, ToadletContext ctx)
-        throws ToadletContextClosedException, IOException {
-      try {
-        core.getClientLayerPersister()
-            .queue(
-                createLocalFileInsertJob(params, done, ctx),
-                NativeThread.PriorityLevel.HIGH_PRIORITY.value + 1);
-        return true;
-      } catch (PersistenceDisabledException _) {
-        sendPersistenceDisabledError(ctx);
-        return false;
-      }
-    }
-
-    private PersistentJob createLocalFileInsertJob(
-        LocalFileInsertParams params, SimpleLatch done, ToadletContext ctx) {
-      return new PersistentJob() {
-
-        @Override
-        public String toString() {
-          return "QueueToadlet StartLocalFileInsert";
-        }
-
-        @Override
-        public boolean run(ClientContext context) {
-          try {
-            return startLocalFileInsert(params, ctx);
-          } catch (IOException | ToadletContextClosedException _) {
-            return false;
-          } finally {
-            done.countDown();
-          }
-        }
-      };
-    }
-
-    private boolean startLocalFileInsert(LocalFileInsertParams params, ToadletContext ctx)
-        throws IOException, ToadletContextClosedException {
-      FileBucket bucket = new FileBucket(params.file(), true, false, false, false);
-      boolean handedOff = false;
-      try {
-        ClientPut clientPut = createLocalFileClientPut(params, bucket);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug(
-              "Started global request to insert {} to CHK@ as {}", params.file(), params.id());
-        }
-        fcp.startBlocking(clientPut);
-        handedOff = true;
-        writePermanentRedirect(ctx, "Done", path());
-        return true;
-      } catch (IdentifierCollisionException _) {
-        LOG.error("Local file insert collision: cannot put same file twice in same millisecond");
-        writePermanentRedirect(ctx, "Done", path());
-        return false;
-      } catch (MalformedURLException _) {
-        writeError(l10n(ERROR_INVALID_URI), l10n(ERROR_INVALID_URI_TO_U), ctx);
-        return false;
-      } catch (FileNotFoundException _) {
-        writeError(
-            l10n(ERROR_NO_FILE_OR_CANNOT_READ),
-            l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.target()),
-            ctx);
-        return false;
-      } catch (NotAllowedException _) {
-        writeError(
-            l10n("errorAccessDenied"),
-            l10n(
-                ERROR_ACCESS_DENIED_FILE_KEY,
-                new String[] {"file"},
-                new String[] {params.file().getName()}),
-            ctx);
-        return false;
-      } catch (MetadataUnresolvedException e) {
-        LOG.error("Unresolved metadata in starting insert from data from file: {}", e, e);
-        writePermanentRedirect(ctx, "Done", path());
-        return false;
-      } catch (PersistenceDisabledException _) {
-        sendPersistenceDisabledError(ctx);
-        return false;
-      } finally {
-        if (!handedOff) {
-          bucket.free();
-        }
-      }
-    }
-
-    private ClientPut createLocalFileClientPut(LocalFileInsertParams params, FileBucket bucket)
-        throws NotAllowedException,
-            MetadataUnresolvedException,
-            IdentifierCollisionException,
-            IOException {
-      return new ClientPut(
-          new FcpInsertRequest(
-              fcp.getGlobalForeverClient(),
-              params.uri(),
-              params.id(),
-              Integer.MAX_VALUE,
-              null,
-              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-              Persistence.FOREVER,
-              null,
-              true),
-          new FcpInsertOptions(
-              new FcpInsertBehaviorOptions(
-                  false, !params.compress(), false, -1, false, false, false),
-              new FcpInsertTuningOptions(
-                  false,
-                  Node.FORK_ON_CACHEABLE_DEFAULT,
-                  null,
-                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-                  params.cmode()),
-              params.overrideSplitfileKey()),
-          new ClientPutUpload(
-              UploadFrom.DISK,
-              params.file(),
-              params.contentType(),
-              bucket,
-              null,
-              params.target(),
-              false),
-          fcp.getCore());
+      InsertOptions options =
+          new InsertOptions(compress, compatibilityMode, overrideSplitfileKey, target);
+      return new LocalFileInsertParams(file, identifier, contentType, furi.toString(), options);
     }
 
     private boolean handleLocalDirSelection(HTTPRequest request, ToadletContext ctx)
@@ -1536,12 +1375,25 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return true;
       }
 
-      SimpleLatch done = new SimpleLatch(1);
-      if (!queueLocalDirInsert(params, done, ctx)) {
-        return true;
+      try {
+        QueueInsertOutcome outcome =
+            queueInsertPort.enqueueLocalDirectoryInsert(
+                new QueueLocalDirectoryInsertRequest(
+                    params.file(),
+                    params.uri(),
+                    params.identifier(),
+                    new QueueInsertOptions(
+                        params.compress(),
+                        params.compatibilityMode(),
+                        params.overrideSplitfileKey())));
+        handleInsertOutcome(outcome, ctx);
+      } catch (QueueInsertRejectedException e) {
+        handleLocalDirectoryInsertRejection(e.reason(), params, ctx);
+      } catch (RequestQueueUnavailableException _) {
+        sendPersistenceDisabledError(ctx);
+      } catch (IOException e) {
+        writeInternalError(e, ctx);
       }
-
-      awaitInsertCompletion(done);
       return true;
     }
 
@@ -1554,7 +1406,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       String identifier = file.getName() + FRED_SUFFIX + System.currentTimeMillis();
       String key = request.getPartAsStringFailsafe("key", MAX_KEY_LENGTH);
       boolean compress = request.isPartSet(COMPRESS_FIELD);
-      CompatibilityMode cmode = parseCompatibilityMode(request);
+      String compatibilityMode = parseCompatibilityMode(request);
       byte[] overrideSplitfileKey =
           normalizeOverrideSplitfileKey(parseOverrideSplitfileKey(request));
       FreenetURI furi;
@@ -1569,112 +1421,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         furi = new FreenetURI("CHK@");
       }
       return new LocalDirInsertParams(
-          file, identifier, furi, compress, cmode, overrideSplitfileKey);
-    }
-
-    private boolean queueLocalDirInsert(
-        LocalDirInsertParams params, SimpleLatch done, ToadletContext ctx)
-        throws ToadletContextClosedException, IOException {
-      try {
-        core.getClientLayerPersister()
-            .queue(
-                createLocalDirInsertJob(params, done, ctx),
-                NativeThread.PriorityLevel.HIGH_PRIORITY.value + 1);
-        return true;
-      } catch (PersistenceDisabledException _) {
-        sendPersistenceDisabledError(ctx);
-        return false;
-      }
-    }
-
-    private PersistentJob createLocalDirInsertJob(
-        LocalDirInsertParams params, SimpleLatch done, ToadletContext ctx) {
-      return new PersistentJob() {
-
-        @Override
-        public String toString() {
-          return "QueueToadlet StartLocalDirInsert";
-        }
-
-        @Override
-        public boolean run(ClientContext context) {
-          try {
-            return startLocalDirInsert(params, ctx);
-          } catch (IOException | ToadletContextClosedException _) {
-            return false;
-          } finally {
-            done.countDown();
-          }
-        }
-      };
-    }
-
-    private boolean startLocalDirInsert(LocalDirInsertParams params, ToadletContext ctx)
-        throws IOException, ToadletContextClosedException {
-      try {
-        ClientPutDir clientPutDir = createLocalDirPut(params);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug(
-              "Started global request to insert dir {} to {} as {}",
-              params.file(),
-              params.uri(),
-              params.identifier());
-        }
-        fcp.startBlocking(clientPutDir);
-        writePermanentRedirect(ctx, "Done", path());
-        return true;
-      } catch (IdentifierCollisionException _) {
-        LOG.error(
-            "Local directory insert collision: cannot put same file twice in same millisecond");
-        writePermanentRedirect(ctx, "Done", path());
-        return false;
-      } catch (MalformedURLException _) {
-        writeError(l10n(ERROR_INVALID_URI), l10n(ERROR_INVALID_URI_TO_U), ctx);
-        return false;
-      } catch (FileNotFoundException _) {
-        writeError(
-            l10n(ERROR_NO_FILE_OR_CANNOT_READ),
-            l10n(ERROR_ACCESS_DENIED_FILE_KEY, "file", params.file().toString()),
-            ctx);
-        return false;
-      } catch (TooManyFilesInsertException _) {
-        writeError(l10n("tooManyFilesInOneFolder"), l10n("tooManyFilesInOneFolder"), ctx);
-        return false;
-      } catch (PersistenceDisabledException _) {
-        sendPersistenceDisabledError(ctx);
-        return false;
-      }
-    }
-
-    private ClientPutDir createLocalDirPut(LocalDirInsertParams params)
-        throws IOException, TooManyFilesInsertException {
-      return new ClientPutDir(
-          new FcpInsertRequest(
-              fcp.getGlobalForeverClient(),
-              params.uri(),
-              params.identifier(),
-              Integer.MAX_VALUE,
-              null,
-              RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
-              Persistence.FOREVER,
-              null,
-              true),
-          new FcpInsertOptions(
-              new FcpInsertBehaviorOptions(
-                  false, !params.compress(), false, -1, false, false, false),
-              new FcpInsertTuningOptions(
-                  false,
-                  Node.FORK_ON_CACHEABLE_DEFAULT,
-                  null,
-                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
-                  HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
-                  params.cmode()),
-              params.overrideSplitfileKey()),
-          params.file(),
-          null,
-          false,
-          false,
-          fcp.getCore());
+          file, identifier, furi.toString(), compress, compatibilityMode, overrideSplitfileKey);
     }
 
     private boolean handleRecommendRequest(HTTPRequest request, ToadletContext ctx)
@@ -2111,40 +1858,6 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       case KEY_LIST_LOCATION -> RequestIntent.KEY_LIST;
       default -> RequestIntent.NORMAL;
     };
-  }
-
-  private static final class SimpleLatch {
-    private int count;
-    private final Object lock = new Object();
-
-    SimpleLatch(int count) {
-      this.count = count;
-    }
-
-    long getCount() {
-      synchronized (lock) {
-        return count;
-      }
-    }
-
-    void await() throws InterruptedException {
-      synchronized (lock) {
-        while (count > 0) {
-          lock.wait();
-        }
-      }
-    }
-
-    void countDown() {
-      synchronized (lock) {
-        if (count > 0) {
-          count--;
-          if (count == 0) {
-            lock.notifyAll();
-          }
-        }
-      }
-    }
   }
 
   private enum RequestIntent {

--- a/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.util.Objects;
 import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -10,9 +11,10 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * Shared runtime-port bundle used by the legacy queue toadlets.
  *
  * <p>The download and upload queue pages share the same detached read-path, mutation, and
- * transfer-policy runtime ports, and the download side also uses the queue-download creation port.
- * Grouping them in one small record keeps constructor signatures stable while preserving the option
- * to add other queue-specific ports later without widening the main toadlet constructor again.
+ * transfer-policy runtime ports, the download side also uses the queue-download creation port, and
+ * the upload side uses the queue-insert creation port. Grouping them in one small record keeps
+ * constructor signatures stable while preserving the option to add other queue-specific ports later
+ * without widening the main toadlet constructor again.
  *
  * <p>This record lives in the HTTP layer because it models HTTP wiring rather than a daemon-side
  * runtime capability. The queue toadlets can accept one stable parameter today and still grow to
@@ -21,12 +23,15 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * @param queuePagePort detached queue-page read port
  * @param transferAccessPort detached transfer-policy port used by queue-local path checks
  * @param queueDownloadPort detached queue-download port used for new persistent downloads
+ * @param queueInsertPort detached queue-insert port used for new persistent uploads and local
+ *     inserts
  * @param queueMutationPort detached queue-mutation port
  */
 public record QueueToadletRuntimePorts(
     QueuePagePort queuePagePort,
     TransferAccessPort transferAccessPort,
     QueueDownloadPort queueDownloadPort,
+    QueueInsertPort queueInsertPort,
     QueueMutationPort queueMutationPort) {
   /**
    * Creates one validated queue-toadlet port bundle.
@@ -36,6 +41,7 @@ public record QueueToadletRuntimePorts(
    *     toadlets
    * @param queueDownloadPort detached queue-download port shared by the download and upload
    *     toadlets
+   * @param queueInsertPort detached queue-insert port shared by the download and upload toadlets
    * @param queueMutationPort detached queue-mutation port shared by the download and upload
    *     toadlets
    * @throws NullPointerException if any port is {@code null}
@@ -44,6 +50,7 @@ public record QueueToadletRuntimePorts(
     Objects.requireNonNull(queuePagePort);
     Objects.requireNonNull(transferAccessPort);
     Objects.requireNonNull(queueDownloadPort);
+    Objects.requireNonNull(queueInsertPort);
     Objects.requireNonNull(queueMutationPort);
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyQueueInsertPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyQueueInsertPort.java
@@ -1,0 +1,432 @@
+package network.crypta.node.runtime;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.HighLevelSimpleClientImpl;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.TooManyFilesInsertException;
+import network.crypta.clients.fcp.ClientPut;
+import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
+import network.crypta.clients.fcp.ClientPutDir;
+import network.crypta.clients.fcp.ClientPutUpload;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpInsertBehaviorOptions;
+import network.crypta.clients.fcp.FcpInsertOptions;
+import network.crypta.clients.fcp.FcpInsertRequest;
+import network.crypta.clients.fcp.FcpInsertTuningOptions;
+import network.crypta.clients.fcp.IdentifierCollisionException;
+import network.crypta.clients.fcp.NotAllowedException;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.ClientEndpoints;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
+import network.crypta.runtime.spi.QueueInsertFailureReason;
+import network.crypta.runtime.spi.QueueInsertOutcome;
+import network.crypta.runtime.spi.QueueInsertPort;
+import network.crypta.runtime.spi.QueueInsertRejectedException;
+import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
+import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
+import network.crypta.runtime.spi.QueueUploadedFile;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.FileBucket;
+import network.crypta.support.io.NativeThread;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Legacy daemon-backed implementation of the queue-insert runtime SPI.
+ *
+ * <p>This adapter keeps the remaining creation of new queue uploads and local inserts inside the
+ * daemon root module while exposing only small JDK-only request shapes upstream. It preserves the
+ * current legacy flow by scheduling work on the client-layer persister, recreating the matching
+ * {@link ClientPut} or {@link ClientPutDir} request, and starting the request through the live
+ * {@link FCPServer}.
+ *
+ * <p>The adapter is intentionally thin and stores only the owning {@link NodeClientCore}. The live
+ * {@link FCPServer} is resolved lazily through {@link NodeClientCore#getEndpoints()} for each
+ * request so runtime-port construction does not force early endpoint initialization during startup.
+ * Browser-upload staging still happens before the persistent job is queued, which preserves the
+ * older queue-toadlet behavior and avoids holding the persister runner while large uploads are
+ * copied.
+ *
+ * <ul>
+ *   <li>HTTP parsing and redirect mapping stay outside this class.
+ *   <li>Persistent queue registration and legacy insert construction happen here.
+ *   <li>Queue-unavailable conditions are translated into {@link RequestQueueUnavailableException}
+ *       for stable caller handling.
+ * </ul>
+ */
+public final class LegacyQueueInsertPort implements QueueInsertPort {
+  private static final Logger LOG = LoggerFactory.getLogger(LegacyQueueInsertPort.class);
+
+  private final NodeClientCore core;
+
+  /**
+   * Creates a queue-insert adapter backed by the supplied client core.
+   *
+   * <p>The adapter does not resolve daemon endpoints during construction. It only keeps the live
+   * client core reference and defers queue access until one of the port methods is invoked.
+   *
+   * @param core live daemon client core that provides queue access, bucket factories, and deferred
+   *     endpoint lookup
+   */
+  public LegacyQueueInsertPort(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public QueueInsertOutcome enqueueBrowserUploadInsert(QueueBrowserUploadInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException {
+    Objects.requireNonNull(request);
+    try (TransferableBucketResource<RandomAccessBucket> copiedBucket =
+        new TransferableBucketResource<>(copyUploadedFile(request.upload()))) {
+      QueueInsertOutcome outcome =
+          runInsertJob(() -> startBrowserUploadInsert(request, copiedBucket.bucket()));
+      if (outcome == QueueInsertOutcome.STARTED) {
+        copiedBucket.release();
+      }
+      return outcome;
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public QueueInsertOutcome enqueueLocalFileInsert(QueueLocalFileInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException {
+    Objects.requireNonNull(request);
+    return runInsertJob(() -> startLocalFileInsert(request));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public QueueInsertOutcome enqueueLocalDirectoryInsert(QueueLocalDirectoryInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException {
+    Objects.requireNonNull(request);
+    return runInsertJob(() -> startLocalDirectoryInsert(request));
+  }
+
+  private QueueInsertOutcome runInsertJob(InsertTask task)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException {
+    CountDownLatch done = new CountDownLatch(1);
+    AtomicReference<QueueInsertOutcome> outcomeRef = new AtomicReference<>();
+    AtomicReference<QueueInsertRejectedException> rejectedRef = new AtomicReference<>();
+    AtomicReference<RequestQueueUnavailableException> unavailableRef = new AtomicReference<>();
+    AtomicReference<IOException> ioRef = new AtomicReference<>();
+    AtomicReference<RuntimeException> runtimeRef = new AtomicReference<>();
+    try {
+      core.getClientLayerPersister()
+          .queue(
+              new PersistentJob() {
+                @Override
+                public String toString() {
+                  return "LegacyQueueInsertPort";
+                }
+
+                @Override
+                public boolean run(ClientContext context) {
+                  try {
+                    QueueInsertOutcome outcome = task.run();
+                    outcomeRef.set(outcome);
+                    return outcome == QueueInsertOutcome.STARTED;
+                  } catch (QueueInsertRejectedException e) {
+                    rejectedRef.set(e);
+                  } catch (RequestQueueUnavailableException e) {
+                    unavailableRef.set(e);
+                  } catch (IOException e) {
+                    ioRef.set(e);
+                  } catch (RuntimeException e) {
+                    runtimeRef.set(e);
+                  } finally {
+                    done.countDown();
+                  }
+                  return false;
+                }
+              },
+              NativeThread.PriorityLevel.HIGH_PRIORITY.value + 1);
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
+    }
+
+    try {
+      done.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while waiting for queue insert creation", e);
+    }
+
+    if (runtimeRef.get() != null) {
+      throw runtimeRef.get();
+    }
+    if (rejectedRef.get() != null) {
+      throw rejectedRef.get();
+    }
+    if (unavailableRef.get() != null) {
+      throw unavailableRef.get();
+    }
+    if (ioRef.get() != null) {
+      throw ioRef.get();
+    }
+    QueueInsertOutcome outcome = outcomeRef.get();
+    if (outcome == null) {
+      throw new IllegalStateException("Missing queue insert outcome");
+    }
+    return outcome;
+  }
+
+  private QueueInsertOutcome startBrowserUploadInsert(
+      QueueBrowserUploadInsertRequest request, RandomAccessBucket copiedBucket)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException {
+    FCPServer fcpServer = fcpServer();
+    try {
+      ClientPut clientPut = createBrowserUploadClientPut(request, copiedBucket, fcpServer);
+      return startClientPut(clientPut, fcpServer, "Upload insert start collision");
+    } catch (IdentifierCollisionException _) {
+      LOG.error("Upload insert request collision: cannot put same file twice in same millisecond");
+      return QueueInsertOutcome.IDENTIFIER_COLLISION;
+    } catch (NotAllowedException e) {
+      throw rejected(QueueInsertFailureReason.ACCESS_DENIED, e);
+    } catch (FileNotFoundException e) {
+      throw rejected(QueueInsertFailureReason.SOURCE_NOT_FOUND, e);
+    } catch (MetadataUnresolvedException e) {
+      LOG.error("Unresolved metadata in starting insert from data uploaded from browser: {}", e, e);
+      return QueueInsertOutcome.METADATA_UNRESOLVED;
+    }
+  }
+
+  private QueueInsertOutcome startLocalFileInsert(QueueLocalFileInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException {
+    try (TransferableBucketResource<FileBucket> bucket =
+        new TransferableBucketResource<>(
+            new FileBucket(request.sourceFile(), true, false, false, false))) {
+      FCPServer fcpServer = fcpServer();
+      try {
+        ClientPut clientPut = createLocalFileClientPut(request, bucket.bucket(), fcpServer);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Started global request to insert {} to {} as {}",
+              request.sourceFile(),
+              request.insertUri(),
+              request.identifier());
+        }
+        QueueInsertOutcome outcome =
+            startClientPut(clientPut, fcpServer, "Local file insert collision");
+        if (outcome == QueueInsertOutcome.STARTED) {
+          bucket.release();
+        }
+        return outcome;
+      } catch (IdentifierCollisionException _) {
+        LOG.error("Local file insert collision: cannot put same file twice in same millisecond");
+        return QueueInsertOutcome.IDENTIFIER_COLLISION;
+      } catch (NotAllowedException e) {
+        throw rejected(QueueInsertFailureReason.ACCESS_DENIED, e);
+      } catch (FileNotFoundException e) {
+        throw rejected(QueueInsertFailureReason.SOURCE_NOT_FOUND, e);
+      } catch (MetadataUnresolvedException e) {
+        LOG.error("Unresolved metadata in starting insert from data from file: {}", e, e);
+        return QueueInsertOutcome.METADATA_UNRESOLVED;
+      }
+    }
+  }
+
+  private QueueInsertOutcome startLocalDirectoryInsert(QueueLocalDirectoryInsertRequest request)
+      throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException {
+    FCPServer fcpServer = fcpServer();
+    try {
+      ClientPutDir clientPutDir = createLocalDirectoryPut(request, fcpServer);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Started global request to insert dir {} to {} as {}",
+            request.sourceDirectory(),
+            request.insertUri(),
+            request.identifier());
+      }
+      return startClientPut(clientPutDir, fcpServer, "Local directory insert collision");
+    } catch (IdentifierCollisionException _) {
+      LOG.error("Local directory insert collision: cannot put same file twice in same millisecond");
+      return QueueInsertOutcome.IDENTIFIER_COLLISION;
+    } catch (FileNotFoundException e) {
+      throw rejected(QueueInsertFailureReason.SOURCE_NOT_FOUND, e);
+    } catch (TooManyFilesInsertException e) {
+      throw rejected(QueueInsertFailureReason.TOO_MANY_FILES, e);
+    }
+  }
+
+  private QueueInsertOutcome startClientPut(
+      network.crypta.clients.fcp.ClientRequest request,
+      FCPServer fcpServer,
+      String collisionMessage)
+      throws RequestQueueUnavailableException, IdentifierCollisionException {
+    try {
+      fcpServer.startBlocking(request);
+      return QueueInsertOutcome.STARTED;
+    } catch (IdentifierCollisionException _) {
+      LOG.error("{}: cannot put same file twice in same millisecond", collisionMessage);
+      return QueueInsertOutcome.IDENTIFIER_COLLISION;
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
+    }
+  }
+
+  private RandomAccessBucket copyUploadedFile(QueueUploadedFile upload) throws IOException {
+    RandomAccessBucket copiedBucket =
+        core.getPersistentTempBucketFactory().makeBucket(upload.size());
+    try (InputStream inputStream = upload.openStream();
+        OutputStream outputStream = copiedBucket.getOutputStream()) {
+      inputStream.transferTo(outputStream);
+      return copiedBucket;
+    } catch (IOException e) {
+      copiedBucket.free();
+      throw e;
+    }
+  }
+
+  private FcpInsertRequest insertRequest(FCPServer fcpServer, String insertUri, String identifier)
+      throws IOException {
+    try {
+      return new FcpInsertRequest(
+          fcpServer.getGlobalForeverClient(),
+          new FreenetURI(insertUri),
+          identifier,
+          Integer.MAX_VALUE,
+          null,
+          RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+          Persistence.FOREVER,
+          null,
+          true);
+    } catch (MalformedURLException e) {
+      throw new IOException("Invalid insert URI", e);
+    }
+  }
+
+  private static FcpInsertOptions insertOptions(
+      boolean compress, String compatibilityMode, byte[] overrideSplitfileCryptoKey) {
+    return new FcpInsertOptions(
+        new FcpInsertBehaviorOptions(false, !compress, false, -1, false, false, false),
+        new FcpInsertTuningOptions(
+            false,
+            Node.FORK_ON_CACHEABLE_DEFAULT,
+            null,
+            HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK,
+            HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER,
+            CompatibilityMode.valueOf(compatibilityMode).intern()),
+        overrideSplitfileCryptoKey);
+  }
+
+  private static QueueInsertRejectedException rejected(
+      QueueInsertFailureReason reason, Exception cause) {
+    return new QueueInsertRejectedException(reason, "Queue insert rejected: " + reason, cause);
+  }
+
+  ClientPut createBrowserUploadClientPut(
+      QueueBrowserUploadInsertRequest request, RandomAccessBucket copiedBucket, FCPServer fcpServer)
+      throws NotAllowedException,
+          MetadataUnresolvedException,
+          IdentifierCollisionException,
+          IOException {
+    return new ClientPut(
+        insertRequest(fcpServer, request.insertUri(), request.identifier()),
+        insertOptions(
+            request.compress(), request.compatibilityMode(), request.overrideSplitfileCryptoKey()),
+        new ClientPutUpload(
+            UploadFrom.DIRECT,
+            null,
+            request.upload().contentType(),
+            copiedBucket,
+            null,
+            request.filenameForKey(),
+            false),
+        core);
+  }
+
+  ClientPut createLocalFileClientPut(
+      QueueLocalFileInsertRequest request, FileBucket bucket, FCPServer fcpServer)
+      throws NotAllowedException,
+          MetadataUnresolvedException,
+          IdentifierCollisionException,
+          IOException {
+    return new ClientPut(
+        insertRequest(fcpServer, request.insertUri(), request.identifier()),
+        insertOptions(
+            request.compress(), request.compatibilityMode(), request.overrideSplitfileCryptoKey()),
+        new ClientPutUpload(
+            UploadFrom.DISK,
+            request.sourceFile(),
+            request.contentType(),
+            bucket,
+            null,
+            request.targetFilename(),
+            false),
+        core);
+  }
+
+  ClientPutDir createLocalDirectoryPut(
+      QueueLocalDirectoryInsertRequest request, FCPServer fcpServer)
+      throws IOException, TooManyFilesInsertException {
+    return new ClientPutDir(
+        insertRequest(fcpServer, request.insertUri(), request.identifier()),
+        insertOptions(
+            request.compress(), request.compatibilityMode(), request.overrideSplitfileCryptoKey()),
+        request.sourceDirectory(),
+        null,
+        false,
+        false,
+        core);
+  }
+
+  private FCPServer fcpServer() throws RequestQueueUnavailableException {
+    ClientEndpoints clientEndpoints = core.getEndpoints();
+    if (clientEndpoints == null) {
+      throw new RequestQueueUnavailableException("Persistent request queue unavailable");
+    }
+    FCPServer fcpServer = clientEndpoints.getFCPServer();
+    if (fcpServer == null) {
+      throw new RequestQueueUnavailableException("Persistent request queue unavailable");
+    }
+    return fcpServer;
+  }
+
+  @FunctionalInterface
+  private interface InsertTask {
+    QueueInsertOutcome run()
+        throws QueueInsertRejectedException, RequestQueueUnavailableException, IOException;
+  }
+
+  private static final class TransferableBucketResource<T extends Bucket> implements AutoCloseable {
+    private T bucket;
+
+    private TransferableBucketResource(T bucket) {
+      this.bucket = Objects.requireNonNull(bucket);
+    }
+
+    private T bucket() {
+      return bucket;
+    }
+
+    private void release() {
+      bucket = null;
+    }
+
+    @Override
+    public void close() {
+      if (bucket != null) {
+        bucket.free();
+      }
+    }
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -17,6 +17,7 @@ import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.RandomnessPort;
@@ -56,6 +57,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DiagnosticPort diagnosticPort;
   private final QueuePagePort queuePagePort;
   private final QueueDownloadPort queueDownloadPort;
+  private final QueueInsertPort queueInsertPort;
   private final QueueMutationPort queueMutationPort;
   private final StatisticsPort statisticsPort;
   private final SecurityLevelsPort securityLevelsPort;
@@ -156,6 +158,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.queuePagePort = new LegacyQueuePagePort(core);
     this.queueDownloadPort = new LegacyQueueDownloadPort(core);
+    this.queueInsertPort = new LegacyQueueInsertPort(core);
     this.queueMutationPort = new LegacyQueueMutationPort(core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.securityLevelsPort = new LegacySecurityLevelsPort(node);
@@ -309,6 +312,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public QueueDownloadPort queueDownload() {
     return queueDownloadPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining new-upload and local-insert queue registration inside
+   * the daemon root module while exposing only narrow JDK-only request shapes upstream.
+   */
+  @Override
+  public QueueInsertPort queueInsert() {
+    return queueInsertPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
@@ -41,6 +41,7 @@ import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRejectedException;
 import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -96,6 +97,7 @@ class QueueToadletPostDownloadTest {
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
   @Mock private QueueDownloadPort queueDownloadPort;
+  @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private UserAlertManager alerts;
   @Mock private PriorityAwareExecutor executor;
@@ -358,7 +360,11 @@ class QueueToadletPostDownloadTest {
             client,
             false,
             new QueueToadletRuntimePorts(
-                queuePagePort, transferAccessPort, queueDownloadPort, queueMutationPort));
+                queuePagePort,
+                transferAccessPort,
+                queueDownloadPort,
+                queueInsertPort,
+                queueMutationPort));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Random;
@@ -35,8 +36,14 @@ import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
 import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertFailureReason;
+import network.crypta.runtime.spi.QueueInsertOutcome;
 import network.crypta.runtime.spi.QueueInsertPort;
+import network.crypta.runtime.spi.QueueInsertRejectedException;
+import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
+import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -45,8 +52,10 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.Ticker;
 import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.api.HTTPUploadedFile;
 import network.crypta.support.api.LockableRandomAccessBufferFactory;
 import network.crypta.support.compress.RealCompressor;
 import network.crypta.support.io.FileRandomAccessBufferFactory;
@@ -64,6 +73,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -80,7 +90,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @SuppressWarnings("java:S100")
-class QueueToadletPostMutationTest {
+class QueueToadletPostInsertTest {
 
   @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
@@ -107,118 +117,193 @@ class QueueToadletPostMutationTest {
     when(ctx.getContainer()).thenReturn(container);
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
+    when(queueDownloadPort.isDiskDownloadDisabled()).thenReturn(false);
   }
 
   @Test
-  void handleMethodPOST_whenRemoveRequestSelected_callsQueueMutationPort() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
-        createRequest(
-            Map.of(
-                "remove_request", "yes",
-                "identifier-a", "download-1",
-                "identifier-b", "download-2"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    String location = captureRedirectLocation(ctx);
-    verify(queueMutationPort).removeRequests(java.util.List.of("download-1", "download-2"));
-    assertEquals(QueueToadlet.PATH_DOWNLOADS, location);
-  }
-
-  @Test
-  void handleMethodPOST_whenRestartRequestSelected_callsQueueMutationPortWithDisableFilterData()
+  void handleMethodPOST_whenBrowserUploadInserted_delegatesToQueueInsertPortAndRedirects()
       throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
-        createRequest(
-            Map.of(
-                "restart_request", "yes",
-                "disableFilterData", "on",
-                "identifier-a", "download-1"));
+    QueueToadlet toadlet = createQueueToadlet();
+    HTTPUploadedFile uploadedFile = uploadedFile();
+    when(queueInsertPort.enqueueBrowserUploadInsert(any()))
+        .thenReturn(QueueInsertOutcome.METADATA_UNRESOLVED);
 
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(Map.of("insert", "yes", "keytype", "CHK"), uploadedFile),
+        ctx);
 
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).restartRequests(java.util.List.of("download-1"), true);
+    assertEquals(QueueToadlet.PATH_UPLOADS, captureRedirectLocation(ctx));
+    ArgumentCaptor<QueueBrowserUploadInsertRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueBrowserUploadInsertRequest.class);
+    verify(queueInsertPort).enqueueBrowserUploadInsert(requestCaptor.capture());
+    QueueBrowserUploadInsertRequest request = requestCaptor.getValue();
+    assertEquals("CHK@", request.insertUri());
+    assertTrue(request.identifier().startsWith("upload.txt-fred-"));
+    assertEquals(defaultCompatibilityMode(), request.compatibilityMode());
+    assertEquals("upload.txt", request.filenameForKey());
+    assertEquals("upload.txt", request.upload().filename());
+    assertEquals("text/plain", request.upload().contentType());
+    try (var inputStream = request.upload().openStream()) {
+      assertArrayEquals("payload".getBytes(StandardCharsets.UTF_8), inputStream.readAllBytes());
+    }
   }
 
   @Test
-  void handleMethodPOST_whenChangePriorityTopSelected_callsQueueMutationPort() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
-        createRequest(
-            Map.of(
-                "change_priority_top", "yes",
-                "priority_top", "4",
-                "identifier-a", "download-1"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).changePriority(java.util.List.of("download-1"), (short) 4);
-  }
-
-  @Test
-  void handleMethodPOST_whenChangePriorityBottomSelected_callsQueueMutationPort() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
-        createRequest(
-            Map.of(
-                "change_priority_bottom", "yes",
-                "priority_bottom", "2",
-                "identifier-a", "download-1"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).changePriority(java.util.List.of("download-1"), (short) 2);
-  }
-
-  @Test
-  void handleMethodPOST_whenRemoveFinishedUploadsSelected_callsQueueMutationPort()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(true);
-    HTTPRequest request = createRequest(Map.of("remove_finished_uploads_request", "yes"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/uploads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).removeFinishedUploads();
-  }
-
-  @Test
-  void handleMethodPOST_whenRemoveFinishedDownloadsSelected_callsQueueMutationPort()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request = createRequest(Map.of("remove_finished_downloads_request", "yes"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    captureRedirectLocation(ctx);
-    verify(queueMutationPort).removeFinishedDownloads();
-  }
-
-  @Test
-  void handleMethodPOST_whenQueueMutationUnavailable_returnsPersistenceDisabledErrorPage()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet(false);
-    HTTPRequest request =
-        createRequest(Map.of("remove_request", "yes", "identifier-a", "download-1"));
-    doThrow(new RequestQueueUnavailableException("queue unavailable"))
-        .when(queueMutationPort)
-        .removeRequests(java.util.List.of("download-1"));
-
+  void handleMethodPOST_whenBrowserUploadRejected_returnsInsertErrorPage() throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    HTTPUploadedFile uploadedFile = uploadedFile();
+    doThrow(new QueueInsertRejectedException(QueueInsertFailureReason.ACCESS_DENIED, "denied"))
+        .when(queueInsertPort)
+        .enqueueBrowserUploadInsert(any());
     ByteArrayOutputStream body = captureBody(ctx);
 
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(Map.of("insert", "yes", "keytype", "CHK"), uploadedFile),
+        ctx);
+
+    assertTrue(body.toString(StandardCharsets.UTF_8).contains("upload.txt"));
+    verify(ctx).sendReplyHeaders(eq(400), eq("Bad request"), any(), anyString(), anyLong());
+  }
+
+  @Test
+  void handleMethodPOST_whenBrowserUploadQueueUnavailable_returnsPersistenceDisabledPage()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    HTTPUploadedFile uploadedFile = uploadedFile();
+    doThrow(new RequestQueueUnavailableException("queue unavailable"))
+        .when(queueInsertPort)
+        .enqueueBrowserUploadInsert(any());
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(Map.of("insert", "yes", "keytype", "CHK"), uploadedFile),
+        ctx);
 
     String html = body.toString(StandardCharsets.UTF_8);
     assertTrue(html.contains(tempDir.toString()));
     assertTrue(html.contains("queue.db"));
   }
 
-  private QueueToadlet createQueueToadlet(boolean uploads) throws Exception {
+  @Test
+  void handleMethodPOST_whenLocalFileSelected_delegatesToQueueInsertPortAndRedirects()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    Path file = Files.writeString(tempDir.resolve("upload.txt"), "payload");
+    when(queueInsertPort.enqueueLocalFileInsert(any())).thenReturn(QueueInsertOutcome.STARTED);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(
+            Map.of(
+                LocalFileBrowserToadlet.SELECT_FILE,
+                "yes",
+                "filename",
+                file.toString(),
+                "key",
+                "CHK@",
+                "compress",
+                "on")),
+        ctx);
+
+    assertEquals(QueueToadlet.PATH_UPLOADS, captureRedirectLocation(ctx));
+    ArgumentCaptor<QueueLocalFileInsertRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueLocalFileInsertRequest.class);
+    verify(queueInsertPort).enqueueLocalFileInsert(requestCaptor.capture());
+    QueueLocalFileInsertRequest request = requestCaptor.getValue();
+    assertEquals(file.toFile(), request.sourceFile());
+    assertEquals("CHK@", request.insertUri());
+    assertTrue(request.identifier().startsWith("upload.txt-fred-"));
+    assertEquals(defaultCompatibilityMode(), request.compatibilityMode());
+    assertEquals("upload.txt", request.targetFilename());
+    assertTrue(request.compress());
+  }
+
+  @Test
+  void handleMethodPOST_whenLocalFileSourceMissing_returnsNoFileErrorPage() throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    Path missing = tempDir.resolve("missing.txt");
+    doThrow(new QueueInsertRejectedException(QueueInsertFailureReason.SOURCE_NOT_FOUND, "missing"))
+        .when(queueInsertPort)
+        .enqueueLocalFileInsert(any());
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(
+            Map.of(
+                LocalFileBrowserToadlet.SELECT_FILE,
+                "yes",
+                "filename",
+                missing.toString(),
+                "key",
+                "CHK@")),
+        ctx);
+
+    assertTrue(body.toString(StandardCharsets.UTF_8).contains("missing.txt"));
+    verify(ctx).sendReplyHeaders(eq(400), eq("Bad request"), any(), anyString(), anyLong());
+  }
+
+  @Test
+  void handleMethodPOST_whenLocalDirectorySelected_delegatesToQueueInsertPortAndRedirects()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    Path dir = Files.createDirectories(tempDir.resolve("site"));
+    when(queueInsertPort.enqueueLocalDirectoryInsert(any())).thenReturn(QueueInsertOutcome.STARTED);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(
+            Map.of(
+                LocalFileBrowserToadlet.SELECT_DIR,
+                "yes",
+                "filename",
+                dir.toString(),
+                "key",
+                "CHK@")),
+        ctx);
+
+    assertEquals(QueueToadlet.PATH_UPLOADS, captureRedirectLocation(ctx));
+    ArgumentCaptor<QueueLocalDirectoryInsertRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueLocalDirectoryInsertRequest.class);
+    verify(queueInsertPort).enqueueLocalDirectoryInsert(requestCaptor.capture());
+    QueueLocalDirectoryInsertRequest request = requestCaptor.getValue();
+    assertEquals(dir.toFile(), request.sourceDirectory());
+    assertEquals("CHK@", request.insertUri());
+    assertTrue(request.identifier().startsWith("site-fred-"));
+    assertEquals(defaultCompatibilityMode(), request.compatibilityMode());
+  }
+
+  @Test
+  void handleMethodPOST_whenLocalDirectoryRejected_returnsTooManyFilesErrorPage() throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    Path dir = Files.createDirectories(tempDir.resolve("site"));
+    doThrow(
+            new QueueInsertRejectedException(
+                QueueInsertFailureReason.TOO_MANY_FILES, "too many files"))
+        .when(queueInsertPort)
+        .enqueueLocalDirectoryInsert(any());
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(
+            Map.of(
+                LocalFileBrowserToadlet.SELECT_DIR,
+                "yes",
+                "filename",
+                dir.toString(),
+                "key",
+                "CHK@")),
+        ctx);
+
+    assertTrue(body.size() > 0);
+    verify(ctx).sendReplyHeaders(eq(400), eq("Bad request"), any(), anyString(), anyLong());
+  }
+
+  private QueueToadlet createQueueToadlet() throws Exception {
     ProgramDirectory userDir = new ProgramDirectory();
     userDir.move(tempDir.toString());
 
@@ -278,7 +363,7 @@ class QueueToadletPostMutationTest {
             core,
             fcp,
             client,
-            uploads,
+            true,
             new QueueToadletRuntimePorts(
                 queuePagePort,
                 transferAccessPort,
@@ -342,13 +427,34 @@ class QueueToadletPostMutationTest {
         new ClientContextDefaults(fetchContext, insertContext, config));
   }
 
+  private HTTPUploadedFile uploadedFile() {
+    HTTPUploadedFile file = org.mockito.Mockito.mock(HTTPUploadedFile.class);
+    when(file.getFilename()).thenReturn("upload.txt");
+    when(file.getContentType()).thenReturn("text/plain");
+    when(file.getData())
+        .thenReturn(new SimpleReadOnlyArrayBucket("payload".getBytes(StandardCharsets.UTF_8)));
+    return file;
+  }
+
+  private String defaultCompatibilityMode() {
+    return InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name();
+  }
+
   private HTTPRequest createRequest(Map<String, String> parts) {
+    return createRequest(parts, null);
+  }
+
+  private HTTPRequest createRequest(Map<String, String> parts, HTTPUploadedFile uploadedFile) {
     HTTPRequest request = org.mockito.Mockito.mock(HTTPRequest.class);
     when(request.getParts()).thenReturn(parts.keySet().stream().sorted().toArray(String[]::new));
     when(request.isPartSet(anyString()))
         .thenAnswer(invocation -> parts.containsKey(invocation.getArgument(0, String.class)));
     when(request.getPartAsStringFailsafe(anyString(), anyInt()))
         .thenAnswer(invocation -> parts.getOrDefault(invocation.getArgument(0, String.class), ""));
+    when(request.getUploadedFile(anyString()))
+        .thenAnswer(
+            invocation ->
+                "filename".equals(invocation.getArgument(0, String.class)) ? uploadedFile : null);
     return request;
   }
 

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -43,6 +43,7 @@ import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.node.useralerts.UserEvent;
 import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
@@ -100,6 +101,7 @@ class QueueToadletTest {
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
   @Mock private QueueDownloadPort queueDownloadPort;
+  @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private UserAlertManager alerts;
   @Mock private PriorityAwareExecutor executor;
@@ -470,7 +472,11 @@ class QueueToadletTest {
             client,
             uploads,
             new QueueToadletRuntimePorts(
-                queuePagePort, transferAccessPort, queueDownloadPort, queueMutationPort));
+                queuePagePort,
+                transferAccessPort,
+                queueDownloadPort,
+                queueInsertPort,
+                queueMutationPort));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/node/runtime/LegacyQueueInsertPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyQueueInsertPortTest.java
@@ -1,0 +1,422 @@
+package network.crypta.node.runtime;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.Metadata;
+import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.HealingQueue;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.TooManyFilesInsertException;
+import network.crypta.client.async.USKManager;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.clients.fcp.ClientPut;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.IdentifierCollisionException;
+import network.crypta.clients.fcp.NotAllowedException;
+import network.crypta.clients.fcp.PersistentRequestClient;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.config.Config;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientContextResources;
+import network.crypta.node.ClientEndpoints;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
+import network.crypta.runtime.spi.QueueInsertFailureReason;
+import network.crypta.runtime.spi.QueueInsertOptions;
+import network.crypta.runtime.spi.QueueInsertOutcome;
+import network.crypta.runtime.spi.QueueInsertRejectedException;
+import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
+import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
+import network.crypta.runtime.spi.QueueUploadedFile;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.ArrayBucket;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class LegacyQueueInsertPortTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientEndpoints endpoints;
+  @Mock private FCPServer fcp;
+  @Mock private ClientLayerPersister jobRunner;
+  @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
+  @Mock private PersistentRequestRoot persistentRoot;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private TransferAccessPort transferAccessPort;
+  @Mock private PriorityAwareExecutor executor;
+
+  @TempDir Path tempDir;
+
+  private LegacyQueueInsertPort port;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    PersistentRequestClient persistentClient =
+        new PersistentRequestClient(
+            "global", null, true, null, Persistence.FOREVER, persistentRoot);
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(fcp);
+    when(core.getClientLayerPersister()).thenReturn(jobRunner);
+    when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
+    when(core.getRuntimePorts()).thenReturn(runtimePorts);
+    when(runtimePorts.transferAccess()).thenReturn(transferAccessPort);
+    when(fcp.getGlobalForeverClient()).thenReturn(persistentClient);
+    when(transferAccessPort.allowUploadFrom(any(File.class))).thenReturn(true);
+    when(persistentTempBucketFactory.makeBucket(anyLong())).thenAnswer(_ -> new ArrayBucket());
+    when(core.getClientContext()).thenReturn(createClientContext());
+    doAnswer(
+            invocation -> {
+              PersistentJob job = invocation.getArgument(0);
+              job.run(null);
+              return null;
+            })
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+    doNothing().when(fcp).startBlocking(any(ClientRequest.class));
+
+    port = new LegacyQueueInsertPort(core);
+  }
+
+  @Test
+  void enqueueBrowserUploadInsert_whenCalled_resolvesFcpLazilyAndReturnsStarted() throws Exception {
+    LegacyQueueInsertPort spyPort = spy(port);
+    ClientPut clientPut = mock(ClientPut.class);
+    AtomicBoolean uploadCopyCompleted = new AtomicBoolean();
+    AtomicReference<Boolean> copiedBeforeQueue = new AtomicReference<>();
+    AtomicReference<Boolean> checkpointRequested = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              copiedBeforeQueue.set(uploadCopyCompleted.get());
+              PersistentJob job = invocation.getArgument(0);
+              checkpointRequested.set(job.run(null));
+              return null;
+            })
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+    QueueUploadedFile upload = upload(() -> uploadCopyCompleted.set(true));
+    doReturn(clientPut).when(spyPort).createBrowserUploadClientPut(any(), any(), any());
+    QueueBrowserUploadInsertRequest request =
+        new QueueBrowserUploadInsertRequest(
+            "CHK@", "upload-1", upload, options(true, defaultCompatibilityMode()), "hello.txt");
+
+    verifyNoInteractions(endpoints, fcp);
+
+    QueueInsertOutcome outcome = spyPort.enqueueBrowserUploadInsert(request);
+
+    assertEquals(QueueInsertOutcome.STARTED, outcome);
+    assertTrue(copiedBeforeQueue.get());
+    assertTrue(checkpointRequested.get());
+    verify(endpoints).getFCPServer();
+    verify(fcp).startBlocking(any(ClientRequest.class));
+  }
+
+  @Test
+  void enqueueBrowserUploadInsert_whenIdentifierCollision_returnsIdentifierCollision()
+      throws Exception {
+    LegacyQueueInsertPort spyPort = spy(port);
+    ClientPut clientPut = mock(ClientPut.class);
+    doReturn(clientPut).when(spyPort).createBrowserUploadClientPut(any(), any(), any());
+    doThrow(new IdentifierCollisionException()).when(fcp).startBlocking(any(ClientRequest.class));
+
+    QueueInsertOutcome outcome =
+        spyPort.enqueueBrowserUploadInsert(
+            new QueueBrowserUploadInsertRequest(
+                "CHK@",
+                "upload-1",
+                upload(),
+                options(true, defaultCompatibilityMode()),
+                "hello.txt"));
+
+    assertEquals(QueueInsertOutcome.IDENTIFIER_COLLISION, outcome);
+  }
+
+  @Test
+  void enqueueBrowserUploadInsert_whenMetadataUnresolved_returnsMetadataUnresolved()
+      throws Exception {
+    LegacyQueueInsertPort spyPort = spy(port);
+    doThrow(new MetadataUnresolvedException(new Metadata[0], "unresolved"))
+        .when(spyPort)
+        .createBrowserUploadClientPut(any(), any(), any());
+
+    QueueInsertOutcome outcome =
+        spyPort.enqueueBrowserUploadInsert(
+            new QueueBrowserUploadInsertRequest(
+                "CHK@",
+                "upload-1",
+                upload(),
+                options(true, defaultCompatibilityMode()),
+                "hello.txt"));
+
+    assertEquals(QueueInsertOutcome.METADATA_UNRESOLVED, outcome);
+  }
+
+  @Test
+  void enqueueLocalFileInsert_whenAccessDenied_translatesToAccessDeniedRejection()
+      throws Exception {
+    LegacyQueueInsertPort spyPort = spy(port);
+    AtomicReference<Boolean> checkpointRequested = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              PersistentJob job = invocation.getArgument(0);
+              checkpointRequested.set(job.run(null));
+              return null;
+            })
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+    doThrow(new NotAllowedException()).when(spyPort).createLocalFileClientPut(any(), any(), any());
+    Path file = Files.writeString(tempDir.resolve("upload.txt"), "hello");
+
+    QueueInsertRejectedException thrown =
+        assertThrows(
+            QueueInsertRejectedException.class,
+            () ->
+                spyPort.enqueueLocalFileInsert(
+                    new QueueLocalFileInsertRequest(
+                        file.toFile(),
+                        "CHK@",
+                        "upload-1",
+                        "text/plain",
+                        options(false, defaultCompatibilityMode()),
+                        file.getFileName().toString())));
+
+    assertEquals(QueueInsertFailureReason.ACCESS_DENIED, thrown.reason());
+    assertFalse(checkpointRequested.get());
+  }
+
+  @Test
+  void enqueueLocalFileInsert_whenSourceMissing_translatesToSourceNotFoundRejection()
+      throws Exception {
+    LegacyQueueInsertPort spyPort = spy(port);
+    doThrow(new java.io.FileNotFoundException())
+        .when(spyPort)
+        .createLocalFileClientPut(any(), any(), any());
+    File missingFile = tempDir.resolve("missing.txt").toFile();
+
+    QueueInsertRejectedException thrown =
+        assertThrows(
+            QueueInsertRejectedException.class,
+            () ->
+                spyPort.enqueueLocalFileInsert(
+                    new QueueLocalFileInsertRequest(
+                        missingFile,
+                        "CHK@",
+                        "upload-1",
+                        "text/plain",
+                        options(false, defaultCompatibilityMode()),
+                        missingFile.getName())));
+
+    assertEquals(QueueInsertFailureReason.SOURCE_NOT_FOUND, thrown.reason());
+  }
+
+  @Test
+  void enqueueLocalDirectoryInsert_whenTooManyFiles_translatesToTooManyFilesRejection()
+      throws Exception {
+    LegacyQueueInsertPort spyPort = spy(port);
+    doThrow(new TooManyFilesInsertException()).when(spyPort).createLocalDirectoryPut(any(), any());
+    Path dir = Files.createDirectories(tempDir.resolve("site"));
+
+    QueueInsertRejectedException thrown =
+        assertThrows(
+            QueueInsertRejectedException.class,
+            () ->
+                spyPort.enqueueLocalDirectoryInsert(
+                    new QueueLocalDirectoryInsertRequest(
+                        dir.toFile(),
+                        "CHK@",
+                        "upload-1",
+                        options(false, defaultCompatibilityMode()))));
+
+    assertEquals(QueueInsertFailureReason.TOO_MANY_FILES, thrown.reason());
+  }
+
+  @Test
+  void enqueueBrowserUploadInsert_whenPersistenceDisabled_translatesToQueueUnavailable()
+      throws Exception {
+    RandomAccessBucket copiedBucket = mock(RandomAccessBucket.class);
+    when(copiedBucket.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+    when(persistentTempBucketFactory.makeBucket(anyLong())).thenReturn(copiedBucket);
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    doThrow(cause).when(jobRunner).queue(any(PersistentJob.class), anyInt());
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(
+            RequestQueueUnavailableException.class,
+            () ->
+                port.enqueueBrowserUploadInsert(
+                    new QueueBrowserUploadInsertRequest(
+                        "CHK@",
+                        "upload-1",
+                        upload(),
+                        options(true, defaultCompatibilityMode()),
+                        "hello.txt")));
+
+    assertSame(cause, thrown.getCause());
+    verify(copiedBucket).free();
+  }
+
+  @Test
+  void enqueueBrowserUploadInsert_whenFcpServerMissing_translatesToQueueUnavailable()
+      throws Exception {
+    RandomAccessBucket copiedBucket = mock(RandomAccessBucket.class);
+    when(copiedBucket.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+    when(persistentTempBucketFactory.makeBucket(anyLong())).thenReturn(copiedBucket);
+    when(endpoints.getFCPServer()).thenReturn(null);
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(
+            RequestQueueUnavailableException.class,
+            () ->
+                port.enqueueBrowserUploadInsert(
+                    new QueueBrowserUploadInsertRequest(
+                        "CHK@",
+                        "upload-1",
+                        upload(),
+                        options(true, defaultCompatibilityMode()),
+                        "hello.txt")));
+
+    assertEquals("Persistent request queue unavailable", thrown.getMessage());
+    verify(copiedBucket).free();
+  }
+
+  private QueueUploadedFile upload() {
+    return upload(() -> {});
+  }
+
+  private QueueUploadedFile upload(Runnable onClose) {
+    byte[] bytes = "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    return new QueueUploadedFile(
+        "hello.txt",
+        "text/plain",
+        bytes.length,
+        () ->
+            new ByteArrayInputStream(bytes) {
+              @Override
+              public void close() {
+                onClose.run();
+              }
+            });
+  }
+
+  private String defaultCompatibilityMode() {
+    return InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name();
+  }
+
+  private QueueInsertOptions options(boolean compress, String compatibilityMode) {
+    return new QueueInsertOptions(compress, compatibilityMode, null);
+  }
+
+  private ClientContext createClientContext() {
+    ArchiveManager archiveManager = org.mockito.Mockito.mock(ArchiveManager.class);
+    PersistentTempBucketFactory ptbf = org.mockito.Mockito.mock(PersistentTempBucketFactory.class);
+    TempBucketFactory tbf = org.mockito.Mockito.mock(TempBucketFactory.class);
+    PersistentFileTracker tracker = org.mockito.Mockito.mock(PersistentFileTracker.class);
+    HealingQueue hq = org.mockito.Mockito.mock(HealingQueue.class);
+    USKManager uskManager = org.mockito.Mockito.mock(USKManager.class);
+    RandomSource strongRandom = org.mockito.Mockito.mock(RandomSource.class);
+    Ticker ticker = org.mockito.Mockito.mock(Ticker.class);
+    MemoryLimitedJobRunner memoryLimitedJobRunner =
+        org.mockito.Mockito.mock(MemoryLimitedJobRunner.class);
+    FilenameGenerator fg = org.mockito.Mockito.mock(FilenameGenerator.class);
+    LockableRandomAccessBufferFactory rafFactory =
+        org.mockito.Mockito.mock(LockableRandomAccessBufferFactory.class);
+    LockableRandomAccessBufferFactory persistentRAFFactory =
+        org.mockito.Mockito.mock(LockableRandomAccessBufferFactory.class);
+    FileRandomAccessBufferFactory fileRAFTransient =
+        org.mockito.Mockito.mock(FileRandomAccessBufferFactory.class);
+    FileRandomAccessBufferFactory fileRAFPersistent =
+        org.mockito.Mockito.mock(FileRandomAccessBufferFactory.class);
+    RealCompressor rc = org.mockito.Mockito.mock(RealCompressor.class);
+    DatastoreChecker checker = org.mockito.Mockito.mock(DatastoreChecker.class);
+    PersistentRequestRoot clientContextPersistentRoot =
+        org.mockito.Mockito.mock(PersistentRequestRoot.class);
+    MasterSecret masterSecret = org.mockito.Mockito.mock(MasterSecret.class);
+    LinkFilterExceptionProvider linkFilterExceptionProvider =
+        org.mockito.Mockito.mock(LinkFilterExceptionProvider.class);
+    FetchContext fetchContext = org.mockito.Mockito.mock(FetchContext.class);
+    InsertContext insertContext = org.mockito.Mockito.mock(InsertContext.class);
+    Config config = org.mockito.Mockito.mock(Config.class);
+
+    return new ClientContext(
+        1L,
+        new ClientContextRuntime(
+            jobRunner,
+            executor,
+            memoryLimitedJobRunner,
+            ticker,
+            strongRandom,
+            new Random(123),
+            masterSecret),
+        new ClientContextStorageFactories(
+            ptbf, tbf, tracker, fg, fg, fileRAFTransient, fileRAFPersistent),
+        new ClientContextRafFactories(rafFactory, persistentRAFFactory),
+        new ClientContextServices(
+            new ClientContextResources(archiveManager, hq),
+            uskManager,
+            rc,
+            checker,
+            clientContextPersistentRoot,
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(fetchContext, insertContext, config));
+  }
+}


### PR DESCRIPTION
## Summary
- add a detached queue-insert SPI in `runtime-spi` and expose it from `RuntimePorts`
- add `LegacyQueueInsertPort` and wire it through `LegacyRuntimePorts`, `FProxyRegistrar`, and `QueueToadletRuntimePorts`
- move the remaining `QueueToadlet` insert creation flows for browser upload, local file, and local directory onto the runtime port
- add focused daemon and HTTP tests for insert delegation, outcome mapping, and queue-unavailable handling

## How to test
- `./gradlew test --tests "network.crypta.node.runtime.LegacyQueueInsertPortTest" --tests "network.crypta.clients.http.QueueToadletPostInsertTest" --tests "network.crypta.clients.http.QueueToadletPostDownloadTest" --tests "network.crypta.clients.http.QueueToadletPostMutationTest"`
