### PR TITLE
refactor(http): Narrow FProxy registrar wiring

### DIFF
--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -12,9 +12,6 @@ import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
 import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.RequestClientBuilder;
-import network.crypta.node.RequestStarter;
 import network.crypta.node.updater.CoreActionToadlet;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -24,18 +21,17 @@ import static network.crypta.node.updater.UpdaterPaths.CORE_UPDATE_PATH;
 /**
  * Registers every FProxy-facing toadlet and menu entry exposed by the Crypta node.
  *
- * <p>This helper centralizes the wiring of the HTTP user interface: it constructs shared
- * client-side helpers, instantiates each toadlet, assigns menu categories, and publishes them on
- * the {@link SimpleToadletServer}. Callers invoke it once during node startup to ensure all public
- * endpoints—browsing, queue management, configuration, alerts, and update actions—are available
- * before handling requests. The registrar is intentionally package-private and stateless; it relies
- * on the provided {@link NodeClientCore} and {@link Config} instances for runtime settings and
- * threat posture.
+ * <p>This helper centralizes the wiring of the HTTP user interface after daemon-only composition
+ * has already happened elsewhere. It assigns menu categories, instantiates secondary toadlets,
+ * connects them to prebuilt collaborators, and publishes them on the {@link SimpleToadletServer}.
+ * Callers invoke it once during node startup to ensure all public endpoints for browsing, queue
+ * management, configuration, alerts, and update actions are available before handling requests. The
+ * registrar is intentionally package-private and stateless; it relies only on the narrow
+ * dependencies bundle assembled by the HTTP shell.
  *
  * <p>Responsibilities include:
  *
  * <ul>
- *   <li>Creating a shared {@link HighLevelSimpleClient} and fetch tracker used by toadlets.
  *   <li>Registering navigation menus under canonical categories for consistent UI grouping.
  *   <li>Instantiating functional toadlets for downloads, uploads, security, chat, stats,
  *       connectivity, first-time wizard flows, and core updates.
@@ -51,36 +47,23 @@ final class FProxyRegistrar {
   /**
    * Builds and registers the full FProxy toadlet set if the environment supports it.
    *
-   * <p>The method seeds shared randomness, prepares a high-level client with interactive priority,
-   * wires a {@link FProxyFetchTracker}, and then registers every relevant toadlet with the provided
-   * server. Registration order aligns with menu placement: browsing first, followed by queue
-   * handlers, configuration, status/alerts, chat, and maintenance endpoints. This method must be
-   * called exactly once during startup; it performs no deduplication and assumes the server is
+   * <p>The method assumes the root FProxy toadlet, interactive client, and runtime ports have
+   * already been assembled by the caller and then registers every relevant toadlet with the
+   * provided server. Registration order aligns with menu placement: browsing first, followed by
+   * queue handlers, configuration, status/alerts, chat, and maintenance endpoints. This method must
+   * be called exactly once during startup; it performs no deduplication and assumes the server is
    * empty.
    *
-   * @param core node client core supplying security levels, download directories, and RNG access;
-   *     must be initialized and non-null.
-   * @param config composite configuration used to enumerate sub-configs for dynamic toadlets.
+   * @param dependencies prebuilt shell dependencies required to register the FProxy HTTP surface
    * @param server toadlet server that exposes HTTP endpoints; expected to be in registration phase.
    */
-  static void maybeCreateFProxyEtc(NodeClientCore core, Config config, SimpleToadletServer server) {
-
-    HighLevelSimpleClient client =
-        core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
-    RuntimePorts runtimePorts = core.getRuntimePorts();
+  static void maybeCreateFProxyEtc(
+      FProxyRegistrarDependencies dependencies, SimpleToadletServer server) {
+    HighLevelSimpleClient client = dependencies.client();
+    RuntimePorts runtimePorts = dependencies.runtimePorts();
+    Config config = dependencies.config();
+    FProxyToadlet fproxy = dependencies.fproxy();
     TransferAccessPort transferAccess = runtimePorts.transferAccess();
-
-    FProxyToadlet.random = new byte[32];
-    core.getRandom().nextBytes(FProxyToadlet.random);
-
-    FProxyFetchTracker fetchTracker =
-        new FProxyFetchTracker(
-            core.getClientContext(),
-            client.getFetchContext(),
-            new RequestClientBuilder().realTime().build());
-
-    FProxyToadlet fproxy = new FProxyToadlet(client, core, fetchTracker);
-    core.getEndpoints().setFProxy(fproxy);
 
     server.registerMenu(
         "/", FProxyToadlet.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
@@ -1,0 +1,48 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.config.Config;
+import network.crypta.runtime.spi.RuntimePorts;
+
+/**
+ * Narrow dependency bundle used to register the FProxy HTTP shell.
+ *
+ * <p>{@link SimpleToadletServer} assembles the live daemon collaborators needed for the root FProxy
+ * endpoint, then hands that prebuilt state to {@link FProxyRegistrar}. The registrar can therefore
+ * stay focused on HTTP concerns such as menu registration, toadlet registration, and wiring
+ * already-created helpers into those routes. This record exists only to make that handoff explicit
+ * and local to the HTTP package.
+ *
+ * <p>The type is intentionally package-private. It is not a general runtime abstraction and does
+ * not try to hide broader node relationships. It simply groups the collaborators that the registrar
+ * actually consumes so startup composition remains in one place while HTTP registration remains
+ * deterministic and easy to test.
+ *
+ * @param client shared interactive client used by registered HTTP toadlets
+ * @param runtimePorts detached runtime ports exposed to the HTTP shell
+ * @param config node configuration used to list sub-config toadlets
+ * @param fproxy prebuilt root FProxy toadlet already published to client endpoints
+ */
+record FProxyRegistrarDependencies(
+    HighLevelSimpleClient client, RuntimePorts runtimePorts, Config config, FProxyToadlet fproxy) {
+  /**
+   * Creates a validated dependency bundle for {@link FProxyRegistrar}.
+   *
+   * <p>All collaborators are required because registration is an all-or-nothing startup step. The
+   * constructor rejects the partially assembled state early, so the caller fails to close to the
+   * HTTP shell composition site rather than later during menu or toadlet registration.
+   *
+   * @param client shared interactive client used by registered HTTP toadlets during registration
+   * @param runtimePorts runtime-spi ports exposed to HTTP-layer toadlets and helper pages
+   * @param config node configuration used to list and filter sub-config toadlets
+   * @param fproxy prebuilt root FProxy toadlet that is registered at the HTTP root path
+   * @throws NullPointerException if any required collaborator is absent at construction time
+   */
+  FProxyRegistrarDependencies {
+    Objects.requireNonNull(client);
+    Objects.requireNonNull(runtimePorts);
+    Objects.requireNonNull(config);
+    Objects.requireNonNull(fproxy);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -9,6 +9,7 @@ import java.security.SecureRandom;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Iterator;
+import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.filter.HTMLFilter;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
@@ -28,9 +29,12 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PrioRunnable;
+import network.crypta.node.RequestClientBuilder;
+import network.crypta.node.RequestStarter;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.PriorityAwareExecutor;
@@ -458,8 +462,8 @@ public final class SimpleToadletServer
    * bookmark handling, interval push scheduling, and UI registration against the active node. This
    * method is idempotent; later calls are ignored after the first successful invocation. It
    * captures the current {@link #core} reference, wires the push managers to the shared {@link
-   * Ticker}, and delegates to {@link FProxyRegistrar} to create request handlers and configuration
-   * entries.
+   * Ticker}, assembles the daemon-only root FProxy collaborators, and delegates to {@link
+   * FProxyRegistrar} for the remaining HTTP shell registration.
    */
   public void createFproxy() {
     NodeClientCore coreRef = this.core;
@@ -471,7 +475,28 @@ public final class SimpleToadletServer
     pushDataManager = new PushDataManager(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
     bookmarkManager = new BookmarkManager(coreRef, publicGatewayMode());
-    FProxyRegistrar.maybeCreateFProxyEtc(coreRef, coreRef.getNode().getConfig(), this);
+
+    HighLevelSimpleClient client =
+        coreRef.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+    RuntimePorts runtimePorts = coreRef.getRuntimePorts();
+    initializeFProxyRandom(runtimePorts.randomness());
+    FProxyFetchTracker fetchTracker =
+        new FProxyFetchTracker(
+            coreRef.getClientContext(),
+            client.getFetchContext(),
+            new RequestClientBuilder().realTime().build());
+    FProxyToadlet fproxy = new FProxyToadlet(client, coreRef, fetchTracker);
+    coreRef.getEndpoints().setFProxy(fproxy);
+
+    FProxyRegistrar.maybeCreateFProxyEtc(
+        new FProxyRegistrarDependencies(
+            client, runtimePorts, coreRef.getNode().getConfig(), fproxy),
+        this);
+  }
+
+  private static synchronized void initializeFProxyRandom(RandomnessPort randomnessPort) {
+    FProxyToadlet.random = new byte[32];
+    randomnessPort.fillSecureRandom(FProxyToadlet.random);
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -4,15 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
-import network.crypta.crypt.RandomSource;
-import network.crypta.node.ClientEndpoints;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -52,15 +47,10 @@ import static org.mockito.Mockito.when;
 class FProxyRegistrarTest {
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private NodeClientCore core;
-
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private RuntimePorts runtimePorts;
 
   @Mock private HighLevelSimpleClient client;
-  @Mock private FetchContext fetchContext;
-  @Mock private RandomSource randomSource;
-  @Mock private ClientEndpoints endpoints;
+  @Mock private FProxyToadlet fproxy;
   @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private WelcomePagePort welcomePagePort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
@@ -89,13 +79,6 @@ class FProxyRegistrarTest {
     SubConfig securityLevelsConfig = config.createSubConfig("security-levels");
     securityLevelsConfig.finishedInitialization();
 
-    when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
-    when(core.getRuntimePorts()).thenReturn(runtimePorts);
-    when(core.getRandom()).thenReturn(randomSource);
-    when(core.getClientContext())
-        .thenReturn(org.mockito.Mockito.mock(network.crypta.client.async.ClientContext.class));
-    when(core.getEndpoints()).thenReturn(endpoints);
-    when(client.getFetchContext()).thenReturn(fetchContext);
     when(runtimePorts.queueCompletion()).thenReturn(queueCompletionPort);
     when(runtimePorts.welcomePage()).thenReturn(welcomePagePort);
     when(runtimePorts.darknetConnections()).thenReturn(darknetConnectionsPort);
@@ -112,16 +95,8 @@ class FProxyRegistrarTest {
 
   @Test
   void maybeCreateFProxyEtc_whenInvoked_registersMenusSetsFProxyAndStartsQueueCompletion() {
-    FProxyRegistrar.maybeCreateFProxyEtc(core, config, server);
-
-    ArgumentCaptor<byte[]> randomCaptor = ArgumentCaptor.forClass(byte[].class);
-    verify(randomSource).nextBytes(randomCaptor.capture());
-    assertSame(FProxyToadlet.random, randomCaptor.getValue());
-    assertEquals(32, randomCaptor.getValue().length);
-
-    ArgumentCaptor<FProxyToadlet> fproxyCaptor = ArgumentCaptor.forClass(FProxyToadlet.class);
-    verify(endpoints).setFProxy(fproxyCaptor.capture());
-    FProxyToadlet fproxyToadlet = fproxyCaptor.getValue();
+    FProxyRegistrar.maybeCreateFProxyEtc(
+        new FProxyRegistrarDependencies(client, runtimePorts, config, fproxy), server);
 
     verify(server)
         .registerMenu("/", FProxyToadlet.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");
@@ -153,7 +128,7 @@ class FProxyRegistrarTest {
         registrations.stream()
             .anyMatch(
                 registered ->
-                    registered.toadlet() == fproxyToadlet
+                    registered.toadlet() == fproxy
                         && "/".equals(registered.registration().urlPrefix())));
     assertTrue(
         registrations.stream()
@@ -221,7 +196,8 @@ class FProxyRegistrarTest {
 
   @Test
   void maybeCreateFProxyEtc_whenSecurityLevelsSubconfigPresent_skipsSecurityLevelsConfigToadlet() {
-    FProxyRegistrar.maybeCreateFProxyEtc(core, config, server);
+    FProxyRegistrar.maybeCreateFProxyEtc(
+        new FProxyRegistrarDependencies(client, runtimePorts, config, fproxy), server);
 
     Set<String> configToadletPrefixes =
         capturedRegistrations().stream()

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -2,20 +2,34 @@ package network.crypta.clients.http;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.FetchContext;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.async.ClientContext;
+import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.config.Config;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
+import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.RandomnessPort;
+import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.Ticker;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.ArrayBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -27,8 +41,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -75,6 +94,67 @@ class SimpleToadletServerTest {
             () -> server.findToadlet(new URI("http://localhost/hidden")));
 
     assertEquals(FirstTimeWizardToadlet.TOADLET_URL, ex.newuri.getPath());
+  }
+
+  @Test
+  void createFproxy_whenInvoked_buildsDaemonDependenciesAndDelegatesOnce() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    PersistentConfig nodeConfig = new PersistentConfig(new SimpleFieldSet(true));
+    Ticker ticker = mock(Ticker.class);
+    ClientContext clientContext = mock(ClientContext.class);
+    ClientEndpoints endpoints = mock(ClientEndpoints.class);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    RandomnessPort randomnessPort = mock(RandomnessPort.class);
+    NodeClientCore core = mock(NodeClientCore.class, Answers.RETURNS_DEEP_STUBS);
+    when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(core.getRuntimePorts()).thenReturn(runtimePorts);
+    when(core.getEndpoints()).thenReturn(endpoints);
+    when(core.getNode().getConfig()).thenReturn(nodeConfig);
+    when(core.getNode().network().ticker()).thenReturn(ticker);
+    when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    when(client.getFetchContext()).thenReturn(fetchContext);
+    server.setCore(core);
+
+    AtomicInteger registrarCalls = new AtomicInteger();
+    AtomicReference<FProxyRegistrarDependencies> dependenciesRef = new AtomicReference<>();
+    try (MockedConstruction<BookmarkManager> bookmarkManagers =
+            mockConstruction(BookmarkManager.class);
+        MockedStatic<FProxyRegistrar> registrarMock = mockStatic(FProxyRegistrar.class)) {
+      registrarMock
+          .when(
+              () ->
+                  FProxyRegistrar.maybeCreateFProxyEtc(
+                      any(FProxyRegistrarDependencies.class), same(server)))
+          .thenAnswer(
+              invocation -> {
+                registrarCalls.incrementAndGet();
+                dependenciesRef.set(invocation.getArgument(0));
+                return null;
+              });
+
+      server.createFproxy();
+      server.createFproxy();
+
+      assertEquals(1, bookmarkManagers.constructed().size());
+    }
+
+    ArgumentCaptor<byte[]> randomCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<FProxyToadlet> fproxyCaptor = ArgumentCaptor.forClass(FProxyToadlet.class);
+    verify(runtimePorts, times(1)).randomness();
+    verify(randomnessPort, times(1)).fillSecureRandom(randomCaptor.capture());
+    assertSame(FProxyToadlet.random, randomCaptor.getValue());
+    assertEquals(32, randomCaptor.getValue().length);
+    verify(core, times(1)).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+    verify(core, never()).getRandom();
+    verify(endpoints, times(1)).setFProxy(fproxyCaptor.capture());
+    assertEquals(1, registrarCalls.get());
+    assertSame(client, dependenciesRef.get().client());
+    assertSame(runtimePorts, dependenciesRef.get().runtimePorts());
+    assertSame(nodeConfig, dependenciesRef.get().config());
+    assertSame(fproxyCaptor.getValue(), dependenciesRef.get().fproxy());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- move daemon-only FProxy root assembly from `FProxyRegistrar` into `SimpleToadletServer.createFproxy()`
- introduce package-private `FProxyRegistrarDependencies` so the registrar only consumes prebuilt HTTP-shell collaborators
- update the focused HTTP tests to cover runtime-spi random seeding, endpoint publication, registrar delegation, and `createFproxy()` idempotency

## Testing
- `./gradlew compileJava`
- `./gradlew test --tests 'network.crypta.clients.http.FProxyRegistrarTest' --tests 'network.crypta.clients.http.SimpleToadletServerTest'`
- `javadoc -quiet -private -Xdoclint:all -classpath "build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main" -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java`