### PR TITLE
refactor(runtime): Move admin toadlets behind runtime SPI

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
@@ -1,0 +1,61 @@
+package network.crypta.runtime.spi;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Exposes the last daemon-backed updater actions still needed by the legacy core-update toadlet.
+ *
+ * <p>This SPI is intentionally small. Implementations answer whether a live core updater is
+ * currently wired, start the same UI-triggered download flow that the legacy admin page expects,
+ * and validate installer paths that come back from form submissions. The interface keeps those
+ * live-daemon checks behind the runtime boundary while avoiding direct exposure of {@code Node},
+ * updater services, or daemon-specific transport and config classes.
+ *
+ * <p>{@code CoreActionToadlet} continues to own request parsing, redirects, result pages, {@code
+ * AppEnv} checks, and OS-specific installer or store-launching behavior. Callers typically fetch
+ * the port from {@link RuntimePorts}, check availability for one request, and then invoke either a
+ * download trigger or installer-path validation step.
+ *
+ * @see RuntimePorts#coreUpdateAction()
+ */
+public interface CoreUpdateActionPort {
+  /**
+   * Returns whether the package-based core updater is currently available.
+   *
+   * <p>Callers use this to preserve the legacy redirect behavior when the updater is disabled,
+   * still starting up, or otherwise unavailable for the current node runtime. The result is a
+   * point-in-time availability check rather than a reservation of updater resources, so callers
+   * should expect a later action to remain best-effort.
+   *
+   * @return {@code true} when the core updater can currently accept UI-triggered actions; {@code
+   *     false} when the updater service is absent or unavailable
+   */
+  boolean isCoreUpdaterAvailable();
+
+  /**
+   * Starts the current core-package download from the updater UI.
+   *
+   * <p>Implementations preserve the daemon-side selection and in-progress checks used by the legacy
+   * updater flow. Callers are expected to check {@link #isCoreUpdaterAvailable()} before invoking
+   * this method and to treat the call as a trigger, not as a completion signal. Follow-up status,
+   * redirects, or operator-visible errors still come from the HTTP layer and the updater itself.
+   */
+  void startCoreDownloadFromUi();
+
+  /**
+   * Resolves one raw installer path to a canonical downloaded-installer path when it stays within
+   * the legacy core-updater download area.
+   *
+   * <p>Implementations preserve the existing {@code <nodeDir>/updates/core} containment check and
+   * return an empty result for blank, invalid, or out-of-tree inputs. The returned path is
+   * canonical, detached from daemon-only file-wrapper types, and suitable for later launcher or
+   * installer handling in the HTTP layer. The method validates location only; callers still handle
+   * later file existence or execution failures through the normal installation flow.
+   *
+   * @param rawPath raw installer path string read from the HTTP request body or query data
+   * @return canonical installer path when accepted; otherwise {@link Optional#empty()} for blank,
+   *     malformed, or out-of-tree input
+   */
+  Optional<Path> resolveDownloadedInstaller(String rawPath);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
@@ -37,8 +37,9 @@ public interface CoreUpdateActionPort {
    * Starts the current core-package download from the updater UI.
    *
    * <p>Implementations preserve the daemon-side selection and in-progress checks used by the legacy
-   * updater flow. Callers are expected to check {@link #isCoreUpdaterAvailable()} before invoking
-   * this method and to treat the call as a trigger, not as a completion signal. Follow-up status,
+   * updater flow. Callers may invoke this method directly for one download request so the updater
+   * lookup and the download trigger use the same daemon snapshot instead of being split across two
+   * separate calls. The method remains a trigger rather than a completion signal; follow-up status,
    * redirects, or operator-visible errors still come from the HTTP layer and the updater itself.
    */
   void startCoreDownloadFromUi();

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
@@ -37,8 +37,8 @@ public interface CoreUpdateActionPort {
    * Starts the current core-package download from the updater UI.
    *
    * <p>Implementations preserve the daemon-side selection and in-progress checks used by the legacy
-   * updater flow. Callers may invoke this method directly for one download request so the updater
-   * lookup and the download trigger use the same daemon snapshot instead of being split across two
+   * updater flow. Callers may invoke this method directly for one download request, so the updater
+   * lookup and the download trigger uses the same daemon snapshot instead of being split across two
    * separate calls. The method remains a trigger rather than a completion signal; follow-up status,
    * redirects, or operator-visible errors still come from the HTTP layer and the updater itself.
    */

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -25,6 +25,7 @@ package network.crypta.runtime.spi;
  * @see DarknetConnectionsPort
  * @see DarknetMessagingPort
  * @see DiagnosticPort
+ * @see CoreUpdateActionPort
  * @see QueueCompletionPort
  * @see QueuePagePort
  * @see QueueDownloadPort
@@ -37,6 +38,7 @@ package network.crypta.runtime.spi;
  * @see RequestQueuePort
  * @see SecurityLevelsPort
  * @see FirstTimeWizardPort
+ * @see ToadletSymlinkPort
  * @see WelcomePagePort
  * @see WelcomeActionPort
  */
@@ -187,6 +189,18 @@ public interface RuntimePorts {
   PageChromePort pageChrome();
 
   /**
+   * Returns the legacy core-update action capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining live core-updater availability checks, UI-triggered download
+   * start, and downloaded-installer containment validation inside the daemon root module while
+   * leaving request parsing, redirects, and OS-specific launcher logic in the HTTP layer.
+   *
+   * @return core-update action runtime port for updater availability, download start, and installer
+   *     path validation
+   */
+  CoreUpdateActionPort coreUpdateAction();
+
+  /**
    * Returns the legacy queue support capability exposed to admin-facing HTTP code.
    *
    * <p>This port keeps the remaining queue-oriented live-runtime helpers behind the runtime
@@ -288,6 +302,17 @@ public interface RuntimePorts {
    * @return first-time-wizard runtime port for detached page state and submission application
    */
   FirstTimeWizardPort firstTimeWizard();
+
+  /**
+   * Returns the legacy symlinker persistence capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port keeps the remaining configuration-backed load and save behavior for short admin
+   * shell aliases inside the daemon root module while leaving the symlinker toadlet's in-memory
+   * alias map and redirect semantics in the HTTP layer.
+   *
+   * @return symlinker runtime port for loading and persisting alias mappings
+   */
+  ToadletSymlinkPort toadletSymlinks();
 
   /**
    * Returns the legacy welcome-page read capability exposed to admin-facing HTTP code.

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ToadletSymlinkEntry.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ToadletSymlinkEntry.java
@@ -1,0 +1,35 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Immutable alias-to-target entry used by the legacy symlinker toadlet SPI.
+ *
+ * <p>This record is intentionally small and JDK-only, so runtime SPI callers can exchange symlink
+ * state without depending on daemon config or HTTP classes. Each instance represents one persisted
+ * mapping from a short admin-shell alias path to the target toadlet path prefix that should replace
+ * it during redirect construction.
+ *
+ * <p>The record does not normalize, canonicalize, or otherwise reinterpret slash conventions.
+ * Callers are expected to preserve the stored values that the symlinker already understands.
+ *
+ * @param alias request-path prefix that the symlinker should match for incoming requests
+ * @param target destination-path prefix that replaces the alias when constructing redirects
+ */
+public record ToadletSymlinkEntry(String alias, String target) {
+  /**
+   * Creates one detached symlink entry.
+   *
+   * <p>The constructor enforces only non-nullity. It does not validate prefix formatting, trailing
+   * slashes, or redirect safety because those behaviors remain the responsibility of the existing
+   * symlinker logic and its callers.
+   *
+   * @param alias request-path prefix to match; never {@code null}
+   * @param target destination-path prefix to substitute during redirect rewriting; never {@code
+   *     null}
+   */
+  public ToadletSymlinkEntry {
+    Objects.requireNonNull(alias, "alias");
+    Objects.requireNonNull(target, "target");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ToadletSymlinkPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ToadletSymlinkPort.java
@@ -1,0 +1,47 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+
+/**
+ * Exposes the narrow persisted-symlink storage still needed by the legacy symlinker toadlet.
+ *
+ * <p>This SPI keeps the existing configuration-backed load and save behavior behind the runtime
+ * boundary while leaving the in-memory alias map, redirect logic, and HTTP 404 behavior in the
+ * toadlet itself. The interface works entirely with detached {@link ToadletSymlinkEntry} lists so
+ * callers do not depend on daemon config classes, callback types, or the concrete map structure
+ * inside {@code SymlinkerToadlet}.
+ *
+ * <p>Typical usage is straightforward: load one snapshot during toadlet construction, then persist
+ * the full alias set after each admin add or remove operation. Implementations may back the data
+ * with legacy node configuration, tests, or another persistence layer, but callers should always
+ * treat returned lists as snapshots and pass the complete desired state on writes.
+ *
+ * @see RuntimePorts#toadletSymlinks()
+ */
+public interface ToadletSymlinkPort {
+  /**
+   * Loads the currently configured alias mappings.
+   *
+   * <p>The returned list is detached request-independent data suitable for constructing the
+   * symlinker's in-memory alias map. Callers should not assume the list is live or mutable, and
+   * they should rebuild any internal lookup structures they need from the returned entries.
+   *
+   * @return detached list of configured alias mappings representing the persisted symlink state at
+   *     load time
+   */
+  List<ToadletSymlinkEntry> loadConfiguredSymlinks();
+
+  /**
+   * Persists the full current alias mapping set.
+   *
+   * <p>Callers provide the complete mapping list after an add or remove operation, so the runtime
+   * implementation can preserve the legacy configuration-store behavior without depending on the
+   * toadlet's internal map structure. Implementations may write immediate or stage data for an
+   * underlying config callback, but callers should assume the supplied list fully replaces the
+   * previously persisted alias set.
+   *
+   * @param entries detached list representing the full current alias mapping set that should remain
+   *     available after restart
+   */
+  void persistConfiguredSymlinks(List<ToadletSymlinkEntry> entries);
+}

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -12,7 +12,6 @@ import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
 import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClientBuilder;
 import network.crypta.node.RequestStarter;
@@ -29,8 +28,8 @@ import static network.crypta.node.updater.UpdaterPaths.CORE_UPDATE_PATH;
  * the {@link SimpleToadletServer}. Callers invoke it once during node startup to ensure all public
  * endpoints—browsing, queue management, configuration, alerts, and update actions—are available
  * before handling requests. The registrar is intentionally package-private and stateless; it relies
- * on the provided {@link NodeClientCore}, {@link Node}, and {@link Config} instances for runtime
- * settings and threat posture.
+ * on the provided {@link NodeClientCore} and {@link Config} instances for runtime settings and
+ * threat posture.
  *
  * <p>Responsibilities include:
  *
@@ -60,12 +59,10 @@ final class FProxyRegistrar {
    *
    * @param core node client core supplying security levels, download directories, and RNG access;
    *     must be initialized and non-null.
-   * @param node running node instance providing transport and runtime data; never null.
    * @param config composite configuration used to enumerate sub-configs for dynamic toadlets.
    * @param server toadlet server that exposes HTTP endpoints; expected to be in registration phase.
    */
-  static void maybeCreateFProxyEtc(
-      NodeClientCore core, Node node, Config config, SimpleToadletServer server) {
+  static void maybeCreateFProxyEtc(NodeClientCore core, Config config, SimpleToadletServer server) {
 
     HighLevelSimpleClient client =
         core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
@@ -226,7 +223,7 @@ final class FProxyRegistrar {
         localFileFilterToadlet,
         ToadletRegistration.basic(null, LocalFileFilterToadlet.BROWSE_PATH, true, false));
 
-    SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, node);
+    SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, runtimePorts.toadletSymlinks());
     server.register(symlinkToadlet, ToadletRegistration.basic(null, "/sl/", true, false));
 
     SecurityLevelsToadletRuntimePorts securityLevelsToadletRuntimePorts =
@@ -288,7 +285,8 @@ final class FProxyRegistrar {
         externalLinkToadlet,
         ToadletRegistration.basic(null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false));
 
-    CoreActionToadlet coreActionToadlet = new CoreActionToadlet(client, node);
+    CoreActionToadlet coreActionToadlet =
+        new CoreActionToadlet(client, runtimePorts.coreUpdateAction());
     server.register(
         coreActionToadlet, ToadletRegistration.basic(null, CORE_UPDATE_PATH, true, false));
 

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -26,7 +26,6 @@ import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PrioRunnable;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
@@ -458,13 +457,12 @@ public final class SimpleToadletServer
    * <p>Call this after {@link #setCore(NodeClientCore)} and before accepting requests to install
    * bookmark handling, interval push scheduling, and UI registration against the active node. This
    * method is idempotent; later calls are ignored after the first successful invocation. It
-   * captures the current {@link #core} and {@link Node} references, wires the push managers to the
-   * shared {@link Ticker}, and delegates to {@link FProxyRegistrar} to create request handlers and
-   * configuration entries.
+   * captures the current {@link #core} reference, wires the push managers to the shared {@link
+   * Ticker}, and delegates to {@link FProxyRegistrar} to create request handlers and configuration
+   * entries.
    */
   public void createFproxy() {
     NodeClientCore coreRef = this.core;
-    Node node = coreRef.getNode();
     synchronized (this) {
       if (haveCalledFProxy) return;
       haveCalledFProxy = true;
@@ -473,7 +471,7 @@ public final class SimpleToadletServer
     pushDataManager = new PushDataManager(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
     bookmarkManager = new BookmarkManager(coreRef, publicGatewayMode());
-    FProxyRegistrar.maybeCreateFProxyEtc(coreRef, node, node.getConfig(), this);
+    FProxyRegistrar.maybeCreateFProxyEtc(coreRef, coreRef.getNode().getConfig(), this);
   }
 
   /**
@@ -1773,7 +1771,7 @@ public final class SimpleToadletServer
    * Provides the ticker used to schedule periodic tasks.
    *
    * <p>The ticker is shared across push managers and other time-based components. It is owned by
-   * the {@link Node} and exposed here for convenience.
+   * the node instance and exposed here for convenience.
    *
    * @return {@link Ticker} from the node; never {@code null} after the core is set.
    */

--- a/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
@@ -3,16 +3,16 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.config.InvalidConfigValueException;
-import network.crypta.config.Option;
-import network.crypta.config.SubConfig;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
+import network.crypta.runtime.spi.ToadletSymlinkEntry;
+import network.crypta.runtime.spi.ToadletSymlinkPort;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.api.StringArrCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,9 +22,9 @@ import org.slf4j.LoggerFactory;
  * <p>This toadlet keeps a synchronized in-memory map of aliases and redirects any request whose
  * path starts with a known alias to the mapped target. It bootstraps from persisted configuration
  * and can persist later edits on demand. Synchronization on the internal {@link Map} keeps link
- * updates and lookups thread-safe. Callers typically create one instance per node, let it register
- * its configuration, and rely on {@link #handleMethodGET(URI, HTTPRequest, ToadletContext)} to
- * perform the resolution work.
+ * updates and lookups thread-safe. Callers typically create one instance per node, let it load its
+ * persisted aliases through the runtime SPI, and rely on {@link #handleMethodGET(URI, HTTPRequest,
+ * ToadletContext)} to perform the resolution work.
  *
  * <p>Responsibilities include:
  *
@@ -42,68 +42,36 @@ public class SymlinkerToadlet extends Toadlet {
   private static final Logger LOG = LoggerFactory.getLogger(SymlinkerToadlet.class);
 
   private final HashMap<String, String> linkMap = new HashMap<>();
-  private final Node node;
-  SubConfig tslconfig;
+  private final ToadletSymlinkPort symlinkPort;
 
   /**
-   * Creates a new symlinker toadlet and registers its configuration.
+   * Creates a new symlinker toadlet backed by detached symlink persistence.
    *
-   * <p>The constructor reads the {@code toadletsymlinker.symlinks} array from the node
-   * configuration, populates the in-memory map, and finalizes the configuration section to prevent
-   * external modifications. Construction is not thread-safe, but further alias access is
-   * synchronized on the internal map.
+   * <p>The constructor loads the current configured alias mappings through the provided runtime
+   * port and populates the in-memory map. Construction is not thread-safe, but further alias access
+   * is synchronized on the internal map.
    *
    * @param client high-level HTTP client used to write responses and redirects for requests.
-   * @param node node instance supplying configuration storage and persistence hooks for aliases.
+   * @param symlinkPort runtime port supplying a configuration-backed alias load and persistence.
    */
-  public SymlinkerToadlet(HighLevelSimpleClient client, final Node node) {
+  public SymlinkerToadlet(HighLevelSimpleClient client, ToadletSymlinkPort symlinkPort) {
     super(client);
-    this.node = node;
-    tslconfig = node.getConfig().createSubConfig("toadletsymlinker");
-    tslconfig.register(
-        "symlinks",
-        null,
-        new Option.Meta(
-            9, true, false, "SymlinkerToadlet.symlinks", "SymlinkerToadlet.symlinksLong"),
-        new StringArrCallback() {
-          @Override
-          public String[] get() {
-            return getConfigLoadString();
-          }
-
-          @Override
-          public void set(String[] val) throws InvalidConfigValueException {
-            throw new InvalidConfigValueException("Cannot set loaded symlinks directly.");
-          }
-
-          @Override
-          public boolean isReadOnly() {
-            return true;
-          }
-        });
-
-    String[] fns = tslconfig.getStringArr("symlinks");
-    if (fns != null) {
-      for (String fn : fns) {
-        int hashIndex = fn.indexOf('#');
-        if (hashIndex > 0 && hashIndex == fn.lastIndexOf('#') && hashIndex < fn.length() - 1) {
-          addLink(fn.substring(0, hashIndex), fn.substring(hashIndex + 1), false);
-        }
-      }
+    this.symlinkPort = Objects.requireNonNull(symlinkPort, "symlinkPort");
+    for (ToadletSymlinkEntry entry : symlinkPort.loadConfiguredSymlinks()) {
+      addLink(entry.alias(), entry.target(), false);
     }
-
-    tslconfig.finishedInitialization();
   }
 
   /**
    * Inserts or updates an alias mapping in memory and optionally persists it to disk.
    *
    * <p>The method acquires a monitor on the alias map, updates the mapping for {@code alias} to the
-   * provided {@code target}, and logs the operation. When {@code store} is {@code true}, the node's
-   * configuration is requested to persist current aliases. No validation or normalization of path
-   * components is performed; callers should pass canonical prefixes, including trailing slashes, to
-   * avoid ambiguous matches. The boolean return indicates whether the previous mapping value was
-   * identical to the alias string before replacement.
+   * provided {@code target}, and logs the operation. When {@code store} is {@code true}, the full
+   * current alias list is persisted through the runtime port before releasing the map monitor so
+   * persisted state follows the same mutation order as the in-memory alias map. No validation or
+   * normalization of path components is performed; callers should pass canonical prefixes,
+   * including trailing slashes, to avoid ambiguous matches. The boolean return indicates whether
+   * the previous mapping value was identical to the alias string before replacement.
    *
    * @param alias request path prefix to match; typically starts and ends with a slash.
    * @param target destination prefix that replaces the alias in constructed redirect paths.
@@ -115,8 +83,10 @@ public class SymlinkerToadlet extends Toadlet {
     synchronized (linkMap) {
       ret = alias.equals(linkMap.put(alias, target));
       LOG.info("Adding link: {} => {}", alias, target);
+      if (store) {
+        symlinkPort.persistConfiguredSymlinks(snapshotEntries());
+      }
     }
-    if (store) node.services().clientCore().storeConfig();
     return ret;
   }
 
@@ -125,9 +95,10 @@ public class SymlinkerToadlet extends Toadlet {
    *
    * <p>The method synchronizes on the alias map, deletes the mapping for {@code alias} when
    * present, and logs the removal together with the previous target. No validation is performed on
-   * the alias format, and requesting persistence only affects configuration storage, not runtime
-   * behavior. Calls are idempotent with respect to non-existent aliases and return a boolean to
-   * signal whether removal occurred.
+   * the alias format, and requesting persistence stores the remaining full alias list through the
+   * runtime port before releasing the map monitor so the persisted state follows in-memory mutation
+   * order. Calls are idempotent with respect to non-existent aliases and return a boolean to signal
+   * whether removal occurred.
    *
    * @param alias path prefix identifying the mapping to delete from the symlinker.
    * @param store whether to trigger configuration persistence after the removal attempt.
@@ -140,20 +111,19 @@ public class SymlinkerToadlet extends Toadlet {
       ret = (o = linkMap.remove(alias)) != null;
 
       LOG.info("Removing link: {} => {}", alias, o);
+      if (store) {
+        symlinkPort.persistConfiguredSymlinks(snapshotEntries());
+      }
     }
-    if (store) node.services().clientCore().storeConfig();
     return ret;
   }
 
-  private String[] getConfigLoadString() {
-    String[] retarr = new String[linkMap.size()];
-    synchronized (linkMap) {
-      int i = 0;
-      for (Map.Entry<String, String> entry : linkMap.entrySet()) {
-        retarr[i++] = entry.getKey() + '#' + entry.getValue();
-      }
+  private List<ToadletSymlinkEntry> snapshotEntries() {
+    List<ToadletSymlinkEntry> entries = new ArrayList<>(linkMap.size());
+    for (Map.Entry<String, String> entry : linkMap.entrySet()) {
+      entries.add(new ToadletSymlinkEntry(entry.getKey(), entry.getValue()));
     }
-    return retarr;
+    return List.copyOf(entries);
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyCoreUpdateActionPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyCoreUpdateActionPort.java
@@ -1,0 +1,79 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+import network.crypta.node.Node;
+import network.crypta.node.updater.CoreUpdater;
+import network.crypta.node.updater.NodeUpdateManager;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
+
+/**
+ * Adapts the core-update action SPI to the legacy daemon runtime.
+ *
+ * <p>This adapter bridges {@link CoreUpdateActionPort} back to the current daemon implementation
+ * without letting HTTP-layer code depend on {@link Node}, {@link NodeUpdateManager}, or {@link
+ * CoreUpdater}. It preserves the legacy behavior that matters to the admin shell: availability
+ * depends on whether a live core updater service is wired, UI download requests delegate to {@code
+ * startDownloadFromUI()}, and installer validation accepts only canonical paths beneath the node's
+ * {@code updates/core} directory.
+ *
+ * <p>The adapter does not launch installers, open stores, or interpret HTTP results. Those
+ * operator-visible choices remain inside the toadlet, which means this class stays focused on
+ * daemon lookups and filesystem containment checks.
+ */
+final class LegacyCoreUpdateActionPort implements CoreUpdateActionPort {
+  private static final String CORE_UPDATE_DIRECTORY = "updates/core";
+
+  private final Node node;
+
+  /**
+   * Creates an adapter bound to one live node instance.
+   *
+   * <p>The adapter resolves updater availability from the node services layer each time a caller
+   * asks for it, so it follows current daemon wiring instead of caching updater objects across
+   * requests.
+   *
+   * @param node live node that owns updater services and the node-directory layout
+   */
+  LegacyCoreUpdateActionPort(Node node) {
+    this.node = Objects.requireNonNull(node, "node");
+  }
+
+  @Override
+  public boolean isCoreUpdaterAvailable() {
+    return getCoreUpdater().isPresent();
+  }
+
+  @Override
+  public void startCoreDownloadFromUi() {
+    getCoreUpdater().ifPresent(CoreUpdater::startDownloadFromUI);
+  }
+
+  @Override
+  public Optional<Path> resolveDownloadedInstaller(String rawPath) {
+    if (rawPath == null || rawPath.isBlank()) {
+      return Optional.empty();
+    }
+
+    try {
+      File base = new File(node.getNodeDir(), CORE_UPDATE_DIRECTORY).getCanonicalFile();
+      File candidate = new File(rawPath).getCanonicalFile();
+      Path candidatePath = candidate.toPath();
+      return candidatePath.startsWith(base.toPath())
+          ? Optional.of(candidatePath)
+          : Optional.empty();
+    } catch (IOException _) {
+      return Optional.empty();
+    }
+  }
+
+  private Optional<CoreUpdater> getCoreUpdater() {
+    NodeUpdateManager nodeUpdateManager = node.services().nodeUpdater();
+    return nodeUpdateManager == null
+        ? Optional.empty()
+        : Optional.ofNullable(nodeUpdateManager.getCoreUpdater());
+  }
+}

--- a/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyRuntimePorts.java
@@ -8,6 +8,7 @@ import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.DiagnosticPort;
@@ -28,6 +29,7 @@ import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.StatisticsPort;
+import network.crypta.runtime.spi.ToadletSymlinkPort;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.runtime.spi.WelcomeActionPort;
 import network.crypta.runtime.spi.WelcomePagePort;
@@ -61,6 +63,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
   private final PageChromePort pageChromePort;
+  private final CoreUpdateActionPort coreUpdateActionPort;
   private final QueueCompletionPort queueCompletionPort;
   private final QueuePagePort queuePagePort;
   private final QueueDownloadPort queueDownloadPort;
@@ -70,6 +73,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final StatisticsPort statisticsPort;
   private final SecurityLevelsPort securityLevelsPort;
   private final FirstTimeWizardPort firstTimeWizardPort;
+  private final ToadletSymlinkPort toadletSymlinkPort;
   private final WelcomePagePort welcomePagePort;
   private final WelcomeActionPort welcomeActionPort;
   private final RequestQueuePort requestQueuePort;
@@ -167,6 +171,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.darknetMessagingPort = new LegacyDarknetMessagingPort(node);
     this.diagnosticPort = new LegacyDiagnosticPort(node, core);
     this.pageChromePort = new LegacyPageChromePort(node);
+    this.coreUpdateActionPort = new LegacyCoreUpdateActionPort(node);
     this.queueCompletionPort = new LegacyQueueCompletionPort(core);
     this.queuePagePort = new LegacyQueuePagePort(core);
     this.queueDownloadPort = new LegacyQueueDownloadPort(core);
@@ -176,6 +181,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.statisticsPort = new LegacyStatisticsPort(node, core);
     this.securityLevelsPort = new LegacySecurityLevelsPort(node);
     this.firstTimeWizardPort = new LegacyFirstTimeWizardPort(node, core);
+    this.toadletSymlinkPort = new LegacyToadletSymlinkPort(node, core);
     this.welcomePagePort = new LegacyWelcomePagePort(node);
     this.welcomeActionPort = new LegacyWelcomeActionPort(node);
     this.requestQueuePort = new LegacyRequestQueuePort(core);
@@ -320,6 +326,18 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   /**
    * {@inheritDoc}
    *
+   * <p>The returned port keeps the remaining core-updater availability checks, UI-triggered
+   * download start, and downloaded-installer path validation inside the daemon root module while
+   * exposing only JDK-only values upstream.
+   */
+  @Override
+  public CoreUpdateActionPort coreUpdateAction() {
+    return coreUpdateActionPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
    * <p>The returned port keeps the remaining queue backend-enabled check, persistence-support state
    * reads, and panic actions inside the daemon root module while exposing only JDK-only values
    * upstream.
@@ -419,6 +437,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public FirstTimeWizardPort firstTimeWizard() {
     return firstTimeWizardPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port keeps the remaining symlinker configuration load and persistence behavior
+   * inside the daemon root module while exposing only detached JDK-only alias entries upstream.
+   */
+  @Override
+  public ToadletSymlinkPort toadletSymlinks() {
+    return toadletSymlinkPort;
   }
 
   /**

--- a/src/main/java/network/crypta/node/runtime/LegacyToadletSymlinkPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyToadletSymlinkPort.java
@@ -1,0 +1,134 @@
+package network.crypta.node.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.Option;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ToadletSymlinkEntry;
+import network.crypta.runtime.spi.ToadletSymlinkPort;
+import network.crypta.support.api.StringArrCallback;
+
+/**
+ * Adapts the symlinker persistence SPI to the legacy daemon runtime.
+ *
+ * <p>This adapter bridges {@link ToadletSymlinkPort} to the existing {@code
+ * toadletsymlinker.symlinks} node configuration. It lazily registers the legacy string array option
+ * the first time a caller loads or persists aliases, parses stored {@code alias#target} entries
+ * into detached DTOs, and writes full snapshots back through the node config store. That lets
+ * {@code SymlinkerToadlet} keep owning the live alias map and redirect semantics while the daemon
+ * module continues to own persistence across restarts.
+ *
+ * <p>The current persisted snapshot is stored separately from the toadlet's runtime map, so config
+ * callbacks and request threads can exchange detached values without pulling daemon config classes
+ * into the HTTP layer.
+ */
+final class LegacyToadletSymlinkPort implements ToadletSymlinkPort {
+  private static final String CONFIG_PREFIX = "toadletsymlinker";
+  private static final String OPTION_SYMLINKS = "symlinks";
+  private static final Option.Meta SYMLINK_OPTION_META =
+      new Option.Meta(9, true, false, "SymlinkerToadlet.symlinks", "SymlinkerToadlet.symlinksLong");
+
+  private final Node node;
+  private final NodeClientCore core;
+
+  private volatile boolean initialized;
+  private final AtomicReference<List<ToadletSymlinkEntry>> configuredEntries =
+      new AtomicReference<>(List.of());
+
+  /**
+   * Creates a lazy adapter for the node's persisted symlink configuration.
+   *
+   * <p>Construction does not immediately register the legacy subconfig. Initialization is deferred
+   * until the first load or persist operation, so runtime-port assembly does not eagerly mutate the
+   * node configuration tree.
+   *
+   * @param node live node that owns the {@code toadletsymlinker} configuration subtree
+   * @param core client-core instance used to request config persistence after updates
+   */
+  LegacyToadletSymlinkPort(Node node, NodeClientCore core) {
+    this.node = Objects.requireNonNull(node, "node");
+    this.core = Objects.requireNonNull(core, "core");
+  }
+
+  @Override
+  public List<ToadletSymlinkEntry> loadConfiguredSymlinks() {
+    ensureInitialized();
+    return configuredEntries.get();
+  }
+
+  @Override
+  public void persistConfiguredSymlinks(List<ToadletSymlinkEntry> entries) {
+    ensureInitialized();
+    configuredEntries.set(List.copyOf(entries));
+    core.storeConfig();
+  }
+
+  private void ensureInitialized() {
+    if (initialized) {
+      return;
+    }
+
+    synchronized (this) {
+      if (initialized) {
+        return;
+      }
+
+      SubConfig symlinkConfig = node.getConfig().createSubConfig(CONFIG_PREFIX);
+      symlinkConfig.register(OPTION_SYMLINKS, null, SYMLINK_OPTION_META, new Callback());
+      configuredEntries.set(parseConfiguredEntries(symlinkConfig.getStringArr(OPTION_SYMLINKS)));
+      symlinkConfig.finishedInitialization();
+      initialized = true;
+    }
+  }
+
+  private static List<ToadletSymlinkEntry> parseConfiguredEntries(String[] rawEntries) {
+    if (rawEntries == null) {
+      return List.of();
+    }
+
+    List<ToadletSymlinkEntry> parsedEntries = new ArrayList<>();
+    for (String rawEntry : rawEntries) {
+      int hashIndex = rawEntry.indexOf('#');
+      if (hashIndex > 0
+          && hashIndex == rawEntry.lastIndexOf('#')
+          && hashIndex < rawEntry.length() - 1) {
+        parsedEntries.add(
+            new ToadletSymlinkEntry(
+                rawEntry.substring(0, hashIndex), rawEntry.substring(hashIndex + 1)));
+      }
+    }
+    return List.copyOf(parsedEntries);
+  }
+
+  private final class Callback extends StringArrCallback {
+    @Override
+    public String[] get() {
+      return serializeConfiguredEntries();
+    }
+
+    private String[] serializeConfiguredEntries() {
+      List<ToadletSymlinkEntry> entries = configuredEntries.get();
+      String[] serialized = new String[entries.size()];
+      for (int i = 0; i < entries.size(); i++) {
+        ToadletSymlinkEntry entry = entries.get(i);
+        serialized[i] = entry.alias() + '#' + entry.target();
+      }
+      return serialized;
+    }
+
+    @Override
+    public void set(String[] value) throws InvalidConfigValueException {
+      throw new InvalidConfigValueException("Cannot set loaded symlinks directly.");
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return true;
+    }
+  }
+}

--- a/src/main/java/network/crypta/node/updater/CoreActionToadlet.java
+++ b/src/main/java/network/crypta/node/updater/CoreActionToadlet.java
@@ -128,7 +128,7 @@ public class CoreActionToadlet extends Toadlet {
    *
    * <p>Accepted actions include download start, local installer launch, and package-store opening.
    * Requests are rejected when form-password validation fails. Download requests are dispatched
-   * directly through the runtime port so updater lookup and start happen as one operation, while
+   * directly through the runtime port, so updater lookup and start happen as one operation, while
    * the remaining actions still redirect when no core updater is available. Unknown actions are
    * redirected back to the updater path.
    *

--- a/src/main/java/network/crypta/node/updater/CoreActionToadlet.java
+++ b/src/main/java/network/crypta/node/updater/CoreActionToadlet.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker;
 import network.crypta.clients.http.PageNode;
@@ -22,7 +23,7 @@ import network.crypta.clients.http.ToadletContextClosedException;
 import network.crypta.fs.AppEnv;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.Node;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
@@ -35,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * <p>Supports three alert-panel actions:
  *
  * <ul>
- *   <li>{@code download}: start package download through {@link CoreUpdater}
+ *   <li>{@code download}: start package download through {@link CoreUpdateActionPort}
  *   <li>{@code install}: launch an OS installer for a previously downloaded package
  *   <li>{@code openStore}: open/store-install package via URL or known package ID
  * </ul>
@@ -89,22 +90,26 @@ public class CoreActionToadlet extends Toadlet {
   private static final List<String> TRUSTED_UNIX_BIN_DIRS =
       List.of("/usr/bin", "/bin", "/usr/sbin", "/sbin", "/usr/local/bin");
 
-  private final Node node;
+  private final CoreUpdateActionPort coreUpdateActionPort;
   private final AppEnv appEnv = new AppEnv();
   private final BaseL10n l10n = NodeL10n.getBase();
 
   /**
    * Creates the toadlet that handles core-update action requests from the updater UI.
    *
-   * <p>The provided node is used to access updater services, runtime environment information, and
-   * localization resources for generated response pages.
+   * <p>The provided runtime port is used to access updater availability, download start, and
+   * installer path validation while the toadlet keeps runtime environment and response rendering
+   * behavior in the HTTP layer.
    *
    * @param client high-level client used by the toadlet base class for HTTP operations
-   * @param node node instance that owns updater state and request handling dependencies
+   * @param coreUpdateActionPort runtime port that exposes the remaining daemon-backed updater
+   *     actions needed by this toadlet
    */
-  public CoreActionToadlet(HighLevelSimpleClient client, Node node) {
+  public CoreActionToadlet(
+      HighLevelSimpleClient client, CoreUpdateActionPort coreUpdateActionPort) {
     super(client);
-    this.node = node;
+    this.coreUpdateActionPort =
+        Objects.requireNonNull(coreUpdateActionPort, "coreUpdateActionPort");
   }
 
   @Override
@@ -140,28 +145,24 @@ public class CoreActionToadlet extends Toadlet {
       return;
     }
 
-    CoreUpdater updater = null;
-    if (node.services().nodeUpdater() != null) {
-      updater = node.services().nodeUpdater().getCoreUpdater();
-    }
-    if (updater == null) {
+    if (!coreUpdateActionPort.isCoreUpdaterAvailable()) {
       redirect(ctx);
       return;
     }
 
     String action = request.getPartAsStringFailsafe("action", 32);
     switch (action) {
-      case ACTION_DOWNLOAD -> handleDownload(updater, ctx);
+      case ACTION_DOWNLOAD -> handleDownload(ctx);
       case ACTION_INSTALL -> handleInstall(request, ctx);
       case ACTION_OPEN_STORE -> handleOpenStore(request, ctx);
       default -> redirect(ctx);
     }
   }
 
-  private void handleDownload(CoreUpdater updater, ToadletContext ctx)
+  private void handleDownload(ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     logInfo("POST /core-update action=download");
-    updater.startDownloadFromUI();
+    coreUpdateActionPort.startCoreDownloadFromUi();
     redirect(ctx);
   }
 
@@ -170,7 +171,8 @@ public class CoreActionToadlet extends Toadlet {
     String path = request.getPartAsStringFailsafe("path", 4096);
     logInfo("POST /core-update action=" + ACTION_INSTALL + " path=" + path);
 
-    File candidate = validatePath(path);
+    File candidate =
+        coreUpdateActionPort.resolveDownloadedInstaller(path).map(Path::toFile).orElse(null);
     if (candidate == null) {
       logInfo("install rejected: invalid path");
       writeMessage(ctx, false, t("invalidPath"));
@@ -236,22 +238,6 @@ public class CoreActionToadlet extends Toadlet {
 
     if (delegate instanceof InstallerDelegate.Manual(LocalMessage message)) {
       writeMessage(ctx, false, message.render(this));
-    }
-  }
-
-  private File validatePath(String rawPath) {
-    if (rawPath == null || rawPath.isBlank()) {
-      return null;
-    }
-
-    try {
-      File base = new File(node.getNodeDir(), "updates/core").getCanonicalFile();
-      File candidate = new File(rawPath).getCanonicalFile();
-      Path basePath = base.toPath();
-      Path candidatePath = candidate.toPath();
-      return candidatePath.startsWith(basePath) ? candidate : null;
-    } catch (IOException _) {
-      return null;
     }
   }
 

--- a/src/main/java/network/crypta/node/updater/CoreActionToadlet.java
+++ b/src/main/java/network/crypta/node/updater/CoreActionToadlet.java
@@ -127,8 +127,10 @@ public class CoreActionToadlet extends Toadlet {
    * Handles action form submissions for core updater operations.
    *
    * <p>Accepted actions include download start, local installer launch, and package-store opening.
-   * Requests are rejected when form-password validation fails, and unknown actions are redirected
-   * back to the updater path.
+   * Requests are rejected when form-password validation fails. Download requests are dispatched
+   * directly through the runtime port so updater lookup and start happen as one operation, while
+   * the remaining actions still redirect when no core updater is available. Unknown actions are
+   * redirected back to the updater path.
    *
    * @param uri request URI for the POST action endpoint
    * @param request parsed HTTP form request containing action and payload fields
@@ -145,14 +147,18 @@ public class CoreActionToadlet extends Toadlet {
       return;
     }
 
+    String action = request.getPartAsStringFailsafe("action", 32);
+    if (ACTION_DOWNLOAD.equals(action)) {
+      handleDownload(ctx);
+      return;
+    }
+
     if (!coreUpdateActionPort.isCoreUpdaterAvailable()) {
       redirect(ctx);
       return;
     }
 
-    String action = request.getPartAsStringFailsafe("action", 32);
     switch (action) {
-      case ACTION_DOWNLOAD -> handleDownload(ctx);
       case ACTION_INSTALL -> handleInstall(request, ctx);
       case ACTION_OPEN_STORE -> handleOpenStore(request, ctx);
       default -> redirect(ctx);

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -11,14 +11,15 @@ import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.ClientEndpoints;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.ToadletSymlinkPort;
 import network.crypta.runtime.spi.WelcomeActionPort;
 import network.crypta.runtime.spi.WelcomePagePort;
 import network.crypta.support.api.IntCallback;
@@ -51,9 +52,6 @@ class FProxyRegistrarTest {
   private NodeClientCore core;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private RuntimePorts runtimePorts;
 
   @Mock private HighLevelSimpleClient client;
@@ -66,6 +64,8 @@ class FProxyRegistrarTest {
   @Mock private LifecyclePort lifecyclePort;
   @Mock private WelcomeActionPort welcomeActionPort;
   @Mock private FirstTimeWizardPort firstTimeWizardPort;
+  @Mock private CoreUpdateActionPort coreUpdateActionPort;
+  @Mock private ToadletSymlinkPort toadletSymlinkPort;
   @Mock private SimpleToadletServer server;
 
   private Config config;
@@ -96,11 +96,14 @@ class FProxyRegistrarTest {
     when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
     when(runtimePorts.welcomeAction()).thenReturn(welcomeActionPort);
     when(runtimePorts.firstTimeWizard()).thenReturn(firstTimeWizardPort);
+    when(runtimePorts.coreUpdateAction()).thenReturn(coreUpdateActionPort);
+    when(runtimePorts.toadletSymlinks()).thenReturn(toadletSymlinkPort);
+    when(toadletSymlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
   }
 
   @Test
   void maybeCreateFProxyEtc_whenInvoked_registersMenusSetsFProxyAndStartsQueueCompletion() {
-    FProxyRegistrar.maybeCreateFProxyEtc(core, node, config, server);
+    FProxyRegistrar.maybeCreateFProxyEtc(core, config, server);
 
     ArgumentCaptor<byte[]> randomCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(randomSource).nextBytes(randomCaptor.capture());
@@ -168,12 +171,27 @@ class FProxyRegistrarTest {
             .findFirst()
             .orElseThrow();
     assertSame(firstTimeWizardPort, readWizardPortField(wizardRegistration.toadlet()));
+    RegisteredToadlet symlinkerRegistration =
+        registrations.stream()
+            .filter(registered -> registered.toadlet() instanceof SymlinkerToadlet)
+            .findFirst()
+            .orElseThrow();
+    assertSame(toadletSymlinkPort, readField(symlinkerRegistration.toadlet(), "symlinkPort"));
+    RegisteredToadlet coreActionRegistration =
+        registrations.stream()
+            .filter(
+                registered ->
+                    registered.toadlet() instanceof network.crypta.node.updater.CoreActionToadlet)
+            .findFirst()
+            .orElseThrow();
+    assertSame(
+        coreUpdateActionPort, readField(coreActionRegistration.toadlet(), "coreUpdateActionPort"));
     verify(runtimePorts, atLeastOnce()).firstTimeWizard();
   }
 
   @Test
   void maybeCreateFProxyEtc_whenSecurityLevelsSubconfigPresent_skipsSecurityLevelsConfigToadlet() {
-    FProxyRegistrar.maybeCreateFProxyEtc(core, node, config, server);
+    FProxyRegistrar.maybeCreateFProxyEtc(core, config, server);
 
     Set<String> configToadletPrefixes =
         capturedRegistrations().stream()
@@ -212,10 +230,14 @@ class FProxyRegistrarTest {
   }
 
   private static FirstTimeWizardPort readWizardPortField(Object target) {
+    return (FirstTimeWizardPort) readField(target, "wizardPort");
+  }
+
+  private static Object readField(Object target, String fieldName) {
     try {
-      java.lang.reflect.Field field = target.getClass().getDeclaredField("wizardPort");
+      java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
       field.setAccessible(true);
-      return (FirstTimeWizardPort) field.get(target);
+      return field.get(target);
     } catch (NoSuchFieldException | IllegalAccessException e) {
       throw new IllegalStateException(e);
     }

--- a/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
@@ -1,13 +1,17 @@
 package network.crypta.clients.http;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.config.PersistentConfig;
-import network.crypta.config.SubConfig;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ToadletSymlinkEntry;
+import network.crypta.runtime.spi.ToadletSymlinkPort;
 import network.crypta.support.api.HTTPRequest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -18,13 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,28 +35,15 @@ import static org.mockito.Mockito.when;
 class SymlinkerToadletTest {
 
   @Mock private HighLevelSimpleClient client;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
-
-  @Mock private PersistentConfig persistentConfig;
-  @Mock private SubConfig subConfig;
-  @Mock private NodeClientCore nodeClientCore;
+  @Mock private ToadletSymlinkPort symlinkPort;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
 
-  @BeforeEach
-  void setUp() {
-    when(node.getConfig()).thenReturn(persistentConfig);
-    when(persistentConfig.createSubConfig("toadletsymlinker")).thenReturn(subConfig);
-
-    doNothing().when(subConfig).finishedInitialization();
-  }
-
   @Test
   void handleMethodGET_whenAliasMatches_redirectsWithOriginalQueryAndFragment() throws Exception {
-    when(subConfig.getStringArr("symlinks")).thenReturn(new String[] {"/cfg/#/target/"});
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+    when(symlinkPort.loadConfiguredSymlinks())
+        .thenReturn(List.of(new ToadletSymlinkEntry("/cfg/", "/target/")));
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
 
     URI incoming = new URI("http://localhost/cfg/path?foo=bar#frag");
 
@@ -69,17 +58,14 @@ class SymlinkerToadletTest {
 
   @Test
   void addLink_whenStoreTrue_persistsAndRedirects() {
-    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+    when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
 
     boolean added = toadlet.addLink("/alias/", "/dest/", true);
 
     assertFalse(added);
-    verify(nodeClientCore, times(1)).storeConfig();
+    verify(symlinkPort)
+        .persistConfiguredSymlinks(List.of(new ToadletSymlinkEntry("/alias/", "/dest/")));
 
     RedirectException redirect =
         assertThrows(
@@ -90,21 +76,52 @@ class SymlinkerToadletTest {
   }
 
   @Test
+  void addLink_whenConcurrentStoredUpdates_persistsSnapshotsInMutationOrder() throws Exception {
+    BlockingToadletSymlinkPort blockingPort = new BlockingToadletSymlinkPort();
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, blockingPort);
+    CountDownLatch secondStarted = new CountDownLatch(1);
+    Thread firstUpdate = new Thread(() -> toadlet.addLink("/a/", "/dest-a/", true));
+    Thread secondUpdate =
+        new Thread(
+            () -> {
+              secondStarted.countDown();
+              toadlet.addLink("/b/", "/dest-b/", true);
+            });
+
+    firstUpdate.start();
+    assertTrue(blockingPort.awaitFirstPersistEntered());
+
+    secondUpdate.start();
+    assertTrue(secondStarted.await(1, TimeUnit.SECONDS));
+    assertFalse(blockingPort.secondPersistStartedWithinShortWindow());
+
+    blockingPort.releaseFirstPersist();
+
+    firstUpdate.join(TimeUnit.SECONDS.toMillis(1));
+    secondUpdate.join(TimeUnit.SECONDS.toMillis(1));
+
+    assertFalse(firstUpdate.isAlive());
+    assertFalse(secondUpdate.isAlive());
+    assertEquals(
+        List.of(
+            List.of(new ToadletSymlinkEntry("/a/", "/dest-a/")),
+            List.of(
+                new ToadletSymlinkEntry("/a/", "/dest-a/"),
+                new ToadletSymlinkEntry("/b/", "/dest-b/"))),
+        blockingPort.persistedSnapshots());
+  }
+
+  @Test
   void removeLink_whenExistingAlias_returnsTrueAndPreventsRedirect() throws Exception {
-    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
-    network.crypta.node.subsystem.NodeServicesSubsystem services =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeServicesSubsystem.class);
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(nodeClientCore);
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+    when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
 
     toadlet.addLink("/remove/", "/kept/", false);
-    reset(nodeClientCore);
 
     boolean removed = toadlet.removeLink("/remove/", true);
 
     assertTrue(removed);
-    verify(nodeClientCore, times(1)).storeConfig();
+    verify(symlinkPort).persistConfiguredSymlinks(List.of());
 
     assertDoesNotThrow(
         () -> toadlet.handleMethodGET(new URI("http://localhost/remove/x"), request, ctx));
@@ -122,8 +139,8 @@ class SymlinkerToadletTest {
 
   @Test
   void handleMethodGET_whenNoMatchingAlias_sends404Response() throws Exception {
-    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+    when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
 
     assertDoesNotThrow(
         () -> toadlet.handleMethodGET(new URI("http://localhost/unknown"), request, ctx));
@@ -141,8 +158,8 @@ class SymlinkerToadletTest {
 
   @Test
   void handleMethodGET_whenTargetContainsSpaces_redirectsWithEncodedPath() {
-    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, node);
+    when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
     toadlet.addLink("/bad/", "/target with space/", false);
 
     RedirectException redirect =
@@ -152,5 +169,66 @@ class SymlinkerToadletTest {
 
     assertEquals("/target with space/here", redirect.getTarget().getPath());
     assertEquals("/target%20with%20space/here", redirect.getTarget().getRawPath());
+  }
+
+  private static final class BlockingToadletSymlinkPort implements ToadletSymlinkPort {
+    private final CountDownLatch firstPersistEntered = new CountDownLatch(1);
+    private final CountDownLatch allowFirstPersistToReturn = new CountDownLatch(1);
+    private final CountDownLatch secondPersistEntered = new CountDownLatch(1);
+    private final AtomicInteger persistCallCount = new AtomicInteger();
+    private final CopyOnWriteArrayList<List<ToadletSymlinkEntry>> persistedSnapshots =
+        new CopyOnWriteArrayList<>();
+
+    @Override
+    public List<ToadletSymlinkEntry> loadConfiguredSymlinks() {
+      return List.of();
+    }
+
+    @Override
+    public void persistConfiguredSymlinks(List<ToadletSymlinkEntry> entries) {
+      persistedSnapshots.add(sortedEntries(entries));
+      int callIndex = persistCallCount.incrementAndGet();
+      if (callIndex == 1) {
+        firstPersistEntered.countDown();
+        awaitOrFail(allowFirstPersistToReturn);
+        return;
+      }
+      if (callIndex == 2) {
+        secondPersistEntered.countDown();
+      }
+    }
+
+    boolean awaitFirstPersistEntered() throws InterruptedException {
+      return firstPersistEntered.await(1, TimeUnit.SECONDS);
+    }
+
+    boolean secondPersistStartedWithinShortWindow() throws InterruptedException {
+      return secondPersistEntered.await(200, TimeUnit.MILLISECONDS);
+    }
+
+    void releaseFirstPersist() {
+      allowFirstPersistToReturn.countDown();
+    }
+
+    List<List<ToadletSymlinkEntry>> persistedSnapshots() {
+      return List.copyOf(persistedSnapshots);
+    }
+
+    private static List<ToadletSymlinkEntry> sortedEntries(List<ToadletSymlinkEntry> entries) {
+      ArrayList<ToadletSymlinkEntry> copy = new ArrayList<>(entries);
+      copy.sort(Comparator.comparing(ToadletSymlinkEntry::alias));
+      return List.copyOf(copy);
+    }
+
+    private static void awaitOrFail(CountDownLatch latch) {
+      try {
+        if (!latch.await(1, TimeUnit.SECONDS)) {
+          fail("Timed out waiting for the blocked persist call to resume.");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        fail(e);
+      }
+    }
   }
 }

--- a/src/test/java/network/crypta/node/runtime/LegacyCoreUpdateActionPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyCoreUpdateActionPortTest.java
@@ -1,0 +1,88 @@
+package network.crypta.node.runtime;
+
+import java.io.File;
+import java.nio.file.Path;
+import network.crypta.node.Node;
+import network.crypta.node.updater.CoreUpdater;
+import network.crypta.node.updater.NodeUpdateManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyCoreUpdateActionPortTest {
+  @TempDir Path tempDir;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock private NodeUpdateManager nodeUpdateManager;
+  @Mock private CoreUpdater coreUpdater;
+
+  @Test
+  void isCoreUpdaterAvailable_whenUpdaterPresent_expectTrue() {
+    when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
+    when(nodeUpdateManager.getCoreUpdater()).thenReturn(coreUpdater);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+
+    assertTrue(port.isCoreUpdaterAvailable());
+  }
+
+  @Test
+  void isCoreUpdaterAvailable_whenUpdaterMissing_expectFalse() {
+    when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
+    when(nodeUpdateManager.getCoreUpdater()).thenReturn(null);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+
+    assertFalse(port.isCoreUpdaterAvailable());
+  }
+
+  @Test
+  void startCoreDownloadFromUi_whenUpdaterPresent_expectDelegatesToCoreUpdater() {
+    when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
+    when(nodeUpdateManager.getCoreUpdater()).thenReturn(coreUpdater);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+    port.startCoreDownloadFromUi();
+
+    verify(coreUpdater).startDownloadFromUI();
+  }
+
+  @Test
+  void resolveDownloadedInstaller_whenPathInsideCoreUpdates_expectCanonicalPath() throws Exception {
+    File nodeDir = tempDir.resolve("node").toFile();
+    File updatesDir = new File(nodeDir, "updates/core");
+    File installer = new File(updatesDir, "version/../cryptad.deb");
+    assertTrue(updatesDir.mkdirs() || updatesDir.isDirectory());
+    when(node.getNodeDir()).thenReturn(nodeDir);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+
+    Path resolved = port.resolveDownloadedInstaller(installer.getPath()).orElseThrow();
+
+    assertEquals(installer.getCanonicalFile().toPath(), resolved);
+  }
+
+  @Test
+  void resolveDownloadedInstaller_whenPathOutsideCoreUpdates_expectEmpty() {
+    File nodeDir = tempDir.resolve("node").toFile();
+    File outside = tempDir.resolve("outside/cryptad.deb").toFile();
+    when(node.getNodeDir()).thenReturn(nodeDir);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+
+    assertTrue(port.resolveDownloadedInstaller(outside.getPath()).isEmpty());
+  }
+}

--- a/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyRuntimePortsTest.java
@@ -81,7 +81,8 @@ class LegacyRuntimePortsTest {
         () -> assertSame(snapshot.darknetConnectionsPort(), ports.darknetConnections()),
         () -> assertSame(snapshot.darknetMessagingPort(), ports.darknetMessaging()),
         () -> assertSame(snapshot.diagnosticPort(), ports.diagnostic()),
-        () -> assertSame(snapshot.pageChromePort(), ports.pageChrome()));
+        () -> assertSame(snapshot.pageChromePort(), ports.pageChrome()),
+        () -> assertSame(snapshot.coreUpdateActionPort(), ports.coreUpdateAction()));
   }
 
   private void assertStableFeaturePorts(PortsSnapshot snapshot) {
@@ -95,6 +96,7 @@ class LegacyRuntimePortsTest {
         () -> assertSame(snapshot.statisticsPort(), ports.statistics()),
         () -> assertSame(snapshot.securityLevelsPort(), ports.securityLevels()),
         () -> assertSame(snapshot.firstTimeWizardPort(), ports.firstTimeWizard()),
+        () -> assertSame(snapshot.toadletSymlinkPort(), ports.toadletSymlinks()),
         () -> assertSame(snapshot.welcomePagePort(), ports.welcomePage()),
         () -> assertSame(snapshot.welcomeActionPort(), ports.welcomeAction()),
         () -> assertSame(snapshot.requestQueuePort(), ports.requestQueue()),
@@ -117,6 +119,7 @@ class LegacyRuntimePortsTest {
         () -> assertInstanceOf(LegacyDarknetMessagingPort.class, snapshot.darknetMessagingPort()),
         () -> assertInstanceOf(LegacyDiagnosticPort.class, snapshot.diagnosticPort()),
         () -> assertInstanceOf(LegacyPageChromePort.class, snapshot.pageChromePort()),
+        () -> assertInstanceOf(LegacyCoreUpdateActionPort.class, snapshot.coreUpdateActionPort()),
         () -> assertInstanceOf(LegacyQueueSupportPort.class, snapshot.queueSupportPort()),
         () -> assertInstanceOf(LegacyQueueCompletionPort.class, snapshot.queueCompletionPort()),
         () -> assertInstanceOf(LegacyQueuePagePort.class, snapshot.queuePagePort()),
@@ -126,6 +129,7 @@ class LegacyRuntimePortsTest {
         () -> assertInstanceOf(LegacyStatisticsPort.class, snapshot.statisticsPort()),
         () -> assertInstanceOf(LegacySecurityLevelsPort.class, snapshot.securityLevelsPort()),
         () -> assertInstanceOf(LegacyFirstTimeWizardPort.class, snapshot.firstTimeWizardPort()),
+        () -> assertInstanceOf(LegacyToadletSymlinkPort.class, snapshot.toadletSymlinkPort()),
         () -> assertInstanceOf(LegacyWelcomePagePort.class, snapshot.welcomePagePort()),
         () -> assertInstanceOf(LegacyWelcomeActionPort.class, snapshot.welcomeActionPort()),
         () -> assertInstanceOf(LegacyRequestQueuePort.class, snapshot.requestQueuePort()),
@@ -199,6 +203,7 @@ class LegacyRuntimePortsTest {
         ports.darknetMessaging(),
         ports.diagnostic(),
         ports.pageChrome(),
+        ports.coreUpdateAction(),
         ports.queueSupport(),
         ports.queueCompletion(),
         ports.queuePage(),
@@ -208,6 +213,7 @@ class LegacyRuntimePortsTest {
         ports.statistics(),
         ports.securityLevels(),
         ports.firstTimeWizard(),
+        ports.toadletSymlinks(),
         ports.welcomePage(),
         ports.welcomeAction(),
         ports.requestQueue(),
@@ -228,6 +234,7 @@ class LegacyRuntimePortsTest {
       Object darknetMessagingPort,
       Object diagnosticPort,
       Object pageChromePort,
+      Object coreUpdateActionPort,
       Object queueSupportPort,
       Object queueCompletionPort,
       Object queuePagePort,
@@ -237,6 +244,7 @@ class LegacyRuntimePortsTest {
       Object statisticsPort,
       Object securityLevelsPort,
       Object firstTimeWizardPort,
+      Object toadletSymlinkPort,
       Object welcomePagePort,
       Object welcomeActionPort,
       Object requestQueuePort,

--- a/src/test/java/network/crypta/node/runtime/LegacyToadletSymlinkPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyToadletSymlinkPortTest.java
@@ -1,0 +1,83 @@
+package network.crypta.node.runtime;
+
+import java.util.List;
+import network.crypta.config.Option;
+import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.ToadletSymlinkEntry;
+import network.crypta.support.api.StringArrCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyToadletSymlinkPortTest {
+  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock private NodeClientCore core;
+  @Mock private PersistentConfig config;
+  @Mock private SubConfig subConfig;
+
+  @BeforeEach
+  void setUp() {
+    when(node.getConfig()).thenReturn(config);
+    when(config.createSubConfig("toadletsymlinker")).thenReturn(subConfig);
+  }
+
+  @Test
+  void loadConfiguredSymlinks_whenEntriesConfigured_expectParsesValidEntriesOnly() {
+    when(subConfig.getStringArr("symlinks"))
+        .thenReturn(
+            new String[] {
+              "/one/#/target/", "missing", "/two/#", "/three#bad#target", "/ok/#/again/"
+            });
+
+    LegacyToadletSymlinkPort port = new LegacyToadletSymlinkPort(node, core);
+
+    List<ToadletSymlinkEntry> entries = port.loadConfiguredSymlinks();
+
+    assertEquals(
+        List.of(
+            new ToadletSymlinkEntry("/one/", "/target/"),
+            new ToadletSymlinkEntry("/ok/", "/again/")),
+        entries);
+    verify(subConfig).finishedInitialization();
+  }
+
+  @Test
+  void persistConfiguredSymlinks_whenUpdated_expectSerializesEntriesAndStoresConfig() {
+    when(subConfig.getStringArr("symlinks")).thenReturn(new String[0]);
+    LegacyToadletSymlinkPort port = new LegacyToadletSymlinkPort(node, core);
+    ArgumentCaptor<StringArrCallback> callbackCaptor =
+        ArgumentCaptor.forClass(StringArrCallback.class);
+
+    port.loadConfiguredSymlinks();
+    verify(subConfig)
+        .register(eq("symlinks"), isNull(), any(Option.Meta.class), callbackCaptor.capture());
+
+    port.persistConfiguredSymlinks(
+        List.of(
+            new ToadletSymlinkEntry("/first/", "/target-a/"),
+            new ToadletSymlinkEntry("/second/", "/target-b/")));
+
+    assertArrayEquals(
+        new String[] {"/first/#/target-a/", "/second/#/target-b/"},
+        callbackCaptor.getValue().get());
+    verify(core).storeConfig();
+  }
+}

--- a/src/test/java/network/crypta/node/updater/CoreActionToadletTest.java
+++ b/src/test/java/network/crypta/node/updater/CoreActionToadletTest.java
@@ -112,13 +112,13 @@ class CoreActionToadletTest {
     CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
-    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
     when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("download");
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
     toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
 
     verify(coreUpdateActionPort).startCoreDownloadFromUi();
+    verify(coreUpdateActionPort, never()).isCoreUpdaterAvailable();
     ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
         (ArgumentCaptor<MultiValueTable<String, String>>)
             (ArgumentCaptor<?>) ArgumentCaptor.forClass(MultiValueTable.class);

--- a/src/test/java/network/crypta/node/updater/CoreActionToadletTest.java
+++ b/src/test/java/network/crypta/node/updater/CoreActionToadletTest.java
@@ -4,20 +4,19 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Optional;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker;
 import network.crypta.clients.http.PageNode;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.fs.AppEnv;
-import network.crypta.node.Node;
-import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -44,8 +43,7 @@ class CoreActionToadletTest {
   @Test
   void path_whenCalled_expectCoreUpdatePath() {
     CoreActionToadlet toadlet =
-        new CoreActionToadlet(
-            mock(HighLevelSimpleClient.class), mock(Node.class, Answers.RETURNS_DEEP_STUBS));
+        new CoreActionToadlet(mock(HighLevelSimpleClient.class), mock(CoreUpdateActionPort.class));
 
     assertEquals(UpdaterPaths.CORE_UPDATE_PATH, toadlet.path());
   }
@@ -55,8 +53,7 @@ class CoreActionToadletTest {
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
     CoreActionToadlet toadlet =
-        new CoreActionToadlet(
-            mock(HighLevelSimpleClient.class), mock(Node.class, Answers.RETURNS_DEEP_STUBS));
+        new CoreActionToadlet(mock(HighLevelSimpleClient.class), mock(CoreUpdateActionPort.class));
 
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
@@ -72,33 +69,29 @@ class CoreActionToadletTest {
   @Test
   void handleMethodPOST_whenFormPasswordInvalid_expectNoRedirect() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, node);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(false);
 
     toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
 
-    verify(node, never()).services();
+    verify(coreUpdateActionPort, never()).isCoreUpdaterAvailable();
     verify(ctx, never()).sendReplyHeaders(anyInt(), anyString(), any(), any(), anyLong());
   }
 
   @Test
   void handleMethodPOST_whenCoreUpdaterMissing_expectRedirect() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    NodeUpdateManager nodeUpdater = mock(NodeUpdateManager.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, node);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
-    when(node.services()).thenReturn(services);
-    when(services.nodeUpdater()).thenReturn(nodeUpdater);
-    when(nodeUpdater.getCoreUpdater()).thenReturn(null);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(false);
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
     toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
@@ -113,24 +106,19 @@ class CoreActionToadletTest {
   @Test
   void handleMethodPOST_whenDownloadAction_expectStartDownloadAndRedirect() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    NodeUpdateManager nodeUpdater = mock(NodeUpdateManager.class);
-    CoreUpdater coreUpdater = mock(CoreUpdater.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, node);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
-    when(node.services()).thenReturn(services);
-    when(services.nodeUpdater()).thenReturn(nodeUpdater);
-    when(nodeUpdater.getCoreUpdater()).thenReturn(coreUpdater);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
     when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("download");
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
     toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
 
-    verify(coreUpdater).startDownloadFromUI();
+    verify(coreUpdateActionPort).startCoreDownloadFromUi();
     ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
         (ArgumentCaptor<MultiValueTable<String, String>>)
             (ArgumentCaptor<?>) ArgumentCaptor.forClass(MultiValueTable.class);
@@ -141,25 +129,18 @@ class CoreActionToadletTest {
   @Test
   void handleMethodPOST_whenInstallPathInvalid_expectFailurePage() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    NodeUpdateManager nodeUpdater = mock(NodeUpdateManager.class);
-    CoreUpdater coreUpdater = mock(CoreUpdater.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, node);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
 
-    File baseDir = tempDir.resolve("node").toFile();
     String invalidPath = tempDir.resolve("outside/installer.deb").toFile().getAbsolutePath();
-    assertTrue(baseDir.mkdirs() || baseDir.isDirectory());
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
-    when(node.services()).thenReturn(services);
-    when(services.nodeUpdater()).thenReturn(nodeUpdater);
-    when(nodeUpdater.getCoreUpdater()).thenReturn(coreUpdater);
-    when(node.getNodeDir()).thenReturn(baseDir);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
     when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("install");
     when(request.getPartAsStringFailsafe(eq("path"), anyInt())).thenReturn(invalidPath);
+    when(coreUpdateActionPort.resolveDownloadedInstaller(invalidPath)).thenReturn(Optional.empty());
 
     stubHtmlContext(ctx);
 
@@ -173,13 +154,10 @@ class CoreActionToadletTest {
   @Test
   void handleMethodPOST_whenInstallPathValidInServiceMode_expectFailurePage() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    NodeUpdateManager nodeUpdater = mock(NodeUpdateManager.class);
-    CoreUpdater coreUpdater = mock(CoreUpdater.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, node);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
 
     File baseDir = tempDir.resolve("node").toFile();
     File updatesDir = new File(baseDir, "updates/core");
@@ -188,13 +166,12 @@ class CoreActionToadletTest {
     assertTrue(installer.createNewFile());
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
-    when(node.services()).thenReturn(services);
-    when(services.nodeUpdater()).thenReturn(nodeUpdater);
-    when(nodeUpdater.getCoreUpdater()).thenReturn(coreUpdater);
-    when(node.getNodeDir()).thenReturn(baseDir);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
     when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("install");
     when(request.getPartAsStringFailsafe(eq("path"), anyInt()))
         .thenReturn(installer.getAbsolutePath());
+    when(coreUpdateActionPort.resolveDownloadedInstaller(installer.getAbsolutePath()))
+        .thenReturn(Optional.of(installer.toPath()));
 
     AppEnv appEnv = mock(AppEnv.class);
     when(appEnv.osKind()).thenReturn(AppEnv.OsKind.LINUX);
@@ -213,18 +190,13 @@ class CoreActionToadletTest {
   @Test
   void handleMethodPOST_whenOpenStoreUnknown_expectFailurePage() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    NodeUpdateManager nodeUpdater = mock(NodeUpdateManager.class);
-    CoreUpdater coreUpdater = mock(CoreUpdater.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, node);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
-    when(node.services()).thenReturn(services);
-    when(services.nodeUpdater()).thenReturn(nodeUpdater);
-    when(nodeUpdater.getCoreUpdater()).thenReturn(coreUpdater);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
     when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("openStore");
     when(request.getPartAsStringFailsafe(eq("kind"), anyInt())).thenReturn("unknown");
     when(request.getPartAsStringFailsafe(eq("id"), anyInt())).thenReturn("");


### PR DESCRIPTION
## Summary
- add `CoreUpdateActionPort`, `ToadletSymlinkPort`, and `ToadletSymlinkEntry` to `runtime-spi`, then wire them through `LegacyRuntimePorts` with legacy adapters for core-update actions and persisted symlink config
- refactor `SymlinkerToadlet` and `CoreActionToadlet` to use runtime ports instead of `Node`, remove the explicit `Node` parameter from `FProxyRegistrar`, and simplify `SimpleToadletServer` FProxy wiring
- update the affected tests, add focused legacy adapter tests, preserve symlink persistence ordering for concurrent admin edits, and tighten Javadocs on the new production files

## How to test
- `./gradlew test --tests 'network.crypta.clients.http.SymlinkerToadletTest' --tests 'network.crypta.node.updater.CoreActionToadletTest' --tests 'network.crypta.clients.http.FProxyRegistrarTest' --tests 'network.crypta.node.runtime.LegacyRuntimePortsTest' --tests 'network.crypta.node.runtime.LegacyCoreUpdateActionPortTest' --tests 'network.crypta.node.runtime.LegacyToadletSymlinkPortTest'`
- `./gradlew test`
- `./gradlew compileJava compileTestJava`