### PR TITLE
refactor(welcome): Move GET read path to runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -36,6 +36,7 @@ package network.crypta.runtime.spi;
  * @see RequestQueuePort
  * @see SecurityLevelsPort
  * @see FirstTimeWizardPort
+ * @see WelcomePagePort
  */
 public interface RuntimePorts {
   /**
@@ -273,6 +274,18 @@ public interface RuntimePorts {
    * @return first-time-wizard runtime port for detached page state and submission application
    */
   FirstTimeWizardPort firstTimeWizard();
+
+  /**
+   * Returns the legacy welcome-page read capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining welcome-page config reads and latest-log tail file selection
+   * inside the daemon root module while exposing only a tiny detached snapshot and one text export
+   * upstream. It is intentionally read-only and should not grow to cover the welcome page's POST
+   * actions.
+   *
+   * @return welcome-page runtime port for detached read-only page state and latest-log export
+   */
+  WelcomePagePort welcomePage();
 
   /**
    * Returns the persistent-request queue-control capability exposed to infrastructure code.

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomePagePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomePagePort.java
@@ -1,0 +1,48 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+
+/**
+ * Exposes the narrow detached runtime surface still needed by the welcome page GET/read path.
+ *
+ * <p>This SPI is intentionally tiny and page-oriented. The HTTP layer still owns the welcome-page
+ * route, bookmark tree, template structure, and every POST or action handler. Implementations
+ * provide only the read-only runtime state that the GET path cannot derive on its own without
+ * reaching back into the live daemon: the fetch-key-box placement flag and the latest node log tail
+ * shown by the legacy {@code latestlog} endpoint.
+ *
+ * <p>Callers typically read {@link #snapshot()} while assembling the main page and call {@link
+ * #latestNodeLogTail()} only for the dedicated log endpoint. Keeping those concerns in a small SPI
+ * lets the HTTP layer detach from the daemon root module without inventing a broader homepage
+ * domain model or pulling POST behavior into this interface.
+ *
+ * @see WelcomePageSnapshot
+ */
+public interface WelcomePagePort {
+  /**
+   * Returns a detached snapshot of the current welcome-page read-only state.
+   *
+   * <p>The returned value is suitable for one request render and captures the small set of
+   * config-backed decisions that the welcome page needs while building its GET response. Callers
+   * should treat the snapshot as immutable request data rather than a handle for later daemon
+   * interaction.
+   *
+   * @return immutable snapshot containing the current fetch-key-box placement flag for this read
+   *     operation
+   */
+  WelcomePageSnapshot snapshot();
+
+  /**
+   * Reads and returns the current latest node log tail used by the welcome page.
+   *
+   * <p>Implementations should preserve the existing logger-directory lookup, file preference, and
+   * tail truncation semantics of the legacy welcome-page handler. The returned text is intended for
+   * direct inclusion in the legacy response body for the {@code latestlog} route, so callers should
+   * not assume the entire log file is available or that the selected filename is stable across
+   * implementations.
+   *
+   * @return the current latest node log tail as text, already reduced to the legacy byte window
+   * @throws IOException if the selected log file cannot be opened or read during this request
+   */
+  String latestNodeLogTail() throws IOException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomePageSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomePageSnapshot.java
@@ -1,0 +1,19 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Captures the detached read-only runtime state needed to render the welcome page.
+ *
+ * <p>The welcome page still owns its HTML structure, bookmark rendering, and action routing. This
+ * record exists so the GET path can make a small number of configuration-backed UI decisions
+ * without reading live daemon configuration directly. The value is immutable and intentionally
+ * narrow: it models only the state that this migration step needs, rather than a broader
+ * representation of the entire home page.
+ *
+ * <p>Callers usually get one snapshot near the start of request handling and reuse it for the rest
+ * of that render. That keeps page assembly deterministic for a single request even if the
+ * underlying configuration changes later.
+ *
+ * @param fetchKeyBoxAboveBookmarks whether the fetch-a-key box should render before the bookmarks
+ *     section for the current request render
+ */
+public record WelcomePageSnapshot(boolean fetchKeyBoxAboveBookmarks) {}

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -275,7 +275,12 @@ final class FProxyRegistrar {
           ToadletRegistration.basic(null, localDirectoryConfigToadlet.path(), true, false));
     }
 
-    WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, node);
+    WelcomeToadletRuntimePorts welcomeToadletRuntimePorts =
+        new WelcomeToadletRuntimePorts(
+            runtimePorts.welcomePage(),
+            runtimePorts.darknetConnections(),
+            runtimePorts.lifecycle());
+    WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, node, welcomeToadletRuntimePorts);
     server.register(
         welcometoadlet, ToadletRegistration.basic(null, FProxyToadlet.WELCOME_PATH, true, false));
 

--- a/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
+++ b/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertBlock;
@@ -23,11 +24,12 @@ import network.crypta.fs.AppEnv;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.BandwidthManager;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.Version;
 import network.crypta.node.useralerts.UpgradeConnectionSpeedUserAlert;
 import network.crypta.node.useralerts.UserAlert;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.WelcomePageSnapshot;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
@@ -46,12 +48,12 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * landing page with alerts, bookmarks, search integration, and version/environment diagnostics so
  * users can assess node health at a glance.
  *
- * <p>The class is intentionally state-light: it holds only a {@link Node} reference and delegates
- * persistence, alerts, and configuration to their respective services. Requests are processed
- * sequentially by the container, so the toadlet itself does not create additional threads; any
- * asynchronous behavior is queued through node subsystems. Form-password checks gate all actions
- * that mutate state or reveal privileged information, while public users see a trimmed bookmark
- * view.
+ * <p>The class is intentionally state-light: it retains the live {@link Node} only for legacy
+ * POST/action paths and uses a small runtime-port bundle for the detached GET/read helpers.
+ * Requests are processed sequentially by the container, so the toadlet itself does not create
+ * additional threads; any asynchronous behavior is queued through node subsystems. Form-password
+ * checks gate all actions that mutate state or reveal privileged information, while public users
+ * see a trimmed bookmark view.
  *
  * <ul>
  *   <li>Homepage rendering combines alerts, bookmark trees, fetch boxes, and version details.
@@ -91,19 +93,20 @@ public class WelcomeToadlet extends Toadlet {
   private static final String PARAM_OUTPUT_BANDWIDTH_LIMIT = "outputBandwidthLimit";
   private static final String PARAM_FILENAME = "filename";
   private static final String PARAM_RESTART = "restart";
-  private static final long LOG_TAIL_BYTE_LIMIT = 100000L;
   private static final String TAG_LABEL = "label";
   private static final String TEXTAREA_DESC_B = "descB";
   private static final String STYLE_BORDER_NONE = "border: none";
   private static final String TARGET_BLANK = "_blank";
 
   final Node node;
+  private final WelcomeToadletRuntimePorts runtimePorts;
 
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly.
 
-  WelcomeToadlet(HighLevelSimpleClient client, Node node) {
+  WelcomeToadlet(HighLevelSimpleClient client, Node node, WelcomeToadletRuntimePorts runtimePorts) {
     super(client);
-    this.node = node;
+    this.node = Objects.requireNonNull(node, "node");
+    this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
   }
 
   void redirectToRoot(ToadletContext ctx) throws ToadletContextClosedException, IOException {
@@ -115,11 +118,12 @@ public class WelcomeToadlet extends Toadlet {
       BookmarkCategory cat, HTMLNode list, boolean noActiveLinks, ToadletContext ctx) {
     boolean disableActiveLinks = !ctx.getPageMaker().getTheme().forceActivelinks && noActiveLinks;
 
-    addCategoryItems(cat, list, disableActiveLinks);
+    addCategoryItems(cat, list, disableActiveLinks, ctx);
     addSubCategories(cat, list, disableActiveLinks, ctx);
   }
 
-  private void addCategoryItems(BookmarkCategory cat, HTMLNode list, boolean noActiveLinks) {
+  private void addCategoryItems(
+      BookmarkCategory cat, HTMLNode list, boolean noActiveLinks, ToadletContext ctx) {
     List<BookmarkItem> items = cat.getItems();
     if (items.isEmpty()) {
       return;
@@ -132,11 +136,12 @@ public class WelcomeToadlet extends Toadlet {
                 new String[] {"border", ATTR_STYLE},
                 new String[] {"0", STYLE_BORDER_NONE});
     for (BookmarkItem item : items) {
-      addBookmarkItemRow(noActiveLinks, table, item);
+      addBookmarkItemRow(noActiveLinks, table, item, ctx);
     }
   }
 
-  private void addBookmarkItemRow(boolean noActiveLinks, HTMLNode table, BookmarkItem item) {
+  private void addBookmarkItemRow(
+      boolean noActiveLinks, HTMLNode table, BookmarkItem item, ToadletContext ctx) {
     HTMLNode row = table.addChild("tr");
     HTMLNode cell = row.addChild("td", ATTR_STYLE, STYLE_BORDER_NONE + ';');
     if (item.hasAnActivelink() && !noActiveLinks) {
@@ -159,9 +164,7 @@ public class WelcomeToadlet extends Toadlet {
     if (updated) {
       HTMLNode alertCell = row.addChild("td", ATTR_STYLE, STYLE_BORDER_NONE);
       alertCell.addChild(
-          node.services()
-              .clientCore()
-              .getAlerts()
+          ctx.getAlertManager()
               .renderDismissButton(item.getUserAlert(), path() + "#" + BOOKMARKS_ANCHOR));
     }
   }
@@ -783,17 +786,18 @@ public class WelcomeToadlet extends Toadlet {
 
     PageNode page = ctx.getPageMaker().getPageNode(l10n("homepageFullTitle"), ctx);
     HTMLNode contentNode = page.getContentNode();
+    WelcomePageSnapshot welcomePageSnapshot = runtimePorts.welcomePagePort().snapshot();
 
     String userAgent = ctx.getHeaders().getFirst("user-agent");
 
     addUserAgentWarnings(ctx, contentNode, userAgent);
     addAlerts(ctx, contentNode);
-    addFetchKeyBoxAboveBookmarks(ctx, contentNode);
+    addFetchKeyBoxAboveBookmarks(ctx, contentNode, welcomePageSnapshot);
     addBookmarksSection(ctx, contentNode, userAgent);
     if (showSearchBox()) {
       addSearchBox(contentNode);
     }
-    addFetchKeyBoxBelowBookmarks(ctx, contentNode);
+    addFetchKeyBoxBelowBookmarks(ctx, contentNode, welcomePageSnapshot);
     addVersionInfoSection(ctx, contentNode);
 
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
@@ -835,12 +839,7 @@ public class WelcomeToadlet extends Toadlet {
 
   private void serveLatestLog(ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    File logDir = new File(node.getConfig().get("logger").getString("dirname"));
-    File crypta = new File(logDir, "crypta-latest.log");
-    File freenet = new File(logDir, "freenet-latest.log");
-    File logs = crypta.exists() ? crypta : freenet;
-    String text = readLogTail(logs);
-    this.writeTextReply(ctx, 200, "OK", text);
+    this.writeTextReply(ctx, 200, "OK", runtimePorts.welcomePagePort().latestNodeLogTail());
   }
 
   private boolean isValidFormPassword(HTTPRequest request, ToadletContext ctx) {
@@ -917,7 +916,7 @@ public class WelcomeToadlet extends Toadlet {
         "textarea",
         new String[] {"id", "name", "row", "cols"},
         new String[] {TEXTAREA_DESC_B, TEXTAREA_DESC_B, "3", "70"});
-    appendDarknetPeersSection(addForm);
+    appendDarknetPeersSection(ctx, addForm);
     addForm.addChild("br");
 
     addForm.addChild(
@@ -932,13 +931,15 @@ public class WelcomeToadlet extends Toadlet {
     this.writeHTMLReply(ctx, 200, "OK", page.generate());
   }
 
-  private void appendDarknetPeersSection(HTMLNode addForm) {
-    if (node.network().darknetConnections().length == 0) {
+  private void appendDarknetPeersSection(ToadletContext ctx, HTMLNode addForm) {
+    List<DarknetConnectionPeerSnapshot> peers = runtimePorts.darknetConnectionsPort().listPeers();
+    if (peers.isEmpty()) {
       return;
     }
     addForm.addChild("br");
     addForm.addChild("br");
-    if (node.isFProxyJavascriptEnabled()) {
+    boolean fProxyJavascriptEnabled = ctx.getContainer().isFProxyJavascriptEnabled();
+    if (fProxyJavascriptEnabled) {
       addForm.addChild(
           "script",
           new String[] {ATTR_TYPE, "src"},
@@ -946,7 +947,7 @@ public class WelcomeToadlet extends Toadlet {
     }
 
     HTMLNode peerTable = addForm.addChild("table", ATTR_CLASS, "darknet_connections");
-    if (node.isFProxyJavascriptEnabled()) {
+    if (fProxyJavascriptEnabled) {
       HTMLNode headerRow = peerTable.addChild("tr");
       headerRow
           .addChild("th")
@@ -964,15 +965,15 @@ public class WelcomeToadlet extends Toadlet {
               "2",
               NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
     }
-    for (DarknetPeerNode peer : node.network().darknetConnections()) {
+    for (DarknetConnectionPeerSnapshot peer : peers) {
       HTMLNode peerRow = peerTable.addChild("tr", ATTR_CLASS, "darknet_connections_normal");
       peerRow
           .addChild("td", ATTR_CLASS, "peer-marker")
           .addChild(
               ELEMENT_INPUT,
               new String[] {ATTR_TYPE, "name"},
-              new String[] {"checkbox", "node_" + peer.hashCode()});
-      peerRow.addChild("td", ATTR_CLASS, "peer-name").addChild("#", peer.getName());
+              new String[] {"checkbox", "node_" + peer.selectionToken()});
+      peerRow.addChild("td", ATTR_CLASS, "peer-name").addChild("#", peer.displayName());
     }
 
     addForm.addChild(
@@ -1007,14 +1008,16 @@ public class WelcomeToadlet extends Toadlet {
     }
   }
 
-  private void addFetchKeyBoxAboveBookmarks(ToadletContext ctx, HTMLNode contentNode) {
-    if (node.getConfig().get("fproxy").getBoolean("fetchKeyBoxAboveBookmarks")) {
+  private void addFetchKeyBoxAboveBookmarks(
+      ToadletContext ctx, HTMLNode contentNode, WelcomePageSnapshot welcomePageSnapshot) {
+    if (welcomePageSnapshot.fetchKeyBoxAboveBookmarks()) {
       this.putFetchKeyBox(ctx, contentNode);
     }
   }
 
-  private void addFetchKeyBoxBelowBookmarks(ToadletContext ctx, HTMLNode contentNode) {
-    if (!node.getConfig().get("fproxy").getBoolean("fetchKeyBoxAboveBookmarks")) {
+  private void addFetchKeyBoxBelowBookmarks(
+      ToadletContext ctx, HTMLNode contentNode, WelcomePageSnapshot welcomePageSnapshot) {
+    if (!welcomePageSnapshot.fetchKeyBoxAboveBookmarks()) {
       this.putFetchKeyBox(ctx, contentNode);
     }
   }
@@ -1112,7 +1115,7 @@ public class WelcomeToadlet extends Toadlet {
         ELEMENT_INPUT,
         new String[] {ATTR_TYPE, ATTR_VALUE},
         new String[] {INPUT_SUBMIT, l10n("shutdownNode")});
-    if (node.isUsingWrapper()) {
+    if (runtimePorts.lifecyclePort().isUsingWrapper()) {
       HTMLNode restartForm = ctx.addFormChild(versionContent, ".", "restartForm");
       restartForm.addChild(
           ELEMENT_INPUT,
@@ -1210,22 +1213,6 @@ public class WelcomeToadlet extends Toadlet {
       } catch (IOException e) {
         LOG.debug("Failed to read wrapper log tail", e);
       }
-    }
-  }
-
-  /**
-   * Reads and returns the trailing portion of {@code logfile}, constrained by {@link
-   * #LOG_TAIL_BYTE_LIMIT}. When the file is larger than the limit, the leading bytes are skipped so
-   * only the newest content is returned; a partial first line is discarded to keep line boundaries
-   * intact.
-   *
-   * @param logfile the file to read; must exist and be readable for a meaningful result
-   * @return the UTF-8 decoded tail of the file, limited to the configured byte budget
-   * @throws IOException if an I/O error occurs while opening or reading the file
-   */
-  private static String readLogTail(File logfile) throws IOException {
-    try (LineReadingInputStream stream = FileUtil.getLogTailReader(logfile, LOG_TAIL_BYTE_LIMIT)) {
-      return FileUtil.readUTF(stream).toString();
     }
   }
 

--- a/src/main/java/network/crypta/clients/http/WelcomeToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/WelcomeToadletRuntimePorts.java
@@ -1,0 +1,42 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.WelcomePagePort;
+
+/**
+ * Bundles the detached runtime ports used by the welcome toadlet's GET/read path.
+ *
+ * <p>{@code WelcomeToadlet} is still in the middle of its runtime-SPI migration. Its GET handling
+ * now reads a few pieces of runtime state through detached ports, while its POST and action paths
+ * still use the legacy live-daemon fields. Collecting the GET-only collaborators in one record
+ * keeps the constructor small, makes the migration boundary explicit, and avoids introducing a
+ * broader HTTP abstraction layer for a single page.
+ *
+ * <p>The bundle is intentionally narrow. It contains only the collaborators that the current PR
+ * needs for read-only page assembly and visibility checks, and nothing for restart, shutdown,
+ * update, or other action routes.
+ *
+ * @param welcomePagePort detached welcome-page read port used for config-backed snapshot and log
+ *     tail reads during welcome-page GET handling
+ * @param darknetConnectionsPort detached darknet connections port used for bookmark recommendation
+ *     peer rendering in GET responses
+ * @param lifecyclePort detached lifecycle port used for wrapper-dependent button visibility
+ */
+record WelcomeToadletRuntimePorts(
+    WelcomePagePort welcomePagePort,
+    DarknetConnectionsPort darknetConnectionsPort,
+    LifecyclePort lifecyclePort) {
+  /**
+   * Validates that every detached collaborator required by the welcome-page GET path is present.
+   *
+   * <p>The record carries dependencies only. Construction fails fast if any required port is
+   * missing, so the registration error appears at startup rather than during request handling.
+   */
+  WelcomeToadletRuntimePorts {
+    Objects.requireNonNull(welcomePagePort);
+    Objects.requireNonNull(darknetConnectionsPort);
+    Objects.requireNonNull(lifecyclePort);
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -28,6 +28,7 @@ import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.StatisticsPort;
 import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.runtime.spi.WelcomePagePort;
 
 /**
  * Bridges the current daemon implementation into the JDK-only runtime SPI.
@@ -66,6 +67,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final StatisticsPort statisticsPort;
   private final SecurityLevelsPort securityLevelsPort;
   private final FirstTimeWizardPort firstTimeWizardPort;
+  private final WelcomePagePort welcomePagePort;
   private final RequestQueuePort requestQueuePort;
   private final NodeInfoPort nodeInfoPort;
   private final PeerPort peerPort;
@@ -169,6 +171,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.securityLevelsPort = new LegacySecurityLevelsPort(node);
     this.firstTimeWizardPort = new LegacyFirstTimeWizardPort(node, core);
+    this.welcomePagePort = new LegacyWelcomePagePort(node);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
@@ -399,6 +402,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public FirstTimeWizardPort firstTimeWizard() {
     return firstTimeWizardPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining welcome-page config reads and latest-log tail
+   * selection inside the daemon root module while exposing only detached read-only values upstream.
+   */
+  @Override
+  public WelcomePagePort welcomePage() {
+    return welcomePagePort;
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyWelcomePagePort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyWelcomePagePort.java
@@ -1,0 +1,75 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import network.crypta.node.Node;
+import network.crypta.runtime.spi.WelcomePagePort;
+import network.crypta.runtime.spi.WelcomePageSnapshot;
+import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LineReadingInputStream;
+
+/**
+ * Adapts the welcome-page read SPI to the legacy daemon runtime.
+ *
+ * <p>This adapter keeps the remaining welcome-page GET-only configuration and file-system reads in
+ * the daemon root module, where the legacy {@link Node} APIs still live. The HTTP layer can then
+ * consume a detached {@link WelcomePagePort} without knowing how configuration is stored or where
+ * log files live on disk. That split keeps this migration conservative: the welcome page moves its
+ * read path first, while POST and action handlers can continue to use the live daemon until later
+ * PRs detach them.
+ *
+ * <p>The adapter preserves the daemon's existing behavior. It reads the {@code
+ * fproxy.fetchKeyBoxAboveBookmarks} flag, resolves the logger directory from the current node
+ * configuration, prefers {@code crypta-latest.log}, falls back to {@code freenet-latest.log}, and
+ * uses the same tail truncation helper that the legacy welcome page used directly.
+ */
+final class LegacyWelcomePagePort implements WelcomePagePort {
+  /** Limits log output to the same byte window used by the legacy welcome-page handler. */
+  private static final long LOG_TAIL_BYTE_LIMIT = 100000L;
+
+  /** Live daemon node that remains the source of truth for config and log discovery. */
+  private final Node node;
+
+  /**
+   * Creates a legacy adapter backed by the live daemon node.
+   *
+   * <p>The supplied node remains the source of truth for configuration lookup and log-file
+   * discovery. The adapter itself is stateless apart from that reference and may be reused across
+   * multiple welcome-page requests.
+   *
+   * @param node live daemon node that supplies config access and logger-directory resolution
+   */
+  LegacyWelcomePagePort(Node node) {
+    this.node = Objects.requireNonNull(node, "node");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public WelcomePageSnapshot snapshot() {
+    return new WelcomePageSnapshot(
+        node.getConfig().get("fproxy").getBoolean("fetchKeyBoxAboveBookmarks"));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String latestNodeLogTail() throws IOException {
+    File logDir = new File(node.getConfig().get("logger").getString("dirname"));
+    File crypta = new File(logDir, "crypta-latest.log");
+    File freenet = new File(logDir, "freenet-latest.log");
+    return readLogTail(crypta.exists() ? crypta : freenet);
+  }
+
+  /**
+   * Reads the truncated tail for the selected log file.
+   *
+   * @param logfile log file chosen by the legacy filename preference rules
+   * @return decoded text from the legacy tail reader for that file
+   * @throws IOException if the log file cannot be opened or decoded
+   */
+  private static String readLogTail(File logfile) throws IOException {
+    try (LineReadingInputStream stream = FileUtil.getLogTailReader(logfile, LOG_TAIL_BYTE_LIMIT)) {
+      return FileUtil.readUTF(stream).toString();
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
@@ -1,13 +1,26 @@
 package network.crypta.clients.http;
 
+import java.lang.reflect.Method;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
+import network.crypta.clients.http.bookmark.BookmarkItem;
 import network.crypta.node.Node;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.WelcomePagePort;
+import network.crypta.runtime.spi.WelcomePageSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,20 +28,26 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @SuppressWarnings("java:S100")
 class WelcomeToadletTest {
 
@@ -37,14 +56,43 @@ class WelcomeToadletTest {
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   private Node node;
 
-  private WelcomeToadlet toadlet;
+  @Mock private WelcomePagePort welcomePagePort;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private LifecyclePort lifecyclePort;
+  @Mock private ToadletContext ctx;
+  @Mock private ToadletContainer container;
+  @Mock private UserAlertManager alertManager;
+  @Mock private HTTPRequest request;
 
+  private WelcomeToadletRuntimePorts runtimePorts;
+  private WelcomeToadlet toadlet;
   private String originalUserDir;
 
   @BeforeEach
   void setUp() {
-    toadlet = new WelcomeToadlet(client, node);
+    runtimePorts =
+        new WelcomeToadletRuntimePorts(welcomePagePort, darknetConnectionsPort, lifecyclePort);
+    toadlet = new WelcomeToadlet(client, node, runtimePorts);
+    toadlet.container = container;
     originalUserDir = System.getProperty("user.dir");
+
+    when(ctx.getContainer()).thenReturn(container);
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(ctx.getHeaders()).thenReturn(new MultiValueTable<>());
+    when(ctx.getFormPassword()).thenReturn("form-password");
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(container.enableActivelinks()).thenReturn(true);
+    when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert-summary"));
+    when(alertManager.renderDismissButton(any(), anyString())).thenReturn(new HTMLNode("button"));
+    when(request.getParam("newbookmark")).thenReturn("");
+    when(ctx.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              HTMLNode form = new HTMLNode("form");
+              parent.addChild(form);
+              return form;
+            });
   }
 
   @AfterEach
@@ -86,24 +134,146 @@ class WelcomeToadletTest {
 
   @Test
   void redirectToRoot_sends302LocationRoot() throws Exception {
-    ToadletContext ctx = mock(ToadletContext.class);
+    ToadletContext redirectContext = mock(ToadletContext.class);
 
-    toadlet.redirectToRoot(ctx);
+    toadlet.redirectToRoot(redirectContext);
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
         ArgumentCaptor.forClass(MultiValueTable.class);
-    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), eq(null), eq(0L));
+    verify(redirectContext)
+        .sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), eq(null), eq(0L));
 
     MultiValueTable<String, String> headers = headersCaptor.getValue();
     assertEquals("/", headers.getFirst("Location"));
   }
 
   @Test
-  void sendRestartingPageInner_addsMetaRefreshAndContent() {
-    ToadletContext ctx = mock(ToadletContext.class);
-    PageMaker pageMaker = mock(PageMaker.class);
+  void handleMethodGET_whenLatestLogRequested_readsLogTailFromWelcomePagePort() throws Exception {
+    WelcomeToadlet spyToadlet = createSpyToadlet();
+    AtomicReference<String> body = new AtomicReference<>();
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(request.isParameterSet("latestlog")).thenReturn(true);
+    when(welcomePagePort.latestNodeLogTail()).thenReturn("latest log tail");
+    doAnswer(
+            invocation -> {
+              body.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeTextReply(eq(ctx), eq(200), eq("OK"), anyString());
+
+    spyToadlet.handleMethodGET(URI.create("http://localhost/?latestlog"), request, ctx);
+
+    assertEquals("latest log tail", body.get());
+    verify(welcomePagePort).latestNodeLogTail();
+  }
+
+  @Test
+  void handleMethodGET_whenFetchKeyBoxConfiguredAbove_rendersItBeforeBookmarks() throws Exception {
+    WelcomeToadlet spyToadlet = createSpyToadlet();
+    AtomicReference<String> html = captureHtmlReply(spyToadlet);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
     when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    when(welcomePagePort.snapshot()).thenReturn(new WelcomePageSnapshot(true));
+
+    spyToadlet.handleMethodGET(URI.create("http://localhost/"), request, ctx);
+
+    String body = html.get();
+    assertTrue(body.contains("id=\"keyfetchbox\""));
+    assertTrue(body.indexOf("id=\"keyfetchbox\"") < body.indexOf("id=\"bookmarks\""));
+    verify(welcomePagePort).snapshot();
+  }
+
+  @Test
+  void handleMethodGET_whenFetchKeyBoxConfiguredBelow_rendersItAfterBookmarks() throws Exception {
+    WelcomeToadlet spyToadlet = createSpyToadlet();
+    AtomicReference<String> html = captureHtmlReply(spyToadlet);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    when(welcomePagePort.snapshot()).thenReturn(new WelcomePageSnapshot(false));
+
+    spyToadlet.handleMethodGET(URI.create("http://localhost/"), request, ctx);
+
+    String body = html.get();
+    assertTrue(body.contains("id=\"keyfetchbox\""));
+    assertTrue(body.indexOf("id=\"keyfetchbox\"") > body.indexOf("id=\"bookmarks\""));
+    verify(welcomePagePort).snapshot();
+  }
+
+  @Test
+  void handleMethodGET_whenWrapperInUse_rendersRestartButtonFromLifecyclePort() throws Exception {
+    WelcomeToadlet spyToadlet = createSpyToadlet();
+    AtomicReference<String> html = captureHtmlReply(spyToadlet);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(welcomePagePort.snapshot()).thenReturn(new WelcomePageSnapshot(false));
+    when(lifecyclePort.isUsingWrapper()).thenReturn(true);
+
+    spyToadlet.handleMethodGET(URI.create("http://localhost/"), request, ctx);
+
+    assertTrue(html.get().contains("restart2"));
+    verify(lifecyclePort).isUsingWrapper();
+  }
+
+  @Test
+  void handleMethodGET_whenConfirmingBookmark_rendersDetachedDarknetPeersAndJavascriptGate()
+      throws Exception {
+    WelcomeToadlet spyToadlet = createSpyToadlet();
+    AtomicReference<String> html = captureHtmlReply(spyToadlet);
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(request.getParam("newbookmark")).thenReturn("CHK@bookmark");
+    when(request.getParam("desc")).thenReturn("Bookmark description");
+    when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(alicePeer()));
+
+    spyToadlet.handleMethodGET(
+        URI.create("http://localhost/?newbookmark=CHK@bookmark"), request, ctx);
+
+    String body = html.get();
+    assertTrue(body.contains("Alice"));
+    assertTrue(body.contains("node_42"));
+    assertTrue(body.contains("/static/js/checkall.js"));
+    verify(darknetConnectionsPort).listPeers();
+  }
+
+  @Test
+  void addBookmarkItemRow_whenBookmarkUpdated_usesContextAlertManagerDismissButton()
+      throws Exception {
+    BookmarkItem item = mock(BookmarkItem.class);
+    UserAlert userAlert = mock(UserAlert.class);
+    HTMLNode table = new HTMLNode("table");
+    when(item.hasAnActivelink()).thenReturn(false);
+    when(item.hasUpdated()).thenReturn(true);
+    when(item.getKey()).thenReturn("CHK@bookmark");
+    when(item.getDescription()).thenReturn("Bookmark description");
+    when(item.getVisibleName()).thenReturn("Bookmark");
+    when(item.getShortDescription()).thenReturn("");
+    when(item.getUserAlert()).thenReturn(userAlert);
+
+    Method method =
+        WelcomeToadlet.class.getDeclaredMethod(
+            "addBookmarkItemRow",
+            boolean.class,
+            HTMLNode.class,
+            BookmarkItem.class,
+            ToadletContext.class);
+    method.setAccessible(true);
+    method.invoke(toadlet, false, table, item, ctx);
+
+    verify(alertManager).renderDismissButton(userAlert, "/#bookmarks");
+  }
+
+  @Test
+  void sendRestartingPageInner_addsMetaRefreshAndContent() {
+    ToadletContext restartContext = mock(ToadletContext.class);
+    PageMaker pageMaker = mock(PageMaker.class);
+    when(restartContext.getPageMaker()).thenReturn(pageMaker);
 
     HTMLNode outer = new HTMLNode("html");
     HTMLNode head = outer.addChild("head");
@@ -113,10 +283,10 @@ class WelcomeToadletTest {
     when(pageMaker.getInfobox(anyString(), anyString(), eq(content), anyString(), eq(true)))
         .thenReturn(new HTMLNode("div"));
 
-    when(pageMaker.getPageNode(eq("Node Restart"), eq(ctx), any(RenderParameters.class)))
+    when(pageMaker.getPageNode(eq("Node Restart"), eq(restartContext), any(RenderParameters.class)))
         .thenReturn(pageNode);
 
-    HTMLNode result = WelcomeToadlet.sendRestartingPageInner(ctx);
+    HTMLNode result = WelcomeToadlet.sendRestartingPageInner(restartContext);
 
     Optional<HTMLNode> metaNode =
         head.getChildren().stream().filter(child -> "meta".equals(child.getName())).findFirst();
@@ -134,17 +304,17 @@ class WelcomeToadletTest {
     byte[] previous = existed ? Files.readAllBytes(logFile) : new byte[0];
     Files.writeString(logFile, "first line\nsecond line\n");
 
-    ToadletContext ctx = mock(ToadletContext.class);
+    ToadletContext wrapperContext = mock(ToadletContext.class);
     PageMaker pageMaker = mock(PageMaker.class);
     HTMLNode contentNode = new HTMLNode("div");
     HTMLNode infobox = new HTMLNode("div");
 
-    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(wrapperContext.getPageMaker()).thenReturn(pageMaker);
     when(pageMaker.getInfobox(anyString(), anyString(), eq(contentNode), anyString(), anyBoolean()))
         .thenReturn(infobox);
 
     try {
-      WelcomeToadlet.maybeDisplayWrapperLogfile(ctx, contentNode);
+      WelcomeToadlet.maybeDisplayWrapperLogfile(wrapperContext, contentNode);
 
       verify(pageMaker)
           .getInfobox(anyString(), anyString(), eq(contentNode), anyString(), eq(true));
@@ -163,10 +333,51 @@ class WelcomeToadletTest {
     Path missingDir = Path.of(originalUserDir).resolve("build/nonexistent");
     System.setProperty("user.dir", missingDir.toString());
 
-    ToadletContext ctx = mock(ToadletContext.class);
+    ToadletContext wrapperContext = mock(ToadletContext.class);
 
-    WelcomeToadlet.maybeDisplayWrapperLogfile(ctx, new HTMLNode("div"));
+    WelcomeToadlet.maybeDisplayWrapperLogfile(wrapperContext, new HTMLNode("div"));
 
-    verifyNoInteractions(ctx);
+    verifyNoInteractions(wrapperContext);
+  }
+
+  private AtomicReference<String> captureHtmlReply(WelcomeToadlet spyToadlet) throws Exception {
+    AtomicReference<String> html = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              html.set(invocation.getArgument(3));
+              return null;
+            })
+        .when(spyToadlet)
+        .writeHTMLReply(eq(ctx), anyInt(), anyString(), anyString());
+    return html;
+  }
+
+  private WelcomeToadlet createSpyToadlet() {
+    WelcomeToadlet spyToadlet = spy(new WelcomeToadlet(client, node, runtimePorts));
+    spyToadlet.container = container;
+    return spyToadlet;
+  }
+
+  private PageMaker stubPageMaker(HTMLNode content) {
+    HTMLNode root = new HTMLNode("html");
+    HTMLNode head = root.addChild("head");
+    root.addChild(content);
+    PageNode page = new PageNode(root, head, content);
+
+    PageMaker stub = mock(PageMaker.class);
+    when(stub.getPageNode(anyString(), eq(ctx))).thenReturn(page);
+    when(stub.getTheme()).thenReturn(PageMaker.THEME.CRYPTAFORGE);
+    doAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(2);
+              return parent.addChild("div");
+            })
+        .when(stub)
+        .getInfobox(anyString(), anyString(), any(HTMLNode.class), any(), anyBoolean());
+    return stub;
+  }
+
+  private static DarknetConnectionPeerSnapshot alicePeer() {
+    return new DarknetConnectionPeerSnapshot(42, "peer-1", "Alice", "", false);
   }
 }

--- a/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
@@ -85,6 +85,7 @@ class LegacyRuntimePortsTest {
         () -> assertSame(snapshot.statisticsPort(), ports.statistics()),
         () -> assertSame(snapshot.securityLevelsPort(), ports.securityLevels()),
         () -> assertSame(snapshot.firstTimeWizardPort(), ports.firstTimeWizard()),
+        () -> assertSame(snapshot.welcomePagePort(), ports.welcomePage()),
         () -> assertSame(snapshot.requestQueuePort(), ports.requestQueue()),
         () -> assertSame(snapshot.nodeInfoPort(), ports.nodeInfo()),
         () -> assertSame(snapshot.peerPort(), ports.peer()));
@@ -113,6 +114,7 @@ class LegacyRuntimePortsTest {
         () -> assertInstanceOf(LegacyStatisticsPort.class, snapshot.statisticsPort()),
         () -> assertInstanceOf(LegacySecurityLevelsPort.class, snapshot.securityLevelsPort()),
         () -> assertInstanceOf(LegacyFirstTimeWizardPort.class, snapshot.firstTimeWizardPort()),
+        () -> assertInstanceOf(LegacyWelcomePagePort.class, snapshot.welcomePagePort()),
         () -> assertInstanceOf(LegacyRequestQueuePort.class, snapshot.requestQueuePort()),
         () -> assertInstanceOf(LegacyNodeInfoPort.class, snapshot.nodeInfoPort()),
         () -> assertInstanceOf(LegacyPeerPort.class, snapshot.peerPort()));
@@ -192,6 +194,7 @@ class LegacyRuntimePortsTest {
         ports.statistics(),
         ports.securityLevels(),
         ports.firstTimeWizard(),
+        ports.welcomePage(),
         ports.requestQueue(),
         ports.nodeInfo(),
         ports.peer());
@@ -218,6 +221,7 @@ class LegacyRuntimePortsTest {
       Object statisticsPort,
       Object securityLevelsPort,
       Object firstTimeWizardPort,
+      Object welcomePagePort,
       Object requestQueuePort,
       Object nodeInfoPort,
       Object peerPort) {}

--- a/src/test/java/network/crypta/node/runtime/LegacyWelcomePagePortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyWelcomePagePortTest.java
@@ -1,0 +1,70 @@
+package network.crypta.node.runtime;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.node.Node;
+import network.crypta.runtime.spi.WelcomePageSnapshot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyWelcomePagePortTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Test
+  void snapshot_whenFetchKeyBoxConfiguredAboveBookmarks_returnsDetachedSnapshot() {
+    when(node.getConfig().get("fproxy").getBoolean("fetchKeyBoxAboveBookmarks")).thenReturn(true);
+
+    WelcomePageSnapshot snapshot = new LegacyWelcomePagePort(node).snapshot();
+
+    assertEquals(new WelcomePageSnapshot(true), snapshot);
+  }
+
+  @Test
+  void latestNodeLogTail_whenCryptaLogExists_prefersCryptaLatestLog(@TempDir Path tmp)
+      throws Exception {
+    Files.writeString(tmp.resolve("crypta-latest.log"), "crypta-tail\n", StandardCharsets.UTF_8);
+    Files.writeString(tmp.resolve("freenet-latest.log"), "freenet-tail\n", StandardCharsets.UTF_8);
+
+    String text = newPort(tmp).latestNodeLogTail();
+
+    assertEquals("crypta-tail\n", text);
+  }
+
+  @Test
+  void latestNodeLogTail_whenCryptaLogMissing_fallsBackToFreenetLatestLog(@TempDir Path tmp)
+      throws Exception {
+    Files.writeString(tmp.resolve("freenet-latest.log"), "freenet-tail\n", StandardCharsets.UTF_8);
+
+    String text = newPort(tmp).latestNodeLogTail();
+
+    assertEquals("freenet-tail\n", text);
+  }
+
+  @Test
+  void latestNodeLogTail_whenLogExceedsLimit_returnsTailFromNextFullLine(@TempDir Path tmp)
+      throws Exception {
+    String content = "x".repeat(100001) + "\nfull-tail-line\n";
+    Files.writeString(tmp.resolve("crypta-latest.log"), content, StandardCharsets.UTF_8);
+
+    String text = newPort(tmp).latestNodeLogTail();
+
+    assertEquals("full-tail-line\n", text);
+  }
+
+  private LegacyWelcomePagePort newPort(Path logDir) {
+    when(node.getConfig().get("logger").getString("dirname")).thenReturn(logDir.toString());
+    return new LegacyWelcomePagePort(node);
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow `WelcomePagePort` and `WelcomePageSnapshot` SPI plus the `LegacyWelcomePagePort` daemon adapter, and expose it from `RuntimePorts` / `LegacyRuntimePorts`
- add `WelcomeToadletRuntimePorts` and move the `WelcomeToadlet` GET/read helpers onto detached runtime ports while intentionally leaving POST and action paths on the legacy `Node` code
- update the welcome-page and runtime-port tests, including a new `LegacyWelcomePagePortTest`, and add Javadoc for the new production types

## Scope notes
- this PR keeps the change narrow and conservative
- `WelcomeToadlet` POST/action paths remain on the existing live-daemon implementation

## Testing
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyWelcomePagePortTest' --tests 'network.crypta.clients.http.WelcomeToadletTest' --tests 'network.crypta.clients.http.StartupToadletTest'`
- `./gradlew -q classes`
- `javadoc -quiet -Xdoclint:all -classpath 'runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomePagePort.java`
- `javadoc -quiet -Xdoclint:all -classpath 'runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomePageSnapshot.java`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/http/WelcomeToadletRuntimePorts.java`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/node/runtime/LegacyWelcomePagePort.java`