### PR TITLE
refactor(bookmark): Detach bookmark runtime from NodeClientCore

### DIFF
--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -15,6 +15,7 @@ import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.PageMaker.THEME;
 import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.clients.http.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.clients.http.updateableelements.PushDataManager;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
@@ -474,7 +475,9 @@ public final class SimpleToadletServer
 
     pushDataManager = new PushDataManager(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
-    bookmarkManager = new BookmarkManager(coreRef, publicGatewayMode());
+    bookmarkManager =
+        new BookmarkManager(
+            new CoreBookmarkRuntimeSupport(coreRef), coreRef.getAlerts(), publicGatewayMode());
 
     HighLevelSimpleClient client =
         coreRef.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkItem.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkItem.java
@@ -8,7 +8,6 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.FSParseException;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.AbstractUserAlert;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
@@ -302,7 +301,7 @@ public final class BookmarkItem extends Bookmark {
    * <p>This method is synchronized to provide a consistent view of the underlying URI during
    * concurrent updates. If callers retain the returned reference, they should re-fetch via this
    * method if they require the latest value after {@link #update(FreenetURI, boolean, String,
-   * String)} or {@link #setEdition(long, NodeClientCore)}.
+   * String)} or {@link #setEdition(long)}.
    *
    * @return the current {@link FreenetURI} instance for this bookmark; never {@code null}
    */
@@ -372,13 +371,12 @@ public final class BookmarkItem extends Bookmark {
    *
    * @param ed the new suggested edition to apply; must be greater than the current suggested
    *     edition
-   * @param node the node context used for diagnostic logging; may be {@code null}
    * @return {@code true} if the edition was updated; {@code false} if {@code ed} was not newer
    */
-  public synchronized boolean setEdition(long ed, NodeClientCore node) {
+  public synchronized boolean setEdition(long ed) {
     if (key.getSuggestedEdition() >= ed) {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Edition {} is too old, not updating {} (nodePresent={})", ed, key, node != null);
+        LOG.debug("Edition {} is too old, not updating {}", ed, key);
       }
       return false;
     }
@@ -444,9 +442,9 @@ public final class BookmarkItem extends Bookmark {
    * Returns whether this bookmark is currently marked as updated.
    *
    * <p>The updated flag is used to decide whether the per-item {@link UserAlert} should be
-   * considered valid and shown to the user. The flag is typically set via {@link #setEdition(long,
-   * NodeClientCore)} for USKs and cleared when the user dismisses the notification or when the
-   * bookmark no longer represents a USK.
+   * considered valid and shown to the user. The flag is typically set via {@link #setEdition(long)}
+   * for USKs and cleared when the user dismisses the notification or when the bookmark no longer
+   * represents a USK.
    *
    * @return {@code true} if the bookmark is marked updated; {@code false} otherwise
    */

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -18,10 +18,9 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.FSParseException;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
  *   <li>Subscribe/unsubscribe to USK updates for USK-typed bookmark items.
  * </ul>
  */
-public class BookmarkManager implements RequestClient {
+public class BookmarkManager {
   private static final Logger LOG = LoggerFactory.getLogger(BookmarkManager.class);
 
   /**
@@ -67,7 +66,8 @@ public class BookmarkManager implements RequestClient {
    */
   public static final SimpleFieldSet DEFAULT_BOOKMARKS;
 
-  private final NodeClientCore node;
+  private final BookmarkRuntimeSupport runtime;
+  private final UserAlertManager alerts;
   private final USKUpdatedCallback uskCB = new USKUpdatedCallback();
 
   /**
@@ -123,14 +123,17 @@ public class BookmarkManager implements RequestClient {
    * <p>When {@code publicGateway} is enabled, the manager also initializes {@link
    * #DEFAULT_CATEGORY} and applies the bundled defaults under that category.
    *
-   * @param n the node core used for filesystem access, scheduling, alerts, and USK subscriptions
+   * @param runtime bookmark-specific runtime support for persistence, scheduling, and USK polling
+   * @param alerts user alert manager associated with the active node context
    * @param publicGateway whether to initialize a secondary default category for gateway-mode hosts
    */
-  public BookmarkManager(NodeClientCore n, boolean publicGateway) {
+  public BookmarkManager(
+      BookmarkRuntimeSupport runtime, UserAlertManager alerts, boolean publicGateway) {
     putPaths("/", MAIN_CATEGORY);
-    this.node = n;
-    this.bookmarksFile = n.getNode().userDir().file("bookmarks.dat");
-    this.backupBookmarksFile = n.getNode().userDir().file("bookmarks.dat.bak");
+    this.runtime = runtime;
+    this.alerts = alerts;
+    this.bookmarksFile = runtime.bookmarksFile();
+    this.backupBookmarksFile = runtime.backupBookmarksFile();
 
     boolean loadedPrimary = false;
     if (!bookmarksFile.exists() || bookmarksFile.length() == 0) {
@@ -215,13 +218,7 @@ public class BookmarkManager implements RequestClient {
     public void onFoundEdition(USKFoundEdition foundEdition) {
       if (!foundEdition.newKnownGood()) {
         FreenetURI uri = foundEdition.key().copy(foundEdition.edition()).getURI();
-        node.makeClient(PRIORITY_PROGRESS, false, false)
-            .prefetch(
-                uri,
-                MINUTES.toMillis(60),
-                FProxyToadlet.getMaxLengthWithProgress(),
-                null,
-                PRIORITY_PROGRESS);
+        runtime.prefetchUpdatedEdition(uri, FProxyToadlet.getMaxLengthWithProgress());
         return;
       }
       long edition = foundEdition.edition();
@@ -240,7 +237,7 @@ public class BookmarkManager implements RequestClient {
             if (LOG.isDebugEnabled())
               LOG.debug("Updating bookmark for {} to edition {}", furi, edition);
             matched = true;
-            updated |= bookmarkItem.setEdition(edition, node);
+            updated |= bookmarkItem.setEdition(edition);
             // We may have bookmarked the same site twice, so continue the search.
           }
         } catch (MalformedURLException _) {
@@ -496,7 +493,7 @@ public class BookmarkManager implements RequestClient {
     try {
       USK u = item.getUSK();
       if (!wantUSK(u, item)) {
-        node.getUskManager().unsubscribe(u, uskCB);
+        runtime.unsubscribeFromUsk(u, uskCB);
       }
     } catch (MalformedURLException _) {
       // Malformed bookmark key; there is nothing to unsubscribe from.
@@ -617,18 +614,15 @@ public class BookmarkManager implements RequestClient {
     synchronized (bookmarks) {
       if (isSavingBookmarksLazy) return;
       isSavingBookmarksLazy = true;
-      node.getNode()
-          .network()
-          .ticker()
-          .queueTimedJob(
-              () -> {
-                try {
-                  storeBookmarks();
-                } finally {
-                  isSavingBookmarksLazy = false;
-                }
-              },
-              MINUTES.toMillis(5));
+      runtime.queueLazyStore(
+          () -> {
+            try {
+              storeBookmarks();
+            } finally {
+              isSavingBookmarksLazy = false;
+            }
+          },
+          MINUTES.toMillis(5));
     }
   }
 
@@ -677,7 +671,7 @@ public class BookmarkManager implements RequestClient {
     if (!"USK".equals(item.getKeyType())) return;
     try {
       USK u = item.getUSK();
-      this.node.getUskManager().subscribe(u, this.uskCB, true, this);
+      runtime.subscribeToUsk(u, this.uskCB);
     } catch (MalformedURLException _) {
       // Malformed bookmark key; ignore and do not subscribe.
     }
@@ -723,7 +717,7 @@ public class BookmarkManager implements RequestClient {
       String prefix, BookmarkCategory category, SimpleFieldSet subset, boolean isRoot)
       throws FSParseException {
     try {
-      BookmarkItem item = new BookmarkItem(subset, this, node.getAlerts());
+      BookmarkItem item = new BookmarkItem(subset, this, alerts);
       String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
       putPaths(name, item);
       category.addBookmark(item);
@@ -804,30 +798,5 @@ public class BookmarkManager implements RequestClient {
     sfs.put(BookmarkItem.BOOKMARK_PREFIX, bi.size());
 
     return sfs;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * <p>This manager does not represent a persistent request client; it is used for UI-driven helper
-   * requests (such as USK polling) and does not require restart persistence at the request layer.
-   *
-   * @return always {@code false}
-   */
-  @Override
-  public boolean persistent() {
-    return false;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * <p>This client does not treat bookmark-related requests as real-time traffic.
-   *
-   * @return always {@code false}
-   */
-  @Override
-  public boolean realTimeFlag() {
-    return false;
   }
 }

--- a/src/main/java/network/crypta/clients/http/bookmark/BookmarkRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/BookmarkRuntimeSupport.java
@@ -1,0 +1,105 @@
+package network.crypta.clients.http.bookmark;
+
+import java.io.File;
+import network.crypta.client.async.USKCallback;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.USK;
+
+/**
+ * Defines the runtime services that the bookmark subsystem needs from the surrounding node.
+ *
+ * <p>{@link BookmarkManager} uses this interface during startup, edition tracking, and deferred
+ * persistence. The surface is intentionally narrow and bookmark-specific. It exposes only the
+ * operations needed to locate bookmark files, manage USK subscriptions, prefetch newly discovered
+ * editions, and queue delayed work. That keeps bookmark code focused on bookmark state and alert
+ * handling instead of on the broader {@code NodeClientCore} API.
+ *
+ * <p>Implementations should preserve the legacy bookmark behavior for file locations, request
+ * scheduling, and subscription wiring. The interface does not prescribe a threading model. Callers
+ * should assume that callbacks and queued jobs may run asynchronously on runtime-managed threads.
+ *
+ * <ul>
+ *   <li>Resolve the primary and backup bookmark persistence files.
+ *   <li>Manage the USK subscription lifecycle for bookmark updates.
+ *   <li>Trigger best-effort prefetch work for newly discovered editions.
+ *   <li>Queue delayed background jobs without exposing ticker details.
+ * </ul>
+ *
+ * @see CoreBookmarkRuntimeSupport
+ */
+public interface BookmarkRuntimeSupport {
+
+  /**
+   * Returns the primary bookmark persistence file.
+   *
+   * <p>{@link BookmarkManager} reads this file first during startup and rewrites it when the
+   * current bookmark tree is flushed to disk. Implementations should return a stable node-local
+   * location so restart recovery and lazy-store cycles keep using the same persistent state.
+   *
+   * @return the file used for normal bookmark persistence for the current node instance
+   */
+  File bookmarksFile();
+
+  /**
+   * Returns the backup bookmark persistence file.
+   *
+   * <p>The bookmark store uses this location for its safety copy and fallback load path when the
+   * primary file is missing or unreadable. Implementations should keep this file paired with {@link
+   * #bookmarksFile()} so backup recovery observes the same bookmark dataset and directory.
+   *
+   * @return the file used as the writing safety copy and recovery fallback
+   */
+  File backupBookmarksFile();
+
+  /**
+   * Prefetches content for a newly discovered bookmark edition.
+   *
+   * <p>This is a best-effort hint to the runtime, not a synchronous fetch contract. Callers use it
+   * after a USK update is discovered, so the node can warm caches and begin retrieval work without
+   * pulling client-construction details into bookmark domain code. The size limit is expressed in
+   * bytes and should reflect the bookmark's configured prefetch budget.
+   *
+   * @param uri the discovered edition URI whose target content should be prefetched
+   * @param maxSize the maximum number of bytes the prefetch should attempt to retrieve
+   */
+  void prefetchUpdatedEdition(FreenetURI uri, long maxSize);
+
+  /**
+   * Subscribes to updates for a bookmark USK.
+   *
+   * <p>Callers typically subscribe when a bookmark is loaded or added, then later pair that
+   * subscription with {@link #unsubscribeFromUsk(USK, USKCallback)} when the bookmark is removed or
+   * the manager shuts down. The runtime implementation owns request-client details and any
+   * underlying subscription bookkeeping that the bookmark package should not see directly.
+   *
+   * @param usk the updatable key to monitor for newer bookmark editions
+   * @param callback the callback that receives edition notifications from the runtime
+   */
+  void subscribeToUsk(USK usk, USKCallback callback);
+
+  /**
+   * Removes a USK subscription previously created through this runtime support.
+   *
+   * <p>Callers should pass the same USK and callback pair that was previously given to {@link
+   * #subscribeToUsk(USK, USKCallback)}. Implementations are responsible for translating that pair
+   * into the underlying runtime's unsubscribing behavior and for releasing any associated resources
+   * or tracking state owned by the runtime.
+   *
+   * @param usk the updatable key that should no longer be monitored for updates
+   * @param callback the callback instance that should be detached from update delivery
+   */
+  void unsubscribeFromUsk(USK usk, USKCallback callback);
+
+  /**
+   * Queues a delayed bookmark persistence job.
+   *
+   * <p>Bookmark code uses this hook to coalesce repeated mutations behind a timer instead of
+   * writing on every state change. The delay is expressed in milliseconds from the time of
+   * scheduling. This interface does not define whether equal jobs are merged, deduplicated, or run
+   * on a specific executor; those policy details belong to the implementation.
+   *
+   * @param job the work item that should run after the requested delay expires
+   * @param delayMillis the scheduling delay, in milliseconds, before the job may run
+   */
+  void queueLazyStore(Runnable job, long delayMillis);
+}

--- a/src/main/java/network/crypta/clients/http/bookmark/CoreBookmarkRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/bookmark/CoreBookmarkRuntimeSupport.java
@@ -1,0 +1,97 @@
+package network.crypta.clients.http.bookmark;
+
+import java.io.File;
+import java.util.Objects;
+import network.crypta.client.async.USKCallback;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.USK;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.node.RequestClientBuilder;
+import network.crypta.node.RequestStarter;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+/**
+ * Adapts the legacy {@link NodeClientCore} API to {@link BookmarkRuntimeSupport}.
+ *
+ * <p>This implementation is the compatibility layer used by the HTTP bookmark subsystem while the
+ * surrounding FProxy runtime still originates from {@link NodeClientCore}. It translates
+ * bookmark-local operations into the existing node services for user-directory file resolution, USK
+ * subscription management, update-priority prefetch, and ticker-backed delayed work. That keeps
+ * bookmark loading, update handling, and lazy persistence behavior stable while moving the direct
+ * core dependency out of {@link BookmarkManager}.
+ *
+ * <p>The adapter is intentionally small and keeps only an immutable reference to the supplied node
+ * core. It is not a general-purpose node facade. Callers are expected to construct it close to
+ * bookmark wiring and share it with bookmark code that needs runtime services.
+ *
+ * <ul>
+ *   <li>Expose the existing bookmark file locations from the node's user directory.
+ *   <li>Own the private {@link RequestClient} used for bookmark USK subscriptions.
+ *   <li>Reuse the node's update-priority client behavior for edition prefetch.
+ *   <li>Delegate delayed store scheduling to the node ticker without exposing ticker APIs.
+ * </ul>
+ *
+ * @see BookmarkManager
+ * @see BookmarkRuntimeSupport
+ */
+public final class CoreBookmarkRuntimeSupport implements BookmarkRuntimeSupport {
+  private static final RequestClient BOOKMARK_REQUEST_CLIENT = new RequestClientBuilder().build();
+  private static final long PREFETCH_TIMEOUT_MILLIS = MINUTES.toMillis(60);
+
+  private final NodeClientCore core;
+
+  /**
+   * Creates runtime support backed by the supplied node core.
+   *
+   * <p>The supplied core must already expose the normal services used by bookmark HTTP handling:
+   * the node user directory, the USK manager, update-priority client creation, and the node ticker.
+   * This constructor performs no eager setup beyond null checking; all runtime work is delegated
+   * when individual adapter methods are invoked.
+   *
+   * @param core live node core used to reach bookmark files, USK subscriptions, and ticker jobs
+   * @throws NullPointerException if {@code core} is {@code null}
+   */
+  public CoreBookmarkRuntimeSupport(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public File bookmarksFile() {
+    return core.getNode().userDir().file("bookmarks.dat");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public File backupBookmarksFile() {
+    return core.getNode().userDir().file("bookmarks.dat.bak");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void prefetchUpdatedEdition(FreenetURI uri, long maxSize) {
+    core.makeClient(RequestStarter.UPDATE_PRIORITY_CLASS, false, false)
+        .prefetch(
+            uri, PREFETCH_TIMEOUT_MILLIS, maxSize, null, RequestStarter.UPDATE_PRIORITY_CLASS);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void subscribeToUsk(USK usk, USKCallback callback) {
+    core.getUskManager().subscribe(usk, callback, true, BOOKMARK_REQUEST_CLIENT);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void unsubscribeFromUsk(USK usk, USKCallback callback) {
+    core.getUskManager().unsubscribe(usk, callback);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void queueLazyStore(Runnable job, long delayMillis) {
+    core.getNode().network().ticker().queueTimedJob(job, delayMillis);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -2,12 +2,14 @@ package network.crypta.clients.http;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.ClientContext;
 import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.clients.http.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.config.Config;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
@@ -17,6 +19,7 @@ import network.crypta.node.ClientEndpoints;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
+import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.HTMLNode;
@@ -35,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -108,10 +112,12 @@ class SimpleToadletServerTest {
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeClientCore core = mock(NodeClientCore.class, Answers.RETURNS_DEEP_STUBS);
+    UserAlertManager alerts = mock(UserAlertManager.class);
     when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
     when(core.getClientContext()).thenReturn(clientContext);
     when(core.getRuntimePorts()).thenReturn(runtimePorts);
     when(core.getEndpoints()).thenReturn(endpoints);
+    when(core.getAlerts()).thenReturn(alerts);
     when(core.getNode().getConfig()).thenReturn(nodeConfig);
     when(core.getNode().network().ticker()).thenReturn(ticker);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
@@ -120,8 +126,11 @@ class SimpleToadletServerTest {
 
     AtomicInteger registrarCalls = new AtomicInteger();
     AtomicReference<FProxyRegistrarDependencies> dependenciesRef = new AtomicReference<>();
+    AtomicReference<List<Object>> bookmarkManagerCtorArgs = new AtomicReference<>();
     try (MockedConstruction<BookmarkManager> bookmarkManagers =
-            mockConstruction(BookmarkManager.class);
+            mockConstruction(
+                BookmarkManager.class,
+                (_, context) -> bookmarkManagerCtorArgs.set(List.copyOf(context.arguments())));
         MockedStatic<FProxyRegistrar> registrarMock = mockStatic(FProxyRegistrar.class)) {
       registrarMock
           .when(
@@ -139,6 +148,9 @@ class SimpleToadletServerTest {
       server.createFproxy();
 
       assertEquals(1, bookmarkManagers.constructed().size());
+      assertInstanceOf(CoreBookmarkRuntimeSupport.class, bookmarkManagerCtorArgs.get().get(0));
+      assertSame(alerts, bookmarkManagerCtorArgs.get().get(1));
+      assertEquals(server.publicGatewayMode(), bookmarkManagerCtorArgs.get().get(2));
     }
 
     ArgumentCaptor<byte[]> randomCaptor = ArgumentCaptor.forClass(byte[].class);
@@ -148,6 +160,7 @@ class SimpleToadletServerTest {
     assertSame(FProxyToadlet.random, randomCaptor.getValue());
     assertEquals(32, randomCaptor.getValue().length);
     verify(core, times(1)).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+    verify(core, times(1)).getAlerts();
     verify(core, never()).getRandom();
     verify(endpoints, times(1)).setFProxy(fproxyCaptor.capture());
     assertEquals(1, registrarCalls.get());

--- a/src/test/java/network/crypta/clients/http/bookmark/BookmarkItemTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/BookmarkItemTest.java
@@ -5,7 +5,6 @@ import java.util.Locale;
 import java.util.stream.Stream;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.UserAlert;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.SimpleFieldSet;
@@ -57,7 +56,6 @@ class BookmarkItemTest {
 
   @Mock BookmarkManager bookmarkManager;
   @Mock UserAlertManager userAlertManager;
-  @Mock NodeClientCore nodeClientCore;
 
   private static FreenetURI uri(String uri) {
     try {
@@ -246,7 +244,7 @@ class BookmarkItemTest {
     BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
 
     // Act
-    boolean updated = item.setEdition(25, nodeClientCore);
+    boolean updated = item.setEdition(25);
 
     // Assert
     assertTrue(updated);
@@ -263,7 +261,7 @@ class BookmarkItemTest {
     long currentEdition = item.getURI().getSuggestedEdition();
 
     // Act
-    boolean updated = item.setEdition(currentEdition, nodeClientCore);
+    boolean updated = item.setEdition(currentEdition);
 
     // Assert
     assertFalse(updated);
@@ -278,8 +276,8 @@ class BookmarkItemTest {
     BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
 
     // Act
-    assertTrue(item.setEdition(25, nodeClientCore));
-    assertTrue(item.setEdition(26, nodeClientCore));
+    assertTrue(item.setEdition(25));
+    assertTrue(item.setEdition(26));
 
     // Assert
     assertEquals(26, item.getURI().getSuggestedEdition());
@@ -291,7 +289,7 @@ class BookmarkItemTest {
   void update_whenNewKeyIsNotUSK_expectDisablesBookmarkAndUnregistersAlert() {
     // Arrange
     BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", true);
-    assertTrue(item.setEdition(25, nodeClientCore));
+    assertTrue(item.setEdition(25));
     verify(userAlertManager).register(same(item.getUserAlert()));
 
     // Act
@@ -311,7 +309,7 @@ class BookmarkItemTest {
   void clearUpdated_whenUpdated_expectClearsFlagButDoesNotUnregister() {
     // Arrange
     BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
-    assertTrue(item.setEdition(25, nodeClientCore));
+    assertTrue(item.setEdition(25));
     verify(userAlertManager).register(same(item.getUserAlert()));
 
     // Act
@@ -327,7 +325,7 @@ class BookmarkItemTest {
   void userAlert_whenMarkedInvalid_expectUnregistersAndClearsUpdated() {
     // Arrange
     BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
-    assertTrue(item.setEdition(25, nodeClientCore));
+    assertTrue(item.setEdition(25));
     verify(userAlertManager).register(same(item.getUserAlert()));
 
     // Act
@@ -343,7 +341,7 @@ class BookmarkItemTest {
   void userAlert_onDismiss_expectUnregistersClearsUpdatedAndStoresBookmarks() {
     // Arrange
     BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", false);
-    assertTrue(item.setEdition(25, nodeClientCore));
+    assertTrue(item.setEdition(25));
     verify(userAlertManager).register(same(item.getUserAlert()));
 
     // Act
@@ -412,7 +410,7 @@ class BookmarkItemTest {
   void getSimpleFieldSet_whenCalled_expectContainsPersistedFields() {
     // Arrange
     BookmarkItem item = newBookmarkItem(uri(USK_24), "N", "D", "S", true);
-    assertTrue(item.setEdition(25, nodeClientCore));
+    assertTrue(item.setEdition(25));
     verify(userAlertManager).register(same(item.getUserAlert()));
 
     // Act

--- a/src/test/java/network/crypta/clients/http/bookmark/BookmarkManagerTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/BookmarkManagerTest.java
@@ -9,14 +9,10 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import network.crypta.client.async.USKManager;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.Ticker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -38,7 +33,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -70,7 +64,7 @@ class BookmarkManagerTest {
   @ParameterizedTest
   @CsvSource({"/,/", "/a,/", "/a/,/", "/a/b,/a/", "/a/b/,/a/", "/a/b/c/,/a/b/"})
   void parentPath_whenGivenPath_expectParent(String input, String expected) {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
 
     String parent = manager.parentPath(input);
 
@@ -79,7 +73,7 @@ class BookmarkManagerTest {
 
   @Test
   void getCategoryByPath_whenPathIsCategory_expectCategoryInstance() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkCategory category = new BookmarkCategory("cat");
     manager.addBookmark("/", category);
 
@@ -90,7 +84,7 @@ class BookmarkManagerTest {
 
   @Test
   void getCategoryByPath_whenPathIsItem_expectNull() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkItem item = mockBookmarkItem("item", "KSK");
     manager.addBookmark("/", item);
 
@@ -101,7 +95,7 @@ class BookmarkManagerTest {
 
   @Test
   void getItemByPath_whenPathIsItem_expectItemInstance() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkItem item = mockBookmarkItem("item", "KSK");
     manager.addBookmark("/", item);
 
@@ -112,7 +106,7 @@ class BookmarkManagerTest {
 
   @Test
   void getItemByPath_whenPathIsCategory_expectNull() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkCategory category = new BookmarkCategory("cat");
     manager.addBookmark("/", category);
 
@@ -123,8 +117,8 @@ class BookmarkManagerTest {
 
   @Test
   void addBookmark_whenAddingUskItem_expectSubscribeCalled() throws Exception {
-    USKManager uskManager = mock(USKManager.class);
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir, uskManager);
+    ManagerFixture fixture = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = fixture.manager();
 
     USK usk = mock(USK.class);
     BookmarkItem item = mockBookmarkItem("site", "USK");
@@ -133,12 +127,12 @@ class BookmarkManagerTest {
     manager.addBookmark("/", item);
 
     assertSame(item, manager.getItemByPath(SITE_PATH));
-    verify(uskManager).subscribe(eq(usk), any(), eq(true), eq(manager));
+    verify(fixture.runtime()).subscribeToUsk(eq(usk), any());
   }
 
   @Test
   void renameBookmark_whenRenamingCategory_expectPathsUpdatedForSubtree() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkCategory category = new BookmarkCategory("cat");
     manager.addBookmark("/", category);
     BookmarkItem item = mockBookmarkItem("item", "KSK");
@@ -153,7 +147,7 @@ class BookmarkManagerTest {
 
   @Test
   void moveBookmark_whenMovingItem_expectPathAndParentUpdated() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkCategory from = new BookmarkCategory("from");
     BookmarkCategory to = new BookmarkCategory("to");
     manager.addBookmark("/", from);
@@ -171,7 +165,7 @@ class BookmarkManagerTest {
 
   @Test
   void removeBookmark_whenPathUnknown_expectNoop() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
 
     manager.removeBookmark("/missing");
 
@@ -180,8 +174,8 @@ class BookmarkManagerTest {
 
   @Test
   void removeBookmark_whenRemovingUskItem_expectUnsubscribeWhenNoOtherWantsUsk() throws Exception {
-    USKManager uskManager = mock(USKManager.class);
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir, uskManager);
+    ManagerFixture fixture = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = fixture.manager();
 
     USK usk = mock(USK.class);
     BookmarkItem item = mockBookmarkItem("site", "USK");
@@ -191,12 +185,12 @@ class BookmarkManagerTest {
     manager.removeBookmark(SITE_PATH);
 
     assertNull(manager.getBookmarkByPath(SITE_PATH));
-    verify(uskManager).unsubscribe(eq(usk), any());
+    verify(fixture.runtime()).unsubscribeFromUsk(eq(usk), any());
   }
 
   @Test
   void moveBookmarkDown_whenStoreFalse_expectReorderedWithoutSaving() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkItem a = mockBookmarkItem("a", "KSK");
     BookmarkItem b = mockBookmarkItem("b", "KSK");
     BookmarkItem c = mockBookmarkItem("c", "KSK");
@@ -211,7 +205,7 @@ class BookmarkManagerTest {
 
   @Test
   void moveBookmarkUp_whenStoreFalse_expectReorderedWithoutSaving() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkItem a = mockBookmarkItem("a", "KSK");
     BookmarkItem b = mockBookmarkItem("b", "KSK");
     BookmarkItem c = mockBookmarkItem("c", "KSK");
@@ -226,7 +220,7 @@ class BookmarkManagerTest {
 
   @Test
   void getBookmarkURIs_whenItemsPresent_expectUrisInTraversalOrder() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     FreenetURI uri1 = mock(FreenetURI.class);
     FreenetURI uri2 = mock(FreenetURI.class);
     BookmarkItem item1 = mockKskBookmarkItemWithUri("one", uri1);
@@ -241,15 +235,16 @@ class BookmarkManagerTest {
 
   @Test
   void storeBookmarksLazy_whenCalledTwiceBeforeJobRuns_expectQueuedOnce() {
-    Ticker ticker = mock(Ticker.class);
-    BookmarkManager manager = spy(newManagerWithEmptyBookmarksFile(testDir, ticker));
+    ManagerFixture fixture = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = spy(fixture.manager());
     doNothing().when(manager).storeBookmarks();
     ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
 
     manager.storeBookmarksLazy();
     manager.storeBookmarksLazy();
 
-    verify(ticker, times(1)).queueTimedJob(runnableCaptor.capture(), eq(5L * 60L * 1000L));
+    verify(fixture.runtime(), times(1))
+        .queueLazyStore(runnableCaptor.capture(), eq(5L * 60L * 1000L));
     verify(manager, never()).storeBookmarks();
 
     runnableCaptor.getValue().run();
@@ -259,24 +254,24 @@ class BookmarkManagerTest {
 
   @Test
   void storeBookmarksLazy_whenJobCompleted_expectSubsequentCallQueuesAgain() {
-    Ticker ticker = mock(Ticker.class);
-    BookmarkManager manager = spy(newManagerWithEmptyBookmarksFile(testDir, ticker));
+    ManagerFixture fixture = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = spy(fixture.manager());
     doNothing().when(manager).storeBookmarks();
     ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
 
     manager.storeBookmarksLazy();
-    verify(ticker).queueTimedJob(runnableCaptor.capture(), anyLong());
+    verify(fixture.runtime()).queueLazyStore(runnableCaptor.capture(), anyLong());
 
     runnableCaptor.getValue().run();
 
     manager.storeBookmarksLazy();
 
-    verify(ticker, times(2)).queueTimedJob(any(Runnable.class), anyLong());
+    verify(fixture.runtime(), times(2)).queueLazyStore(any(Runnable.class), anyLong());
   }
 
   @Test
   void toSimpleFieldSet_whenEmpty_expectVersionAndZeroCounts() throws Exception {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
 
     SimpleFieldSet sfs = manager.toSimpleFieldSet();
 
@@ -287,7 +282,7 @@ class BookmarkManagerTest {
 
   @Test
   void toSimpleFieldSet_whenCategoryAndItemPresent_expectCountsMatch() throws Exception {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     BookmarkCategory category = new BookmarkCategory("cat");
     manager.addBookmark("/", category);
     BookmarkItem item = mockBookmarkItem("item", "KSK");
@@ -307,7 +302,7 @@ class BookmarkManagerTest {
   void reAddDefaultBookmarks_whenDefaultBookmarksAvailable_expectCategoryAdded() throws Exception {
     assertNotNull(BookmarkManager.DEFAULT_BOOKMARKS);
 
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
 
     manager.reAddDefaultBookmarks();
 
@@ -328,7 +323,7 @@ class BookmarkManagerTest {
 
   @Test
   void storeBookmarks_whenCalled_expectBookmarksFileWritten() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
+    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir).manager();
     manager.addBookmark("/", new BookmarkCategory("cat"));
 
     manager.storeBookmarks();
@@ -336,20 +331,6 @@ class BookmarkManagerTest {
     File bookmarksFile = testDir.resolve("bookmarks.dat").toFile();
     assertTrue(bookmarksFile.isFile());
     assertTrue(bookmarksFile.length() > 0);
-  }
-
-  @Test
-  void persistent_whenCalled_expectFalse() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
-
-    assertFalse(manager.persistent());
-  }
-
-  @Test
-  void realTimeFlag_whenCalled_expectFalse() {
-    BookmarkManager manager = newManagerWithEmptyBookmarksFile(testDir);
-
-    assertFalse(manager.realTimeFlag());
   }
 
   private static BookmarkItem mockBookmarkItem(String name, String keyType) {
@@ -365,22 +346,20 @@ class BookmarkManagerTest {
     return item;
   }
 
-  private static BookmarkManager newManagerWithEmptyBookmarksFile(Path tmp) {
-    return newManagerWithEmptyBookmarksFile(tmp, mock(Ticker.class), mock(USKManager.class));
+  private static ManagerFixture newManagerWithEmptyBookmarksFile(Path tmp) {
+    return newManagerWithEmptyBookmarksFile(tmp, mock(BookmarkRuntimeSupport.class));
   }
 
-  private static BookmarkManager newManagerWithEmptyBookmarksFile(Path tmp, USKManager uskManager) {
-    return newManagerWithEmptyBookmarksFile(tmp, mock(Ticker.class), uskManager);
+  private static ManagerFixture newManagerWithEmptyBookmarksFile(
+      Path tmp, BookmarkRuntimeSupport runtime) {
+    return newManagerWithEmptyBookmarksFile(tmp, runtime, mock(UserAlertManager.class));
   }
 
-  private static BookmarkManager newManagerWithEmptyBookmarksFile(Path tmp, Ticker ticker) {
-    return newManagerWithEmptyBookmarksFile(tmp, ticker, mock(USKManager.class));
-  }
-
-  private static BookmarkManager newManagerWithEmptyBookmarksFile(
-      Path tmp, Ticker ticker, USKManager uskManager) {
+  private static ManagerFixture newManagerWithEmptyBookmarksFile(
+      Path tmp, BookmarkRuntimeSupport runtime, UserAlertManager alerts) {
+    File bookmarksFile = tmp.resolve("bookmarks.dat").toFile();
+    File backupBookmarksFile = tmp.resolve("bookmarks.dat.bak").toFile();
     try {
-      File bookmarksFile = tmp.resolve("bookmarks.dat").toFile();
       SimpleFieldSet empty = new SimpleFieldSet(true);
       empty.put(BookmarkItem.BOOKMARK_PREFIX, 0);
       empty.put(BookmarkCategory.SFS_KEY, 0);
@@ -389,27 +368,14 @@ class BookmarkManagerTest {
       throw new IllegalStateException("Failed to write initial bookmarks file for test", e);
     }
 
-    NodeClientCore core = mock(NodeClientCore.class);
-    UserAlertManager alerts = mock(UserAlertManager.class);
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    network.crypta.node.ProgramDirectory userDir = new network.crypta.node.ProgramDirectory();
-    try {
-      userDir.move(tmp.toString());
-    } catch (IOException e) {
-      throw new IllegalStateException("Failed to initialize ProgramDirectory for test", e);
-    }
+    when(runtime.bookmarksFile()).thenReturn(bookmarksFile);
+    when(runtime.backupBookmarksFile()).thenReturn(backupBookmarksFile);
 
-    when(node.userDir()).thenReturn(userDir);
-    network.crypta.node.subsystem.NodeNetworkSubsystem network =
-        org.mockito.Mockito.mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
-    lenient().when(network.ticker()).thenReturn(ticker);
-    when(core.getNode()).thenReturn(node);
-    lenient().when(core.getUskManager()).thenReturn(uskManager);
-    lenient().when(core.getAlerts()).thenReturn(alerts);
-
-    return new BookmarkManager(core, false);
+    return new ManagerFixture(new BookmarkManager(runtime, alerts, false), runtime, alerts);
   }
+
+  private record ManagerFixture(
+      BookmarkManager manager, BookmarkRuntimeSupport runtime, UserAlertManager alerts) {}
 
   private static void writeSimpleFieldSet(File file, SimpleFieldSet sfs) throws IOException {
     try (FileOutputStream out = new FileOutputStream(file)) {

--- a/src/test/java/network/crypta/clients/http/bookmark/CoreBookmarkRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/clients/http/bookmark/CoreBookmarkRuntimeSupportTest.java
@@ -1,0 +1,117 @@
+package network.crypta.clients.http.bookmark;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.async.USKCallback;
+import network.crypta.client.async.USKManager;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.USK;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.ProgramDirectory;
+import network.crypta.node.RequestClient;
+import network.crypta.node.RequestStarter;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class CoreBookmarkRuntimeSupportTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void bookmarkFiles_whenCalled_expectFilesResolvedFromUserDir() throws IOException {
+    ProgramDirectory userDir = new ProgramDirectory();
+    userDir.move(tempDir.toString());
+    Node node = mock(Node.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(node.userDir()).thenReturn(userDir);
+    when(core.getNode()).thenReturn(node);
+    CoreBookmarkRuntimeSupport runtime = new CoreBookmarkRuntimeSupport(core);
+
+    assertEquals(tempDir.resolve("bookmarks.dat").toFile(), runtime.bookmarksFile());
+    assertEquals(tempDir.resolve("bookmarks.dat.bak").toFile(), runtime.backupBookmarksFile());
+  }
+
+  @Test
+  void queueLazyStore_whenCalled_expectDelegatesToTicker() {
+    Runnable job = mock(Runnable.class);
+    Ticker ticker = mock(Ticker.class);
+    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
+    Node node = mock(Node.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(network.ticker()).thenReturn(ticker);
+    when(node.network()).thenReturn(network);
+    when(core.getNode()).thenReturn(node);
+    CoreBookmarkRuntimeSupport runtime = new CoreBookmarkRuntimeSupport(core);
+
+    runtime.queueLazyStore(job, 123L);
+
+    verify(ticker).queueTimedJob(job, 123L);
+  }
+
+  @Test
+  void subscribeToUsk_whenCalled_expectDelegatesWithBackgroundFetchAndEphemeralClient() {
+    USKManager uskManager = mock(USKManager.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    USK usk = mock(USK.class);
+    USKCallback callback = mock(USKCallback.class);
+    when(core.getUskManager()).thenReturn(uskManager);
+    CoreBookmarkRuntimeSupport runtime = new CoreBookmarkRuntimeSupport(core);
+    ArgumentCaptor<RequestClient> clientCaptor = ArgumentCaptor.forClass(RequestClient.class);
+
+    runtime.subscribeToUsk(usk, callback);
+
+    verify(uskManager).subscribe(same(usk), same(callback), eq(true), clientCaptor.capture());
+    assertFalse(clientCaptor.getValue().persistent());
+    assertFalse(clientCaptor.getValue().realTimeFlag());
+  }
+
+  @Test
+  void unsubscribeFromUsk_whenCalled_expectDelegatesToUskManager() {
+    USKManager uskManager = mock(USKManager.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    USK usk = mock(USK.class);
+    USKCallback callback = mock(USKCallback.class);
+    when(core.getUskManager()).thenReturn(uskManager);
+    CoreBookmarkRuntimeSupport runtime = new CoreBookmarkRuntimeSupport(core);
+
+    runtime.unsubscribeFromUsk(usk, callback);
+
+    verify(uskManager).unsubscribe(usk, callback);
+  }
+
+  @Test
+  void prefetchUpdatedEdition_whenCalled_expectDelegatesToUpdatePriorityClient() {
+    FreenetURI uri = mock(FreenetURI.class);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.makeClient(RequestStarter.UPDATE_PRIORITY_CLASS, false, false)).thenReturn(client);
+    CoreBookmarkRuntimeSupport runtime = new CoreBookmarkRuntimeSupport(core);
+
+    runtime.prefetchUpdatedEdition(uri, 456L);
+
+    verify(core).makeClient(RequestStarter.UPDATE_PRIORITY_CLASS, false, false);
+    verify(client)
+        .prefetch(
+            same(uri),
+            eq(MINUTES.toMillis(60)),
+            eq(456L),
+            isNull(),
+            eq(RequestStarter.UPDATE_PRIORITY_CLASS));
+  }
+}


### PR DESCRIPTION
## Summary
- add a bookmark-local `BookmarkRuntimeSupport` interface plus a `CoreBookmarkRuntimeSupport` adapter that preserves the existing `NodeClientCore`-backed behavior
- refactor `BookmarkManager` to depend on the local runtime adapter instead of `NodeClientCore`, remove its `RequestClient` role, and route bookmark file access, USK subscription management, prefetch, and lazy-store scheduling through the adapter
- simplify `BookmarkItem#setEdition(long)` into pure bookmark-domain logic and update `SimpleToadletServer.createFproxy()` plus the focused bookmark/FProxy tests to use the new wiring

## Testing
- `./gradlew test --tests 'network.crypta.clients.http.bookmark.BookmarkManagerTest' --tests 'network.crypta.clients.http.bookmark.BookmarkItemTest' --tests 'network.crypta.clients.http.SimpleToadletServerTest' --tests 'network.crypta.clients.http.bookmark.CoreBookmarkRuntimeSupportTest'`
- `javadoc -quiet -Xdoclint:all -classpath "<project binaries + compile classpath>" -d /tmp/doclint-bookmark-runtime src/main/java/network/crypta/clients/http/bookmark/BookmarkRuntimeSupport.java`
- `javadoc -quiet -Xdoclint:all -classpath "<project binaries + compile classpath>" -d /tmp/doclint-core-bookmark-runtime src/main/java/network/crypta/clients/http/bookmark/CoreBookmarkRuntimeSupport.java`

## Out of Scope
- no `runtime-spi` changes
- no `FProxyToadlet` refactor
- no changes to `SimpleToadletServer.setCore()`, `finishStart()`, or other shell lifecycle wiring
- no changes to `StatisticsToadlet`, `wizardsteps/BandwidthLimit`, bookmark DTOs, or any platform API