### PR TITLE
refactor(http): Extract shell runtime support

### DIFF
--- a/src/main/java/network/crypta/clients/http/CoreHttpShellRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/CoreHttpShellRuntimeSupport.java
@@ -1,0 +1,154 @@
+package network.crypta.clients.http;
+
+import java.io.File;
+import java.util.Objects;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.clients.http.bookmark.CoreBookmarkRuntimeSupport;
+import network.crypta.config.Config;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClientBuilder;
+import network.crypta.node.RequestStarter;
+import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
+import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.Ticker;
+
+/**
+ * Adapts {@link NodeClientCore} to the narrow runtime surface used by {@link SimpleToadletServer}.
+ *
+ * <p>This record keeps the remaining HTTP-shell coupling local to {@code
+ * network.crypta.clients.http} instead of letting the server reach directly into the daemon core.
+ * Callers normally create one instance during a server bootstrap and then treat it as an immutable
+ * delegate. The adapter is intentionally HTTP-local rather than a reusable platform API: it still
+ * exposes alerts, config storage, upload permission checks, and FProxy bootstrap work because those
+ * behaviors remain part of the HTTP shell in the current architecture.
+ *
+ * @param core daemon core that backs delegated shell services and FProxy bootstrap wiring
+ */
+record CoreHttpShellRuntimeSupport(NodeClientCore core) implements HttpShellRuntimeSupport {
+  /**
+   * Creates a core-backed HTTP runtime adapter.
+   *
+   * <p>The supplied daemon core must stay valid for the lifetime of the surrounding HTTP shell.
+   * This adapter retains the reference and delegates every runtime operation to it.
+   *
+   * @param core daemon core that supplies the shell-level runtime services
+   * @throws NullPointerException if {@code core} is {@code null}
+   */
+  CoreHttpShellRuntimeSupport(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  @Override
+  public RuntimePorts runtimePorts() {
+    return core.getRuntimePorts();
+  }
+
+  @Override
+  public Config config() {
+    return core.getNode().getConfig();
+  }
+
+  @Override
+  public Ticker ticker() {
+    return core.getNode().network().ticker();
+  }
+
+  @Override
+  public UserAlertManager userAlerts() {
+    return core.getAlerts();
+  }
+
+  @Override
+  public String formPassword() {
+    return core.getFormPassword();
+  }
+
+  @Override
+  public boolean allowUploadFrom(File filename) {
+    return core.allowUploadFrom(filename);
+  }
+
+  @Override
+  public void storeConfig() {
+    config().store();
+  }
+
+  @Override
+  public boolean canRedirectToWizard() {
+    return true;
+  }
+
+  @Override
+  public void addNetworkThreatLevelListener(ThreatLevelListener<NetworkThreatLevel> listener) {
+    Objects.requireNonNull(listener);
+    core.getNode()
+        .services()
+        .securityLevels()
+        .addNetworkThreatLevelListener(
+            (oldLevel, newLevel) ->
+                listener.onChange(
+                    mapNetworkThreatLevel(oldLevel), mapNetworkThreatLevel(newLevel)));
+  }
+
+  @Override
+  public void addPhysicalThreatLevelListener(ThreatLevelListener<PhysicalThreatLevel> listener) {
+    Objects.requireNonNull(listener);
+    core.getNode()
+        .services()
+        .securityLevels()
+        .addPhysicalThreatLevelListener(
+            (oldLevel, newLevel) ->
+                listener.onChange(
+                    mapPhysicalThreatLevel(oldLevel), mapPhysicalThreatLevel(newLevel)));
+  }
+
+  @Override
+  public HttpShellFProxyBootstrap createFProxyBootstrap(boolean publicGatewayMode) {
+    BookmarkManager bookmarkManager =
+        new BookmarkManager(
+            new CoreBookmarkRuntimeSupport(core), core.getAlerts(), publicGatewayMode);
+    HighLevelSimpleClient client =
+        core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+    FProxyFetchTracker fetchTracker =
+        new FProxyFetchTracker(
+            core.getClientContext(),
+            client.getFetchContext(),
+            new RequestClientBuilder().realTime().build());
+    FProxyToadlet fproxy = new FProxyToadlet(client, core, fetchTracker);
+    core.getEndpoints().setFProxy(fproxy);
+    return new HttpShellFProxyBootstrap(bookmarkManager, client, fproxy);
+  }
+
+  /**
+   * Maps daemon network threat levels into the detached enum used by the HTTP shell.
+   *
+   * @param threatLevel daemon threat level reported by node security listeners
+   * @return matching HTTP-local threat level value for shell callbacks
+   */
+  private static NetworkThreatLevel mapNetworkThreatLevel(NETWORK_THREAT_LEVEL threatLevel) {
+    return switch (threatLevel) {
+      case LOW -> NetworkThreatLevel.LOW;
+      case NORMAL -> NetworkThreatLevel.NORMAL;
+      case HIGH -> NetworkThreatLevel.HIGH;
+      case MAXIMUM -> NetworkThreatLevel.MAXIMUM;
+    };
+  }
+
+  /**
+   * Maps daemon physical threat levels into the detached enum used by the HTTP shell.
+   *
+   * @param threatLevel daemon threat level reported by node security listeners
+   * @return matching HTTP-local threat level value for shell callbacks
+   */
+  private static PhysicalThreatLevel mapPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL threatLevel) {
+    return switch (threatLevel) {
+      case LOW -> PhysicalThreatLevel.LOW;
+      case NORMAL -> PhysicalThreatLevel.NORMAL;
+      case HIGH -> PhysicalThreatLevel.HIGH;
+      case MAXIMUM -> PhysicalThreatLevel.MAXIMUM;
+    };
+  }
+}

--- a/src/main/java/network/crypta/clients/http/HttpShellFProxyBootstrap.java
+++ b/src/main/java/network/crypta/clients/http/HttpShellFProxyBootstrap.java
@@ -1,0 +1,34 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.bookmark.BookmarkManager;
+
+/**
+ * Bundles the daemon-built collaborators that the HTTP shell needs after root FProxy bootstrap.
+ *
+ * <p>{@link SimpleToadletServer} creates the root FProxy stack only once and then reuses the
+ * resulting collaborators when it registers child toadlets and bookmark-dependent views. This
+ * record keeps that handoff explicit and minimal: the bookmark manager carries the daemon-backed
+ * bookmark runtime, the interactive client is shared by HTTP toadlets, and the root {@link
+ * FProxyToadlet} has already been published to client endpoints by the time the shell receives this
+ * bundle.
+ *
+ * @param bookmarkManager bookmark manager wired against the daemon-backed bookmark runtime support
+ * @param client interactive client shared by HTTP toadlets created during shell startup
+ * @param fproxy root FProxy toadlet that has already been connected to daemon client endpoints
+ */
+record HttpShellFProxyBootstrap(
+    BookmarkManager bookmarkManager, HighLevelSimpleClient client, FProxyToadlet fproxy) {
+
+  /**
+   * Validates that every required bootstrap collaborator is present.
+   *
+   * @throws NullPointerException if any bootstrap collaborator is {@code null}
+   */
+  HttpShellFProxyBootstrap {
+    Objects.requireNonNull(bookmarkManager);
+    Objects.requireNonNull(client);
+    Objects.requireNonNull(fproxy);
+  }
+}

--- a/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
@@ -1,0 +1,177 @@
+package network.crypta.clients.http;
+
+import java.io.File;
+import network.crypta.config.Config;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.Ticker;
+
+/**
+ * Defines the daemon-backed services that the HTTP shell still needs at runtime.
+ *
+ * <p>This interface is intentionally package-private and scoped to {@code
+ * network.crypta.clients.http}. It narrows the remaining surface that {@link SimpleToadletServer}
+ * uses while the larger daemon bootstrap still starts from the legacy node core. Implementations
+ * may expose old HTTP-local concepts such as alerts, ticker access, and FProxy bootstrap work, but
+ * the seam is not a new cross-module platform abstraction. Its purpose is to keep shell behavior
+ * explicit, locally testable, and detached from direct {@link network.crypta.node.NodeClientCore}
+ * field access inside the server itself.
+ */
+interface HttpShellRuntimeSupport {
+
+  /**
+   * Returns the runtime ports used by the shell for low-level services such as randomness.
+   *
+   * <p>The returned ports stay owned by the surrounding daemon runtime. Callers treat them as
+   * shared infrastructure and should not assume exclusive access or independent lifecycle control.
+   *
+   * @return runtime ports that expose shell-relevant low-level services
+   */
+  RuntimePorts runtimePorts();
+
+  /**
+   * Returns the live node configuration visible to the HTTP shell.
+   *
+   * <p>Shell callbacks use this configuration to read and persist settings that still live in the
+   * daemon config tree. The returned object remains mutable and reflects the daemon's current
+   * runtime state.
+   *
+   * @return live configuration object used by HTTP shell callbacks and startup checks
+   */
+  Config config();
+
+  /**
+   * Returns the ticker used for shell tasks that rely on the daemon scheduler.
+   *
+   * <p>The ticker remains owned by the daemon network services. The HTTP shell uses it for
+   * time-based tasks rather than creating its own independent scheduler.
+   *
+   * @return shared daemon ticker used by shell-level timed work
+   */
+  Ticker ticker();
+
+  /**
+   * Returns the alert manager surfaced through HTTP status and warning pages.
+   *
+   * <p>The manager is shared with the rest of the daemon. Shell code should treat it as a live
+   * runtime service whose contents may change as the node state changes.
+   *
+   * @return shared user-alert manager visible to HTTP toadlets
+   */
+  UserAlertManager userAlerts();
+
+  /**
+   * Returns the current hidden form password inserted into shell-generated forms.
+   *
+   * <p>The shell uses this token when it renders actions that must be protected against unwanted
+   * submission. Callers should treat the returned value as a sensitive process-local state.
+   *
+   * @return current form password for hidden HTTP form fields
+   */
+  String formPassword();
+
+  /**
+   * Checks whether the current runtime policy allows uploads from a local file.
+   *
+   * <p>This preserves the existing daemon-side permission check instead of duplicating policy in
+   * the HTTP shell. The decision may depend on current security settings and operator choices.
+   *
+   * @param filename local file the user wants to upload through the HTTP shell
+   * @return {@code true} when uploads from the supplied file are currently permitted
+   */
+  boolean allowUploadFrom(File filename);
+
+  /**
+   * Persists the current configuration after shell code changes a stored setting.
+   *
+   * <p>Implementations are responsible for forwarding the save request to the daemon-side config
+   * storage layer used by the existing node runtime.
+   */
+  void storeConfig();
+
+  /**
+   * Indicates whether the shell may still redirect requests to the first-time setup wizard.
+   *
+   * <p>This allows tests or future adapters to suppress wizard redirects without reproducing the
+   * full daemon bootstrap state. Production core-backed wiring currently allows the redirect check.
+   *
+   * @return {@code true} when wizard redirect decisions should remain active
+   */
+  boolean canRedirectToWizard();
+
+  /**
+   * Registers a listener for network threat-level changes using HTTP-local enum values.
+   *
+   * <p>The callback receives detached values so {@link SimpleToadletServer} does not have to depend
+   * on daemon threat-level enums directly. Listener invocation timing remains controlled by the
+   * underlying runtime implementation.
+   *
+   * @param listener callback notified when the runtime network threat level changes
+   */
+  void addNetworkThreatLevelListener(ThreatLevelListener<NetworkThreatLevel> listener);
+
+  /**
+   * Registers a listener for physical threat-level changes using HTTP-local enum values.
+   *
+   * <p>The callback receives detached values, so shell code can react to local security changes
+   * without importing daemon threat-level types directly.
+   *
+   * @param listener callback notified when the runtime physical threat level changes
+   */
+  void addPhysicalThreatLevelListener(ThreatLevelListener<PhysicalThreatLevel> listener);
+
+  /**
+   * Creates the root FProxy collaborators required before the shell registers child toadlets.
+   *
+   * <p>Implementations may perform daemon-side publication as part of this operation because the
+   * root FProxy wiring still belongs to the daemon-backed bootstrap path. Callers should treat the
+   * result as a one-time bootstrap bundle for the current shell instance.
+   *
+   * @param publicGatewayMode whether the shell should bootstrap public-gateway bookmark behavior
+   * @return bootstrap bundle containing the bookmark manager, interactive client, and root FProxy
+   */
+  HttpShellFProxyBootstrap createFProxyBootstrap(boolean publicGatewayMode);
+
+  /**
+   * Receives detached threat-level change notifications from the runtime support implementation.
+   *
+   * @param <T> HTTP-local threat-level enum type delivered to the listener
+   */
+  @FunctionalInterface
+  interface ThreatLevelListener<T> {
+    /**
+     * Handles a threat-level transition.
+     *
+     * <p>The callback receives the previous and new level using the detached enum type chosen by
+     * the surrounding listener registration.
+     *
+     * @param oldLevel previous detached threat level before the change
+     * @param newLevel new detached threat level after the change
+     */
+    void onChange(T oldLevel, T newLevel);
+  }
+
+  /** Represents the lowest network threat posture exposed to the HTTP shell. */
+  enum NetworkThreatLevel {
+    /** Indicates low network-side threat assumptions. */
+    LOW,
+    /** Indicates the default network threat posture used during normal operation. */
+    NORMAL,
+    /** Indicates elevated network-side threat assumptions. */
+    HIGH,
+    /** Indicates the most restrictive network threat posture available to the shell. */
+    MAXIMUM
+  }
+
+  /** Represents the local physical threat posture exposed to the HTTP shell. */
+  enum PhysicalThreatLevel {
+    /** Indicates low physical compromise risk for the local node environment. */
+    LOW,
+    /** Indicates the default physical threat posture used during normal operation. */
+    NORMAL,
+    /** Indicates elevated concern about local physical compromise. */
+    HIGH,
+    /** Indicates the most restrictive physical threat posture available to the shell. */
+    MAXIMUM
+  }
+}

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -9,13 +9,12 @@ import java.security.SecureRandom;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Iterator;
-import network.crypta.client.HighLevelSimpleClient;
+import java.util.Objects;
 import network.crypta.client.filter.HTMLFilter;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.PageMaker.THEME;
 import network.crypta.clients.http.bookmark.BookmarkManager;
-import network.crypta.clients.http.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.clients.http.updateableelements.PushDataManager;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
@@ -30,10 +29,6 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PrioRunnable;
-import network.crypta.node.RequestClientBuilder;
-import network.crypta.node.RequestStarter;
-import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
-import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -57,18 +52,20 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * <p>SimpleToadletServer owns the embedded HTTP listener that exposes FProxy and assorted control
  * endpoints to browsers and local tools. It wires configuration callbacks, constructs the network
  * interface, and manages registration of individual {@link Toadlet} handlers. Typical lifecycle:
- * construct the server with the node configuration, call {@link #setCore(NodeClientCore)} once the
- * node core becomes available, start the listener, and invoke {@link #finishStart()} after startup
- * housekeeping completes. The server keeps track of theme selection, panic button visibility,
- * gateway mode, and access controls. It also delegates bookmark management, push managers, and
- * theme overrides to the core and supporting helper classes.
+ * construct the server with the node configuration, publish runtime support through {@link
+ * #setCore(NodeClientCore)} or {@link #setRuntimeSupport(HttpShellRuntimeSupport)} once the daemon
+ * is ready, start the listener, and invoke {@link #finishStart()} after startup housekeeping
+ * completes. The server keeps track of theme selection, panic button visibility, gateway mode, and
+ * access controls. It also delegates bookmark management, push managers, and theme overrides to the
+ * HTTP-local runtime adapter and supporting helper classes.
  *
  * <p>Concurrency: the network listener and request handling threads read shared state such as the
- * {@link #core} reference, panic flags, and theme settings. The core reference is published through
- * a volatile write-in {@link #setCore(NodeClientCore)} so request threads see it once set.
- * Mutability: most configuration is thread-safe via synchronized blocks or volatile fields; URL
- * registration is guarded by the server monitor. Extended configuration callbacks are invoked on
- * the configuration thread; request handlers run on the executor.
+ * {@link #runtimeSupport} reference, panic flags, and theme settings. The runtime support reference
+ * is published through a volatile write-in {@link #setCore(NodeClientCore)} or {@link
+ * #setRuntimeSupport(HttpShellRuntimeSupport)} so request threads see it once set. Mutability: most
+ * configuration is thread-safe via synchronized blocks or volatile fields; URL registration is
+ * guarded by the server monitor. Extended configuration callbacks are invoked on the configuration
+ * thread; request handlers run on the executor.
  *
  * <ul>
  *   <li>Responsibilities: bind sockets, dispatch toadlets, surface configuration, and relay alerts.
@@ -135,7 +132,7 @@ public final class SimpleToadletServer
   private BucketFactory bf;
 
   @SuppressWarnings("java:S3077")
-  private volatile NodeClientCore core;
+  private volatile HttpShellRuntimeSupport runtimeSupport;
 
   // HTTP Option
   private boolean doRobots;
@@ -313,12 +310,12 @@ public final class SimpleToadletServer
 
     @Override
     public void set(String val) throws InvalidConfigValueException {
-      NodeClientCore coreRef = SimpleToadletServer.this.core;
-      if (coreRef == null) return;
+      HttpShellRuntimeSupport runtimeSupportRef = SimpleToadletServer.this.runtimeSupport;
+      if (runtimeSupportRef == null) return;
       if (val.equals(get()) || val.isEmpty()) cssOverride = null;
       else {
         File tmp = new File(val.trim());
-        if (!coreRef.allowUploadFrom(tmp))
+        if (!runtimeSupportRef.allowUploadFrom(tmp))
           throw new InvalidConfigValueException(
               l10n("cssOverrideNotInUploads", FILENAME_KEY, tmp.toString()));
         else if (!tmp.canRead() || !tmp.isFile())
@@ -459,41 +456,32 @@ public final class SimpleToadletServer
   /**
    * Builds the FProxy runtime structures once the core is ready.
    *
-   * <p>Call this after {@link #setCore(NodeClientCore)} and before accepting requests to install
-   * bookmark handling, interval push scheduling, and UI registration against the active node. This
-   * method is idempotent; later calls are ignored after the first successful invocation. It
-   * captures the current {@link #core} reference, wires the push managers to the shared {@link
-   * Ticker}, assembles the daemon-only root FProxy collaborators, and delegates to {@link
-   * FProxyRegistrar} for the remaining HTTP shell registration.
+   * <p>Call this after {@link #setCore(NodeClientCore)} or {@link
+   * #setRuntimeSupport(HttpShellRuntimeSupport)} and before accepting requests to install bookmark
+   * handling, interval push scheduling, and UI registration against the active node. This method is
+   * idempotent; later calls are ignored after the first successful invocation. It captures the
+   * current runtime support reference, wires the push managers to the shared {@link Ticker},
+   * assembles the daemon-only root FProxy collaborators, and delegates to {@link FProxyRegistrar}
+   * for the remaining HTTP shell registration.
    */
   public void createFproxy() {
-    NodeClientCore coreRef = this.core;
     synchronized (this) {
       if (haveCalledFProxy) return;
       haveCalledFProxy = true;
     }
 
+    HttpShellRuntimeSupport runtimeSupportRef = requireRuntimeSupport();
     pushDataManager = new PushDataManager(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
-    bookmarkManager =
-        new BookmarkManager(
-            new CoreBookmarkRuntimeSupport(coreRef), coreRef.getAlerts(), publicGatewayMode());
-
-    HighLevelSimpleClient client =
-        coreRef.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
-    RuntimePorts runtimePorts = coreRef.getRuntimePorts();
+    HttpShellFProxyBootstrap bootstrap =
+        runtimeSupportRef.createFProxyBootstrap(publicGatewayMode());
+    bookmarkManager = bootstrap.bookmarkManager();
+    RuntimePorts runtimePorts = runtimeSupportRef.runtimePorts();
     initializeFProxyRandom(runtimePorts.randomness());
-    FProxyFetchTracker fetchTracker =
-        new FProxyFetchTracker(
-            coreRef.getClientContext(),
-            client.getFetchContext(),
-            new RequestClientBuilder().realTime().build());
-    FProxyToadlet fproxy = new FProxyToadlet(client, coreRef, fetchTracker);
-    coreRef.getEndpoints().setFProxy(fproxy);
 
     FProxyRegistrar.maybeCreateFProxyEtc(
         new FProxyRegistrarDependencies(
-            client, runtimePorts, coreRef.getNode().getConfig(), fproxy),
+            bootstrap.client(), runtimePorts, runtimeSupportRef.config(), bootstrap.fproxy()),
         this);
   }
 
@@ -503,20 +491,25 @@ public final class SimpleToadletServer
   }
 
   /**
-   * Publishes the initialized node core to request handlers.
+   * Publishes the initialized node core to request handlers through the HTTP-local runtime adapter.
    *
-   * <p>The core reference is written with volatile semantics so that listener threads see it after
+   * <p>This compatibility shim wraps the supplied core in {@link CoreHttpShellRuntimeSupport}. The
+   * runtime support reference is written with volatile semantics, so listener threads see it after
    * startup. Call this exactly once, immediately after the node finishes constructing its {@link
-   * NodeClientCore}, and before invoking {@link #createFproxy()} or {@link #start()}. When the core
-   * exposes runtime SPI ports, this method also late-injects the detached page-chrome port into the
-   * shared {@link PageMaker}. Passing {@code null} is not supported and leaves the server unable to
-   * service requests.
+   * NodeClientCore}, and before invoking {@link #createFproxy()} or {@link #start()}. When the
+   * runtime support exposes runtime SPI ports, this method also late-injects the detached
+   * page-chrome port into the shared {@link PageMaker}. Passing {@code null} leaves the server
+   * unable to service requests.
    *
    * @param core fully constructed {@link NodeClientCore}; must not be {@code null}.
    */
   public void setCore(NodeClientCore core) {
-    this.core = core;
-    RuntimePorts runtimePorts = core == null ? null : core.getRuntimePorts();
+    setRuntimeSupport(core == null ? null : new CoreHttpShellRuntimeSupport(core));
+  }
+
+  void setRuntimeSupport(HttpShellRuntimeSupport runtimeSupport) {
+    this.runtimeSupport = runtimeSupport;
+    RuntimePorts runtimePorts = runtimeSupport == null ? null : runtimeSupport.runtimePorts();
     pageMaker.setPageChromePort(runtimePorts == null ? null : runtimePorts.pageChrome());
   }
 
@@ -524,10 +517,11 @@ public final class SimpleToadletServer
    * Creates a SimpleToadletServer bound to the given FProxy configuration.
    *
    * <p>The constructor performs lightweight configuration registration, initializes option
-   * callbacks, and defers expensive wiring (core assignment, network listener startup) to later
-   * calls. It seeds random sources, sets the initial access control list, and records whether the
-   * server should start enabled. The {@link #core} is left {@code null}; callers must invoke {@link
-   * #setCore(NodeClientCore)} before servicing requests.
+   * callbacks, and defers expensive wiring (runtime support assignment, network listener startup)
+   * to later calls. It seeds random sources, sets the initial access control list, and records
+   * whether the server should start enabled. The {@link #runtimeSupport} is left {@code null};
+   * callers must invoke {@link #setCore(NodeClientCore)} or {@link
+   * #setRuntimeSupport(HttpShellRuntimeSupport)} before servicing requests.
    *
    * @param fproxyConfig configuration subsection containing fproxy.* keys that drive listener
    *     options, theme settings, limits, and ACLs; must be non-null.
@@ -543,7 +537,7 @@ public final class SimpleToadletServer
       throws InvalidConfigValueException {
 
     this.executor = executor;
-    this.core = null; // setCore() will be called later.
+    this.runtimeSupport = null; // setCore() or setRuntimeSupport() will be called later.
     this.random = new SecureRandom();
 
     int configItemOrder = registerInitialOptions(fproxyConfig);
@@ -1262,11 +1256,11 @@ public final class SimpleToadletServer
   /**
    * Starts the HTTP listener thread if it has been initialized.
    *
-   * <p>Callers should ensure {@link #setCore(NodeClientCore)} and {@link #createFproxy()} have
-   * completed before invoking this method. When {@link #myThread} is non-null, the network
-   * interface is lazily created and the thread is started, logging the bind address and port. This
-   * call is idempotent when {@link #myThread} is already {@code null} or the thread has previously
-   * been started.
+   * <p>Callers should ensure {@link #setCore(NodeClientCore)} or {@link
+   * #setRuntimeSupport(HttpShellRuntimeSupport)} and {@link #createFproxy()} have completed before
+   * invoking this method. When {@link #myThread} is non-null, the network interface is lazily
+   * created and the thread is started, logging the bind address and port. This call is idempotent
+   * when {@link #myThread} is already {@code null} or the thread has previously been started.
    */
   @SuppressWarnings("java:S106")
   public void start() {
@@ -1292,31 +1286,27 @@ public final class SimpleToadletServer
    * succeeds, {@link #finishedStartup} becomes true, allowing deferred operations to proceed.
    */
   public void finishStart() {
-    core.getNode()
-        .services()
-        .securityLevels()
-        .addNetworkThreatLevelListener(
-            (oldLevel, newLevel) -> {
-              // At LOW, we do ACCEPT_OLD.
-              // Otherwise, we do RE_FILTER.
-              // But we don't change it unless it changes from LOW to not LOW.
-              if (newLevel == NETWORK_THREAT_LEVEL.LOW && newLevel != oldLevel) {
-                refilterPolicy = REFILTER_POLICY.ACCEPT_OLD;
-              } else if (oldLevel == NETWORK_THREAT_LEVEL.LOW && newLevel != oldLevel) {
-                refilterPolicy = REFILTER_POLICY.RE_FILTER;
-              }
-            });
-    core.getNode()
-        .services()
-        .securityLevels()
-        .addPhysicalThreatLevelListener(
-            (oldLevel, newLevel) -> {
-              if (newLevel != oldLevel && newLevel == PHYSICAL_THREAT_LEVEL.LOW) {
-                setPanicButtonVisibility(false);
-              } else if (newLevel != oldLevel) {
-                setPanicButtonVisibility(true);
-              }
-            });
+    HttpShellRuntimeSupport runtimeSupportRef = requireRuntimeSupport();
+    runtimeSupportRef.addNetworkThreatLevelListener(
+        (oldLevel, newLevel) -> {
+          // At LOW, we do ACCEPT_OLD.
+          // Otherwise, we do RE_FILTER.
+          // But we don't change it unless it changes from LOW to not LOW.
+          if (newLevel == HttpShellRuntimeSupport.NetworkThreatLevel.LOW && newLevel != oldLevel) {
+            refilterPolicy = REFILTER_POLICY.ACCEPT_OLD;
+          } else if (oldLevel == HttpShellRuntimeSupport.NetworkThreatLevel.LOW
+              && newLevel != oldLevel) {
+            refilterPolicy = REFILTER_POLICY.RE_FILTER;
+          }
+        });
+    runtimeSupportRef.addPhysicalThreatLevelListener(
+        (oldLevel, newLevel) -> {
+          if (newLevel != oldLevel && newLevel == HttpShellRuntimeSupport.PhysicalThreatLevel.LOW) {
+            setPanicButtonVisibility(false);
+          } else if (newLevel != oldLevel) {
+            setPanicButtonVisibility(true);
+          }
+        });
     synchronized (this) {
       finishedStartup = true;
     }
@@ -1402,8 +1392,10 @@ public final class SimpleToadletServer
   }
 
   private boolean shouldRedirectToWizard(String path) {
-    NodeClientCore coreLocal = this.core;
-    if (coreLocal == null || coreLocal.getNode() == null || fproxyHasCompletedWizard) {
+    HttpShellRuntimeSupport runtimeSupportLocal = this.runtimeSupport;
+    if (runtimeSupportLocal == null
+        || !runtimeSupportLocal.canRedirectToWizard()
+        || fproxyHasCompletedWizard) {
       return false;
     }
     return !isWizardPathAllowed(path);
@@ -1549,18 +1541,19 @@ public final class SimpleToadletServer
   }
 
   /**
-   * Returns the user alert manager associated with the current core.
+   * Returns the user alert manager associated with the current runtime support.
    *
    * <p>The alert manager surfaces node warnings and informational banners to the UI and handles
-   * their dismissal state. When the core has not yet been assigned this method returns {@code
-   * null}; callers should therefore wait until after {@link #setCore(NodeClientCore)} is invoked.
+   * their dismissal state. When runtime support has not yet been assigned this method returns
+   * {@code null}; callers should therefore wait until after {@link #setCore(NodeClientCore)} or
+   * {@link #setRuntimeSupport(HttpShellRuntimeSupport)} is invoked.
    *
-   * @return active {@link UserAlertManager} from the core, or {@code null} when unavailable.
+   * @return active {@link UserAlertManager}, or {@code null} when unavailable.
    */
   public UserAlertManager getUserAlertManager() {
-    NodeClientCore coreRef = this.core;
-    if (coreRef == null) return null;
-    return coreRef.getAlerts();
+    HttpShellRuntimeSupport runtimeSupportRef = this.runtimeSupport;
+    if (runtimeSupportRef == null) return null;
+    return runtimeSupportRef.userAlerts();
   }
 
   /**
@@ -1592,7 +1585,7 @@ public final class SimpleToadletServer
       if (advancedModeEnabled == enabled) return;
       advancedModeEnabled = enabled;
     }
-    core.getNode().getConfig().store();
+    requireRuntimeSupport().storeConfig();
   }
 
   @Override
@@ -1635,8 +1628,9 @@ public final class SimpleToadletServer
 
   @Override
   public String getFormPassword() {
-    if (core == null) return "";
-    return core.getFormPassword();
+    HttpShellRuntimeSupport runtimeSupportRef = this.runtimeSupport;
+    if (runtimeSupportRef == null) return "";
+    return runtimeSupportRef.formPassword();
   }
 
   @Override
@@ -1804,19 +1798,28 @@ public final class SimpleToadletServer
    * @return {@link Ticker} from the node; never {@code null} after the core is set.
    */
   public Ticker getTicker() {
-    return core.getNode().network().ticker();
+    return requireRuntimeSupport().ticker();
   }
 
   /**
-   * Returns the currently bound node core.
+   * Returns the currently bound node core when runtime support is core-backed.
    *
-   * <p>Callers must not mutate the core state in ways that violate server invariants. The reference
-   * may change only through {@link #setCore(NodeClientCore)} during startup.
+   * <p>This compatibility accessor is retained for callers that still expect a {@link
+   * NodeClientCore}. When the server was initialized with a non-core-backed runtime adapter, this
+   * method returns {@code null}.
    *
    * @return {@link NodeClientCore} instance or {@code null} when unset.
    */
   public NodeClientCore getCore() {
-    return core;
+    HttpShellRuntimeSupport runtimeSupportRef = this.runtimeSupport;
+    if (runtimeSupportRef instanceof CoreHttpShellRuntimeSupport(NodeClientCore core)) {
+      return core;
+    }
+    return null;
+  }
+
+  private HttpShellRuntimeSupport requireRuntimeSupport() {
+    return Objects.requireNonNull(runtimeSupport);
   }
 
   private REFILTER_POLICY refilterPolicy;

--- a/src/test/java/network/crypta/clients/http/CoreHttpShellRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/clients/http/CoreHttpShellRuntimeSupportTest.java
@@ -1,0 +1,377 @@
+package network.crypta.clients.http;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import network.crypta.client.FetchContext;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.async.ClientContext;
+import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.clients.http.bookmark.CoreBookmarkRuntimeSupport;
+import network.crypta.config.PersistentConfig;
+import network.crypta.node.ClientEndpoints;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.node.SecurityLevelListener;
+import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
+import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.node.SecurityLevels;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.node.subsystem.NodeServicesSubsystem;
+import network.crypta.node.useralerts.UserAlertManager;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.Ticker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class CoreHttpShellRuntimeSupportTest {
+
+  @Test
+  void constructor_whenCoreIsNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new CoreHttpShellRuntimeSupport(null));
+  }
+
+  @Test
+  void runtimePorts_whenCoreProvidesPorts_returnsSamePorts() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    when(core.getRuntimePorts()).thenReturn(runtimePorts);
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    RuntimePorts actualRuntimePorts = runtimeSupport.runtimePorts();
+
+    assertSame(runtimePorts, actualRuntimePorts);
+  }
+
+  @Test
+  void config_whenNodeProvidesConfig_returnsSameConfig() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    PersistentConfig config = mock(PersistentConfig.class);
+    when(core.getNode()).thenReturn(node);
+    when(node.getConfig()).thenReturn(config);
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    PersistentConfig actualConfig = (PersistentConfig) runtimeSupport.config();
+
+    assertSame(config, actualConfig);
+  }
+
+  @Test
+  void ticker_whenNodeProvidesTicker_returnsSameTicker() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
+    Ticker ticker = mock(Ticker.class);
+    when(core.getNode()).thenReturn(node);
+    when(node.network()).thenReturn(network);
+    when(network.ticker()).thenReturn(ticker);
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    Ticker actualTicker = runtimeSupport.ticker();
+
+    assertSame(ticker, actualTicker);
+  }
+
+  @Test
+  void userAlerts_whenCoreProvidesAlerts_returnsSameAlerts() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    when(core.getAlerts()).thenReturn(alerts);
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    UserAlertManager actualAlerts = runtimeSupport.userAlerts();
+
+    assertSame(alerts, actualAlerts);
+  }
+
+  @Test
+  void formPassword_whenCoreProvidesPassword_returnsSamePassword() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    when(core.getFormPassword()).thenReturn("secret-token");
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    String formPassword = runtimeSupport.formPassword();
+
+    assertEquals("secret-token", formPassword);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void allowUploadFrom_whenCoreReturnsDecision_propagatesDecision(boolean allowed) {
+    NodeClientCore core = mock(NodeClientCore.class);
+    File uploadTarget = new File("allowed-upload.txt");
+    when(core.allowUploadFrom(uploadTarget)).thenReturn(allowed);
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    boolean uploadAllowed = runtimeSupport.allowUploadFrom(uploadTarget);
+
+    assertEquals(allowed, uploadAllowed);
+  }
+
+  @Test
+  void storeConfig_whenInvoked_storesConfig() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    PersistentConfig config = mock(PersistentConfig.class);
+    when(core.getNode()).thenReturn(node);
+    when(node.getConfig()).thenReturn(config);
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    runtimeSupport.storeConfig();
+
+    verify(config).store();
+  }
+
+  @Test
+  void canRedirectToWizard_whenUsingCoreRuntime_returnsTrue() {
+    CoreHttpShellRuntimeSupport runtimeSupport =
+        new CoreHttpShellRuntimeSupport(mock(NodeClientCore.class));
+
+    boolean canRedirect = runtimeSupport.canRedirectToWizard();
+
+    assertTrue(canRedirect);
+  }
+
+  @Test
+  void addNetworkThreatLevelListener_whenListenerIsNull_throwsNullPointerException() {
+    CoreHttpShellRuntimeSupport runtimeSupport =
+        new CoreHttpShellRuntimeSupport(mock(NodeClientCore.class));
+
+    assertThrows(
+        NullPointerException.class, () -> runtimeSupport.addNetworkThreatLevelListener(null));
+  }
+
+  @Test
+  void addPhysicalThreatLevelListener_whenListenerIsNull_throwsNullPointerException() {
+    CoreHttpShellRuntimeSupport runtimeSupport =
+        new CoreHttpShellRuntimeSupport(mock(NodeClientCore.class));
+
+    assertThrows(
+        NullPointerException.class, () -> runtimeSupport.addPhysicalThreatLevelListener(null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("networkThreatLevelMappings")
+  void addNetworkThreatLevelListener_whenSecurityLevelsChange_mapsDetachedEnums(
+      NETWORK_THREAT_LEVEL oldLevel,
+      HttpShellRuntimeSupport.NetworkThreatLevel expectedOldLevel,
+      NETWORK_THREAT_LEVEL newLevel,
+      HttpShellRuntimeSupport.NetworkThreatLevel expectedNewLevel) {
+    NetworkListenerContext context = newNetworkListenerContext();
+    AtomicReference<HttpShellRuntimeSupport.NetworkThreatLevel> actualOldLevel =
+        new AtomicReference<>();
+    AtomicReference<HttpShellRuntimeSupport.NetworkThreatLevel> actualNewLevel =
+        new AtomicReference<>();
+
+    context.runtimeSupport.addNetworkThreatLevelListener(
+        (capturedOldLevel, capturedNewLevel) -> {
+          actualOldLevel.set(capturedOldLevel);
+          actualNewLevel.set(capturedNewLevel);
+        });
+
+    assertNotNull(context.listener.get());
+
+    context.listener.get().onChange(oldLevel, newLevel);
+
+    assertEquals(expectedOldLevel, actualOldLevel.get());
+    assertEquals(expectedNewLevel, actualNewLevel.get());
+  }
+
+  @ParameterizedTest
+  @MethodSource("physicalThreatLevelMappings")
+  void addPhysicalThreatLevelListener_whenSecurityLevelsChange_mapsDetachedEnums(
+      PHYSICAL_THREAT_LEVEL oldLevel,
+      HttpShellRuntimeSupport.PhysicalThreatLevel expectedOldLevel,
+      PHYSICAL_THREAT_LEVEL newLevel,
+      HttpShellRuntimeSupport.PhysicalThreatLevel expectedNewLevel) {
+    PhysicalListenerContext context = newPhysicalListenerContext();
+    AtomicReference<HttpShellRuntimeSupport.PhysicalThreatLevel> actualOldLevel =
+        new AtomicReference<>();
+    AtomicReference<HttpShellRuntimeSupport.PhysicalThreatLevel> actualNewLevel =
+        new AtomicReference<>();
+
+    context.runtimeSupport.addPhysicalThreatLevelListener(
+        (capturedOldLevel, capturedNewLevel) -> {
+          actualOldLevel.set(capturedOldLevel);
+          actualNewLevel.set(capturedNewLevel);
+        });
+
+    assertNotNull(context.listener.get());
+
+    context.listener.get().onChange(oldLevel, newLevel);
+
+    assertEquals(expectedOldLevel, actualOldLevel.get());
+    assertEquals(expectedNewLevel, actualNewLevel.get());
+  }
+
+  @Test
+  void createFProxyBootstrap_whenInvoked_constructsDependenciesAndPublishesFProxy() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    ClientContext clientContext = mock(ClientContext.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    ClientEndpoints endpoints = mock(ClientEndpoints.class);
+    AtomicReference<List<Object>> bookmarkManagerArguments = new AtomicReference<>();
+    AtomicReference<List<Object>> fetchTrackerArguments = new AtomicReference<>();
+    AtomicReference<List<Object>> fproxyArguments = new AtomicReference<>();
+    when(core.getAlerts()).thenReturn(alerts);
+    when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(client.getFetchContext()).thenReturn(fetchContext);
+    when(core.getEndpoints()).thenReturn(endpoints);
+    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+
+    try (MockedConstruction<BookmarkManager> bookmarkManagers =
+            mockConstruction(
+                BookmarkManager.class,
+                (_, invocation) ->
+                    bookmarkManagerArguments.set(List.copyOf(invocation.arguments())));
+        MockedConstruction<FProxyFetchTracker> fetchTrackers =
+            mockConstruction(
+                FProxyFetchTracker.class,
+                (_, invocation) -> fetchTrackerArguments.set(List.copyOf(invocation.arguments())));
+        MockedConstruction<FProxyToadlet> fproxies =
+            mockConstruction(
+                FProxyToadlet.class,
+                (_, invocation) -> fproxyArguments.set(List.copyOf(invocation.arguments())))) {
+      HttpShellFProxyBootstrap bootstrap = runtimeSupport.createFProxyBootstrap(true);
+
+      assertEquals(1, bookmarkManagers.constructed().size());
+      assertEquals(1, fetchTrackers.constructed().size());
+      assertEquals(1, fproxies.constructed().size());
+      assertInstanceOf(CoreBookmarkRuntimeSupport.class, bookmarkManagerArguments.get().get(0));
+      assertSame(alerts, bookmarkManagerArguments.get().get(1));
+      assertEquals(Boolean.TRUE, bookmarkManagerArguments.get().get(2));
+      assertSame(clientContext, fetchTrackerArguments.get().get(0));
+      assertSame(fetchContext, fetchTrackerArguments.get().get(1));
+      assertNotNull(fetchTrackerArguments.get().get(2));
+      assertSame(client, fproxyArguments.get().get(0));
+      assertSame(core, fproxyArguments.get().get(1));
+      assertSame(fetchTrackers.constructed().getFirst(), fproxyArguments.get().get(2));
+      assertSame(bookmarkManagers.constructed().getFirst(), bootstrap.bookmarkManager());
+      assertSame(client, bootstrap.client());
+      assertSame(fproxies.constructed().getFirst(), bootstrap.fproxy());
+      verify(endpoints).setFProxy(fproxies.constructed().getFirst());
+    }
+  }
+
+  private static Stream<Arguments> networkThreatLevelMappings() {
+    return Stream.of(
+        Arguments.of(
+            NETWORK_THREAT_LEVEL.LOW,
+            HttpShellRuntimeSupport.NetworkThreatLevel.LOW,
+            NETWORK_THREAT_LEVEL.NORMAL,
+            HttpShellRuntimeSupport.NetworkThreatLevel.NORMAL),
+        Arguments.of(
+            NETWORK_THREAT_LEVEL.NORMAL,
+            HttpShellRuntimeSupport.NetworkThreatLevel.NORMAL,
+            NETWORK_THREAT_LEVEL.HIGH,
+            HttpShellRuntimeSupport.NetworkThreatLevel.HIGH),
+        Arguments.of(
+            NETWORK_THREAT_LEVEL.HIGH,
+            HttpShellRuntimeSupport.NetworkThreatLevel.HIGH,
+            NETWORK_THREAT_LEVEL.MAXIMUM,
+            HttpShellRuntimeSupport.NetworkThreatLevel.MAXIMUM),
+        Arguments.of(
+            NETWORK_THREAT_LEVEL.MAXIMUM,
+            HttpShellRuntimeSupport.NetworkThreatLevel.MAXIMUM,
+            NETWORK_THREAT_LEVEL.LOW,
+            HttpShellRuntimeSupport.NetworkThreatLevel.LOW));
+  }
+
+  private static Stream<Arguments> physicalThreatLevelMappings() {
+    return Stream.of(
+        Arguments.of(
+            PHYSICAL_THREAT_LEVEL.LOW,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.LOW,
+            PHYSICAL_THREAT_LEVEL.NORMAL,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.NORMAL),
+        Arguments.of(
+            PHYSICAL_THREAT_LEVEL.NORMAL,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.NORMAL,
+            PHYSICAL_THREAT_LEVEL.HIGH,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.HIGH),
+        Arguments.of(
+            PHYSICAL_THREAT_LEVEL.HIGH,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.HIGH,
+            PHYSICAL_THREAT_LEVEL.MAXIMUM,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.MAXIMUM),
+        Arguments.of(
+            PHYSICAL_THREAT_LEVEL.MAXIMUM,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.MAXIMUM,
+            PHYSICAL_THREAT_LEVEL.LOW,
+            HttpShellRuntimeSupport.PhysicalThreatLevel.LOW));
+  }
+
+  private static NetworkListenerContext newNetworkListenerContext() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    SecurityLevels securityLevels = mock(SecurityLevels.class);
+    AtomicReference<SecurityLevelListener<NETWORK_THREAT_LEVEL>> listener = new AtomicReference<>();
+    when(core.getNode()).thenReturn(node);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    doAnswer(
+            invocation -> {
+              listener.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(securityLevels)
+        .addNetworkThreatLevelListener(any());
+    return new NetworkListenerContext(new CoreHttpShellRuntimeSupport(core), listener);
+  }
+
+  private static PhysicalListenerContext newPhysicalListenerContext() {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    SecurityLevels securityLevels = mock(SecurityLevels.class);
+    AtomicReference<SecurityLevelListener<PHYSICAL_THREAT_LEVEL>> listener =
+        new AtomicReference<>();
+    when(core.getNode()).thenReturn(node);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    doAnswer(
+            invocation -> {
+              listener.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(securityLevels)
+        .addPhysicalThreatLevelListener(any());
+    return new PhysicalListenerContext(new CoreHttpShellRuntimeSupport(core), listener);
+  }
+
+  private record NetworkListenerContext(
+      CoreHttpShellRuntimeSupport runtimeSupport,
+      AtomicReference<SecurityLevelListener<NETWORK_THREAT_LEVEL>> listener) {}
+
+  private record PhysicalListenerContext(
+      CoreHttpShellRuntimeSupport runtimeSupport,
+      AtomicReference<SecurityLevelListener<PHYSICAL_THREAT_LEVEL>> listener) {}
+}

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -16,7 +16,6 @@ import network.crypta.config.SubConfig;
 import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
 import network.crypta.node.ClientEndpoints;
-import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.useralerts.UserAlertManager;
@@ -39,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -85,19 +86,19 @@ class SimpleToadletServerTest {
   }
 
   @Test
-  void findToadlet_whenWizardIncomplete_redirectsToWizard() throws Exception {
+  void findToadlet_whenWizardIncomplete_redirectsToWizardAndPreservesQuery() throws Exception {
     SimpleToadletServer server = newServerWithDefaults();
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getNode()).thenReturn(node);
-    server.setCore(core);
+    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
+    when(runtimeSupport.canRedirectToWizard()).thenReturn(true);
+    server.setRuntimeSupport(runtimeSupport);
 
     PermanentRedirectException ex =
         assertThrows(
             PermanentRedirectException.class,
-            () -> server.findToadlet(new URI("http://localhost/hidden")));
+            () -> server.findToadlet(new URI("http://localhost/hidden?step=1")));
 
     assertEquals(FirstTimeWizardToadlet.TOADLET_URL, ex.newuri.getPath());
+    assertEquals("step=1", ex.newuri.getQuery());
   }
 
   @Test
@@ -191,11 +192,79 @@ class SimpleToadletServerTest {
   }
 
   @Test
-  void addFormChild_whenCoreProvidesPassword_includesHiddenInput() throws Exception {
+  void finishStart_whenThreatLevelsChange_updatesRefilterPolicyAndPanicVisibility()
+      throws Exception {
     SimpleToadletServer server = newServerWithDefaults();
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getFormPassword()).thenReturn("secret-token");
-    server.setCore(core);
+    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
+    AtomicReference<
+            HttpShellRuntimeSupport.ThreatLevelListener<HttpShellRuntimeSupport.NetworkThreatLevel>>
+        networkListener = new AtomicReference<>();
+    AtomicReference<
+            HttpShellRuntimeSupport.ThreatLevelListener<
+                HttpShellRuntimeSupport.PhysicalThreatLevel>>
+        physicalListener = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              networkListener.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(runtimeSupport)
+        .addNetworkThreatLevelListener(any());
+    doAnswer(
+            invocation -> {
+              physicalListener.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(runtimeSupport)
+        .addPhysicalThreatLevelListener(any());
+    server.setRuntimeSupport(runtimeSupport);
+    boolean originalPanicButtonState = SimpleToadletServer.isPanicButtonToBeShown;
+    try {
+      SimpleToadletServer.isPanicButtonToBeShown = true;
+
+      server.finishStart();
+
+      assertNotNull(networkListener.get());
+      assertNotNull(physicalListener.get());
+
+      networkListener
+          .get()
+          .onChange(
+              HttpShellRuntimeSupport.NetworkThreatLevel.NORMAL,
+              HttpShellRuntimeSupport.NetworkThreatLevel.LOW);
+      assertEquals(FProxyFetchInProgress.REFILTER_POLICY.ACCEPT_OLD, server.getReFilterPolicy());
+
+      networkListener
+          .get()
+          .onChange(
+              HttpShellRuntimeSupport.NetworkThreatLevel.LOW,
+              HttpShellRuntimeSupport.NetworkThreatLevel.NORMAL);
+      assertEquals(FProxyFetchInProgress.REFILTER_POLICY.RE_FILTER, server.getReFilterPolicy());
+
+      physicalListener
+          .get()
+          .onChange(
+              HttpShellRuntimeSupport.PhysicalThreatLevel.NORMAL,
+              HttpShellRuntimeSupport.PhysicalThreatLevel.LOW);
+      assertFalse(SimpleToadletServer.isPanicButtonToBeShown);
+
+      physicalListener
+          .get()
+          .onChange(
+              HttpShellRuntimeSupport.PhysicalThreatLevel.LOW,
+              HttpShellRuntimeSupport.PhysicalThreatLevel.NORMAL);
+      assertTrue(SimpleToadletServer.isPanicButtonToBeShown);
+    } finally {
+      SimpleToadletServer.isPanicButtonToBeShown = originalPanicButtonState;
+    }
+  }
+
+  @Test
+  void addFormChild_whenRuntimeSupportProvidesPassword_includesHiddenInput() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
+    when(runtimeSupport.formPassword()).thenReturn("secret-token");
+    server.setRuntimeSupport(runtimeSupport);
 
     HTMLNode parent = new HTMLNode("div");
 


### PR DESCRIPTION
## Summary
- add a package-local HTTP runtime seam with `HttpShellRuntimeSupport`, `CoreHttpShellRuntimeSupport`, and `HttpShellFProxyBootstrap`
- refactor `SimpleToadletServer` to depend on the local runtime adapter instead of storing `NodeClientCore`, while keeping `setCore(NodeClientCore)` as a compatibility shim
- add focused HTTP tests for the core-backed adapter and update shell tests; add doclint-clean Javadoc for the new production files

## Testing
- `./gradlew test --tests 'network.crypta.clients.http.SimpleToadletServerTest'`
- `./gradlew test --tests 'network.crypta.clients.http.FProxyRegistrarTest' --tests 'network.crypta.clients.http.bookmark.*'`
- `./gradlew test --tests 'network.crypta.clients.http.CoreHttpShellRuntimeSupportTest'`
- `./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/clients/http/CoreHttpShellRuntimeSupportTest.java`
- `./gradlew test`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/http/CoreHttpShellRuntimeSupport.java`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/http/HttpShellFProxyBootstrap.java`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java`
