### PR TITLE
refactor(http): Add FProxy runtime adapter

### DIFF
--- a/src/main/java/network/crypta/clients/http/CoreFProxyRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/CoreFProxyRuntimeSupport.java
@@ -1,0 +1,132 @@
+package network.crypta.clients.http;
+
+import java.io.File;
+import java.util.Objects;
+import network.crypta.client.async.ClientContext;
+import network.crypta.config.SubConfig;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
+import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+
+/**
+ * Core-backed implementation of {@link FProxyRuntimeSupport}.
+ *
+ * <p>This adapter is the HTTP package's assembly seam between {@link FProxyToadlet} and {@link
+ * NodeClientCore}. It translates the broad daemon API into the small set of values and callbacks
+ * that FProxy currently consumes, including threat-level state, download policy, and the node
+ * executor used for background follow-up work. The adapter stays package-private because it is an
+ * internal wiring detail of {@code clients/http}, not a reusable cross-module contract.
+ *
+ * <p>The record is immutable after construction and delegates every call directly to the wrapped
+ * core. It does not cache mutable security state or configuration snapshots, so callers continue to
+ * observe the current daemon settings each time they consult the adapter.
+ */
+record CoreFProxyRuntimeSupport(NodeClientCore core) implements FProxyRuntimeSupport {
+
+  /**
+   * Creates an adapter over the supplied node core.
+   *
+   * <p>The constructor rejects {@code null} eagerly because all later methods delegate directly to
+   * the wrapped core and would otherwise fail at unrelated call sites. Callers typically create one
+   * instance during HTTP bootstrap and pass it into the long-lived {@link FProxyToadlet}.
+   *
+   * @param core live daemon core that provides FProxy runtime services.
+   */
+  CoreFProxyRuntimeSupport(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ClientContext clientContext() {
+    return core.getClientContext();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PhysicalThreatLevel physicalThreatLevel() {
+    return mapPhysicalThreatLevel(
+        core.getNode().services().securityLevels().getPhysicalThreatLevel());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public NetworkThreatLevel networkThreatLevel() {
+    return mapNetworkThreatLevel(
+        core.getNode().services().securityLevels().getNetworkThreatLevel());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isDownloadDisabled() {
+    return core.isDownloadDisabled();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public File downloadsDir() {
+    return core.getDownloadsDir();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean allowDownloadTo(File file) {
+    return core.allowDownloadTo(file);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public File[] allowedDownloadDirs() {
+    return core.getAllowedDownloadDirs();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void executeBackground(Runnable task) {
+    core.getNode().network().executor().execute(task);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SubConfig fproxyConfig() {
+    return core.getNode().getConfig().get("fproxy");
+  }
+
+  /**
+   * Maps the node's physical-threat enum into the local HTTP-facing enum.
+   *
+   * <p>This translation keeps {@link FProxyToadlet} independent of node security types while
+   * preserving the one-to-one meaning of each threat level.
+   *
+   * @param threatLevel physical-threat value reported by the node security subsystem.
+   * @return the equivalent local threat-level value used by HTTP code.
+   */
+  private static FProxyRuntimeSupport.PhysicalThreatLevel mapPhysicalThreatLevel(
+      PHYSICAL_THREAT_LEVEL threatLevel) {
+    return switch (threatLevel) {
+      case LOW -> FProxyRuntimeSupport.PhysicalThreatLevel.LOW;
+      case NORMAL -> FProxyRuntimeSupport.PhysicalThreatLevel.NORMAL;
+      case HIGH -> FProxyRuntimeSupport.PhysicalThreatLevel.HIGH;
+      case MAXIMUM -> FProxyRuntimeSupport.PhysicalThreatLevel.MAXIMUM;
+    };
+  }
+
+  /**
+   * Maps the node's network-threat enum into the local HTTP-facing enum.
+   *
+   * <p>This translation mirrors {@link #mapPhysicalThreatLevel(PHYSICAL_THREAT_LEVEL)} and keeps
+   * the package-local runtime seam free of node security API types.
+   *
+   * @param threatLevel network-threat value reported by the node security subsystem.
+   * @return the equivalent local threat-level value used by HTTP code.
+   */
+  private static FProxyRuntimeSupport.NetworkThreatLevel mapNetworkThreatLevel(
+      NETWORK_THREAT_LEVEL threatLevel) {
+    return switch (threatLevel) {
+      case LOW -> FProxyRuntimeSupport.NetworkThreatLevel.LOW;
+      case NORMAL -> FProxyRuntimeSupport.NetworkThreatLevel.NORMAL;
+      case HIGH -> FProxyRuntimeSupport.NetworkThreatLevel.HIGH;
+      case MAXIMUM -> FProxyRuntimeSupport.NetworkThreatLevel.MAXIMUM;
+    };
+  }
+}

--- a/src/main/java/network/crypta/clients/http/CoreHttpShellRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/CoreHttpShellRuntimeSupport.java
@@ -117,7 +117,8 @@ record CoreHttpShellRuntimeSupport(NodeClientCore core) implements HttpShellRunt
             core.getClientContext(),
             client.getFetchContext(),
             new RequestClientBuilder().realTime().build());
-    FProxyToadlet fproxy = new FProxyToadlet(client, core, fetchTracker);
+    FProxyRuntimeSupport fproxyRuntimeSupport = new CoreFProxyRuntimeSupport(core);
+    FProxyToadlet fproxy = new FProxyToadlet(client, fproxyRuntimeSupport, fetchTracker);
     core.getEndpoints().setFProxy(fproxy);
     return new HttpShellFProxyBootstrap(bookmarkManager, client, fproxy);
   }

--- a/src/main/java/network/crypta/clients/http/FProxyRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRuntimeSupport.java
@@ -1,0 +1,147 @@
+package network.crypta.clients.http;
+
+import java.io.File;
+import network.crypta.client.async.ClientContext;
+import network.crypta.config.SubConfig;
+
+/**
+ * Supplies the runtime-facing services that {@link FProxyToadlet} needs from the live daemon.
+ *
+ * <p>This interface keeps the HTTP-side FProxy code coupled to a narrow, package-local contract
+ * instead of the full node core. The surface is intentionally small: it exposes only the client
+ * context, threat-level state, download-policy checks, background execution, and the FProxy
+ * sub-configuration needed to preserve current behavior. Code in {@code clients/http} can depend on
+ * this seam without pulling in broader node assembly concerns.
+ *
+ * <p>Implementations typically wrap a long-lived daemon object and delegate directly. Callers are
+ * expected to get one instance during HTTP bootstrap and reuse it for the lifetime of the toadlet
+ * registration.
+ */
+interface FProxyRuntimeSupport {
+
+  /**
+   * Returns the client context used to schedule and track FProxy fetch operations.
+   *
+   * <p>The returned context is the same one that would previously have been read from the live
+   * daemon core. {@link FProxyToadlet} caches this reference at construction time so later request
+   * handling can create fetchers and callbacks without needing additional access to the core
+   * object.
+   *
+   * @return the active client context backing HTTP-side fetch work.
+   */
+  ClientContext clientContext();
+
+  /**
+   * Returns the current physical-threat policy that should govern local download behavior.
+   *
+   * <p>FProxy uses this value to decide whether disk-download controls should be shown or
+   * suppressed for the current node security posture. The enum is a local to the HTTP package, so
+   * callers do not need to import node-level security types.
+   *
+   * @return the physical-threat level currently enforced for the node.
+   */
+  PhysicalThreatLevel physicalThreatLevel();
+
+  /**
+   * Returns the current network-threat policy that should govern local download behavior.
+   *
+   * <p>Combined with {@link #physicalThreatLevel()}, this value determines which download actions
+   * remain available from the browser UI. The local enum preserves the existing decision points
+   * while avoiding a direct dependency on the node security API from {@link FProxyToadlet}.
+   *
+   * @return the network-threat level currently enforced for the node.
+   */
+  NetworkThreatLevel networkThreatLevel();
+
+  /**
+   * Reports whether downloads to local storage are globally disabled.
+   *
+   * <p>This check represents a hard gate. When it returns {@code true}, FProxy should avoid
+   * presenting or executing disk-download flows even if the request path would otherwise be valid.
+   *
+   * @return {@code true} when local downloads are disabled for this node instance.
+   */
+  boolean isDownloadDisabled();
+
+  /**
+   * Returns the default download directory configured for the local node.
+   *
+   * <p>FProxy uses this path as the primary destination suggestion when it offers download-to-disk
+   * actions. The path may still be subject to additional allowlist checks via {@link
+   * #allowDownloadTo(File)} and {@link #allowedDownloadDirs()}.
+   *
+   * @return the configured default directory for downloads.
+   */
+  File downloadsDir();
+
+  /**
+   * Checks whether a specific destination path is allowed for download-to-disk operations.
+   *
+   * <p>The check is used to preserve the node's existing download sandbox rules. Callers should
+   * treat a {@code false} result as authoritative and avoid presenting the corresponding location
+   * as a selectable writing target.
+   *
+   * @param file destination file or directory candidate to validate against node policy.
+   * @return {@code true} when the supplied path is allowed for downloads.
+   */
+  boolean allowDownloadTo(File file);
+
+  /**
+   * Returns the configured allowlist roots for download-to-disk operations.
+   *
+   * <p>FProxy uses these directories when it needs to explain or evaluate where files may be saved.
+   * The returned array is owned by the implementation; callers should treat it as read-only
+   * configuration data.
+   *
+   * @return the allowed download directory roots currently configured for the node.
+   */
+  File[] allowedDownloadDirs();
+
+  /**
+   * Schedules background work needed for asynchronous HTTP-side follow-up tasks.
+   *
+   * <p>The supplied task runs on the node-managed executor associated with FProxy support work.
+   * Callers use this hook for fire-and-forget tasks such as prefetch follow-up, not for request
+   * threads that must complete inline with the current HTTP response.
+   *
+   * @param task runnable unit of background work to execute.
+   */
+  void executeBackground(Runnable task);
+
+  /**
+   * Returns the live {@code fproxy} sub-configuration.
+   *
+   * <p>This remains part of the local seam because FProxy still reads a few settings directly from
+   * the HTTP layer. The method intentionally exposes {@link SubConfig} instead of introducing a
+   * wider shared SPI before the rest of the HTTP refactor is ready.
+   *
+   * @return the sub-configuration containing FProxy-specific settings.
+   */
+  SubConfig fproxyConfig();
+
+  /**
+   * Describes the local machine-threat posture used when deciding whether disk actions are safe.
+   */
+  enum PhysicalThreatLevel {
+    /** Local physical access is treated as low risk. */
+    LOW,
+    /** Local physical access is treated as requiring the default safeguards. */
+    NORMAL,
+    /** Local physical access is treated as high risk, and disk actions become more restricted. */
+    HIGH,
+    /** Local physical access is treated as maximally hostile and disk actions are suppressed. */
+    MAXIMUM
+  }
+
+  /** Describes the network-threat posture used when deciding whether disk actions are safe. */
+  enum NetworkThreatLevel {
+    /** Remote network observation or interference is treated as low risk. */
+    LOW,
+    /** Remote network observation or interference is treated as requiring default safeguards. */
+    NORMAL,
+    /** Remote network observation or interference is treated as high risk. */
+    HIGH,
+    /** Remote network observation or interference is treated as maximally hostile. */
+    MAXIMUM
+  }
+}

--- a/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,12 +39,9 @@ import network.crypta.crypt.SHA256;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
 import network.crypta.node.RequestStarter;
-import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
-import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.HexUtil;
@@ -141,7 +139,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
   static final String CATEGORY_CONFIG = L10N_PREFIX + "categoryConfig";
 
   static byte[] random;
-  final NodeClientCore core;
+  final FProxyRuntimeSupport runtimeSupport;
   final ClientContext context;
   final FProxyFetchTracker fetchTracker;
 
@@ -264,20 +262,24 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
    * Creates a toadlet bound to the given client and node services.
    *
    * <p>The constructor wires the high-level client with size limits suitable for non-progress
-   * transfers and caches references to the node core, client context, and fetch tracker. Instances
-   * are expected to be registered once with the container and reused across requests.
+   * transfers and caches references to the local runtime support, client context, and fetch
+   * tracker. Instances are expected to be registered once with the container and reused across
+   * requests.
    *
    * @param client high-level fetch client used to perform HTTP-facing retrievals.
-   * @param core node core providing configuration, security levels, and download paths.
+   * @param runtimeSupport local runtime support providing configuration, security levels, and
+   *     download paths.
    * @param tracker shared fetch tracker coordinating progress reporting and reuse.
    */
-  public FProxyToadlet(
-      final HighLevelSimpleClient client, NodeClientCore core, FProxyFetchTracker tracker) {
+  FProxyToadlet(
+      final HighLevelSimpleClient client,
+      FProxyRuntimeSupport runtimeSupport,
+      FProxyFetchTracker tracker) {
     super(client);
     client.setMaxLength(getMaxLengthNoProgress());
     client.setMaxIntermediateLength(getMaxLengthNoProgress());
-    this.core = core;
-    this.context = core.getClientContext();
+    this.runtimeSupport = runtimeSupport;
+    this.context = runtimeSupport.clientContext();
     fetchTracker = tracker;
   }
 
@@ -323,24 +325,25 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       String mimeType,
       boolean disableFiltration,
       boolean dontShowFilter,
-      NodeClientCore core) {
-    PHYSICAL_THREAT_LEVEL threatLevel =
-        core.getNode().services().securityLevels().getPhysicalThreatLevel();
-    NETWORK_THREAT_LEVEL netLevel =
-        core.getNode().services().securityLevels().getNetworkThreatLevel();
+      FProxyRuntimeSupport runtimeSupport) {
+    FProxyRuntimeSupport.PhysicalThreatLevel threatLevel = runtimeSupport.physicalThreatLevel();
+    FProxyRuntimeSupport.NetworkThreatLevel netLevel = runtimeSupport.networkThreatLevel();
     boolean filterChecked = shouldEnableFilter(mimeType, disableFiltration, threatLevel, netLevel);
 
-    addDownloadToDiskOption(ctx, optionList, key, mimeType, filterChecked, dontShowFilter, core);
-    addDirectFetchOption(ctx, optionList, key, mimeType, filterChecked, dontShowFilter, core);
+    addDownloadToDiskOption(
+        ctx, optionList, key, mimeType, filterChecked, dontShowFilter, runtimeSupport);
+    addDirectFetchOption(
+        ctx, optionList, key, mimeType, filterChecked, dontShowFilter, runtimeSupport);
   }
 
   private static boolean shouldEnableFilter(
       String mimeType,
       boolean disableFiltration,
-      PHYSICAL_THREAT_LEVEL threatLevel,
-      NETWORK_THREAT_LEVEL netLevel) {
+      FProxyRuntimeSupport.PhysicalThreatLevel threatLevel,
+      FProxyRuntimeSupport.NetworkThreatLevel netLevel) {
     boolean filterChecked =
-        !((threatLevel == PHYSICAL_THREAT_LEVEL.LOW && netLevel == NETWORK_THREAT_LEVEL.LOW)
+        !((threatLevel == FProxyRuntimeSupport.PhysicalThreatLevel.LOW
+                && netLevel == FProxyRuntimeSupport.NetworkThreatLevel.LOW)
             || disableFiltration);
     if (filterChecked
         && mimeType != null
@@ -348,10 +351,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
         && !mimeType.isEmpty()) {
       FilterMIMEType type = ContentFilter.getMIMEType(mimeType);
       if ((type == null || !(type.safeToRead || type.readFilter != null))
-          && !(threatLevel == PHYSICAL_THREAT_LEVEL.HIGH
-              || threatLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM
-              || netLevel == NETWORK_THREAT_LEVEL.HIGH
-              || netLevel == NETWORK_THREAT_LEVEL.MAXIMUM)) {
+          && !(threatLevel == FProxyRuntimeSupport.PhysicalThreatLevel.HIGH
+              || threatLevel == FProxyRuntimeSupport.PhysicalThreatLevel.MAXIMUM
+              || netLevel == FProxyRuntimeSupport.NetworkThreatLevel.HIGH
+              || netLevel == FProxyRuntimeSupport.NetworkThreatLevel.MAXIMUM)) {
         filterChecked = false;
       }
     }
@@ -365,10 +368,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       String mimeType,
       boolean filterChecked,
       boolean dontShowFilter,
-      NodeClientCore core) {
-    PHYSICAL_THREAT_LEVEL threatLevel =
-        core.getNode().services().securityLevels().getPhysicalThreatLevel();
-    if (threatLevel == PHYSICAL_THREAT_LEVEL.MAXIMUM || isDownloadDisabledOrUnsafe(ctx, core)) {
+      FProxyRuntimeSupport runtimeSupport) {
+    FProxyRuntimeSupport.PhysicalThreatLevel threatLevel = runtimeSupport.physicalThreatLevel();
+    if (threatLevel == FProxyRuntimeSupport.PhysicalThreatLevel.MAXIMUM
+        || isDownloadDisabledOrUnsafe(ctx, runtimeSupport)) {
       return;
     }
     HTMLNode option = optionList.addChild("li");
@@ -395,9 +398,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
         TAG_INPUT,
         new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
         new String[] {TYPE_SUBMIT, "download", l10n("downloadInBackgroundToDiskButton")});
-    String downloadLocation = core.getDownloadsDir().getAbsolutePath();
-    if (!core.allowDownloadTo(core.getDownloadsDir())) {
-      downloadLocation = core.getAllowedDownloadDirs()[0].getAbsolutePath();
+    File downloadsDir = runtimeSupport.downloadsDir();
+    String downloadLocation = downloadsDir.getAbsolutePath();
+    if (!runtimeSupport.allowDownloadTo(downloadsDir)) {
+      downloadLocation = runtimeSupport.allowedDownloadDirs()[0].getAbsolutePath();
     }
     NodeL10n.getBase()
         .addL10nSubstitution(
@@ -435,7 +439,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     if (!dontShowFilter) {
       addFilterControl(optionForm, filterChecked);
     }
-    if (threatLevel == PHYSICAL_THREAT_LEVEL.HIGH) {
+    if (threatLevel == FProxyRuntimeSupport.PhysicalThreatLevel.HIGH) {
       optionForm.addChild("br");
       NodeL10n.getBase()
           .addL10nSubstitution(
@@ -453,10 +457,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       String mimeType,
       boolean filterChecked,
       boolean dontShowFilter,
-      NodeClientCore core) {
-    PHYSICAL_THREAT_LEVEL threatLevel =
-        core.getNode().services().securityLevels().getPhysicalThreatLevel();
-    if (threatLevel != PHYSICAL_THREAT_LEVEL.LOW || isDownloadDisabledOrUnsafe(ctx, core)) {
+      FProxyRuntimeSupport runtimeSupport) {
+    FProxyRuntimeSupport.PhysicalThreatLevel threatLevel = runtimeSupport.physicalThreatLevel();
+    if (threatLevel != FProxyRuntimeSupport.PhysicalThreatLevel.LOW
+        || isDownloadDisabledOrUnsafe(ctx, runtimeSupport)) {
       HTMLNode option = optionList.addChild("li");
       HTMLNode optionForm = ctx.addFormChild(option, DOWNLOADS_PATH, "tooBigQueueForm");
       optionForm.addChild(
@@ -506,10 +510,11 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     filterControl.addChild("div", l10n("filterDataMessage"));
   }
 
-  static boolean isDownloadDisabledOrUnsafe(ToadletContext ctx, NodeClientCore core) {
+  static boolean isDownloadDisabledOrUnsafe(
+      ToadletContext ctx, FProxyRuntimeSupport runtimeSupport) {
     return
     // download is either disabled fully on this node
-    core.isDownloadDisabled()
+    runtimeSupport.isDownloadDisabled()
         // or we're accessing in public gateway mode and do not have full access
         || (ctx.getContainer().publicGatewayMode() && !ctx.isAllowedFullAccess());
   }
@@ -808,9 +813,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
         fctx.setPrefetchHook(createPrefetchHook());
       }
       if (container.isFProxyWebPushingEnabled()) {
-        fctx.setTagReplacer(
-            new PushingTagReplacerCallback(
-                core.getEndpoints().getFProxy().fetchTracker, defaultMaxSize, ctx));
+        fctx.setTagReplacer(new PushingTagReplacerCallback(fetchTracker, defaultMaxSize, ctx));
       }
     }
 
@@ -850,16 +853,12 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
         @Override
         public void onFinishedPage() {
-          core.getNode()
-              .network()
-              .executor()
-              .execute(
-                  () -> {
-                    for (FreenetURI uri1 : uris) {
-                      client.prefetch(
-                          uri1, SECONDS.toMillis(60), 512L * 1024, prefetchAllowedTypes);
-                    }
-                  });
+          runtimeSupport.executeBackground(
+              () -> {
+                for (FreenetURI uri1 : uris) {
+                  client.prefetch(uri1, SECONDS.toMillis(60), 512L * 1024, prefetchAllowedTypes);
+                }
+              });
         }
       };
     }
@@ -978,7 +977,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       HTMLNode optionList = infoboxContent.addChild("ul");
       optionList.addChild("li").addChild("p", l10n("progressOptionZero"));
 
-      addDownloadOptions(ctx, optionList, key, mimeType, false, false, core);
+      addDownloadOptions(ctx, optionList, key, mimeType, false, false, runtimeSupport);
 
       optionList
           .addChild("li")
@@ -1198,7 +1197,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
                         + extras),
                 HTMLNode.STRONG
               });
-      addDownloadOptions(ctx, optionList, key, mimeType, true, false, core);
+      addDownloadOptions(ctx, optionList, key, mimeType, true, false, runtimeSupport);
       if (referrer != null) {
         option = optionList.addChild("li");
         NodeL10n.getBase()
@@ -1472,7 +1471,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
           new String[] {ATTR_TYPE, ATTR_NAME, ATTR_VALUE},
           new String[] {TYPE_SUBMIT, "fetch", l10n("fetchLargeFileAnywayAndDisplayButton")});
       optionForm.addChild("#", " - " + l10n("fetchLargeFileAnywayAndDisplay"));
-      addDownloadOptions(ctx, optionList, key, mime, false, false, core);
+      addDownloadOptions(ctx, optionList, key, mime, false, false, runtimeSupport);
     }
 
     private void handleGenericFetchException(FetchException e, String msg)
@@ -1616,7 +1615,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
             mimeType,
             e.getCause() instanceof UnsafeContentTypeException,
             e.getCause() instanceof UnsafeContentTypeException,
-            core);
+            runtimeSupport);
         if (!(e.getCause() instanceof UnsafeContentTypeException)) {
           optionList
               .addChild("li")
@@ -1660,7 +1659,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
     private String getSchemeHostAndPort(ToadletContext ctx) {
       // retrieve config from froxy
-      SubConfig fProxyConfig = core.getNode().getConfig().get("fproxy");
+      SubConfig fProxyConfig = runtimeSupport.fproxyConfig();
 
       Option<?> fProxyPort = fProxyConfig.getOption("port");
       Option<?> fProxyBindTo = fProxyConfig.getOption("bindTo");

--- a/src/test/java/network/crypta/clients/http/CoreHttpShellRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/clients/http/CoreHttpShellRuntimeSupportTest.java
@@ -271,7 +271,7 @@ class CoreHttpShellRuntimeSupportTest {
       assertSame(fetchContext, fetchTrackerArguments.get().get(1));
       assertNotNull(fetchTrackerArguments.get().get(2));
       assertSame(client, fproxyArguments.get().get(0));
-      assertSame(core, fproxyArguments.get().get(1));
+      assertInstanceOf(CoreFProxyRuntimeSupport.class, fproxyArguments.get().get(1));
       assertSame(fetchTrackers.constructed().getFirst(), fproxyArguments.get().get(2));
       assertSame(bookmarkManagers.constructed().getFirst(), bootstrap.bookmarkManager());
       assertSame(client, bootstrap.client());

--- a/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.ClientContext;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,7 +26,7 @@ class FProxyToadletTest {
 
   @Mock private HighLevelSimpleClient client;
 
-  @Mock private NodeClientCore core;
+  @Mock private FProxyRuntimeSupport runtimeSupport;
 
   @Mock private FProxyFetchTracker fetchTracker;
 
@@ -35,12 +34,13 @@ class FProxyToadletTest {
 
   @Test
   void constructor_setsMaxLengthsOnClient() {
-    when(core.getClientContext()).thenReturn(clientContext);
+    when(runtimeSupport.clientContext()).thenReturn(clientContext);
 
-    new FProxyToadlet(client, core, fetchTracker);
+    new FProxyToadlet(client, runtimeSupport, fetchTracker);
 
     verify(client).setMaxLength(FProxyToadlet.getMaxLengthNoProgress());
     verify(client).setMaxIntermediateLength(FProxyToadlet.getMaxLengthNoProgress());
+    verify(runtimeSupport).clientContext();
   }
 
   @Test
@@ -121,8 +121,8 @@ class FProxyToadletTest {
   }
 
   private FProxyToadlet newFProxy() {
-    when(core.getClientContext()).thenReturn(clientContext);
-    return new FProxyToadlet(client, core, fetchTracker);
+    when(runtimeSupport.clientContext()).thenReturn(clientContext);
+    return new FProxyToadlet(client, runtimeSupport, fetchTracker);
   }
 
   private long[] invokeParseRange(String value) throws Exception {


### PR DESCRIPTION
## Summary
- add a package-private `FProxyRuntimeSupport` seam and a core-backed `CoreFProxyRuntimeSupport` adapter in `clients/http`
- route `FProxyToadlet` through the adapter instead of a direct `NodeClientCore` dependency, while keeping its cached `ClientContext` and `FProxyFetchTracker` behavior intact
- update `CoreHttpShellRuntimeSupport` assembly and the focused HTTP tests to construct and verify the new adapter wiring

## How to test
- `./gradlew test --tests network.crypta.clients.http.FProxyToadletTest --tests network.crypta.clients.http.CoreHttpShellRuntimeSupportTest --tests network.crypta.clients.http.FProxyRegistrarTest --tests network.crypta.clients.http.SimpleToadletServerTest`