### PR TITLE
refactor(http): Detach page chrome from Node

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PageChromePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PageChromePort.java
@@ -1,0 +1,30 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Exposes the narrow detached runtime state needed by the shared admin page chrome.
+ *
+ * <p>This SPI exists only for the legacy HTTP shell that still needs a few live daemon reads to
+ * render the status bar. The HTTP layer keeps ownership of alerts, menus, mode switching,
+ * localization, and HTML structure; implementations provide only a detached snapshot containing the
+ * current security posture and peer-count progress values.
+ *
+ * <p>The contract is intentionally read-only and page-shell-specific. It should not grow into a
+ * general admin API or absorb unrelated browse, queue, or FCP concerns. Callers typically treat
+ * this port as optional startup wiring: if the shell has not been connected to a runtime yet, the
+ * page can still render safely without a status bar.
+ *
+ * @see PageChromeSnapshot
+ */
+public interface PageChromePort {
+  /**
+   * Returns a detached snapshot of the current page-chrome state.
+   *
+   * <p>Callers typically read one snapshot near the start of page rendering and use it for the rest
+   * of that request so the status bar stays internally consistent even if the live daemon state
+   * changes moments later. Implementations may gather that data from several live services, but the
+   * returned record itself is immutable and side-effect-free for the caller.
+   *
+   * @return immutable snapshot containing the current security-level and peer-progress state
+   */
+  PageChromeSnapshot snapshot();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PageChromeSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PageChromeSnapshot.java
@@ -1,0 +1,50 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Captures the detached read-only runtime state needed by the shared admin page chrome.
+ *
+ * <p>The legacy HTTP shell still shows two security-level labels and one peer-progress bar in its
+ * shared status area. This record carries only the values required to reproduce that existing UI:
+ * detached threat-level enums, current connected-peer counts, the enabled-darknet total used when
+ * opennet is disabled, and the opennet target count used when it is enabled.
+ *
+ * <p>The snapshot is intentionally narrow and does not model alerts, menus, mode-switch state, or
+ * other request-context concerns that remain owned by the HTTP layer. It is designed to be created
+ * once per request and then passed through rendering code as a stable, immutable view of the
+ * daemon's shell-related status.
+ *
+ * @param networkThreatLevel current detached network threat level shown in the status bar
+ * @param physicalThreatLevel current detached physical threat level shown in the status bar
+ * @param connectedPeerCount current total number of connected peers across all transport modes
+ * @param connectedDarknetPeerCount current number of connected darknet peers in the live roster
+ * @param connectedOpennetPeerCount current number of connected opennet peers in the live roster
+ * @param enabledDarknetPeerCount current number of enabled darknet peers used for darknet targets
+ * @param opennetEnabled whether opennet is currently enabled for the node
+ * @param opennetTargetIncludingDarknetPeerCount current opennet-connected-peers target, including
+ *     darknet peers, or {@code 0} when opennet is disabled
+ */
+public record PageChromeSnapshot(
+    SecurityNetworkThreatLevel networkThreatLevel,
+    SecurityPhysicalThreatLevel physicalThreatLevel,
+    int connectedPeerCount,
+    int connectedDarknetPeerCount,
+    int connectedOpennetPeerCount,
+    int enabledDarknetPeerCount,
+    boolean opennetEnabled,
+    int opennetTargetIncludingDarknetPeerCount) {
+  /**
+   * Creates an immutable page-chrome snapshot.
+   *
+   * <p>The constructor enforces only the presence of the detached threat-level values. Peer counts
+   * are stored exactly as supplied by the adapter, so the HTTP shell can preserve its current
+   * rendering behavior without adding extra normalization in the shared SPI layer.
+   *
+   * @throws NullPointerException if either detached threat-level enum is {@code null}
+   */
+  public PageChromeSnapshot {
+    Objects.requireNonNull(networkThreatLevel, "networkThreatLevel");
+    Objects.requireNonNull(physicalThreatLevel, "physicalThreatLevel");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -31,6 +31,7 @@ package network.crypta.runtime.spi;
  * @see QueueMutationPort
  * @see QueueSupportPort
  * @see StatisticsPort
+ * @see PageChromePort
  * @see NodeInfoPort
  * @see PeerPort
  * @see RequestQueuePort
@@ -172,6 +173,18 @@ public interface RuntimePorts {
    * @return diagnostic-report runtime port for read-only report snapshots
    */
   DiagnosticPort diagnostic();
+
+  /**
+   * Returns the shared admin page-chrome capability exposed to HTTP shell rendering code.
+   *
+   * <p>This port lets higher layers request one detached status-bar snapshot containing the current
+   * detached security levels plus peer-progress counts without depending on daemon-only node, peer,
+   * opennet, or security-level classes. The HTTP layer still owns alerts, language selection, mode
+   * switching, menu rendering, and all HTML structures.
+   *
+   * @return page-chrome runtime port for detached shared shell state
+   */
+  PageChromePort pageChrome();
 
   /**
    * Returns the legacy queue support capability exposed to admin-facing HTTP code.

--- a/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
@@ -16,8 +15,8 @@ import network.crypta.support.api.HTTPRequest;
  *
  * <p>The toadlet is invoked when a user action would open a non-FProxy URL. It renders a warning
  * page that summarizes the destination and asks the user to continue or cancel. The class keeps no
- * mutable state beyond a reference to the running {@link Node}, so it can be reused safely across
- * requests as long as the surrounding toadlet container manages threading correctly.
+ * mutable state beyond its inherited client reference, so it can be reused safely across requests
+ * as long as the surrounding toadlet container manages threading correctly.
  *
  * <p>Typical flow:
  *
@@ -56,11 +55,8 @@ public class ExternalLinkToadlet extends Toadlet {
   private static final String TAG_INPUT = "input";
   private static final String ATTR_VALUE = "value";
 
-  private final Node node;
-
-  ExternalLinkToadlet(HighLevelSimpleClient client, Node node) {
+  ExternalLinkToadlet(HighLevelSimpleClient client) {
     super(client);
-    this.node = node;
   }
 
   @Override
@@ -90,7 +86,7 @@ public class ExternalLinkToadlet extends Toadlet {
     Objects.requireNonNull(uri, "uri");
     String url = request.getPartAsStringFailsafe(MAGIC_HTTP_ESCAPE_STRING, MAX_URL_LENGTH);
     // If the user clicked cancel, or the URL is not defined, return to the main page.
-    // Redirecting here restarts the welcome flow when it is still in progress; that behaviour is
+    // Redirecting here restarts the welcome flow when it is still in progress; that behavior is
     // intentional until the wizard gains partial-resume support.
     if (request.getPartAsStringFailsafe("Go", 32).isEmpty() || url.isEmpty()) {
       url = WelcomeToadlet.ROOT_PATH;
@@ -106,14 +102,14 @@ public class ExternalLinkToadlet extends Toadlet {
    * <p>The method requires a query parameter named {@link #MAGIC_HTTP_ESCAPE_STRING}; when missing
    * it redirects back to the welcome page to avoid issuing open redirects. When present, it
    * generates a warning infobox that shows the destination, offers cancel/continue buttons, and
-   * optionally includes navigation/status bars if the setup wizard already completed. No network
+   * optionally includes navigation/status bars if the setup wizard is already completed. No network
    * access is attempted at this stage.
    *
    * @param uri request URI of this toadlet; must not be {@code null}.
    * @param request inbound HTTP request providing the external URL parameter and localization
    *     context.
    * @param ctx toadlet context used for building the page and writing the HTML response.
-   * @throws ToadletContextClosedException if the connection closes before the response is fully
+   * @throws ToadletContextClosedException if the connection closes before, the response is fully
    *     written.
    * @throws IOException if rendering or sending the response fails.
    */
@@ -132,12 +128,8 @@ public class ExternalLinkToadlet extends Toadlet {
 
     // Confirm whether the user really means to access an HTTP link.
     // Only render status and navigation bars if the user has completed the wizard.
-    boolean renderBars =
-        node.services()
-            .clientCore()
-            .getEndpoints()
-            .getToadletContainer()
-            .fproxyHasCompletedWizard();
+    ToadletContainer container = ctx.getContainer();
+    boolean renderBars = container != null && container.fproxyHasCompletedWizard();
     PageNode page =
         ctx.getPageMaker()
             .getPageNode(

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -283,7 +283,7 @@ final class FProxyRegistrar {
     server.register(
         welcometoadlet, ToadletRegistration.basic(null, FProxyToadlet.WELCOME_PATH, true, false));
 
-    ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client, node);
+    ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client);
     server.register(
         externalLinkToadlet,
         ToadletRegistration.basic(null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false));

--- a/src/main/java/network/crypta/clients/http/PageMaker.java
+++ b/src/main/java/network/crypta/clients/http/PageMaker.java
@@ -9,9 +9,10 @@ import java.util.Map;
 import network.crypta.client.filter.PushingTagReplacerCallback;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.Node;
-import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.PageChromePort;
+import network.crypta.runtime.spi.PageChromeSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 import org.slf4j.Logger;
@@ -26,10 +27,11 @@ import org.slf4j.LoggerFactory;
  * {@link PageNode} for each response via {@link #getPageNode(String, ToadletContext)}, injecting
  * their own content into the returned container.
  *
- * <p>State is limited to configured menus and the active {@linkplain #setTheme(THEME) theme};
- * rendering itself is stateless and produces fresh node trees on each invocation. The class is safe
- * to use from multiple threads provided callers synchronize mutations to shared navigation
- * configuration. Expensive assets are loaded lazily and reused through standard browser caching.
+ * <p>State is limited to configured menus, the active {@linkplain #setTheme(THEME) theme}, and an
+ * optional late-injected {@link PageChromePort} used for status-bar rendering. Rendering itself is
+ * otherwise stateless and produces fresh node trees on each invocation. The class is safe to use
+ * from multiple threads provided callers synchronize mutations to shared navigation configuration.
+ * Expensive assets are loaded lazily and reused through standard browser caching.
  *
  * <ul>
  *   <li>Composes page heads with optional web-push bootstrap and theme assets.
@@ -166,9 +168,21 @@ public final class PageMaker {
     }
   }
 
-  PageMaker(THEME t, Node n) {
+  PageMaker(THEME t) {
     setTheme(t);
-    this.node = n;
+  }
+
+  /**
+   * Installs or clears the detached page-chrome collaborator used for status-bar rendering.
+   *
+   * <p>This setter supports the startup sequence where {@link PageMaker} is created before the
+   * runtime SPI is fully available. Passing {@code null} leaves status-bar rendering disabled; once
+   * a port is injected, future renders will include the existing status-bar shell again.
+   *
+   * @param pageChromePort detached page-chrome runtime port, or {@code null} to hide the status bar
+   */
+  void setPageChromePort(PageChromePort pageChromePort) {
+    this.pageChromePort = pageChromePort;
   }
 
   /**
@@ -582,17 +596,19 @@ public final class PageMaker {
 
   private void renderStatusBar(
       HTMLNode pageDiv, ToadletContext ctx, RenderParameters renderParameters) {
-    if (node == null || node.services().clientCore() == null) {
+    PageChromePort chromePort = pageChromePort;
+    if (chromePort == null) {
       return;
     }
+    PageChromeSnapshot chromeSnapshot = chromePort.snapshot();
     HTMLNode statusBarDiv =
         pageDiv.addChild(TAG_DIV, "id", "statusbar-container").addChild(TAG_DIV, "id", "statusbar");
 
     addAlerts(statusBarDiv, ctx);
     addLanguageSelector(statusBarDiv);
     addModeSwitch(statusBarDiv, ctx, renderParameters);
-    addSecurityLevels(statusBarDiv);
-    addPeerStatus(statusBarDiv);
+    addSecurityLevels(statusBarDiv, chromeSnapshot);
+    addPeerStatus(statusBarDiv, chromeSnapshot);
   }
 
   private void addAlerts(HTMLNode statusBarDiv, ToadletContext ctx) {
@@ -615,9 +631,7 @@ public final class PageMaker {
 
   private void addModeSwitch(
       HTMLNode statusBarDiv, ToadletContext ctx, RenderParameters renderParameters) {
-    if (node.services().clientCore() == null
-        || ctx == null
-        || !renderParameters.isRenderModeSwitch()) {
+    if (ctx == null || !renderParameters.isRenderModeSwitch()) {
       return;
     }
     boolean isAdvancedMode = ctx.isAdvancedModeEnabled();
@@ -639,7 +653,7 @@ public final class PageMaker {
             : NodeL10n.getBase().getString("StatusBar.switchToAdvancedMode"));
   }
 
-  private void addSecurityLevels(HTMLNode statusBarDiv) {
+  private void addSecurityLevels(HTMLNode statusBarDiv, PageChromeSnapshot chromeSnapshot) {
     addSeparator(statusBarDiv);
     HTMLNode secLevels =
         statusBarDiv.addChild(
@@ -653,45 +667,33 @@ public final class PageMaker {
             TAG_A,
             "href",
             "/seclevels/",
-            SecurityLevels.localisedName(node.services().securityLevels().getNetworkThreatLevel())
-                + "\u00a0");
+            localiseNetworkThreatLevel(chromeSnapshot.networkThreatLevel()) + "\u00a0");
     network.addAttribute(
         ATTR_TITLE, NodeL10n.getBase().getString("SecurityLevels.networkThreatLevelShort"));
     network.addAttribute(
-        ATTR_CLASS,
-        node.services()
-            .securityLevels()
-            .getNetworkThreatLevel()
-            .toString()
-            .toLowerCase(Locale.ROOT));
+        ATTR_CLASS, chromeSnapshot.networkThreatLevel().name().toLowerCase(Locale.ROOT));
 
     HTMLNode physical =
         secLevels.addChild(
             TAG_A,
             "href",
             "/seclevels/",
-            SecurityLevels.localisedName(
-                node.services().securityLevels().getPhysicalThreatLevel()));
+            localisePhysicalThreatLevel(chromeSnapshot.physicalThreatLevel()));
     physical.addAttribute(
         ATTR_TITLE, NodeL10n.getBase().getString("SecurityLevels.physicalThreatLevelShort"));
     physical.addAttribute(
-        ATTR_CLASS,
-        node.services()
-            .securityLevels()
-            .getPhysicalThreatLevel()
-            .toString()
-            .toLowerCase(Locale.ROOT));
+        ATTR_CLASS, chromeSnapshot.physicalThreatLevel().name().toLowerCase(Locale.ROOT));
   }
 
-  private void addPeerStatus(HTMLNode statusBarDiv) {
+  private void addPeerStatus(HTMLNode statusBarDiv, PageChromeSnapshot chromeSnapshot) {
     addSeparator(statusBarDiv);
-    int connectedPeers = node.network().peers().countConnectedPeers();
-    int darknetTotal = countEnabledDarknetPeers();
-    int connectedDarknetPeers = node.network().peers().countConnectedDarknetPeers();
+    int connectedPeers = chromeSnapshot.connectedPeerCount();
+    int darknetTotal = chromeSnapshot.enabledDarknetPeerCount();
+    int connectedDarknetPeers = chromeSnapshot.connectedDarknetPeerCount();
     int totalPeers =
-        node.network().opennet() == null
-            ? determineDarknetTotal(darknetTotal)
-            : node.network().opennet().getNumberOfConnectedPeersToAimIncludingDarknet();
+        chromeSnapshot.opennetEnabled()
+            ? chromeSnapshot.opennetTargetIncludingDarknetPeerCount()
+            : determineDarknetTotal(darknetTotal);
     double connectedRatio = ((double) connectedPeers) / (double) totalPeers;
     String additionalClass =
         classifyPeerStatus(connectedPeers, connectedDarknetPeers, connectedRatio);
@@ -715,11 +717,21 @@ public final class PageMaker {
                   "StatusBar.connectedPeers",
                   new String[] {"X", "Y"},
                   new String[] {
-                    Integer.toString(node.network().peers().countConnectedDarknetPeers()),
-                    Integer.toString(node.network().peers().countConnectedOpennetPeers())
+                    Integer.toString(chromeSnapshot.connectedDarknetPeerCount()),
+                    Integer.toString(chromeSnapshot.connectedOpennetPeerCount())
                   })
         },
         connectedPeers + ((totalPeers != Integer.MAX_VALUE) ? " / " + totalPeers : ""));
+  }
+
+  private String localiseNetworkThreatLevel(SecurityNetworkThreatLevel networkThreatLevel) {
+    return NodeL10n.getBase()
+        .getString("SecurityLevels.networkThreatLevel.name." + networkThreatLevel.name());
+  }
+
+  private String localisePhysicalThreatLevel(SecurityPhysicalThreatLevel physicalThreatLevel) {
+    return NodeL10n.getBase()
+        .getString("SecurityLevels.physicalThreatLevel.name." + physicalThreatLevel.name());
   }
 
   private String classifyPeerStatus(
@@ -751,16 +763,6 @@ public final class PageMaker {
 
   private int determineDarknetTotal(int darknetTotal) {
     return darknetTotal > 0 ? darknetTotal : Integer.MAX_VALUE;
-  }
-
-  private int countEnabledDarknetPeers() {
-    int darknetTotal = 0;
-    for (DarknetPeerNode peer : node.network().peers().roster().getDarknetPeers()) {
-      if (peer != null && !peer.isDisabled()) {
-        darknetTotal++;
-      }
-    }
-    return darknetTotal;
   }
 
   private void addSeparator(HTMLNode statusBarDiv) {
@@ -1392,9 +1394,12 @@ public final class PageMaker {
   /** Parameter for simple/advanced mode switch. */
   private static final String MODE_SWITCH_PARAMETER = "fproxyAdvancedMode";
 
-  private final Node node;
   private final List<SubMenu> menuList = new ArrayList<>();
   private final Map<String, SubMenu> subMenus = new HashMap<>();
+
+  @SuppressWarnings("java:S3077")
+  private volatile PageChromePort pageChromePort;
+
   private THEME theme;
   private String override;
 }

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -32,6 +32,7 @@ import network.crypta.node.PrioRunnable;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -480,13 +481,17 @@ public final class SimpleToadletServer
    *
    * <p>The core reference is written with volatile semantics so that listener threads see it after
    * startup. Call this exactly once, immediately after the node finishes constructing its {@link
-   * NodeClientCore}, and before invoking {@link #createFproxy()} or {@link #start()}. Passing
-   * {@code null} is not supported and leaves the server unable to service requests.
+   * NodeClientCore}, and before invoking {@link #createFproxy()} or {@link #start()}. When the core
+   * exposes runtime SPI ports, this method also late-injects the detached page-chrome port into the
+   * shared {@link PageMaker}. Passing {@code null} is not supported and leaves the server unable to
+   * service requests.
    *
    * @param core fully constructed {@link NodeClientCore}; must not be {@code null}.
    */
   public void setCore(NodeClientCore core) {
     this.core = core;
+    RuntimePorts runtimePorts = core == null ? null : core.getRuntimePorts();
+    pageMaker.setPageChromePort(runtimePorts == null ? null : runtimePorts.pageChrome());
   }
 
   /**
@@ -504,15 +509,11 @@ public final class SimpleToadletServer
    *     later replace it via {@link #setBucketFactory(BucketFactory)}.
    * @param executor executor that runs HTTP worker threads with priority awareness; ownership stays
    *     with the caller.
-   * @param node parent {@link Node} providing global services such as logging and runtime state.
    * @throws InvalidConfigValueException if any configuration entry is invalid or fails validation
    *     during registration.
    */
   public SimpleToadletServer(
-      SubConfig fproxyConfig,
-      BucketFactory bucketFactory,
-      PriorityAwareExecutor executor,
-      Node node)
+      SubConfig fproxyConfig, BucketFactory bucketFactory, PriorityAwareExecutor executor)
       throws InvalidConfigValueException {
 
     this.executor = executor;
@@ -547,7 +548,7 @@ public final class SimpleToadletServer
     if ((cssName.indexOf(':') != -1) || (cssName.indexOf('/') != -1))
       throw new InvalidConfigValueException("CSS name must not contain slashes or colons!");
     cssTheme = THEME.themeFromName(cssName);
-    pageMaker = new PageMaker(cssTheme, node);
+    pageMaker = new PageMaker(cssTheme);
 
     if (!fproxyConfig.getOption(CSS_OVERRIDE_KEY).isDefault()) {
       cssOverride = new File(fproxyConfig.getString(CSS_OVERRIDE_KEY));

--- a/src/main/java/network/crypta/node/runtime/LegacyPageChromePort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyPageChromePort.java
@@ -1,0 +1,103 @@
+package network.crypta.node.runtime;
+
+import java.util.Objects;
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.OpennetManager;
+import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.PageChromePort;
+import network.crypta.runtime.spi.PageChromeSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+
+/**
+ * Adapts the shared page-chrome SPI to the legacy daemon runtime.
+ *
+ * <p>This adapter keeps the remaining status-bar reads inside the daemon root module, where the
+ * legacy {@link Node}, peer roster, opennet manager, and security-level services still live. The
+ * HTTP layer can then render the existing shared admin shell from one detached snapshot without
+ * traversing live daemon internals directly.
+ *
+ * <p>The adapter is intentionally conservative. It mirrors the current page chrome only: detached
+ * threat-level enums, connected peer counts, enabled-darknet totals, and the opennet target count
+ * used by the existing progress bar.
+ */
+final class LegacyPageChromePort implements PageChromePort {
+  /** Live daemon node that remains the source of truth for legacy page-chrome reads. */
+  private final Node node;
+
+  /**
+   * Creates a legacy adapter backed by the live daemon node.
+   *
+   * @param node live daemon node that remains the source of truth for shared page-chrome state
+   */
+  LegacyPageChromePort(Node node) {
+    this.node = Objects.requireNonNull(node, "node");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PageChromeSnapshot snapshot() {
+    OpennetManager opennet = node.network().opennet();
+    return new PageChromeSnapshot(
+        mapNetworkThreatLevel(node.services().securityLevels().getNetworkThreatLevel()),
+        mapPhysicalThreatLevel(node.services().securityLevels().getPhysicalThreatLevel()),
+        node.network().peers().countConnectedPeers(),
+        node.network().peers().countConnectedDarknetPeers(),
+        node.network().peers().countConnectedOpennetPeers(),
+        countEnabledDarknetPeers(),
+        opennet != null,
+        opennet == null ? 0 : opennet.getNumberOfConnectedPeersToAimIncludingDarknet());
+  }
+
+  /**
+   * Counts enabled darknet peers for the legacy status-bar target calculation.
+   *
+   * <p>The legacy shell ignores {@code null} entries and disabled peers when computing the
+   * denominator shown for darknet-only operation. This preserves the existing rendering behavior
+   * while keeping the roster walk inside the daemon module.
+   *
+   * @return number of enabled darknet peers currently present in the live roster
+   */
+  private int countEnabledDarknetPeers() {
+    int enabledDarknetPeers = 0;
+    for (DarknetPeerNode peer : node.network().peers().roster().getDarknetPeers()) {
+      if (peer != null && !peer.isDisabled()) {
+        enabledDarknetPeers++;
+      }
+    }
+    return enabledDarknetPeers;
+  }
+
+  /**
+   * Maps the legacy daemon network threat enum to the detached runtime-spi enum.
+   *
+   * @param networkThreatLevel live daemon network threat level to translate
+   * @return detached enum value with the same semantic posture and name
+   */
+  private static SecurityNetworkThreatLevel mapNetworkThreatLevel(
+      SecurityLevels.NETWORK_THREAT_LEVEL networkThreatLevel) {
+    return switch (networkThreatLevel) {
+      case LOW -> SecurityNetworkThreatLevel.LOW;
+      case NORMAL -> SecurityNetworkThreatLevel.NORMAL;
+      case HIGH -> SecurityNetworkThreatLevel.HIGH;
+      case MAXIMUM -> SecurityNetworkThreatLevel.MAXIMUM;
+    };
+  }
+
+  /**
+   * Maps the legacy daemon physical threat enum to the detached runtime-spi enum.
+   *
+   * @param physicalThreatLevel live daemon physical threat level to translate
+   * @return detached enum value with the same semantic posture and name
+   */
+  private static SecurityPhysicalThreatLevel mapPhysicalThreatLevel(
+      SecurityLevels.PHYSICAL_THREAT_LEVEL physicalThreatLevel) {
+    return switch (physicalThreatLevel) {
+      case LOW -> SecurityPhysicalThreatLevel.LOW;
+      case NORMAL -> SecurityPhysicalThreatLevel.NORMAL;
+      case HIGH -> SecurityPhysicalThreatLevel.HIGH;
+      case MAXIMUM -> SecurityPhysicalThreatLevel.MAXIMUM;
+    };
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -15,6 +15,7 @@ import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.PageChromePort;
 import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
@@ -59,6 +60,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DarknetConnectionsPort darknetConnectionsPort;
   private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
+  private final PageChromePort pageChromePort;
   private final QueueCompletionPort queueCompletionPort;
   private final QueuePagePort queuePagePort;
   private final QueueDownloadPort queueDownloadPort;
@@ -164,6 +166,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.darknetConnectionsPort = new LegacyDarknetConnectionsPort(node);
     this.darknetMessagingPort = new LegacyDarknetMessagingPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
+    this.pageChromePort = new LegacyPageChromePort(node);
     this.queueCompletionPort = new LegacyQueueCompletionPort(core);
     this.queuePagePort = new LegacyQueuePagePort(core);
     this.queueDownloadPort = new LegacyQueueDownloadPort(core);
@@ -301,6 +304,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public DiagnosticPort diagnostic() {
     return diagnosticPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining shared status-bar security-level and peer-count reads
+   * inside the daemon root module while exposing only detached SPI-local values upstream.
+   */
+  @Override
+  public PageChromePort pageChrome() {
+    return pageChromePort;
   }
 
   /**

--- a/src/main/java/network/crypta/node/subsystem/NodeServicesSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeServicesSubsystem.java
@@ -94,7 +94,7 @@ public final class NodeServicesSubsystem {
       throws NodeInitException {
     SubConfig fproxyConfig = config.createSubConfig("fproxy");
     try {
-      toadlets = new SimpleToadletServer(fproxyConfig, new ArrayBucketFactory(), executor, node);
+      toadlets = new SimpleToadletServer(fproxyConfig, new ArrayBucketFactory(), executor);
       fproxyConfig.finishedInitialization();
       toadlets.start();
     } catch (InvalidConfigValueException e4) {

--- a/src/test/java/network/crypta/clients/http/ExternalLinkToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ExternalLinkToadletTest.java
@@ -7,9 +7,6 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.ClientEndpoints;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
@@ -47,11 +44,6 @@ import static org.mockito.Mockito.when;
 class ExternalLinkToadletTest {
 
   @Mock private HighLevelSimpleClient client;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private NodeClientCore nodeClientCore;
   @Mock private SimpleToadletServer toadletContainer;
   @Mock private ToadletContext context;
   @Mock private PageMaker pageMaker;
@@ -61,16 +53,10 @@ class ExternalLinkToadletTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    toadlet = new ExternalLinkToadlet(client, node);
+    toadlet = new ExternalLinkToadlet(client);
 
     when(context.getPageMaker()).thenReturn(pageMaker);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    ClientEndpoints endpoints = mock(ClientEndpoints.class);
-    when(nodeClientCore.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getToadletContainer()).thenReturn(toadletContainer);
+    when(context.getContainer()).thenReturn(toadletContainer);
 
     doNothing()
         .when(context)
@@ -157,6 +143,29 @@ class ExternalLinkToadletTest {
     when(request.getParam(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING)).thenReturn(target);
     when(toadletContainer.fproxyHasCompletedWizard()).thenReturn(false);
 
+    RenderParameters params = renderConfirmationPage(target);
+
+    assertNotNull(params);
+    assertFalse(params.isRenderNavigationLinks());
+    assertFalse(params.isRenderStatus());
+  }
+
+  @Test
+  void handleMethodGET_whenWizardCompleted_rendersConfirmationFormWithBars() throws Exception {
+    String target = "http://external.example/path";
+    when(request.getParam(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING)).thenReturn(target);
+    when(toadletContainer.fproxyHasCompletedWizard()).thenReturn(true);
+
+    RenderParameters params = renderConfirmationPage(target);
+
+    assertNotNull(params);
+    assertTrue(params.isRenderNavigationLinks());
+    assertTrue(params.isRenderStatus());
+  }
+
+  private RenderParameters renderConfirmationPage(String target) throws Exception {
+    when(request.getParam(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING)).thenReturn(target);
+
     HTMLNode page = new HTMLNode("html");
     HTMLNode head = new HTMLNode("head");
     HTMLNode content = new HTMLNode("div");
@@ -221,11 +230,7 @@ class ExternalLinkToadletTest {
     String html = new String(dataCaptor.getValue(), StandardCharsets.UTF_8);
     assertTrue(html.contains(target));
     assertTrue(html.contains(ExternalLinkToadlet.MAGIC_HTTP_ESCAPE_STRING));
-
-    RenderParameters params = renderParameters.get();
-    assertNotNull(params);
-    assertFalse(params.isRenderNavigationLinks());
-    assertFalse(params.isRenderStatus());
+    return renderParameters.get();
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/network/crypta/clients/http/PageMakerTest.java
+++ b/src/test/java/network/crypta/clients/http/PageMakerTest.java
@@ -1,5 +1,9 @@
 package network.crypta.clients.http;
 
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.PageChromeSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
@@ -18,9 +22,10 @@ class PageMakerTest {
   @Mock private HTTPRequest request;
   @Mock private ToadletContainer container;
   @Mock private ToadletContext context;
+  @Mock private UserAlertManager alertManager;
 
   private PageMaker newPageMaker() {
-    return new PageMaker(PageMaker.THEME.CRYPTAFORGE, null);
+    return new PageMaker(PageMaker.THEME.CRYPTAFORGE);
   }
 
   @Test
@@ -152,11 +157,56 @@ class PageMakerTest {
 
   @Test
   void setTheme_whenPassedNull_resetsToDefault() {
-    PageMaker maker = new PageMaker(PageMaker.THEME.CRYPTAFORGE, null);
+    PageMaker maker = new PageMaker(PageMaker.THEME.CRYPTAFORGE);
 
     maker.setTheme(null);
 
     assertEquals(PageMaker.THEME.getDefault(), maker.getTheme());
+  }
+
+  @Test
+  void getPageNode_whenPageChromePortMissing_hidesStatusBar() {
+    PageMaker maker = newPageMaker();
+    stubPageRenderingContext(false);
+
+    PageNode page =
+        maker.getPageNode(
+            "Status",
+            context,
+            new PageMaker.RenderParameters().renderNavigationLinks(false).renderModeSwitch(false));
+
+    assertFalse(page.generate().contains("statusbar-container"));
+  }
+
+  @Test
+  void getPageNode_whenPageChromeSnapshotProvided_rendersStatusBarShell() {
+    PageMaker maker = newPageMaker();
+    stubPageRenderingContext(true);
+    maker.setPageChromePort(
+        () ->
+            new PageChromeSnapshot(
+                SecurityNetworkThreatLevel.HIGH,
+                SecurityPhysicalThreatLevel.MAXIMUM,
+                4,
+                2,
+                2,
+                5,
+                true,
+                10));
+
+    PageNode page =
+        maker.getPageNode(
+            "Status",
+            context,
+            new PageMaker.RenderParameters().renderNavigationLinks(false).renderModeSwitch(false));
+
+    String html = page.generate();
+
+    assertTrue(html.contains("statusbar-container"));
+    assertTrue(html.contains("statusbar-seclevels"));
+    assertTrue(html.contains("progressbar-peers"));
+    assertTrue(html.contains("/seclevels/"));
+    assertTrue(html.contains("4 / 10"));
   }
 
   @Test
@@ -191,5 +241,17 @@ class PageMakerTest {
     assertThrows(
         NullPointerException.class,
         () -> maker.addNavigationLink("missing", "/path", "name", "title", false, null));
+  }
+
+  private void stubPageRenderingContext(boolean renderStatusBar) {
+    when(context.isAllowedFullAccess()).thenReturn(true);
+    when(context.getContainer()).thenReturn(container);
+    when(container.isFProxyJavascriptEnabled()).thenReturn(false);
+    when(container.sendAllThemes()).thenReturn(false);
+    when(context.activeToadlet()).thenReturn(null);
+    if (renderStatusBar) {
+      when(context.getAlertManager()).thenReturn(alertManager);
+      when(alertManager.createSummary(true)).thenReturn(null);
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -19,9 +19,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
@@ -137,6 +145,7 @@ class SimpleToadletServerTest {
   }
 
   @Test
+  @SuppressWarnings("resource")
   void allowedHostsFullAccess_whenLoadedFromPersistentConfig_expectConfiguredValueRetained()
       throws Exception {
     // Arrange
@@ -145,7 +154,6 @@ class SimpleToadletServerTest {
     initial.putSingle("fproxy.allowedHostsFullAccess", configuredHost);
     PersistentConfig rootConfig = new PersistentConfig(initial);
     SubConfig config = rootConfig.createSubConfig("fproxy");
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
     BucketFactory bucketFactory = mock(BucketFactory.class);
     PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
 
@@ -159,7 +167,7 @@ class SimpleToadletServerTest {
       sslMock
           .when(() -> SSLNetworkInterface.createSsl(anyInt(), any(), any(), any(), anyBoolean()))
           .thenReturn(iface);
-      server = new SimpleToadletServer(config, bucketFactory, executor, node);
+      server = new SimpleToadletServer(config, bucketFactory, executor);
     }
 
     // Act
@@ -176,7 +184,6 @@ class SimpleToadletServerTest {
   private SimpleToadletServer newServerWithDefaults() throws Exception {
     Config rootConfig = new Config();
     SubConfig config = rootConfig.createSubConfig("fproxy");
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
     BucketFactory bucketFactory = mock(BucketFactory.class);
     PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
 
@@ -189,7 +196,7 @@ class SimpleToadletServerTest {
       sslMock
           .when(() -> SSLNetworkInterface.createSsl(anyInt(), any(), any(), any(), anyBoolean()))
           .thenReturn(iface);
-      return new SimpleToadletServer(config, bucketFactory, executor, node);
+      return new SimpleToadletServer(config, bucketFactory, executor);
     }
   }
 

--- a/src/test/java/network/crypta/node/runtime/LegacyPageChromePortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyPageChromePortTest.java
@@ -1,0 +1,61 @@
+package network.crypta.node.runtime;
+
+import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.Node;
+import network.crypta.node.OpennetManager;
+import network.crypta.node.SecurityLevels;
+import network.crypta.runtime.spi.PageChromeSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyPageChromePortTest {
+
+  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock private SecurityLevels securityLevels;
+  @Mock private OpennetManager opennetManager;
+  @Mock private DarknetPeerNode enabledPeer;
+  @Mock private DarknetPeerNode disabledPeer;
+
+  @Test
+  void snapshot_whenCalled_mapsThreatLevelsAndPeerCounts() {
+    when(node.services().securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getNetworkThreatLevel())
+        .thenReturn(SecurityLevels.NETWORK_THREAT_LEVEL.HIGH);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.MAXIMUM);
+    when(node.network().peers().countConnectedPeers()).thenReturn(4);
+    when(node.network().peers().countConnectedDarknetPeers()).thenReturn(2);
+    when(node.network().peers().countConnectedOpennetPeers()).thenReturn(2);
+    when(node.network().peers().roster().getDarknetPeers())
+        .thenReturn(new DarknetPeerNode[] {enabledPeer, disabledPeer, null});
+    when(enabledPeer.isDisabled()).thenReturn(false);
+    when(disabledPeer.isDisabled()).thenReturn(true);
+    when(node.network().opennet()).thenReturn(opennetManager);
+    when(opennetManager.getNumberOfConnectedPeersToAimIncludingDarknet()).thenReturn(10);
+
+    LegacyPageChromePort port = new LegacyPageChromePort(node);
+
+    PageChromeSnapshot snapshot = port.snapshot();
+
+    assertEquals(SecurityNetworkThreatLevel.HIGH, snapshot.networkThreatLevel());
+    assertEquals(SecurityPhysicalThreatLevel.MAXIMUM, snapshot.physicalThreatLevel());
+    assertEquals(4, snapshot.connectedPeerCount());
+    assertEquals(2, snapshot.connectedDarknetPeerCount());
+    assertEquals(2, snapshot.connectedOpennetPeerCount());
+    assertEquals(1, snapshot.enabledDarknetPeerCount());
+    assertTrue(snapshot.opennetEnabled());
+    assertEquals(10, snapshot.opennetTargetIncludingDarknetPeerCount());
+  }
+}

--- a/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
@@ -80,7 +80,8 @@ class LegacyRuntimePortsTest {
         () -> assertSame(snapshot.connectionsSupportPort(), ports.connectionsSupport()),
         () -> assertSame(snapshot.darknetConnectionsPort(), ports.darknetConnections()),
         () -> assertSame(snapshot.darknetMessagingPort(), ports.darknetMessaging()),
-        () -> assertSame(snapshot.diagnosticPort(), ports.diagnostic()));
+        () -> assertSame(snapshot.diagnosticPort(), ports.diagnostic()),
+        () -> assertSame(snapshot.pageChromePort(), ports.pageChrome()));
   }
 
   private void assertStableFeaturePorts(PortsSnapshot snapshot) {
@@ -115,6 +116,7 @@ class LegacyRuntimePortsTest {
             assertInstanceOf(LegacyDarknetConnectionsPort.class, snapshot.darknetConnectionsPort()),
         () -> assertInstanceOf(LegacyDarknetMessagingPort.class, snapshot.darknetMessagingPort()),
         () -> assertInstanceOf(LegacyDiagnosticPort.class, snapshot.diagnosticPort()),
+        () -> assertInstanceOf(LegacyPageChromePort.class, snapshot.pageChromePort()),
         () -> assertInstanceOf(LegacyQueueSupportPort.class, snapshot.queueSupportPort()),
         () -> assertInstanceOf(LegacyQueueCompletionPort.class, snapshot.queueCompletionPort()),
         () -> assertInstanceOf(LegacyQueuePagePort.class, snapshot.queuePagePort()),
@@ -196,6 +198,7 @@ class LegacyRuntimePortsTest {
         ports.darknetConnections(),
         ports.darknetMessaging(),
         ports.diagnostic(),
+        ports.pageChrome(),
         ports.queueSupport(),
         ports.queueCompletion(),
         ports.queuePage(),
@@ -224,6 +227,7 @@ class LegacyRuntimePortsTest {
       Object darknetConnectionsPort,
       Object darknetMessagingPort,
       Object diagnosticPort,
+      Object pageChromePort,
       Object queueSupportPort,
       Object queueCompletionPort,
       Object queuePagePort,


### PR DESCRIPTION
## Summary
- add the narrow `PageChromePort` and `PageChromeSnapshot` runtime SPI, expose it through `RuntimePorts`, and adapt the legacy daemon runtime with `LegacyPageChromePort`
- refactor `PageMaker`, `SimpleToadletServer`, and `ExternalLinkToadlet` so the shared admin shell no longer stores `Node` for page-chrome state, with startup-safe injection from `setCore()`
- update the focused HTTP/runtime tests and enrich the new production-file Javadocs for the added SPI and adapter classes

## Testing
- `./gradlew test --tests 'network.crypta.node.runtime.LegacyPageChromePortTest' --tests 'network.crypta.clients.http.PageMakerTest' --tests 'network.crypta.clients.http.ExternalLinkToadletTest' --tests 'network.crypta.clients.http.SimpleToadletServerTest'`
- `./gradlew test`

## Docs verification
- `javadoc -quiet -Xdoclint:all -classpath 'runtime-spi/build/classes/java/main:runtime-spi/build/resources/main:build/classes/java/main:build/resources/main' -sourcepath 'runtime-spi/src/main/java:src/main/java' -d /tmp/doclint-pagechrome-port runtime-spi/src/main/java/network/crypta/runtime/spi/PageChromePort.java`
- `javadoc -quiet -Xdoclint:all -classpath 'runtime-spi/build/classes/java/main:runtime-spi/build/resources/main:build/classes/java/main:build/resources/main' -sourcepath 'runtime-spi/src/main/java:src/main/java' -d /tmp/doclint-pagechrome-snapshot runtime-spi/src/main/java/network/crypta/runtime/spi/PageChromeSnapshot.java`
- `javac -proc:none -Xdoclint:all -Werror -classpath "<project compile classpath>" -d /tmp/doclint-legacy-pagechrome-port-javac src/main/java/network/crypta/node/runtime/LegacyPageChromePort.java`