### PR TITLE
refactor(http): Detach insert and help toadlets from core

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -190,7 +190,9 @@ final class FProxyRegistrar {
             false,
             uploadToadlet));
 
-    FileInsertWizardToadlet fiw = new FileInsertWizardToadlet(client, core);
+    FileInsertWizardToadlet fiw =
+        new FileInsertWizardToadlet(
+            client, new FileInsertWizardToadletRuntimePorts(runtimePorts.securityLevels()));
     server.register(
         fiw,
         ToadletRegistration.menuLink(
@@ -432,7 +434,7 @@ final class FProxyRegistrar {
         firstTimeWizardNewToadlet,
         ToadletRegistration.basic(null, FirstTimeWizardNewToadlet.TOADLET_URL, true, false));
 
-    SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet(client, core);
+    SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet(client);
     server.register(simpleHelpToadlet, ToadletRegistration.basic(null, "/help/", true, false));
 
     PushDataToadlet pushDataToadlet = new PushDataToadlet(client);

--- a/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
@@ -2,14 +2,14 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertContext;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.clients.http.ContentFilterToadlet.ResultHandling;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
@@ -30,34 +30,36 @@ import network.crypta.support.api.HTTPRequest;
  *   <li>{@link #handleMethodGET(URI, HTTPRequest, ToadletContext)} builds the HTML page and
  *       enforces access rules.
  *   <li>{@link #reportCanonicalInsert()} or {@link #reportRandomInsert()} record the user’s last
- *       selection to bias subsequent renders.
+ *       selection to bias further renders.
  * </ul>
  *
- * <p>The toadlet relies on {@link NodeClientCore} to derive security defaults, {@link PageMaker} to
- * assemble infoboxes, and the surrounding {@link ToadletContext} for permissions and localization.
- * It performs no I/O beyond HTML generation and delegates upload handling to queue endpoints.
+ * <p>The toadlet relies on a detached security-level snapshot to derive security defaults, {@link
+ * PageMaker} to assemble infoboxes, and the surrounding {@link ToadletContext} for permissions and
+ * localization. It performs no I/O beyond HTML generation and delegates upload handling to queue
+ * endpoints.
  */
 public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallback {
 
   /**
-   * Creates the toadlet that renders the file-insert wizard for the given client and node core. The
-   * instance keeps only lightweight preferences and is intended to be short-lived; callers
-   * typically construct one per incoming HTTP request or per handler registration. The constructor
-   * does not perform I/O, and all dependencies are assumed to remain valid for the lifetime of the
-   * toadlet. State stored in the instance is not synchronized and should not be shared across
-   * threads without external coordination.
+   * Creates the toadlet that renders the file-insert wizard for the given client and detached
+   * runtime ports. The instance keeps only lightweight preferences and is intended to be
+   * short-lived; callers typically construct one per incoming HTTP request or per handler
+   * registration. The constructor does not perform I/O, and all dependencies are assumed to remain
+   * valid for the lifetime of the toadlet. State stored in the instance is not synchronized and
+   * should not be shared across threads without external coordination.
    *
    * @param client high-level client used to bind uploads to the current session; never {@code
    *     null}.
-   * @param clientCore backing node core providing security defaults and queue endpoints; never
-   *     {@code null}.
+   * @param runtimePorts detached runtime collaborators used to read the current network threat
+   *     level; never {@code null}.
    */
-  protected FileInsertWizardToadlet(HighLevelSimpleClient client, NodeClientCore clientCore) {
+  FileInsertWizardToadlet(
+      HighLevelSimpleClient client, FileInsertWizardToadletRuntimePorts runtimePorts) {
     super(client);
-    this.core = clientCore;
+    this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
   }
 
-  final NodeClientCore core;
+  private final FileInsertWizardToadletRuntimePorts runtimePorts;
 
   // IMHO there isn't much point synchronizing these.
   private boolean rememberedLastTime;
@@ -86,9 +88,9 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
   }
 
   /**
-   * Records that the most recent insert used a canonical CHK key so the next rendered form defaults
-   * to the same choice. The hint influences only UI defaults; it does not persist beyond this
-   * instance and does not bypass explicit user selections on later requests. This method only
+   * Records that the most recent insert used a canonical CHK key, so the next rendered form
+   * defaults to the same choice. The hint influences only UI defaults; it does not persist beyond
+   * this instance and does not bypass explicit user selections on later requests. This method only
    * updates in-memory hints and is safe to call after a successful queue submission.
    */
   public void reportCanonicalInsert() {
@@ -97,7 +99,7 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
   }
 
   /**
-   * Records that the most recent insert used a random SSK key so subsequent renders bias toward the
+   * Records that the most recent insert used a random SSK key, so further renders bias toward the
    * same option. The flag affects only default radio-button selection and never forces a key type
    * when the caller provides explicit form data. State is retained only for the lifetime of this
    * toadlet instance.
@@ -157,14 +159,14 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     HTMLNode insertBox = infobox.getOuterNode();
     HTMLNode insertContent = infobox.getContentNode();
     insertContent.addChild("p", l10n("insertIntro"));
-    NETWORK_THREAT_LEVEL seclevel =
-        core.getNode().services().securityLevels().getNetworkThreatLevel();
+    SecurityNetworkThreatLevel seclevel =
+        runtimePorts.securityLevelsPort().snapshot().networkThreatLevel();
     HTMLNode insertForm =
         ctx.addFormChild(insertContent, QueueToadlet.PATH_UPLOADS, "queueInsertForm");
     boolean preselectSsk =
-        (!rememberedLastTime && seclevel != NETWORK_THREAT_LEVEL.LOW)
+        (!rememberedLastTime && seclevel != SecurityNetworkThreatLevel.LOW)
             || (rememberedLastTime && !wasCanonicalLastTime)
-            || seclevel == NETWORK_THREAT_LEVEL.MAXIMUM;
+            || seclevel == SecurityNetworkThreatLevel.MAXIMUM;
 
     addKeyTypeOptions(insertForm, preselectSsk, isAdvancedModeEnabled);
     addCompressionOption(insertForm, isAdvancedModeEnabled);

--- a/src/main/java/network/crypta/clients/http/FileInsertWizardToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/FileInsertWizardToadletRuntimePorts.java
@@ -1,0 +1,36 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+
+/**
+ * Carries the detached runtime dependency needed by the file-insert wizard.
+ *
+ * <p>{@link FileInsertWizardToadlet} no longer needs direct access to the live daemon core, but it
+ * still has to read the current network threat level before rendering `/insertfile/`. This record
+ * keeps that dependency explicit and local to the HTTP package. Callers create it during toadlet
+ * wiring, usually in {@link FProxyRegistrar}, and then pass the immutable bundle into the wizard
+ * constructor.
+ *
+ * <p>The record has one invariant: the referenced {@link SecurityLevelsPort} is always present.
+ * That keeps the page logic simple because default CHK or SSK selection can rely on an available
+ * detached snapshot instead of handling a missing runtime collaborator. The type is immutable and
+ * thread-safe as long as the supplied port implementation is safe for concurrent reads.
+ *
+ * @param securityLevelsPort detached runtime view that supplies the current network threat level
+ *     used when the wizard chooses its default key type
+ */
+record FileInsertWizardToadletRuntimePorts(SecurityLevelsPort securityLevelsPort) {
+  /**
+   * Creates the runtime bundle for the file-insert wizard.
+   *
+   * <p>The compact constructor performs only null validation. It does not capture the mutable
+   * daemon state, perform I/O, or read the current threat level eagerly. That keeps construction
+   * cheap and lets the caller defer all runtime reads until the wizard actually renders a page.
+   *
+   * @throws NullPointerException if the detached security-levels port reference is {@code null}
+   */
+  FileInsertWizardToadletRuntimePorts {
+    Objects.requireNonNull(securityLevelsPort);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/SimpleHelpToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SimpleHelpToadlet.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
@@ -21,10 +20,9 @@ import network.crypta.support.api.HTTPRequest;
  * Output is rendered as standard HTML and returned as a 200 OK response suitable for embedding into
  * the FProxy navigation flow.
  *
- * <p>Instances are effectively stateless apart from the injected {@link NodeClientCore} reference
- * used for client interactions, so they can be shared across requests without additional
- * synchronization. The class does not mutate the core, and callers register it at the {@link
- * #path()} URI to expose the documentation to users.
+ * <p>Instances are effectively stateless apart from the inherited client binding, so they can be
+ * shared across requests without additional synchronization. Callers register the toadlet at the
+ * {@link #path()} URI to expose the documentation to users.
  *
  * <ul>
  *   <li>Responsibilities: render localized help, outline key types, and summarize connectivity
@@ -41,24 +39,21 @@ import network.crypta.support.api.HTTPRequest;
 public class SimpleHelpToadlet extends Toadlet {
   private static final String INFOBOX_CONTENT = "infobox-content";
 
-  SimpleHelpToadlet(HighLevelSimpleClient client, NodeClientCore c) {
+  SimpleHelpToadlet(HighLevelSimpleClient client) {
     super(client);
-    this.core = c;
   }
-
-  final NodeClientCore core;
 
   /**
    * Handles HTTP GET requests by rendering the offline help page and streaming it to the client.
    * The method builds a page composed of descriptive and connectivity-focused infoboxes, injects
    * alert summaries when the requester has full access, and finalizes the response with a 200 OK
-   * status. It performs no modification of server state, making repeated calls idempotent and safe
-   * for refresh or bookmark access patterns.
+   * status. It performs no modification of the server state, making repeated calls idempotent and
+   * safe for refresh or bookmark access patterns.
    *
    * <p>All content is derived from localization bundles so that translations remain consistent with
    * the node's configured language. The returned HTML explains core key types (CHK, SSK, USK) and
    * offers short guidance on tasks such as port forwarding to improve reachability. Should the
-   * toadlet context close mid-write or an I/O fault occur, the method surfaces the corresponding
+   * toadlet context close mid-write or an I/O fault occurs, the method surfaces the corresponding
    * exception to the caller for upstream handling.
    *
    * <pre>{@code
@@ -69,7 +64,7 @@ public class SimpleHelpToadlet extends Toadlet {
    * @param uri requested help page URI; provided for signature parity and logging context.
    * @param request inbound HTTP request containing headers and parameters; never modified here.
    * @param ctx active toadlet context that supplies page construction utilities and access checks.
-   * @throws ToadletContextClosedException if the context is closed before the response is flushed.
+   * @throws ToadletContextClosedException if the context is closed before, the response is flushed.
    * @throws IOException if writing the generated HTML to the client output stream fails.
    */
   @Override

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -19,6 +19,7 @@ import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.ToadletSymlinkPort;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.runtime.spi.WelcomeActionPort;
@@ -65,6 +66,7 @@ class FProxyRegistrarTest {
   @Mock private LifecyclePort lifecyclePort;
   @Mock private WelcomeActionPort welcomeActionPort;
   @Mock private FirstTimeWizardPort firstTimeWizardPort;
+  @Mock private SecurityLevelsPort securityLevelsPort;
   @Mock private CoreUpdateActionPort coreUpdateActionPort;
   @Mock private ToadletSymlinkPort toadletSymlinkPort;
   @Mock private TransferAccessPort transferAccess;
@@ -98,6 +100,7 @@ class FProxyRegistrarTest {
     when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
     when(runtimePorts.welcomeAction()).thenReturn(welcomeActionPort);
     when(runtimePorts.firstTimeWizard()).thenReturn(firstTimeWizardPort);
+    when(runtimePorts.securityLevels()).thenReturn(securityLevelsPort);
     when(runtimePorts.coreUpdateAction()).thenReturn(coreUpdateActionPort);
     when(runtimePorts.toadletSymlinks()).thenReturn(toadletSymlinkPort);
     when(runtimePorts.transferAccess()).thenReturn(transferAccess);
@@ -189,6 +192,17 @@ class FProxyRegistrarTest {
             .orElseThrow();
     assertSame(
         coreUpdateActionPort, readField(coreActionRegistration.toadlet(), "coreUpdateActionPort"));
+    RegisteredToadlet fileInsertWizardRegistration =
+        registrations.stream()
+            .filter(
+                registered ->
+                    FileInsertWizardToadlet.PATH.equals(registered.registration().urlPrefix()))
+            .findFirst()
+            .orElseThrow();
+    FileInsertWizardToadletRuntimePorts fileInsertWizardRuntimePorts =
+        (FileInsertWizardToadletRuntimePorts)
+            readField(fileInsertWizardRegistration.toadlet(), "runtimePorts");
+    assertSame(securityLevelsPort, fileInsertWizardRuntimePorts.securityLevelsPort());
     verify(runtimePorts, atLeastOnce()).firstTimeWizard();
   }
 

--- a/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
@@ -6,12 +6,11 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.time.Instant;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
-import network.crypta.node.SecurityLevels;
-import network.crypta.node.subsystem.NodeServicesSubsystem;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
@@ -20,12 +19,12 @@ import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,8 +43,7 @@ class FileInsertWizardToadletTest {
 
   @Mock HighLevelSimpleClient client;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  NodeClientCore core;
+  @Mock SecurityLevelsPort securityLevelsPort;
 
   @Mock ToadletContainer container;
 
@@ -53,13 +51,23 @@ class FileInsertWizardToadletTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    toadlet = new FileInsertWizardToadlet(client, core);
+    toadlet =
+        new FileInsertWizardToadlet(
+            client, new FileInsertWizardToadletRuntimePorts(securityLevelsPort));
     setContainer(toadlet, container);
   }
 
   @Test
   void path_returnsConfiguredPath() {
     assertEquals(FileInsertWizardToadlet.PATH, toadlet.path());
+  }
+
+  @Test
+  void constructor_whenRuntimePortsProvided_noLongerNeedsNodeClientCore() {
+    assertEquals(1, FileInsertWizardToadlet.class.getDeclaredConstructors().length);
+    assertArrayEquals(
+        new Class<?>[] {HighLevelSimpleClient.class, FileInsertWizardToadletRuntimePorts.class},
+        FileInsertWizardToadlet.class.getDeclaredConstructors()[0].getParameterTypes());
   }
 
   @Test
@@ -86,13 +94,8 @@ class FileInsertWizardToadletTest {
   @Test
   void handleMethodGET_whenLowThreat_prefersCanonicalRadio() throws Exception {
     when(container.publicGatewayMode()).thenReturn(false);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
-    SecurityLevels securityLevels = mock(SecurityLevels.class);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    when(core.getNode()).thenReturn(node);
-    when(node.services()).thenReturn(services);
-    when(services.securityLevels()).thenReturn(securityLevels);
-    when(securityLevels.getNetworkThreatLevel()).thenReturn(NETWORK_THREAT_LEVEL.LOW);
+    when(securityLevelsPort.snapshot())
+        .thenReturn(securitySnapshot(SecurityNetworkThreatLevel.LOW));
 
     PageHolder holder = new PageHolder();
     PageMaker pageMaker = buildPageMaker(holder);
@@ -112,19 +115,35 @@ class FileInsertWizardToadletTest {
   @Test
   void handleMethodGET_afterRandomInsert_prefersSskRadio() throws Exception {
     when(container.publicGatewayMode()).thenReturn(false);
-    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
-    SecurityLevels securityLevels = mock(SecurityLevels.class);
-    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
-    when(core.getNode()).thenReturn(node);
-    when(node.services()).thenReturn(services);
-    when(services.securityLevels()).thenReturn(securityLevels);
-    when(securityLevels.getNetworkThreatLevel()).thenReturn(NETWORK_THREAT_LEVEL.LOW);
+    when(securityLevelsPort.snapshot())
+        .thenReturn(securitySnapshot(SecurityNetworkThreatLevel.LOW));
 
     PageHolder holder = new PageHolder();
     PageMaker pageMaker = buildPageMaker(holder);
     CapturingContext ctx = new CapturingContext(pageMaker, true, false);
 
     toadlet.reportRandomInsert();
+
+    toadlet.handleMethodGET(new URI("http://localhost/insertfile/"), mock(HTTPRequest.class), ctx);
+
+    HTMLNode chkInput = findById(holder.page.getContentNode(), "keytypeChk");
+    HTMLNode sskInput = findById(holder.page.getContentNode(), "keytypeSsk");
+
+    assertNotNull(chkInput);
+    assertNotNull(sskInput);
+    assertNull(chkInput.getAttribute("checked"));
+    assertEquals("checked", sskInput.getAttribute("checked"));
+  }
+
+  @Test
+  void handleMethodGET_whenMaximumThreat_prefersSskRadio() throws Exception {
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(securityLevelsPort.snapshot())
+        .thenReturn(securitySnapshot(SecurityNetworkThreatLevel.MAXIMUM));
+
+    PageHolder holder = new PageHolder();
+    PageMaker pageMaker = buildPageMaker(holder);
+    CapturingContext ctx = new CapturingContext(pageMaker, true, false);
 
     toadlet.handleMethodGET(new URI("http://localhost/insertfile/"), mock(HTTPRequest.class), ctx);
 
@@ -170,6 +189,10 @@ class FileInsertWizardToadletTest {
     return null;
   }
 
+  private static SecurityLevelsSnapshot securitySnapshot(SecurityNetworkThreatLevel level) {
+    return new SecurityLevelsSnapshot(level, SecurityPhysicalThreatLevel.NORMAL, false, false, "");
+  }
+
   private static final class PageHolder {
     PageNode page;
   }
@@ -178,7 +201,7 @@ class FileInsertWizardToadletTest {
     PageMaker pageMaker = mock(PageMaker.class);
     when(pageMaker.getPageNode(anyString(), any(ToadletContext.class)))
         .thenAnswer(
-            invocation -> {
+            _ -> {
               HTMLNode outer = new HTMLNode("div");
               HTMLNode head = new HTMLNode("head");
               HTMLNode content = new HTMLNode("div");
@@ -187,7 +210,7 @@ class FileInsertWizardToadletTest {
             });
     when(pageMaker.getInfobox(anyString(), anyString(), anyBoolean()))
         .thenAnswer(
-            invocation -> {
+            _ -> {
               HTMLNode outer = new HTMLNode("div");
               HTMLNode content = outer.addChild("div");
               return new InfoboxNode(outer, content);
@@ -206,8 +229,7 @@ class FileInsertWizardToadletTest {
   }
 
   /**
-   * Captures response data while providing just enough context behaviour for the toadlet under
-   * test.
+   * Captures response data while providing just enough context behavior for the toadlet under test.
    */
   private static final class CapturingContext implements ToadletContext {
 

--- a/src/test/java/network/crypta/clients/http/SimpleHelpToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleHelpToadletTest.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
@@ -12,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,8 +32,7 @@ class SimpleHelpToadletTest {
   @Test
   void handleMethodGET_whenFullAccess_addsSummaryAndWritesHtml() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    NodeClientCore core = mock(NodeClientCore.class);
-    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet(client, core));
+    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet(client));
 
     ToadletContext ctx = mock(ToadletContext.class);
     PageMaker pageMaker = mock(PageMaker.class);
@@ -51,7 +50,7 @@ class SimpleHelpToadletTest {
     when(ctx.getAlertManager()).thenReturn(alertManager);
     when(alertManager.createSummary()).thenReturn(summaryNode);
     when(pageMaker.getInfobox(anyString(), anyString(), eq(contentNode), anyString(), anyBoolean()))
-        .thenAnswer(invocation -> new HTMLNode("div"));
+        .thenAnswer(_ -> new HTMLNode("div"));
 
     AtomicReference<Integer> statusCode = new AtomicReference<>();
     AtomicReference<String> reasonPhrase = new AtomicReference<>();
@@ -80,8 +79,7 @@ class SimpleHelpToadletTest {
   @Test
   void handleMethodGET_whenRestricted_doesNotAddSummary() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    NodeClientCore core = mock(NodeClientCore.class);
-    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet(client, core));
+    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet(client));
 
     ToadletContext ctx = mock(ToadletContext.class);
     PageMaker pageMaker = mock(PageMaker.class);
@@ -97,11 +95,9 @@ class SimpleHelpToadletTest {
     when(pageNode.generate()).thenReturn("generated-page");
     when(ctx.isAllowedFullAccess()).thenReturn(false);
     when(pageMaker.getInfobox(anyString(), anyString(), eq(contentNode), anyString(), anyBoolean()))
-        .thenAnswer(invocation -> new HTMLNode("div"));
+        .thenAnswer(_ -> new HTMLNode("div"));
 
-    doAnswer(invocation -> null)
-        .when(toadlet)
-        .writeHTMLReply(eq(ctx), anyInt(), anyString(), anyString());
+    doAnswer(_ -> null).when(toadlet).writeHTMLReply(eq(ctx), anyInt(), anyString(), anyString());
 
     toadlet.handleMethodGET(new URI("http://localhost/help/"), request, ctx);
 
@@ -110,9 +106,16 @@ class SimpleHelpToadletTest {
   }
 
   @Test
+  void constructor_withoutCoreDependency_acceptsClientOnly() {
+    assertEquals(1, SimpleHelpToadlet.class.getDeclaredConstructors().length);
+    assertArrayEquals(
+        new Class<?>[] {HighLevelSimpleClient.class},
+        SimpleHelpToadlet.class.getDeclaredConstructors()[0].getParameterTypes());
+  }
+
+  @Test
   void path_whenCalled_returnsHelpPath() {
-    SimpleHelpToadlet toadlet =
-        new SimpleHelpToadlet(mock(HighLevelSimpleClient.class), mock(NodeClientCore.class));
+    SimpleHelpToadlet toadlet = new SimpleHelpToadlet(mock(HighLevelSimpleClient.class));
     assertEquals("/help/", toadlet.path());
   }
 }


### PR DESCRIPTION
## Summary
- route `FileInsertWizardToadlet` through a narrow HTTP-side runtime bundle backed by `SecurityLevelsPort` instead of `NodeClientCore`
- remove the unused `NodeClientCore` dependency from `SimpleHelpToadlet` and stop passing `core` to both toadlets from `FProxyRegistrar`
- keep `/insertfile/` default key selection behavior and `/help/` behavior covered with focused toadlet and registrar tests

## How to test
- `./gradlew test --tests 'network.crypta.clients.http.FileInsertWizardToadletTest' --tests 'network.crypta.clients.http.SimpleHelpToadletTest' --tests 'network.crypta.clients.http.FProxyRegistrarTest'`
- `./gradlew -q classes`
- `javadoc -quiet -private -Xdoclint:all -classpath "build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main" -sourcepath . -d /tmp/doclint-out "src/main/java/network/crypta/clients/http/FileInsertWizardToadletRuntimePorts.java"`