### PR TITLE
refactor(welcome): Move WelcomeToadlet actions to runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -37,6 +37,7 @@ package network.crypta.runtime.spi;
  * @see SecurityLevelsPort
  * @see FirstTimeWizardPort
  * @see WelcomePagePort
+ * @see WelcomeActionPort
  */
 public interface RuntimePorts {
   /**
@@ -286,6 +287,17 @@ public interface RuntimePorts {
    * @return welcome-page runtime port for detached read-only page state and latest-log export
    */
   WelcomePagePort welcomePage();
+
+  /**
+   * Returns the legacy welcome-page action capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining welcome-page POST actions inside the daemon root module while
+   * exposing only a very small page-specific mutation surface upstream. It is intentionally
+   * transitional and should not expand into a general maintenance API.
+   *
+   * @return welcome-page action runtime port for update, restart, shutdown, and bandwidth upgrade
+   */
+  WelcomeActionPort welcomeAction();
 
   /**
    * Returns the persistent-request queue-control capability exposed to infrastructure code.

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomeActionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomeActionPort.java
@@ -1,0 +1,63 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Exposes the remaining welcome-page maintenance actions that still need daemon-backed behavior.
+ *
+ * <p>This SPI exists so the welcome-page HTTP layer can stop reaching into live-daemon objects
+ * directly while still preserving the legacy POST/action paths that operators already use. Typical
+ * callers read form fields, validate access at the HTTP boundary, and then delegate the daemon-side
+ * effect through this port. The implementation keeps the existing update arming, delayed
+ * shutdown/restart scheduling, and upgrade-connection-speed behavior in the daemon root module.
+ *
+ * <p>This is intentionally not a general maintenance or lifecycle API. It stays narrow,
+ * page-shaped, and biased toward preserving existing welcome-page semantics rather than introducing
+ * a reusable admin surface. Redirect handling, confirmation pages, wrapper integration, and other
+ * HTTP concerns remain outside this contract.
+ *
+ * @see RuntimePorts#welcomeAction()
+ */
+public interface WelcomeActionPort {
+  /**
+   * Arms the existing node-update flow from the welcome page.
+   *
+   * <p>Callers invoke this after the HTTP layer has validated the request and completed whatever
+   * confirmation-page rendering or redirect handling is required. Implementations preserve the
+   * daemon-side behavior that the legacy welcome page previously reached through direct {@code
+   * Node}-level access.
+   */
+  void armNodeUpdate();
+
+  /**
+   * Queues the legacy welcome-page shutdown action.
+   *
+   * <p>Implementations preserve the existing delayed scheduling semantics used by the welcome page
+   * so the HTTP redirect can be sent before the live daemon begins shutting down. The call is
+   * intentionally page-scoped: it represents only the welcome-page shutdown flow, not a general
+   * node-administration primitive.
+   */
+  void queueShutdownFromWelcome();
+
+  /**
+   * Queues the legacy welcome-page restart action.
+   *
+   * <p>Implementations preserve the existing delayed scheduling semantics used by the welcome page
+   * so the HTTP redirect can be sent before the live daemon begins restarting. As with shutdown,
+   * this remains deliberately narrow and models the existing welcome-page action rather than a
+   * broader restart API.
+   */
+  void queueRestartFromWelcome();
+
+  /**
+   * Applies the legacy upgrade-connection-speed submission from the welcome page.
+   *
+   * <p>The supplied values are the raw request parts read by the HTTP layer. Implementations own
+   * the legacy validation rules, config writes, alert lookup, and success or error updates on the
+   * existing upgrade alert. They also preserve the historical behavior around restart-required
+   * configuration changes, so the HTTP layer does not need to know about daemon-side config
+   * details.
+   *
+   * @param inputBandwidthLimit raw download-limit text read from the welcome-page form submission
+   * @param outputBandwidthLimit raw upload-limit text read from the welcome-page form submission
+   */
+  void applyUpgradeConnectionSpeed(String inputBandwidthLimit, String outputBandwidthLimit);
+}

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -279,8 +279,9 @@ final class FProxyRegistrar {
         new WelcomeToadletRuntimePorts(
             runtimePorts.welcomePage(),
             runtimePorts.darknetConnections(),
-            runtimePorts.lifecycle());
-    WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, node, welcomeToadletRuntimePorts);
+            runtimePorts.lifecycle(),
+            runtimePorts.welcomeAction());
+    WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, welcomeToadletRuntimePorts);
     server.register(
         welcometoadlet, ToadletRegistration.basic(null, FProxyToadlet.WELCOME_PATH, true, false));
 

--- a/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
+++ b/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
@@ -18,19 +18,13 @@ import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.clients.http.bookmark.BookmarkCategory;
 import network.crypta.clients.http.bookmark.BookmarkItem;
 import network.crypta.clients.http.bookmark.BookmarkManager;
-import network.crypta.config.InvalidConfigValueException;
-import network.crypta.config.NodeNeedRestartException;
 import network.crypta.fs.AppEnv;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.BandwidthManager;
-import network.crypta.node.Node;
 import network.crypta.node.Version;
-import network.crypta.node.useralerts.UpgradeConnectionSpeedUserAlert;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.WelcomePageSnapshot;
-import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.URLDecoder;
@@ -48,12 +42,12 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * landing page with alerts, bookmarks, search integration, and version/environment diagnostics so
  * users can assess node health at a glance.
  *
- * <p>The class is intentionally state-light: it retains the live {@link Node} only for legacy
- * POST/action paths and uses a small runtime-port bundle for the detached GET/read helpers.
- * Requests are processed sequentially by the container, so the toadlet itself does not create
- * additional threads; any asynchronous behavior is queued through node subsystems. Form-password
- * checks gate all actions that mutate state or reveal privileged information, while public users
- * see a trimmed bookmark view.
+ * <p>The class is intentionally state-light: it uses a small runtime-port bundle for both detached
+ * welcome-page reads and the remaining maintenance POST/action helpers. Requests are processed
+ * sequentially by the container, so the toadlet itself does not create additional threads; any
+ * asynchronous behavior is queued through the runtime layer. Form-password checks gate all actions
+ * that mutate state or reveal privileged information, while public users see a trimmed bookmark
+ * view.
  *
  * <ul>
  *   <li>Homepage rendering combines alerts, bookmark trees, fetch boxes, and version details.
@@ -98,14 +92,12 @@ public class WelcomeToadlet extends Toadlet {
   private static final String STYLE_BORDER_NONE = "border: none";
   private static final String TARGET_BLANK = "_blank";
 
-  final Node node;
   private final WelcomeToadletRuntimePorts runtimePorts;
 
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly.
 
-  WelcomeToadlet(HighLevelSimpleClient client, Node node, WelcomeToadletRuntimePorts runtimePorts) {
+  WelcomeToadlet(HighLevelSimpleClient client, WelcomeToadletRuntimePorts runtimePorts) {
     super(client);
-    this.node = Objects.requireNonNull(node, "node");
     this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
   }
 
@@ -350,7 +342,7 @@ public class WelcomeToadlet extends Toadlet {
     content.addChild("p").addChild("#", l10n("thanks"));
     writeHTMLReply(ctx, 200, "OK", page.generate());
     LOG.info("Node is updating/restarting");
-    node.services().nodeUpdater().arm();
+    runtimePorts.welcomeActionPort().armNodeUpdate();
     return true;
   }
 
@@ -396,7 +388,7 @@ public class WelcomeToadlet extends Toadlet {
     }
     PageNode page = ctx.getPageMaker().getPageNode(l10n("threadDumpTitle"), ctx);
     HTMLNode contentNode = page.getContentNode();
-    if (node.isUsingWrapper()) {
+    if (runtimePorts.lifecyclePort().isUsingWrapper()) {
       ctx.getPageMaker()
           .getInfobox("#", l10n("threadDumpSubTitle"), contentNode, "thread-dump-generation", true)
           .addChild(
@@ -600,7 +592,7 @@ public class WelcomeToadlet extends Toadlet {
         MultiValueTable.from(
             HEADER_LOCATION, "/?terminated&" + PARAM_FORM_PASSWORD + '=' + ctx.getFormPassword());
     ctx.sendReplyHeaders(302, STATUS_FOUND, headers, null, 0);
-    node.network().ticker().queueTimedJob(() -> node.exit("Shutdown from fproxy"), 1);
+    runtimePorts.welcomeActionPort().queueShutdownFromWelcome();
     return true;
   }
 
@@ -643,7 +635,7 @@ public class WelcomeToadlet extends Toadlet {
         MultiValueTable.from(
             HEADER_LOCATION, "/?restarted&" + PARAM_FORM_PASSWORD + '=' + ctx.getFormPassword());
     ctx.sendReplyHeaders(302, STATUS_FOUND, headers, null, 0);
-    node.network().ticker().queueTimedJob(() -> node.getNodeStarter().restart(), 1);
+    runtimePorts.welcomeActionPort().queueRestartFromWelcome();
     return true;
   }
 
@@ -672,92 +664,14 @@ public class WelcomeToadlet extends Toadlet {
     if (!ctx.checkFormPassword(request)) {
       return true;
     }
-
-    UpgradeConnectionSpeedUserAlert upgradeConnectionSpeedAlert = findUpgradeConnectionSpeedAlert();
-
-    String errorMessage = validateBandwidthLimits(request);
-
-    if (errorMessage == null) {
-      applyBandwidthLimits(request, upgradeConnectionSpeedAlert);
-    } else if (upgradeConnectionSpeedAlert != null) {
-      upgradeConnectionSpeedAlert.setError(errorMessage);
-    }
+    runtimePorts
+        .welcomeActionPort()
+        .applyUpgradeConnectionSpeed(
+            request.getPartAsStringFailsafe(PARAM_INPUT_BANDWIDTH_LIMIT, Byte.MAX_VALUE),
+            request.getPartAsStringFailsafe(PARAM_OUTPUT_BANDWIDTH_LIMIT, Byte.MAX_VALUE));
 
     redirectToRoot(ctx);
     return true;
-  }
-
-  private UpgradeConnectionSpeedUserAlert findUpgradeConnectionSpeedAlert() {
-    for (UserAlert alert : node.services().clientCore().getAlerts().getAlerts()) {
-      if (alert instanceof UpgradeConnectionSpeedUserAlert userAlert) {
-        return userAlert;
-      }
-    }
-    return null;
-  }
-
-  private String validateBandwidthLimits(HTTPRequest request) {
-    String errorMessage = null;
-    try {
-      int outputBandwidthLimit =
-          Fields.parseInt(
-              request.getPartAsStringFailsafe(PARAM_OUTPUT_BANDWIDTH_LIMIT, Byte.MAX_VALUE));
-      BandwidthManager.checkOutputBandwidthLimit(outputBandwidthLimit);
-    } catch (NumberFormatException _) {
-      errorMessage =
-          NodeL10n.getBase()
-              .getString("UpgradeConnectionSpeedUserAlert.InvalidValue", "type", "upload");
-    } catch (InvalidConfigValueException e) {
-      errorMessage = e.getMessage();
-    }
-    try {
-      int inputBandwidthLimit =
-          Fields.parseInt(
-              request.getPartAsStringFailsafe(PARAM_INPUT_BANDWIDTH_LIMIT, Byte.MAX_VALUE));
-      BandwidthManager.checkInputBandwidthLimit(inputBandwidthLimit);
-    } catch (NumberFormatException _) {
-      errorMessage =
-          combineErrorMessage(
-              errorMessage,
-              NodeL10n.getBase()
-                  .getString("UpgradeConnectionSpeedUserAlert.InvalidValue", "type", "download"));
-    } catch (InvalidConfigValueException e) {
-      errorMessage = combineErrorMessage(errorMessage, e.getMessage());
-    }
-    return errorMessage;
-  }
-
-  private String combineErrorMessage(String existing, String newMessage) {
-    if (existing == null) {
-      return newMessage;
-    }
-    return existing + " " + newMessage;
-  }
-
-  private void applyBandwidthLimits(
-      HTTPRequest request, UpgradeConnectionSpeedUserAlert upgradeConnectionSpeedAlert) {
-    try {
-      node.getConfig()
-          .get("node")
-          .set(
-              PARAM_INPUT_BANDWIDTH_LIMIT,
-              request.getPartAsStringFailsafe(PARAM_INPUT_BANDWIDTH_LIMIT, Byte.MAX_VALUE));
-      node.getConfig()
-          .get("node")
-          .set(
-              PARAM_OUTPUT_BANDWIDTH_LIMIT,
-              request.getPartAsStringFailsafe(PARAM_OUTPUT_BANDWIDTH_LIMIT, Byte.MAX_VALUE));
-
-      if (upgradeConnectionSpeedAlert != null) {
-        upgradeConnectionSpeedAlert.setUpgraded(true);
-      }
-    } catch (InvalidConfigValueException e) {
-      if (upgradeConnectionSpeedAlert != null) {
-        upgradeConnectionSpeedAlert.setError(e.getMessage());
-      }
-    } catch (NodeNeedRestartException _) {
-      // The user will restart later if necessary.
-    }
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/WelcomeToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/WelcomeToadletRuntimePorts.java
@@ -3,33 +3,35 @@ package network.crypta.clients.http;
 import java.util.Objects;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.WelcomeActionPort;
 import network.crypta.runtime.spi.WelcomePagePort;
 
 /**
- * Bundles the detached runtime ports used by the welcome toadlet's GET/read path.
+ * Bundles the detached runtime ports used by the welcome toadlet.
  *
- * <p>{@code WelcomeToadlet} is still in the middle of its runtime-SPI migration. Its GET handling
- * now reads a few pieces of runtime state through detached ports, while its POST and action paths
- * still use the legacy live-daemon fields. Collecting the GET-only collaborators in one record
- * keeps the constructor small, makes the migration boundary explicit, and avoids introducing a
- * broader HTTP abstraction layer for a single page.
+ * <p>The welcome page now reaches the daemon only through detached runtime ports. Collecting the
+ * page-specific collaborators in one record keeps the constructor small, makes the migration
+ * boundary explicit, and avoids introducing a broader HTTP abstraction layer for a single page.
  *
- * <p>The bundle is intentionally narrow. It contains only the collaborators that the current PR
- * needs for read-only page assembly and visibility checks, and nothing for restart, shutdown,
- * update, or other action routes.
+ * <p>The bundle is intentionally narrow. It contains only the collaborators that the welcome page
+ * currently needs for read-only page assembly, wrapper-dependent visibility checks, bookmark peer
+ * rendering, and the remaining welcome-page maintenance actions.
  *
  * @param welcomePagePort detached welcome-page read port used for config-backed snapshot and log
  *     tail reads during welcome-page GET handling
  * @param darknetConnectionsPort detached darknet connections port used for bookmark recommendation
  *     peer rendering in GET responses
  * @param lifecyclePort detached lifecycle port used for wrapper-dependent button visibility
+ * @param welcomeActionPort detached welcome-page action port used for update/restart/shutdown and
+ *     connection-speed upgrade POST handlers
  */
 record WelcomeToadletRuntimePorts(
     WelcomePagePort welcomePagePort,
     DarknetConnectionsPort darknetConnectionsPort,
-    LifecyclePort lifecyclePort) {
+    LifecyclePort lifecyclePort,
+    WelcomeActionPort welcomeActionPort) {
   /**
-   * Validates that every detached collaborator required by the welcome-page GET path is present.
+   * Validates that every detached collaborator required by the welcome page is present.
    *
    * <p>The record carries dependencies only. Construction fails fast if any required port is
    * missing, so the registration error appears at startup rather than during request handling.
@@ -38,5 +40,6 @@ record WelcomeToadletRuntimePorts(
     Objects.requireNonNull(welcomePagePort);
     Objects.requireNonNull(darknetConnectionsPort);
     Objects.requireNonNull(lifecyclePort);
+    Objects.requireNonNull(welcomeActionPort);
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -28,6 +28,7 @@ import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.StatisticsPort;
 import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.runtime.spi.WelcomeActionPort;
 import network.crypta.runtime.spi.WelcomePagePort;
 
 /**
@@ -68,6 +69,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final SecurityLevelsPort securityLevelsPort;
   private final FirstTimeWizardPort firstTimeWizardPort;
   private final WelcomePagePort welcomePagePort;
+  private final WelcomeActionPort welcomeActionPort;
   private final RequestQueuePort requestQueuePort;
   private final NodeInfoPort nodeInfoPort;
   private final PeerPort peerPort;
@@ -172,6 +174,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.securityLevelsPort = new LegacySecurityLevelsPort(node);
     this.firstTimeWizardPort = new LegacyFirstTimeWizardPort(node, core);
     this.welcomePagePort = new LegacyWelcomePagePort(node);
+    this.welcomeActionPort = new LegacyWelcomeActionPort(node);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
@@ -413,6 +416,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public WelcomePagePort welcomePage() {
     return welcomePagePort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining welcome-page update, restart, shutdown, and
+   * bandwidth-upgrade actions inside the daemon root module while exposing only the narrow legacy
+   * action surface upstream.
+   */
+  @Override
+  public WelcomeActionPort welcomeAction() {
+    return welcomeActionPort;
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyWelcomeActionPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyWelcomeActionPort.java
@@ -1,0 +1,196 @@
+package network.crypta.node.runtime;
+
+import java.util.Objects;
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.NodeNeedRestartException;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.node.BandwidthManager;
+import network.crypta.node.Node;
+import network.crypta.node.useralerts.UpgradeConnectionSpeedUserAlert;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.runtime.spi.WelcomeActionPort;
+import network.crypta.support.Fields;
+
+/**
+ * Bridges the remaining legacy welcome-page POST actions onto the runtime SPI.
+ *
+ * <p>This adapter keeps the welcome page's last live-daemon action paths in the root module: update
+ * arming, delayed shutdown or restart scheduling, and bandwidth-upgrade validation plus alert
+ * mutation. {@code WelcomeToadlet} and related HTTP code pass already-parsed form data into this
+ * adapter, while the daemon side remains the source of truth for the effects that touch node
+ * services, config, and existing user alerts.
+ *
+ * <p>The adapter intentionally preserves the current semantics instead of generalizing them. It
+ * validates the bandwidth fields using the existing rules, updates the existing upgrade alert when
+ * present, writes the same config keys, and swallows restart-required exceptions exactly as the
+ * legacy welcome toadlet did. The class is package-private because it is an implementation detail
+ * behind {@link WelcomeActionPort}; callers should depend on the SPI surface exposed through {@link
+ * LegacyRuntimePorts} instead of constructing this adapter directly.
+ */
+final class LegacyWelcomeActionPort implements WelcomeActionPort {
+  /** Small delay that lets the HTTP layer finish its redirect before shutdown or restart begins. */
+  private static final long WELCOME_ACTION_DELAY_MILLIS = 1L;
+
+  /** Name of the node sub-configuration that stores the bandwidth-upgrade values. */
+  private static final String NODE_CONFIG_PREFIX = "node";
+
+  /** Config key for the welcome-page download-bandwidth upgrade field. */
+  private static final String INPUT_BANDWIDTH_LIMIT = "inputBandwidthLimit";
+
+  /** Config key for the welcome-page upload-bandwidth upgrade field. */
+  private static final String OUTPUT_BANDWIDTH_LIMIT = "outputBandwidthLimit";
+
+  /** Live daemon node that still owns the underlying welcome-page maintenance behaviors. */
+  private final Node node;
+
+  /**
+   * Creates a welcome-page action adapter backed by the current daemon runtime.
+   *
+   * @param node live daemon node that owns the existing welcome-page maintenance actions
+   */
+  LegacyWelcomeActionPort(Node node) {
+    this.node = Objects.requireNonNull(node, "node");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void armNodeUpdate() {
+    node.services().nodeUpdater().arm();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void queueShutdownFromWelcome() {
+    node.network()
+        .ticker()
+        .queueTimedJob(() -> node.exit("Shutdown from fproxy"), WELCOME_ACTION_DELAY_MILLIS);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void queueRestartFromWelcome() {
+    node.network()
+        .ticker()
+        .queueTimedJob(() -> node.getNodeStarter().restart(), WELCOME_ACTION_DELAY_MILLIS);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void applyUpgradeConnectionSpeed(String inputBandwidthLimit, String outputBandwidthLimit) {
+    Objects.requireNonNull(inputBandwidthLimit, INPUT_BANDWIDTH_LIMIT);
+    Objects.requireNonNull(outputBandwidthLimit, OUTPUT_BANDWIDTH_LIMIT);
+
+    UpgradeConnectionSpeedUserAlert upgradeAlert = findUpgradeConnectionSpeedAlert();
+    String errorMessage = validateBandwidthLimits(inputBandwidthLimit, outputBandwidthLimit);
+
+    if (errorMessage == null) {
+      applyBandwidthLimits(inputBandwidthLimit, outputBandwidthLimit, upgradeAlert);
+    } else if (upgradeAlert != null) {
+      upgradeAlert.setError(errorMessage);
+    }
+  }
+
+  /**
+   * Finds the existing upgrade-connection-speed alert if the daemon has already published one.
+   *
+   * <p>The legacy welcome flow mutates a pre-existing {@link UpgradeConnectionSpeedUserAlert}
+   * rather than creating a new alert for each submission. Returning {@code null} means no such
+   * alert is currently registered, so the caller should preserve the config-side effect without
+   * attempting any alert mutation.
+   *
+   * @return the existing upgrade alert, or {@code null} when the alert is not registered
+   */
+  private UpgradeConnectionSpeedUserAlert findUpgradeConnectionSpeedAlert() {
+    for (UserAlert alert : node.services().clientCore().getAlerts().getAlerts()) {
+      if (alert instanceof UpgradeConnectionSpeedUserAlert userAlert) {
+        return userAlert;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Applies the legacy bandwidth validation rules and combines any resulting error text.
+   *
+   * <p>The welcome page historically validates upload and download limits independently, then joins
+   * both messages into a single human-readable error string. A {@code null} result means both
+   * values passed validation and the config writing may proceed. The input strings are expected to
+   * be the raw form values already extracted by the HTTP layer.
+   *
+   * @param inputBandwidthLimit raw download-limit text from the welcome-page submission
+   * @param outputBandwidthLimit raw upload-limit text from the welcome-page submission
+   * @return a combined validation error message, or {@code null} when both values are valid
+   */
+  private String validateBandwidthLimits(String inputBandwidthLimit, String outputBandwidthLimit) {
+    String errorMessage = null;
+    try {
+      BandwidthManager.checkOutputBandwidthLimit(Fields.parseInt(outputBandwidthLimit));
+    } catch (NumberFormatException _) {
+      errorMessage =
+          NodeL10n.getBase()
+              .getString("UpgradeConnectionSpeedUserAlert.InvalidValue", "type", "upload");
+    } catch (InvalidConfigValueException e) {
+      errorMessage = e.getMessage();
+    }
+
+    try {
+      BandwidthManager.checkInputBandwidthLimit(Fields.parseInt(inputBandwidthLimit));
+    } catch (NumberFormatException _) {
+      errorMessage =
+          combineErrorMessage(
+              errorMessage,
+              NodeL10n.getBase()
+                  .getString("UpgradeConnectionSpeedUserAlert.InvalidValue", "type", "download"));
+    } catch (InvalidConfigValueException e) {
+      errorMessage = combineErrorMessage(errorMessage, e.getMessage());
+    }
+
+    return errorMessage;
+  }
+
+  /**
+   * Joins two validation messages using the legacy single-space separator.
+   *
+   * @param existing previously accumulated validation message, or {@code null} for none
+   * @param newMessage newly generated validation message to append
+   * @return {@code newMessage} when no earlier message exists, otherwise both messages joined
+   */
+  private static String combineErrorMessage(String existing, String newMessage) {
+    if (existing == null) {
+      return newMessage;
+    }
+    return existing + " " + newMessage;
+  }
+
+  /**
+   * Persists validated bandwidth values and updates the existing alert with the legacy semantics.
+   *
+   * <p>Successful writes mark the existing upgrade alert as upgraded when such an alert is present.
+   * Invalid config values are surfaced back into the existing alert, while {@link
+   * NodeNeedRestartException} is swallowed so the HTTP flow can preserve the historical "restart
+   * later" behavior from the welcome page.
+   *
+   * @param inputBandwidthLimit validated download-limit text to write into node config
+   * @param outputBandwidthLimit validated upload-limit text to write into node config
+   * @param upgradeAlert existing upgrade alert to mutate, or {@code null} when none is registered
+   */
+  private void applyBandwidthLimits(
+      String inputBandwidthLimit,
+      String outputBandwidthLimit,
+      UpgradeConnectionSpeedUserAlert upgradeAlert) {
+    try {
+      node.getConfig().get(NODE_CONFIG_PREFIX).set(INPUT_BANDWIDTH_LIMIT, inputBandwidthLimit);
+      node.getConfig().get(NODE_CONFIG_PREFIX).set(OUTPUT_BANDWIDTH_LIMIT, outputBandwidthLimit);
+
+      if (upgradeAlert != null) {
+        upgradeAlert.setUpgraded(true);
+      }
+    } catch (InvalidConfigValueException e) {
+      if (upgradeAlert != null) {
+        upgradeAlert.setError(e.getMessage());
+      }
+    } catch (NodeNeedRestartException _) {
+      // The user will restart later if necessary.
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -16,8 +16,12 @@ import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.WelcomeActionPort;
+import network.crypta.runtime.spi.WelcomePagePort;
 import network.crypta.support.api.IntCallback;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,6 +64,10 @@ class FProxyRegistrarTest {
   @Mock private RandomSource randomSource;
   @Mock private ClientEndpoints endpoints;
   @Mock private QueueCompletionPort queueCompletionPort;
+  @Mock private WelcomePagePort welcomePagePort;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private LifecyclePort lifecyclePort;
+  @Mock private WelcomeActionPort welcomeActionPort;
   @Mock private SimpleToadletServer server;
 
   private Config config;
@@ -86,6 +94,10 @@ class FProxyRegistrarTest {
     when(core.getEndpoints()).thenReturn(endpoints);
     when(client.getFetchContext()).thenReturn(fetchContext);
     when(runtimePorts.queueCompletion()).thenReturn(queueCompletionPort);
+    when(runtimePorts.welcomePage()).thenReturn(welcomePagePort);
+    when(runtimePorts.darknetConnections()).thenReturn(darknetConnectionsPort);
+    when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
+    when(runtimePorts.welcomeAction()).thenReturn(welcomeActionPort);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
@@ -10,12 +10,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.clients.http.bookmark.BookmarkItem;
-import network.crypta.node.Node;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.WelcomeActionPort;
 import network.crypta.runtime.spi.WelcomePagePort;
 import network.crypta.runtime.spi.WelcomePageSnapshot;
 import network.crypta.support.HTMLNode;
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,12 +54,10 @@ class WelcomeToadletTest {
 
   @Mock private HighLevelSimpleClient client;
 
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
   @Mock private WelcomePagePort welcomePagePort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private LifecyclePort lifecyclePort;
+  @Mock private WelcomeActionPort welcomeActionPort;
   @Mock private ToadletContext ctx;
   @Mock private ToadletContainer container;
   @Mock private UserAlertManager alertManager;
@@ -71,8 +70,9 @@ class WelcomeToadletTest {
   @BeforeEach
   void setUp() {
     runtimePorts =
-        new WelcomeToadletRuntimePorts(welcomePagePort, darknetConnectionsPort, lifecyclePort);
-    toadlet = new WelcomeToadlet(client, node, runtimePorts);
+        new WelcomeToadletRuntimePorts(
+            welcomePagePort, darknetConnectionsPort, lifecyclePort, welcomeActionPort);
+    toadlet = new WelcomeToadlet(client, runtimePorts);
     toadlet.container = container;
     originalUserDir = System.getProperty("user.dir");
 
@@ -85,6 +85,8 @@ class WelcomeToadletTest {
     when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert-summary"));
     when(alertManager.renderDismissButton(any(), anyString())).thenReturn(new HTMLNode("button"));
     when(request.getParam("newbookmark")).thenReturn("");
+    when(request.getPartAsStringFailsafe("updateconfirm", 32)).thenReturn("");
+    when(request.getPartAsStringFailsafe("update", 32)).thenReturn("");
     when(ctx.addFormChild(any(HTMLNode.class), anyString(), anyString()))
         .thenAnswer(
             invocation -> {
@@ -130,6 +132,14 @@ class WelcomeToadletTest {
   @Test
   void path_returnsRootSlash() {
     assertEquals(WelcomeToadlet.ROOT_PATH, toadlet.path());
+  }
+
+  @Test
+  void constructor_whenRuntimePortsProvided_noLongerNeedsNodeDependency() {
+    assertEquals(1, WelcomeToadlet.class.getDeclaredConstructors().length);
+    assertArrayEquals(
+        new Class<?>[] {HighLevelSimpleClient.class, WelcomeToadletRuntimePorts.class},
+        WelcomeToadlet.class.getDeclaredConstructors()[0].getParameterTypes());
   }
 
   @Test
@@ -201,6 +211,88 @@ class WelcomeToadletTest {
     assertTrue(body.contains("id=\"keyfetchbox\""));
     assertTrue(body.indexOf("id=\"keyfetchbox\"") > body.indexOf("id=\"bookmarks\""));
     verify(welcomePagePort).snapshot();
+  }
+
+  @Test
+  void handleMethodPOST_whenUpdateConfirmed_delegatesToWelcomeActionPort() throws Exception {
+    WelcomeToadlet spyToadlet = createSpyToadlet();
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(request.getPartAsStringFailsafe("updateconfirm", 32)).thenReturn("update-now");
+    captureHtmlReply(spyToadlet);
+
+    spyToadlet.handleMethodPOST(URI.create("http://localhost/"), request, ctx);
+
+    verify(welcomeActionPort).armNodeUpdate();
+  }
+
+  @Test
+  void handleMethodPOST_whenShutdownConfirmed_redirectsAndDelegatesToWelcomeActionPort()
+      throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(request.isPartSet("shutdownconfirm")).thenReturn(true);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/"), request, ctx);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), eq(null), eq(0L));
+    assertEquals(
+        "/?terminated&formPassword=form-password", headersCaptor.getValue().getFirst("Location"));
+    verify(welcomeActionPort).queueShutdownFromWelcome();
+  }
+
+  @Test
+  void handleMethodPOST_whenRestartConfirmed_redirectsAndDelegatesToWelcomeActionPort()
+      throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(request.isPartSet("restartconfirm")).thenReturn(true);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/"), request, ctx);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), eq(null), eq(0L));
+    assertEquals(
+        "/?restarted&formPassword=form-password", headersCaptor.getValue().getFirst("Location"));
+    verify(welcomeActionPort).queueRestartFromWelcome();
+  }
+
+  @Test
+  void handleMethodPOST_whenUpgradeConnectionSpeedSubmitted_delegatesToWelcomeActionPort()
+      throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(request.isPartSet("upgradeConnectionSpeed")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("inputBandwidthLimit", Byte.MAX_VALUE)).thenReturn("4KiB");
+    when(request.getPartAsStringFailsafe("outputBandwidthLimit", Byte.MAX_VALUE))
+        .thenReturn("1KiB");
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/"), request, ctx);
+
+    verify(welcomeActionPort).applyUpgradeConnectionSpeed("4KiB", "1KiB");
+  }
+
+  @Test
+  void handleMethodPOST_whenThreadDumpRequested_checksLifecyclePort() throws Exception {
+    WelcomeToadlet spyToadlet = createSpyToadlet();
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(request.isPartSet("getThreadDump")).thenReturn(true);
+    when(lifecyclePort.isUsingWrapper()).thenReturn(false);
+    captureHtmlReply(spyToadlet);
+
+    spyToadlet.handleMethodPOST(URI.create("http://localhost/"), request, ctx);
+
+    verify(lifecyclePort).isUsingWrapper();
   }
 
   @Test
@@ -353,7 +445,7 @@ class WelcomeToadletTest {
   }
 
   private WelcomeToadlet createSpyToadlet() {
-    WelcomeToadlet spyToadlet = spy(new WelcomeToadlet(client, node, runtimePorts));
+    WelcomeToadlet spyToadlet = spy(new WelcomeToadlet(client, runtimePorts));
     spyToadlet.container = container;
     return spyToadlet;
   }

--- a/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
@@ -64,6 +64,11 @@ class LegacyRuntimePortsTest {
   void getters_whenRequested_expectStablePortReferences() {
     PortsSnapshot snapshot = capturePorts();
 
+    assertStableInfrastructurePorts(snapshot);
+    assertStableFeaturePorts(snapshot);
+  }
+
+  private void assertStableInfrastructurePorts(PortsSnapshot snapshot) {
     assertAll(
         () -> assertSame(snapshot.executionPort(), ports.execution()),
         () -> assertSame(snapshot.randomnessPort(), ports.randomness()),
@@ -75,7 +80,11 @@ class LegacyRuntimePortsTest {
         () -> assertSame(snapshot.connectionsSupportPort(), ports.connectionsSupport()),
         () -> assertSame(snapshot.darknetConnectionsPort(), ports.darknetConnections()),
         () -> assertSame(snapshot.darknetMessagingPort(), ports.darknetMessaging()),
-        () -> assertSame(snapshot.diagnosticPort(), ports.diagnostic()),
+        () -> assertSame(snapshot.diagnosticPort(), ports.diagnostic()));
+  }
+
+  private void assertStableFeaturePorts(PortsSnapshot snapshot) {
+    assertAll(
         () -> assertSame(snapshot.queueSupportPort(), ports.queueSupport()),
         () -> assertSame(snapshot.queueCompletionPort(), ports.queueCompletion()),
         () -> assertSame(snapshot.queuePagePort(), ports.queuePage()),
@@ -86,6 +95,7 @@ class LegacyRuntimePortsTest {
         () -> assertSame(snapshot.securityLevelsPort(), ports.securityLevels()),
         () -> assertSame(snapshot.firstTimeWizardPort(), ports.firstTimeWizard()),
         () -> assertSame(snapshot.welcomePagePort(), ports.welcomePage()),
+        () -> assertSame(snapshot.welcomeActionPort(), ports.welcomeAction()),
         () -> assertSame(snapshot.requestQueuePort(), ports.requestQueue()),
         () -> assertSame(snapshot.nodeInfoPort(), ports.nodeInfo()),
         () -> assertSame(snapshot.peerPort(), ports.peer()));
@@ -115,6 +125,7 @@ class LegacyRuntimePortsTest {
         () -> assertInstanceOf(LegacySecurityLevelsPort.class, snapshot.securityLevelsPort()),
         () -> assertInstanceOf(LegacyFirstTimeWizardPort.class, snapshot.firstTimeWizardPort()),
         () -> assertInstanceOf(LegacyWelcomePagePort.class, snapshot.welcomePagePort()),
+        () -> assertInstanceOf(LegacyWelcomeActionPort.class, snapshot.welcomeActionPort()),
         () -> assertInstanceOf(LegacyRequestQueuePort.class, snapshot.requestQueuePort()),
         () -> assertInstanceOf(LegacyNodeInfoPort.class, snapshot.nodeInfoPort()),
         () -> assertInstanceOf(LegacyPeerPort.class, snapshot.peerPort()));
@@ -195,6 +206,7 @@ class LegacyRuntimePortsTest {
         ports.securityLevels(),
         ports.firstTimeWizard(),
         ports.welcomePage(),
+        ports.welcomeAction(),
         ports.requestQueue(),
         ports.nodeInfo(),
         ports.peer());
@@ -222,6 +234,7 @@ class LegacyRuntimePortsTest {
       Object securityLevelsPort,
       Object firstTimeWizardPort,
       Object welcomePagePort,
+      Object welcomeActionPort,
       Object requestQueuePort,
       Object nodeInfoPort,
       Object peerPort) {}

--- a/src/test/java/network/crypta/node/runtime/LegacyWelcomeActionPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyWelcomeActionPortTest.java
@@ -1,0 +1,132 @@
+package network.crypta.node.runtime;
+
+import network.crypta.config.NodeNeedRestartException;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeStarter;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.node.useralerts.UpgradeConnectionSpeedUserAlert;
+import network.crypta.node.useralerts.UserAlert;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class LegacyWelcomeActionPortTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock private Ticker ticker;
+  @Mock private PersistentConfig config;
+  @Mock private SubConfig nodeConfig;
+  @Mock private NodeStarter nodeStarter;
+  @Mock private NodeUpdateManager nodeUpdateManager;
+  @Mock private UserAlertManager alertManager;
+  @Mock private UpgradeConnectionSpeedUserAlert upgradeAlert;
+
+  private LegacyWelcomeActionPort port;
+
+  @BeforeEach
+  void setUp() {
+    when(node.network().ticker()).thenReturn(ticker);
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeConfig);
+    when(node.getNodeStarter()).thenReturn(nodeStarter);
+    when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
+    when(node.services().clientCore().getAlerts()).thenReturn(alertManager);
+
+    port = new LegacyWelcomeActionPort(node);
+  }
+
+  @Test
+  void armNodeUpdate_whenInvoked_delegatesToNodeUpdater() {
+    port.armNodeUpdate();
+
+    verify(nodeUpdateManager).arm();
+  }
+
+  @Test
+  void queueShutdownFromWelcome_whenInvoked_schedulesNodeExit() {
+    ArgumentCaptor<Runnable> shutdownJob = ArgumentCaptor.forClass(Runnable.class);
+
+    port.queueShutdownFromWelcome();
+
+    verify(ticker).queueTimedJob(shutdownJob.capture(), eq(1L));
+    shutdownJob.getValue().run();
+    verify(node).exit("Shutdown from fproxy");
+  }
+
+  @Test
+  void queueRestartFromWelcome_whenInvoked_schedulesNodeRestart() {
+    ArgumentCaptor<Runnable> restartJob = ArgumentCaptor.forClass(Runnable.class);
+
+    port.queueRestartFromWelcome();
+
+    verify(ticker).queueTimedJob(restartJob.capture(), eq(1L));
+    restartJob.getValue().run();
+    verify(nodeStarter).restart();
+  }
+
+  @Test
+  void applyUpgradeConnectionSpeed_whenValuesValid_updatesConfigAndAlert() throws Exception {
+    when(alertManager.getAlerts()).thenReturn(new UserAlert[] {upgradeAlert});
+
+    port.applyUpgradeConnectionSpeed("32KiB", "16KiB");
+
+    verify(nodeConfig).set("inputBandwidthLimit", "32KiB");
+    verify(nodeConfig).set("outputBandwidthLimit", "16KiB");
+    verify(upgradeAlert).setUpgraded(true);
+  }
+
+  @Test
+  void applyUpgradeConnectionSpeed_whenValuesInvalid_setsAlertErrorWithoutWritingConfig() {
+    ArgumentCaptor<String> errorMessage = ArgumentCaptor.forClass(String.class);
+    when(alertManager.getAlerts()).thenReturn(new UserAlert[] {upgradeAlert});
+
+    port.applyUpgradeConnectionSpeed("not-a-limit", "also-invalid");
+
+    verify(upgradeAlert).setError(errorMessage.capture());
+    assertNotNull(errorMessage.getValue());
+    assertFalse(errorMessage.getValue().isBlank());
+    verifyNoInteractions(nodeConfig);
+  }
+
+  @Test
+  void applyUpgradeConnectionSpeed_whenConfigWriteNeedsRestart_swallowsException()
+      throws Exception {
+    when(alertManager.getAlerts()).thenReturn(new UserAlert[] {upgradeAlert});
+    doThrow(new NodeNeedRestartException("restart required"))
+        .when(nodeConfig)
+        .set("outputBandwidthLimit", "16KiB");
+
+    assertDoesNotThrow(() -> port.applyUpgradeConnectionSpeed("32KiB", "16KiB"));
+
+    verify(nodeConfig).set("inputBandwidthLimit", "32KiB");
+    verify(nodeConfig).set("outputBandwidthLimit", "16KiB");
+    verify(upgradeAlert, never()).setUpgraded(true);
+    verify(upgradeAlert, never()).setError(anyString());
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow `WelcomeActionPort` to `runtime-spi` and wire it through `RuntimePorts` and `LegacyRuntimePorts`
- move the remaining `WelcomeToadlet` POST/action paths off direct `Node` access, including update, shutdown, restart, and upgrade-connection-speed handling, while switching thread-dump wrapper gating to `LifecyclePort`
- add focused tests for `WelcomeToadlet`, `LegacyWelcomeActionPort`, and `LegacyRuntimePorts`, and add doclint-clean Javadocs for the new production types

## Testing
- `./gradlew test --tests 'network.crypta.clients.http.WelcomeToadletTest' --tests 'network.crypta.node.runtime.LegacyWelcomeActionPortTest' --tests 'network.crypta.node.runtime.LegacyRuntimePortsTest'`
- `./gradlew -q classes`
- `javadoc -quiet -Xdoclint:all -classpath 'runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out-welcome-action runtime-spi/src/main/java/network/crypta/runtime/spi/WelcomeActionPort.java`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out-legacy-welcome-action src/main/java/network/crypta/node/runtime/LegacyWelcomeActionPort.java`

## Scope
- keeps the PR limited to the welcome-page runtime-SPI migration
- does not include admin-shell cleanup, broad `FProxyRegistrar` cleanup, bookmark or browse refactors, or FCP content-path work