### PR TITLE
refactor(wizard): Detach legacy runtime reads

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardCurrentBandwidthLimits.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardCurrentBandwidthLimits.java
@@ -1,0 +1,21 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Carries the detached current-bandwidth row for the legacy first-time wizard rate page.
+ *
+ * <p>The legacy multipage wizard can show a "current settings" row ahead of its fixed presets when
+ * the running node already has an explicit upload limit. This record transports just the two
+ * byte-per-second values needed to render that row through the detached wizard snapshot, without
+ * exposing HTTP-only helper types or live daemon objects across the runtime SPI boundary.
+ *
+ * <p>This type is intentionally small and immutable. Producers compute the values from live daemon
+ * state at snapshot time, while consumers treat the record as detached display data. The record
+ * does not encode whether the row should be shown; callers use the presence or absence of the
+ * record in the surrounding snapshot to make that decision.
+ *
+ * @param downloadBytes effective downstream limit, expressed in bytes per second for detached UI
+ *     rendering
+ * @param uploadBytes effective upstream limit, expressed in bytes per second for detached UI
+ *     rendering
+ */
+public record FirstTimeWizardCurrentBandwidthLimits(long downloadBytes, long uploadBytes) {}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
@@ -27,6 +27,8 @@ import java.util.Objects;
  *     display and error messages
  * @param maxStorageLimitBytes maximum datastore size accepted by the page, expressed in exact bytes
  *     for validation
+ * @param legacyMaxStorageLimitBytes store-dir-aware maximum datastore size used by the legacy
+ *     multipage wizard dropdown thresholds
  * @param minBandwidthKiB minimum direct download or upload limit accepted by the page, in KiB/s
  * @param maxUploadLimitKiB maximum direct upload limit accepted by the page, in KiB/s
  * @param minBandwidthMonthlyLimitGiB minimum monthly transfer budget accepted by the page,
@@ -35,6 +37,8 @@ import java.util.Objects;
  *     string when automatic detection is unavailable
  * @param detectedUploadLimitKiB recommended direct upload limit in KiB/s text or an empty string
  *     when automatic detection is unavailable
+ * @param currentBandwidthLimits detached effective bandwidth row for the legacy rate page, or
+ *     {@code null} when the page should omit the current-settings row
  * @param autodetectedStorageLimitBytes autodetected datastore suggestion in exact bytes, or {@code
  *     -1} when the legacy datastore page should fall back to its fixed-size defaults
  */
@@ -45,11 +49,13 @@ public record FirstTimeWizardSnapshot(
     long minStorageLimitBytes,
     String maxStorageLimitGiB,
     long maxStorageLimitBytes,
+    long legacyMaxStorageLimitBytes,
     long minBandwidthKiB,
     long maxUploadLimitKiB,
     String minBandwidthMonthlyLimitGiB,
     String detectedDownloadLimitKiB,
     String detectedUploadLimitKiB,
+    FirstTimeWizardCurrentBandwidthLimits currentBandwidthLimits,
     long autodetectedStorageLimitBytes) {
   /**
    * Creates an immutable first-time-wizard snapshot.
@@ -67,5 +73,43 @@ public record FirstTimeWizardSnapshot(
     Objects.requireNonNull(minBandwidthMonthlyLimitGiB, "minBandwidthMonthlyLimitGiB");
     Objects.requireNonNull(detectedDownloadLimitKiB, "detectedDownloadLimitKiB");
     Objects.requireNonNull(detectedUploadLimitKiB, "detectedUploadLimitKiB");
+  }
+
+  /**
+   * Creates a first-time-wizard snapshot without legacy-only detached fields.
+   *
+   * <p>This compatibility constructor keeps existing call sites concise when they do not care about
+   * the legacy datastore dropdown cap or the optional current-bandwidth row. The legacy datastore
+   * bound defaults to {@code maxStorageLimitBytes}, and the current-bandwidth row defaults to
+   * {@code null}.
+   */
+  public FirstTimeWizardSnapshot(
+      boolean passwordAlreadySet,
+      String initialStorageLimitGiB,
+      String minStorageLimitGiB,
+      long minStorageLimitBytes,
+      String maxStorageLimitGiB,
+      long maxStorageLimitBytes,
+      long minBandwidthKiB,
+      long maxUploadLimitKiB,
+      String minBandwidthMonthlyLimitGiB,
+      String detectedDownloadLimitKiB,
+      String detectedUploadLimitKiB,
+      long autodetectedStorageLimitBytes) {
+    this(
+        passwordAlreadySet,
+        initialStorageLimitGiB,
+        minStorageLimitGiB,
+        minStorageLimitBytes,
+        maxStorageLimitGiB,
+        maxStorageLimitBytes,
+        maxStorageLimitBytes,
+        minBandwidthKiB,
+        maxUploadLimitKiB,
+        minBandwidthMonthlyLimitGiB,
+        detectedDownloadLimitKiB,
+        detectedUploadLimitKiB,
+        null,
+        autodetectedStorageLimitBytes);
   }
 }

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -10,8 +10,6 @@ import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
 import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
 import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
 import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
-import network.crypta.clients.http.wizardsteps.BandwidthLimit;
-import network.crypta.clients.http.wizardsteps.DatastoreSize;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
@@ -420,12 +418,7 @@ final class FProxyRegistrar {
 
     FirstTimeWizardToadlet firstTimeWizardToadlet =
         new FirstTimeWizardToadlet(
-            client,
-            config,
-            new FirstTimeWizardToadletRuntimePorts(
-                runtimePorts.firstTimeWizard(),
-                () -> DatastoreSize.maxDatastoreSize(node),
-                () -> legacyCurrentBandwidthLimits(config, node)));
+            client, config, new FirstTimeWizardToadletRuntimePorts(runtimePorts.firstTimeWizard()));
     server.register(
         firstTimeWizardToadlet,
         ToadletRegistration.basic(null, FirstTimeWizardToadlet.TOADLET_URL, true, false));
@@ -481,17 +474,5 @@ final class FProxyRegistrar {
     server.register(
         dismissAlertToadlet,
         ToadletRegistration.basic(null, dismissAlertToadlet.path(), true, false));
-  }
-
-  private static BandwidthLimit legacyCurrentBandwidthLimits(Config config, Node node) {
-    if (config.get("node").getOption("outputBandwidthLimit").isDefault()) {
-      return null;
-    }
-
-    return new BandwidthLimit(
-        node.network().inputBandwidthLimit(),
-        node.network().outputBandwidthLimit(),
-        "bandwidthCurrent",
-        false);
   }
 }

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -44,9 +44,7 @@ import org.slf4j.LoggerFactory;
  * <p>The toadlet coordinates several step handlers, each responsible for rendering and validating a
  * portion of the workflow. Requests are stateless; the wizard rebuilds its flow from submitted form
  * parameters and redirects between steps instead of maintaining a server-side session state. The
- * remaining live daemon reads and writes flow through the injected {@link FirstTimeWizardPort},
- * while a small HTTP-local runtime bundle still carries the legacy datastore and bandwidth
- * collaborators that have not been folded into the shared wizard snapshot.
+ * remaining live daemon reads and writes flow through the injected {@link FirstTimeWizardPort}.
  *
  * <p>Concurrency: requests for the same user are serialized by the HTTP layer, but the class does
  * not assume single-threaded execution. All I/O and state changes are delegated to the injected
@@ -168,18 +166,12 @@ public class FirstTimeWizardToadlet extends Toadlet {
     steps.put(WIZARD_STEP.WELCOME, new Welcome(config));
     steps.put(WIZARD_STEP.BROWSER_WARNING, new BrowserWarning());
     steps.put(WIZARD_STEP.NAME_SELECTION, new NameSelection(config));
-    steps.put(
-        WIZARD_STEP.DATASTORE_SIZE,
-        new DatastoreSize(
-            ports.firstTimeWizardPort(), config, ports.legacyDatastoreMaxStorageLimitBytes()));
+    steps.put(WIZARD_STEP.DATASTORE_SIZE, new DatastoreSize(ports.firstTimeWizardPort(), config));
     steps.put(WIZARD_STEP.OPENNET, new Opennet());
     steps.put(WIZARD_STEP.BANDWIDTH, new Bandwidth());
     steps.put(
         WIZARD_STEP.BANDWIDTH_MONTHLY, new BandwidthMonthly(ports.firstTimeWizardPort(), config));
-    steps.put(
-        WIZARD_STEP.BANDWIDTH_RATE,
-        new BandwidthRate(
-            ports.firstTimeWizardPort(), config, ports.legacyCurrentBandwidthLimits()));
+    steps.put(WIZARD_STEP.BANDWIDTH_RATE, new BandwidthRate(ports.firstTimeWizardPort(), config));
 
     // Add step handlers that presets set
     stepMISC = new Misc(config);

--- a/src/main/java/network/crypta/clients/http/FirstTimeWizardToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/FirstTimeWizardToadletRuntimePorts.java
@@ -1,30 +1,19 @@
 package network.crypta.clients.http;
 
 import java.util.Objects;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
-import network.crypta.clients.http.wizardsteps.BandwidthLimit;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 
 /**
  * Shared runtime-port bundle used by the legacy first-time wizard toadlet.
  *
  * <p>The legacy multipage wizard still owns its HTTP routing, redirects, and most config writes,
- * but the remaining live daemon interactions now route through the existing first-time-wizard SPI.
- * It also needs the legacy datastore dropdown cap, which still comes from the live store-directory
- * heuristic rather than the shared wizard snapshot. Grouping those collaborators keeps the toadlet
- * constructor narrow without threading the full runtime aggregate through the HTTP layer.
+ * but its remaining live daemon interactions now route through the existing first-time-wizard SPI.
+ * Grouping that collaborator keeps the toadlet constructor narrow without threading the full
+ * runtime aggregate through the HTTP layer.
  *
  * @param firstTimeWizardPort detached wizard runtime used by the legacy multipage wizard
- * @param legacyDatastoreMaxStorageLimitBytes store-dir-aware cap supplier used by the legacy
- *     datastore dropdown to preserve its historical thresholds
- * @param legacyCurrentBandwidthLimits supplier for the legacy rate-page “current settings” row,
- *     backed by the live network subsystem instead of config-derived defaults
  */
-record FirstTimeWizardToadletRuntimePorts(
-    FirstTimeWizardPort firstTimeWizardPort,
-    LongSupplier legacyDatastoreMaxStorageLimitBytes,
-    Supplier<BandwidthLimit> legacyCurrentBandwidthLimits) {
+record FirstTimeWizardToadletRuntimePorts(FirstTimeWizardPort firstTimeWizardPort) {
   /**
    * Creates the legacy wizard's HTTP-local runtime bundle.
    *
@@ -37,7 +26,5 @@ record FirstTimeWizardToadletRuntimePorts(
    */
   FirstTimeWizardToadletRuntimePorts {
     Objects.requireNonNull(firstTimeWizardPort);
-    Objects.requireNonNull(legacyDatastoreMaxStorageLimitBytes);
-    Objects.requireNonNull(legacyCurrentBandwidthLimits);
   }
 }

--- a/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthManipulator.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthManipulator.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.http.wizardsteps;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 import network.crypta.compat.BandwidthIndicator;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigException;
@@ -28,7 +27,6 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Applies an input or output limit string to the {@code node.*BandwidthLimit} option.
  *   <li>Builds a warning infobox for invalid or rejected bandwidth inputs.
- *   <li>Optionally displays “current” limits when the node is configured non-default.
  *   <li>Persists {@code fproxy.hasCompletedWizard} at the end of the wizard flow.
  * </ul>
  */
@@ -46,8 +44,6 @@ public abstract class BandwidthManipulator {
    */
   protected final Config config;
 
-  private final Supplier<BandwidthLimit> currentBandwidthLimitsSupplier;
-
   /**
    * Creates a new helper bound to the given configuration.
    *
@@ -59,26 +55,7 @@ public abstract class BandwidthManipulator {
    *     should refer to the node's live configuration.
    */
   protected BandwidthManipulator(Config config) {
-    this(config, () -> null);
-  }
-
-  /**
-   * Creates a new helper bound to the given configuration and current-bandwidth supplier.
-   *
-   * <p>The supplier is used only for rendering the legacy “current settings” preset on the
-   * rate-based bandwidth page. Callers should return {@code null} when no current preset row should
-   * be shown.
-   *
-   * @param config Configuration handle used to read and update wizard options; must be non-null and
-   *     should refer to the node's live configuration.
-   * @param currentBandwidthLimitsSupplier supplier for the live current bandwidth limits used by
-   *     the “current settings” row; must be non-null but may return {@code null}
-   */
-  protected BandwidthManipulator(
-      Config config, Supplier<BandwidthLimit> currentBandwidthLimitsSupplier) {
-    this.config = config;
-    this.currentBandwidthLimitsSupplier =
-        Objects.requireNonNull(currentBandwidthLimitsSupplier, "currentBandwidthLimitsSupplier");
+    this.config = Objects.requireNonNull(config, "config");
   }
 
   /**
@@ -136,22 +113,6 @@ public abstract class BandwidthManipulator {
     infoBox.addChild("p", message);
 
     return infoBox;
-  }
-
-  /**
-   * Returns the node's currently effective bandwidth limits for the legacy “current settings” row.
-   *
-   * <p>This helper delegates to the supplier provided by the surrounding HTTP wiring. Callers
-   * should return {@code null} when the wizard should omit the “current” row.
-   *
-   * <p>The returned {@link BandwidthLimit} is intended for display only; it does not imply that the
-   * wizard has validated or re-applied these settings during the current request.
-   *
-   * @return A {@link BandwidthLimit} describing the node's current limits, or {@code null} when the
-   *     wizard should treat the node as using defaults.
-   */
-  protected BandwidthLimit getCurrentBandwidthLimitsOrNull() {
-    return currentBandwidthLimitsSupplier.get();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthRate.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthRate.java
@@ -2,11 +2,11 @@ package network.crypta.clients.http.wizardsteps;
 
 import java.text.DecimalFormat;
 import java.util.Objects;
-import java.util.function.Supplier;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLNode;
@@ -53,29 +53,12 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
    * PageHelper)}. Construction does not apply configuration changes; persistence occurs only after
    * a successful {@link #postStep(HTTPRequest)} submission.
    *
-   * @param wizardPort detached wizard runtime used for detected-bandwidth suggestions
+   * @param wizardPort detached wizard runtime used for detected-bandwidth suggestions and the
+   *     optional current-bandwidth row
    * @param config node configuration instance that receives the selected bandwidth limits
    */
   public BandwidthRate(FirstTimeWizardPort wizardPort, Config config) {
-    this(wizardPort, config, () -> null);
-  }
-
-  /**
-   * Creates a new bandwidth-rate wizard step with a fixed set of preset profiles.
-   *
-   * <p>The extra supplier is used only for the legacy “current settings” row, so the page can
-   * render the node's live effective limits instead of reconstructing them from config defaults.
-   *
-   * @param wizardPort detached wizard runtime used for detected-bandwidth suggestions
-   * @param config node configuration instance that receives the selected bandwidth limits
-   * @param currentBandwidthLimitsSupplier supplier for the live current-bandwidth row; must be
-   *     non-null but may return {@code null}
-   */
-  public BandwidthRate(
-      FirstTimeWizardPort wizardPort,
-      Config config,
-      Supplier<BandwidthLimit> currentBandwidthLimitsSupplier) {
-    super(config, currentBandwidthLimitsSupplier);
+    super(config);
     this.wizardPort = Objects.requireNonNull(wizardPort, "wizardPort");
     final long KiB = 1024L;
     limits =
@@ -151,7 +134,7 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
       addedDefault = true;
     }
 
-    BandwidthLimit current = getCurrentBandwidthLimitsOrNull();
+    BandwidthLimit current = currentBandwidthLimitOrNull(snapshot);
     if (current != null) {
       addLimitRow(table, current, false, !addedDefault);
       addedDefault = true;
@@ -264,6 +247,16 @@ public class BandwidthRate extends BandwidthManipulator implements Step {
       LOG.info("Ignoring malformed detected bandwidth suggestion.", e);
       return null;
     }
+  }
+
+  private static BandwidthLimit currentBandwidthLimitOrNull(FirstTimeWizardSnapshot snapshot) {
+    FirstTimeWizardCurrentBandwidthLimits current = snapshot.currentBandwidthLimits();
+    if (current == null) {
+      return null;
+    }
+
+    return new BandwidthLimit(
+        current.downloadBytes(), current.uploadBytes(), "bandwidthCurrent", false);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
+++ b/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
@@ -1,16 +1,12 @@
 package network.crypta.clients.http.wizardsteps;
 
-import java.io.File;
 import java.util.Objects;
-import java.util.function.LongSupplier;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigException;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.Option;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
-import network.crypta.node.NodeStarter;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.Fields;
@@ -29,12 +25,12 @@ import static network.crypta.support.io.DatastoreUtil.ONE_GIB;
  * <p>This step is used by the HTTP first-time wizard to present a dropdown of sensible datastore
  * sizes based on the local environment. The UI is populated from the current {@link Config} (when
  * present) and from a best-effort auto-detection via {@link DatastoreUtil}; it also considers hard
- * limits derived from available disk space and a memory-based upper bound for slot filters.
+ * limits exported through the detached first-time-wizard snapshot.
  *
  * <p>When the user submits the form, this step updates multiple related configuration keys under
  * {@code node.*} (datastore size and cache sizes) in a consistent way. On the first run it also
- * sets the corresponding {@code *Type} options to the expected defaults. No I/O is performed beyond
- * querying the node's store directory for free space.
+ * sets the corresponding {@code *Type} options to the expected defaults. No live daemon reads are
+ * performed here beyond consuming the detached wizard snapshot.
  *
  * <p><b>Notable behaviors</b>
  *
@@ -54,11 +50,10 @@ public class DatastoreSize implements Step {
   private static final String TAG_OPTION = "option";
 
   private final FirstTimeWizardPort wizardPort;
-  private final LongSupplier legacyDatastoreMaxStorageLimitBytes;
   private final Config config;
 
   /**
-   * Creates a wizard step bound to the detached wizard runtime and legacy datastore cap.
+   * Creates a wizard step bound to the detached wizard runtime.
    *
    * <p>The instance is lightweight and holds references to the provided objects; it does not
    * perform any environment detection until {@link #getStep(HTTPRequest, PageHelper)} is called.
@@ -67,18 +62,10 @@ public class DatastoreSize implements Step {
    *
    * @param wizardPort detached wizard runtime used for datastore suggestions and size bounds
    * @param config mutable configuration that receives the selected datastore and cache settings
-   * @param legacyDatastoreMaxStorageLimitBytes store-dir-aware cap supplier used to preserve the
-   *     legacy dropdown thresholds
    */
-  public DatastoreSize(
-      FirstTimeWizardPort wizardPort,
-      Config config,
-      LongSupplier legacyDatastoreMaxStorageLimitBytes) {
-    this.config = config;
+  public DatastoreSize(FirstTimeWizardPort wizardPort, Config config) {
+    this.config = Objects.requireNonNull(config, "config");
     this.wizardPort = Objects.requireNonNull(wizardPort, "wizardPort");
-    this.legacyDatastoreMaxStorageLimitBytes =
-        Objects.requireNonNull(
-            legacyDatastoreMaxStorageLimitBytes, "legacyDatastoreMaxStorageLimitBytes");
   }
 
   /**
@@ -87,8 +74,8 @@ public class DatastoreSize implements Step {
    * <p>This method populates a {@code <select>} element with options derived from three sources:
    * the current configured sizes (when non-default), a best-effort auto-detected size (when
    * available), and a set of fixed fallback sizes. The resulting options are additionally bounded
-   * by {@link #maxDatastoreSize(Node)} to avoid offering sizes that exceed current disk or
-   * memory-based constraints.
+   * by the detached legacy datastore cap from {@link FirstTimeWizardSnapshot} so the page preserves
+   * its historical dropdown thresholds without consulting live daemon objects directly.
    *
    * <p>This method does not mutate {@link Config}; it only constructs the HTML content for the
    * current request.
@@ -108,7 +95,7 @@ public class DatastoreSize implements Step {
     HTMLNode bandwidthForm = helper.addFormChild(bandwidthInfoboxContent, ".", "dsForm");
     HTMLNode result = bandwidthForm.addChild("select", "name", "ds");
 
-    long maxSize = legacyDatastoreMaxStorageLimitBytes.getAsLong();
+    long maxSize = snapshot.legacyMaxStorageLimitBytes();
     long autodetectedSize = snapshot.autodetectedStorageLimitBytes();
     if (maxSize < autodetectedSize) autodetectedSize = maxSize;
 
@@ -290,62 +277,5 @@ public class DatastoreSize implements Step {
       result.addChild(TAG_OPTION, ATTR_VALUE, "200G", "200GiB");
     if (maxSize >= 500L * 1024 * 1024 * 1024)
       result.addChild(TAG_OPTION, ATTR_VALUE, "500G", "500GiB");
-  }
-
-  /**
-   * Computes an upper bound for the datastore size for the given node.
-   *
-   * <p>The returned value is expressed in bytes and is derived from two independent constraints: a
-   * memory-based cap (used to avoid over-allocating slot filters) and the usable free space in the
-   * node's store directory. When free space is considered, the implementation assumes the datastore
-   * is currently empty and adds the sizes of existing files in the store directory back into the
-   * free-space estimate. A margin of 1&nbsp;GiB is reserved to reduce the chance of exhausting the
-   * filesystem.
-   *
-   * @param node node whose store directory and runtime constraints are used for the calculation
-   * @return maximum datastore size in bytes based on current environment constraints
-   */
-  public static long maxDatastoreSize(Node node) {
-    long maxMemory = NodeStarter.getMemoryLimitBytes();
-    if (maxMemory == Long.MAX_VALUE) return ONE_GIB; // Treat as don't know.
-    if (maxMemory < 128L * 1024 * 1024)
-      return ONE_GIB; // 1GB default if you don't know or very small memory.
-    long maxSize = maxDatastoreSizeFromMemory(maxMemory);
-
-    // Datastore can never be larger than free disk space, assuming datastore is zero now.
-    File storeDir = node.getStoreDir();
-    long freeSpace = storeDir.getUsableSpace();
-    File[] files = storeDir.listFiles();
-
-    if (files != null) {
-      for (File file : files) {
-        freeSpace += file.length();
-      }
-    }
-
-    if (freeSpace < maxSize) {
-      maxSize = freeSpace;
-    }
-
-    // Leave some margin.
-    maxSize = maxSize - ONE_GIB;
-
-    return maxSize;
-  }
-
-  private static long maxDatastoreSizeFromMemory(long maxMemory) {
-    // Don't use the first 100MB for slot filters.
-    long available = maxMemory - 100L * 1024 * 1024;
-    // Don't use more than 50% of available memory for slot filters.
-    available = available / 2;
-    // Slot filters are 4 bytes per slot.
-    long slots = available / 4;
-    // There are 3 types of keys. We want the number of { SSK, CHK, pubkey } i.e., the number of
-    // slots in each store.
-    slots /= 3;
-    // We return the total size, so we don't need to worry about cache vs. store or even client
-    // cache.
-    // One key of all 3 types combined uses NodeStorageSubsystem.SIZE_PER_KEY bytes on disk.
-    return slots * network.crypta.node.subsystem.NodeStorageSubsystem.SIZE_PER_KEY;
   }
 }

--- a/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyFirstTimeWizardPort.java
@@ -18,6 +18,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.runtime.spi.FirstTimeWizardSubmission;
@@ -98,8 +99,10 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
     Config config = node.getConfig();
     long minStorageLimitBytes = MIN_STORAGE_LIMIT;
     long maxStorageLimitBytes = DatastoreUtil.maxDatastoreSize();
+    long legacyMaxStorageLimitBytes = DatastoreUtil.maxDatastoreSize(node);
     long autodetectedStorageLimitBytes = autodetectedStorageLimitBytes(config);
     String[] detectedBandwidthLimits = detectedBandwidthLimits();
+    FirstTimeWizardCurrentBandwidthLimits currentBandwidthLimits = currentBandwidthLimits(config);
     return new FirstTimeWizardSnapshot(
         passwordAlreadySet(),
         initialStorageLimitGiB(config, autodetectedStorageLimitBytes),
@@ -107,11 +110,13 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
         minStorageLimitBytes,
         formatGiB(maxStorageLimitBytes),
         maxStorageLimitBytes,
+        legacyMaxStorageLimitBytes,
         Node.getMinimumBandwidth() / KIB,
         SECONDS.toNanos(1) / KIB,
         String.format(Locale.ENGLISH, "%.2f", BandwidthLimit.MIN_MONTHLY_LIMIT),
         detectedBandwidthLimits[0],
         detectedBandwidthLimits[1],
+        currentBandwidthLimits,
         autodetectedStorageLimitBytes);
   }
 
@@ -292,6 +297,25 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
   }
 
   /**
+   * Returns the legacy rate-page current-bandwidth row when the node is not using defaults.
+   *
+   * <p>The old multipage wizard showed a detached "current settings" row only when the upload limit
+   * had been explicitly configured. That behavior is preserved here so the HTTP layer can render
+   * the row without directly consulting live daemon config or network state.
+   *
+   * @param config live daemon config used to determine whether the current-bandwidth row is needed
+   * @return detached current-bandwidth row, or {@code null} when the legacy page should omit it
+   */
+  private FirstTimeWizardCurrentBandwidthLimits currentBandwidthLimits(Config config) {
+    if (config.get("node").getOption(LegacyWelcomeActionPort.OUTPUT_BANDWIDTH_LIMIT).isDefault()) {
+      return null;
+    }
+
+    return new FirstTimeWizardCurrentBandwidthLimits(
+        node.network().inputBandwidthLimit(), node.network().outputBandwidthLimit());
+  }
+
+  /**
    * Applies the submission's bandwidth settings through the legacy config keys.
    *
    * <p>Direct per-second limits are written back as KiB-formatted strings. Monthly transfer budgets
@@ -306,14 +330,20 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
     try {
       if (!submission.haveMonthlyLimit()) {
         config.get("node").set("inputBandwidthLimit", submission.downloadLimitKiB() + "KiB");
-        config.get("node").set("outputBandwidthLimit", submission.uploadLimitKiB() + "KiB");
+        config
+            .get("node")
+            .set(
+                LegacyWelcomeActionPort.OUTPUT_BANDWIDTH_LIMIT,
+                submission.uploadLimitKiB() + "KiB");
         return;
       }
 
       BandwidthLimit bandwidth =
           new BandwidthLimit(Fields.parseLong(submission.bandwidthMonthlyLimitGiB() + "GiB"));
       config.get("node").set("inputBandwidthLimit", Long.toString(bandwidth.downBytes));
-      config.get("node").set("outputBandwidthLimit", Long.toString(bandwidth.upBytes));
+      config
+          .get("node")
+          .set(LegacyWelcomeActionPort.OUTPUT_BANDWIDTH_LIMIT, Long.toString(bandwidth.upBytes));
     } catch (ConfigException e) {
       LOG.error(UNEXPECTED_ERROR_MESSAGE, e, e);
     }

--- a/src/main/java/network/crypta/node/runtime/LegacyWelcomeActionPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyWelcomeActionPort.java
@@ -38,7 +38,7 @@ final class LegacyWelcomeActionPort implements WelcomeActionPort {
   private static final String INPUT_BANDWIDTH_LIMIT = "inputBandwidthLimit";
 
   /** Config key for the welcome-page upload-bandwidth upgrade field. */
-  private static final String OUTPUT_BANDWIDTH_LIMIT = "outputBandwidthLimit";
+  static final String OUTPUT_BANDWIDTH_LIMIT = "outputBandwidthLimit";
 
   /** Live daemon node that still owns the underlying welcome-page maintenance behaviors. */
   private final Node node;

--- a/src/main/java/network/crypta/node/useralerts/DatastoreTooSmallAlert.java
+++ b/src/main/java/network/crypta/node/useralerts/DatastoreTooSmallAlert.java
@@ -2,13 +2,13 @@ package network.crypta.node.useralerts;
 
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.clients.fcp.FeedMessage;
-import network.crypta.clients.http.wizardsteps.DatastoreSize;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigException;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.Version;
 import network.crypta.support.HTMLNode;
+import network.crypta.support.io.DatastoreUtil;
 
 /**
  * User alert indicating that the configured datastore capacity is below a safe minimum relative to
@@ -23,7 +23,7 @@ import network.crypta.support.HTMLNode;
  * space.
  *
  * <p>When dismissed, the alert remains hidden until the node is upgraded to a newer build. This
- * throttling avoids repeatedly prompting the user about the same decision across restarts while
+ * throttling avoids repeatedly prompting the user to make the same decision across restarts while
  * still re‑evaluating the guidance for future versions. The alert provides both plain‑text and HTML
  * variants and includes a direct link to the First‑Time Wizard step for datastore sizing so the
  * user can immediately adjust settings.
@@ -57,8 +57,8 @@ public class DatastoreTooSmallAlert implements UserAlert {
    * Creates a new alert bound to the provided node core.
    *
    * <p>The alert reads configuration through the core when generating text and determining
-   * validity. It does not cache derived values; each call evaluates the current configuration state
-   * so changes take effect immediately.
+   * validity. It does not cache derived values; each call evaluates the current configuration
+   * state, so changes take effect immediately.
    *
    * @param core non-null node core used to access configuration, localization, and utilities; the
    *     reference is retained for the lifetime of the alert but is not modified.
@@ -122,7 +122,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
   public String getText() {
     Config config = core.getNode().getConfig();
 
-    // Datastore size as configured in wizard is the sum of these three.
+    // Datastore size as configured in the wizard is the sum of these three.
     long storeSize = config.get("node").getLong(KEY_STORE_SIZE);
     long clientCacheSize = config.get("node").getLong(KEY_CLIENT_CACHE_SIZE);
     long slashdotCacheSize = config.get("node").getLong(KEY_SLASHDOT_CACHE_SIZE);
@@ -132,7 +132,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
     // And round it, in case manually configured and not exact multiple of GiB.
     long currentSize = (totalSize + 512 * 1024 * 1024) / (1024 * 1024 * 1024);
     // Calculate available size the same way as in wizard, recommend at least 20% of that.
-    long availableSize = DatastoreSize.maxDatastoreSize(core.getNode()) / (1024 * 1024 * 1024);
+    long availableSize = DatastoreUtil.maxDatastoreSize(core.getNode()) / (1024 * 1024 * 1024);
     long minSize = availableSize / 5;
     // Wizard never recommends sizes above 100 GiB, so claim a minimum of at most 50 GiB.
     if (minSize > 50) minSize = 50;
@@ -157,7 +157,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
   public HTMLNode getHTMLText() {
     Config config = core.getNode().getConfig();
 
-    // Datastore size as configured in wizard is the sum of these three.
+    // Datastore size as configured in the wizard is the sum of these three.
     long storeSize = config.get("node").getLong(KEY_STORE_SIZE);
     long clientCacheSize = config.get("node").getLong(KEY_CLIENT_CACHE_SIZE);
     long slashdotCacheSize = config.get("node").getLong(KEY_SLASHDOT_CACHE_SIZE);
@@ -167,7 +167,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
     // And round it, in case manually configured and not exact multiple of GiB.
     long currentSize = (totalSize + 512 * 1024 * 1024) / (1024 * 1024 * 1024);
     // Calculate available size the same way as in wizard, recommend at least 20% of that.
-    long availableSize = DatastoreSize.maxDatastoreSize(core.getNode()) / (1024 * 1024 * 1024);
+    long availableSize = DatastoreUtil.maxDatastoreSize(core.getNode()) / (1024 * 1024 * 1024);
     long minSize = availableSize / 5;
     // Wizard never recommends sizes above 100 GiB, so claim a minimum of at most 50 GiB.
     if (minSize > 50) minSize = 50;
@@ -202,9 +202,9 @@ public class DatastoreTooSmallAlert implements UserAlert {
   /**
    * Determines whether the alert should currently be shown.
    *
-   * <p>Validity is computed dynamically from configuration on each call. The alert is valid only
-   * when the configured size is below 10% of the available size (bounded) and the user has not
-   * dismissed the alert for the current build.
+   * <p>Validity is computed dynamically from the configuration on each call. The alert is valid
+   * only when the configured size is below 10% of the available size (bounded), and the user has
+   * not dismissed the alert for the current build.
    *
    * @return {@code true} if the alert should be displayed; otherwise {@code false}.
    */
@@ -212,7 +212,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
   public boolean isValid() {
     Config config = core.getNode().getConfig();
 
-    // Datastore size as configured in wizard is the sum of these three.
+    // Datastore size as configured in the wizard is the sum of these three.
     long storeSize = config.get("node").getLong(KEY_STORE_SIZE);
     long clientCacheSize = config.get("node").getLong(KEY_CLIENT_CACHE_SIZE);
     long slashdotCacheSize = config.get("node").getLong(KEY_SLASHDOT_CACHE_SIZE);
@@ -222,12 +222,12 @@ public class DatastoreTooSmallAlert implements UserAlert {
     // And round it, in case manually configured and not exact multiple of GiB.
     long currentSize = (totalSize + 512 * 1024 * 1024) / (1024 * 1024 * 1024);
     // Calculate available size the same way as in wizard, only warn if below 10% of that.
-    long availableSize = DatastoreSize.maxDatastoreSize(core.getNode()) / (1024 * 1024 * 1024);
+    long availableSize = DatastoreUtil.maxDatastoreSize(core.getNode()) / (1024 * 1024 * 1024);
     long minSize = availableSize / 10;
     // Wizard never recommends sizes above 100 GiB, so never warn if above 25 GiB.
     if (minSize > 25) minSize = 25;
 
-    // Check if warning has already been dismissed on this Freenet version
+    // Check if a warning has already been dismissed on this Freenet version
     int currentVersion = Version.currentBuildNumber();
     int dismissedVersion =
         core.getNode().getConfig().get("node").getInt("datastoreTooSmallDismissed");
@@ -239,7 +239,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
    * No-op setter for validity.
    *
    * <p>The validity of this alert is derived from configuration and cannot be forced externally;
-   * therefore this override intentionally does nothing.
+   * therefore, this override intentionally does nothing.
    *
    * @param validity ignored. Present to satisfy the {@link UserAlert} contract.
    */
@@ -262,7 +262,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
    * Indicates that the alert should be unregistered once the user dismisses it.
    *
    * <p>Unregistering reduces UI churn: the alert will reappear only if it becomes valid again in a
-   * subsequent build.
+   * further build.
    *
    * @return {@code true} to request unregistration after dismissal.
    */
@@ -272,7 +272,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
   }
 
   /**
-   * Persists dismissal for the current build so the alert remains hidden until the node is updated
+   * Persists dismissal for the current build, so the alert remains hidden until the node is updated
    * to a newer version.
    *
    * <p>Failure to persist the flag is intentionally ignored so that runtime behavior is never
@@ -327,7 +327,7 @@ public class DatastoreTooSmallAlert implements UserAlert {
    * Produces an FCP feed message containing the alert content for consumption by FCP clients.
    *
    * <p>The message includes the title, summary, full text, priority, and an updated timestamp. The
-   * content is generated on demand and reflects current configuration.
+   * content is generated on demand and reflects the current configuration.
    *
    * @return a new {@link FCPMessage} describing this alert; never {@code null}.
    */

--- a/src/main/java/network/crypta/support/io/DatastoreUtil.java
+++ b/src/main/java/network/crypta/support/io/DatastoreUtil.java
@@ -1,5 +1,6 @@
 package network.crypta.support.io;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -8,6 +9,7 @@ import network.crypta.fs.AppDirs;
 import network.crypta.fs.AppEnv;
 import network.crypta.fs.Resolved;
 import network.crypta.fs.ServiceDirs;
+import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeStarter;
 import org.slf4j.Logger;
@@ -81,6 +83,40 @@ public final class DatastoreUtil {
     }
 
     return maxDatastoreSize;
+  }
+
+  /**
+   * Computes the legacy first-time-wizard datastore cap for a specific live node.
+   *
+   * <p>The legacy multipage wizard and related alerting code historically bounded datastore sizes
+   * against the current store directory rather than the broader data directory. This helper
+   * preserves that behavior by combining the memory-derived cap with the store directory's usable
+   * space, adding back the sizes of existing files under the assumption that the datastore may be
+   * resized in place, and then reserving a 1&nbsp;GiB margin.
+   *
+   * @param node live node whose store directory should bound the legacy datastore size options
+   * @return maximum datastore size in bytes using the legacy store-directory heuristic
+   */
+  public static long maxDatastoreSize(Node node) {
+    long maxMemory = NodeStarter.getMemoryLimitBytes();
+    if (maxMemory == Long.MAX_VALUE || maxMemory < 128L * ONE_MIB) {
+      return ONE_GIB;
+    }
+
+    long maxDatastoreSize = getMaxDatastoreSize();
+
+    File storeDir = node.getStoreDir();
+    long freeSpace = storeDir.getUsableSpace();
+    File[] files = storeDir.listFiles();
+
+    if (files != null) {
+      for (File file : files) {
+        freeSpace += file.length();
+      }
+    }
+
+    long boundedSize = Math.min(freeSpace, maxDatastoreSize);
+    return boundedSize - ONE_GIB;
   }
 
   private static long getMaxDatastoreSize() {

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -1,13 +1,11 @@
 package network.crypta.clients.http;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.clients.http.wizardsteps.BandwidthLimit;
 import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
@@ -17,6 +15,7 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -36,8 +35,6 @@ import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
@@ -68,15 +65,15 @@ class FProxyRegistrarTest {
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private LifecyclePort lifecyclePort;
   @Mock private WelcomeActionPort welcomeActionPort;
+  @Mock private FirstTimeWizardPort firstTimeWizardPort;
   @Mock private SimpleToadletServer server;
 
   private Config config;
-  private SubConfig nodeConfig;
 
   @BeforeEach
   void setUp() {
     config = new Config();
-    nodeConfig = config.createSubConfig("node");
+    SubConfig nodeConfig = config.createSubConfig("node");
     registerBandwidthOption(nodeConfig, "outputBandwidthLimit", 1024);
     registerBandwidthOption(nodeConfig, "inputBandwidthLimit", 2048);
     nodeConfig.finishedInitialization();
@@ -98,6 +95,7 @@ class FProxyRegistrarTest {
     when(runtimePorts.darknetConnections()).thenReturn(darknetConnectionsPort);
     when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
     when(runtimePorts.welcomeAction()).thenReturn(welcomeActionPort);
+    when(runtimePorts.firstTimeWizard()).thenReturn(firstTimeWizardPort);
   }
 
   @Test
@@ -161,6 +159,16 @@ class FProxyRegistrarTest {
                 registered ->
                     FirstTimeWizardToadlet.TOADLET_URL.equals(
                         registered.registration().urlPrefix())));
+    RegisteredToadlet wizardRegistration =
+        registrations.stream()
+            .filter(
+                registered ->
+                    FirstTimeWizardToadlet.TOADLET_URL.equals(
+                        registered.registration().urlPrefix()))
+            .findFirst()
+            .orElseThrow();
+    assertSame(firstTimeWizardPort, readWizardPortField(wizardRegistration.toadlet()));
+    verify(runtimePorts, atLeastOnce()).firstTimeWizard();
   }
 
   @Test
@@ -179,30 +187,6 @@ class FProxyRegistrarTest {
     assertFalse(configToadletPrefixes.contains(FProxyToadlet.CONFIG_PATH + "security-levels"));
   }
 
-  @Test
-  void legacyCurrentBandwidthLimits_whenOutputBandwidthLimitIsDefault_returnsNull()
-      throws Exception {
-    BandwidthLimit bandwidthLimit = invokeLegacyCurrentBandwidthLimits(config, node);
-
-    assertNull(bandwidthLimit);
-  }
-
-  @Test
-  void legacyCurrentBandwidthLimits_whenOutputBandwidthLimitIsConfigured_returnsCurrentLimit()
-      throws Exception {
-    nodeConfig.set("outputBandwidthLimit", "8192");
-    when(node.network().inputBandwidthLimit()).thenReturn(2048);
-    when(node.network().outputBandwidthLimit()).thenReturn(4096);
-
-    BandwidthLimit bandwidthLimit = invokeLegacyCurrentBandwidthLimits(config, node);
-
-    assertNotNull(bandwidthLimit);
-    assertEquals(2048L, bandwidthLimit.downBytes);
-    assertEquals(4096L, bandwidthLimit.upBytes);
-    assertEquals("bandwidthCurrent", bandwidthLimit.descriptionKey);
-    assertFalse(bandwidthLimit.maybeDefault);
-  }
-
   private static void registerBandwidthOption(
       SubConfig subConfig, String optionName, int defaultValue) {
     subConfig.register(optionName, defaultValue, optionMeta(), new MemoryIntCallback(defaultValue));
@@ -210,15 +194,6 @@ class FProxyRegistrarTest {
 
   private static Option.Meta optionMeta() {
     return new Option.Meta(0, false, false, "", "");
-  }
-
-  private BandwidthLimit invokeLegacyCurrentBandwidthLimits(Config config, Node node)
-      throws Exception {
-    Method method =
-        FProxyRegistrar.class.getDeclaredMethod(
-            "legacyCurrentBandwidthLimits", Config.class, Node.class);
-    method.setAccessible(true);
-    return (BandwidthLimit) method.invoke(null, config, node);
   }
 
   private List<RegisteredToadlet> capturedRegistrations() {
@@ -234,6 +209,16 @@ class FProxyRegistrarTest {
       registrations.add(new RegisteredToadlet(toadlets.get(i), registrationValues.get(i)));
     }
     return registrations;
+  }
+
+  private static FirstTimeWizardPort readWizardPortField(Object target) {
+    try {
+      java.lang.reflect.Field field = target.getClass().getDeclaredField("wizardPort");
+      field.setAccessible(true);
+      return (FirstTimeWizardPort) field.get(target);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   private static final class MemoryIntCallback extends IntCallback {

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
@@ -70,10 +70,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client,
-                config,
-                new FirstTimeWizardToadletRuntimePorts(
-                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
+                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -101,10 +98,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client,
-                config,
-                new FirstTimeWizardToadletRuntimePorts(
-                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
+                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -132,10 +126,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client,
-                config,
-                new FirstTimeWizardToadletRuntimePorts(
-                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
+                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -160,10 +151,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client,
-                config,
-                new FirstTimeWizardToadletRuntimePorts(
-                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
+                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe("step", 20)).thenReturn("WELCOME");
@@ -205,10 +193,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client,
-                config,
-                new FirstTimeWizardToadletRuntimePorts(
-                    firstTimeWizardPort, () -> Long.MAX_VALUE, () -> null)));
+                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe("step", 20)).thenReturn("MISC");

--- a/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthRateTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthRateTest.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
+import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLEncoder;
@@ -218,7 +219,7 @@ class BandwidthRateTest {
     Config config = mock(Config.class);
     when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
 
-    BandwidthRate step = new TestableBandwidthRate(wizardPort, config, null);
+    BandwidthRate step = new TestableBandwidthRate(wizardPort, config);
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
     stubHelperToAttachInfoboxesAndForms();
@@ -241,7 +242,7 @@ class BandwidthRateTest {
     Config config = mock(Config.class);
     when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
 
-    BandwidthRate step = new TestableBandwidthRate(wizardPort, config, null);
+    BandwidthRate step = new TestableBandwidthRate(wizardPort, config);
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
     stubHelperToAttachInfoboxesAndForms();
@@ -260,14 +261,12 @@ class BandwidthRateTest {
   }
 
   @Test
-  void getStep_whenLiveCurrentLimitAvailable_expectCurrentOptionRendered() {
+  void getStep_whenSnapshotHasCurrentLimit_expectCurrentOptionRendered() {
     FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
     Config config = mock(Config.class);
-    when(wizardPort.snapshot()).thenReturn(DEFAULT_SNAPSHOT);
+    when(wizardPort.snapshot()).thenReturn(snapshotWithCurrentBandwidth());
 
-    BandwidthRate step =
-        new BandwidthRate(
-            wizardPort, config, () -> new BandwidthLimit(4096L, 1024L, "bandwidthCurrent", false));
+    BandwidthRate step = new BandwidthRate(wizardPort, config);
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
     stubHelperToAttachInfoboxesAndForms();
@@ -306,7 +305,7 @@ class BandwidthRateTest {
                 false, "2.00", "1.25", 1L, "10.00", 10L, 10L, 976562L, "49.44", "1024", "512",
                 -1L));
 
-    BandwidthRate step = new TestableBandwidthRate(wizardPort, config, null);
+    BandwidthRate step = new TestableBandwidthRate(wizardPort, config);
 
     when(helper.getPageContent(anyString())).thenReturn(pageContent);
     stubHelperToAttachInfoboxesAndForms();
@@ -412,15 +411,12 @@ class BandwidthRateTest {
     String rejectNextDownSetWithMessage;
     String rejectNextUpSetWithMessage;
 
-    private final BandwidthLimit current;
-
     TestableBandwidthRate() {
-      this(mock(FirstTimeWizardPort.class), mock(Config.class), null);
+      this(mock(FirstTimeWizardPort.class), mock(Config.class));
     }
 
-    TestableBandwidthRate(FirstTimeWizardPort wizardPort, Config config, BandwidthLimit current) {
+    TestableBandwidthRate(FirstTimeWizardPort wizardPort, Config config) {
       super(wizardPort, config);
-      this.current = current;
     }
 
     @Override
@@ -445,12 +441,25 @@ class BandwidthRateTest {
     protected void setWizardComplete() {
       wizardComplete = true;
     }
-
-    @Override
-    protected BandwidthLimit getCurrentBandwidthLimitsOrNull() {
-      return current;
-    }
   }
 
   private record SetCall(String limit, boolean setOutputLimit) {}
+
+  private static FirstTimeWizardSnapshot snapshotWithCurrentBandwidth() {
+    return new FirstTimeWizardSnapshot(
+        false,
+        "2.00",
+        "1.25",
+        1L,
+        "10.00",
+        10L,
+        10L,
+        10L,
+        976562L,
+        "49.44",
+        "",
+        "",
+        new FirstTimeWizardCurrentBandwidthLimits(4096L, 1024L),
+        -1L);
+  }
 }

--- a/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
@@ -60,7 +60,7 @@ class DatastoreSizeTest {
     try (MockedStatic<NodeStarter> nodeStarter = mockStatic(NodeStarter.class)) {
       nodeStarter.when(NodeStarter::getMemoryLimitBytes).thenReturn(Long.MAX_VALUE);
 
-      long result = DatastoreSize.maxDatastoreSize(node);
+      long result = DatastoreUtil.maxDatastoreSize(node);
 
       assertEquals(1024L * 1024 * 1024, result);
     }
@@ -72,7 +72,7 @@ class DatastoreSizeTest {
     try (MockedStatic<NodeStarter> nodeStarter = mockStatic(NodeStarter.class)) {
       nodeStarter.when(NodeStarter::getMemoryLimitBytes).thenReturn(127L * 1024 * 1024);
 
-      long result = DatastoreSize.maxDatastoreSize(node);
+      long result = DatastoreUtil.maxDatastoreSize(node);
 
       assertEquals(1024L * 1024 * 1024, result);
     }
@@ -107,7 +107,7 @@ class DatastoreSizeTest {
     try (MockedStatic<NodeStarter> nodeStarter = mockStatic(NodeStarter.class)) {
       nodeStarter.when(NodeStarter::getMemoryLimitBytes).thenReturn(mockedMaxMemoryBytes);
 
-      long result = DatastoreSize.maxDatastoreSize(node);
+      long result = DatastoreUtil.maxDatastoreSize(node);
 
       assertEquals(expectedCap - 1024L * 1024 * 1024, result);
     }
@@ -176,8 +176,7 @@ class DatastoreSizeTest {
   @Test
   void postStep_whenFirstTime_expectNextStepBandwidthAndUsesSelected() {
     Config config = newConfigWithNodeDefaults(10, 0, 1000L);
-    DatastoreSize step =
-        new DatastoreSize(mock(FirstTimeWizardPort.class), config, () -> MAX_STORAGE_LIMIT_BYTES);
+    DatastoreSize step = new DatastoreSize(mock(FirstTimeWizardPort.class), config);
 
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.isPartSet("singlestep")).thenReturn(false);
@@ -205,8 +204,7 @@ class DatastoreSizeTest {
     assertEquals(VALUE_DEFAULT, node.getString(KEY_STORE_TYPE));
     assertEquals(VALUE_DEFAULT, node.getString(KEY_CLIENT_CACHE_TYPE));
 
-    DatastoreSize step =
-        new DatastoreSize(mock(FirstTimeWizardPort.class), config, () -> MAX_STORAGE_LIMIT_BYTES);
+    DatastoreSize step = new DatastoreSize(mock(FirstTimeWizardPort.class), config);
 
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.isPartSet("singlestep")).thenReturn(true);
@@ -253,7 +251,7 @@ class DatastoreSizeTest {
     FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
     when(wizardPort.snapshot()).thenReturn(snapshot(512L * 1024 * 1024));
 
-    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> MAX_STORAGE_LIMIT_BYTES);
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -277,7 +275,7 @@ class DatastoreSizeTest {
     FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
     when(wizardPort.snapshot()).thenReturn(snapshot(2L * 1024 * 1024 * 1024));
 
-    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> MAX_STORAGE_LIMIT_BYTES);
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -307,7 +305,7 @@ class DatastoreSizeTest {
     FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
     when(wizardPort.snapshot()).thenReturn(snapshot(-1L));
 
-    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> MAX_STORAGE_LIMIT_BYTES);
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -343,9 +341,9 @@ class DatastoreSizeTest {
   void getStep_whenLegacyCapIsBelowSnapshotMax_expectLegacyThresholdsPreserved() {
     Config config = newConfigWithNodeDefaults(10, 10, 1000L);
     FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
-    when(wizardPort.snapshot()).thenReturn(snapshot(-1L));
+    when(wizardPort.snapshot()).thenReturn(snapshot(4L * 1024 * 1024 * 1024, -1L));
 
-    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> 4L * 1024 * 1024 * 1024);
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -367,9 +365,9 @@ class DatastoreSizeTest {
   void getStep_whenLegacyCapIsAboveSnapshotMax_expectLegacyThresholdsPreserved() {
     Config config = newConfigWithNodeDefaults(10, 10, 1000L);
     FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
-    when(wizardPort.snapshot()).thenReturn(snapshot(-1L));
+    when(wizardPort.snapshot()).thenReturn(snapshot(50L * 1024 * 1024 * 1024, -1L));
 
-    DatastoreSize step = new DatastoreSize(wizardPort, config, () -> 50L * 1024 * 1024 * 1024);
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
 
     PageHelper helper = mock(PageHelper.class);
     HTMLNode contentNode = new HTMLNode("div");
@@ -432,6 +430,11 @@ class DatastoreSizeTest {
   }
 
   private static FirstTimeWizardSnapshot snapshot(long autodetectedSize) {
+    return snapshot(MAX_STORAGE_LIMIT_BYTES, autodetectedSize);
+  }
+
+  private static FirstTimeWizardSnapshot snapshot(
+      long legacyMaxStorageLimitBytes, long autodetectedSize) {
     return new FirstTimeWizardSnapshot(
         false,
         "2.00",
@@ -439,11 +442,13 @@ class DatastoreSizeTest {
         1L,
         SizeUtil.formatSize(MAX_STORAGE_LIMIT_BYTES),
         MAX_STORAGE_LIMIT_BYTES,
+        legacyMaxStorageLimitBytes,
         10L,
         976562L,
         "49.44",
         "",
         "",
+        null,
         autodetectedSize);
   }
 

--- a/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyFirstTimeWizardPortTest.java
@@ -19,6 +19,7 @@ import network.crypta.node.NodeIPDetector;
 import network.crypta.node.SecurityLevels;
 import network.crypta.node.subsystem.NodeServicesSubsystem;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.runtime.spi.FirstTimeWizardSubmission;
 import network.crypta.runtime.spi.MasterPasswordMutationStatus;
@@ -37,8 +38,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -68,6 +72,7 @@ class LegacyFirstTimeWizardPortTest {
     Option<Long> storeSize = mockLongOption();
     Option<Long> clientCache = mockLongOption();
     Option<Long> slashdotCache = mockLongOption();
+    Option<?> outputBandwidthLimit = mockOption();
     BandwidthIndicator bandwidthIndicator = mock(BandwidthIndicator.class);
     NodeIPDetector ipDetector = mock(NodeIPDetector.class);
     NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
@@ -81,8 +86,12 @@ class LegacyFirstTimeWizardPortTest {
     when(node.network()).thenReturn(networkSubsystem);
     when(networkSubsystem.ipDetector()).thenReturn(ipDetector);
     when(ipDetector.getBandwidthIndicator()).thenReturn(bandwidthIndicator);
+    when(networkSubsystem.inputBandwidthLimit()).thenReturn(2048);
+    when(networkSubsystem.outputBandwidthLimit()).thenReturn(1024);
     when(securityLevels.getPhysicalThreatLevel())
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(outputBandwidthLimit.isDefault()).thenReturn(false);
     when(storeSize.isDefault()).thenReturn(false);
     when(storeSize.getValue()).thenReturn(2L * DatastoreUtil.ONE_GIB);
     when(clientCache.getValue()).thenReturn(0L);
@@ -99,6 +108,9 @@ class LegacyFirstTimeWizardPortTest {
           .when(() -> Config.longOption(nodeSubConfig, "slashdotCacheSize"))
           .thenReturn(slashdotCache);
       datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      datastore
+          .when(() -> DatastoreUtil.maxDatastoreSize(node))
+          .thenReturn(8L * DatastoreUtil.ONE_GIB);
       bandwidth
           .when(() -> BandwidthManipulator.detectBandwidthLimits(bandwidthIndicator))
           .thenReturn(new BandwidthLimit(2097152L, 1048576L, "desc", false));
@@ -118,6 +130,7 @@ class LegacyFirstTimeWizardPortTest {
       assertEquals(NodeStorageSubsystem.MIN_STORE_SIZE * 5 / 4, snapshot.minStorageLimitBytes());
       assertEquals("10.00", snapshot.maxStorageLimitGiB());
       assertEquals(10L * DatastoreUtil.ONE_GIB, snapshot.maxStorageLimitBytes());
+      assertEquals(8L * DatastoreUtil.ONE_GIB, snapshot.legacyMaxStorageLimitBytes());
       assertEquals(Node.getMinimumBandwidth() / 1024L, snapshot.minBandwidthKiB());
       assertEquals(SECONDS.toNanos(1) / 1024L, snapshot.maxUploadLimitKiB());
       assertEquals(
@@ -125,6 +138,11 @@ class LegacyFirstTimeWizardPortTest {
           snapshot.minBandwidthMonthlyLimitGiB());
       assertEquals("1024", snapshot.detectedDownloadLimitKiB());
       assertEquals("512", snapshot.detectedUploadLimitKiB());
+      FirstTimeWizardCurrentBandwidthLimits currentBandwidthLimits =
+          snapshot.currentBandwidthLimits();
+      assertNotNull(currentBandwidthLimits);
+      assertEquals(2048L, currentBandwidthLimits.downloadBytes());
+      assertEquals(1024L, currentBandwidthLimits.uploadBytes());
       assertEquals(-1L, snapshot.autodetectedStorageLimitBytes());
     }
   }
@@ -132,6 +150,7 @@ class LegacyFirstTimeWizardPortTest {
   @Test
   void snapshot_whenAutodetectAndDetectionUnavailable_returnsFallbackAndEmptySuggestions() {
     Option<Long> storeSize = mockLongOption();
+    Option<?> outputBandwidthLimit = mockOption();
     NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
 
     when(node.getConfig()).thenReturn(config);
@@ -140,6 +159,8 @@ class LegacyFirstTimeWizardPortTest {
     when(services.securityLevels()).thenReturn(securityLevels);
     when(securityLevels.getPhysicalThreatLevel())
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(outputBandwidthLimit.isDefault()).thenReturn(true);
 
     try (MockedStatic<Config> configStatic = mockStatic(Config.class);
         MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
@@ -148,6 +169,9 @@ class LegacyFirstTimeWizardPortTest {
       when(storeSize.isDefault()).thenReturn(true);
       datastore.when(() -> DatastoreUtil.autodetectDatastoreSize(core, config)).thenReturn(0L);
       datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      datastore
+          .when(() -> DatastoreUtil.maxDatastoreSize(node))
+          .thenReturn(9L * DatastoreUtil.ONE_GIB);
       bandwidth
           .when(
               () ->
@@ -163,6 +187,8 @@ class LegacyFirstTimeWizardPortTest {
       assertEquals("100.00", snapshot.initialStorageLimitGiB());
       assertEquals("", snapshot.detectedDownloadLimitKiB());
       assertEquals("", snapshot.detectedUploadLimitKiB());
+      assertEquals(9L * DatastoreUtil.ONE_GIB, snapshot.legacyMaxStorageLimitBytes());
+      assertNull(snapshot.currentBandwidthLimits());
       assertEquals(-1L, snapshot.autodetectedStorageLimitBytes());
     }
   }
@@ -170,6 +196,7 @@ class LegacyFirstTimeWizardPortTest {
   @Test
   void snapshot_whenIpDetectorNotInitialized_returnsStorageSuggestionAndEmptyBandwidthHints() {
     Option<Long> storeSize = mockLongOption();
+    Option<?> outputBandwidthLimit = mockOption();
     NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
     network.crypta.node.subsystem.NodeNetworkSubsystem networkSubsystem =
         mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
@@ -183,6 +210,8 @@ class LegacyFirstTimeWizardPortTest {
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
     when(node.network()).thenReturn(networkSubsystem);
     when(networkSubsystem.ipDetector()).thenReturn(null);
+    doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(outputBandwidthLimit.isDefault()).thenReturn(true);
 
     try (MockedStatic<Config> configStatic = mockStatic(Config.class);
         MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class)) {
@@ -192,6 +221,9 @@ class LegacyFirstTimeWizardPortTest {
           .when(() -> DatastoreUtil.autodetectDatastoreSize(core, config))
           .thenReturn(autodetectedStorageLimitBytes);
       datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      datastore
+          .when(() -> DatastoreUtil.maxDatastoreSize(node))
+          .thenReturn(6L * DatastoreUtil.ONE_GIB);
 
       LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
 
@@ -200,6 +232,8 @@ class LegacyFirstTimeWizardPortTest {
       assertEquals("3.00", snapshot.initialStorageLimitGiB());
       assertEquals("", snapshot.detectedDownloadLimitKiB());
       assertEquals("", snapshot.detectedUploadLimitKiB());
+      assertEquals(6L * DatastoreUtil.ONE_GIB, snapshot.legacyMaxStorageLimitBytes());
+      assertNull(snapshot.currentBandwidthLimits());
       assertEquals(autodetectedStorageLimitBytes, snapshot.autodetectedStorageLimitBytes());
     }
   }
@@ -207,6 +241,7 @@ class LegacyFirstTimeWizardPortTest {
   @Test
   void snapshot_whenStorageCapNeedsRounding_preservesExactStorageBytes() {
     Option<Long> storeSize = mockLongOption();
+    Option<?> outputBandwidthLimit = mockOption();
     NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
     long roundedUpMaxStorageLimitBytes = Fields.parseLong("1.235GiB");
 
@@ -216,6 +251,8 @@ class LegacyFirstTimeWizardPortTest {
     when(services.securityLevels()).thenReturn(securityLevels);
     when(securityLevels.getPhysicalThreatLevel())
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(outputBandwidthLimit.isDefault()).thenReturn(true);
 
     try (MockedStatic<Config> configStatic = mockStatic(Config.class);
         MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class);
@@ -224,6 +261,9 @@ class LegacyFirstTimeWizardPortTest {
       when(storeSize.isDefault()).thenReturn(true);
       datastore.when(() -> DatastoreUtil.autodetectDatastoreSize(core, config)).thenReturn(0L);
       datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(roundedUpMaxStorageLimitBytes);
+      datastore
+          .when(() -> DatastoreUtil.maxDatastoreSize(node))
+          .thenReturn(5L * DatastoreUtil.ONE_GIB);
       bandwidth
           .when(
               () ->
@@ -237,6 +277,8 @@ class LegacyFirstTimeWizardPortTest {
 
       assertEquals("1.24", snapshot.maxStorageLimitGiB());
       assertEquals(roundedUpMaxStorageLimitBytes, snapshot.maxStorageLimitBytes());
+      assertEquals(5L * DatastoreUtil.ONE_GIB, snapshot.legacyMaxStorageLimitBytes());
+      assertNull(snapshot.currentBandwidthLimits());
     }
   }
 
@@ -501,5 +543,9 @@ class LegacyFirstTimeWizardPortTest {
     @SuppressWarnings("unchecked")
     Option<Long> option = (Option<Long>) mock(Option.class);
     return option;
+  }
+
+  private static Option<?> mockOption() {
+    return mock(Option.class);
   }
 }


### PR DESCRIPTION
## Summary
- add detached legacy wizard fields to `FirstTimeWizardSnapshot`, including the new `FirstTimeWizardCurrentBandwidthLimits` DTO
- move the remaining live legacy datastore and bandwidth snapshot logic into `LegacyFirstTimeWizardPort` and `DatastoreUtil`
- remove registrar-injected legacy wizard callbacks so the legacy HTTP wizard reads runtime state only through `FirstTimeWizardPort`
- update the legacy wizard steps and focused tests to consume the detached snapshot data

## How to test
- `./gradlew compileJava compileTestJava test --tests 'network.crypta.node.runtime.LegacyFirstTimeWizardPortTest' --tests 'network.crypta.clients.http.FProxyRegistrarTest' --tests 'network.crypta.clients.http.wizardsteps.DatastoreSizeTest' --tests 'network.crypta.clients.http.wizardsteps.BandwidthRateTest' --tests 'network.crypta.clients.http.FirstTimeWizardToadletTest'`

## Notes
- preserves legacy datastore dropdown thresholds and the optional current-bandwidth row behavior while removing the last callback-based runtime reads from the old multi-page wizard