### PR TITLE
refactor(queue): Move recommendations to runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessagingPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessagingPort.java
@@ -2,6 +2,7 @@ package network.crypta.runtime.spi;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Exposes the legacy node-to-node message compose/send capability.
@@ -72,6 +73,30 @@ public interface DarknetMessagingPort {
    */
   void sendUploadedFileOffer(String nodeIdentifier, DarknetUploadedFile upload, String messageHead)
       throws UnknownPeerException, DarknetPeerRequiredException, IOException;
+
+  /**
+   * Sends one or more download recommendations to the selected detached darknet peer.
+   *
+   * <p>This is the detached equivalent of the legacy queue "recommend to friends" path. Callers
+   * keep request parsing, URI validation, checkbox selection, and user-facing error handling in the
+   * HTTP layer. They then pass the validated URI strings in encounter order. The implementation
+   * resolves the detached peer identity on demand, converts the strings into daemon URI objects,
+   * and delegates to the existing download-feed send API.
+   *
+   * <p>The implementation should preserve the caller-provided URI order and description value
+   * exactly for the selected peer. As with the other methods on this port, detached identity
+   * resolution is request-scoped and may fail if the peer roster changes between form render and
+   * submit.
+   *
+   * @param nodeIdentifier detached peer identity selected from the legacy friends page and used for
+   *     request-scoped peer lookup
+   * @param uris validated URI strings to recommend to the resolved peer, in encounter order
+   * @param description optional human-readable description sent with each recommendation
+   * @throws UnknownPeerException if the detached peer identity no longer resolves at sending time
+   * @throws DarknetPeerRequiredException if the resolved peer exists but is not a darknet peer
+   */
+  void recommendDownloads(String nodeIdentifier, List<String> uris, String description)
+      throws UnknownPeerException, DarknetPeerRequiredException;
 
   /**
    * Sends one composed N2NTM to the selected detached darknet peer.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -150,7 +150,9 @@ final class FProxyRegistrar {
                 runtimePorts.transferAccess(),
                 runtimePorts.queueDownload(),
                 runtimePorts.queueInsert(),
-                runtimePorts.queueMutation()));
+                runtimePorts.queueMutation(),
+                runtimePorts.darknetConnections(),
+                runtimePorts.darknetMessaging()));
     server.register(
         downloadToadlet,
         ToadletRegistration.menuLink(
@@ -177,7 +179,9 @@ final class FProxyRegistrar {
                 runtimePorts.transferAccess(),
                 runtimePorts.queueDownload(),
                 runtimePorts.queueInsert(),
-                runtimePorts.queueMutation()));
+                runtimePorts.queueMutation(),
+                runtimePorts.darknetConnections(),
+                runtimePorts.darknetMessaging()));
     server.register(
         uploadToadlet,
         ToadletRegistration.menuLink(

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -40,10 +40,13 @@ import network.crypta.clients.fcp.NotAllowedException;
 import network.crypta.clients.fcp.RequestCompletionCallback;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.StoringUserEvent;
 import network.crypta.node.useralerts.UserAlert;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRejectedException;
@@ -62,6 +65,7 @@ import network.crypta.runtime.spi.QueuePageSnapshot;
 import network.crypta.runtime.spi.QueueUploadedFile;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SizeUtil;
@@ -141,6 +145,8 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private final QueueDownloadPort queueDownloadPort;
   private final QueueInsertPort queueInsertPort;
   private final QueueMutationPort queueMutationPort;
+  private final DarknetConnectionsPort darknetConnectionsPort;
+  private final DarknetMessagingPort darknetMessagingPort;
   private FileInsertWizardToadlet fiw;
   private final QueuePostHandler postHandler;
 
@@ -221,6 +227,8 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     this.queueDownloadPort = ports.queueDownloadPort();
     this.queueInsertPort = ports.queueInsertPort();
     this.queueMutationPort = ports.queueMutationPort();
+    this.darknetConnectionsPort = ports.darknetConnectionsPort();
+    this.darknetMessagingPort = ports.darknetMessagingPort();
     this.uploads = uploads;
     this.postHandler = new QueuePostHandler();
     QueueCompletionTracker completionTracker = new QueueCompletionTracker();
@@ -1454,14 +1462,15 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           new String[] {"id", "name", "row", "cols"},
           new String[] {"descB", "description", "3", "70"});
       form.addChild("br");
-      if (core.getNode().isFProxyJavascriptEnabled()) {
+      boolean fProxyJavascriptEnabled = ctx.getContainer().isFProxyJavascriptEnabled();
+      if (fProxyJavascriptEnabled) {
         form.addChild(
             "script",
             new String[] {ATTR_TYPE, "src"},
             new String[] {"text/javascript", "/static/js/checkall.js"});
       }
       HTMLNode peerTable = form.addChild(TAG_TABLE, ATTR_CLASS, "darknet_connections");
-      if (core.getNode().isFProxyJavascriptEnabled()) {
+      if (fProxyJavascriptEnabled) {
         HTMLNode headerRow = peerTable.addChild("tr");
         headerRow
             .addChild("th")
@@ -1473,15 +1482,15 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       } else {
         peerTable.addChild("tr").addChild("th", "colspan", "2", l10n("recommendToFriends"));
       }
-      for (DarknetPeerNode peer : core.getNode().network().darknetConnections()) {
+      for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
         HTMLNode peerRow = peerTable.addChild("tr", ATTR_CLASS, "darknet_connections_normal");
         peerRow
             .addChild("td", ATTR_CLASS, "peer-marker")
             .addChild(
                 TAG_INPUT,
                 new String[] {ATTR_TYPE, ATTR_NAME},
-                new String[] {INPUT_TYPE_CHECKBOX, "node_" + peer.hashCode()});
-        peerRow.addChild("td", ATTR_CLASS, "peer-name").addChild("#", peer.getName());
+                new String[] {INPUT_TYPE_CHECKBOX, "node_" + peer.selectionToken()});
+        peerRow.addChild("td", ATTR_CLASS, "peer-name").addChild("#", peer.displayName());
       }
 
       form.addChild(
@@ -1560,22 +1569,30 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return false;
       }
       String description = request.getPartAsStringFailsafe("description", 32768);
-      List<FreenetURI> uris = new ArrayList<>();
+      List<String> uris = new ArrayList<>();
       for (String part : request.getParts()) {
         if (!part.startsWith(KEY_PREFIX)) continue;
         String key = request.getPartAsStringFailsafe(part, MAX_KEY_LENGTH);
         try {
-          FreenetURI furi = new FreenetURI(key);
-          uris.add(furi);
+          new FreenetURI(key);
+          uris.add(key);
         } catch (MalformedURLException _) {
           writeError(l10n(ERROR_INVALID_URI), l10n(ERROR_INVALID_URI_TO_U), ctx);
           return true;
         }
       }
 
-      for (DarknetPeerNode peer : core.getNode().network().darknetConnections()) {
-        if (request.isPartSet("node_" + peer.hashCode())) {
-          for (FreenetURI furi : uris) peer.sendDownloadFeed(furi, description);
+      if (!uris.isEmpty()) {
+        for (DarknetConnectionPeerSnapshot peer : darknetConnectionsPort.listPeers()) {
+          if (!request.isPartSet("node_" + peer.selectionToken())) {
+            continue;
+          }
+          try {
+            darknetMessagingPort.recommendDownloads(peer.nodeIdentifier(), uris, description);
+          } catch (UnknownPeerException | DarknetPeerRequiredException e) {
+            LOG.warn(
+                "Skipping queue recommendation for unresolved peer {}", peer.nodeIdentifier(), e);
+          }
         }
       }
       writePermanentRedirect(ctx, "Done", path());

--- a/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.http;
 
 import java.util.Objects;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -12,9 +14,11 @@ import network.crypta.runtime.spi.TransferAccessPort;
  *
  * <p>The download and upload queue pages share the same detached read-path, mutation, and
  * transfer-policy runtime ports, the download side also uses the queue-download creation port, and
- * the upload side uses the queue-insert creation port. Grouping them in one small record keeps
- * constructor signatures stable while preserving the option to add other queue-specific ports later
- * without widening the main toadlet constructor again.
+ * the upload side uses the queue-insert creation port. The shared queue UI also still exposes the
+ * legacy "recommend to friends" action, so the bundle now carries the detached darknet peer-list
+ * and messaging ports used by that path. Grouping them in one small record keeps constructor
+ * signatures stable while preserving the option to add other queue-specific ports later without
+ * widening the main toadlet constructor again.
  *
  * <p>This record lives in the HTTP layer because it models HTTP wiring rather than a daemon-side
  * runtime capability. The queue toadlets can accept one stable parameter today and still grow to
@@ -26,13 +30,18 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * @param queueInsertPort detached queue-insert port used for new persistent uploads and local
  *     inserts
  * @param queueMutationPort detached queue-mutation port
+ * @param darknetConnectionsPort detached darknet friends-page companion port used by queue
+ *     recommendation rendering
+ * @param darknetMessagingPort detached darknet messaging port used by queue recommendation sends
  */
 public record QueueToadletRuntimePorts(
     QueuePagePort queuePagePort,
     TransferAccessPort transferAccessPort,
     QueueDownloadPort queueDownloadPort,
     QueueInsertPort queueInsertPort,
-    QueueMutationPort queueMutationPort) {
+    QueueMutationPort queueMutationPort,
+    DarknetConnectionsPort darknetConnectionsPort,
+    DarknetMessagingPort darknetMessagingPort) {
   /**
    * Creates one validated queue-toadlet port bundle.
    *
@@ -44,6 +53,10 @@ public record QueueToadletRuntimePorts(
    * @param queueInsertPort detached queue-insert port shared by the download and upload toadlets
    * @param queueMutationPort detached queue-mutation port shared by the download and upload
    *     toadlets
+   * @param darknetConnectionsPort detached darknet friends-page companion port shared by the
+   *     download and upload toadlets for queue recommendation rendering
+   * @param darknetMessagingPort detached darknet messaging port shared by the download and upload
+   *     toadlets for queue recommendation sends
    * @throws NullPointerException if any port is {@code null}
    */
   public QueueToadletRuntimePorts {
@@ -52,5 +65,7 @@ public record QueueToadletRuntimePorts(
     Objects.requireNonNull(queueDownloadPort);
     Objects.requireNonNull(queueInsertPort);
     Objects.requireNonNull(queueMutationPort);
+    Objects.requireNonNull(darknetConnectionsPort);
+    Objects.requireNonNull(darknetMessagingPort);
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyDarknetMessagingPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyDarknetMessagingPort.java
@@ -5,8 +5,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.util.List;
 import java.util.Objects;
 import network.crypta.client.async.ClientContext;
+import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.PeerManager;
@@ -76,6 +79,17 @@ final class LegacyDarknetMessagingPort implements DarknetMessagingPort {
 
   /** {@inheritDoc} */
   @Override
+  public void recommendDownloads(String nodeIdentifier, List<String> uris, String description)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    Objects.requireNonNull(uris, "uris");
+    DarknetPeerNode peer = peerResolver.resolveByIdentity(nodeIdentifier);
+    for (String uri : uris) {
+      peer.sendDownloadFeed(toFreenetUri(uri), description);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public DarknetMessageSendStatus sendComposedMessage(
       String nodeIdentifier,
       String message,
@@ -105,6 +119,26 @@ final class LegacyDarknetMessagingPort implements DarknetMessagingPort {
       case PeerManager.PEER_NODE_STATUS_ROUTING_BACKED_OFF -> DarknetMessageSendStatus.DELAYED;
       default -> DarknetMessageSendStatus.QUEUED;
     };
+  }
+
+  /**
+   * Converts one validated detached URI string into the daemon URI type.
+   *
+   * <p>Queue recommendations validate URI syntax in the HTTP layer before crossing the runtime
+   * boundary. A malformed value at this stage therefore indicates caller misuse or a regression in
+   * that validation path, so the adapter reports it as an unchecked failure instead of widening the
+   * SPI contract with queue-specific parsing errors.
+   *
+   * @param uri detached URI string supplied by the caller
+   * @return daemon URI object ready for the legacy download-feed API
+   */
+  private static FreenetURI toFreenetUri(String uri) {
+    Objects.requireNonNull(uri, "uri");
+    try {
+      return new FreenetURI(uri);
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException("Malformed recommendation URI: " + uri, e);
+    }
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
@@ -36,6 +36,8 @@ import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertFailureReason;
@@ -99,6 +101,8 @@ class QueueToadletPostInsertTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
   @Mock private PriorityAwareExecutor executor;
   @Mock private ClientLayerPersister jobRunner;
@@ -369,7 +373,9 @@ class QueueToadletPostInsertTest {
                 transferAccessPort,
                 queueDownloadPort,
                 queueInsertPort,
-                queueMutationPort));
+                queueMutationPort,
+                darknetConnectionsPort,
+                darknetMessagingPort));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
@@ -35,6 +35,8 @@ import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -89,6 +91,8 @@ class QueueToadletPostMutationTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
   @Mock private PriorityAwareExecutor executor;
   @Mock private ClientLayerPersister jobRunner;
@@ -284,7 +288,9 @@ class QueueToadletPostMutationTest {
                 transferAccessPort,
                 queueDownloadPort,
                 queueInsertPort,
-                queueMutationPort));
+                queueMutationPort,
+                darknetConnectionsPort,
+                darknetMessagingPort));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
@@ -1,10 +1,8 @@
 package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -31,23 +29,24 @@ import network.crypta.clients.fcp.RequestCompletionCallback;
 import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
+import network.crypta.l10n.NodeL10n;
 import network.crypta.node.ClientContextResources;
+import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
-import network.crypta.runtime.spi.QueueDownloadRejectedException;
-import network.crypta.runtime.spi.QueueDownloadRequest;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
-import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.MultiValueTable;
@@ -61,6 +60,7 @@ import network.crypta.support.io.FilenameGenerator;
 import network.crypta.support.io.PersistentFileTracker;
 import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,7 +73,6 @@ import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -82,17 +81,16 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 @SuppressWarnings("java:S100")
-class QueueToadletPostDownloadTest {
+class QueueToadletRecommendTest {
 
   @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
@@ -111,6 +109,13 @@ class QueueToadletPostDownloadTest {
 
   @TempDir Path tempDir;
 
+  private Node node;
+
+  @BeforeAll
+  static void initL10n() {
+    new NodeL10n();
+  }
+
   @BeforeEach
   void setUp() {
     PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
@@ -121,197 +126,142 @@ class QueueToadletPostDownloadTest {
     when(ctx.getContainer()).thenReturn(container);
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
-    when(queueDownloadPort.isDiskDownloadDisabled()).thenReturn(false);
+    when(ctx.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              HTMLNode form = new HTMLNode("form");
+              parent.addChild(form);
+              return form;
+            });
   }
 
   @Test
-  void handleMethodPOST_whenSingleDownloadRequested_callsQueueDownloadPort() throws Exception {
+  void handleMethodPOST_whenRecommendFormRequested_rendersDetachedPeersAndLegacyCheckboxNames()
+      throws Exception {
     QueueToadlet toadlet = createQueueToadlet();
-    Path downloadsDir = Files.createDirectories(tempDir.resolve("downloads"));
-    String downloadPath = downloadsDir.toString();
-    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(true);
-    HTTPRequest request =
+    when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(node.isFProxyJavascriptEnabled()).thenReturn(false);
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeer(), bobPeer()));
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
+        createRequest(
+            Map.of("recommend_request", "yes", "identifier-a", "download-1", "key-a", "CHK@")),
+        ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertTrue(html.contains("Alice"));
+    assertTrue(html.contains("Bob"));
+    assertTrue(html.contains("node_42"));
+    assertTrue(html.contains("node_99"));
+    assertTrue(html.contains("recommend_uri"));
+    assertTrue(html.contains("darknet_connections"));
+    verify(darknetConnectionsPort).listPeers();
+  }
+
+  @Test
+  void handleMethodPOST_whenRecommendFormRequestedAndJavascriptDisabled_omitsCheckAllScript()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    when(container.isFProxyJavascriptEnabled()).thenReturn(false);
+    when(node.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeer()));
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
+        createRequest(
+            Map.of("recommend_request", "yes", "identifier-a", "download-1", "key-a", "CHK@")),
+        ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertFalse(html.contains("/static/js/checkall.js"));
+    assertFalse(html.contains("checkAll(this, 'darknet_connections')"));
+  }
+
+  @Test
+  void handleMethodPOST_whenRecommendSubmitted_callsRuntimePortOnlyForSelectedPeers()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeer(), bobPeer()));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
         createRequest(
             Map.of(
-                "download", "yes",
-                "key", "CHK@",
-                "type", "text/plain",
-                "persistence", "forever",
-                "return-type", "disk",
-                "path", downloadPath,
-                "filterData", "on"));
+                "recommend_uri", "yes",
+                "description", "look at these",
+                "key-0", "CHK@",
+                "key-1", "SSK@",
+                "node_42", "on")),
+        ctx);
 
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
+    verify(darknetMessagingPort)
+        .recommendDownloads("peer-1", List.of("CHK@", "SSK@"), "look at these");
+    verify(darknetMessagingPort, never()).recommendDownloads(eq("peer-2"), any(), anyString());
     assertEquals(QueueToadlet.PATH_DOWNLOADS, captureRedirectLocation(ctx));
-    ArgumentCaptor<QueueDownloadRequest> requestCaptor =
-        ArgumentCaptor.forClass(QueueDownloadRequest.class);
-    verify(queueDownloadPort).enqueueDownload(requestCaptor.capture());
-    QueueDownloadRequest queueRequest = requestCaptor.getValue();
-    assertEquals("CHK@", queueRequest.fetchUri());
-    assertTrue(queueRequest.filterData());
-    assertEquals("text/plain", queueRequest.expectedMimeType());
-    assertEquals("forever", queueRequest.persistenceType());
-    assertEquals("disk", queueRequest.returnType());
-    assertEquals(new File(downloadPath), queueRequest.downloadsDir());
   }
 
   @Test
-  void handleMethodPOST_whenBulkDownloadsRequested_callsQueueDownloadPortOncePerValidKey()
+  void handleMethodPOST_whenSelectedPeerDisappears_continuesBestEffortAndRedirects()
       throws Exception {
     QueueToadlet toadlet = createQueueToadlet();
-    Path downloadsDir = Files.createDirectories(tempDir.resolve("bulk-downloads"));
-    String downloadPath = downloadsDir.toString();
-    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(true);
-    ByteArrayOutputStream body = captureBody(ctx);
-    HTTPRequest request =
-        createRequest(
-            Map.of(
-                "bulkDownloads", "CHK@\nnot-a-uri\n\nSSK@\n",
-                "target", "disk",
-                "path", downloadPath,
-                "filterData", "on"));
-
-    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
-
-    ArgumentCaptor<QueueDownloadRequest> requestCaptor =
-        ArgumentCaptor.forClass(QueueDownloadRequest.class);
-    verify(queueDownloadPort, times(2)).enqueueDownload(requestCaptor.capture());
-    List<QueueDownloadRequest> requests = requestCaptor.getAllValues();
-    assertEquals("CHK@", requests.getFirst().fetchUri());
-    assertEquals("SSK@", requests.get(1).fetchUri());
-    assertEquals("disk", requests.getFirst().returnType());
-    assertEquals(new File(downloadPath), requests.getFirst().downloadsDir());
-    assertTrue(body.toString(StandardCharsets.UTF_8).contains("not-a-uri"));
-  }
-
-  @Test
-  void handleMethodPOST_whenSingleDownloadRejected_returnsDiskConfigErrorPage() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet();
-    Path downloadsDir = Files.createDirectories(tempDir.resolve("downloads"));
-    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(true);
-    doThrow(new QueueDownloadRejectedException("rejected"))
-        .when(queueDownloadPort)
-        .enqueueDownload(any(QueueDownloadRequest.class));
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeer(), bobPeer()));
+    doThrow(new UnknownPeerException("peer-1"))
+        .when(darknetMessagingPort)
+        .recommendDownloads("peer-1", List.of("CHK@"), "look at these");
 
     toadlet.handleMethodPOST(
         URI.create("http://localhost/downloads/"),
         createRequest(
             Map.of(
-                "download", "yes",
-                "key", "CHK@",
-                "persistence", "forever",
-                "return-type", "disk",
-                "path", downloadsDir.toString())),
+                "recommend_uri", "yes",
+                "description", "look at these",
+                "key-0", "CHK@",
+                "node_42", "on",
+                "node_99", "on")),
         ctx);
 
-    verify(queueDownloadPort).enqueueDownload(any(QueueDownloadRequest.class));
+    verify(darknetMessagingPort).recommendDownloads("peer-1", List.of("CHK@"), "look at these");
+    verify(darknetMessagingPort).recommendDownloads("peer-2", List.of("CHK@"), "look at these");
+    assertEquals(QueueToadlet.PATH_DOWNLOADS, captureRedirectLocation(ctx));
+  }
+
+  @Test
+  void handleMethodPOST_whenRecommendationUriIsMalformed_returnsInvalidUriErrorWithoutSend()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/downloads/"),
+        createRequest(
+            Map.of(
+                "recommend_uri", "yes",
+                "description", "broken",
+                "key-0", "not-a-uri",
+                "node_42", "on")),
+        ctx);
+
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertFalse(html.isBlank());
     verify(ctx).sendReplyHeaders(eq(400), eq("Bad request"), any(), anyString(), anyLong());
-  }
-
-  @Test
-  void handleMethodPOST_whenBulkQueueUnavailable_rendersBulkFailureResultPage() throws Exception {
-    QueueToadlet toadlet = createQueueToadlet();
-    doThrow(new RequestQueueUnavailableException("queue unavailable"))
-        .when(queueDownloadPort)
-        .enqueueDownload(any(QueueDownloadRequest.class));
-    ByteArrayOutputStream body = captureBody(ctx);
-
-    toadlet.handleMethodPOST(
-        URI.create("http://localhost/downloads/"),
-        createRequest(Map.of("bulkDownloads", "CHK@\n", "target", "direct")),
-        ctx);
-
-    String html = body.toString(StandardCharsets.UTF_8);
-    assertTrue(html.contains("CHK@"));
-    assertFalse(html.contains("queue.db"));
-    verify(ctx).sendReplyHeaders(eq(200), eq("OK"), any(), anyString(), anyLong());
-  }
-
-  @Test
-  void handleMethodPOST_whenBulkQueueUnavailableAfterPartialSuccess_preservesAcceptedKeys()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet();
-    doNothing()
-        .doThrow(new RequestQueueUnavailableException("queue unavailable"))
-        .when(queueDownloadPort)
-        .enqueueDownload(any(QueueDownloadRequest.class));
-    ByteArrayOutputStream body = captureBody(ctx);
-
-    toadlet.handleMethodPOST(
-        URI.create("http://localhost/downloads/"),
-        createRequest(Map.of("bulkDownloads", "CHK@\nSSK@\n", "target", "direct")),
-        ctx);
-
-    String html = body.toString(StandardCharsets.UTF_8);
-    assertTrue(html.contains("CHK@"));
-    assertTrue(html.contains("SSK@"));
-    assertFalse(html.contains("queue.db"));
-    verify(queueDownloadPort, times(2)).enqueueDownload(any(QueueDownloadRequest.class));
-    verify(ctx).sendReplyHeaders(eq(200), eq("OK"), any(), anyString(), anyLong());
-  }
-
-  @Test
-  void handleMethodPOST_whenDownloadPathDisallowed_returnsDisallowedPageWithoutQueueDownloadCall()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet();
-    String downloadPath = tempDir.resolve("blocked").toString();
-    when(transferAccessPort.allowDownloadTo(any(File.class))).thenReturn(false);
-    ByteArrayOutputStream body = captureBody(ctx);
-
-    toadlet.handleMethodPOST(
-        URI.create("http://localhost/downloads/"),
-        createRequest(
-            Map.of(
-                "download", "yes",
-                "key", "CHK@",
-                "persistence", "forever",
-                "return-type", "disk",
-                "path", downloadPath)),
-        ctx);
-
-    String html = body.toString(StandardCharsets.UTF_8);
-    assertTrue(html.contains(downloadPath));
-    assertTrue(html.contains("disallowed"));
-    verify(queueDownloadPort, never()).enqueueDownload(any(QueueDownloadRequest.class));
-  }
-
-  @Test
-  void handleMethodPOST_whenDiskDownloadsDisabled_fallsBackToDirectReturnWithoutPathCheck()
-      throws Exception {
-    QueueToadlet toadlet = createQueueToadlet();
-    when(queueDownloadPort.isDiskDownloadDisabled()).thenReturn(true);
-
-    toadlet.handleMethodPOST(
-        URI.create("http://localhost/downloads/"),
-        createRequest(
-            Map.of(
-                "download", "yes",
-                "key", "CHK@",
-                "persistence", "forever",
-                "return-type", "disk",
-                "path", tempDir.resolve("downloads").toString())),
-        ctx);
-
-    ArgumentCaptor<QueueDownloadRequest> requestCaptor =
-        ArgumentCaptor.forClass(QueueDownloadRequest.class);
-    verify(queueDownloadPort).enqueueDownload(requestCaptor.capture());
-    QueueDownloadRequest queueRequest = requestCaptor.getValue();
-    assertEquals("direct", queueRequest.returnType());
-    assertNull(queueRequest.downloadsDir());
-    verify(transferAccessPort, never()).allowDownloadTo(any(File.class));
+    verifyNoInteractions(darknetMessagingPort);
   }
 
   private QueueToadlet createQueueToadlet() throws Exception {
     ProgramDirectory userDir = new ProgramDirectory();
     userDir.move(tempDir.toString());
 
-    Node node = org.mockito.Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+    node = org.mockito.Mockito.mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
     when(node.userDir()).thenReturn(userDir);
     when(node.getUserDir()).thenReturn(userDir.dir());
     when(node.awaitingPassword()).thenReturn(false);
     when(node.isStopping()).thenReturn(false);
     when(node.getDatabasePath()).thenReturn(tempDir.resolve("queue.db").toString());
+    when(node.isFProxyJavascriptEnabled()).thenReturn(false);
 
     RequestStarterGroup starters = org.mockito.Mockito.mock(RequestStarterGroup.class);
     NodeClientCore core = org.mockito.Mockito.mock(NodeClientCore.class);
@@ -322,6 +272,7 @@ class QueueToadletPostDownloadTest {
     NodeNetworkSubsystem network = org.mockito.Mockito.mock(NodeNetworkSubsystem.class);
     when(node.network()).thenReturn(network);
     when(network.executor()).thenReturn(executor);
+    when(network.darknetConnections()).thenReturn(new DarknetPeerNode[0]);
 
     ClientContext context = createClientContext();
     context.init(starters, alerts);
@@ -482,5 +433,13 @@ class QueueToadletPostDownloadTest {
         .when(stub)
         .getInfobox(anyString(), anyString(), any(HTMLNode.class), any(), anyBoolean());
     return stub;
+  }
+
+  private static DarknetConnectionPeerSnapshot alicePeer() {
+    return new DarknetConnectionPeerSnapshot(42, "peer-1", "Alice", "", false);
+  }
+
+  private static DarknetConnectionPeerSnapshot bobPeer() {
+    return new DarknetConnectionPeerSnapshot(99, "peer-2", "Bob", "", false);
   }
 }

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -42,6 +42,8 @@ import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.node.useralerts.UserEvent;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -103,6 +105,8 @@ class QueueToadletTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
   @Mock private PriorityAwareExecutor executor;
   @Mock private ClientLayerPersister jobRunner;
@@ -476,7 +480,9 @@ class QueueToadletTest {
                 transferAccessPort,
                 queueDownloadPort,
                 queueInsertPort,
-                queueMutationPort));
+                queueMutationPort,
+                darknetConnectionsPort,
+                darknetMessagingPort));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/node/runtime/LegacyDarknetMessagingPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyDarknetMessagingPortTest.java
@@ -3,6 +3,8 @@ package network.crypta.node.runtime;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.PeerManager;
@@ -23,9 +25,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -111,6 +116,36 @@ class LegacyDarknetMessagingPortTest {
   }
 
   @Test
+  void recommendDownloads_whenIdentityResolves_sendsEveryUriInOrderWithDescription()
+      throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    FreenetURI firstUri = new FreenetURI("CHK@");
+    FreenetURI secondUri = new FreenetURI("SSK@");
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    port.recommendDownloads("peer-1", List.of("CHK@", "SSK@"), "check these out");
+
+    InOrder sendOrder = inOrder(darknetPeer);
+    sendOrder.verify(darknetPeer).sendDownloadFeed(firstUri, "check these out");
+    sendOrder.verify(darknetPeer).sendDownloadFeed(secondUri, "check these out");
+    verify(darknetPeer, never()).sendDownloadFeed(any(FreenetURI.class), eq(null));
+  }
+
+  @Test
+  void recommendDownloads_whenDescriptionIsNull_preservesNullDescription() throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+    ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+
+    port.recommendDownloads("peer-1", List.of("CHK@"), null);
+
+    verify(darknetPeer).sendDownloadFeed(any(FreenetURI.class), descriptionCaptor.capture());
+    assertNull(descriptionCaptor.getValue());
+  }
+
+  @Test
   void sendComposedMessage_whenLocalFilePresent_usesOnePeerResolutionForOfferAndText()
       throws Exception {
     LegacyDarknetMessagingPort port = newPort();
@@ -126,6 +161,27 @@ class LegacyDarknetMessagingPortTest {
     InOrder sendOrder = inOrder(darknetPeer);
     sendOrder.verify(darknetPeer).sendFileOffer(file, "message-head");
     sendOrder.verify(darknetPeer).sendTextFeed("hello");
+  }
+
+  @Test
+  void recommendDownloads_whenPeerIdentityIsUnknown_throwsUnknownPeerException() {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[0]);
+
+    assertThrows(
+        UnknownPeerException.class,
+        () -> port.recommendDownloads("missing-peer", List.of("CHK@"), "hello"));
+  }
+
+  @Test
+  void recommendDownloads_whenResolvedPeerIsNotDarknet_throwsDarknetPeerRequiredException() {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {nonDarknetPeer});
+    when(nonDarknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    assertThrows(
+        DarknetPeerRequiredException.class,
+        () -> port.recommendDownloads("peer-1", List.of("CHK@"), "hello"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- extend the detached darknet messaging SPI with a narrow queue recommendation send method and implement it in the legacy runtime adapter
- wire `DarknetConnectionsPort` and `DarknetMessagingPort` into `QueueToadletRuntimePorts` so both queue toadlets receive detached darknet ports from `FProxyRegistrar`
- migrate the `recommend_request` and `recommend_uri` QueueToadlet paths off live peer traversal and direct `DarknetPeerNode.sendDownloadFeed(...)` calls while preserving the legacy checkbox scheme, redirect behavior, and invalid-URI handling
- add focused daemon and HTTP tests for queue recommendation behavior and update queue test helpers for the expanded runtime port bundle

## Testing
- `./gradlew test --tests "network.crypta.node.runtime.LegacyDarknetMessagingPortTest"`
- `./gradlew test --tests "network.crypta.clients.http.QueueToadletRecommendTest"`
- `./gradlew test --tests "network.crypta.clients.http.N2NTMToadletTest"`
- `./gradlew test --tests "network.crypta.clients.http.QueueToadletTest"`
- `./gradlew :runtime-spi:compileJava`

## Scope Notes
- removed from the migrated QueueToadlet recommend path: direct `core.getNode().network().darknetConnections()` traversal, direct `DarknetPeerNode` usage, direct `DarknetPeerNode.sendDownloadFeed(...)`, and direct `core.getNode().isFProxyJavascriptEnabled()` checks
- intentionally left for later PRs: `panic` / `confirmpanic`, queue completion tracker and completed-list persistence, the `fcp.isEnabled()` gate, and persistence-disabled / shutdown error-page handling