### PR TITLE
refactor(queue): Move support flow behind runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueuePersistenceStatusSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueuePersistenceStatusSnapshot.java
@@ -1,0 +1,30 @@
+package network.crypta.runtime.spi;
+
+import java.io.File;
+
+/**
+ * Captures the queue-persistence support state needed by the HTTP queue pages.
+ *
+ * <p>This record is the detached data shape returned by {@link
+ * QueueSupportPort#persistenceStatus()} while the queue support pages are being migrated off direct
+ * daemon access. It carries only the state that the legacy HTTP layer still needs to decide which
+ * existing support page to render: whether the node is awaiting the master password, whether
+ * shutdown is already in progress, and the persistence path details shown on the final
+ * persistence-broken page.
+ *
+ * <p>The snapshot is immutable and intentionally limited to JDK types. Callers should treat it as a
+ * point-in-time view rather than a live handle into daemon state. When {@code awaitingPassword} or
+ * {@code stopping} is {@code true}, the path fields may be absent because the queue pages should
+ * continue to short-circuit to the password or shutdown page without dereferencing persistence-file
+ * state.
+ *
+ * @param awaitingPassword {@code true} when the node is currently waiting for the master password
+ * @param stopping {@code true} when shutdown is in progress
+ * @param persistentTempDir persistent temp directory shown on the legacy persistence-broken page;
+ *     may be {@code null} when {@code awaitingPassword} or {@code stopping} is {@code true}
+ * @param databasePath database path shown on the legacy persistence-broken page; may be {@code
+ *     null} when {@code awaitingPassword} or {@code stopping} is {@code true}
+ * @see QueueSupportPort
+ */
+public record QueuePersistenceStatusSnapshot(
+    boolean awaitingPassword, boolean stopping, File persistentTempDir, String databasePath) {}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueSupportPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueSupportPort.java
@@ -1,0 +1,73 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+
+/**
+ * Exposes the remaining queue support hooks still needed by the HTTP layer.
+ *
+ * <p>This SPI is intentionally narrow and transitional. The queue toadlets still have a small
+ * support-oriented slice that must preserve existing behavior while the daemon continues to own the
+ * real queue backend, persistence lifecycle, and panic mechanics. Instead of letting the HTTP layer
+ * reach into the live daemon state directly, callers use this port to ask a few targeted questions
+ * and to trigger the existing order-sensitive panic flow.
+ *
+ * <p>The port is not a general queue-management API. Queue reads, queue creation, completed-list
+ * tracking, and existing-request mutations stay on their dedicated ports. Implementations may still
+ * consult live daemon objects internally, but callers should only rely on the detached contract
+ * defined here.
+ *
+ * <ul>
+ *   <li>Availability gating for the queue backend.
+ *   <li>Point-in-time persistence support state for queue error pages.
+ *   <li>Start and finish hooks for the legacy panic workflow.
+ * </ul>
+ *
+ * @see QueuePersistenceStatusSnapshot
+ */
+public interface QueueSupportPort {
+  /**
+   * Returns whether the queue backend is currently enabled.
+   *
+   * <p>Callers use this to preserve the existing "please enable FCP" gate without depending on
+   * daemon-local FCP types or daemon-global singletons. The result is a live availability check,
+   * not a configuration snapshot, so implementations may consult the current daemon state each time
+   * the queue page is rendered.
+   *
+   * @return {@code true} when the live queue backend is enabled
+   */
+  boolean isQueueBackendEnabled();
+
+  /**
+   * Returns the current detached persistence-support status for the queue pages.
+   *
+   * <p>The returned snapshot preserves the legacy queue-page support branches: awaiting-password,
+   * shutting-down, and persistence-broken rendering. Implementations may leave the persistence path
+   * fields empty for the awaiting-password and shutting-down branches because those values are only
+   * rendered on the persistence-broken page. Callers should treat the snapshot as a detached state
+   * for one response rather than a live object that stays in sync with daemon transitions.
+   *
+   * @return current queue-persistence status snapshot
+   */
+  QueuePersistenceStatusSnapshot persistenceStatus();
+
+  /**
+   * Starts the legacy panic sequence.
+   *
+   * <p>Callers should preserve the existing order-sensitive flow: invoke this method, render the
+   * panicking page, then call {@link #finishPanic()}. Implementations may perform irreversible
+   * daemon-side work here, so callers should not treat the method as idempotent or retry-safe
+   * unless a specific implementation documents stronger guarantees.
+   *
+   * @throws IOException if the daemon's panic-start sequence fails while deleting the master keys
+   *     file
+   */
+  void beginPanic() throws IOException;
+
+  /**
+   * Completes the legacy panic sequence after the panicking page has been rendered.
+   *
+   * <p>This second step lets the HTTP layer preserve the historic user-visible ordering while the
+   * daemon keeps ownership of the underlying shutdown and cleanup mechanics.
+   */
+  void finishPanic();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -28,6 +28,7 @@ package network.crypta.runtime.spi;
  * @see QueuePagePort
  * @see QueueDownloadPort
  * @see QueueMutationPort
+ * @see QueueSupportPort
  * @see StatisticsPort
  * @see NodeInfoPort
  * @see PeerPort
@@ -168,6 +169,18 @@ public interface RuntimePorts {
    * @return diagnostic-report runtime port for read-only report snapshots
    */
   DiagnosticPort diagnostic();
+
+  /**
+   * Returns the legacy queue support capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining queue-oriented live-runtime helpers behind the runtime
+   * boundary: the backend-enabled gate, the persistence-disabled support snapshot, and the panic
+   * start / finish actions. It is intentionally page-support-oriented rather than a general queue
+   * API.
+   *
+   * @return queue support port for backend enablement, persistence state, and panic actions
+   */
+  QueueSupportPort queueSupport();
 
   /**
    * Returns the legacy queue-page read capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -151,6 +151,7 @@ final class FProxyRegistrar {
                 runtimePorts.queueDownload(),
                 runtimePorts.queueInsert(),
                 runtimePorts.queueMutation(),
+                runtimePorts.queueSupport(),
                 runtimePorts.darknetConnections(),
                 runtimePorts.darknetMessaging()));
     server.register(
@@ -180,6 +181,7 @@ final class FProxyRegistrar {
                 runtimePorts.queueDownload(),
                 runtimePorts.queueInsert(),
                 runtimePorts.queueMutation(),
+                runtimePorts.queueSupport(),
                 runtimePorts.darknetConnections(),
                 runtimePorts.darknetMessaging()));
     server.register(

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -62,6 +62,8 @@ import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.QueueUploadedFile;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -145,6 +147,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private final QueueDownloadPort queueDownloadPort;
   private final QueueInsertPort queueInsertPort;
   private final QueueMutationPort queueMutationPort;
+  private final QueueSupportPort queueSupportPort;
   private final DarknetConnectionsPort darknetConnectionsPort;
   private final DarknetMessagingPort darknetMessagingPort;
   private FileInsertWizardToadlet fiw;
@@ -227,6 +230,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     this.queueDownloadPort = ports.queueDownloadPort();
     this.queueInsertPort = ports.queueInsertPort();
     this.queueMutationPort = ports.queueMutationPort();
+    this.queueSupportPort = ports.queueSupportPort();
     this.darknetConnectionsPort = ports.darknetConnectionsPort();
     this.darknetMessagingPort = ports.darknetMessagingPort();
     this.uploads = uploads;
@@ -571,10 +575,9 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         return false;
       }
       if (SimpleToadletServer.noConfirmPanic) {
-        core.getNode().storage().killMasterKeysFile();
-        core.getNode().panic();
+        queueSupportPort.beginPanic();
         sendPanicingPage(ctx);
-        core.getNode().finishPanic();
+        queueSupportPort.finishPanic();
       } else {
         sendConfirmPanicPage(ctx);
       }
@@ -587,10 +590,9 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           || request.getPartAsStringFailsafe(CONFIRM_PANIC, 128).isEmpty()) {
         return false;
       }
-      core.getNode().storage().killMasterKeysFile();
-      core.getNode().panic();
+      queueSupportPort.beginPanic();
       sendPanicingPage(ctx);
-      core.getNode().finishPanic();
+      queueSupportPort.finishPanic();
       return true;
     }
 
@@ -1709,8 +1711,9 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
 
   private void sendPersistenceDisabledError(ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
+    QueuePersistenceStatusSnapshot persistenceStatus = queueSupportPort.persistenceStatus();
     String title = l10n("awaitingPasswordTitle" + (uploads ? "Uploads" : "Downloads"));
-    if (core.getNode().awaitingPassword()) {
+    if (persistenceStatus.awaitingPassword()) {
       PageNode page = ctx.getPageMaker().getPageNode(title, ctx);
       HTMLNode contentNode = page.getContentNode();
 
@@ -1727,7 +1730,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       writeHTMLReply(ctx, 500, "Internal Server Error", page.generate());
       return;
     }
-    if (core.getNode().isStopping())
+    if (persistenceStatus.stopping())
       sendErrorPage(ctx, 200, l10n("shuttingDownTitle"), l10n("shuttingDown"));
     else
       sendErrorPage(
@@ -1738,8 +1741,9 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
               "persistenceBroken",
               new String[] {"TEMPDIR", "DBFILE"},
               new String[] {
-                FileUtil.getCanonicalFile(core.getPersistentTempDir()).toString() + File.separator,
-                core.getNode().getDatabasePath()
+                FileUtil.getCanonicalFile(persistenceStatus.persistentTempDir()).toString()
+                    + File.separator,
+                persistenceStatus.databasePath()
               }));
   }
 
@@ -1797,7 +1801,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   public void handleMethodGET(URI uri, final HTTPRequest request, final ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
 
-    if (!fcp.isEnabled()) {
+    if (!queueSupportPort.isQueueBackendEnabled()) {
       writeError(l10n("fcpIsMissing"), l10n("pleaseEnableFCP"), ctx, false, false);
       return;
     }

--- a/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
@@ -7,6 +7,7 @@ import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.TransferAccessPort;
 
 /**
@@ -15,10 +16,11 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * <p>The download and upload queue pages share the same detached read-path, mutation, and
  * transfer-policy runtime ports, the download side also uses the queue-download creation port, and
  * the upload side uses the queue-insert creation port. The shared queue UI also still exposes the
- * legacy "recommend to friends" action, so the bundle now carries the detached darknet peer-list
- * and messaging ports used by that path. Grouping them in one small record keeps constructor
- * signatures stable while preserving the option to add other queue-specific ports later without
- * widening the main toadlet constructor again.
+ * remaining support-oriented availability, persistence, and panic helpers, plus the legacy
+ * "recommend to friends" action, so the bundle now carries the detached queue-support, darknet
+ * peer-list, and messaging ports used by those paths. Grouping them in one small record keeps
+ * constructor signatures stable while preserving the option to add other queue-specific ports later
+ * without widening the main toadlet constructor again.
  *
  * <p>This record lives in the HTTP layer because it models HTTP wiring rather than a daemon-side
  * runtime capability. The queue toadlets can accept one stable parameter today and still grow to
@@ -30,6 +32,8 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * @param queueInsertPort detached queue-insert port used for new persistent uploads and local
  *     inserts
  * @param queueMutationPort detached queue-mutation port
+ * @param queueSupportPort detached queue-support port used for backend enablement, persistence
+ *     state, and panic actions
  * @param darknetConnectionsPort detached darknet friends-page companion port used by queue
  *     recommendation rendering
  * @param darknetMessagingPort detached darknet messaging port used by queue recommendation sends
@@ -40,6 +44,7 @@ public record QueueToadletRuntimePorts(
     QueueDownloadPort queueDownloadPort,
     QueueInsertPort queueInsertPort,
     QueueMutationPort queueMutationPort,
+    QueueSupportPort queueSupportPort,
     DarknetConnectionsPort darknetConnectionsPort,
     DarknetMessagingPort darknetMessagingPort) {
   /**
@@ -53,6 +58,8 @@ public record QueueToadletRuntimePorts(
    * @param queueInsertPort detached queue-insert port shared by the download and upload toadlets
    * @param queueMutationPort detached queue-mutation port shared by the download and upload
    *     toadlets
+   * @param queueSupportPort detached queue-support port shared by the download and upload toadlets
+   *     for backend enablement, persistence state, and panic actions
    * @param darknetConnectionsPort detached darknet friends-page companion port shared by the
    *     download and upload toadlets for queue recommendation rendering
    * @param darknetMessagingPort detached darknet messaging port shared by the download and upload
@@ -65,6 +72,7 @@ public record QueueToadletRuntimePorts(
     Objects.requireNonNull(queueDownloadPort);
     Objects.requireNonNull(queueInsertPort);
     Objects.requireNonNull(queueMutationPort);
+    Objects.requireNonNull(queueSupportPort);
     Objects.requireNonNull(darknetConnectionsPort);
     Objects.requireNonNull(darknetMessagingPort);
   }

--- a/src/main/java/network/crypta/node/runtime/LegacyQueueSupportPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyQueueSupportPort.java
@@ -1,0 +1,97 @@
+package network.crypta.node.runtime;
+
+import java.io.IOException;
+import java.util.Objects;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
+
+/**
+ * Bridges the remaining legacy queue support helpers onto the runtime SPI.
+ *
+ * <p>This adapter is intentionally small. It keeps the queue backend availability check, the
+ * persistence support-state inspection, and the panic start / finish sequence in the daemon root
+ * module while presenting the HTTP layer with the detached contract defined by {@link
+ * QueueSupportPort}. That split lets the queue toadlets preserve their current pages and flow
+ * ordering without continuing to read live daemon objects directly for this support slice.
+ *
+ * <p>The adapter does not attempt to normalize or reinterpret daemon state. It forwards the live
+ * checks in the same order the legacy queue code previously used, including the short-circuit that
+ * avoids resolving persistence-broken path details while the node is still awaiting a password or
+ * already stopping.
+ */
+final class LegacyQueueSupportPort implements QueueSupportPort {
+  /** Shared daemon client core used to reach the live queue support state. */
+  private final NodeClientCore core;
+
+  /**
+   * Creates a queue support adapter backed by the current daemon runtime.
+   *
+   * <p>The adapter keeps a direct reference to {@code core} because the remaining queue support
+   * helpers still span FCP availability, node persistence state, and the panic lifecycle.
+   *
+   * @param core daemon client core that owns the live queue support collaborators
+   */
+  LegacyQueueSupportPort(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core, "core");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation consults the live FCP server exported through the daemon endpoints and
+   * treats a missing server instance as disabled.
+   */
+  @Override
+  public boolean isQueueBackendEnabled() {
+    FCPServer fcpServer = core.getEndpoints().getFCPServer();
+    return fcpServer != null && fcpServer.isEnabled();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation preserves the legacy branch order. It reads the password and shutdown
+   * flags first, returns a short-circuit snapshot for those states, and only resolves the
+   * persistence-broken path details when the queue page should actually render them.
+   */
+  @Override
+  public QueuePersistenceStatusSnapshot persistenceStatus() {
+    Node node = core.getNode();
+    boolean awaitingPassword = node.awaitingPassword();
+    boolean stopping = node.isStopping();
+
+    if (awaitingPassword || stopping) {
+      return new QueuePersistenceStatusSnapshot(awaitingPassword, stopping, null, null);
+    }
+
+    return new QueuePersistenceStatusSnapshot(
+        false, false, core.getPersistentTempDir(), node.getDatabasePath());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The adapter preserves the existing daemon-side ordering by deleting the master keys file
+   * before triggering the live node panic sequence.
+   */
+  @Override
+  public void beginPanic() throws IOException {
+    Node node = core.getNode();
+    node.storage().killMasterKeysFile();
+    node.panic();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This delegates to the node's final panic completion step after the HTTP layer has already
+   * rendered the panicking page.
+   */
+  @Override
+  public void finishPanic() {
+    core.getNode().finishPanic();
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -20,6 +20,7 @@ import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -59,6 +60,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final QueueDownloadPort queueDownloadPort;
   private final QueueInsertPort queueInsertPort;
   private final QueueMutationPort queueMutationPort;
+  private final QueueSupportPort queueSupportPort;
   private final StatisticsPort statisticsPort;
   private final SecurityLevelsPort securityLevelsPort;
   private final FirstTimeWizardPort firstTimeWizardPort;
@@ -160,6 +162,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.queueDownloadPort = new LegacyQueueDownloadPort(core);
     this.queueInsertPort = new LegacyQueueInsertPort(core);
     this.queueMutationPort = new LegacyQueueMutationPort(core);
+    this.queueSupportPort = new LegacyQueueSupportPort(core);
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.securityLevelsPort = new LegacySecurityLevelsPort(node);
     this.firstTimeWizardPort = new LegacyFirstTimeWizardPort(node, core);
@@ -289,6 +292,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public DiagnosticPort diagnostic() {
     return diagnosticPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining queue backend-enabled check, persistence-support state
+   * reads, and panic actions inside the daemon root module while exposing only JDK-only values
+   * upstream.
+   */
+  @Override
+  public QueueSupportPort queueSupport() {
+    return queueSupportPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
@@ -46,6 +46,8 @@ import network.crypta.runtime.spi.QueueDownloadRequest;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -101,6 +103,7 @@ class QueueToadletPostDownloadTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private QueueSupportPort queueSupportPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -122,6 +125,11 @@ class QueueToadletPostDownloadTest {
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
     when(queueDownloadPort.isDiskDownloadDisabled()).thenReturn(false);
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(
+            new QueuePersistenceStatusSnapshot(
+                false, false, tempDir.toFile(), tempDir.resolve("queue.db").toString()));
   }
 
   @Test
@@ -369,6 +377,7 @@ class QueueToadletPostDownloadTest {
                 queueDownloadPort,
                 queueInsertPort,
                 queueMutationPort,
+                queueSupportPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
@@ -48,6 +48,8 @@ import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
 import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -101,6 +103,7 @@ class QueueToadletPostInsertTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private QueueSupportPort queueSupportPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -122,6 +125,11 @@ class QueueToadletPostInsertTest {
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
     when(queueDownloadPort.isDiskDownloadDisabled()).thenReturn(false);
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(
+            new QueuePersistenceStatusSnapshot(
+                false, false, tempDir.toFile(), tempDir.resolve("queue.db").toString()));
   }
 
   @Test
@@ -374,6 +382,7 @@ class QueueToadletPostInsertTest {
                 queueDownloadPort,
                 queueInsertPort,
                 queueMutationPort,
+                queueSupportPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
@@ -41,6 +41,8 @@ import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -56,11 +58,13 @@ import network.crypta.support.io.FilenameGenerator;
 import network.crypta.support.io.PersistentFileTracker;
 import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -75,6 +79,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -91,6 +96,7 @@ class QueueToadletPostMutationTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private QueueSupportPort queueSupportPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -100,6 +106,7 @@ class QueueToadletPostMutationTest {
   @Mock private ToadletContainer container;
 
   @TempDir Path tempDir;
+  private boolean originalNoConfirmPanic;
 
   @BeforeEach
   void setUp() {
@@ -111,6 +118,17 @@ class QueueToadletPostMutationTest {
     when(ctx.getContainer()).thenReturn(container);
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(
+            new QueuePersistenceStatusSnapshot(
+                false, false, tempDir.toFile(), tempDir.resolve("queue.db").toString()));
+    originalNoConfirmPanic = SimpleToadletServer.noConfirmPanic;
+  }
+
+  @AfterEach
+  void tearDown() {
+    SimpleToadletServer.noConfirmPanic = originalNoConfirmPanic;
   }
 
   @Test
@@ -207,8 +225,16 @@ class QueueToadletPostMutationTest {
   void handleMethodPOST_whenQueueMutationUnavailable_returnsPersistenceDisabledErrorPage()
       throws Exception {
     QueueToadlet toadlet = createQueueToadlet(false);
+    Path detachedTempDir = tempDir.resolve("detached-persistent-temp");
     HTTPRequest request =
         createRequest(Map.of("remove_request", "yes", "identifier-a", "download-1"));
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(
+            new QueuePersistenceStatusSnapshot(
+                false,
+                false,
+                detachedTempDir.toFile(),
+                tempDir.resolve("detached-queue.db").toString()));
     doThrow(new RequestQueueUnavailableException("queue unavailable"))
         .when(queueMutationPort)
         .removeRequests(java.util.List.of("download-1"));
@@ -218,8 +244,45 @@ class QueueToadletPostMutationTest {
     toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
 
     String html = body.toString(StandardCharsets.UTF_8);
-    assertTrue(html.contains(tempDir.toString()));
-    assertTrue(html.contains("queue.db"));
+    assertTrue(html.contains(detachedTempDir.toString()));
+    assertTrue(html.contains("detached-queue.db"));
+    verify(queueSupportPort).persistenceStatus();
+  }
+
+  @Test
+  void handleMethodPOST_whenPanicSelectedAndNoConfirmPanic_callsSupportPortAndRendersBeforeFinish()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet(false);
+    SimpleToadletServer.noConfirmPanic = true;
+    HTTPRequest request = createRequest(Map.of("panic", "yes"));
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
+
+    InOrder inOrder = org.mockito.Mockito.inOrder(queueSupportPort, ctx);
+    inOrder.verify(queueSupportPort).beginPanic();
+    inOrder.verify(ctx).sendReplyHeaders(eq(200), eq("OK"), any(), anyString(), anyLong());
+    inOrder.verify(ctx).writeData(any(byte[].class), anyInt(), anyInt());
+    inOrder.verify(queueSupportPort).finishPanic();
+    assertTrue(body.size() > 0);
+  }
+
+  @Test
+  void handleMethodPOST_whenConfirmPanicSelected_callsSupportPortAndRendersBeforeFinish()
+      throws Exception {
+    QueueToadlet toadlet = createQueueToadlet(false);
+    SimpleToadletServer.noConfirmPanic = false;
+    HTTPRequest request = createRequest(Map.of("confirmpanic", "yes"));
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/downloads/"), request, ctx);
+
+    InOrder inOrder = org.mockito.Mockito.inOrder(queueSupportPort, ctx);
+    inOrder.verify(queueSupportPort).beginPanic();
+    inOrder.verify(ctx).sendReplyHeaders(eq(200), eq("OK"), any(), anyString(), anyLong());
+    inOrder.verify(ctx).writeData(any(byte[].class), anyInt(), anyInt());
+    inOrder.verify(queueSupportPort).finishPanic();
+    assertTrue(body.size() > 0);
   }
 
   private QueueToadlet createQueueToadlet(boolean uploads) throws Exception {
@@ -289,6 +352,7 @@ class QueueToadletPostMutationTest {
                 queueDownloadPort,
                 queueInsertPort,
                 queueMutationPort,
+                queueSupportPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;
@@ -393,7 +457,10 @@ class QueueToadletPostMutationTest {
     PageNode page = new PageNode(root, head, content);
 
     PageMaker stub = org.mockito.Mockito.mock(PageMaker.class);
-    when(stub.getPageNode(anyString(), any(ToadletContext.class))).thenReturn(page);
+    doReturn(page).when(stub).getPageNode(anyString(), any(ToadletContext.class));
+    doReturn(page)
+        .when(stub)
+        .getPageNode(anyString(), any(ToadletContext.class), any(PageMaker.RenderParameters.class));
     doAnswer(
             invocation -> {
               HTMLNode parent = invocation.getArgument(2);

--- a/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
@@ -45,6 +45,8 @@ import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
@@ -99,6 +101,7 @@ class QueueToadletRecommendTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private QueueSupportPort queueSupportPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -126,6 +129,11 @@ class QueueToadletRecommendTest {
     when(ctx.getContainer()).thenReturn(container);
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(
+            new QueuePersistenceStatusSnapshot(
+                false, false, tempDir.toFile(), tempDir.resolve("queue.db").toString()));
     when(ctx.addFormChild(any(HTMLNode.class), anyString(), anyString()))
         .thenAnswer(
             invocation -> {
@@ -320,6 +328,7 @@ class QueueToadletRecommendTest {
                 queueDownloadPort,
                 queueInsertPort,
                 queueMutationPort,
+                queueSupportPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -50,6 +50,8 @@ import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -82,6 +84,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -105,6 +108,7 @@ class QueueToadletTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
+  @Mock private QueueSupportPort queueSupportPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -129,7 +133,14 @@ class QueueToadletTest {
     when(ctx.getContainer()).thenReturn(container);
     when(alerts.createSummary()).thenReturn(new HTMLNode("div", "id", "default-alert-summary"));
     when(container.publicGatewayMode()).thenReturn(false);
-    when(fcp.isEnabled()).thenReturn(true);
+    doAnswer(invocation -> invocation.getArgument(0, HTMLNode.class).addChild("form"))
+        .when(container)
+        .addFormChild(any(HTMLNode.class), anyString(), anyString());
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(
+            new QueuePersistenceStatusSnapshot(
+                false, false, tempDir.toFile(), tempDir.resolve("queue.db").toString()));
   }
 
   @Test
@@ -350,10 +361,12 @@ class QueueToadletTest {
   }
 
   @Test
-  void handleMethodGET_whenFcpDisabled_returnsBadRequestWithoutDelegating() throws Exception {
+  void handleMethodGET_whenQueueBackendDisabled_returnsBadRequestWithoutDelegating()
+      throws Exception {
     // Arrange
     QueueToadlet toadlet = createQueueToadlet(false);
-    when(fcp.isEnabled()).thenReturn(false);
+    when(fcp.isEnabled()).thenReturn(true);
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(false);
 
     ByteArrayOutputStream body = captureBody(ctx);
 
@@ -363,6 +376,8 @@ class QueueToadletTest {
     // Assert
     String html = body.toString(StandardCharsets.UTF_8);
     assertTrue(html.contains("You need to enable the FCP server to access this page"));
+    verify(queueSupportPort).isQueueBackendEnabled();
+    verify(fcp, never()).isEnabled();
     verifyNoInteractions(queuePagePort);
   }
 
@@ -390,6 +405,13 @@ class QueueToadletTest {
       throws Exception {
     // Arrange
     QueueToadlet toadlet = createQueueToadlet(false);
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(
+            new QueuePersistenceStatusSnapshot(
+                false,
+                false,
+                tempDir.resolve("detached-persistent-temp").toFile(),
+                tempDir.resolve("snapshot-only.db").toString()));
     when(request.getPath()).thenReturn(QueueToadlet.PATH_DOWNLOADS);
     when(request.isParameterSet("sortBy")).thenReturn(false);
     when(request.isParameterSet("reversed")).thenReturn(false);
@@ -403,9 +425,36 @@ class QueueToadletTest {
 
     // Assert
     String html = body.toString(StandardCharsets.UTF_8);
-    assertTrue(html.contains(tempDir.toString()));
-    assertTrue(html.contains("queue.db"));
+    assertTrue(html.contains("detached-persistent-temp"));
+    assertTrue(html.contains("snapshot-only.db"));
+    verify(queueSupportPort).persistenceStatus();
     verify(queuePagePort).renderPage(any());
+  }
+
+  @Test
+  void handleMethodGET_whenQueueUnavailableAndAwaitingPassword_rendersPasswordPageWithoutPaths()
+      throws Exception {
+    // Arrange
+    QueueToadlet toadlet = createQueueToadlet(false);
+    when(queueSupportPort.persistenceStatus())
+        .thenReturn(new QueuePersistenceStatusSnapshot(true, false, null, null));
+    when(request.getPath()).thenReturn(QueueToadlet.PATH_DOWNLOADS);
+    when(request.isParameterSet("sortBy")).thenReturn(false);
+    when(request.isParameterSet("reversed")).thenReturn(false);
+    when(queuePagePort.renderPage(any()))
+        .thenThrow(new RequestQueueUnavailableException("queue unavailable"));
+
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    // Act
+    toadlet.handleMethodGET(URI.create("http://localhost/downloads/"), request, ctx);
+
+    // Assert
+    assertTrue(body.size() > 0);
+    verify(ctx)
+        .sendReplyHeaders(eq(500), eq("Internal Server Error"), any(), anyString(), anyLong());
+    verify(container).addFormChild(any(HTMLNode.class), anyString(), anyString());
+    verify(queueSupportPort).persistenceStatus();
   }
 
   private QueueToadlet createQueueToadlet(boolean uploads) throws Exception {
@@ -481,6 +530,7 @@ class QueueToadletTest {
                 queueDownloadPort,
                 queueInsertPort,
                 queueMutationPort,
+                queueSupportPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/node/runtime/LegacyQueueSupportPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyQueueSupportPortTest.java
@@ -1,0 +1,127 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.nio.file.Path;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.node.ClientEndpoints;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyQueueSupportPortTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientEndpoints endpoints;
+  @Mock private FCPServer fcp;
+  @Mock private Node node;
+  @Mock private NodeStorageSubsystem storage;
+
+  @TempDir Path tempDir;
+
+  private LegacyQueueSupportPort port;
+
+  @BeforeEach
+  void setUp() {
+    port = new LegacyQueueSupportPort(core);
+  }
+
+  @Test
+  void isQueueBackendEnabled_whenQueried_delegatesToFcpServerFlag() {
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(endpoints.getFCPServer()).thenReturn(fcp);
+    when(fcp.isEnabled()).thenReturn(true).thenReturn(false);
+
+    assertTrue(port.isQueueBackendEnabled());
+    assertFalse(port.isQueueBackendEnabled());
+  }
+
+  @Test
+  void persistenceStatus_whenQueried_exportsAwaitingPasswordStoppingTempDirAndDatabasePath() {
+    File persistentTempDir = tempDir.resolve("persistent-temp").toFile();
+    String databasePath = tempDir.resolve("queue.db").toString();
+    when(core.getNode()).thenReturn(node);
+    when(node.awaitingPassword()).thenReturn(false);
+    when(node.isStopping()).thenReturn(false);
+    when(core.getPersistentTempDir()).thenReturn(persistentTempDir);
+    when(node.getDatabasePath()).thenReturn(databasePath);
+
+    QueuePersistenceStatusSnapshot snapshot = port.persistenceStatus();
+
+    assertFalse(snapshot.awaitingPassword());
+    assertFalse(snapshot.stopping());
+    assertSame(persistentTempDir, snapshot.persistentTempDir());
+    assertEquals(databasePath, snapshot.databasePath());
+  }
+
+  @Test
+  void persistenceStatus_whenAwaitingPasswordShortCircuits_doesNotResolvePersistenceBrokenPaths() {
+    when(core.getNode()).thenReturn(node);
+    when(node.awaitingPassword()).thenReturn(true);
+    when(node.isStopping()).thenReturn(false);
+
+    QueuePersistenceStatusSnapshot snapshot = port.persistenceStatus();
+
+    assertTrue(snapshot.awaitingPassword());
+    assertFalse(snapshot.stopping());
+    assertNull(snapshot.persistentTempDir());
+    assertNull(snapshot.databasePath());
+    verify(core, never()).getPersistentTempDir();
+    verify(node, never()).getDatabasePath();
+  }
+
+  @Test
+  void persistenceStatus_whenStoppingShortCircuits_doesNotResolvePersistenceBrokenPaths() {
+    when(core.getNode()).thenReturn(node);
+    when(node.awaitingPassword()).thenReturn(false);
+    when(node.isStopping()).thenReturn(true);
+
+    QueuePersistenceStatusSnapshot snapshot = port.persistenceStatus();
+
+    assertFalse(snapshot.awaitingPassword());
+    assertTrue(snapshot.stopping());
+    assertNull(snapshot.persistentTempDir());
+    assertNull(snapshot.databasePath());
+    verify(core, never()).getPersistentTempDir();
+    verify(node, never()).getDatabasePath();
+  }
+
+  @Test
+  void beginPanic_whenCalled_triggersExistingPanicStartBehavior() throws Exception {
+    when(core.getNode()).thenReturn(node);
+    when(node.storage()).thenReturn(storage);
+
+    port.beginPanic();
+
+    InOrder inOrder = org.mockito.Mockito.inOrder(storage, node);
+    inOrder.verify(storage).killMasterKeysFile();
+    inOrder.verify(node).panic();
+  }
+
+  @Test
+  void finishPanic_whenCalled_delegatesToNodeFinishPanic() {
+    when(core.getNode()).thenReturn(node);
+
+    port.finishPanic();
+
+    verify(node).finishPanic();
+  }
+}


### PR DESCRIPTION
## Summary

- add `QueueSupportPort` and `QueuePersistenceStatusSnapshot` to the runtime SPI for the remaining queue support slice
- route `QueueToadlet` queue-backend availability, persistence-disabled rendering state, and panic / confirm-panic actions through `LegacyQueueSupportPort`
- extend queue HTTP tests and add focused daemon-side coverage for `LegacyQueueSupportPort`, while keeping the new production files doclint-clean

## Details

- `QueueToadlet` no longer directly calls `fcp.isEnabled()` for the support path
- `QueueToadlet` no longer directly reads `awaitingPassword()`, `isStopping()`, `getPersistentTempDir()`, or `getDatabasePath()` for the persistence-disabled error flow
- `QueueToadlet` no longer performs the panic start / finish sequence directly through `Node`
- completion-tracker concerns such as `fcp.getGlobalRequest(...)` and completion callback registration are intentionally left in place for later cleanup

## How to test

- `./gradlew test --tests "network.crypta.node.runtime.LegacyQueueSupportPortTest" --tests "network.crypta.clients.http.*QueueToadlet*"`
- `./gradlew compileJava`
- `javadoc -quiet -Xdoclint:all -classpath "runtime-spi/build/classes/java/main:runtime-spi/build/resources/main" -sourcepath runtime-spi/src/main/java -d /tmp/doclint-queuesupport runtime-spi/src/main/java/network/crypta/runtime/spi/QueueSupportPort.java`

## Notes

- the follow-up review regression around eager `getDatabasePath()` access is fixed by preserving the old short-circuit order in `LegacyQueueSupportPort.persistenceStatus()`