### PR TITLE
refactor(http): Remove NodeClientCore from auxiliary toadlets

### DIFF
--- a/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
@@ -15,9 +15,9 @@ import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilterCallbacks;
 import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
@@ -47,8 +47,8 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Responsibilities: render UI, validate parameters, feed data into the filter, report
  *       outcomes.
- *   <li>Notable behaviors: respects configurable endpoint path, enforces advanced-mode access, and
- *       cleans up upload parts to conserve memory.
+ *   <li>Notable behaviors: respects the configurable endpoint path, enforces advanced-mode access,
+ *       and cleans up upload parts to conserve memory.
  * </ul>
  *
  * @see LocalFileFilterToadlet
@@ -90,23 +90,18 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
   public enum ResultHandling {
     /** Render the filtered content directly back to the browser in the HTTP response. */
     DISPLAY,
-    /** Save the filtered content to disk using the node's standard download location. */
+    /** Save the filtered content to the disk using the node's standard download location. */
     SAVE
   }
 
-  private final NodeClientCore core;
-
   /**
-   * Creates a content filter toadlet bound to the given client core and HTTP client abstraction.
+   * Creates a content filter toadlet bound to the given HTTP client abstraction.
    *
    * @param client HTTP client utility used for link-aware rendering and helper operations; must not
    *     be {@code null}.
-   * @param clientCore node client core providing access to filtering services and access-control
-   *     checks; must not be {@code null}.
    */
-  public ContentFilterToadlet(HighLevelSimpleClient client, NodeClientCore clientCore) {
+  public ContentFilterToadlet(HighLevelSimpleClient client) {
     super(client);
-    this.core = clientCore;
   }
 
   private static String resolvePath() {
@@ -152,7 +147,7 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
    * @param request parsed HTTP request carrying query parameters; must not be {@code null}.
    * @param ctx toadlet context used for authorization, localization, and response writing; must not
    *     be {@code null}.
-   * @throws ToadletContextClosedException if the client connection closes before the response is
+   * @throws ToadletContextClosedException if the client connection closes before, the response is
    *     fully written.
    * @throws IOException if the response cannot be streamed to the caller.
    * @throws RedirectException if a redirect is required by the underlying framework while building
@@ -186,8 +181,8 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
    * parameters between steps, and frees request parts in a {@code finally} block to avoid resource
    * leaks. Access control mirrors {@link #handleMethodGET(URI, HTTPRequest, ToadletContext)}.
    *
-   * @param uri target URI of the request, retained for compatibility with the Toadlet contract; may
-   *     be unused by some branches.
+   * @param uri the target URI of the request, retained for compatibility with the Toadlet contract,
+   *     may be unused by some branches.
    * @param request multipart POST request containing user input and optional file data; must not be
    *     {@code null} and is released after processing.
    * @param ctx context for permission checks, localization, and response handling; must not be
@@ -203,7 +198,7 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
       return;
     }
     try {
-      // Browse... button on filter page
+      // Browse... button on the filter page
       if (request.isPartSet("filter-local")) {
         try {
           FilterOperation filterOperation = getFilterOperation(request);
@@ -231,10 +226,10 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
         }
         // Filter button on local file browser
       } else if (request.isPartSet(LocalFileBrowserToadlet.SELECT_FILE)) {
-        handleFilterRequest(request, ctx, core, true);
-        // Filter File button on filter page
+        handleFilterRequest(request, ctx, true);
+        // Filter File button on the filter page
       } else if (request.isPartSet("filter-upload")) {
-        handleFilterRequest(request, ctx, core, false);
+        handleFilterRequest(request, ctx, false);
       } else {
         handleMethodGET(uri, new HTTPRequestImpl(uri, "GET"), ctx);
       }
@@ -363,17 +358,16 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
   }
 
   /** Handle a request to filter a file. */
-  private void handleFilterRequest(
-      HTTPRequest request, ToadletContext ctx, NodeClientCore core, boolean localFile)
+  private void handleFilterRequest(HTTPRequest request, ToadletContext ctx, boolean localFile)
       throws ToadletContextClosedException, IOException {
     try {
       FilterOperation filterOperation = getFilterOperation(request);
       ResultHandling resultHandling = getResultHandling(request);
       String mimeType = request.getPartAsStringFailsafe(MIME_TYPE_PART, 100);
       if (localFile) {
-        handleLocalFilterRequest(request, ctx, core, filterOperation, resultHandling, mimeType);
+        handleLocalFilterRequest(request, ctx, filterOperation, resultHandling, mimeType);
       } else {
-        handleUploadedFilterRequest(request, ctx, core, filterOperation, resultHandling, mimeType);
+        handleUploadedFilterRequest(request, ctx, filterOperation, resultHandling, mimeType);
       }
     } catch (BadRequestException e) {
       handleInvalidPart(e.getInvalidRequestPart(), ctx);
@@ -383,7 +377,6 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
   private void handleLocalFilterRequest(
       HTTPRequest request,
       ToadletContext ctx,
-      NodeClientCore core,
       FilterOperation filterOperation,
       ResultHandling resultHandling,
       String mimeType)
@@ -397,7 +390,7 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
     }
     File file = new File(filename);
     try (Bucket bucket = new FileBucket(file, true, false, false, false)) {
-      processFilter(bucket, filename, resolvedMimeType, filterOperation, resultHandling, ctx, core);
+      processFilter(bucket, filename, resolvedMimeType, filterOperation, resultHandling, ctx);
     } catch (FileNotFoundException _) {
       writeBadRequestError(
           l10n("errorNoFileOrCannotReadTitle"), cannotReadFileMessage(filename), ctx);
@@ -407,7 +400,6 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
   private void handleUploadedFilterRequest(
       HTTPRequest request,
       ToadletContext ctx,
-      NodeClientCore core,
       FilterOperation filterOperation,
       ResultHandling resultHandling,
       String mimeType)
@@ -422,7 +414,7 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
       throw new BadRequestException(FILENAME_PART);
     }
     try (Bucket bucket = file.getData()) {
-      processFilter(bucket, filename, resolvedMimeType, filterOperation, resultHandling, ctx, core);
+      processFilter(bucket, filename, resolvedMimeType, filterOperation, resultHandling, ctx);
     } catch (FileNotFoundException _) {
       writeBadRequestError(
           l10n("errorNoFileOrCannotReadTitle"), cannotReadFileMessage(filename), ctx);
@@ -453,11 +445,10 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
       String mimeType,
       FilterOperation filterOperation,
       ResultHandling resultHandling,
-      ToadletContext ctx,
-      NodeClientCore core)
+      ToadletContext ctx)
       throws ToadletContextClosedException, IOException, BadRequestException {
     String resultFilename = makeResultFilename(filename, mimeType);
-    handleFilter(bucket, mimeType, filterOperation, resultHandling, resultFilename, ctx, core);
+    handleFilter(bucket, mimeType, filterOperation, resultHandling, resultFilename, ctx);
   }
 
   private String makeResultFilename(String originalFilename, String mimeType) {
@@ -479,14 +470,13 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
       FilterOperation operation,
       ResultHandling resultHandling,
       String resultFilename,
-      ToadletContext ctx,
-      NodeClientCore core)
+      ToadletContext ctx)
       throws ToadletContextClosedException, IOException, BadRequestException {
     Bucket resultBucket = ctx.getBucketFactory().makeBucket(-1);
     String resultMimeType = null;
     boolean unsafe = false;
     try {
-      FilterStatus status = applyFilter(data, resultBucket, mimeType, operation, core);
+      FilterStatus status = applyFilter(data, resultBucket, mimeType, operation);
       resultMimeType = status.mimeType;
     } catch (UnsafeContentTypeException _) {
       unsafe = true;
@@ -518,28 +508,34 @@ public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback
   }
 
   private FilterStatus applyFilter(
-      Bucket input, Bucket output, String mimeType, FilterOperation operation, NodeClientCore core)
-      throws IOException {
+      Bucket input, Bucket output, String mimeType, FilterOperation operation) throws IOException {
     try (InputStream inputStream = input.getInputStream();
         OutputStream outputStream = output.getOutputStream()) {
-      return applyFilter(inputStream, outputStream, mimeType, operation, core);
+      return applyFilter(inputStream, outputStream, mimeType, operation);
     }
   }
 
   private FilterStatus applyFilter(
-      InputStream input,
-      OutputStream output,
-      String mimeType,
-      FilterOperation operation,
-      NodeClientCore core)
+      InputStream input, OutputStream output, String mimeType, FilterOperation operation)
       throws IOException {
     validateOperation(operation);
     URI fakeUri = resolveFilterUri();
     ContentFilterRequest request =
         new ContentFilterRequest(input, output, mimeType, null, null, null);
     ContentFilterCallbacks callbacks =
-        new ContentFilterCallbacks(fakeUri, null, null, core.getEndpoints().getToadletContainer());
+        new ContentFilterCallbacks(fakeUri, null, null, getLinkFilterExceptionProvider());
     return ContentFilter.filter(request, callbacks);
+  }
+
+  private LinkFilterExceptionProvider getLinkFilterExceptionProvider() {
+    if (container == null) {
+      throw new IllegalStateException("ContentFilterToadlet requires a registered container");
+    }
+    if (container instanceof LinkFilterExceptionProvider provider) {
+      return provider;
+    }
+    throw new IllegalStateException(
+        "ContentFilterToadlet container must implement LinkFilterExceptionProvider");
   }
 
   private void validateOperation(FilterOperation operation) {

--- a/src/main/java/network/crypta/clients/http/DecodeToadlet.java
+++ b/src/main/java/network/crypta/clients/http/DecodeToadlet.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 
@@ -18,7 +17,8 @@ import network.crypta.support.api.HTTPRequest;
  *
  * <p>Instances rely on {@link ToadletContext} for request-scoped state and keep no mutable fields.
  * Deployments typically register one instance and let the dispatcher invoke it concurrently; no
- * internal synchronization is necessary because state lives in the supplied context and page maker.
+ * internal synchronization is necessary because the state lives in the supplied context and page
+ * maker.
  *
  * <ul>
  *   <li>Responsible for translating {@code /decode/<key>} to the {@code /<key>} target.
@@ -30,12 +30,9 @@ import network.crypta.support.api.HTTPRequest;
  * @see ToadletContext
  */
 public class DecodeToadlet extends Toadlet {
-  DecodeToadlet(HighLevelSimpleClient client, NodeClientCore c) {
+  DecodeToadlet(HighLevelSimpleClient client) {
     super(client);
-    this.core = c;
   }
-
-  final NodeClientCore core;
 
   /**
    * Handles GET requests under {@code /decode/} by emitting a 301 redirect and a manual fallback
@@ -44,13 +41,13 @@ public class DecodeToadlet extends Toadlet {
    * <p>The method preserves the request path after the toadlet mount point, prepends a leading
    * slash to form a Freenet key, and builds a small HTML page that includes both an automatic
    * redirect and a clickable anchor. When full access is permitted, any configured alert summary is
-   * added to the page so callers still see status banners while being forwarded. The method writes
+   * added to the page, so callers still see status banners while being forwarded. The method writes
    * the response immediately; callers should not attempt further output after invocation.
    *
    * @param uri fully qualified request URI supplied by the HTTP stack; never mutated by this
    *     handler
-   * @param request HTTP request wrapper containing the original path segment after the decode mount
-   *     point
+   * @param request HTTP request wrapper containing the original path segment after the decoding
+   *     mount point
    * @param ctx toadlet context used for permission checks, page creation, and response streaming
    * @throws ToadletContextClosedException if the context output channel closes before the reply is
    *     written
@@ -81,7 +78,7 @@ public class DecodeToadlet extends Toadlet {
   /**
    * Returns the mount path used to dispatch decode requests to this toadlet.
    *
-   * <p>The path is a constant {@code /decode/} with a trailing slash so that subsequent path
+   * <p>The path is a constant {@code /decode/} with a trailing slash so that the following path
    * segments are treated as the encoded key to redirect. Dispatchers rely on this value to strip
    * the prefix before handing the remaining portion to {@link #handleMethodGET(URI, HTTPRequest,
    * ToadletContext)}; callers should avoid trimming or normalizing it further to preserve

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -109,7 +109,7 @@ final class FProxyRegistrar {
             false,
             null));
 
-    DecodeToadlet decodeKeywordURL = new DecodeToadlet(client, core);
+    DecodeToadlet decodeKeywordURL = new DecodeToadlet(client);
     server.register(decodeKeywordURL, ToadletRegistration.basic(null, "/decode/", true, false));
 
     InsertFreesiteToadlet siteinsert = new InsertFreesiteToadlet(client);
@@ -211,7 +211,7 @@ final class FProxyRegistrar {
         localFileInsertToadlet,
         ToadletRegistration.basic(null, LocalFileInsertToadlet.INSERT_BROWSE_PATH, true, false));
 
-    ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client, core);
+    ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client);
     server.register(
         contentFilterToadlet,
         ToadletRegistration.menuLink(

--- a/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
@@ -5,7 +5,12 @@ import java.io.Serial;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.filter.ContentFilter.FilterStatus;
 import network.crypta.client.filter.ContentFilter;
@@ -13,20 +18,27 @@ import network.crypta.client.filter.ContentFilterCallbacks;
 import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.api.HTTPUploadedFile;
 import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,11 +56,20 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class ContentFilterToadletTest {
+  private static final String FILTER_URI_PROPERTY =
+      "network.crypta.clients.http.ContentFilterToadlet.loopbackUri";
+  private static final URI DEFAULT_FILTER_URI = URI.create("http://127.0.0.1:8888/");
 
   private HighLevelSimpleClient client;
   private SimpleToadletServer container;
   private ToadletContext ctx;
   private BucketFactory bucketFactory;
+  private PageMaker pageMaker;
+  private PageNode pageNode;
+  private HTMLNode contentNode;
+  private UserAlertManager alertManager;
+
+  @TempDir Path tempDir;
 
   @BeforeEach
   void setUp() {
@@ -56,6 +77,15 @@ class ContentFilterToadletTest {
     container = mock(SimpleToadletServer.class);
     ctx = mock(ToadletContext.class);
     bucketFactory = mock(BucketFactory.class);
+    pageMaker = mock(PageMaker.class);
+    pageNode = mock(PageNode.class);
+    contentNode = mock(HTMLNode.class);
+    alertManager = mock(UserAlertManager.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(FILTER_URI_PROPERTY);
   }
 
   @Test
@@ -82,6 +112,21 @@ class ContentFilterToadletTest {
   }
 
   @Test
+  void isEnabled_whenContextIsNull_returnsFalse() {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+    toadlet.container = container;
+
+    assertFalse(toadlet.isEnabled(null));
+  }
+
+  @Test
+  void path_whenInvoked_returnsContentFilterPath() {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+
+    assertEquals(ContentFilterToadlet.CONTENT_FILTER_PATH, toadlet.path());
+  }
+
+  @Test
   void getFilterOperation_whenInvalidValue_throwsBadRequestException() throws Exception {
     ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
     HTTPRequest request = mock(HTTPRequest.class);
@@ -92,6 +137,230 @@ class ContentFilterToadletTest {
     method.setAccessible(true);
 
     assertThrows(BadRequestException.class, () -> invokeWithException(method, toadlet, request));
+  }
+
+  @Test
+  void getResultHandling_whenInvalidValue_throwsBadRequestException() throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.getPartAsStringFailsafe("result-handling", 100)).thenReturn("not-an-enum");
+
+    Method method =
+        ContentFilterToadlet.class.getDeclaredMethod("getResultHandling", HTTPRequest.class);
+    method.setAccessible(true);
+
+    assertThrows(BadRequestException.class, () -> invokeWithException(method, toadlet, request));
+  }
+
+  @Test
+  void handleMethodGET_whenPublicGatewayWithoutFullAccess_sendsUnauthorizedPage() throws Exception {
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client));
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(true);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    doNothing().when(toadlet).sendUnauthorizedPage(ctx);
+
+    toadlet.handleMethodGET(
+        URI.create("http://localhost" + ContentFilterToadlet.CONTENT_FILTER_PATH),
+        mock(HTTPRequest.class),
+        ctx);
+
+    verify(toadlet).sendUnauthorizedPage(ctx);
+    verify(ctx, never()).getPageMaker();
+  }
+
+  @Test
+  void handleMethodGET_whenAllowed_rendersFilterPage() throws Exception {
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client));
+    toadlet.container = container;
+    HTMLNode summaryNode = new HTMLNode("div", "summary");
+    HTMLNode infoboxOuter = new HTMLNode("div");
+    HTMLNode infoboxContent = infoboxOuter.addChild("div");
+    InfoboxNode infobox = new InfoboxNode(infoboxOuter, infoboxContent);
+    HTMLNode formNode = new HTMLNode("form");
+    String generatedHtml = "<html>filter-page</html>";
+
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(alertManager.createSummary()).thenReturn(summaryNode);
+    when(pageMaker.getPageNode(ContentFilterToadlet.l10n("pageTitle"), ctx)).thenReturn(pageNode);
+    when(pageNode.getContentNode()).thenReturn(contentNode);
+    when(pageNode.generate()).thenReturn(generatedHtml);
+    when(pageMaker.getInfobox(ContentFilterToadlet.l10n("filterFile"), "filter-file", true))
+        .thenReturn(infobox);
+    when(ctx.addFormChild(infoboxContent, ContentFilterToadlet.CONTENT_FILTER_PATH, "filterForm"))
+        .thenReturn(formNode);
+    doNothing()
+        .when(toadlet)
+        .writeHTMLReply(ctx, ReplyHeaders.of(200, "OK", "text/html; charset=utf-8"), generatedHtml);
+
+    toadlet.handleMethodGET(
+        URI.create("http://localhost" + ContentFilterToadlet.CONTENT_FILTER_PATH),
+        mock(HTTPRequest.class),
+        ctx);
+
+    verify(contentNode).addChild(summaryNode);
+    verify(ctx)
+        .addFormChild(infoboxContent, ContentFilterToadlet.CONTENT_FILTER_PATH, "filterForm");
+    verify(contentNode).addChild(infoboxOuter);
+    verify(toadlet)
+        .writeHTMLReply(ctx, ReplyHeaders.of(200, "OK", "text/html; charset=utf-8"), generatedHtml);
+  }
+
+  @Test
+  void handleMethodPOST_whenPublicGatewayWithoutFullAccess_sendsUnauthorizedPage()
+      throws Exception {
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client));
+    HTTPRequest request = mock(HTTPRequest.class);
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(true);
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+    doNothing().when(toadlet).sendUnauthorizedPage(ctx);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost" + ContentFilterToadlet.CONTENT_FILTER_PATH), request, ctx);
+
+    verify(toadlet).sendUnauthorizedPage(ctx);
+  }
+
+  @Test
+  void handleMethodPOST_whenBrowseRequested_redirectsToLocalFileBrowserAndFreesParts()
+      throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+    HTTPRequest request = mock(HTTPRequest.class);
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(request.isPartSet("filter-local")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("filter-operation", 100))
+        .thenReturn(FilterOperation.BOTH.toString());
+    when(request.getPartAsStringFailsafe("result-handling", 100))
+        .thenReturn(ContentFilterToadlet.ResultHandling.DISPLAY.toString());
+    when(request.getPartAsStringFailsafe("mime-type", 100)).thenReturn("text/plain");
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost" + ContentFilterToadlet.CONTENT_FILTER_PATH), request, ctx);
+
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), eq(null), eq(0L));
+    assertEquals(
+        LocalFileFilterToadlet.BROWSE_PATH
+            + "?filter-operation=BOTH&result-handling=DISPLAY&mime-type=text/plain",
+        headersCaptor.getValue().getFirst("Location"));
+    verify(request).freeParts();
+  }
+
+  @Test
+  void handleMethodPOST_whenNoActionParts_delegatesToGetAndFreesParts() throws Exception {
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client));
+    HTTPRequest request = mock(HTTPRequest.class);
+    URI uri = URI.create("http://localhost" + ContentFilterToadlet.CONTENT_FILTER_PATH);
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(false);
+    doNothing().when(toadlet).handleMethodGET(eq(uri), any(HTTPRequest.class), eq(ctx));
+    ArgumentCaptor<HTTPRequest> requestCaptor = ArgumentCaptor.forClass(HTTPRequest.class);
+
+    toadlet.handleMethodPOST(uri, request, ctx);
+
+    verify(toadlet).handleMethodGET(eq(uri), requestCaptor.capture(), eq(ctx));
+    assertInstanceOf(HTTPRequestImpl.class, requestCaptor.getValue());
+    verify(request).freeParts();
+  }
+
+  @Test
+  void handleMethodPOST_whenUploadRequested_filtersUploadedFileUsingUploadedMimeTypeAndDefaultUri()
+      throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+    HTTPRequest request = mock(HTTPRequest.class);
+    HTTPUploadedFile uploadedFile = mock(HTTPUploadedFile.class);
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(request.isPartSet("filter-local")).thenReturn(false);
+    when(request.isPartSet(LocalFileBrowserToadlet.SELECT_FILE)).thenReturn(false);
+    when(request.isPartSet("filter-upload")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("filter-operation", 100))
+        .thenReturn(FilterOperation.READ.toString());
+    when(request.getPartAsStringFailsafe("result-handling", 100))
+        .thenReturn(ContentFilterToadlet.ResultHandling.DISPLAY.toString());
+    when(request.getPartAsStringFailsafe("mime-type", 100)).thenReturn("");
+    when(request.getUploadedFile("filename")).thenReturn(uploadedFile);
+    when(uploadedFile.getFilename()).thenReturn("upload.txt");
+    when(uploadedFile.getContentType()).thenReturn("text/uploaded");
+    AtomicReference<ContentFilterRequest> capturedRequest = new AtomicReference<>();
+    AtomicReference<ContentFilterCallbacks> capturedCallbacks = new AtomicReference<>();
+    byte[] filtered = "filtered-upload".getBytes(StandardCharsets.UTF_8);
+
+    try (ArrayBucket uploadData = new ArrayBucket("input".getBytes(StandardCharsets.UTF_8));
+        ArrayBucket resultBucket = new ArrayBucket()) {
+      when(uploadedFile.getData()).thenReturn(uploadData);
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+      System.setProperty(FILTER_URI_PROPERTY, "not a uri");
+
+      try (MockedStatic<ContentFilter> mockedFilter =
+          org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+        stubFilter(mockedFilter, filtered, "text/filtered", capturedRequest, capturedCallbacks);
+
+        toadlet.handleMethodPOST(
+            URI.create("http://localhost" + ContentFilterToadlet.CONTENT_FILTER_PATH),
+            request,
+            ctx);
+      }
+
+      assertEquals("text/uploaded", capturedRequest.get().typeName());
+      assertEquals(DEFAULT_FILTER_URI, capturedCallbacks.get().baseURI());
+      assertSame(container, capturedCallbacks.get().linkFilterExceptionProvider());
+      verify(ctx).sendReplyHeaders(200, "OK", null, "text/filtered", resultBucket.size());
+      verify(ctx).writeData(resultBucket);
+      verify(request).freeParts();
+    }
+  }
+
+  @Test
+  void handleMethodPOST_whenLocalFileSelected_filtersExistingFileUsingGuessedMimeType()
+      throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+    HTTPRequest request = mock(HTTPRequest.class);
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(request.isPartSet("filter-local")).thenReturn(false);
+    when(request.isPartSet(LocalFileBrowserToadlet.SELECT_FILE)).thenReturn(true);
+    when(request.getPartAsStringFailsafe("filter-operation", 100))
+        .thenReturn(FilterOperation.READ.toString());
+    when(request.getPartAsStringFailsafe("result-handling", 100))
+        .thenReturn(ContentFilterToadlet.ResultHandling.DISPLAY.toString());
+    when(request.getPartAsStringFailsafe("mime-type", 100)).thenReturn("");
+    Path inputFile = tempDir.resolve("page.html");
+    Files.writeString(inputFile, "<html>input</html>", StandardCharsets.UTF_8);
+    when(request.getPartAsStringFailsafe("filename", QueueToadlet.MAX_FILENAME_LENGTH))
+        .thenReturn(inputFile.toString());
+    String expectedMimeType = DefaultMIMETypes.guessMIMEType(inputFile.toString(), false);
+    AtomicReference<ContentFilterRequest> capturedRequest = new AtomicReference<>();
+    byte[] filtered = "filtered-local".getBytes(StandardCharsets.UTF_8);
+
+    try (ArrayBucket resultBucket = new ArrayBucket()) {
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+
+      try (MockedStatic<ContentFilter> mockedFilter =
+          org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+        stubFilter(mockedFilter, filtered, "text/html", capturedRequest, new AtomicReference<>());
+
+        toadlet.handleMethodPOST(
+            URI.create("http://localhost" + ContentFilterToadlet.CONTENT_FILTER_PATH),
+            request,
+            ctx);
+      }
+
+      assertEquals(expectedMimeType, capturedRequest.get().typeName());
+      verify(ctx).sendReplyHeaders(200, "OK", null, "text/html", resultBucket.size());
+      verify(ctx).writeData(resultBucket);
+      verify(request).freeParts();
+    }
   }
 
   @Test
@@ -200,6 +469,50 @@ class ContentFilterToadletTest {
   }
 
   @Test
+  void handleFilter_whenContainerMissing_throwsIllegalStateException() throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+    try (ArrayBucket inputBucket = new ArrayBucket();
+        ArrayBucket resultBucket = new ArrayBucket()) {
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+
+      assertThrows(
+          IllegalStateException.class,
+          () ->
+              invokeHandleFilter(
+                  toadlet,
+                  inputBucket,
+                  "text/plain",
+                  FilterOperation.READ,
+                  ContentFilterToadlet.ResultHandling.DISPLAY,
+                  "result.txt"));
+    }
+  }
+
+  @Test
+  void handleFilter_whenContainerDoesNotProvideLinkExceptions_throwsIllegalStateException()
+      throws Exception {
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
+    toadlet.container = mock(ToadletContainer.class);
+    try (ArrayBucket inputBucket = new ArrayBucket();
+        ArrayBucket resultBucket = new ArrayBucket()) {
+      when(ctx.getBucketFactory()).thenReturn(bucketFactory);
+      when(bucketFactory.makeBucket(-1)).thenReturn(resultBucket);
+
+      assertThrows(
+          IllegalStateException.class,
+          () ->
+              invokeHandleFilter(
+                  toadlet,
+                  inputBucket,
+                  "text/plain",
+                  FilterOperation.READ,
+                  ContentFilterToadlet.ResultHandling.DISPLAY,
+                  "result.txt"));
+    }
+  }
+
+  @Test
   void handleFilter_whenResultHandlingUnknown_throwsBadRequestException() throws Exception {
     ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
     toadlet.container = container;
@@ -273,6 +586,33 @@ class ContentFilterToadletTest {
         FilterStatus.class.getDeclaredConstructor(String.class, String.class);
     constructor.setAccessible(true);
     return constructor.newInstance(charset, mimeType);
+  }
+
+  private void stubFilter(
+      MockedStatic<ContentFilter> mockedFilter,
+      byte[] filtered,
+      String resultMimeType,
+      AtomicReference<ContentFilterRequest> capturedRequest,
+      AtomicReference<ContentFilterCallbacks> capturedCallbacks) {
+    mockedFilter
+        .when(
+            () ->
+                ContentFilter.filter(
+                    any(ContentFilterRequest.class), any(ContentFilterCallbacks.class)))
+        .thenAnswer(
+            invocation -> {
+              capturedRequest.set(invocation.getArgument(0));
+              capturedCallbacks.set(invocation.getArgument(1));
+              ContentFilterRequest request = invocation.getArgument(0);
+              //noinspection resource
+              OutputStream output = request.output();
+              output.write(filtered);
+              try {
+                return newFilterStatus(null, resultMimeType);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
   }
 
   private void invokeHandleFilter(

--- a/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ContentFilterToadletTest.java
@@ -13,8 +13,6 @@ import network.crypta.client.filter.ContentFilterCallbacks;
 import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
-import network.crypta.node.ClientEndpoints;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -37,7 +35,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -49,7 +46,6 @@ import static org.mockito.Mockito.when;
 class ContentFilterToadletTest {
 
   private HighLevelSimpleClient client;
-  private NodeClientCore core;
   private SimpleToadletServer container;
   private ToadletContext ctx;
   private BucketFactory bucketFactory;
@@ -57,18 +53,14 @@ class ContentFilterToadletTest {
   @BeforeEach
   void setUp() {
     client = mock(HighLevelSimpleClient.class);
-    core = mock(NodeClientCore.class);
     container = mock(SimpleToadletServer.class);
     ctx = mock(ToadletContext.class);
     bucketFactory = mock(BucketFactory.class);
-    ClientEndpoints endpoints = mock(ClientEndpoints.class);
-    lenient().when(core.getEndpoints()).thenReturn(endpoints);
-    lenient().when(endpoints.getToadletContainer()).thenReturn(container);
   }
 
   @Test
   void isEnabled_whenAdvancedAndPrivateMode_returnsTrue() {
-    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
     toadlet.container = container;
 
     when(container.publicGatewayMode()).thenReturn(false);
@@ -79,7 +71,7 @@ class ContentFilterToadletTest {
 
   @Test
   void isEnabled_whenPublicGatewayWithoutFullAccess_returnsFalse() {
-    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
     toadlet.container = container;
 
     when(container.publicGatewayMode()).thenReturn(true);
@@ -91,7 +83,7 @@ class ContentFilterToadletTest {
 
   @Test
   void getFilterOperation_whenInvalidValue_throwsBadRequestException() throws Exception {
-    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.getPartAsStringFailsafe("filter-operation", 100)).thenReturn("not-an-enum");
 
@@ -104,7 +96,7 @@ class ContentFilterToadletTest {
 
   @Test
   void handleFilter_whenDisplayHandling_writesHeadersAndBucket() throws Exception {
-    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client, core));
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client));
     toadlet.container = container;
     try (ArrayBucket inputBucket = new ArrayBucket("input".getBytes(StandardCharsets.UTF_8));
         ArrayBucket resultBucket = new ArrayBucket()) {
@@ -123,6 +115,7 @@ class ContentFilterToadletTest {
             .thenAnswer(
                 invocation -> {
                   ContentFilterRequest request = invocation.getArgument(0);
+                  //noinspection resource
                   OutputStream output = request.output();
                   output.write(filtered);
                   try {
@@ -149,7 +142,7 @@ class ContentFilterToadletTest {
 
   @Test
   void handleFilter_whenSaveHandling_setsAttachmentHeaders() throws Exception {
-    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client, core));
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client));
     toadlet.container = container;
     try (ArrayBucket inputBucket = new ArrayBucket("input".getBytes(StandardCharsets.UTF_8));
         ArrayBucket resultBucket = new ArrayBucket()) {
@@ -168,6 +161,7 @@ class ContentFilterToadletTest {
             .thenAnswer(
                 invocation -> {
                   ContentFilterRequest request = invocation.getArgument(0);
+                  //noinspection resource
                   OutputStream output = request.output();
                   output.write(filtered);
                   try {
@@ -207,7 +201,7 @@ class ContentFilterToadletTest {
 
   @Test
   void handleFilter_whenResultHandlingUnknown_throwsBadRequestException() throws Exception {
-    ContentFilterToadlet toadlet = new ContentFilterToadlet(client, core);
+    ContentFilterToadlet toadlet = new ContentFilterToadlet(client);
     toadlet.container = container;
     try (ArrayBucket inputBucket = new ArrayBucket();
         ArrayBucket resultBucket = new ArrayBucket()) {
@@ -224,7 +218,7 @@ class ContentFilterToadletTest {
 
   @Test
   void handleFilter_whenFilterMarksUnsafe_sendsErrorPage() throws Exception {
-    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client, core));
+    ContentFilterToadlet toadlet = spy(new ContentFilterToadlet(client));
     toadlet.container = container;
     try (ArrayBucket inputBucket = new ArrayBucket();
         ArrayBucket resultBucket = new ArrayBucket()) {
@@ -297,11 +291,10 @@ class ContentFilterToadletTest {
             FilterOperation.class,
             ContentFilterToadlet.ResultHandling.class,
             String.class,
-            ToadletContext.class,
-            NodeClientCore.class);
+            ToadletContext.class);
     method.setAccessible(true);
     try {
-      method.invoke(toadlet, data, mimeType, operation, handling, resultFilename, ctx, core);
+      method.invoke(toadlet, data, mimeType, operation, handling, resultFilename, ctx);
     } catch (InvocationTargetException e) {
       Throwable cause = e.getCause();
       if (cause instanceof Exception exception) {

--- a/src/test/java/network/crypta/clients/http/DecodeToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DecodeToadletTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
@@ -25,7 +24,6 @@ import static org.mockito.Mockito.when;
 class DecodeToadletTest {
 
   @Mock private HighLevelSimpleClient client;
-  @Mock private NodeClientCore core;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
   @Mock private PageMaker pageMaker;
@@ -38,7 +36,7 @@ class DecodeToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = spy(new DecodeToadlet(client, core));
+    toadlet = spy(new DecodeToadlet(client));
   }
 
   private void mockPageRenderingChain() {
@@ -110,7 +108,7 @@ class DecodeToadletTest {
 
   @Test
   void path_whenInvoked_returnsDecodePath() {
-    DecodeToadlet freshToadlet = new DecodeToadlet(mock(HighLevelSimpleClient.class), core);
+    DecodeToadlet freshToadlet = new DecodeToadlet(mock(HighLevelSimpleClient.class));
 
     assertEquals("/decode/", freshToadlet.path());
   }


### PR DESCRIPTION
## Summary
- remove the direct `NodeClientCore` dependency from `DecodeToadlet`
- remove the direct `NodeClientCore` dependency from `ContentFilterToadlet` and resolve its `LinkFilterExceptionProvider` from the registered container
- update `FProxyRegistrar` and the focused `DecodeToadletTest` and `ContentFilterToadletTest` constructors to match the narrower wiring

## How to test
- `./gradlew test --tests 'network.crypta.clients.http.DecodeToadletTest' --tests 'network.crypta.clients.http.ContentFilterToadletTest'`
