### PR TITLE
refactor(queue): Move completion tracking behind runtime SPI

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -31,7 +31,10 @@ Use this skill when you need to:
   - The root project implements those ports in `network.crypta.node.runtime.LegacyRuntimePorts`
     plus per-slice adapters such as `LegacyConfigPort`, `LegacyNodeInfoPort`, `LegacyPeerPort`,
     `LegacyConnectionsPagePort`, `LegacyConnectionsSupportPort`,
-    `LegacyDarknetConnectionsPort`, and `LegacyDarknetMessagingPort`.
+    `LegacyDarknetConnectionsPort`, `LegacyDarknetMessagingPort`,
+    `LegacyQueuePagePort`, `LegacyQueueDownloadPort`, `LegacyQueueInsertPort`,
+    `LegacyQueueMutationPort`, `LegacyQueueSupportPort`, `LegacyQueueCompletionPort`,
+    `LegacySecurityLevelsPort`, and `LegacyFirstTimeWizardPort`.
 - The large cyclic daemon core still lives in the root project:
   `network.crypta.node`, `network.crypta.io`, `network.crypta.client`,
   `network.crypta.clients`, `network.crypta.support`, `network.crypta.config`,
@@ -73,9 +76,19 @@ Use this skill when you need to:
 - HTTP interface: `network.crypta.clients.http`
   - The migrated management slices no longer depend directly on live daemon peers or node-info
     exports for their core data flow.
+  - `ConfigToadlet` now takes detached configuration export/update capabilities from
+    `ConfigPort` through `ConfigToadletRuntimePorts`.
   - `ConnectionsToadlet`, `DarknetConnectionsToadlet`, `OpennetConnectionsToadlet`, and
     `DarknetAddRefToadlet` use detached ports such as `ConnectionsPagePort`,
     `ConnectionsSupportPort`, `PeerPort`, and `NodeInfoPort`.
+  - `QueueToadlet` now acts as an HTTP adapter over `QueuePagePort`, `QueueDownloadPort`,
+    `QueueInsertPort`, `QueueMutationPort`, `QueueSupportPort`, `QueueCompletionPort`,
+    `TransferAccessPort`, `DarknetConnectionsPort`, and `DarknetMessagingPort`.
+  - `SecurityLevelsToadlet` uses `SecurityLevelsPort` for detached page state, warning HTML, and
+    master-password mutation flows.
+  - `FirstTimeWizardToadlet` and `FirstTimeWizardNewToadlet` use `FirstTimeWizardPort` for
+    detached snapshot export, validation bounds, bandwidth/security suggestions, and submission
+    handling.
   - `N2NTMToadlet` uses `DarknetConnectionsPort` and `DarknetMessagingPort` for selected-peer
     lookup, transfer confirmations, and compose/send actions.
 
@@ -83,12 +96,16 @@ Use this skill when you need to:
 - Aggregate boundary: `RuntimePorts`
 - Small ports include: `ExecutionPort`, `RandomnessPort`, `TransferAccessPort`, `LifecyclePort`,
   `ConfigPort`, `ConnectivityPort`, `ConnectionsPagePort`, `ConnectionsSupportPort`,
-  `DarknetConnectionsPort`, `DarknetMessagingPort`, `DiagnosticPort`, `StatisticsPort`,
+  `DarknetConnectionsPort`, `DarknetMessagingPort`, `DiagnosticPort`, `QueueSupportPort`,
+  `QueueCompletionPort`, `QueuePagePort`, `QueueDownloadPort`, `QueueInsertPort`,
+  `QueueMutationPort`, `StatisticsPort`, `SecurityLevelsPort`, `FirstTimeWizardPort`,
   `RequestQueuePort`, `NodeInfoPort`, and `PeerPort`
-- Detached DTOs include config, connectivity, peer, darknet-friends, node-reference, and
-  statistics/report snapshot types such as `ConfigSnapshot`, `ConfigFieldSet`, `ConfigSection`,
-  `PeerSnapshot`, `DarknetConnectionPeerSnapshot`, `DarknetUploadedFile`, and
-  `NodeReferenceSnapshot`
+- Detached DTOs include config, connectivity, peer, darknet-friends, node-reference, queue,
+  security-level, first-time-wizard, and statistics/report snapshot types such as
+  `ConfigSnapshot`, `ConfigFieldSet`, `ConfigSection`, `PeerSnapshot`,
+  `DarknetConnectionPeerSnapshot`, `DarknetUploadedFile`, `NodeReferenceSnapshot`,
+  `QueuePageSnapshot`, `QueuePersistenceStatusSnapshot`, `QueueInsertOutcome`,
+  `SecurityLevelsSnapshot`, and `FirstTimeWizardSnapshot`
 - Root adapters: `network.crypta.node.runtime.LegacyRuntimePorts`,
   `network.crypta.node.runtime.LegacyConfigPort`,
   `network.crypta.node.runtime.LegacyNodeInfoPort`,
@@ -96,7 +113,15 @@ Use this skill when you need to:
   `network.crypta.node.runtime.LegacyConnectionsPagePort`,
   `network.crypta.node.runtime.LegacyConnectionsSupportPort`,
   `network.crypta.node.runtime.LegacyDarknetConnectionsPort`,
-  `network.crypta.node.runtime.LegacyDarknetMessagingPort`
+  `network.crypta.node.runtime.LegacyDarknetMessagingPort`,
+  `network.crypta.node.runtime.LegacyQueuePagePort`,
+  `network.crypta.node.runtime.LegacyQueueDownloadPort`,
+  `network.crypta.node.runtime.LegacyQueueInsertPort`,
+  `network.crypta.node.runtime.LegacyQueueMutationPort`,
+  `network.crypta.node.runtime.LegacyQueueSupportPort`,
+  `network.crypta.node.runtime.LegacyQueueCompletionPort`,
+  `network.crypta.node.runtime.LegacySecurityLevelsPort`,
+  `network.crypta.node.runtime.LegacyFirstTimeWizardPort`
 
 ### Plugin system (`network.crypta.pluginmanager`)
 - Management: `PluginManager`
@@ -107,8 +132,9 @@ Use this skill when you need to:
 - Type-safe configuration with persistence
 - Higher layers should prefer the narrow `RuntimePorts` sub-port that already covers the needed
   operation (`config()`, `peer()`, `nodeInfo()`, `connectionsPage()`, `connectionsSupport()`,
-  `darknetConnections()`, `darknetMessaging()`, etc.) instead of traversing daemon internals
-  directly
+  `darknetConnections()`, `darknetMessaging()`, `queuePage()`, `queueDownload()`,
+  `queueInsert()`, `queueMutation()`, `queueSupport()`, `queueCompletion()`,
+  `securityLevels()`, `firstTimeWizard()`, etc.) instead of traversing daemon internals directly
 
 ### Supporting infrastructure (`network.crypta.support`)
 - Logging, data structures, threading, helpers

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ Cryptad now uses a partial multi-project Gradle build.
 - `:foundation-fs` owns `network.crypta.fs`.
 - `:foundation-compat` owns `network.crypta.compat`.
 - `:runtime-spi` owns `network.crypta.runtime.spi` and the JDK-only runtime/config boundary used
-  by higher layers, including the migrated FCP peer-management and admin-HTTP connections-family
-  slices.
+  by higher layers, including the migrated FCP peer-management plus the admin-HTTP config,
+  connections, queue, security-levels, and first-time-wizard slices.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
@@ -179,8 +179,12 @@ Cryptad now uses a partial multi-project Gradle build.
 - The large cyclic daemon core remains in the root project for now, and all tests still live there.
 - Higher-level infrastructure now crosses a narrower boundary through
   `network.crypta.runtime.spi.RuntimePorts`, implemented in the root project by
-  `network.crypta.node.runtime.LegacyRuntimePorts`, plus a few HTTP-local wiring records such as
-  `network.crypta.clients.http.ConnectionsToadletRuntimePorts`.
+  `network.crypta.node.runtime.LegacyRuntimePorts`, plus HTTP-local wiring records such as
+  `network.crypta.clients.http.ConfigToadletRuntimePorts`,
+  `network.crypta.clients.http.ConnectionsToadletRuntimePorts`,
+  `network.crypta.clients.http.FirstTimeWizardToadletRuntimePorts`,
+  `network.crypta.clients.http.QueueToadletRuntimePorts`, and
+  `network.crypta.clients.http.SecurityLevelsToadletRuntimePorts`.
 
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
 `gradle/wrapper/gradle-wrapper.properties`). To also verify the download by checksum, add
@@ -507,13 +511,18 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   (`network.crypta.clients.http`). FCP now consumes execution, randomness, transfer policy,
   lifecycle, config access, and detached peer mutations through `RuntimePorts` and FCP-local
   adapters instead of reaching directly into daemon internals for those concerns. The migrated HTTP
-  management slices now also consume detached runtime ports for connectivity, friends/strangers
-  page snapshots, add-friend installer metadata, local noderef export, selected-peer actions, and
-  N2NTM compose/send flows.
+  management/configuration slices now also consume detached runtime ports for config export and
+  persistence, connectivity and friends/strangers page snapshots, add-friend installer metadata,
+  local noderef export, selected-peer actions, queue page/download/insert/mutation/support and
+  completion flows, security-level state and warnings, first-time-wizard snapshot/submission
+  handling, and N2NTM compose/send flows.
 - Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and detached DTOs such as
   `RuntimePorts`, `ConfigPort`, `NodeInfoPort`, `PeerPort`, `ConnectionsPagePort`,
-  `ConnectionsSupportPort`, `DarknetConnectionsPort`, `DarknetMessagingPort`, `ConfigSnapshot`,
-  and `ConfigFieldSet`.
+  `ConnectionsSupportPort`, `DarknetConnectionsPort`, `DarknetMessagingPort`, `QueuePagePort`,
+  `QueueDownloadPort`, `QueueInsertPort`, `QueueMutationPort`, `QueueSupportPort`,
+  `QueueCompletionPort`, `SecurityLevelsPort`, `FirstTimeWizardPort`, `ConfigSnapshot`,
+  `ConfigFieldSet`, `QueuePageSnapshot`, `QueueInsertOutcome`, `SecurityLevelsSnapshot`, and
+  `FirstTimeWizardSnapshot`.
 - Config (`network.crypta.config`): type‑safe persisted configuration retained in the root daemon
   and exposed upstream through `network.crypta.node.runtime.LegacyConfigPort` via
   `RuntimePorts#config()`.

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueCompletionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueCompletionPort.java
@@ -1,0 +1,26 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Queue-completion tracking capability exposed through the runtime SPI.
+ *
+ * <p>This port gives higher layers one minimal hook to ensure the daemon-side completion-tracking
+ * machinery is active for the selected queue side. The HTTP layer does not need to know how
+ * completion callbacks are registered, how completed identifiers are persisted and replayed, or how
+ * completion alerts are emitted; it only requests that the runtime start that tracking when needed.
+ *
+ * <p>The operation must be idempotent per queue side. Calling {@link
+ * #ensureTrackingStarted(boolean)} repeatedly for downloads or uploads must not register duplicate
+ * callbacks or repeat one-time recovery work for that side.
+ */
+public interface QueueCompletionPort {
+  /**
+   * Ensures completion tracking has been started for the selected queue side.
+   *
+   * <p>The operation is idempotent per side. Repeated calls for the same side must not register
+   * duplicate callbacks or duplicate recovery work.
+   *
+   * @param uploads {@code true} to start upload-side tracking, {@code false} for download-side
+   *     tracking
+   */
+  void ensureTrackingStarted(boolean uploads);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -25,6 +25,7 @@ package network.crypta.runtime.spi;
  * @see DarknetConnectionsPort
  * @see DarknetMessagingPort
  * @see DiagnosticPort
+ * @see QueueCompletionPort
  * @see QueuePagePort
  * @see QueueDownloadPort
  * @see QueueMutationPort
@@ -181,6 +182,17 @@ public interface RuntimePorts {
    * @return queue support port for backend enablement, persistence state, and panic actions
    */
   QueueSupportPort queueSupport();
+
+  /**
+   * Returns the legacy queue-completion tracking capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining completion callback registration, persisted completed-request
+   * recovery, and completion alert registration inside the daemon root module while exposing only a
+   * minimal idempotent startup hook upstream.
+   *
+   * @return queue-completion runtime port for per-side completion-tracker startup
+   */
+  QueueCompletionPort queueCompletion();
 
   /**
    * Returns the legacy queue-page read capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -141,8 +141,6 @@ final class FProxyRegistrar {
 
     QueueToadlet downloadToadlet =
         new QueueToadlet(
-            core,
-            core.getEndpoints().getFCPServer(),
             client,
             false,
             new QueueToadletRuntimePorts(
@@ -152,6 +150,7 @@ final class FProxyRegistrar {
                 runtimePorts.queueInsert(),
                 runtimePorts.queueMutation(),
                 runtimePorts.queueSupport(),
+                runtimePorts.queueCompletion(),
                 runtimePorts.darknetConnections(),
                 runtimePorts.darknetMessaging()));
     server.register(
@@ -171,8 +170,6 @@ final class FProxyRegistrar {
         ToadletRegistration.basic(null, localDownloadDirectoryToadlet.path(), true, false));
     QueueToadlet uploadToadlet =
         new QueueToadlet(
-            core,
-            core.getEndpoints().getFCPServer(),
             client,
             true,
             new QueueToadletRuntimePorts(
@@ -182,6 +179,7 @@ final class FProxyRegistrar {
                 runtimePorts.queueInsert(),
                 runtimePorts.queueMutation(),
                 runtimePorts.queueSupport(),
+                runtimePorts.queueCompletion(),
                 runtimePorts.darknetConnections(),
                 runtimePorts.darknetMessaging()));
     server.register(

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -1,48 +1,22 @@
 package network.crypta.clients.http;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext.CompatibilityMode;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
 import network.crypta.client.events.SplitfileProgressCounts;
-import network.crypta.clients.fcp.ClientGet;
 import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
-import network.crypta.clients.fcp.ClientPut;
-import network.crypta.clients.fcp.ClientPutDir;
-import network.crypta.clients.fcp.ClientRequest;
-import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.NotAllowedException;
-import network.crypta.clients.fcp.RequestCompletionCallback;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.useralerts.StoringUserEvent;
-import network.crypta.node.useralerts.UserAlert;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -70,12 +44,10 @@ import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
-import network.crypta.support.SizeUtil;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.api.HTTPUploadedFile;
 import network.crypta.support.io.FileUtil;
-import network.crypta.support.io.NativeThread;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,25 +55,22 @@ import org.slf4j.LoggerFactory;
 /**
  * Presents and mutates the FProxy request queues for both downloads and uploads.
  *
- * <p>This toadlet serves queue HTML pages, processes form submissions for starting, stopping,
- * deleting, or restarting requests, and emits user alerts when completed transfers need attention.
- * It coordinates with the {@link network.crypta.clients.fcp.FCPServer} to get live request state,
- * persists completed identifiers so notifications survive restarts, and delegates file-browsing
- * workflows to the dedicated local toadlets. Instances are bound either to the download or upload
- * queue and reuse shared rendering helpers that build tables, progress cells, and bulk action
- * forms.
+ * <p>This toadlet serves queue HTML pages and processes form submissions for starting, stopping,
+ * deleting, or restarting requests. Live queue reads, mutations, creation paths, support checks,
+ * and completion-tracker startup are delegated to runtime ports, while the HTTP layer retains only
+ * request parsing, response rendering, and request-context-only placeholders such as alert
+ * summaries and form passwords. Instances are bound either to the download or upload queue and
+ * reuse shared rendering helpers that build tables, progress cells, and bulk action forms.
  *
- * <p>The class is stateful and not thread-safe; it caches completed identifiers and keeps
- * per-request bookkeeping to avoid double-signaling events. The HTTP server invokes all
- * request-handling entry points on the same thread that processes the incoming toadlet request;
- * longer-running operations are kept minimal to avoid blocking the request pipeline. Callers should
- * therefore avoid expensive per-request work and rely on the existing asynchronous FCP callbacks to
- * feed fresh status.
+ * <p>The class keeps only a lightweight HTTP-facing state: the selected queue side, the optional
+ * file-insert wizard link, and the runtime-port bundle used by request handlers. The HTTP server
+ * invokes all request-handling entry points on the thread that processes the incoming request, so
+ * the toadlet avoids heavyweight daemon work directly and hands that off through the runtime SPI.
  *
  * <ul>
  *   <li>Renders queue pages with sortable columns and per-item actions.
  *   <li>Enforces public-gateway restrictions before mutating queue state.
- *   <li>Persists completion alerts per queue side to survive restarts.
+ *   <li>Ensures queue completion tracking has been started for the selected side.
  *   <li>Provides utility helpers used by other UI components, such as progress cells.
  * </ul>
  *
@@ -140,8 +109,6 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private static final String CMODE_LABEL = ", cmode=";
   private static final String OVERRIDE_SPLITFILE_KEY_LABEL = ", overrideSplitfileKey=";
 
-  private final NodeClientCore core;
-  final FCPServer fcp;
   private final QueuePagePort queuePagePort;
   private final TransferAccessPort transferAccessPort;
   private final QueueDownloadPort queueDownloadPort;
@@ -193,37 +160,25 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private static final String SORT_BY = "sortBy";
   private static final String UNKNOWN = "unknown";
   private static final String CSS_WIDTH_PREFIX = "width: ";
-  private static final String COMPLETED_LIST_PREFIX = "completed.list.";
   private static final String QUEUE_TOADLET_PREFIX = "QueueToadlet.";
-  private static final String USER_ALERT_HIDE = "UserAlert.hide";
 
   /**
    * Creates a queue toadlet bound to either the upload or download side of the node.
    *
-   * <p>The instance immediately registers itself as an FCP completion callback, loads any persisted
-   * completion identifiers, and retains references to the networking core and HTTP client used for
-   * serving pages. Construction performs no heavyweight work beyond setup and persistence reads, so
-   * it is safe to create during HTTP server initialization. The {@code uploads} flag permanently
-   * selects which queue this instance renders and which operations it allows; callers should create
-   * one instance per queue side.
+   * <p>The instance immediately ensures daemon-side completion tracking is active for the selected
+   * queue side and retains the detached runtime ports needed by the legacy HTTP handlers.
+   * Construction performs no heavyweight queue traversal in the HTTP layer, so it is safe to create
+   * during HTTP server initialization. The {@code uploads} flag permanently selects which queue
+   * this instance renders and which operations it allows; callers should create one instance per
+   * queue side.
    *
-   * @param core node client core for config, persistence, and permission checks.
-   * @param fcp FCP server used to read and mutate queue state.
    * @param client HTTP client used by {@link Toadlet} for replies and navigation.
    * @param uploads {@code true} for upload queues, {@code false} for download queues.
-   * @throws NullPointerException if {@code fcp} is {@code null}, mirroring existing constructor
-   *     guardrails.
+   * @param runtimePorts queue-specific runtime-port bundle used by the legacy HTTP handlers
    */
   public QueueToadlet(
-      NodeClientCore core,
-      FCPServer fcp,
-      HighLevelSimpleClient client,
-      boolean uploads,
-      QueueToadletRuntimePorts runtimePorts) {
-    requireFcpServer(fcp);
+      HighLevelSimpleClient client, boolean uploads, QueueToadletRuntimePorts runtimePorts) {
     super(client);
-    this.core = core;
-    this.fcp = fcp;
     QueueToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts);
     this.queuePagePort = ports.queuePagePort();
     this.transferAccessPort = ports.transferAccessPort();
@@ -235,17 +190,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     this.darknetMessagingPort = ports.darknetMessagingPort();
     this.uploads = uploads;
     this.postHandler = new QueuePostHandler();
-    QueueCompletionTracker completionTracker = new QueueCompletionTracker();
-    fcp.setCompletionCallback(completionTracker);
-    try {
-      completionTracker.loadCompletedIdentifiers();
-    } catch (PersistenceDisabledException _) {
-      // The user will know soon enoughUpdate Toadlet.java
-    }
-  }
-
-  private static void requireFcpServer(FCPServer fcp) {
-    if (fcp == null) throw new NullPointerException();
+    ports.queueCompletionPort().ensureTrackingStarted(uploads);
   }
 
   /**
@@ -2078,7 +2023,6 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   }
 
   private static final String DEFAULT_UPLOADS_SEGMENT = "uploads";
-  private static final String DEFAULT_DOWNLOADS_SEGMENT = "downloads";
 
   static final String PATH_UPLOADS =
       normalizePath(System.getProperty("queue.uploads.path", DEFAULT_UPLOADS_SEGMENT));
@@ -2108,514 +2052,5 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       normalized = normalized + '/';
     }
     return normalized;
-  }
-
-  /**
-   * Tracks completed requests, persists acknowledgements, and registers user alerts for finished
-   * transfers. Registered as the FCP completion callback for this toadlet.
-   */
-  private final class QueueCompletionTracker implements RequestCompletionCallback {
-    /** List of completed request identifiers which the user hasn't acknowledged yet. */
-    private final HashSet<String> completedRequestIdentifiers = new HashSet<>();
-
-    private final Map<String, GetCompletedEvent> completedGets = new LinkedHashMap<>();
-    private final Map<String, PutCompletedEvent> completedPuts = new LinkedHashMap<>();
-    private final Map<String, PutDirCompletedEvent> completedPutDirs = new LinkedHashMap<>();
-
-    @Override
-    public void notifyFailure(ClientRequest req) {
-      LOG.debug(
-          "Request {} failed; no further action registered in QueueToadlet", req.getIdentifier());
-    }
-
-    @Override
-    public void notifySuccess(ClientRequest req) {
-      if (uploads == req instanceof ClientGet) return;
-      synchronized (completedRequestIdentifiers) {
-        completedRequestIdentifiers.add(req.getIdentifier());
-      }
-      registerAlert(req); // should be safe here
-      saveCompletedIdentifiersOffThread();
-    }
-
-    private void saveCompletedIdentifiersOffThread() {
-      core.getNode()
-          .network()
-          .executor()
-          .execute(this::saveCompletedIdentifiers, "Save completed identifiers");
-    }
-
-    private void loadCompletedIdentifiers() throws PersistenceDisabledException {
-      String dl = uploads ? DEFAULT_UPLOADS_SEGMENT : DEFAULT_DOWNLOADS_SEGMENT;
-      File completedIdentifiersList = core.getNode().userDir().file(COMPLETED_LIST_PREFIX + dl);
-      File completedIdentifiersListNew =
-          core.getNode().userDir().file(COMPLETED_LIST_PREFIX + dl + ".bak");
-      File oldCompletedIdentifiersList = core.getNode().userDir().file("completed.list");
-      boolean migrated = false;
-      if (!readCompletedIdentifiers(completedIdentifiersList)) {
-        if (!readCompletedIdentifiers(completedIdentifiersListNew)) {
-          readCompletedIdentifiers(oldCompletedIdentifiersList);
-          migrated = true;
-        }
-      } else {
-        deleteIfExists(
-            oldCompletedIdentifiersList,
-            "legacy completed identifiers list " + oldCompletedIdentifiersList);
-      }
-      final boolean writeAnyway = migrated;
-      core.getClientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
-
-                @Override
-                public String toString() {
-                  return "QueueToadlet LoadCompletedIdentifiers";
-                }
-
-                @Override
-                public boolean run(ClientContext context) {
-                  String[] identifiers;
-                  boolean changed = writeAnyway;
-                  synchronized (completedRequestIdentifiers) {
-                    identifiers = completedRequestIdentifiers.toArray(new String[0]);
-                  }
-                  for (String identifier : identifiers) {
-                    ClientRequest req = fcp.getGlobalRequest(identifier);
-                    if (req == null || req instanceof ClientGet == uploads) {
-                      synchronized (completedRequestIdentifiers) {
-                        completedRequestIdentifiers.remove(identifier);
-                      }
-                      changed = true;
-                      continue;
-                    }
-                    registerAlert(req);
-                  }
-                  if (changed) saveCompletedIdentifiers();
-                  return false;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
-    }
-
-    private boolean readCompletedIdentifiers(File file) {
-      try (FileInputStream fis = new FileInputStream(file);
-          BufferedInputStream bis = new BufferedInputStream(fis);
-          InputStreamReader isr = new InputStreamReader(bis, StandardCharsets.UTF_8);
-          BufferedReader br = new BufferedReader(isr)) {
-        synchronized (completedRequestIdentifiers) {
-          completedRequestIdentifiers.clear();
-          while (true) {
-            String identifier = br.readLine();
-            if (identifier == null) return true;
-            completedRequestIdentifiers.add(identifier);
-          }
-        }
-      } catch (EOFException _) {
-        // Normal
-        return true;
-      } catch (FileNotFoundException _) {
-        // Normal
-        return false;
-      } catch (IOException _) {
-        LOG.error("Could not read completed identifiers list from {}", file);
-        return false;
-      }
-    }
-
-    private void saveCompletedIdentifiers() {
-      String dl = uploads ? DEFAULT_UPLOADS_SEGMENT : DEFAULT_DOWNLOADS_SEGMENT;
-      File completedIdentifiersList = core.getNode().userDir().file(COMPLETED_LIST_PREFIX + dl);
-      File completedIdentifiersListNew =
-          core.getNode().userDir().file(COMPLETED_LIST_PREFIX + dl + ".bak");
-      File temp = createTemporaryCompletedListFile();
-      if (temp == null) {
-        return;
-      }
-      if (!writeCompletedIdentifiers(temp)) {
-        return;
-      }
-      replaceCompletedListFiles(completedIdentifiersList, completedIdentifiersListNew, temp);
-    }
-
-    private File createTemporaryCompletedListFile() {
-      try {
-        File temp = File.createTempFile("completed.list", ".tmp", core.getNode().getUserDir());
-        temp.deleteOnExit();
-        return temp;
-      } catch (IOException e) {
-        LOG.error(
-            "Unable to create temporary completed requests list (node dir missing?): {}", e, e);
-        return null;
-      }
-    }
-
-    private boolean writeCompletedIdentifiers(File temp) {
-      try (FileOutputStream fos = new FileOutputStream(temp);
-          OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
-          BufferedWriter bw = new BufferedWriter(osw)) {
-        String[] identifiers;
-        synchronized (completedRequestIdentifiers) {
-          identifiers = completedRequestIdentifiers.toArray(new String[0]);
-        }
-        for (String identifier : identifiers) {
-          bw.write(identifier);
-          bw.write('\n');
-        }
-        return true;
-      } catch (FileNotFoundException e) {
-        LOG.error(
-            "Unable to open completed requests temp list for writing (node dir missing?): {}",
-            e,
-            e);
-        return false;
-      } catch (IOException e) {
-        LOG.error("Unable to save completed requests list: {}", e, e);
-        return false;
-      }
-    }
-
-    private void replaceCompletedListFiles(
-        File completedIdentifiersList, File completedIdentifiersListNew, File temp) {
-      deleteIfExists(
-          completedIdentifiersListNew,
-          "backup completed identifiers list " + completedIdentifiersListNew);
-      boolean renamedToBackup = temp.renameTo(completedIdentifiersListNew);
-      if (!renamedToBackup) {
-        LOG.error(
-            "Unable to move completed identifiers list temp {} to backup {}",
-            temp,
-            completedIdentifiersListNew);
-        return;
-      }
-      if (!completedIdentifiersListNew.renameTo(completedIdentifiersList)) {
-        deleteIfExists(
-            completedIdentifiersList,
-            "existing completed identifiers list " + completedIdentifiersList);
-        if (!completedIdentifiersListNew.renameTo(completedIdentifiersList)) {
-          LOG.error(
-              "Unable to move completed identifiers list backup {} to final {}",
-              completedIdentifiersListNew,
-              completedIdentifiersList);
-        }
-      }
-    }
-
-    private void deleteIfExists(File file, String description) {
-      if (file.exists()) {
-        try {
-          Files.delete(file.toPath());
-        } catch (IOException e) {
-          LOG.warn("Unable to delete {}", description, e);
-        }
-      }
-    }
-
-    private void registerAlert(ClientRequest req) {
-      final String identifier = req.getIdentifier();
-      if (LOG.isDebugEnabled()) LOG.debug("Registering alert for {}", identifier);
-      if (!req.hasFinished()) {
-        if (LOG.isDebugEnabled()) LOG.debug("Request hasn't finished: {} for {}", req, identifier);
-        return;
-      }
-      switch (req) {
-        case ClientGet get -> {
-          FreenetURI uri = get.getURI();
-          if (uri == null) {
-            LOG.error("No URI for finished GET request {}", req);
-            return;
-          }
-          long size = get.getDataSize();
-          GetCompletedEvent event = new GetCompletedEvent(identifier, uri, size);
-          synchronized (completedGets) {
-            completedGets.put(identifier, event);
-          }
-          core.getAlerts().register(event);
-        }
-        case ClientPut put -> {
-          FreenetURI uri = put.getFinalURI();
-          if (uri == null) {
-            LOG.error("No URI for finished PUT request {}", req);
-            return;
-          }
-          long size = put.getDataSize();
-          PutCompletedEvent event = new PutCompletedEvent(identifier, uri, size);
-          synchronized (completedPuts) {
-            completedPuts.put(identifier, event);
-          }
-          core.getAlerts().register(event);
-        }
-        case ClientPutDir dir -> {
-          FreenetURI uri = dir.getFinalURI();
-          if (uri == null) {
-            LOG.error("No URI for finished PUTDIR request {}", req);
-            return;
-          }
-          long size = dir.getTotalDataSize();
-          int files = dir.getNumberOfFiles();
-          PutDirCompletedEvent event = new PutDirCompletedEvent(identifier, uri, size, files);
-          synchronized (completedPutDirs) {
-            completedPutDirs.put(identifier, event);
-          }
-          core.getAlerts().register(event);
-        }
-        default -> {
-          // No extra bookkeeping needed for other request types.
-        }
-      }
-    }
-
-    @Override
-    public void onRemove(ClientRequest req) {
-      String identifier = req.getIdentifier();
-      synchronized (completedRequestIdentifiers) {
-        completedRequestIdentifiers.remove(identifier);
-      }
-      switch (req) {
-        case ClientGet _ -> {
-          synchronized (completedGets) {
-            completedGets.remove(identifier);
-          }
-        }
-        case ClientPut _ -> {
-          synchronized (completedPuts) {
-            completedPuts.remove(identifier);
-          }
-        }
-        case ClientPutDir _ -> {
-          synchronized (completedPutDirs) {
-            completedPutDirs.remove(identifier);
-          }
-        }
-        default -> {
-          // Nothing to remove for other request types.
-        }
-      }
-      saveCompletedIdentifiersOffThread();
-    }
-
-    private class GetCompletedEvent extends StoringUserEvent<GetCompletedEvent> {
-
-      private final String identifier;
-      private final FreenetURI uri;
-      private final long size;
-
-      public GetCompletedEvent(String identifier, FreenetURI uri, long size) {
-        super(
-            new UserEventDetails(
-                Type.GET_COMPLETED,
-                true,
-                null,
-                Body.of(null, null, null),
-                UserAlert.MINOR,
-                true,
-                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
-            completedGets);
-        this.identifier = identifier;
-        this.uri = uri;
-        this.size = size;
-      }
-
-      @Override
-      public void onDismiss() {
-        super.onDismiss();
-        saveCompletedIdentifiersOffThread();
-      }
-
-      @Override
-      public void onEventDismiss() {
-        synchronized (completedRequestIdentifiers) {
-          completedRequestIdentifiers.remove(identifier);
-        }
-      }
-
-      @Override
-      public HTMLNode getEventHTMLText() {
-        HTMLNode text = new HTMLNode("div");
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                text,
-                QUEUE_TOADLET_PREFIX + "downloadSucceeded",
-                new String[] {"link", "origlink", FILENAME, "size"},
-                new HTMLNode[] {
-                  HTMLNode.link("/" + uri.toASCIIString() + "?max-size=" + size),
-                  HTMLNode.link("/" + uri.toASCIIString()),
-                  HTMLNode.text(uri.getPreferredFilename()),
-                  HTMLNode.text(SizeUtil.formatSize(size))
-                });
-        return text;
-      }
-
-      @Override
-      public String getTitle() {
-        String title;
-        synchronized (events) {
-          if (events.size() == 1)
-            title = l10n("downloadSucceededTitle", FILENAME, uri.getPreferredFilename());
-          else title = l10n("downloadsSucceededTitle", "nr", Integer.toString(events.size()));
-        }
-        return title;
-      }
-
-      @Override
-      public String getShortText() {
-        return getTitle();
-      }
-
-      @Override
-      public String getEventText() {
-        return l10n("downloadSucceededTitle", FILENAME, uri.getPreferredFilename());
-      }
-    }
-
-    private class PutCompletedEvent extends StoringUserEvent<PutCompletedEvent> {
-
-      private final String identifier;
-      private final FreenetURI uri;
-      private final long size;
-
-      public PutCompletedEvent(String identifier, FreenetURI uri, long size) {
-        super(
-            new UserEventDetails(
-                Type.PUT_COMPLETED,
-                true,
-                null,
-                Body.of(null, null, null),
-                UserAlert.MINOR,
-                true,
-                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
-            completedPuts);
-        this.identifier = identifier;
-        this.uri = uri;
-        this.size = size;
-      }
-
-      @Override
-      public void onDismiss() {
-        super.onDismiss();
-        saveCompletedIdentifiersOffThread();
-      }
-
-      @Override
-      public void onEventDismiss() {
-        synchronized (completedRequestIdentifiers) {
-          completedRequestIdentifiers.remove(identifier);
-        }
-      }
-
-      @Override
-      public HTMLNode getEventHTMLText() {
-        HTMLNode text = new HTMLNode("div");
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                text,
-                QUEUE_TOADLET_PREFIX + "uploadSucceeded",
-                new String[] {"link", FILENAME, "size"},
-                new HTMLNode[] {
-                  HTMLNode.link("/" + uri.toASCIIString()),
-                  HTMLNode.text(uri.getPreferredFilename()),
-                  HTMLNode.text(SizeUtil.formatSize(size))
-                });
-        return text;
-      }
-
-      @Override
-      public String getTitle() {
-        String title;
-        synchronized (events) {
-          if (events.size() == 1)
-            title = l10n("uploadSucceededTitle", FILENAME, uri.getPreferredFilename());
-          else title = l10n("uploadsSucceededTitle", "nr", Integer.toString(events.size()));
-        }
-        return title;
-      }
-
-      @Override
-      public String getShortText() {
-        return getTitle();
-      }
-
-      @Override
-      public String getEventText() {
-        return l10n("uploadSucceededTitle", FILENAME, uri.getPreferredFilename());
-      }
-    }
-
-    private class PutDirCompletedEvent extends StoringUserEvent<PutDirCompletedEvent> {
-
-      private final String identifier;
-      private final FreenetURI uri;
-      private final long size;
-      private final int files;
-
-      public PutDirCompletedEvent(String identifier, FreenetURI uri, long size, int files) {
-        super(
-            new UserEventDetails(
-                Type.PUT_DIR_COMPLETED,
-                true,
-                null,
-                Body.of(null, null, null),
-                UserAlert.MINOR,
-                true,
-                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
-            completedPutDirs);
-        this.identifier = identifier;
-        this.uri = uri;
-        this.size = size;
-        this.files = files;
-      }
-
-      @Override
-      public void onDismiss() {
-        super.onDismiss();
-        saveCompletedIdentifiersOffThread();
-      }
-
-      @Override
-      public void onEventDismiss() {
-        synchronized (completedRequestIdentifiers) {
-          completedRequestIdentifiers.remove(identifier);
-        }
-      }
-
-      @Override
-      public HTMLNode getEventHTMLText() {
-        String name = uri.getPreferredFilename();
-        HTMLNode text = new HTMLNode("div");
-        NodeL10n.getBase()
-            .addL10nSubstitution(
-                text,
-                QUEUE_TOADLET_PREFIX + "siteUploadSucceeded",
-                new String[] {"link", FILENAME, "size", "files"},
-                new HTMLNode[] {
-                  HTMLNode.link("/" + uri.toASCIIString()),
-                  HTMLNode.text(name),
-                  HTMLNode.text(SizeUtil.formatSize(size)),
-                  HTMLNode.text(files)
-                });
-        return text;
-      }
-
-      @Override
-      public String getTitle() {
-        String title;
-        synchronized (events) {
-          if (events.size() == 1)
-            title = l10n("siteUploadSucceededTitle", FILENAME, uri.getPreferredFilename());
-          else title = l10n("sitesUploadSucceededTitle", "nr", Integer.toString(events.size()));
-        }
-        return title;
-      }
-
-      @Override
-      public String getShortText() {
-        return getTitle();
-      }
-
-      @Override
-      public String getEventText() {
-        return l10n("siteUploadSucceededTitle", FILENAME, uri.getPreferredFilename());
-      }
-    }
   }
 }

--- a/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http;
 import java.util.Objects;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -34,6 +35,8 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * @param queueMutationPort detached queue-mutation port
  * @param queueSupportPort detached queue-support port used for backend enablement, persistence
  *     state, and panic actions
+ * @param queueCompletionPort detached queue-completion port used for per-side completion-tracker
+ *     startup
  * @param darknetConnectionsPort detached darknet friends-page companion port used by queue
  *     recommendation rendering
  * @param darknetMessagingPort detached darknet messaging port used by queue recommendation sends
@@ -45,6 +48,7 @@ public record QueueToadletRuntimePorts(
     QueueInsertPort queueInsertPort,
     QueueMutationPort queueMutationPort,
     QueueSupportPort queueSupportPort,
+    QueueCompletionPort queueCompletionPort,
     DarknetConnectionsPort darknetConnectionsPort,
     DarknetMessagingPort darknetMessagingPort) {
   /**
@@ -60,6 +64,8 @@ public record QueueToadletRuntimePorts(
    *     toadlets
    * @param queueSupportPort detached queue-support port shared by the download and upload toadlets
    *     for backend enablement, persistence state, and panic actions
+   * @param queueCompletionPort detached queue-completion port shared by the download and upload
+   *     toadlets for per-side completion-tracker startup
    * @param darknetConnectionsPort detached darknet friends-page companion port shared by the
    *     download and upload toadlets for queue recommendation rendering
    * @param darknetMessagingPort detached darknet messaging port shared by the download and upload
@@ -73,6 +79,7 @@ public record QueueToadletRuntimePorts(
     Objects.requireNonNull(queueInsertPort);
     Objects.requireNonNull(queueMutationPort);
     Objects.requireNonNull(queueSupportPort);
+    Objects.requireNonNull(queueCompletionPort);
     Objects.requireNonNull(darknetConnectionsPort);
     Objects.requireNonNull(darknetMessagingPort);
   }

--- a/src/main/java/network/crypta/node/runtime/LegacyQueueCompletionPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyQueueCompletionPort.java
@@ -1,0 +1,639 @@
+package network.crypta.node.runtime;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.clients.fcp.ClientGet;
+import network.crypta.clients.fcp.ClientPut;
+import network.crypta.clients.fcp.ClientPutDir;
+import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.RequestCompletionCallback;
+import network.crypta.keys.FreenetURI;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.useralerts.StoringUserEvent;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserEvent;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.SizeUtil;
+import network.crypta.support.io.NativeThread;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Legacy daemon-backed implementation of the queue-completion runtime SPI.
+ *
+ * <p>This adapter keeps the remaining queue completion-tracking behavior inside the daemon root
+ * module: FCP completion callback registration, completed-request persistence and recovery, and
+ * completion user-alert registration. The HTTP layer only asks the adapter to ensure tracking is
+ * active for one queue side and no longer depends directly on daemon-owned queue or alert types.
+ *
+ * <p>Tracking startup is idempotent per side. Repeated calls for downloads or uploads must not
+ * register duplicate callbacks or repeat recovery work for that side, but downloads and uploads
+ * still keep separate persisted identifier sets and alert collections exactly as before.
+ */
+public final class LegacyQueueCompletionPort implements QueueCompletionPort {
+  private static final Logger LOG = LoggerFactory.getLogger(LegacyQueueCompletionPort.class);
+
+  private static final String COMPLETED_LIST_PREFIX = "completed.list.";
+  private static final String LEGACY_COMPLETED_LIST = "completed.list";
+  private static final String DOWNLOADS_SEGMENT = "downloads";
+  private static final String UPLOADS_SEGMENT = "uploads";
+  private static final String QUEUE_TOADLET_PREFIX = "QueueToadlet.";
+  private static final String USER_ALERT_HIDE = "UserAlert.hide";
+  private static final String FILENAME_L10N_KEY = "filename";
+
+  private final NodeClientCore core;
+  private final Object trackingLock = new Object();
+
+  private QueueCompletionTracker downloadTracker;
+  private QueueCompletionTracker uploadTracker;
+
+  /**
+   * Creates a queue-completion adapter backed by the supplied client core.
+   *
+   * <p>The adapter resolves the live {@link FCPServer} lazily from the endpoint wiring when
+   * tracking is started or replay runs. Construction itself, therefore, does not force early FCP
+   * server access during startup.
+   *
+   * @param core live daemon client core that owns the endpoint registry, alerts, and persistence
+   *     infrastructure
+   */
+  public LegacyQueueCompletionPort(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  @Override
+  public void ensureTrackingStarted(boolean uploads) {
+    synchronized (trackingLock) {
+      if (trackerFor(uploads) != null) {
+        return;
+      }
+
+      QueueCompletionTracker tracker = new QueueCompletionTracker(uploads);
+      fcpServer().setCompletionCallback(tracker);
+      if (uploads) {
+        uploadTracker = tracker;
+      } else {
+        downloadTracker = tracker;
+      }
+      try {
+        tracker.loadCompletedIdentifiers();
+      } catch (PersistenceDisabledException _) {
+        // Preserve the legacy tolerance during startup recovery.
+      }
+    }
+  }
+
+  private QueueCompletionTracker trackerFor(boolean uploads) {
+    return uploads ? uploadTracker : downloadTracker;
+  }
+
+  private FCPServer fcpServer() {
+    FCPServer fcpServer = core.getEndpoints().getFCPServer();
+    if (fcpServer == null) {
+      throw new IllegalStateException("FCP server unavailable");
+    }
+    return fcpServer;
+  }
+
+  private final class QueueCompletionTracker implements RequestCompletionCallback {
+    private final boolean uploads;
+    private final HashSet<String> completedRequestIdentifiers = new HashSet<>();
+    private final Map<String, GetCompletedEvent> completedGets = new LinkedHashMap<>();
+    private final Map<String, PutCompletedEvent> completedPuts = new LinkedHashMap<>();
+    private final Map<String, PutDirCompletedEvent> completedPutDirs = new LinkedHashMap<>();
+
+    private QueueCompletionTracker(boolean uploads) {
+      this.uploads = uploads;
+    }
+
+    @Override
+    public void notifyFailure(ClientRequest req) {
+      LOG.debug(
+          "Request {} failed; no further action registered in QueueToadlet", req.getIdentifier());
+    }
+
+    @Override
+    public void notifySuccess(ClientRequest req) {
+      if (uploads == req instanceof ClientGet) {
+        return;
+      }
+      synchronized (completedRequestIdentifiers) {
+        completedRequestIdentifiers.add(req.getIdentifier());
+      }
+      registerAlert(req);
+      saveCompletedIdentifiersOffThread();
+    }
+
+    @Override
+    public void onRemove(ClientRequest req) {
+      String identifier = req.getIdentifier();
+      synchronized (completedRequestIdentifiers) {
+        completedRequestIdentifiers.remove(identifier);
+      }
+      switch (req) {
+        case ClientGet _ -> {
+          synchronized (completedGets) {
+            completedGets.remove(identifier);
+          }
+        }
+        case ClientPut _ -> {
+          synchronized (completedPuts) {
+            completedPuts.remove(identifier);
+          }
+        }
+        case ClientPutDir _ -> {
+          synchronized (completedPutDirs) {
+            completedPutDirs.remove(identifier);
+          }
+        }
+        default -> {
+          // Nothing to remove for other request types.
+        }
+      }
+      saveCompletedIdentifiersOffThread();
+    }
+
+    private void saveCompletedIdentifiersOffThread() {
+      core.getNode()
+          .network()
+          .executor()
+          .execute(this::saveCompletedIdentifiers, "Save completed identifiers");
+    }
+
+    private void loadCompletedIdentifiers() throws PersistenceDisabledException {
+      File completedIdentifiersList = completedIdentifiersFile();
+      File completedIdentifiersListNew = completedIdentifiersBackupFile();
+      File oldCompletedIdentifiersList = core.getNode().userDir().file(LEGACY_COMPLETED_LIST);
+      boolean migrated = false;
+      if (!readCompletedIdentifiers(completedIdentifiersList)) {
+        if (!readCompletedIdentifiers(completedIdentifiersListNew)) {
+          readCompletedIdentifiers(oldCompletedIdentifiersList);
+          migrated = true;
+        }
+      } else {
+        deleteIfExists(
+            oldCompletedIdentifiersList,
+            "legacy completed identifiers list " + oldCompletedIdentifiersList);
+      }
+      final boolean writeAnyway = migrated;
+      core.getClientContext()
+          .jobRunner
+          .queue(
+              new PersistentJob() {
+
+                @Override
+                public String toString() {
+                  return "LegacyQueueCompletionPort LoadCompletedIdentifiers";
+                }
+
+                @Override
+                public boolean run(ClientContext context) {
+                  String[] identifiers;
+                  boolean changed = writeAnyway;
+                  synchronized (completedRequestIdentifiers) {
+                    identifiers = completedRequestIdentifiers.toArray(new String[0]);
+                  }
+                  for (String identifier : identifiers) {
+                    ClientRequest req = fcpServer().getGlobalRequest(identifier);
+                    if (req == null || req instanceof ClientGet == uploads) {
+                      synchronized (completedRequestIdentifiers) {
+                        completedRequestIdentifiers.remove(identifier);
+                      }
+                      changed = true;
+                      continue;
+                    }
+                    registerAlert(req);
+                  }
+                  if (changed) {
+                    saveCompletedIdentifiers();
+                  }
+                  return false;
+                }
+              },
+              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+    }
+
+    private boolean readCompletedIdentifiers(File file) {
+      try (FileInputStream fis = new FileInputStream(file);
+          BufferedInputStream bis = new BufferedInputStream(fis);
+          InputStreamReader isr = new InputStreamReader(bis, StandardCharsets.UTF_8);
+          BufferedReader br = new BufferedReader(isr)) {
+        synchronized (completedRequestIdentifiers) {
+          completedRequestIdentifiers.clear();
+          while (true) {
+            String identifier = br.readLine();
+            if (identifier == null) {
+              return true;
+            }
+            completedRequestIdentifiers.add(identifier);
+          }
+        }
+      } catch (EOFException _) {
+        return true;
+      } catch (FileNotFoundException _) {
+        return false;
+      } catch (IOException _) {
+        LOG.error("Could not read completed identifiers list from {}", file);
+        return false;
+      }
+    }
+
+    private void saveCompletedIdentifiers() {
+      File completedIdentifiersList = completedIdentifiersFile();
+      File completedIdentifiersListNew = completedIdentifiersBackupFile();
+      File temp = createTemporaryCompletedListFile();
+      if (temp == null) {
+        return;
+      }
+      if (!writeCompletedIdentifiers(temp)) {
+        return;
+      }
+      replaceCompletedListFiles(completedIdentifiersList, completedIdentifiersListNew, temp);
+    }
+
+    private File completedIdentifiersFile() {
+      return core.getNode().userDir().file(COMPLETED_LIST_PREFIX + queueSideSegment());
+    }
+
+    private File completedIdentifiersBackupFile() {
+      return core.getNode().userDir().file(COMPLETED_LIST_PREFIX + queueSideSegment() + ".bak");
+    }
+
+    private String queueSideSegment() {
+      return uploads ? UPLOADS_SEGMENT : DOWNLOADS_SEGMENT;
+    }
+
+    private File createTemporaryCompletedListFile() {
+      try {
+        File temp = File.createTempFile(LEGACY_COMPLETED_LIST, ".tmp", core.getNode().getUserDir());
+        temp.deleteOnExit();
+        return temp;
+      } catch (IOException e) {
+        LOG.error(
+            "Unable to create temporary completed requests list (node dir missing?): {}", e, e);
+        return null;
+      }
+    }
+
+    private boolean writeCompletedIdentifiers(File temp) {
+      try (FileOutputStream fos = new FileOutputStream(temp);
+          OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+          BufferedWriter bw = new BufferedWriter(osw)) {
+        String[] identifiers;
+        synchronized (completedRequestIdentifiers) {
+          identifiers = completedRequestIdentifiers.toArray(new String[0]);
+        }
+        for (String identifier : identifiers) {
+          bw.write(identifier);
+          bw.write('\n');
+        }
+        return true;
+      } catch (FileNotFoundException e) {
+        LOG.error(
+            "Unable to open completed requests temp list for writing (node dir missing?): {}",
+            e,
+            e);
+        return false;
+      } catch (IOException e) {
+        LOG.error("Unable to save completed requests list: {}", e, e);
+        return false;
+      }
+    }
+
+    private void replaceCompletedListFiles(
+        File completedIdentifiersList, File completedIdentifiersListNew, File temp) {
+      deleteIfExists(
+          completedIdentifiersListNew,
+          "backup completed identifiers list " + completedIdentifiersListNew);
+      boolean renamedToBackup = temp.renameTo(completedIdentifiersListNew);
+      if (!renamedToBackup) {
+        LOG.error(
+            "Unable to move completed identifiers list temp {} to backup {}",
+            temp,
+            completedIdentifiersListNew);
+        return;
+      }
+      if (!completedIdentifiersListNew.renameTo(completedIdentifiersList)) {
+        deleteIfExists(
+            completedIdentifiersList,
+            "existing completed identifiers list " + completedIdentifiersList);
+        if (!completedIdentifiersListNew.renameTo(completedIdentifiersList)) {
+          LOG.error(
+              "Unable to move completed identifiers list backup {} to final {}",
+              completedIdentifiersListNew,
+              completedIdentifiersList);
+        }
+      }
+    }
+
+    private void deleteIfExists(File file, String description) {
+      if (file.exists()) {
+        try {
+          Files.delete(file.toPath());
+        } catch (IOException e) {
+          LOG.warn("Unable to delete {}", description, e);
+        }
+      }
+    }
+
+    private void registerAlert(ClientRequest req) {
+      String identifier = req.getIdentifier();
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Registering alert for {}", identifier);
+      }
+      if (!req.hasFinished()) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Request hasn't finished: {} for {}", req, identifier);
+        }
+        return;
+      }
+      switch (req) {
+        case ClientGet get -> {
+          FreenetURI uri = get.getURI();
+          if (uri == null) {
+            LOG.error("No URI for finished GET request {}", req);
+            return;
+          }
+          long size = get.getDataSize();
+          GetCompletedEvent event = new GetCompletedEvent(identifier, uri, size);
+          synchronized (completedGets) {
+            completedGets.put(identifier, event);
+          }
+          core.getAlerts().register(event);
+        }
+        case ClientPut put -> {
+          FreenetURI uri = put.getFinalURI();
+          if (uri == null) {
+            LOG.error("No URI for finished PUT request {}", req);
+            return;
+          }
+          long size = put.getDataSize();
+          PutCompletedEvent event = new PutCompletedEvent(identifier, uri, size);
+          synchronized (completedPuts) {
+            completedPuts.put(identifier, event);
+          }
+          core.getAlerts().register(event);
+        }
+        case ClientPutDir dir -> {
+          FreenetURI uri = dir.getFinalURI();
+          if (uri == null) {
+            LOG.error("No URI for finished PUTDIR request {}", req);
+            return;
+          }
+          long size = dir.getTotalDataSize();
+          int files = dir.getNumberOfFiles();
+          PutDirCompletedEvent event = new PutDirCompletedEvent(identifier, uri, size, files);
+          synchronized (completedPutDirs) {
+            completedPutDirs.put(identifier, event);
+          }
+          core.getAlerts().register(event);
+        }
+        default -> {
+          // No extra bookkeeping needed for other request types.
+        }
+      }
+    }
+
+    private final class GetCompletedEvent extends StoringUserEvent<GetCompletedEvent> {
+      private final String identifier;
+      private final FreenetURI uri;
+      private final long size;
+
+      private GetCompletedEvent(String identifier, FreenetURI uri, long size) {
+        super(
+            new UserEventDetails(
+                UserEvent.Type.GET_COMPLETED,
+                true,
+                null,
+                Body.of(null, null, null),
+                UserAlert.MINOR,
+                true,
+                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
+            completedGets);
+        this.identifier = identifier;
+        this.uri = uri;
+        this.size = size;
+      }
+
+      @Override
+      public void onDismiss() {
+        super.onDismiss();
+        saveCompletedIdentifiersOffThread();
+      }
+
+      @Override
+      public void onEventDismiss() {
+        synchronized (completedRequestIdentifiers) {
+          completedRequestIdentifiers.remove(identifier);
+        }
+      }
+
+      @Override
+      public HTMLNode getEventHTMLText() {
+        HTMLNode text = new HTMLNode("div");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                text,
+                QUEUE_TOADLET_PREFIX + "downloadSucceeded",
+                new String[] {"link", "origlink", FILENAME_L10N_KEY, "size"},
+                new HTMLNode[] {
+                  HTMLNode.link("/" + uri.toASCIIString() + "?max-size=" + size),
+                  HTMLNode.link("/" + uri.toASCIIString()),
+                  HTMLNode.text(uri.getPreferredFilename()),
+                  HTMLNode.text(SizeUtil.formatSize(size))
+                });
+        return text;
+      }
+
+      @Override
+      public String getTitle() {
+        synchronized (events) {
+          if (events.size() == 1) {
+            return l10n("downloadSucceededTitle", FILENAME_L10N_KEY, uri.getPreferredFilename());
+          }
+          return l10n("downloadsSucceededTitle", "nr", Integer.toString(events.size()));
+        }
+      }
+
+      @Override
+      public String getShortText() {
+        return getTitle();
+      }
+
+      @Override
+      public String getEventText() {
+        return l10n("downloadSucceededTitle", FILENAME_L10N_KEY, uri.getPreferredFilename());
+      }
+    }
+
+    private final class PutCompletedEvent extends StoringUserEvent<PutCompletedEvent> {
+      private final String identifier;
+      private final FreenetURI uri;
+      private final long size;
+
+      private PutCompletedEvent(String identifier, FreenetURI uri, long size) {
+        super(
+            new UserEventDetails(
+                UserEvent.Type.PUT_COMPLETED,
+                true,
+                null,
+                Body.of(null, null, null),
+                UserAlert.MINOR,
+                true,
+                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
+            completedPuts);
+        this.identifier = identifier;
+        this.uri = uri;
+        this.size = size;
+      }
+
+      @Override
+      public void onDismiss() {
+        super.onDismiss();
+        saveCompletedIdentifiersOffThread();
+      }
+
+      @Override
+      public void onEventDismiss() {
+        synchronized (completedRequestIdentifiers) {
+          completedRequestIdentifiers.remove(identifier);
+        }
+      }
+
+      @Override
+      public HTMLNode getEventHTMLText() {
+        HTMLNode text = new HTMLNode("div");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                text,
+                QUEUE_TOADLET_PREFIX + "uploadSucceeded",
+                new String[] {"link", FILENAME_L10N_KEY, "size"},
+                new HTMLNode[] {
+                  HTMLNode.link("/" + uri.toASCIIString()),
+                  HTMLNode.text(uri.getPreferredFilename()),
+                  HTMLNode.text(SizeUtil.formatSize(size))
+                });
+        return text;
+      }
+
+      @Override
+      public String getTitle() {
+        synchronized (events) {
+          if (events.size() == 1) {
+            return l10n("uploadSucceededTitle", FILENAME_L10N_KEY, uri.getPreferredFilename());
+          }
+          return l10n("uploadsSucceededTitle", "nr", Integer.toString(events.size()));
+        }
+      }
+
+      @Override
+      public String getShortText() {
+        return getTitle();
+      }
+
+      @Override
+      public String getEventText() {
+        return l10n("uploadSucceededTitle", FILENAME_L10N_KEY, uri.getPreferredFilename());
+      }
+    }
+
+    private final class PutDirCompletedEvent extends StoringUserEvent<PutDirCompletedEvent> {
+      private final String identifier;
+      private final FreenetURI uri;
+      private final long size;
+      private final int files;
+
+      private PutDirCompletedEvent(String identifier, FreenetURI uri, long size, int files) {
+        super(
+            new UserEventDetails(
+                UserEvent.Type.PUT_DIR_COMPLETED,
+                true,
+                null,
+                Body.of(null, null, null),
+                UserAlert.MINOR,
+                true,
+                new DismissOptions(NodeL10n.getBase().getString(USER_ALERT_HIDE), true)),
+            completedPutDirs);
+        this.identifier = identifier;
+        this.uri = uri;
+        this.size = size;
+        this.files = files;
+      }
+
+      @Override
+      public void onDismiss() {
+        super.onDismiss();
+        saveCompletedIdentifiersOffThread();
+      }
+
+      @Override
+      public void onEventDismiss() {
+        synchronized (completedRequestIdentifiers) {
+          completedRequestIdentifiers.remove(identifier);
+        }
+      }
+
+      @Override
+      public HTMLNode getEventHTMLText() {
+        HTMLNode text = new HTMLNode("div");
+        NodeL10n.getBase()
+            .addL10nSubstitution(
+                text,
+                QUEUE_TOADLET_PREFIX + "siteUploadSucceeded",
+                new String[] {"link", FILENAME_L10N_KEY, "size", "files"},
+                new HTMLNode[] {
+                  HTMLNode.link("/" + uri.toASCIIString()),
+                  HTMLNode.text(uri.getPreferredFilename()),
+                  HTMLNode.text(SizeUtil.formatSize(size)),
+                  HTMLNode.text(files)
+                });
+        return text;
+      }
+
+      @Override
+      public String getTitle() {
+        synchronized (events) {
+          if (events.size() == 1) {
+            return l10n("siteUploadSucceededTitle", FILENAME_L10N_KEY, uri.getPreferredFilename());
+          }
+          return l10n("sitesUploadSucceededTitle", "nr", Integer.toString(events.size()));
+        }
+      }
+
+      @Override
+      public String getShortText() {
+        return getTitle();
+      }
+
+      @Override
+      public String getEventText() {
+        return l10n("siteUploadSucceededTitle", FILENAME_L10N_KEY, uri.getPreferredFilename());
+      }
+    }
+  }
+
+  private static String l10n(String key, String pattern, String value) {
+    return NodeL10n.getBase().getString(QUEUE_TOADLET_PREFIX + key, pattern, value);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -16,6 +16,7 @@ import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -56,6 +57,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DarknetConnectionsPort darknetConnectionsPort;
   private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
+  private final QueueCompletionPort queueCompletionPort;
   private final QueuePagePort queuePagePort;
   private final QueueDownloadPort queueDownloadPort;
   private final QueueInsertPort queueInsertPort;
@@ -158,6 +160,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.darknetConnectionsPort = new LegacyDarknetConnectionsPort(node);
     this.darknetMessagingPort = new LegacyDarknetMessagingPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
+    this.queueCompletionPort = new LegacyQueueCompletionPort(core);
     this.queuePagePort = new LegacyQueuePagePort(core);
     this.queueDownloadPort = new LegacyQueueDownloadPort(core);
     this.queueInsertPort = new LegacyQueueInsertPort(core);
@@ -304,6 +307,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public QueueSupportPort queueSupport() {
     return queueSupportPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps legacy queue-completion callback registration, persisted completed
+   * request recovery, and completion-alert registration inside the daemon root module while
+   * exposing only an idempotent startup hook upstream.
+   */
+  @Override
+  public QueueCompletionPort queueCompletion() {
+    return queueCompletionPort;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -1,0 +1,246 @@
+package network.crypta.clients.http;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import network.crypta.client.FetchContext;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.wizardsteps.BandwidthLimit;
+import network.crypta.config.Config;
+import network.crypta.config.Option;
+import network.crypta.config.SubConfig;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.ClientEndpoints;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.api.IntCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class FProxyRegistrarTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private NodeClientCore core;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private RuntimePorts runtimePorts;
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private FetchContext fetchContext;
+  @Mock private RandomSource randomSource;
+  @Mock private ClientEndpoints endpoints;
+  @Mock private QueueCompletionPort queueCompletionPort;
+  @Mock private SimpleToadletServer server;
+
+  private Config config;
+  private SubConfig nodeConfig;
+
+  @BeforeEach
+  void setUp() {
+    config = new Config();
+    nodeConfig = config.createSubConfig("node");
+    registerBandwidthOption(nodeConfig, "outputBandwidthLimit", 1024);
+    registerBandwidthOption(nodeConfig, "inputBandwidthLimit", 2048);
+    nodeConfig.finishedInitialization();
+
+    SubConfig alphaConfig = config.createSubConfig("alpha");
+    alphaConfig.finishedInitialization();
+    SubConfig securityLevelsConfig = config.createSubConfig("security-levels");
+    securityLevelsConfig.finishedInitialization();
+
+    when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
+    when(core.getRuntimePorts()).thenReturn(runtimePorts);
+    when(core.getRandom()).thenReturn(randomSource);
+    when(core.getClientContext())
+        .thenReturn(org.mockito.Mockito.mock(network.crypta.client.async.ClientContext.class));
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(client.getFetchContext()).thenReturn(fetchContext);
+    when(runtimePorts.queueCompletion()).thenReturn(queueCompletionPort);
+  }
+
+  @Test
+  void maybeCreateFProxyEtc_whenInvoked_registersMenusSetsFProxyAndStartsQueueCompletion() {
+    FProxyRegistrar.maybeCreateFProxyEtc(core, node, config, server);
+
+    ArgumentCaptor<byte[]> randomCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(randomSource).nextBytes(randomCaptor.capture());
+    assertSame(FProxyToadlet.random, randomCaptor.getValue());
+    assertEquals(32, randomCaptor.getValue().length);
+
+    ArgumentCaptor<FProxyToadlet> fproxyCaptor = ArgumentCaptor.forClass(FProxyToadlet.class);
+    verify(endpoints).setFProxy(fproxyCaptor.capture());
+    FProxyToadlet fproxyToadlet = fproxyCaptor.getValue();
+
+    verify(server)
+        .registerMenu("/", FProxyToadlet.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");
+    verify(server)
+        .registerMenu(
+            FProxyToadlet.DOWNLOADS_PATH,
+            FProxyToadlet.CATEGORY_QUEUE,
+            "FProxyToadlet.categoryTitleQueue");
+    verify(server)
+        .registerMenu(
+            FProxyToadlet.FRIENDS_PATH,
+            FProxyToadlet.CATEGORY_FRIENDS,
+            "FProxyToadlet.categoryTitleFriends");
+    verify(server)
+        .registerMenu("/chat/", "FProxyToadlet.categoryChat", "FProxyToadlet.categoryTitleChat");
+    verify(server)
+        .registerMenu(
+            "/alerts/", FProxyToadlet.CATEGORY_STATUS, "FProxyToadlet.categoryTitleStatus");
+    verify(server)
+        .registerMenu(
+            "/seclevels/", FProxyToadlet.CATEGORY_CONFIG, "FProxyToadlet.categoryTitleConfig");
+
+    InOrder queueCompletionOrder = inOrder(queueCompletionPort);
+    queueCompletionOrder.verify(queueCompletionPort).ensureTrackingStarted(false);
+    queueCompletionOrder.verify(queueCompletionPort).ensureTrackingStarted(true);
+
+    List<RegisteredToadlet> registrations = capturedRegistrations();
+    assertTrue(
+        registrations.stream()
+            .anyMatch(
+                registered ->
+                    registered.toadlet() == fproxyToadlet
+                        && "/".equals(registered.registration().urlPrefix())));
+    assertTrue(
+        registrations.stream()
+            .anyMatch(
+                registered ->
+                    QueueToadlet.PATH_DOWNLOADS.equals(registered.registration().urlPrefix())));
+    assertTrue(
+        registrations.stream()
+            .anyMatch(
+                registered ->
+                    QueueToadlet.PATH_UPLOADS.equals(registered.registration().urlPrefix())));
+    assertTrue(
+        registrations.stream()
+            .anyMatch(
+                registered ->
+                    FirstTimeWizardToadlet.TOADLET_URL.equals(
+                        registered.registration().urlPrefix())));
+  }
+
+  @Test
+  void maybeCreateFProxyEtc_whenSecurityLevelsSubconfigPresent_skipsSecurityLevelsConfigToadlet() {
+    FProxyRegistrar.maybeCreateFProxyEtc(core, node, config, server);
+
+    Set<String> configToadletPrefixes =
+        capturedRegistrations().stream()
+            .filter(registered -> registered.toadlet() instanceof ConfigToadlet)
+            .map(registered -> registered.registration().urlPrefix())
+            .collect(Collectors.toSet());
+
+    assertEquals(
+        Set.of(FProxyToadlet.CONFIG_PATH + "alpha", FProxyToadlet.CONFIG_PATH + "node"),
+        configToadletPrefixes);
+    assertFalse(configToadletPrefixes.contains(FProxyToadlet.CONFIG_PATH + "security-levels"));
+  }
+
+  @Test
+  void legacyCurrentBandwidthLimits_whenOutputBandwidthLimitIsDefault_returnsNull()
+      throws Exception {
+    BandwidthLimit bandwidthLimit = invokeLegacyCurrentBandwidthLimits(config, node);
+
+    assertNull(bandwidthLimit);
+  }
+
+  @Test
+  void legacyCurrentBandwidthLimits_whenOutputBandwidthLimitIsConfigured_returnsCurrentLimit()
+      throws Exception {
+    nodeConfig.set("outputBandwidthLimit", "8192");
+    when(node.network().inputBandwidthLimit()).thenReturn(2048);
+    when(node.network().outputBandwidthLimit()).thenReturn(4096);
+
+    BandwidthLimit bandwidthLimit = invokeLegacyCurrentBandwidthLimits(config, node);
+
+    assertNotNull(bandwidthLimit);
+    assertEquals(2048L, bandwidthLimit.downBytes);
+    assertEquals(4096L, bandwidthLimit.upBytes);
+    assertEquals("bandwidthCurrent", bandwidthLimit.descriptionKey);
+    assertFalse(bandwidthLimit.maybeDefault);
+  }
+
+  private static void registerBandwidthOption(
+      SubConfig subConfig, String optionName, int defaultValue) {
+    subConfig.register(optionName, defaultValue, optionMeta(), new MemoryIntCallback(defaultValue));
+  }
+
+  private static Option.Meta optionMeta() {
+    return new Option.Meta(0, false, false, "", "");
+  }
+
+  private BandwidthLimit invokeLegacyCurrentBandwidthLimits(Config config, Node node)
+      throws Exception {
+    Method method =
+        FProxyRegistrar.class.getDeclaredMethod(
+            "legacyCurrentBandwidthLimits", Config.class, Node.class);
+    method.setAccessible(true);
+    return (BandwidthLimit) method.invoke(null, config, node);
+  }
+
+  private List<RegisteredToadlet> capturedRegistrations() {
+    ArgumentCaptor<Toadlet> toadletCaptor = ArgumentCaptor.forClass(Toadlet.class);
+    ArgumentCaptor<ToadletRegistration> registrationCaptor =
+        ArgumentCaptor.forClass(ToadletRegistration.class);
+    verify(server, atLeastOnce()).register(toadletCaptor.capture(), registrationCaptor.capture());
+
+    List<RegisteredToadlet> registrations = new ArrayList<>();
+    List<Toadlet> toadlets = toadletCaptor.getAllValues();
+    List<ToadletRegistration> registrationValues = registrationCaptor.getAllValues();
+    for (int i = 0; i < toadlets.size(); i++) {
+      registrations.add(new RegisteredToadlet(toadlets.get(i), registrationValues.get(i)));
+    }
+    return registrations;
+  }
+
+  private static final class MemoryIntCallback extends IntCallback {
+    private int value;
+
+    private MemoryIntCallback(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public Integer get() {
+      return value;
+    }
+
+    @Override
+    public void set(Integer value) {
+      this.value = value;
+    }
+  }
+
+  private record RegisteredToadlet(Toadlet toadlet, ToadletRegistration registration) {}
+}

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
@@ -40,6 +40,7 @@ import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRejectedException;
 import network.crypta.runtime.spi.QueueDownloadRequest;
@@ -93,7 +94,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@SuppressWarnings("java:S100")
+@SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletPostDownloadTest {
 
   @Mock private HighLevelSimpleClient client;
@@ -104,6 +105,7 @@ class QueueToadletPostDownloadTest {
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueSupportPort queueSupportPort;
+  @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -367,8 +369,6 @@ class QueueToadletPostDownloadTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            core,
-            fcp,
             client,
             false,
             new QueueToadletRuntimePorts(
@@ -378,6 +378,7 @@ class QueueToadletPostDownloadTest {
                 queueInsertPort,
                 queueMutationPort,
                 queueSupportPort,
+                queueCompletionPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
@@ -39,6 +39,7 @@ import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
+import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertFailureReason;
 import network.crypta.runtime.spi.QueueInsertOutcome;
@@ -93,7 +94,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@SuppressWarnings("java:S100")
+@SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletPostInsertTest {
 
   @Mock private HighLevelSimpleClient client;
@@ -104,6 +105,7 @@ class QueueToadletPostInsertTest {
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueSupportPort queueSupportPort;
+  @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -372,8 +374,6 @@ class QueueToadletPostInsertTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            core,
-            fcp,
             client,
             true,
             new QueueToadletRuntimePorts(
@@ -383,6 +383,7 @@ class QueueToadletPostInsertTest {
                 queueInsertPort,
                 queueMutationPort,
                 queueSupportPort,
+                queueCompletionPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
@@ -37,6 +37,7 @@ import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -86,7 +87,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@SuppressWarnings("java:S100")
+@SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletPostMutationTest {
 
   @Mock private HighLevelSimpleClient client;
@@ -97,6 +98,7 @@ class QueueToadletPostMutationTest {
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueSupportPort queueSupportPort;
+  @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -342,8 +344,6 @@ class QueueToadletPostMutationTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            core,
-            fcp,
             client,
             uploads,
             new QueueToadletRuntimePorts(
@@ -353,6 +353,7 @@ class QueueToadletPostMutationTest {
                 queueInsertPort,
                 queueMutationPort,
                 queueSupportPort,
+                queueCompletionPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
@@ -41,6 +41,7 @@ import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -91,7 +92,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-@SuppressWarnings("java:S100")
+@SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletRecommendTest {
 
   @Mock private HighLevelSimpleClient client;
@@ -102,6 +103,7 @@ class QueueToadletRecommendTest {
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueSupportPort queueSupportPort;
+  @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
@@ -318,8 +320,6 @@ class QueueToadletRecommendTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            core,
-            fcp,
             client,
             false,
             new QueueToadletRuntimePorts(
@@ -329,6 +329,7 @@ class QueueToadletRecommendTest {
                 queueInsertPort,
                 queueMutationPort,
                 queueSupportPort,
+                queueCompletionPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -1,49 +1,14 @@
 package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
-import java.util.Random;
-import network.crypta.client.ArchiveManager;
-import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.client.InsertContext;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientContextDefaults;
-import network.crypta.client.async.ClientContextRafFactories;
-import network.crypta.client.async.ClientContextRuntime;
-import network.crypta.client.async.ClientContextServices;
-import network.crypta.client.async.ClientContextStorageFactories;
-import network.crypta.client.async.ClientLayerPersister;
-import network.crypta.client.async.DatastoreChecker;
-import network.crypta.client.async.HealingQueue;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.USKManager;
-import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.clients.fcp.ClientGet;
-import network.crypta.clients.fcp.ClientPut;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.PersistentRequestRoot;
-import network.crypta.clients.fcp.RequestCompletionCallback;
-import network.crypta.config.Config;
-import network.crypta.crypt.MasterSecret;
-import network.crypta.crypt.RandomSource;
-import network.crypta.keys.FreenetURI;
-import network.crypta.node.ClientContextResources;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.ProgramDirectory;
-import network.crypta.node.RequestStarterGroup;
-import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
-import network.crypta.node.useralerts.UserEvent;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.QueueMutationPort;
@@ -55,17 +20,7 @@ import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.MemoryLimitedJobRunner;
-import network.crypta.support.PriorityAwareExecutor;
-import network.crypta.support.Ticker;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.api.LockableRandomAccessBufferFactory;
-import network.crypta.support.compress.RealCompressor;
-import network.crypta.support.io.FileRandomAccessBufferFactory;
-import network.crypta.support.io.FilenameGenerator;
-import network.crypta.support.io.PersistentFileTracker;
-import network.crypta.support.io.PersistentTempBucketFactory;
-import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,11 +40,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -102,25 +55,22 @@ class QueueToadletTest {
   private static final String TEST_FORM_PASSWORD = "queue-form-password";
 
   @Mock private HighLevelSimpleClient client;
-  @Mock private FCPServer fcp;
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueSupportPort queueSupportPort;
+  @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private UserAlertManager alerts;
-  @Mock private PriorityAwareExecutor executor;
-  @Mock private ClientLayerPersister jobRunner;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
   @Mock private ToadletContainer container;
 
   @TempDir Path tempDir;
 
-  private RequestCompletionCallback completionCallback;
   private PageMaker pageMaker;
 
   @BeforeEach
@@ -144,98 +94,23 @@ class QueueToadletTest {
   }
 
   @Test
-  void constructor_whenInstantiated_setsCompletionCallbackAndQueuesLoadJob() throws Exception {
+  void constructor_whenInstantiated_startsQueueCompletionTrackingForSelectedSide() {
     // Arrange
     QueueToadlet toadlet = createQueueToadlet(false);
 
     // Assert
-    RequestCompletionCallback callback = getCompletionCallback();
-    verify(fcp).setCompletionCallback(callback);
-    verify(jobRunner, times(1)).queue(any(PersistentJob.class), anyInt());
+    verify(queueCompletionPort).ensureTrackingStarted(false);
     assertEquals(QueueToadlet.PATH_DOWNLOADS, toadlet.path());
   }
 
   @Test
-  void path_whenUploadsFlagTrue_returnsUploadsPath() throws Exception {
+  void path_whenUploadsFlagTrue_returnsUploadsPath() {
     // Arrange
     QueueToadlet toadlet = createQueueToadlet(true);
 
     // Assert
+    verify(queueCompletionPort).ensureTrackingStarted(true);
     assertEquals(QueueToadlet.PATH_UPLOADS, toadlet.path());
-  }
-
-  @Test
-  void notifySuccess_whenDownloadCompleted_recordsIdentifierAndRegistersAlert() throws Exception {
-    // Arrange
-    createQueueToadlet(false);
-    clearInvocations(executor, alerts, jobRunner);
-
-    ClientGet completedRequest = mock(ClientGet.class);
-    when(completedRequest.getIdentifier()).thenReturn("download-1");
-    when(completedRequest.hasFinished()).thenReturn(true);
-    when(completedRequest.getURI()).thenReturn(sampleUri());
-    when(completedRequest.getDataSize()).thenReturn(123L);
-
-    // Act
-    getCompletionCallback().notifySuccess(completedRequest);
-
-    // Assert
-    File completedList = tempDir.resolve("completed.list.downloads").toFile();
-    assertTrue(completedList.exists());
-    assertEquals("download-1\n", Files.readString(completedList.toPath()));
-
-    ArgumentCaptor<UserEvent> alertCaptor = ArgumentCaptor.forClass(UserEvent.class);
-    verify(alerts).register(alertCaptor.capture());
-    assertTrue(alertCaptor.getValue().getClass().getSimpleName().contains("GetCompletedEvent"));
-    verify(executor).execute(any(Runnable.class), anyString());
-  }
-
-  @Test
-  void notifySuccess_whenDirectionMismatch_doesNothing() throws Exception {
-    // Arrange
-    createQueueToadlet(false);
-    clearInvocations(executor, alerts);
-
-    ClientPut uploadRequest = mock(ClientPut.class);
-
-    // Act
-    getCompletionCallback().notifySuccess(uploadRequest);
-
-    // Assert
-    File completedList = tempDir.resolve("completed.list.downloads").toFile();
-    if (completedList.exists()) {
-      assertEquals(0, Files.size(completedList.toPath()));
-    }
-    verifyNoInteractions(alerts);
-    verify(executor, times(0)).execute(any(Runnable.class), anyString());
-  }
-
-  @Test
-  void onRemove_whenEntryExists_removesAndPersistsEmptyList() throws Exception {
-    // Arrange
-    createQueueToadlet(false);
-    clearInvocations(executor, alerts, jobRunner);
-
-    ClientGet completedRequest = mock(ClientGet.class);
-    when(completedRequest.getIdentifier()).thenReturn("download-2");
-    when(completedRequest.hasFinished()).thenReturn(true);
-    when(completedRequest.getURI()).thenReturn(sampleUri());
-    when(completedRequest.getDataSize()).thenReturn(500L);
-
-    getCompletionCallback().notifySuccess(completedRequest);
-    clearInvocations(executor, alerts);
-
-    // Act
-    getCompletionCallback().onRemove(completedRequest);
-
-    // Assert
-    File completedList = tempDir.resolve("completed.list.downloads").toFile();
-    assertTrue(completedList.exists());
-    assertEquals(0, Files.readAllBytes(completedList.toPath()).length);
-
-    Map<?, ?> completedGets = getCompletedGets();
-    assertFalse(completedGets.containsKey("download-2"));
-    verify(executor).execute(any(Runnable.class), anyString());
   }
 
   @Test
@@ -365,7 +240,6 @@ class QueueToadletTest {
       throws Exception {
     // Arrange
     QueueToadlet toadlet = createQueueToadlet(false);
-    when(fcp.isEnabled()).thenReturn(true);
     when(queueSupportPort.isQueueBackendEnabled()).thenReturn(false);
 
     ByteArrayOutputStream body = captureBody(ctx);
@@ -377,7 +251,6 @@ class QueueToadletTest {
     String html = body.toString(StandardCharsets.UTF_8);
     assertTrue(html.contains("You need to enable the FCP server to access this page"));
     verify(queueSupportPort).isQueueBackendEnabled();
-    verify(fcp, never()).isEnabled();
     verifyNoInteractions(queuePagePort);
   }
 
@@ -457,71 +330,9 @@ class QueueToadletTest {
     verify(queueSupportPort).persistenceStatus();
   }
 
-  private QueueToadlet createQueueToadlet(boolean uploads) throws Exception {
-    ProgramDirectory userDir = new ProgramDirectory();
-    userDir.move(tempDir.toString());
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    when(node.userDir()).thenReturn(userDir);
-    when(node.getUserDir()).thenReturn(userDir.dir());
-    when(node.awaitingPassword()).thenReturn(false);
-    when(node.isStopping()).thenReturn(false);
-    when(node.getDatabasePath()).thenReturn(tempDir.resolve("queue.db").toString());
-
-    RequestStarterGroup starters = mock(RequestStarterGroup.class);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getNode()).thenReturn(node);
-    when(core.getAlerts()).thenReturn(alerts);
-    when(core.getPersistentTempDir()).thenReturn(tempDir.toFile());
-
-    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.executor()).thenReturn(executor);
-
-    ClientContext context = createClientContext();
-    context.init(starters, alerts);
-    when(core.getClientContext()).thenReturn(context);
-
-    when(fcp.getGlobalRequest(anyString())).thenReturn(null);
-    doAnswer(
-            invocation -> {
-              completionCallback = invocation.getArgument(0);
-              return null;
-            })
-        .when(fcp)
-        .setCompletionCallback(any(RequestCompletionCallback.class));
-
-    doAnswer(
-            invocation -> {
-              PersistentJob job = invocation.getArgument(0);
-              job.run(null);
-              return null;
-            })
-        .when(jobRunner)
-        .queue(any(PersistentJob.class), anyInt());
-
-    doAnswer(
-            invocation -> {
-              Runnable runnable = invocation.getArgument(0);
-              runnable.run();
-              return null;
-            })
-        .when(executor)
-        .execute(any(Runnable.class), anyString());
-
-    doAnswer(
-            invocation -> {
-              Runnable runnable = invocation.getArgument(0);
-              runnable.run();
-              return null;
-            })
-        .when(executor)
-        .execute(any(Runnable.class));
-
+  private QueueToadlet createQueueToadlet(boolean uploads) {
     QueueToadlet toadlet =
         new QueueToadlet(
-            core,
-            fcp,
             client,
             uploads,
             new QueueToadletRuntimePorts(
@@ -531,87 +342,11 @@ class QueueToadletTest {
                 queueInsertPort,
                 queueMutationPort,
                 queueSupportPort,
+                queueCompletionPort,
                 darknetConnectionsPort,
                 darknetMessagingPort));
     toadlet.container = container;
     return toadlet;
-  }
-
-  private ClientContext createClientContext() {
-    ArchiveManager archiveManager = mock(ArchiveManager.class);
-    PersistentTempBucketFactory ptbf = mock(PersistentTempBucketFactory.class);
-    TempBucketFactory tbf = mock(TempBucketFactory.class);
-    PersistentFileTracker tracker = mock(PersistentFileTracker.class);
-    HealingQueue hq = mock(HealingQueue.class);
-    USKManager uskManager = mock(USKManager.class);
-    RandomSource strongRandom = mock(RandomSource.class);
-    Ticker ticker = mock(Ticker.class);
-    MemoryLimitedJobRunner memoryLimitedJobRunner = mock(MemoryLimitedJobRunner.class);
-    FilenameGenerator fg = mock(FilenameGenerator.class);
-    LockableRandomAccessBufferFactory rafFactory = mock(LockableRandomAccessBufferFactory.class);
-    LockableRandomAccessBufferFactory persistentRAFFactory =
-        mock(LockableRandomAccessBufferFactory.class);
-    FileRandomAccessBufferFactory fileRAFTransient = mock(FileRandomAccessBufferFactory.class);
-    FileRandomAccessBufferFactory fileRAFPersistent = mock(FileRandomAccessBufferFactory.class);
-    RealCompressor rc = mock(RealCompressor.class);
-    DatastoreChecker checker = mock(DatastoreChecker.class);
-    PersistentRequestRoot persistentRoot = mock(PersistentRequestRoot.class);
-    MasterSecret masterSecret = mock(MasterSecret.class);
-    LinkFilterExceptionProvider linkFilterExceptionProvider =
-        mock(LinkFilterExceptionProvider.class);
-    FetchContext fetchContext = mock(FetchContext.class);
-    InsertContext insertContext = mock(InsertContext.class);
-    Config config = mock(Config.class);
-
-    return new ClientContext(
-        1L,
-        new ClientContextRuntime(
-            jobRunner,
-            executor,
-            memoryLimitedJobRunner,
-            ticker,
-            strongRandom,
-            new Random(123),
-            masterSecret),
-        new ClientContextStorageFactories(
-            ptbf, tbf, tracker, fg, fg, fileRAFTransient, fileRAFPersistent),
-        new ClientContextRafFactories(rafFactory, persistentRAFFactory),
-        new ClientContextServices(
-            new ClientContextResources(archiveManager, hq),
-            uskManager,
-            rc,
-            checker,
-            persistentRoot,
-            linkFilterExceptionProvider),
-        new ClientContextDefaults(fetchContext, insertContext, config));
-  }
-
-  private FreenetURI sampleUri() {
-    try {
-      return new FreenetURI(
-          "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml");
-    } catch (MalformedURLException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private Map<String, ?> getCompletedGets() throws NoSuchFieldException, IllegalAccessException {
-    Object tracker = getCompletionTracker();
-    var field = tracker.getClass().getDeclaredField("completedGets");
-    field.setAccessible(true);
-    return (Map<String, ?>) field.get(tracker);
-  }
-
-  private RequestCompletionCallback getCompletionCallback() {
-    return (RequestCompletionCallback) getCompletionTracker();
-  }
-
-  private Object getCompletionTracker() {
-    if (completionCallback == null) {
-      throw new IllegalStateException("Completion callback was not captured.");
-    }
-    return completionCallback;
   }
 
   private PageMaker stubPageMaker(HTMLNode content) {

--- a/src/test/java/network/crypta/node/runtime/LegacyQueueCompletionPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyQueueCompletionPortTest.java
@@ -17,11 +17,13 @@ import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.HealingQueue;
+import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.USKManager;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.ClientGet;
 import network.crypta.clients.fcp.ClientPut;
+import network.crypta.clients.fcp.ClientPutDir;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.clients.fcp.RequestCompletionCallback;
@@ -57,15 +59,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -153,15 +161,48 @@ class LegacyQueueCompletionPortTest {
   }
 
   @Test
+  void ensureTrackingStarted_whenUploadsRequestedAfterDownloads_registersIndependentTracker()
+      throws Exception {
+    port.ensureTrackingStarted(false);
+    RequestCompletionCallback downloadCallback = completionCallback;
+
+    port.ensureTrackingStarted(true);
+
+    assertNotNull(completionCallback);
+    assertNotSame(downloadCallback, completionCallback);
+    verify(fcp, times(2)).setCompletionCallback(any(RequestCompletionCallback.class));
+    verify(jobRunner, times(2)).queue(any(PersistentJob.class), anyInt());
+  }
+
+  @Test
+  void ensureTrackingStarted_whenPersistenceDisabledDuringLoad_ignoresException() throws Exception {
+    doThrow(new PersistenceDisabledException())
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+
+    assertDoesNotThrow(() -> port.ensureTrackingStarted(false));
+
+    assertNotNull(completionCallback);
+    verify(fcp).setCompletionCallback(any(RequestCompletionCallback.class));
+    verify(jobRunner).queue(any(PersistentJob.class), anyInt());
+  }
+
+  @Test
+  void ensureTrackingStarted_whenFcpServerUnavailable_throwsIllegalStateException() {
+    when(endpoints.getFCPServer()).thenReturn(null);
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> port.ensureTrackingStarted(false));
+
+    assertEquals("FCP server unavailable", thrown.getMessage());
+  }
+
+  @Test
   void notifySuccess_whenDownloadCompleted_writesIdentifierAndRegistersAlert() throws Exception {
     port.ensureTrackingStarted(false);
     clearInvocations(executor, alerts);
 
-    ClientGet completedRequest = org.mockito.Mockito.mock(ClientGet.class);
-    when(completedRequest.getIdentifier()).thenReturn("download-1");
-    when(completedRequest.hasFinished()).thenReturn(true);
-    when(completedRequest.getURI()).thenReturn(sampleUri());
-    when(completedRequest.getDataSize()).thenReturn(123L);
+    ClientGet completedRequest = mockCompletedDownload("download-1", 123L);
 
     completionCallback.notifySuccess(completedRequest);
 
@@ -172,6 +213,24 @@ class LegacyQueueCompletionPortTest {
     ArgumentCaptor<UserEvent> alertCaptor = ArgumentCaptor.forClass(UserEvent.class);
     verify(alerts).register(alertCaptor.capture());
     assertTrue(alertCaptor.getValue().getClass().getSimpleName().contains("GetCompletedEvent"));
+    verify(executor).execute(any(Runnable.class), anyString());
+  }
+
+  @Test
+  void notifySuccess_whenDownloadNotFinished_persistsIdentifierWithoutRegisteringAlert()
+      throws Exception {
+    port.ensureTrackingStarted(false);
+    clearInvocations(executor, alerts);
+
+    ClientGet incompleteRequest = org.mockito.Mockito.mock(ClientGet.class);
+    when(incompleteRequest.getIdentifier()).thenReturn("download-pending");
+    when(incompleteRequest.hasFinished()).thenReturn(false);
+
+    completionCallback.notifySuccess(incompleteRequest);
+
+    assertEquals(
+        "download-pending\n", Files.readString(tempDir.resolve("completed.list.downloads")));
+    verifyNoInteractions(alerts);
     verify(executor).execute(any(Runnable.class), anyString());
   }
 
@@ -193,14 +252,63 @@ class LegacyQueueCompletionPortTest {
   }
 
   @Test
+  void notifySuccess_whenUploadCompleted_writesIdentifierAndRegistersUploadAlert()
+      throws Exception {
+    port.ensureTrackingStarted(true);
+    clearInvocations(executor, alerts);
+
+    ClientPut completedRequest = org.mockito.Mockito.mock(ClientPut.class);
+    when(completedRequest.getIdentifier()).thenReturn("upload-1");
+    when(completedRequest.hasFinished()).thenReturn(true);
+    when(completedRequest.getFinalURI()).thenReturn(sampleUri());
+    when(completedRequest.getDataSize()).thenReturn(456L);
+
+    completionCallback.notifySuccess(completedRequest);
+
+    assertEquals("upload-1\n", Files.readString(tempDir.resolve("completed.list.uploads")));
+    ArgumentCaptor<UserEvent> alertCaptor = ArgumentCaptor.forClass(UserEvent.class);
+    verify(alerts).register(alertCaptor.capture());
+    UserEvent alert = alertCaptor.getValue();
+    assertEquals(UserEvent.Type.PUT_COMPLETED, alert.getEventType());
+    assertTrue(alert.getTitle().contains(sampleUri().getPreferredFilename()));
+    assertTrue(alert.getHTMLText().generate().contains(sampleUri().getPreferredFilename()));
+    verify(executor).execute(any(Runnable.class), anyString());
+  }
+
+  @Test
+  void notifySuccess_whenDirectoryUploadDismissed_clearsIdentifierAndInvalidatesAlert()
+      throws Exception {
+    port.ensureTrackingStarted(true);
+    clearInvocations(executor, alerts);
+
+    ClientPutDir completedRequest = org.mockito.Mockito.mock(ClientPutDir.class);
+    when(completedRequest.getIdentifier()).thenReturn("site-1");
+    when(completedRequest.hasFinished()).thenReturn(true);
+    when(completedRequest.getFinalURI()).thenReturn(sampleUri());
+    when(completedRequest.getTotalDataSize()).thenReturn(789L);
+    when(completedRequest.getNumberOfFiles()).thenReturn(4);
+
+    completionCallback.notifySuccess(completedRequest);
+
+    ArgumentCaptor<UserEvent> alertCaptor = ArgumentCaptor.forClass(UserEvent.class);
+    verify(alerts).register(alertCaptor.capture());
+    UserEvent alert = alertCaptor.getValue();
+    assertEquals(UserEvent.Type.PUT_DIR_COMPLETED, alert.getEventType());
+    assertTrue(alert.getTitle().contains(sampleUri().getPreferredFilename()));
+
+    clearInvocations(executor);
+    alert.onDismiss();
+
+    assertEquals("", Files.readString(tempDir.resolve("completed.list.uploads")));
+    assertFalse(alert.isValid());
+    verify(executor).execute(any(Runnable.class), anyString());
+  }
+
+  @Test
   void onRemove_whenEntryExists_clearsIdentifierAndPersistsChange() throws Exception {
     port.ensureTrackingStarted(false);
 
-    ClientGet completedRequest = org.mockito.Mockito.mock(ClientGet.class);
-    when(completedRequest.getIdentifier()).thenReturn("download-2");
-    when(completedRequest.hasFinished()).thenReturn(true);
-    when(completedRequest.getURI()).thenReturn(sampleUri());
-    when(completedRequest.getDataSize()).thenReturn(500L);
+    ClientGet completedRequest = mockCompletedDownload("download-2", 500L);
 
     completionCallback.notifySuccess(completedRequest);
     clearInvocations(executor, alerts);
@@ -240,6 +348,45 @@ class LegacyQueueCompletionPortTest {
     verify(fcp).getGlobalRequest("download-stale");
     verify(fcp).getGlobalRequest("upload-wrong-side");
     verify(alerts).register(any(UserEvent.class));
+  }
+
+  @Test
+  void ensureTrackingStarted_whenLegacyCompletedListExists_migratesToSideSpecificFile()
+      throws Exception {
+    Files.writeString(tempDir.resolve("completed.list"), "download-legacy\n");
+    ClientGet replayedDownload = mockCompletedDownload("download-legacy", 654L);
+    when(fcp.getGlobalRequest("download-legacy")).thenReturn(replayedDownload);
+
+    port.ensureTrackingStarted(false);
+
+    assertEquals(
+        "download-legacy\n", Files.readString(tempDir.resolve("completed.list.downloads")));
+    verify(fcp).getGlobalRequest("download-legacy");
+    verify(alerts).register(any(UserEvent.class));
+  }
+
+  @Test
+  void ensureTrackingStarted_whenSideSpecificListExists_deletesLegacyCompletedList()
+      throws Exception {
+    Files.writeString(tempDir.resolve("completed.list.downloads"), "download-current\n");
+    Files.writeString(tempDir.resolve("completed.list"), "download-legacy\n");
+    ClientGet replayedDownload = mockCompletedDownload("download-current", 111L);
+    when(fcp.getGlobalRequest("download-current")).thenReturn(replayedDownload);
+
+    port.ensureTrackingStarted(false);
+
+    assertFalse(Files.exists(tempDir.resolve("completed.list")));
+    assertEquals(
+        "download-current\n", Files.readString(tempDir.resolve("completed.list.downloads")));
+  }
+
+  private ClientGet mockCompletedDownload(String identifier, long size) {
+    ClientGet completedRequest = org.mockito.Mockito.mock(ClientGet.class);
+    when(completedRequest.getIdentifier()).thenReturn(identifier);
+    when(completedRequest.hasFinished()).thenReturn(true);
+    when(completedRequest.getURI()).thenReturn(sampleUri());
+    when(completedRequest.getDataSize()).thenReturn(size);
+    return completedRequest;
   }
 
   private ClientContext createClientContext() {

--- a/src/test/java/network/crypta/node/runtime/LegacyQueueCompletionPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyQueueCompletionPortTest.java
@@ -1,0 +1,306 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.HealingQueue;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.USKManager;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.clients.fcp.ClientGet;
+import network.crypta.clients.fcp.ClientPut;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.clients.fcp.RequestCompletionCallback;
+import network.crypta.config.Config;
+import network.crypta.crypt.MasterSecret;
+import network.crypta.crypt.RandomSource;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.ClientContextResources;
+import network.crypta.node.ClientEndpoints;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.ProgramDirectory;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.node.useralerts.UserEvent;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class LegacyQueueCompletionPortTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private Node node;
+  @Mock private NodeNetworkSubsystem network;
+  @Mock private PriorityAwareExecutor executor;
+  @Mock private ClientLayerPersister jobRunner;
+  @Mock private ClientEndpoints endpoints;
+  @Mock private FCPServer fcp;
+  @Mock private UserAlertManager alerts;
+
+  @TempDir Path tempDir;
+
+  private ClientContext clientContext;
+  private RequestCompletionCallback completionCallback;
+  private LegacyQueueCompletionPort port;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ProgramDirectory userDir = new ProgramDirectory();
+    userDir.move(tempDir.toString());
+
+    clientContext = createClientContext();
+    when(core.getNode()).thenReturn(node);
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(core.getAlerts()).thenReturn(alerts);
+    when(node.userDir()).thenReturn(userDir);
+    when(node.getUserDir()).thenReturn(userDir.dir());
+    when(node.network()).thenReturn(network);
+    when(network.executor()).thenReturn(executor);
+    when(endpoints.getFCPServer()).thenReturn(fcp);
+
+    doAnswer(
+            invocation -> {
+              completionCallback = invocation.getArgument(0);
+              return null;
+            })
+        .when(fcp)
+        .setCompletionCallback(any(RequestCompletionCallback.class));
+    doAnswer(
+            invocation -> {
+              PersistentJob job = invocation.getArgument(0);
+              job.run(clientContext);
+              return null;
+            })
+        .when(jobRunner)
+        .queue(any(PersistentJob.class), anyInt());
+    doAnswer(
+            invocation -> {
+              Runnable task = invocation.getArgument(0);
+              task.run();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class), anyString());
+
+    port = new LegacyQueueCompletionPort(core);
+  }
+
+  @Test
+  void ensureTrackingStarted_whenDownloadsRequested_registersCallbackAndQueuesRecoveryWork()
+      throws Exception {
+    port.ensureTrackingStarted(false);
+
+    assertNotNull(completionCallback);
+    verify(fcp).setCompletionCallback(completionCallback);
+    verify(jobRunner).queue(any(PersistentJob.class), anyInt());
+  }
+
+  @Test
+  void ensureTrackingStarted_whenCalledTwiceForSameSide_isIdempotent() throws Exception {
+    port.ensureTrackingStarted(false);
+    port.ensureTrackingStarted(false);
+
+    verify(fcp).setCompletionCallback(any(RequestCompletionCallback.class));
+    verify(jobRunner).queue(any(PersistentJob.class), anyInt());
+  }
+
+  @Test
+  void notifySuccess_whenDownloadCompleted_writesIdentifierAndRegistersAlert() throws Exception {
+    port.ensureTrackingStarted(false);
+    clearInvocations(executor, alerts);
+
+    ClientGet completedRequest = org.mockito.Mockito.mock(ClientGet.class);
+    when(completedRequest.getIdentifier()).thenReturn("download-1");
+    when(completedRequest.hasFinished()).thenReturn(true);
+    when(completedRequest.getURI()).thenReturn(sampleUri());
+    when(completedRequest.getDataSize()).thenReturn(123L);
+
+    completionCallback.notifySuccess(completedRequest);
+
+    File completedList = tempDir.resolve("completed.list.downloads").toFile();
+    assertTrue(completedList.exists());
+    assertEquals("download-1\n", Files.readString(completedList.toPath()));
+
+    ArgumentCaptor<UserEvent> alertCaptor = ArgumentCaptor.forClass(UserEvent.class);
+    verify(alerts).register(alertCaptor.capture());
+    assertTrue(alertCaptor.getValue().getClass().getSimpleName().contains("GetCompletedEvent"));
+    verify(executor).execute(any(Runnable.class), anyString());
+  }
+
+  @Test
+  void notifySuccess_whenDirectionMismatch_ignoresRequest() throws Exception {
+    port.ensureTrackingStarted(false);
+    clearInvocations(executor, alerts);
+
+    ClientPut uploadRequest = org.mockito.Mockito.mock(ClientPut.class);
+
+    completionCallback.notifySuccess(uploadRequest);
+
+    File completedList = tempDir.resolve("completed.list.downloads").toFile();
+    if (completedList.exists()) {
+      assertEquals("", Files.readString(completedList.toPath()));
+    }
+    verifyNoInteractions(alerts);
+    verify(executor, never()).execute(any(Runnable.class), anyString());
+  }
+
+  @Test
+  void onRemove_whenEntryExists_clearsIdentifierAndPersistsChange() throws Exception {
+    port.ensureTrackingStarted(false);
+
+    ClientGet completedRequest = org.mockito.Mockito.mock(ClientGet.class);
+    when(completedRequest.getIdentifier()).thenReturn("download-2");
+    when(completedRequest.hasFinished()).thenReturn(true);
+    when(completedRequest.getURI()).thenReturn(sampleUri());
+    when(completedRequest.getDataSize()).thenReturn(500L);
+
+    completionCallback.notifySuccess(completedRequest);
+    clearInvocations(executor, alerts);
+
+    completionCallback.onRemove(completedRequest);
+
+    File completedList = tempDir.resolve("completed.list.downloads").toFile();
+    assertTrue(completedList.exists());
+    assertEquals("", Files.readString(completedList.toPath()));
+    verify(executor).execute(any(Runnable.class), anyString());
+  }
+
+  @Test
+  void ensureTrackingStarted_whenPersistedIdentifiersReplayed_cleansStaleEntries()
+      throws Exception {
+    Files.writeString(
+        tempDir.resolve("completed.list.downloads"),
+        "download-keep\ndownload-stale\nupload-wrong-side\n");
+
+    ClientGet replayedDownload = org.mockito.Mockito.mock(ClientGet.class);
+    when(replayedDownload.getIdentifier()).thenReturn("download-keep");
+    when(replayedDownload.hasFinished()).thenReturn(true);
+    when(replayedDownload.getURI()).thenReturn(sampleUri());
+    when(replayedDownload.getDataSize()).thenReturn(321L);
+
+    ClientPut wrongSideUpload = org.mockito.Mockito.mock(ClientPut.class);
+    when(wrongSideUpload.getIdentifier()).thenReturn("upload-wrong-side");
+
+    when(fcp.getGlobalRequest("download-keep")).thenReturn(replayedDownload);
+    when(fcp.getGlobalRequest("download-stale")).thenReturn(null);
+    when(fcp.getGlobalRequest("upload-wrong-side")).thenReturn(wrongSideUpload);
+
+    port.ensureTrackingStarted(false);
+
+    assertEquals("download-keep\n", Files.readString(tempDir.resolve("completed.list.downloads")));
+    verify(fcp).getGlobalRequest("download-keep");
+    verify(fcp).getGlobalRequest("download-stale");
+    verify(fcp).getGlobalRequest("upload-wrong-side");
+    verify(alerts).register(any(UserEvent.class));
+  }
+
+  private ClientContext createClientContext() {
+    ArchiveManager archiveManager = org.mockito.Mockito.mock(ArchiveManager.class);
+    PersistentTempBucketFactory ptbf = org.mockito.Mockito.mock(PersistentTempBucketFactory.class);
+    TempBucketFactory tbf = org.mockito.Mockito.mock(TempBucketFactory.class);
+    PersistentFileTracker tracker = org.mockito.Mockito.mock(PersistentFileTracker.class);
+    HealingQueue hq = org.mockito.Mockito.mock(HealingQueue.class);
+    USKManager uskManager = org.mockito.Mockito.mock(USKManager.class);
+    RandomSource strongRandom = org.mockito.Mockito.mock(RandomSource.class);
+    Ticker ticker = org.mockito.Mockito.mock(Ticker.class);
+    MemoryLimitedJobRunner memoryLimitedJobRunner =
+        org.mockito.Mockito.mock(MemoryLimitedJobRunner.class);
+    FilenameGenerator fg = org.mockito.Mockito.mock(FilenameGenerator.class);
+    LockableRandomAccessBufferFactory rafFactory =
+        org.mockito.Mockito.mock(LockableRandomAccessBufferFactory.class);
+    LockableRandomAccessBufferFactory persistentRafFactory =
+        org.mockito.Mockito.mock(LockableRandomAccessBufferFactory.class);
+    FileRandomAccessBufferFactory fileRafTransient =
+        org.mockito.Mockito.mock(FileRandomAccessBufferFactory.class);
+    FileRandomAccessBufferFactory fileRafPersistent =
+        org.mockito.Mockito.mock(FileRandomAccessBufferFactory.class);
+    RealCompressor rc = org.mockito.Mockito.mock(RealCompressor.class);
+    DatastoreChecker checker = org.mockito.Mockito.mock(DatastoreChecker.class);
+    PersistentRequestRoot persistentRoot = org.mockito.Mockito.mock(PersistentRequestRoot.class);
+    MasterSecret masterSecret = org.mockito.Mockito.mock(MasterSecret.class);
+    LinkFilterExceptionProvider linkFilterExceptionProvider =
+        org.mockito.Mockito.mock(LinkFilterExceptionProvider.class);
+    FetchContext fetchContext = org.mockito.Mockito.mock(FetchContext.class);
+    InsertContext insertContext = org.mockito.Mockito.mock(InsertContext.class);
+    Config config = org.mockito.Mockito.mock(Config.class);
+
+    return new ClientContext(
+        1L,
+        new ClientContextRuntime(
+            jobRunner,
+            executor,
+            memoryLimitedJobRunner,
+            ticker,
+            strongRandom,
+            new Random(123),
+            masterSecret),
+        new ClientContextStorageFactories(
+            ptbf, tbf, tracker, fg, fg, fileRafTransient, fileRafPersistent),
+        new ClientContextRafFactories(rafFactory, persistentRafFactory),
+        new ClientContextServices(
+            new ClientContextResources(archiveManager, hq),
+            uskManager,
+            rc,
+            checker,
+            persistentRoot,
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(fetchContext, insertContext, config));
+  }
+
+  private FreenetURI sampleUri() {
+    try {
+      return new FreenetURI(
+          "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml");
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
@@ -1,0 +1,224 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.util.Random;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.PriorityAwareExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class LegacyRuntimePortsTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private NodeClientCore core;
+
+  @Mock private PriorityAwareExecutor executor;
+  @Mock private RandomSource secureRandom;
+
+  private final Random weakRandom = new Random(1234L);
+  private final File downloadsDir = new File("downloads");
+  private final File persistentTempDir = new File("persistent");
+  private final File[] allowedUploadDirs = {new File("upload-a"), new File("upload-b")};
+  private final File[] allowedDownloadDirs = {new File("download-a"), new File("download-b")};
+
+  private LegacyRuntimePorts ports;
+
+  @BeforeEach
+  void setUp() {
+    when(node.network().executor()).thenReturn(executor);
+    when(node.bootstrap().random()).thenReturn(secureRandom);
+    when(node.bootstrap().fastWeakRandom()).thenReturn(weakRandom);
+    when(core.getDownloadsDir()).thenReturn(downloadsDir);
+    when(core.getPersistentTempDir()).thenReturn(persistentTempDir);
+    when(core.getAllowedUploadDirs()).thenReturn(allowedUploadDirs);
+    when(core.getAllowedDownloadDirs()).thenReturn(allowedDownloadDirs);
+
+    ports = new LegacyRuntimePorts(node, core);
+  }
+
+  @Test
+  void getters_whenRequested_expectStablePortReferences() {
+    PortsSnapshot snapshot = capturePorts();
+
+    assertAll(
+        () -> assertSame(snapshot.executionPort(), ports.execution()),
+        () -> assertSame(snapshot.randomnessPort(), ports.randomness()),
+        () -> assertSame(snapshot.transferAccessPort(), ports.transferAccess()),
+        () -> assertSame(snapshot.lifecyclePort(), ports.lifecycle()),
+        () -> assertSame(snapshot.configPort(), ports.config()),
+        () -> assertSame(snapshot.connectivityPort(), ports.connectivity()),
+        () -> assertSame(snapshot.connectionsPagePort(), ports.connectionsPage()),
+        () -> assertSame(snapshot.connectionsSupportPort(), ports.connectionsSupport()),
+        () -> assertSame(snapshot.darknetConnectionsPort(), ports.darknetConnections()),
+        () -> assertSame(snapshot.darknetMessagingPort(), ports.darknetMessaging()),
+        () -> assertSame(snapshot.diagnosticPort(), ports.diagnostic()),
+        () -> assertSame(snapshot.queueSupportPort(), ports.queueSupport()),
+        () -> assertSame(snapshot.queueCompletionPort(), ports.queueCompletion()),
+        () -> assertSame(snapshot.queuePagePort(), ports.queuePage()),
+        () -> assertSame(snapshot.queueDownloadPort(), ports.queueDownload()),
+        () -> assertSame(snapshot.queueInsertPort(), ports.queueInsert()),
+        () -> assertSame(snapshot.queueMutationPort(), ports.queueMutation()),
+        () -> assertSame(snapshot.statisticsPort(), ports.statistics()),
+        () -> assertSame(snapshot.securityLevelsPort(), ports.securityLevels()),
+        () -> assertSame(snapshot.firstTimeWizardPort(), ports.firstTimeWizard()),
+        () -> assertSame(snapshot.requestQueuePort(), ports.requestQueue()),
+        () -> assertSame(snapshot.nodeInfoPort(), ports.nodeInfo()),
+        () -> assertSame(snapshot.peerPort(), ports.peer()));
+  }
+
+  @Test
+  void getters_whenRequested_expectLegacyAdapterTypes() {
+    PortsSnapshot snapshot = capturePorts();
+
+    assertAll(
+        () -> assertInstanceOf(LegacyConfigPort.class, snapshot.configPort()),
+        () -> assertInstanceOf(LegacyConnectivityPort.class, snapshot.connectivityPort()),
+        () -> assertInstanceOf(LegacyConnectionsPagePort.class, snapshot.connectionsPagePort()),
+        () ->
+            assertInstanceOf(LegacyConnectionsSupportPort.class, snapshot.connectionsSupportPort()),
+        () ->
+            assertInstanceOf(LegacyDarknetConnectionsPort.class, snapshot.darknetConnectionsPort()),
+        () -> assertInstanceOf(LegacyDarknetMessagingPort.class, snapshot.darknetMessagingPort()),
+        () -> assertInstanceOf(LegacyDiagnosticPort.class, snapshot.diagnosticPort()),
+        () -> assertInstanceOf(LegacyQueueSupportPort.class, snapshot.queueSupportPort()),
+        () -> assertInstanceOf(LegacyQueueCompletionPort.class, snapshot.queueCompletionPort()),
+        () -> assertInstanceOf(LegacyQueuePagePort.class, snapshot.queuePagePort()),
+        () -> assertInstanceOf(LegacyQueueDownloadPort.class, snapshot.queueDownloadPort()),
+        () -> assertInstanceOf(LegacyQueueInsertPort.class, snapshot.queueInsertPort()),
+        () -> assertInstanceOf(LegacyQueueMutationPort.class, snapshot.queueMutationPort()),
+        () -> assertInstanceOf(LegacyStatisticsPort.class, snapshot.statisticsPort()),
+        () -> assertInstanceOf(LegacySecurityLevelsPort.class, snapshot.securityLevelsPort()),
+        () -> assertInstanceOf(LegacyFirstTimeWizardPort.class, snapshot.firstTimeWizardPort()),
+        () -> assertInstanceOf(LegacyRequestQueuePort.class, snapshot.requestQueuePort()),
+        () -> assertInstanceOf(LegacyNodeInfoPort.class, snapshot.nodeInfoPort()),
+        () -> assertInstanceOf(LegacyPeerPort.class, snapshot.peerPort()));
+  }
+
+  @Test
+  void execution_whenTaskSubmitted_expectDelegatesToNodeExecutor() {
+    Runnable task = () -> {};
+
+    ports.execution().execute(task, "runtime-task");
+
+    verify(executor).execute(task, "runtime-task");
+  }
+
+  @Test
+  void randomness_whenRequested_expectDelegatesToBootstrapRandomSources() {
+    byte[] target = new byte[8];
+
+    ports.randomness().fillSecureRandom(target);
+    Random fastWeakRandom = ports.randomness().fastWeakRandom();
+
+    verify(secureRandom).nextBytes(target);
+    assertSame(weakRandom, fastWeakRandom);
+  }
+
+  @Test
+  void transferAccess_whenRequested_expectDelegatesToCoreTransferPolicy() {
+    File uploadCandidate = new File("candidate-upload");
+    File downloadCandidate = new File("candidate-download");
+    when(core.allowUploadFrom(uploadCandidate)).thenReturn(true);
+    when(core.allowDownloadTo(downloadCandidate)).thenReturn(true);
+
+    boolean uploadAllowed = ports.transferAccess().allowUploadFrom(uploadCandidate);
+    boolean downloadAllowed = ports.transferAccess().allowDownloadTo(downloadCandidate);
+
+    assertTrue(uploadAllowed);
+    assertTrue(downloadAllowed);
+    assertSame(downloadsDir, ports.transferAccess().downloadsDir());
+    assertSame(persistentTempDir, ports.transferAccess().persistentTempDir());
+    assertArrayEquals(allowedUploadDirs, ports.transferAccess().allowedUploadDirs());
+    assertArrayEquals(allowedDownloadDirs, ports.transferAccess().allowedDownloadDirs());
+  }
+
+  @Test
+  void lifecycle_whenRequested_expectDelegatesToNodeLifecycleState() {
+    when(node.isHasStarted()).thenReturn(true);
+    when(node.isStopping()).thenReturn(false);
+    when(node.isUsingWrapper()).thenReturn(true);
+    when(node.getStartupTime()).thenReturn(123456789L);
+
+    assertAll(
+        () -> assertTrue(ports.lifecycle().hasStarted()),
+        () -> assertFalse(ports.lifecycle().isStopping()),
+        () -> assertTrue(ports.lifecycle().isUsingWrapper()),
+        () -> assertEquals(123456789L, ports.lifecycle().startupTimeMillis()));
+  }
+
+  private PortsSnapshot capturePorts() {
+    return new PortsSnapshot(
+        ports.execution(),
+        ports.randomness(),
+        ports.transferAccess(),
+        ports.lifecycle(),
+        ports.config(),
+        ports.connectivity(),
+        ports.connectionsPage(),
+        ports.connectionsSupport(),
+        ports.darknetConnections(),
+        ports.darknetMessaging(),
+        ports.diagnostic(),
+        ports.queueSupport(),
+        ports.queueCompletion(),
+        ports.queuePage(),
+        ports.queueDownload(),
+        ports.queueInsert(),
+        ports.queueMutation(),
+        ports.statistics(),
+        ports.securityLevels(),
+        ports.firstTimeWizard(),
+        ports.requestQueue(),
+        ports.nodeInfo(),
+        ports.peer());
+  }
+
+  private record PortsSnapshot(
+      Object executionPort,
+      Object randomnessPort,
+      Object transferAccessPort,
+      Object lifecyclePort,
+      Object configPort,
+      Object connectivityPort,
+      Object connectionsPagePort,
+      Object connectionsSupportPort,
+      Object darknetConnectionsPort,
+      Object darknetMessagingPort,
+      Object diagnosticPort,
+      Object queueSupportPort,
+      Object queueCompletionPort,
+      Object queuePagePort,
+      Object queueDownloadPort,
+      Object queueInsertPort,
+      Object queueMutationPort,
+      Object statisticsPort,
+      Object securityLevelsPort,
+      Object firstTimeWizardPort,
+      Object requestQueuePort,
+      Object nodeInfoPort,
+      Object peerPort) {}
+}


### PR DESCRIPTION
## Summary
- add `QueueCompletionPort` to the runtime SPI and wire it through `RuntimePorts`, `LegacyRuntimePorts`, `QueueToadletRuntimePorts`, and `FProxyRegistrar`
- move QueueToadlet's remaining completion-tracking behavior into `LegacyQueueCompletionPort`, including callback registration, completed-list persistence/recovery, replay, and alert registration
- simplify `QueueToadlet` and its tests to focus on HTTP responsibilities, and update the architecture docs/skill notes for the expanded runtime SPI surface

## How to test
- `./gradlew test --tests "network.crypta.node.runtime.LegacyQueueCompletionPortTest" --tests "network.crypta.clients.http.QueueToadletTest" --tests "network.crypta.clients.http.QueueToadletPostMutationTest" --tests "network.crypta.clients.http.QueueToadletPostDownloadTest" --tests "network.crypta.clients.http.QueueToadletPostInsertTest" --tests "network.crypta.clients.http.QueueToadletRecommendTest"`
- `./gradlew spotlessApply`