### PR TITLE
refactor(http): Decouple bookmark editor from node core

### DIFF
--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessagingPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/DarknetMessagingPort.java
@@ -99,6 +99,33 @@ public interface DarknetMessagingPort {
       throws UnknownPeerException, DarknetPeerRequiredException;
 
   /**
+   * Sends one bookmark recommendation to the selected detached darknet peer.
+   *
+   * <p>This is the detached equivalent of the legacy bookmark-editor share action. Callers keep
+   * bookmark lookup, checkbox selection, and HTTP form handling in the web layer, then pass only
+   * the detached peer identity plus bookmark fields that are already ready for the legacy message
+   * format. Implementations resolve the detached identity on demand, convert the URI string back to
+   * the daemon URI type, and delegate to the existing bookmark-feed send path.
+   *
+   * <p>The operation intentionally stays narrow: it shares exactly one bookmark to exactly one
+   * selected peer, preserving the current page semantics and avoiding bookmark-domain types in the
+   * SPI. As with other detached peer actions, identity resolution is request-scoped and may fail if
+   * the peer roster changes between form render and submit.
+   *
+   * @param nodeIdentifier detached peer identity selected from the legacy friends page and used for
+   *     request-scoped peer lookup
+   * @param uri validated bookmark URI string to share with the resolved peer
+   * @param name bookmark display name to include in the shared feed entry
+   * @param description optional human-readable public description to include in the shared feed
+   * @param hasActiveLink whether the shared bookmark should be marked as having an active link
+   * @throws UnknownPeerException if the detached peer identity no longer resolves at sending time
+   * @throws DarknetPeerRequiredException if the resolved peer exists but is not a darknet peer
+   */
+  void shareBookmark(
+      String nodeIdentifier, String uri, String name, String description, boolean hasActiveLink)
+      throws UnknownPeerException, DarknetPeerRequiredException;
+
+  /**
    * Sends one composed N2NTM to the selected detached darknet peer.
    *
    * <p>Implementations must resolve the peer once for the whole operation, then send the optional

--- a/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
+++ b/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
@@ -12,8 +12,9 @@ import network.crypta.clients.http.bookmark.BookmarkItem;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.URLDecoder;
 import network.crypta.support.URLEncodedFormatException;
@@ -121,14 +122,15 @@ public class BookmarkEditorToadlet extends Toadlet {
 
   private static final int MAX_EXPLANATION_LENGTH = 1024;
 
-  private final NodeClientCore core;
+  private final BookmarkEditorToadletRuntimePorts runtimePorts;
   private String cutedPath;
 
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly.
 
-  BookmarkEditorToadlet(HighLevelSimpleClient client, NodeClientCore core) {
+  BookmarkEditorToadlet(
+      HighLevelSimpleClient client, BookmarkEditorToadletRuntimePorts runtimePorts) {
     super(client);
-    this.core = core;
+    this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
     this.cutedPath = null;
   }
 
@@ -145,7 +147,7 @@ public class BookmarkEditorToadlet extends Toadlet {
             NodeL10n.getBase().getString("BookmarkEditorToadlet.paste"),
             NodeL10n.getBase().getString("BookmarkEditorToadlet.addBookmark"),
             NodeL10n.getBase().getString("BookmarkEditorToadlet.addCategory"),
-            core.getNode().network().darknetConnections().length > 0);
+            hasDarknetPeers());
     List<BookmarkItem> items = cat.getItems();
     for (int i = 0; i < items.size(); i++) {
       addBookmarkItemToList(items, path, list, labels, i);
@@ -318,11 +320,28 @@ public class BookmarkEditorToadlet extends Toadlet {
     return ACTION_QUERY_PREFIX + action + BOOKMARK_QUERY_PARAM + bookmarkPath;
   }
 
+  private boolean hasDarknetPeers() {
+    return !runtimePorts.darknetConnectionsPort().listPeers().isEmpty();
+  }
+
   private void sendBookmarkFeeds(HTTPRequest req, BookmarkItem item, String publicDescription) {
-    for (DarknetPeerNode peer : core.getNode().network().darknetConnections())
-      if (req.isPartSet("node_" + peer.hashCode()))
-        peer.sendBookmarkFeed(
-            item.getURI(), item.getName(), publicDescription, item.hasAnActivelink());
+    for (DarknetConnectionPeerSnapshot peer : runtimePorts.darknetConnectionsPort().listPeers()) {
+      if (!req.isPartSet("node_" + peer.selectionToken())) {
+        continue;
+      }
+      try {
+        runtimePorts
+            .darknetMessagingPort()
+            .shareBookmark(
+                peer.nodeIdentifier(),
+                item.getURI().toString(),
+                item.getName(),
+                publicDescription,
+                item.hasAnActivelink());
+      } catch (UnknownPeerException | DarknetPeerRequiredException e) {
+        LOG.warn("Skipping bookmark share for unresolved peer {}", peer.nodeIdentifier(), e);
+      }
+    }
   }
 
   private HTMLNode getBookmarksList(BookmarkManager bookmarkManager) {
@@ -364,12 +383,14 @@ public class BookmarkEditorToadlet extends Toadlet {
    * Handles GET requests for the bookmark editor page, rendering the current tree and any pending
    * action forms.
    *
-   * <p>The method enforces full-access checks, decodes and validates the requested bookmark path,
-   * dispatches lightweight actions (move, cut, paste, delete confirmation, edit/share forms), and
-   * finally emits an HTML page containing the bookmark list plus auxiliary controls such as the
+   * <p>The method enforces full-access checks and validates the requested bookmark path. It also
+   * dispatches lightweight actions such as move, cut, paste, delete confirmation, and edit/share
+   * forms.
+   *
+   * <p>It then emits an HTML page containing the bookmark list plus auxiliary controls such as the
    * “Add default bookmarks” button. Responses are written directly to the provided {@link
-   * ToadletContext}, and no storage mutation occurs unless an action explicitly requires it (for
-   * example, moving a bookmark up/down).
+   * ToadletContext}. No storage mutation occurs unless an action explicitly requires it, for
+   * example, when moving a bookmark up or down.
    *
    * @param uri request target URI; only the path is relevant and must match {@link #path()}.
    * @param req HTTP request containing query parameters such as {@code action} and {@code
@@ -561,7 +582,7 @@ public class BookmarkEditorToadlet extends Toadlet {
     HTMLNode form = ctx.addFormChild(actionBoxContent, "", "editBookmarkForm");
     addNameField(form, isNew, bookmark);
     addItemSectionIfNeeded(action, isNew, bookmark, form);
-    addShareSectionIfNeeded(action, isNew, bookmark, form);
+    addShareSectionIfNeeded(action, isNew, bookmark, form, ctx);
 
     addHiddenFields(form, bookmarkPath, req.getParam(PARAM_ACTION));
     addSubmitButton(form, action);
@@ -656,46 +677,43 @@ public class BookmarkEditorToadlet extends Toadlet {
         "for",
         ACTIVE_LINK_FIELD,
         (NodeL10n.getBase().getString("BookmarkEditorToadlet.hasAnActivelinkLabel") + ' '));
+    HTMLNode activeLinkInput =
+        form.addChild(
+            TAG_INPUT,
+            new String[] {"type", "id", "name"},
+            new String[] {CHECKBOX, ACTIVE_LINK_FIELD, ACTIVE_LINK_FIELD});
     if (!isNew && item.hasAnActivelink()) {
-      form.addChild(
-          TAG_INPUT,
-          new String[] {"type", "id", "name", "checked"},
-          new String[] {
-            CHECKBOX, ACTIVE_LINK_FIELD, ACTIVE_LINK_FIELD, String.valueOf(item.hasAnActivelink())
-          });
-    } else {
-      form.addChild(
-          TAG_INPUT,
-          new String[] {"type", "id", "name"},
-          new String[] {CHECKBOX, ACTIVE_LINK_FIELD, ACTIVE_LINK_FIELD});
+      activeLinkInput.addAttribute("checked", "checked");
     }
   }
 
   private void addShareSectionIfNeeded(
-      String action, boolean isNew, Bookmark bookmark, HTMLNode form) {
-    if (!shouldDisplayShareSection(action)) {
+      String action, boolean isNew, Bookmark bookmark, HTMLNode form, ToadletContext ctx) {
+    List<DarknetConnectionPeerSnapshot> peers = runtimePorts.darknetConnectionsPort().listPeers();
+    if (!shouldDisplayShareSection(action, peers)) {
       return;
     }
     BookmarkItem item = isNew ? null : (BookmarkItem) bookmark;
     form.addChild("br");
     form.addChild("br");
-    if (core.getNode().isFProxyJavascriptEnabled()) {
+    boolean fProxyJavascriptEnabled = ctx.getContainer().isFProxyJavascriptEnabled();
+    if (fProxyJavascriptEnabled) {
       form.addChild(
           "script",
           new String[] {"type", "src"},
           new String[] {"text/javascript", "/static/js/checkall.js"});
     }
     HTMLNode peerTable = form.addChild("table", ATTRIBUTE_CLASS, "darknet_connections");
-    addPeerTableHeader(peerTable);
-    for (DarknetPeerNode peer : core.getNode().network().darknetConnections()) {
+    addPeerTableHeader(peerTable, fProxyJavascriptEnabled);
+    for (DarknetConnectionPeerSnapshot peer : peers) {
       HTMLNode peerRow = peerTable.addChild("tr", ATTRIBUTE_CLASS, "darknet_connections_normal");
       peerRow
           .addChild("td", ATTRIBUTE_CLASS, "peer-marker")
           .addChild(
               TAG_INPUT,
               new String[] {"type", "name"},
-              new String[] {CHECKBOX, "node_" + peer.hashCode()});
-      peerRow.addChild("td", ATTRIBUTE_CLASS, "peer-name").addChild("#", peer.getName());
+              new String[] {CHECKBOX, "node_" + peer.selectionToken()});
+      peerRow.addChild("td", ATTRIBUTE_CLASS, "peer-name").addChild("#", peer.displayName());
     }
     form.addChild(
         TAG_LABEL,
@@ -711,8 +729,8 @@ public class BookmarkEditorToadlet extends Toadlet {
     form.addChild("br");
   }
 
-  private void addPeerTableHeader(HTMLNode peerTable) {
-    if (core.getNode().isFProxyJavascriptEnabled()) {
+  private void addPeerTableHeader(HTMLNode peerTable, boolean fProxyJavascriptEnabled) {
+    if (fProxyJavascriptEnabled) {
       HTMLNode headerRow = peerTable.addChild("tr");
       headerRow
           .addChild("th")
@@ -732,9 +750,9 @@ public class BookmarkEditorToadlet extends Toadlet {
     }
   }
 
-  private boolean shouldDisplayShareSection(String action) {
-    return core.getNode().network().darknetConnections().length > 0
-        && (ACTION_ADD_ITEM.equals(action) || ACTION_SHARE.equals(action));
+  private boolean shouldDisplayShareSection(
+      String action, List<DarknetConnectionPeerSnapshot> peers) {
+    return !peers.isEmpty() && (ACTION_ADD_ITEM.equals(action) || ACTION_SHARE.equals(action));
   }
 
   private void addHiddenFields(HTMLNode form, String bookmarkPath, String action) {
@@ -1037,13 +1055,13 @@ public class BookmarkEditorToadlet extends Toadlet {
   /**
    * Returns the mount path used to register this toadlet within the HTTP dispatcher.
    *
-   * <p>The value is constant and includes leading and trailing slashes so it can be concatenated
+   * <p>The value is constant and includes leading and trailing slashes, so it can be concatenated
    * directly with relative resource links in generated pages. Callers typically read this during
    * registration with the router and when building redirects or form actions from other toadlets.
-   * The string is immutable, contains only ASCII characters, and does not reflect runtime state,
-   * making it safe to cache across requests. Any incoming request whose {@link URI#getPath()} does
-   * not match this value will be rejected by the surrounding dispatcher before reaching the
-   * handler.
+   * The string is immutable, contains only ASCII characters, and does not reflect the runtime
+   * state, making it safe to cache across requests. Any incoming request whose {@link
+   * URI#getPath()} does not match this value will be rejected by the surrounding dispatcher before
+   * reaching the handler.
    *
    * @return fixed path segment {@code "/bookmarkEditor/"} identifying the editor endpoint.
    */

--- a/src/main/java/network/crypta/clients/http/BookmarkEditorToadletRuntimePorts.java
+++ b/src/main/java/network/crypta/clients/http/BookmarkEditorToadletRuntimePorts.java
@@ -1,0 +1,44 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
+
+/**
+ * Bundles the detached runtime ports that the bookmark editor HTTP page needs.
+ *
+ * <p>This record keeps the remaining runtime-facing collaborators for {@code BookmarkEditorToadlet}
+ * explicit without reintroducing a direct dependency on {@code NodeClientCore}. The toadlet still
+ * performs local bookmark-manager work in the HTTP layer, but friend discovery and bookmark-feed
+ * delivery cross the runtime SPI through this narrow bundle. That keeps the page boundary small and
+ * makes the runtime migration visible in the constructor shape used by HTTP wiring.
+ *
+ * <p>The record is immutable after construction and has no lifecycle logic of its own. It only
+ * groups the detached collaborators needed by the bookmark sharing flow:
+ *
+ * <ul>
+ *   <li>{@link DarknetConnectionsPort} for detached peer snapshots used by the share form
+ *   <li>{@link DarknetMessagingPort} for sending bookmark feeds to selected peers
+ * </ul>
+ *
+ * @param darknetConnectionsPort detached peer-list port used to determine whether sharing is
+ *     available and to render the legacy checkbox table
+ * @param darknetMessagingPort detached messaging port used to send bookmark feeds to the selected
+ *     peers after form submission
+ */
+record BookmarkEditorToadletRuntimePorts(
+    DarknetConnectionsPort darknetConnectionsPort, DarknetMessagingPort darknetMessagingPort) {
+  /**
+   * Validates that the bookmark editor received all detached collaborators it needs.
+   *
+   * <p>Construction fails fast, so HTTP wiring errors surface during setup instead of later during
+   * a request. Callers should provide both ports from the same runtime bundle so the editor sees a
+   * consistent view of the detached darknet state.
+   *
+   * @throws NullPointerException if either detached runtime port is missing from the HTTP wiring
+   */
+  BookmarkEditorToadletRuntimePorts {
+    Objects.requireNonNull(darknetConnectionsPort);
+    Objects.requireNonNull(darknetMessagingPort);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -365,7 +365,11 @@ final class FProxyRegistrar {
         localFileN2NMToadlet,
         ToadletRegistration.basic(null, LocalFileN2NMToadlet.BROWSE_PATH, true, false));
 
-    BookmarkEditorToadlet bookmarkEditorToadlet = new BookmarkEditorToadlet(client, core);
+    BookmarkEditorToadlet bookmarkEditorToadlet =
+        new BookmarkEditorToadlet(
+            client,
+            new BookmarkEditorToadletRuntimePorts(
+                runtimePorts.darknetConnections(), runtimePorts.darknetMessaging()));
     server.register(
         bookmarkEditorToadlet, ToadletRegistration.basic(null, "/bookmarkEditor/", true, false));
 

--- a/src/main/java/network/crypta/node/runtime/LegacyDarknetMessagingPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyDarknetMessagingPort.java
@@ -90,6 +90,17 @@ final class LegacyDarknetMessagingPort implements DarknetMessagingPort {
 
   /** {@inheritDoc} */
   @Override
+  public void shareBookmark(
+      String nodeIdentifier, String uri, String name, String description, boolean hasActiveLink)
+      throws UnknownPeerException, DarknetPeerRequiredException {
+    Objects.requireNonNull(name, "name");
+    peerResolver
+        .resolveByIdentity(nodeIdentifier)
+        .sendBookmarkFeed(toFreenetUri(uri), name, description, hasActiveLink);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public DarknetMessageSendStatus sendComposedMessage(
       String nodeIdentifier,
       String message,

--- a/src/test/java/network/crypta/clients/http/BookmarkEditorToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/BookmarkEditorToadletTest.java
@@ -2,13 +2,16 @@ package network.crypta.clients.http;
 
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.bookmark.BookmarkCategory;
 import network.crypta.clients.http.bookmark.BookmarkItem;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +25,7 @@ import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -42,31 +46,30 @@ class BookmarkEditorToadletTest {
   private static final URI DUMMY_URI = URI.create("http://localhost/bookmarkEditor/");
 
   @Mock private HighLevelSimpleClient client;
-  @Mock private NodeClientCore core;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private DarknetMessagingPort darknetMessagingPort;
 
   @Mock private BookmarkManager bookmarkManager;
   @Mock private PageMaker pageMaker;
   @Mock private ToadletContext context;
+  @Mock private ToadletContainer container;
 
   private BookmarkEditorToadlet toadlet;
 
   @BeforeEach
   void setUp() throws Exception {
-    toadlet = new BookmarkEditorToadlet(client, core);
+    toadlet =
+        new BookmarkEditorToadlet(
+            client,
+            new BookmarkEditorToadletRuntimePorts(darknetConnectionsPort, darknetMessagingPort));
 
-    when(core.getNode()).thenReturn(node);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    when(network.darknetConnections()).thenReturn(new network.crypta.node.DarknetPeerNode[0]);
-    when(node.isFProxyJavascriptEnabled()).thenReturn(false);
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of());
 
     when(context.getPageMaker()).thenReturn(pageMaker);
     when(context.getBookmarkManager()).thenReturn(bookmarkManager);
+    when(context.getContainer()).thenReturn(container);
     when(context.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(container.isFProxyJavascriptEnabled()).thenReturn(false);
     when(context.addFormChild(any(HTMLNode.class), anyString(), anyString()))
         .thenAnswer(
             invocation -> {
@@ -85,7 +88,7 @@ class BookmarkEditorToadletTest {
     doNothing().when(context).writeData(any(byte[].class), anyInt(), anyInt());
 
     when(pageMaker.getPageNode(anyString(), any(ToadletContext.class)))
-        .thenAnswer(invocation -> createPageNode());
+        .thenAnswer(_ -> createPageNode());
     when(pageMaker.getInfobox(
             anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
         .thenAnswer(
@@ -172,6 +175,40 @@ class BookmarkEditorToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenShareActionSelected_delegatesBookmarkSharesViaRuntimePorts()
+      throws Exception {
+    String bookmarkPath = "/parent/item";
+    BookmarkItem item = mock(BookmarkItem.class);
+    HTTPRequest request = mock(HTTPRequest.class);
+    DarknetConnectionPeerSnapshot selectedPeer =
+        new DarknetConnectionPeerSnapshot(101, "peer-1", "Alice", "", false);
+    DarknetConnectionPeerSnapshot unselectedPeer =
+        new DarknetConnectionPeerSnapshot(202, "peer-2", "Bob", "", false);
+
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(selectedPeer, unselectedPeer));
+    when(request.isPartSet("AddDefaultBookmarks")).thenReturn(false);
+    when(request.getPartAsStringFailsafe("bookmark", 5000)).thenReturn(bookmarkPath);
+    when(request.getPartAsStringFailsafe("action", 20)).thenReturn("share");
+    when(request.isPartSet("confirmdelete")).thenReturn(false);
+    when(request.isPartSet("cancelCut")).thenReturn(false);
+    when(request.isPartSet("node_101")).thenReturn(true);
+    when(request.isPartSet("node_202")).thenReturn(false);
+    when(request.getPartAsStringFailsafe("publicDescB", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("publicDesc");
+    when(bookmarkManager.getItemByPath(bookmarkPath)).thenReturn(item);
+    when(item.getURI()).thenReturn(new FreenetURI("KSK@shared"));
+    when(item.getName()).thenReturn("shared-name");
+    when(item.hasAnActivelink()).thenReturn(true);
+
+    toadlet.handleMethodPOST(DUMMY_URI, request, context);
+
+    verify(darknetMessagingPort)
+        .shareBookmark("peer-1", "KSK@shared", "shared-name", "publicDesc", true);
+    verify(darknetMessagingPort, never())
+        .shareBookmark(eq("peer-2"), anyString(), anyString(), anyString(), anyBoolean());
+  }
+
+  @Test
   void handleMethodGET_whenPasteAction_movesBookmarkAndClearsCutBuffer() throws Exception {
     setCutedPathToSource(toadlet);
 
@@ -201,6 +238,40 @@ class BookmarkEditorToadletTest {
 
     verify(bookmarkManager).getItemByPath("/missing");
     verify(bookmarkManager, never()).moveBookmark(anyString(), anyString());
+  }
+
+  @Test
+  void handleMethodGET_whenShareActionAndJavascriptEnabled_rendersDetachedFriendCheckboxes()
+      throws Exception {
+    BookmarkItem item = mock(BookmarkItem.class);
+    HTTPRequest request = mock(HTTPRequest.class);
+    DarknetConnectionPeerSnapshot peer =
+        new DarknetConnectionPeerSnapshot(101, "peer-1", "Alice", "", false);
+    when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(darknetConnectionsPort.listPeers()).thenReturn(List.of(peer));
+    when(request.getParam("action")).thenReturn("share");
+    when(request.getParam("bookmark")).thenReturn("/item");
+    when(bookmarkManager.getItemByPath("/item")).thenReturn(item);
+    when(item.getVisibleName()).thenReturn("Item");
+    when(item.getKey()).thenReturn("KSK@item");
+    when(item.hasAnActivelink()).thenReturn(true);
+    when(item.getDescription()).thenReturn("description");
+
+    toadlet.handleMethodGET(DUMMY_URI, request, context);
+
+    ArgumentCaptor<byte[]> bodyCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> lengthCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(context).writeData(bodyCaptor.capture(), offsetCaptor.capture(), lengthCaptor.capture());
+    String html =
+        new String(
+            bodyCaptor.getValue(),
+            offsetCaptor.getValue(),
+            lengthCaptor.getValue(),
+            StandardCharsets.UTF_8);
+    assertTrue(html.contains("name=\"node_101\""));
+    assertTrue(html.contains("Alice"));
+    assertTrue(html.contains("/static/js/checkall.js"));
   }
 
   private PageNode createPageNode() {

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -15,6 +15,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.LifecyclePort;
 import network.crypta.runtime.spi.QueueCompletionPort;
@@ -63,6 +64,7 @@ class FProxyRegistrarTest {
   @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private WelcomePagePort welcomePagePort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private LifecyclePort lifecyclePort;
   @Mock private WelcomeActionPort welcomeActionPort;
   @Mock private FirstTimeWizardPort firstTimeWizardPort;
@@ -97,6 +99,7 @@ class FProxyRegistrarTest {
     when(runtimePorts.queueCompletion()).thenReturn(queueCompletionPort);
     when(runtimePorts.welcomePage()).thenReturn(welcomePagePort);
     when(runtimePorts.darknetConnections()).thenReturn(darknetConnectionsPort);
+    when(runtimePorts.darknetMessaging()).thenReturn(darknetMessagingPort);
     when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
     when(runtimePorts.welcomeAction()).thenReturn(welcomeActionPort);
     when(runtimePorts.firstTimeWizard()).thenReturn(firstTimeWizardPort);
@@ -203,6 +206,16 @@ class FProxyRegistrarTest {
         (FileInsertWizardToadletRuntimePorts)
             readField(fileInsertWizardRegistration.toadlet(), "runtimePorts");
     assertSame(securityLevelsPort, fileInsertWizardRuntimePorts.securityLevelsPort());
+    RegisteredToadlet bookmarkEditorRegistration =
+        registrations.stream()
+            .filter(registered -> registered.toadlet() instanceof BookmarkEditorToadlet)
+            .findFirst()
+            .orElseThrow();
+    BookmarkEditorToadletRuntimePorts bookmarkRuntimePorts =
+        (BookmarkEditorToadletRuntimePorts)
+            readField(bookmarkEditorRegistration.toadlet(), "runtimePorts");
+    assertSame(darknetConnectionsPort, bookmarkRuntimePorts.darknetConnectionsPort());
+    assertSame(darknetMessagingPort, bookmarkRuntimePorts.darknetMessagingPort());
     verify(runtimePorts, atLeastOnce()).firstTimeWizard();
   }
 

--- a/src/test/java/network/crypta/node/runtime/LegacyDarknetMessagingPortTest.java
+++ b/src/test/java/network/crypta/node/runtime/LegacyDarknetMessagingPortTest.java
@@ -146,6 +146,40 @@ class LegacyDarknetMessagingPortTest {
   }
 
   @Test
+  void shareBookmark_whenIdentityResolves_delegatesToLegacyBookmarkFeed() throws Exception {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {darknetPeer});
+    when(darknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    port.shareBookmark("peer-1", "KSK@bookmark", "bookmark-name", "public description", true);
+
+    verify(darknetPeer)
+        .sendBookmarkFeed(
+            new FreenetURI("KSK@bookmark"), "bookmark-name", "public description", true);
+  }
+
+  @Test
+  void shareBookmark_whenPeerIdentityIsUnknown_throwsUnknownPeerException() {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[0]);
+
+    assertThrows(
+        UnknownPeerException.class,
+        () -> port.shareBookmark("missing-peer", "KSK@bookmark", "bookmark-name", null, false));
+  }
+
+  @Test
+  void shareBookmark_whenResolvedPeerIsNotDarknet_throwsDarknetPeerRequiredException() {
+    LegacyDarknetMessagingPort port = newPort();
+    when(network.peerNodes()).thenReturn(new PeerNode[] {nonDarknetPeer});
+    when(nonDarknetPeer.getIdentityString()).thenReturn("peer-1");
+
+    assertThrows(
+        DarknetPeerRequiredException.class,
+        () -> port.shareBookmark("peer-1", "KSK@bookmark", "bookmark-name", null, false));
+  }
+
+  @Test
   void sendComposedMessage_whenLocalFilePresent_usesOnePeerResolutionForOfferAndText()
       throws Exception {
     LegacyDarknetMessagingPort port = newPort();


### PR DESCRIPTION
## Summary
- remove the direct `NodeClientCore` dependency from `BookmarkEditorToadlet`
- route bookmark friend-list rendering and share submission through detached runtime ports
- add a narrow `DarknetMessagingPort.shareBookmark(...)` SPI method and adapt it in `LegacyDarknetMessagingPort`
- wire the bookmark editor from `FProxyRegistrar` with `BookmarkEditorToadletRuntimePorts`
- update targeted tests for the bookmark editor, legacy runtime adapter, and registrar wiring

## How to test
```bash
./gradlew test \
  --tests 'network.crypta.clients.http.BookmarkEditorToadletTest' \
  --tests 'network.crypta.node.runtime.LegacyDarknetMessagingPortTest' \
  --tests 'network.crypta.clients.http.FProxyRegistrarTest'
```

## Notes
- page URLs, checkbox names, and share form behavior remain unchanged
- the bookmark editor now reads the JavaScript toggle from `ctx.getContainer().isFProxyJavascriptEnabled()`
- `BookmarkEditorToadletRuntimePorts` Javadoc was expanded and verified with file-local doclint
