### PR TITLE
refactor(fcp): Add GET fetch support seam

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -10,14 +10,13 @@ import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
-import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
@@ -93,11 +92,7 @@ public final class ClientGet extends ClientRequest {
   @SuppressWarnings("java:S1948")
   private final Bucket initialMetadata;
 
-  private transient ClientGetMessageReplay messageReplay;
-  private transient ClientGetLifecycle lifecycle;
-  private transient ClientGetStatusSnapshotBuilder statusSnapshotBuilder;
-  private transient ClientGetRestartCoordinator restartCoordinator;
-  private transient ClientGetStatusReporter statusReporter;
+  private transient ClientGetHelpers helpers;
 
   // Verbosity bitmasks
   static final int VERBOSITY_SPLITFILE_PROGRESS = 1;
@@ -190,66 +185,6 @@ public final class ClientGet extends ClientRequest {
   }
 
   /**
-   * Bundles configuration for persistent global GET requests to keep constructors concise.
-   *
-   * <p>Instances capture all per-request tuning parameters that are otherwise passed positionally.
-   * The record is intentionally immutable, so callers can safely reuse it across retries or
-   * validation steps without worrying about concurrent mutation. Callers typically populate it from
-   * parsed FCP messages or persisted metadata before invoking the global-queue constructor, and the
-   * values are meant to be safe for logging or storage because they avoid holding live buckets.
-   *
-   * <ul>
-   *   <li>Queue scope: persistence flags, identifiers, and real-time scheduling hints.
-   *   <li>Data handling: maximum output sizes, return type, and disk destination path.
-   *   <li>Behavior flags: datastore reachability, filtering, and cache-write preferences.
-   * </ul>
-   *
-   * @param dsOnly true to restrict fetches to the local datastore only.
-   * @param ignoreDS true to bypass datastore reads when evaluating availability hints.
-   * @param filterData true to apply content filtering before delivery or disk write.
-   * @param maxSplitfileRetries maximum retry count per splitfile block; must be non-negative.
-   * @param maxNonSplitfileRetries maximum retry count for non-splitfile requests; must be
-   *     non-negative.
-   * @param maxOutputLength maximum bytes allowed for payload and temporary storage.
-   * @param returnType delivery mode describing how payload bytes are surfaced.
-   * @param persistRebootOnly true to persist across reboots, false for forever.
-   * @param identifier caller-supplied identifier echoed in progress and status messages.
-   * @param verbosity bitmask controlling which progress events are emitted.
-   * @param prioClass priority class guiding scheduler ordering and bandwidth share.
-   * @param returnFilename disk destination path used only when ReturnType.DISK applies.
-   * @param charset legacy charset hint; ignored but preserved for compatibility logging.
-   * @param writeToClientCache true to allow writing the payload into the client cache.
-   * @param realTimeFlag true for realtime scheduler lane, false for bulk queue.
-   * @param binaryBlob true to return BinaryBlob output instead of a raw bucket.
-   */
-  public record GlobalRequestConfig(
-      boolean dsOnly,
-      boolean ignoreDS,
-      boolean filterData,
-      int maxSplitfileRetries,
-      int maxNonSplitfileRetries,
-      long maxOutputLength,
-      ReturnType returnType,
-      boolean persistRebootOnly,
-      String identifier,
-      int verbosity,
-      short prioClass,
-      File returnFilename,
-      String charset,
-      boolean writeToClientCache,
-      boolean realTimeFlag,
-      boolean binaryBlob) {}
-
-  /** Bundles construction inputs to keep request constructors compact. */
-  record ClientGetSetup(
-      FetchContext fetchContext,
-      ClientGetReturnPlanner.ReturnSetup returnSetup,
-      ReturnType returnType,
-      boolean binaryBlob,
-      Bucket initialMetadata,
-      NodeClientCore core) {}
-
-  /**
    * Creates a new request that has already been validated and configured by {@link
    * ClientGetFactory}.
    *
@@ -269,7 +204,7 @@ public final class ClientGet extends ClientRequest {
     this.targetFile = returnSetup.targetFile();
     this.extensionCheck = returnSetup.extension();
     this.initialMetadata = setup.initialMetadata();
-    getter = makeGetter(setup.core(), returnSetup.bucket());
+    getter = makeGetter(setup.fetchRuntimeSupport(), returnSetup.bucket());
     applyDiagnosticIdentifier(getter);
     initHelpers();
   }
@@ -290,7 +225,7 @@ public final class ClientGet extends ClientRequest {
     this.targetFile = returnSetup.targetFile();
     this.extensionCheck = returnSetup.extension();
     this.initialMetadata = setup.initialMetadata();
-    getter = makeGetter(setup.core(), returnSetup.bucket());
+    getter = makeGetter(setup.fetchRuntimeSupport(), returnSetup.bucket());
     applyDiagnosticIdentifier(getter);
     initHelpers();
   }
@@ -299,8 +234,9 @@ public final class ClientGet extends ClientRequest {
     return makeGetter(null, ret);
   }
 
-  private ClientGetter makeGetter(NodeClientCore core, Bucket ret) throws IOException {
-    return ClientGetGetterFactory.createGetterForRequest(this, ret, core);
+  private ClientGetter makeGetter(FcpFetchRuntimeSupport fetchRuntimeSupport, Bucket ret)
+      throws IOException {
+    return ClientGetGetterFactory.createGetterForRequest(this, ret, fetchRuntimeSupport);
   }
 
   ClientGetter makeGetterForPersistence(Bucket ret) throws IOException {
@@ -330,46 +266,14 @@ public final class ClientGet extends ClientRequest {
   }
 
   private void initHelpers() {
-    if (messageReplay == null) {
-      messageReplay = new ClientGetMessageReplay(this);
-    }
-    if (lifecycle == null) {
-      lifecycle = new ClientGetLifecycle(this);
-    }
-    if (statusSnapshotBuilder == null) {
-      statusSnapshotBuilder = new ClientGetStatusSnapshotBuilder(this);
-    }
-    if (restartCoordinator == null) {
-      restartCoordinator = new ClientGetRestartCoordinator(this);
-    }
-    if (statusReporter == null) {
-      statusReporter = new ClientGetStatusReporter(this);
+    if (helpers == null) {
+      helpers = new ClientGetHelpers(this);
     }
   }
 
-  private ClientGetMessageReplay messageReplay() {
+  private ClientGetHelpers helpers() {
     initHelpers();
-    return messageReplay;
-  }
-
-  private ClientGetLifecycle lifecycle() {
-    initHelpers();
-    return lifecycle;
-  }
-
-  private ClientGetStatusSnapshotBuilder statusSnapshotBuilder() {
-    initHelpers();
-    return statusSnapshotBuilder;
-  }
-
-  private ClientGetRestartCoordinator restartCoordinator() {
-    initHelpers();
-    return restartCoordinator;
-  }
-
-  private ClientGetStatusReporter statusReporter() {
-    initHelpers();
-    return statusReporter;
+    return helpers;
   }
 
   ClientGetState state() {
@@ -518,7 +422,7 @@ public final class ClientGet extends ClientRequest {
    * @param state client getter instance used to access BinaryBlob payload buckets.
    */
   public void onSuccess(FetchResult result, ClientGetter state) {
-    lifecycle().onSuccess(result, state);
+    helpers().lifecycle().onSuccess(result, state);
   }
 
   /**
@@ -543,20 +447,20 @@ public final class ClientGet extends ClientRequest {
   @SuppressWarnings("unused")
   public void setSuccessForMigration(ClientContext context, long completionTime, Bucket data)
       throws ResumeFailedException {
-    lifecycle().setSuccessForMigration(context, completionTime, data);
+    helpers().lifecycle().setSuccessForMigration(context, completionTime, data);
   }
 
   void trySendDataFoundOrGetFailed(
       FCPConnectionOutputHandler handler, String listRequestIdentifier) {
-    messageReplay().trySendDataFoundOrGetFailed(handler, listRequestIdentifier);
+    helpers().messageReplay().trySendDataFoundOrGetFailed(handler, listRequestIdentifier);
   }
 
   void trySendAllDataMessage(FCPConnectionOutputHandler handler, String listRequestIdentifier) {
-    messageReplay().trySendAllDataMessage(handler, listRequestIdentifier);
+    helpers().messageReplay().trySendAllDataMessage(handler, listRequestIdentifier);
   }
 
   void queueProgressMessageInner(FCPMessage msg, int verbosityMask) {
-    messageReplay().queueProgressMessageInner(msg, verbosityMask);
+    helpers().messageReplay().queueProgressMessageInner(msg, verbosityMask);
   }
 
   /**
@@ -585,11 +489,13 @@ public final class ClientGet extends ClientRequest {
       String listRequestIdentifier,
       boolean includeData,
       boolean onlyData) {
-    messageReplay().sendPendingMessages(handler, listRequestIdentifier, includeData, onlyData);
+    helpers()
+        .messageReplay()
+        .sendPendingMessages(handler, listRequestIdentifier, includeData, onlyData);
   }
 
   FCPMessage persistentTagMessage() {
-    return statusSnapshotBuilder().persistentTagMessage();
+    return helpers().statusSnapshotBuilder().persistentTagMessage();
   }
 
   // Mirrors ClientPut/ClientPutDir to keep low-level scheduling flags accessible to subclasses.
@@ -618,7 +524,7 @@ public final class ClientGet extends ClientRequest {
    * @param e failure descriptor that supplies the expected size, MIME type, and mode.
    */
   public void onFailure(FetchException e) {
-    lifecycle().onFailure(e);
+    helpers().lifecycle().onFailure(e);
   }
 
   /**
@@ -637,7 +543,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public void requestWasRemoved(ClientContext context) {
-    lifecycle().requestWasRemoved();
+    helpers().lifecycle().requestWasRemoved();
     super.requestWasRemoved(context);
   }
 
@@ -860,7 +766,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public double getSuccessFraction() {
-    return statusReporter().getSuccessFraction();
+    return helpers().statusReporter().getSuccessFraction();
   }
 
   /**
@@ -874,7 +780,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public double getTotalBlocks() {
-    return statusReporter().getTotalBlocks();
+    return helpers().statusReporter().getTotalBlocks();
   }
 
   /**
@@ -888,7 +794,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public double getMinBlocks() {
-    return statusReporter().getMinBlocks();
+    return helpers().statusReporter().getMinBlocks();
   }
 
   /**
@@ -902,7 +808,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public double getFailedBlocks() {
-    return statusReporter().getFailedBlocks();
+    return helpers().statusReporter().getFailedBlocks();
   }
 
   /**
@@ -916,7 +822,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public double getFatalyFailedBlocks() {
-    return statusReporter().getFatalyFailedBlocks();
+    return helpers().statusReporter().getFatalyFailedBlocks();
   }
 
   /**
@@ -931,7 +837,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public double getFetchedBlocks() {
-    return statusReporter().getFetchedBlocks();
+    return helpers().statusReporter().getFetchedBlocks();
   }
 
   /**
@@ -944,7 +850,7 @@ public final class ClientGet extends ClientRequest {
    *
    * @return array of compatibility modes; may be empty but never {@code null}.
    */
-  public InsertContext.CompatibilityMode[] getCompatibilityMode() {
+  public CompatibilityMode[] getCompatibilityMode() {
     return state.getCompatibilityMode();
   }
 
@@ -992,7 +898,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public String getFailureReason(boolean longDescription) {
-    return statusReporter().getFailureReason(longDescription);
+    return helpers().statusReporter().getFailureReason(longDescription);
   }
 
   GetFailedMessage getFailureMessage() {
@@ -1012,7 +918,7 @@ public final class ClientGet extends ClientRequest {
    * @return failure classification mode, or {@code null} when no failure exists.
    */
   public FetchExceptionMode getFailureReasonCode() {
-    return statusReporter().getFailureReasonCode();
+    return helpers().statusReporter().getFailureReasonCode();
   }
 
   /**
@@ -1029,7 +935,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public boolean isTotalFinalized() {
-    return statusReporter().isTotalFinalized();
+    return helpers().statusReporter().isTotalFinalized();
   }
 
   /**
@@ -1075,7 +981,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public boolean canRestart() {
-    return restartCoordinator().canRestart();
+    return helpers().restartCoordinator().canRestart();
   }
 
   /**
@@ -1096,7 +1002,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   public boolean restart(ClientContext context, final boolean disableFilterData) {
-    return restartCoordinator().restart(context, disableFilterData);
+    return helpers().restartCoordinator().restart(context, disableFilterData);
   }
 
   /**
@@ -1114,7 +1020,7 @@ public final class ClientGet extends ClientRequest {
    * @return {@code true} when a permanent redirect URI is stored in failure state.
    */
   public synchronized boolean hasPermRedirect() {
-    return restartCoordinator().hasPermRedirect();
+    return helpers().restartCoordinator().hasPermRedirect();
   }
 
   /**
@@ -1137,7 +1043,7 @@ public final class ClientGet extends ClientRequest {
   @Override
   RequestStatus getStatus() {
     synchronized (persistenceLock()) {
-      return statusReporter().getStatus();
+      return helpers().statusReporter().getStatus();
     }
   }
 

--- a/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -185,6 +185,72 @@ public final class ClientGet extends ClientRequest {
   }
 
   /**
+   * Public compatibility alias for global GET request configuration.
+   *
+   * <p>This nested record existed before the GET-path seam refactor and remains part of the public
+   * {@code ClientGet} API so out-of-package code can continue to compile against {@code
+   * ClientGet.GlobalRequestConfig}. Internally, the GET factory now uses the package-local {@link
+   * ClientGetGlobalRequestConfig} record for the refactored assembly path; this type bridges the
+   * legacy public surface to that internal representation without changing request semantics.
+   *
+   * @param dsOnly whether the fetch is restricted to local datastore lookups only
+   * @param ignoreDS whether the datastore should be skipped in favor of network retrieval
+   * @param filterData whether fetched content should be filtered before delivery
+   * @param maxSplitfileRetries maximum retry count applied to splitfile block fetches
+   * @param maxNonSplitfileRetries maximum retry count applied to non-splitfile fetches
+   * @param maxOutputLength upper bound, in bytes, for the returned payload and temp data
+   * @param returnType delivery mode describing whether data is returned directly, discarded, or
+   *     written to disk
+   * @param persistRebootOnly whether the request should survive only until the next node restart
+   * @param identifier stable request identifier used for queue ownership and collision checks
+   * @param verbosity bitmask controlling which FCP progress messages are emitted to clients
+   * @param prioClass scheduler priority class used when the request is started
+   * @param returnFilename target file for disk-return requests, or {@code null} when not applicable
+   * @param charset optional charset hint preserved for compatibility with legacy inputs
+   * @param writeToClientCache whether successful fetches may populate the client cache
+   * @param realTimeFlag whether the request should use real-time scheduling behavior
+   * @param binaryBlob whether the request should emit Binary Blob output instead of ordinary data
+   */
+  public record GlobalRequestConfig(
+      boolean dsOnly,
+      boolean ignoreDS,
+      boolean filterData,
+      int maxSplitfileRetries,
+      int maxNonSplitfileRetries,
+      long maxOutputLength,
+      ReturnType returnType,
+      boolean persistRebootOnly,
+      String identifier,
+      int verbosity,
+      short prioClass,
+      File returnFilename,
+      String charset,
+      boolean writeToClientCache,
+      boolean realTimeFlag,
+      boolean binaryBlob) {
+
+    ClientGetGlobalRequestConfig toInternalConfig() {
+      return new ClientGetGlobalRequestConfig(
+          dsOnly,
+          ignoreDS,
+          filterData,
+          maxSplitfileRetries,
+          maxNonSplitfileRetries,
+          maxOutputLength,
+          returnType,
+          persistRebootOnly,
+          identifier,
+          verbosity,
+          prioClass,
+          returnFilename,
+          charset,
+          writeToClientCache,
+          realTimeFlag,
+          binaryBlob);
+    }
+  }
+
+  /**
    * Creates a new request that has already been validated and configured by {@link
    * ClientGetFactory}.
    *

--- a/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
@@ -3,8 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.IOException;
 import network.crypta.client.FetchContext;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
-import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,10 +12,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The factory performs the deterministic wiring for GET requests: it validates identifiers,
  * assembles an appropriate {@link FetchContext}, plans return handling, and packages everything
- * into a {@link ClientGet.ClientGetSetup}. Callers use the resulting request object for
- * registration and execution; the factory does not start or enqueue the request itself. Because it
- * is stateless and uses only local variables, the class is thread-safe and can be called
- * concurrently.
+ * into a {@link ClientGetSetup}. Callers use the resulting request object for registration and
+ * execution; the factory does not start or enqueue the request itself. Because it is stateless and
+ * uses only local variables, the class is thread-safe and can be called concurrently.
  *
  * <p>The factory is intentionally conservative about side effects: it only logs ignored parameters
  * (such as a legacy charset hint) and throws explicit exceptions for identifier collisions or
@@ -55,8 +52,8 @@ final class ClientGetFactory {
    * @param globalClient persistent client used for global-queue ownership and id checks.
    * @param uri target {@link FreenetURI} describing the key to fetch; must be non-null.
    * @param requestConfig immutable configuration with limits, flags, and return preferences.
-   * @param core node core providing fetch contexts, planners, and bucket factories.
-   * @param transferAccess transfer policy used for disk-return planning in this request flow.
+   * @param fetchRuntimeSupport fetch runtime support providing fetch defaults, planners, and bucket
+   *     allocation.
    * @return configured {@link ClientGet} instance ready for registration and start.
    * @throws IdentifierCollisionException if the identifier is already registered globally.
    * @throws NotAllowedException if disk output violates policy or DDA restrictions.
@@ -65,12 +62,11 @@ final class ClientGetFactory {
   static ClientGet fromGlobal(
       PersistentRequestClient globalClient,
       FreenetURI uri,
-      ClientGet.GlobalRequestConfig requestConfig,
-      NodeClientCore core,
-      TransferAccessPort transferAccess)
+      ClientGetGlobalRequestConfig requestConfig,
+      FcpFetchRuntimeSupport fetchRuntimeSupport)
       throws IdentifierCollisionException, NotAllowedException, IOException {
     ensureGlobalIdentifierAvailable(globalClient, requestConfig.identifier());
-    FetchContext fctx = buildFetchContextForGlobal(core, requestConfig);
+    FetchContext fctx = buildFetchContextForGlobal(fetchRuntimeSupport, requestConfig);
     if (requestConfig.charset() != null && LOG.isDebugEnabled()) {
       LOG.debug(
           "Charset parameter is ignored for ClientGet global queue requests: {}",
@@ -83,7 +79,7 @@ final class ClientGetFactory {
             requestConfig.returnType(),
             requestConfig.returnFilename(),
             requestConfig.filterData(),
-            transferAccess);
+            fetchRuntimeSupport.transferAccess());
     ClientRequestParams params =
         new ClientRequestParams(
             uri,
@@ -96,9 +92,14 @@ final class ClientGetFactory {
             requestConfig.realTimeFlag(),
             null,
             true);
-    ClientGet.ClientGetSetup requestSetup =
-        new ClientGet.ClientGetSetup(
-            fctx, returnSetup, requestConfig.returnType(), requestConfig.binaryBlob(), null, core);
+    ClientGetSetup requestSetup =
+        new ClientGetSetup(
+            fctx,
+            returnSetup,
+            requestConfig.returnType(),
+            requestConfig.binaryBlob(),
+            null,
+            fetchRuntimeSupport);
     return new ClientGet(params, globalClient, requestSetup);
   }
 
@@ -115,13 +116,15 @@ final class ClientGetFactory {
    *
    * @param handler connection handler supplying scope checks and DDA enforcement hooks.
    * @param message parsed FCP GET message containing identifiers, flags, and limits.
-   * @param core node core providing contexts, planners, and bucket factories.
+   * @param fetchRuntimeSupport fetch runtime support providing contexts, planners, and buckets.
    * @return configured {@link ClientGet} instance ready for registration and start.
    * @throws IdentifierCollisionException if the identifier is already used in scope.
    * @throws MessageInvalidException if validation fails or bucket setup throws I/O errors.
    */
   static ClientGet fromMessage(
-      FCPConnectionHandler handler, ClientGetMessage message, NodeClientCore core)
+      FCPConnectionHandler handler,
+      ClientGetMessage message,
+      FcpFetchRuntimeSupport fetchRuntimeSupport)
       throws IdentifierCollisionException, MessageInvalidException {
     ClientRequestParams params =
         new ClientRequestParams(
@@ -136,16 +139,25 @@ final class ClientGetFactory {
     if (message.persistence == ClientRequest.Persistence.CONNECTION) {
       ensureConnectionIdentifierAvailable(handler, message.identifier);
     }
-    FetchContext fctx = buildFetchContextForMessage(core, message);
-    TransferAccessPort transferAccess = core.getRuntimePorts().transferAccess();
+    FetchContext fctx = buildFetchContextForMessage(fetchRuntimeSupport, message);
     ClientGetReturnPlanner.ReturnSetup returnSetup =
         ClientGetGetterFactory.planReturnForMessage(
-            message.identifier, message.global, fctx, message, transferAccess, handler);
+            message.identifier,
+            message.global,
+            fctx,
+            message,
+            fetchRuntimeSupport.transferAccess(),
+            handler);
     Bucket initialMetadata = message.getInitialMetadata();
     try {
-      ClientGet.ClientGetSetup requestSetup =
-          new ClientGet.ClientGetSetup(
-              fctx, returnSetup, message.returnType, message.binaryBlob, initialMetadata, core);
+      ClientGetSetup requestSetup =
+          new ClientGetSetup(
+              fctx,
+              returnSetup,
+              message.returnType,
+              message.binaryBlob,
+              initialMetadata,
+              fetchRuntimeSupport);
       return new ClientGet(params, handler, requestSetup);
     } catch (IOException e) {
       throw bucketCreationFailure(e, message.identifier, message.global);
@@ -195,13 +207,14 @@ final class ClientGetFactory {
    * configuration's limits, datastore flags, and filtering preferences. The returned context is
    * mutable and owned by the caller; further modifications affect only the request being built.
    *
-   * @param core node core providing the default persistent fetch context.
+   * @param fetchRuntimeSupport fetch runtime support providing the default persistent fetch
+   *     context.
    * @param requestConfig configuration containing datastore flags and retry limits.
    * @return configured fetch context instance tailored for this request.
    */
   private static FetchContext buildFetchContextForGlobal(
-      NodeClientCore core, ClientGet.GlobalRequestConfig requestConfig) {
-    FetchContext fctx = core.getClientContext().getDefaultPersistentFetchContext();
+      FcpFetchRuntimeSupport fetchRuntimeSupport, ClientGetGlobalRequestConfig requestConfig) {
+    FetchContext fctx = fetchRuntimeSupport.defaultPersistentFetchContext();
     fctx.setLocalRequestOnly(requestConfig.dsOnly());
     fctx.setIgnoreStore(requestConfig.ignoreDS());
     fctx.setMaxNonSplitfileRetries(requestConfig.maxNonSplitfileRetries());
@@ -220,13 +233,14 @@ final class ClientGetFactory {
    * retry limits, size limits, allowed MIME types, and USK date hint behavior. The returned context
    * is owned by the caller and can be further adjusted before the request starts.
    *
-   * @param core node core providing the default persistent fetch context.
+   * @param fetchRuntimeSupport fetch runtime support providing the default persistent fetch
+   *     context.
    * @param message the parsed message supplying overrides and allowed MIME type hints.
    * @return configured fetch context instance tailored for the message.
    */
   private static FetchContext buildFetchContextForMessage(
-      NodeClientCore core, ClientGetMessage message) {
-    FetchContext fctx = core.getClientContext().getDefaultPersistentFetchContext();
+      FcpFetchRuntimeSupport fetchRuntimeSupport, ClientGetMessage message) {
+    FetchContext fctx = fetchRuntimeSupport.defaultPersistentFetchContext();
     fctx.setLocalRequestOnly(message.dsOnly);
     fctx.setIgnoreStore(message.ignoreDS);
     fctx.setMaxNonSplitfileRetries(message.maxRetries);

--- a/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
@@ -62,6 +62,32 @@ final class ClientGetFactory {
   static ClientGet fromGlobal(
       PersistentRequestClient globalClient,
       FreenetURI uri,
+      ClientGet.GlobalRequestConfig requestConfig,
+      FcpFetchRuntimeSupport fetchRuntimeSupport)
+      throws IdentifierCollisionException, NotAllowedException, IOException {
+    return fromGlobal(globalClient, uri, requestConfig.toInternalConfig(), fetchRuntimeSupport);
+  }
+
+  /**
+   * Creates a persistent, global-queue {@link ClientGet} from the package-local configuration
+   * record used by the refactored GET path.
+   *
+   * <p>This overload keeps the internal seam narrow while the public {@link
+   * ClientGet.GlobalRequestConfig} compatibility alias remains available for external callers.
+   *
+   * @param globalClient persistent client used for global-queue ownership and id checks.
+   * @param uri target {@link FreenetURI} describing the key to fetch; must be non-null.
+   * @param requestConfig immutable configuration with limits, flags, and return preferences.
+   * @param fetchRuntimeSupport fetch runtime support providing fetch defaults, planners, and bucket
+   *     allocation.
+   * @return configured {@link ClientGet} instance ready for registration and start.
+   * @throws IdentifierCollisionException if the identifier is already registered globally.
+   * @throws NotAllowedException if disk output violates policy or DDA restrictions.
+   * @throws IOException if bucket or file initialization fails during setup.
+   */
+  static ClientGet fromGlobal(
+      PersistentRequestClient globalClient,
+      FreenetURI uri,
       ClientGetGlobalRequestConfig requestConfig,
       FcpFetchRuntimeSupport fetchRuntimeSupport)
       throws IdentifierCollisionException, NotAllowedException, IOException {

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -24,7 +24,6 @@ import network.crypta.client.async.PersistentClientCallback;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
@@ -50,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * is effectively stateless. Thread-safety is therefore determined by the collaborators passed in,
  * not by this factory. The method contracts favor explicit inputs (for example, whether to discard
  * data or enable Binary Blob recording) and will fail fast when required dependencies such as
- * {@link NodeClientCore} are missing.
+ * {@link FcpFetchRuntimeSupport} are missing.
  *
  * <ul>
  *   <li>Wires request callbacks via an adapter that implements persistence interfaces.
@@ -484,12 +483,13 @@ final class ClientGetGetterFactory {
    *
    * @param request owning request that receives fetch callbacks.
    * @param returnBucket bucket holding returned data when not discarded.
-   * @param core node core used to allocate buckets when required.
+   * @param fetchRuntimeSupport fetch runtime support used to allocate buckets when required.
    * @return a configured {@link ClientGetter} ready to run.
    * @throws IOException if bucket allocation fails.
    */
   static ClientGetter createGetterForRequest(
-      ClientGet request, Bucket returnBucket, NodeClientCore core) throws IOException {
+      ClientGet request, Bucket returnBucket, FcpFetchRuntimeSupport fetchRuntimeSupport)
+      throws IOException {
     ClientGetterRequest getterRequest =
         createGetterRequest(
             request, request.getURI(), request.fetchContextForGetter(), request.getPriority());
@@ -506,7 +506,7 @@ final class ClientGetGetterFactory {
             returnType == ClientGet.ReturnType.NONE,
             request.binaryBlobRequested(),
             request.persistence == ClientRequest.Persistence.FOREVER);
-    return createGetter(getterRequest, options, flags, core);
+    return createGetter(getterRequest, options, flags, fetchRuntimeSupport);
   }
 
   /**
@@ -514,25 +514,25 @@ final class ClientGetGetterFactory {
    *
    * <p>The factory chooses the correct return bucket strategy and optionally sets up a {@link
    * BinaryBlobWriter} when Binary Blob recording is requested. If Binary Blob recording is enabled
-   * and the options do not specify a return bucket, the method uses {@code core} to allocate a
-   * bucket sized to {@link FetchContext#getMaxOutputLength()}. When {@link
+   * and the options do not specify a return bucket, the method uses {@code fetchRuntimeSupport} to
+   * allocate a bucket sized to {@link FetchContext#getMaxOutputLength()}. When {@link
    * ClientGetGetterFlags#discardData()} is true and Binary Blob is disabled, the returned fetcher
    * writes into a shared {@link NullBucket} instead of the provided bucket.
    *
    * @param request request parameters including the callback, URI, and fetch context.
    * @param options return bucket, metadata, and extension options for the fetcher.
    * @param flags behavior flags for Binary Blob recording and discard handling.
-   * @param core node core used to allocate buckets when needed; required if Binary Blob recording
-   *     is enabled and no return bucket is supplied.
+   * @param fetchRuntimeSupport fetch runtime support used to allocate buckets when needed; required
+   *     if Binary Blob recording is enabled and no return bucket is supplied.
    * @return a fully constructed {@link ClientGetter} ready to start.
    * @throws IOException if bucket allocation fails or underlying stream setup fails.
-   * @throws NullPointerException if {@code core} is required but not provided.
+   * @throws NullPointerException if {@code fetchRuntimeSupport} is required but not provided.
    */
   static ClientGetter createGetter(
       ClientGetterRequest request,
       ClientGetterOptions options,
       ClientGetGetterFlags flags,
-      NodeClientCore core)
+      FcpFetchRuntimeSupport fetchRuntimeSupport)
       throws IOException {
     Bucket returnBucket = options.returnBucket();
     Bucket initialMetadata = options.initialMetadata();
@@ -540,11 +540,10 @@ final class ClientGetGetterFactory {
     Bucket blobBucket = returnBucket;
     if (flags.binaryBlob()) {
       if (blobBucket == null) {
-        Objects.requireNonNull(core, "core");
+        Objects.requireNonNull(fetchRuntimeSupport, "fetchRuntimeSupport");
         blobBucket =
-            core.getClientContext()
-                .getBucketFactory(flags.persistenceForever())
-                .makeBucket(request.ctx().getMaxOutputLength());
+            fetchRuntimeSupport.allocateBinaryBlobBucket(
+                request.ctx().getMaxOutputLength(), flags.persistenceForever());
       }
       return new ClientGetter(
           request,

--- a/src/main/java/network/crypta/clients/fcp/ClientGetGlobalRequestConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetGlobalRequestConfig.java
@@ -1,0 +1,53 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+
+/**
+ * Immutable configuration for constructing a persistent global {@link ClientGet}.
+ *
+ * <p>The record groups the validated inputs needed to create a global-queue GET request. Callers
+ * assemble one instance after parsing FCP inputs and deriving defaults from the runtime, then hand
+ * it to {@link ClientGetFactory} for the actual request construction. Keeping these values in a
+ * single record makes the factory signature smaller without widening the package API surface or
+ * changing how request validation works.
+ *
+ * <p>The instance is a pure data carrier. It does not normalize or lazily compute anything after
+ * construction, so the contained values should already reflect the final policy decisions for the
+ * request, including persistence scope, DDA-planned return routing, retry limits, and scheduling
+ * hints.
+ *
+ * @param dsOnly whether the fetch is restricted to local datastore lookups only
+ * @param ignoreDS whether the datastore should be skipped in favor of network retrieval
+ * @param filterData whether fetched content should be filtered before delivery
+ * @param maxSplitfileRetries maximum retry count applied to splitfile block fetches
+ * @param maxNonSplitfileRetries maximum retry count applied to non-splitfile fetches
+ * @param maxOutputLength upper bound, in bytes, for the returned payload and temp data
+ * @param returnType delivery mode describing whether data is returned directly, discarded, or
+ *     written to disk
+ * @param persistRebootOnly whether the request should survive only until the next node restart
+ * @param identifier stable request identifier used for queue ownership and collision checks
+ * @param verbosity bitmask controlling which FCP progress messages are emitted to clients
+ * @param prioClass scheduler priority class used when the request is started
+ * @param returnFilename target file for disk-return requests, or {@code null} when not applicable
+ * @param charset optional charset hint preserved for compatibility with legacy inputs
+ * @param writeToClientCache whether successful fetches may populate the client cache
+ * @param realTimeFlag whether the request should use real-time scheduling behavior
+ * @param binaryBlob whether the request should emit Binary Blob output instead of ordinary data
+ */
+record ClientGetGlobalRequestConfig(
+    boolean dsOnly,
+    boolean ignoreDS,
+    boolean filterData,
+    int maxSplitfileRetries,
+    int maxNonSplitfileRetries,
+    long maxOutputLength,
+    ClientGet.ReturnType returnType,
+    boolean persistRebootOnly,
+    String identifier,
+    int verbosity,
+    short prioClass,
+    File returnFilename,
+    String charset,
+    boolean writeToClientCache,
+    boolean realTimeFlag,
+    boolean binaryBlob) {}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetHelpers.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetHelpers.java
@@ -1,0 +1,93 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Groups the transient helper collaborators owned by {@link ClientGet}.
+ *
+ * <p>The request still delegates lifecycle, replay, restart, and status duties to specialized
+ * helper classes, but it depends on a single bundle instead of storing each helper directly. This
+ * keeps the outer request class below the coupling threshold enforced in this repository while
+ * preserving the existing runtime behavior and ownership model.
+ *
+ * <p>Instances are short-lived companions to one {@link ClientGet}. They are created during request
+ * assembly, retained only in-memory, and reused for the lifetime of that request. The bundle does
+ * not add synchronization of its own; thread-safety remains the same as the underlying helpers and
+ * the owning request.
+ */
+final class ClientGetHelpers {
+  /** Helper that rebuilds replayable FCP messages from the request state. */
+  private final ClientGetMessageReplay messageReplay;
+
+  /** Helper that applies success, failure, and cleanup transitions to the request. */
+  private final ClientGetLifecycle lifecycle;
+
+  /** Helper that captures the request state used to build status snapshots. */
+  private final ClientGetStatusSnapshotBuilder statusSnapshotBuilder;
+
+  /** Helper that recreates or restarts the underlying getter when needed. */
+  private final ClientGetRestartCoordinator restartCoordinator;
+
+  /** Helper that sends or derives status-oriented protocol messages for the request. */
+  private final ClientGetStatusReporter statusReporter;
+
+  /**
+   * Creates the full helper bundle for one request.
+   *
+   * <p>Each specialized helper receives the same owning request instance, so they can coordinate on
+   * a shared state without the outer request exposing extra fields. The constructor performs only
+   * deterministic object creation and does not trigger network or persistence work.
+   *
+   * @param request owning request whose lifecycle and status state the helpers operate on
+   */
+  ClientGetHelpers(ClientGet request) {
+    messageReplay = new ClientGetMessageReplay(request);
+    lifecycle = new ClientGetLifecycle(request);
+    statusSnapshotBuilder = new ClientGetStatusSnapshotBuilder(request);
+    restartCoordinator = new ClientGetRestartCoordinator(request);
+    statusReporter = new ClientGetStatusReporter(request);
+  }
+
+  /**
+   * Returns the helper responsible for rebuilding replayable FCP messages.
+   *
+   * @return replay helper shared by the owning request for repeated message emission
+   */
+  ClientGetMessageReplay messageReplay() {
+    return messageReplay;
+  }
+
+  /**
+   * Returns the helper that applies request lifecycle transitions.
+   *
+   * @return lifecycle helper used for success, failure, and cleanup handling
+   */
+  ClientGetLifecycle lifecycle() {
+    return lifecycle;
+  }
+
+  /**
+   * Returns the helper that captures status snapshot input data.
+   *
+   * @return snapshot builder used when the request exposes status to clients
+   */
+  ClientGetStatusSnapshotBuilder statusSnapshotBuilder() {
+    return statusSnapshotBuilder;
+  }
+
+  /**
+   * Returns the helper that coordinates getter restart behavior.
+   *
+   * @return restart helper responsible for recreating or resuming fetch execution
+   */
+  ClientGetRestartCoordinator restartCoordinator() {
+    return restartCoordinator;
+  }
+
+  /**
+   * Returns the helper that reports request status through FCP messages.
+   *
+   * @return status reporter used for synchronous and asynchronous request status output
+   */
+  ClientGetStatusReporter statusReporter() {
+    return statusReporter;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/ClientGetSetup.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetSetup.java
@@ -1,0 +1,32 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.FetchContext;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Immutable constructor bundle for a validated {@link ClientGet}.
+ *
+ * <p>The factory resolves the fetch context, return plan, optional metadata bucket, and runtime
+ * support before invoking the request constructor, then stores that assembly state in this record.
+ * This keeps request wiring distinct from the request's own lifecycle code, which only needs to
+ * consume already-validated inputs. The record is package-local because it exists only to simplify
+ * construction flow inside {@code clients.fcp}; it is not part of the FCP protocol surface.
+ *
+ * <p>The values are intended to be complete and final for a single request instance. Callers do not
+ * mutate or enrich the record later, so a {@link ClientGet} can treat each component as the
+ * authoritative setup decided by the factory stage.
+ *
+ * @param fetchContext fully prepared fetch context that should be used by the request
+ * @param returnSetup resolved return-handling plan, including any bucket or target file
+ * @param returnType requested return mode that controls how fetched data is exposed
+ * @param binaryBlob whether the request should produce Binary Blob output
+ * @param initialMetadata optional metadata bucket supplied by the caller before the fetch starts
+ * @param fetchRuntimeSupport runtime support seam used for getter creation and request start
+ */
+record ClientGetSetup(
+    FetchContext fetchContext,
+    ClientGetReturnPlanner.ReturnSetup returnSetup,
+    ClientGet.ReturnType returnType,
+    boolean binaryBlob,
+    Bucket initialMetadata,
+    FcpFetchRuntimeSupport fetchRuntimeSupport) {}

--- a/src/main/java/network/crypta/clients/fcp/CoreFcpFetchRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/CoreFcpFetchRuntimeSupport.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.function.Supplier;
 import network.crypta.client.FetchContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.node.NodeClientCore;
@@ -14,20 +15,21 @@ import network.crypta.support.api.Bucket;
  * <p>This adapter is the GET-path assembly seam between {@code clients.fcp} and the broader daemon
  * runtime. It keeps the fetch-specific wiring local to this package by translating the small set of
  * GET dependencies into direct delegations on the wrapped {@link NodeClientCore} plus the owning
- * server's transfer-access policy. The adapter is immutable after construction and observes the
- * live daemon state on each call.
+ * server's transfer-access policy supplier. The adapter is immutable after construction and
+ * observes the live daemon state on each call.
  *
- * <p>The split between {@code core} and {@code transferAccess} is intentional. Fetch creation still
- * needs the live client context and bucket factories from the daemon core, while DDA checks and
- * default download locations must remain aligned with the {@link FCPServer} runtime that owns the
- * request flow. Keeping both collaborators here preserves that behavior without letting the GET
- * classes depend on {@code NodeClientCore} directly.
+ * <p>The split between {@code core} and {@code transferAccessSupplier} is intentional. Fetch
+ * creation still needs the live client context and bucket factories from the daemon core, while DDA
+ * checks and default download locations must remain aligned with the {@link FCPServer} runtime that
+ * owns the request flow. Keeping both collaborators here preserves that behavior without letting
+ * the GET classes depend on {@code NodeClientCore} directly.
  *
  * @param core live daemon core used for fetch contexts, client starts, and bucket allocation
- * @param transferAccess transfer policy from the owning server runtime, used for DDA checks and
- *     download-path defaults
+ * @param transferAccessSupplier live transfer-policy lookup from the owning runtime, used for DDA
+ *     checks and download-path defaults
  */
-record CoreFcpFetchRuntimeSupport(NodeClientCore core, TransferAccessPort transferAccess)
+record CoreFcpFetchRuntimeSupport(
+    NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier)
     implements FcpFetchRuntimeSupport {
 
   /**
@@ -35,15 +37,16 @@ record CoreFcpFetchRuntimeSupport(NodeClientCore core, TransferAccessPort transf
    *
    * <p>The adapter is a thin wrapper and does not snapshot mutable daemon state. Later method calls
    * continue to observe the live client context and bucket factories exposed by {@code core}, while
-   * transfer checks continue to use the server-owned {@code transferAccess} instance passed here.
+   * transfer checks continue to read the current port from the supplied runtime lookup.
    *
    * @param core live daemon core providing fetch contexts and bucket allocation
-   * @param transferAccess transfer policy from the owning server runtime, used for DDA checks and
-   *     default download locations
+   * @param transferAccessSupplier live transfer-policy lookup from the owning runtime, used for DDA
+   *     checks and default download locations
    */
-  CoreFcpFetchRuntimeSupport(NodeClientCore core, TransferAccessPort transferAccess) {
+  CoreFcpFetchRuntimeSupport(
+      NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier) {
     this.core = Objects.requireNonNull(core);
-    this.transferAccess = Objects.requireNonNull(transferAccess);
+    this.transferAccessSupplier = Objects.requireNonNull(transferAccessSupplier);
   }
 
   /**
@@ -75,15 +78,15 @@ record CoreFcpFetchRuntimeSupport(NodeClientCore core, TransferAccessPort transf
   /**
    * Returns the transfer-access policy owned by the surrounding FCP server runtime.
    *
-   * <p>This intentionally does not read from {@code core.getRuntimePorts()}. Persistent global GET
-   * request planning must stay aligned with the server runtime that supplied the download policy
-   * and default directories.
+   * <p>This intentionally resolves the transfer policy on each call instead of caching a
+   * constructor-time reference. Persistent global GET request planning must stay aligned with the
+   * runtime that supplied the current download policy and default directories.
    *
    * @return transfer policy used for DDA checks and default download resolution
    */
   @Override
   public TransferAccessPort transferAccess() {
-    return transferAccess;
+    return Objects.requireNonNull(transferAccessSupplier.get());
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/CoreFcpFetchRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/CoreFcpFetchRuntimeSupport.java
@@ -63,7 +63,7 @@ record CoreFcpFetchRuntimeSupport(NodeClientCore core, TransferAccessPort transf
    * Returns the default persistent fetch context supplied by the wrapped daemon core.
    *
    * <p>Factories typically adjust the returned context immediately for one request, but the
-   * baseline always comes from the live core so persistent GET defaults remain unchanged.
+   * baseline always comes from the live core, so persistent GET defaults remain unchanged.
    *
    * @return default persistent fetch context template from the daemon core
    */

--- a/src/main/java/network/crypta/clients/fcp/CoreFcpFetchRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/CoreFcpFetchRuntimeSupport.java
@@ -1,0 +1,106 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import java.util.Objects;
+import network.crypta.client.FetchContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Core-backed implementation of {@link FcpFetchRuntimeSupport}.
+ *
+ * <p>This adapter is the GET-path assembly seam between {@code clients.fcp} and the broader daemon
+ * runtime. It keeps the fetch-specific wiring local to this package by translating the small set of
+ * GET dependencies into direct delegations on the wrapped {@link NodeClientCore} plus the owning
+ * server's transfer-access policy. The adapter is immutable after construction and observes the
+ * live daemon state on each call.
+ *
+ * <p>The split between {@code core} and {@code transferAccess} is intentional. Fetch creation still
+ * needs the live client context and bucket factories from the daemon core, while DDA checks and
+ * default download locations must remain aligned with the {@link FCPServer} runtime that owns the
+ * request flow. Keeping both collaborators here preserves that behavior without letting the GET
+ * classes depend on {@code NodeClientCore} directly.
+ *
+ * @param core live daemon core used for fetch contexts, client starts, and bucket allocation
+ * @param transferAccess transfer policy from the owning server runtime, used for DDA checks and
+ *     download-path defaults
+ */
+record CoreFcpFetchRuntimeSupport(NodeClientCore core, TransferAccessPort transferAccess)
+    implements FcpFetchRuntimeSupport {
+
+  /**
+   * Creates a fetch runtime adapter for the supplied node core.
+   *
+   * <p>The adapter is a thin wrapper and does not snapshot mutable daemon state. Later method calls
+   * continue to observe the live client context and bucket factories exposed by {@code core}, while
+   * transfer checks continue to use the server-owned {@code transferAccess} instance passed here.
+   *
+   * @param core live daemon core providing fetch contexts and bucket allocation
+   * @param transferAccess transfer policy from the owning server runtime, used for DDA checks and
+   *     default download locations
+   */
+  CoreFcpFetchRuntimeSupport(NodeClientCore core, TransferAccessPort transferAccess) {
+    this.core = Objects.requireNonNull(core);
+    this.transferAccess = Objects.requireNonNull(transferAccess);
+  }
+
+  /**
+   * Returns the live client context from the wrapped daemon core.
+   *
+   * <p>GET requests use this context when they start or resume execution. The adapter does not
+   * cache or clone the value, so callers observe the same live context the core currently exposes.
+   *
+   * @return current client context used for FCP fetch execution
+   */
+  @Override
+  public ClientContext clientContext() {
+    return core.getClientContext();
+  }
+
+  /**
+   * Returns the default persistent fetch context supplied by the wrapped daemon core.
+   *
+   * <p>Factories typically adjust the returned context immediately for one request, but the
+   * baseline always comes from the live core so persistent GET defaults remain unchanged.
+   *
+   * @return default persistent fetch context template from the daemon core
+   */
+  @Override
+  public FetchContext defaultPersistentFetchContext() {
+    return core.getClientContext().getDefaultPersistentFetchContext();
+  }
+
+  /**
+   * Returns the transfer-access policy owned by the surrounding FCP server runtime.
+   *
+   * <p>This intentionally does not read from {@code core.getRuntimePorts()}. Persistent global GET
+   * request planning must stay aligned with the server runtime that supplied the download policy
+   * and default directories.
+   *
+   * @return transfer policy used for DDA checks and default download resolution
+   */
+  @Override
+  public TransferAccessPort transferAccess() {
+    return transferAccess;
+  }
+
+  /**
+   * Allocates a Binary Blob bucket through the wrapped daemon core.
+   *
+   * <p>The bucket comes from the core's bucket factory for the requested persistence class. This
+   * keeps Binary Blob storage behavior identical to the pre-refactor GET path while exposing only a
+   * narrow package-local seam to callers.
+   *
+   * @param maxOutputLength maximum number of bytes the bucket should be prepared to hold
+   * @param persistentForever whether the forever-persistent bucket factory should be used
+   * @return newly allocated bucket suitable for Binary Blob output
+   * @throws IOException if the underlying bucket factory cannot create the bucket
+   */
+  @Override
+  public Bucket allocateBinaryBlobBucket(long maxOutputLength, boolean persistentForever)
+      throws IOException {
+    return core.getClientContext().getBucketFactory(persistentForever).makeBucket(maxOutputLength);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -482,7 +482,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(server.getCore().getClientContext());
+    request.start(server.fetchRuntimeSupport().clientContext());
   }
 
   private void startRebootClientGet(ClientGetMessage message) {
@@ -493,7 +493,7 @@ public class FCPConnectionHandler implements Closeable {
     if (!registerPersistentRequest(request, message.identifier, message.global)) {
       return;
     }
-    request.start(server.getCore().getClientContext());
+    request.start(server.fetchRuntimeSupport().clientContext());
   }
 
   private void startForeverClientGet(ClientGetMessage message) {
@@ -516,7 +516,7 @@ public class FCPConnectionHandler implements Closeable {
 
   private ClientGet buildClientGet(ClientGetMessage message) {
     try {
-      return ClientGetFactory.fromMessage(this, message, server.getCore());
+      return ClientGetFactory.fromMessage(this, message, server.fetchRuntimeSupport());
     } catch (IdentifierCollisionException _) {
       handleIdentifierCollision(message.identifier, message.global);
     } catch (MessageInvalidException e) {

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -516,7 +516,7 @@ public class FCPConnectionHandler implements Closeable {
 
   private ClientGet buildClientGet(ClientGetMessage message) {
     try {
-      return ClientGetFactory.fromMessage(this, message, server.fetchRuntimeSupport());
+      return ClientGetFactory.fromMessage(this, message, server.messageFetchRuntimeSupport());
     } catch (IdentifierCollisionException _) {
       handleIdentifierCollision(message.identifier, message.global);
     } catch (MessageInvalidException e) {

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -109,7 +109,7 @@ public class FCPServer implements Runnable, DownloadCache {
     this.enabled = config.enabled();
     this.core = dependencies.core();
     this.runtime = dependencies.runtimePorts();
-    this.fetchRuntimeSupport = new CoreFcpFetchRuntimeSupport(core, this.runtime.transferAccess());
+    this.fetchRuntimeSupport = new CoreFcpFetchRuntimeSupport(core, this.runtime::transferAccess);
     this.assumeDownloadDDAIsAllowed = config.assumeDownloadDDAAllowed();
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();
@@ -760,7 +760,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return fetch runtime support that uses the core runtime's transfer policy for message flows
    */
   FcpFetchRuntimeSupport messageFetchRuntimeSupport() {
-    return new CoreFcpFetchRuntimeSupport(core, core.getRuntimePorts().transferAccess());
+    return new CoreFcpFetchRuntimeSupport(core, () -> core.getRuntimePorts().transferAccess());
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -738,13 +738,29 @@ public class FCPServer implements Runnable, DownloadCache {
    * Returns the package-local runtime support used by the FCP GET/fetch path.
    *
    * <p>This seam keeps fetch request construction and getter setup independent of direct {@link
-   * NodeClientCore} access while preserving current runtime behavior. It is package-private because
-   * it is an internal wiring detail of {@code clients.fcp}, not a public server API.
+   * NodeClientCore} access while preserving current runtime behavior. This accessor is used for the
+   * server-owned persistent/global GET flow, so its transfer policy stays aligned with {@link
+   * #runtime()}. It is package-private because it is an internal wiring detail of {@code
+   * clients.fcp}, not a public server API.
    *
    * @return fetch runtime support backing GET request construction and execution
    */
   FcpFetchRuntimeSupport fetchRuntimeSupport() {
     return fetchRuntimeSupport;
+  }
+
+  /**
+   * Returns fetch runtime support for GET requests created directly from inbound FCP messages.
+   *
+   * <p>Socket/message request validation historically consulted the core runtime's transfer policy,
+   * even when the enclosing {@link FCPServer} was constructed with a different {@link RuntimePorts}
+   * facade. Preserving that behavior keeps connection, reboot, and forever message-based GETs on
+   * the same DDA policy they used before the GET seam refactor.
+   *
+   * @return fetch runtime support that uses the core runtime's transfer policy for message flows
+   */
+  FcpFetchRuntimeSupport messageFetchRuntimeSupport() {
+    return new CoreFcpFetchRuntimeSupport(core, core.getRuntimePorts().transferAccess());
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -52,6 +52,8 @@ public class FCPServer implements Runnable, DownloadCache {
   /* It’s not the field that is deprecated, but accessing it directly is. */
   private final NodeClientCore core;
 
+  private final FcpFetchRuntimeSupport fetchRuntimeSupport;
+
   private final RuntimePorts runtime;
 
   final int port;
@@ -107,6 +109,7 @@ public class FCPServer implements Runnable, DownloadCache {
     this.enabled = config.enabled();
     this.core = dependencies.core();
     this.runtime = dependencies.runtimePorts();
+    this.fetchRuntimeSupport = new CoreFcpFetchRuntimeSupport(core, this.runtime.transferAccess());
     this.assumeDownloadDDAIsAllowed = config.assumeDownloadDDAAllowed();
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();
@@ -729,6 +732,19 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public NodeClientCore getCore() {
     return core;
+  }
+
+  /**
+   * Returns the package-local runtime support used by the FCP GET/fetch path.
+   *
+   * <p>This seam keeps fetch request construction and getter setup independent of direct {@link
+   * NodeClientCore} access while preserving current runtime behavior. It is package-private because
+   * it is an internal wiring detail of {@code clients.fcp}, not a public server API.
+   *
+   * @return fetch runtime support backing GET request construction and execution
+   */
+  FcpFetchRuntimeSupport fetchRuntimeSupport() {
+    return fetchRuntimeSupport;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FcpFetchRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpFetchRuntimeSupport.java
@@ -1,0 +1,73 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import network.crypta.client.FetchContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Narrow runtime support seam for the FCP GET/fetch path.
+ *
+ * <p>This package-local adapter keeps the GET request creation and getter wiring independent of
+ * direct {@code NodeClientCore} access while preserving the current runtime behavior. It exposes
+ * only the fetch-specific services needed by {@link ClientGet}, {@link ClientGetFactory}, and
+ * {@link ClientGetGetterFactory}: the live {@link ClientContext}, the default persistent {@link
+ * FetchContext}, transfer-policy checks, and binary-blob bucket allocation.
+ *
+ * <p>The interface is intentionally small and local to {@code clients.fcp}. It is not a general FCP
+ * runtime facade and does not widen {@code runtime-spi}; callers should add new methods only when a
+ * later refactoring needs a demonstrably GET-specific seam. Typical call flow starts with {@link
+ * ClientGetFactory} reading the default context and transfer policy during request construction,
+ * then {@link ClientGet} and {@link ClientGetGetterFactory} using the same support object again
+ * when the request starts or allocates Binary Blob output.
+ */
+interface FcpFetchRuntimeSupport {
+
+  /**
+   * Returns the live client context used to start or resume fetch requests.
+   *
+   * <p>The returned context is the same runtime object that request code should pass into start or
+   * resume operations. Callers should treat it as a live daemon state rather than a detached
+   * snapshot.
+   *
+   * @return current client context backing FCP fetch operations
+   */
+  ClientContext clientContext();
+
+  /**
+   * Returns the default persistent fetch context template for new GET requests.
+   *
+   * <p>Factories typically clone or adjust the returned context immediately for one request. The
+   * value acts as the persistent-fetch baseline from which request-specific flags and limits are
+   * derived.
+   *
+   * @return persistent fetch context defaults supplied by the daemon runtime
+   */
+  FetchContext defaultPersistentFetchContext();
+
+  /**
+   * Returns the transfer-access policy used for disk-return planning.
+   *
+   * <p>This policy must stay aligned with the owning FCP server runtime, so default download
+   * directories and DDA decisions match the rest of the server's request handling.
+   *
+   * @return transfer policy for download path validation and defaults
+   */
+  TransferAccessPort transferAccess();
+
+  /**
+   * Allocates a bucket for binary-blob output when a request has no caller-provided return bucket.
+   *
+   * <p>The request path uses this only for Binary Blob fetches that still need a storage target.
+   * The caller handles ordinary return planning earlier.
+   *
+   * @param maxOutputLength maximum expected payload size for the fetch
+   * @param persistentForever whether the request persists forever and therefore needs the forever
+   *     bucket factory
+   * @return newly allocated bucket for binary-blob output
+   * @throws IOException if bucket allocation fails
+   */
+  Bucket allocateBinaryBlobBucket(long maxOutputLength, boolean persistentForever)
+      throws IOException;
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -608,9 +608,10 @@ final class FcpServerPersistentOps implements DownloadCache {
 
   private void innerMakePersistentGlobalRequest(PersistentGlobalRequestSpec spec)
       throws IdentifierCollisionException, NotAllowedException, IOException {
-    FetchContext defaultFetchContext = core.getClientContext().getDefaultPersistentFetchContext();
-    ClientGet.GlobalRequestConfig requestConfig =
-        new ClientGet.GlobalRequestConfig(
+    FcpFetchRuntimeSupport fetchRuntimeSupport = server.fetchRuntimeSupport();
+    FetchContext defaultFetchContext = fetchRuntimeSupport.defaultPersistentFetchContext();
+    ClientGetGlobalRequestConfig requestConfig =
+        new ClientGetGlobalRequestConfig(
             defaultFetchContext.getLocalRequestOnly(),
             defaultFetchContext.getIgnoreStore(),
             spec.filterData(),
@@ -632,10 +633,9 @@ final class FcpServerPersistentOps implements DownloadCache {
             spec.persistRebootOnly() ? globalRebootClient : globalForeverClient,
             spec.fetchURI(),
             requestConfig,
-            core,
-            transferAccess());
+            fetchRuntimeSupport);
     cg.register(false);
-    cg.start(core.getClientContext());
+    cg.start(fetchRuntimeSupport.clientContext());
   }
 
   PersistentRequestClient getGlobalForeverClient() {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -9,17 +9,14 @@ import network.crypta.client.FetchContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.events.ClientEventProducer;
-import network.crypta.clients.fcp.ClientGet.GlobalRequestConfig;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.api.BucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,11 +41,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ClientGetFactoryTest {
 
-  @Mock private NodeClientCore core;
-  @Mock private ClientContext clientContext;
+  @Mock private FcpFetchRuntimeSupport fetchRuntimeSupport;
   @Mock private FetchContext fetchContext;
   @Mock private ClientEventProducer eventProducer;
-  @Mock private RuntimePorts runtimePorts;
   @Mock private TransferAccessPort transferAccess;
 
   @Test
@@ -57,8 +52,8 @@ class ClientGetFactoryTest {
     PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
     client.register(new StubClientRequest(client, "dup-global"));
 
-    GlobalRequestConfig config =
-        new GlobalRequestConfig(
+    ClientGetGlobalRequestConfig config =
+        new ClientGetGlobalRequestConfig(
             false,
             false,
             false,
@@ -80,19 +75,19 @@ class ClientGetFactoryTest {
         IdentifierCollisionException.class,
         () ->
             ClientGetFactory.fromGlobal(
-                client, new FreenetURI("KSK@global-collision"), config, core, transferAccess));
+                client, new FreenetURI("KSK@global-collision"), config, fetchRuntimeSupport));
   }
 
   @ParameterizedTest
   @CsvSource({"true,false", "false,true"})
   void fromGlobal_whenValidConfig_buildsRequestAndAppliesFetchContext(
       boolean persistRebootOnly, boolean expectedForever) throws Exception {
-    configureCoreWithFetchContext();
+    configureFetchRuntimeSupportWithFetchContext();
     PersistentRequestClient client =
         newPersistentClient(persistRebootOnly ? Persistence.REBOOT : Persistence.FOREVER);
     FreenetURI uri = new FreenetURI("KSK@global-ok-" + persistRebootOnly);
-    GlobalRequestConfig config =
-        new GlobalRequestConfig(
+    ClientGetGlobalRequestConfig config =
+        new ClientGetGlobalRequestConfig(
             true,
             true,
             true,
@@ -110,7 +105,7 @@ class ClientGetFactoryTest {
             true,
             false);
 
-    ClientGet request = ClientGetFactory.fromGlobal(client, uri, config, core, transferAccess);
+    ClientGet request = ClientGetFactory.fromGlobal(client, uri, config, fetchRuntimeSupport);
 
     assertNotNull(request);
     assertEquals(config.identifier(), request.getIdentifier());
@@ -133,18 +128,19 @@ class ClientGetFactoryTest {
     verify(fetchContext).setMaxOutputLength(config.maxOutputLength());
     verify(fetchContext).setMaxTempLength(config.maxOutputLength());
     verify(fetchContext).setCanWriteClientCache(config.writeToClientCache());
+    verify(fetchRuntimeSupport).defaultPersistentFetchContext();
+    verify(fetchRuntimeSupport).transferAccess();
     verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
   }
 
   @Test
   void fromGlobal_whenDiskReturnDenied_throwsNotAllowedException(@TempDir Path tempDir) {
-    when(core.getClientContext()).thenReturn(clientContext);
-    when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
+    configureFetchRuntimeSupportDefaults();
     PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
     File target = tempDir.resolve("target.bin").toFile();
     when(transferAccess.allowDownloadTo(target)).thenReturn(false);
-    GlobalRequestConfig config =
-        new GlobalRequestConfig(
+    ClientGetGlobalRequestConfig config =
+        new ClientGetGlobalRequestConfig(
             false,
             false,
             false,
@@ -166,7 +162,7 @@ class ClientGetFactoryTest {
         NotAllowedException.class,
         () ->
             ClientGetFactory.fromGlobal(
-                client, new FreenetURI("KSK@global-disk"), config, core, transferAccess));
+                client, new FreenetURI("KSK@global-disk"), config, fetchRuntimeSupport));
   }
 
   @Test
@@ -179,7 +175,7 @@ class ClientGetFactoryTest {
 
       assertThrows(
           IdentifierCollisionException.class,
-          () -> ClientGetFactory.fromMessage(handler, message, core));
+          () -> ClientGetFactory.fromMessage(handler, message, fetchRuntimeSupport));
       handler.requestsByIdentifier.clear();
     }
   }
@@ -187,8 +183,7 @@ class ClientGetFactoryTest {
   @Test
   void fromMessage_whenValidConnectionMessage_buildsRequestAndAppliesFetchContext()
       throws Exception {
-    configureCoreWithFetchContext();
-    configureRuntimePorts();
+    configureFetchRuntimeSupportWithFetchContext();
     SimpleFieldSet fs = baseMessageFieldSet("message-ok");
     fs.putOverwrite("DSOnly", "true");
     fs.putOverwrite("IgnoreDS", "true");
@@ -202,7 +197,7 @@ class ClientGetFactoryTest {
     fs.putOverwrite("RealTimeFlag", "true");
     ClientGetMessage message = new ClientGetMessage(fs);
 
-    ClientGet request = ClientGetFactory.fromMessage(null, message, core);
+    ClientGet request = ClientGetFactory.fromMessage(null, message, fetchRuntimeSupport);
 
     assertNotNull(request);
     assertEquals("message-ok", request.getIdentifier());
@@ -223,19 +218,18 @@ class ClientGetFactoryTest {
     verify(fetchContext).setCanWriteClientCache(false);
     verify(fetchContext).setFilterData(true);
     verify(fetchContext).setIgnoreUSKDatehints(true);
+    verify(fetchRuntimeSupport).defaultPersistentFetchContext();
+    verify(fetchRuntimeSupport).transferAccess();
     verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
   }
 
   @Test
   void fromMessage_whenBinaryBlobBucketCreationFails_wrapsIntoMessageInvalidException()
       throws Exception {
-    configureCoreWithFetchContext();
-    configureRuntimePorts();
-    BucketFactory bucketFactory = mock(BucketFactory.class);
+    configureFetchRuntimeSupportWithFetchContext();
     IOException ioFailure = new IOException("disk-full");
     when(fetchContext.getMaxOutputLength()).thenReturn(333L);
-    when(clientContext.getBucketFactory(false)).thenReturn(bucketFactory);
-    when(bucketFactory.makeBucket(333L)).thenThrow(ioFailure);
+    when(fetchRuntimeSupport.allocateBinaryBlobBucket(333L, false)).thenThrow(ioFailure);
 
     SimpleFieldSet fs = baseMessageFieldSet("blob-io");
     fs.putOverwrite("BinaryBlob", "true");
@@ -243,24 +237,26 @@ class ClientGetFactoryTest {
 
     MessageInvalidException exception =
         assertThrows(
-            MessageInvalidException.class, () -> ClientGetFactory.fromMessage(null, message, core));
+            MessageInvalidException.class,
+            () -> ClientGetFactory.fromMessage(null, message, fetchRuntimeSupport));
 
     assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, exception.protocolCode);
     assertEquals("blob-io", exception.ident);
     assertFalse(exception.global);
     assertSame(ioFailure, exception.getCause());
     assertTrue(exception.getMessage().contains("Cannot create bucket for temporary storage"));
+    //noinspection resource
+    verify(fetchRuntimeSupport).allocateBinaryBlobBucket(333L, false);
   }
 
-  private void configureCoreWithFetchContext() {
-    when(core.getClientContext()).thenReturn(clientContext);
-    when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
+  private void configureFetchRuntimeSupportWithFetchContext() {
+    configureFetchRuntimeSupportDefaults();
     when(fetchContext.getEventProducer()).thenReturn(eventProducer);
   }
 
-  private void configureRuntimePorts() {
-    when(core.getRuntimePorts()).thenReturn(runtimePorts);
-    when(runtimePorts.transferAccess()).thenReturn(transferAccess);
+  private void configureFetchRuntimeSupportDefaults() {
+    when(fetchRuntimeSupport.defaultPersistentFetchContext()).thenReturn(fetchContext);
+    when(fetchRuntimeSupport.transferAccess()).thenReturn(transferAccess);
   }
 
   private FCPConnectionHandler newConnectionHandler() {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -134,6 +134,39 @@ class ClientGetFactoryTest {
   }
 
   @Test
+  void fromGlobal_whenUsingLegacyPublicConfigAlias_buildsRequest() throws Exception {
+    configureFetchRuntimeSupportWithFetchContext();
+    PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
+    FreenetURI uri = new FreenetURI("KSK@legacy-global-config");
+    ClientGet.GlobalRequestConfig config =
+        new ClientGet.GlobalRequestConfig(
+            false,
+            true,
+            false,
+            4,
+            5,
+            2048,
+            ReturnType.DIRECT,
+            true,
+            "legacy-global",
+            7,
+            (short) 3,
+            null,
+            "UTF-8",
+            true,
+            false,
+            false);
+
+    ClientGet request = ClientGetFactory.fromGlobal(client, uri, config, fetchRuntimeSupport);
+
+    assertNotNull(request);
+    assertEquals(config.identifier(), request.getIdentifier());
+    assertSame(uri, request.getURI());
+    verify(fetchRuntimeSupport).defaultPersistentFetchContext();
+    verify(fetchRuntimeSupport).transferAccess();
+  }
+
+  @Test
   void fromGlobal_whenDiskReturnDenied_throwsNotAllowedException(@TempDir Path tempDir) {
     configureFetchRuntimeSupportDefaults();
     PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);

--- a/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
@@ -47,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -182,10 +183,7 @@ class ClientGetGetterFactoryTest {
             request,
             mock(FreenetURI.class),
             fetchContext,
-            (short) 1,
             returnBucket,
-            null,
-            null,
             false,
             true,
             false,
@@ -209,46 +207,41 @@ class ClientGetGetterFactoryTest {
         NullPointerException.class,
         () ->
             createGetter(
-                request,
-                mock(FreenetURI.class),
-                fetchContext,
-                (short) 1,
-                null,
-                null,
-                null,
-                false,
-                true,
-                false,
-                null));
+                request, mock(FreenetURI.class), fetchContext, null, false, true, false, null));
   }
 
   @Test
   void createGetter_whenBinaryBlobTrueAndReturnBucketNull_allocatesBucket() throws Exception {
     ClientGet request = mockRequestWithClient();
     FetchContext fetchContext = mock(FetchContext.class);
-    Bucket createdBucket = mock(Bucket.class);
 
-    when(fetchContext.getMaxOutputLength()).thenReturn(128L);
-    when(fetchRuntimeSupport.allocateBinaryBlobBucket(128L, true)).thenReturn(createdBucket);
+    try (Bucket createdBucket = new NullBucket()) {
+      when(fetchContext.getMaxOutputLength()).thenReturn(128L);
+      when(fetchRuntimeSupport.allocateBinaryBlobBucket(128L, true)).thenReturn(createdBucket);
 
-    ClientGetter getter =
-        createGetter(
-            request,
-            mock(FreenetURI.class),
-            fetchContext,
-            (short) 1,
-            null,
-            null,
-            null,
-            false,
-            true,
-            true,
-            fetchRuntimeSupport);
+      ClientGetter getter =
+          createGetter(
+              request,
+              mock(FreenetURI.class),
+              fetchContext,
+              null,
+              false,
+              true,
+              true,
+              fetchRuntimeSupport);
 
-    BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
-    assertNotNull(writer);
-    assertSame(createdBucket, readField(writer, "out"));
-    verify(fetchRuntimeSupport).allocateBinaryBlobBucket(128L, true);
+      BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
+      assertNotNull(writer);
+      assertSame(createdBucket, readField(writer, "out"));
+      assertEquals(
+          1,
+          mockingDetails(fetchRuntimeSupport).getInvocations().stream()
+              .filter(
+                  invocation -> invocation.getMethod().getName().equals("allocateBinaryBlobBucket"))
+              .filter(invocation -> invocation.getArguments()[0].equals(128L))
+              .filter(invocation -> invocation.getArguments()[1].equals(true))
+              .count());
+    }
   }
 
   @Test
@@ -262,10 +255,7 @@ class ClientGetGetterFactoryTest {
             request,
             mock(FreenetURI.class),
             fetchContext,
-            (short) 1,
             returnBucket,
-            null,
-            null,
             true,
             false,
             false,
@@ -288,10 +278,7 @@ class ClientGetGetterFactoryTest {
             request,
             mock(FreenetURI.class),
             fetchContext,
-            (short) 1,
             returnBucket,
-            null,
-            null,
             false,
             false,
             false,
@@ -324,9 +311,6 @@ class ClientGetGetterFactoryTest {
             request,
             mock(FreenetURI.class),
             fetchContext,
-            (short) 1,
-            null,
-            null,
             null,
             false,
             false,
@@ -355,19 +339,15 @@ class ClientGetGetterFactoryTest {
       ClientGet request,
       FreenetURI uri,
       FetchContext fetchContext,
-      short priorityClass,
       Bucket returnBucket,
-      Bucket initialMetadata,
-      String extensionCheck,
       boolean discardData,
       boolean binaryBlob,
       boolean persistenceForever,
       FcpFetchRuntimeSupport fetchRuntimeSupport)
       throws IOException {
     ClientGetterRequest getterRequest =
-        ClientGetGetterFactory.createGetterRequest(request, uri, fetchContext, priorityClass);
-    ClientGetterOptions options =
-        new ClientGetterOptions(returnBucket, null, false, initialMetadata, extensionCheck);
+        ClientGetGetterFactory.createGetterRequest(request, uri, fetchContext, (short) 1);
+    ClientGetterOptions options = new ClientGetterOptions(returnBucket, null, false, null, null);
     ClientGetGetterFlags flags =
         new ClientGetGetterFlags(discardData, binaryBlob, persistenceForever);
     return ClientGetGetterFactory.createGetter(getterRequest, options, flags, fetchRuntimeSupport);

--- a/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
@@ -25,11 +25,8 @@ import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
 import network.crypta.crypt.HashType;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.support.api.Bucket;
-import network.crypta.support.api.BucketFactory;
-import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.FileBucket;
 import network.crypta.support.io.NullBucket;
 import org.junit.jupiter.api.Test;
@@ -37,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,6 +55,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 class ClientGetGetterFactoryTest {
   @TempDir File tempDir;
+  @Mock private FcpFetchRuntimeSupport fetchRuntimeSupport;
 
   @Test
   void binaryBlobMimeType_whenCalled_returnsBinaryBlobMimeType() {
@@ -190,7 +189,7 @@ class ClientGetGetterFactoryTest {
             false,
             true,
             false,
-            null);
+            fetchRuntimeSupport);
 
     Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
     BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
@@ -198,10 +197,11 @@ class ClientGetGetterFactoryTest {
     assertInstanceOf(NullBucket.class, storedReturnBucket);
     assertNotNull(writer);
     assertSame(returnBucket, readField(writer, "out"));
+    verifyNoInteractions(fetchRuntimeSupport);
   }
 
   @Test
-  void createGetter_whenBinaryBlobTrueAndReturnBucketNull_requiresCore() {
+  void createGetter_whenBinaryBlobTrueAndReturnBucketNull_requiresRuntimeSupport() {
     ClientGet request = mock(ClientGet.class);
     FetchContext fetchContext = mock(FetchContext.class);
 
@@ -226,15 +226,10 @@ class ClientGetGetterFactoryTest {
   void createGetter_whenBinaryBlobTrueAndReturnBucketNull_allocatesBucket() throws Exception {
     ClientGet request = mockRequestWithClient();
     FetchContext fetchContext = mock(FetchContext.class);
-    NodeClientCore core = mock(NodeClientCore.class);
-    ClientContext clientContext = mock(ClientContext.class);
-    BucketFactory bucketFactory = mock(BucketFactory.class);
-    RandomAccessBucket createdBucket = mock(RandomAccessBucket.class);
+    Bucket createdBucket = mock(Bucket.class);
 
     when(fetchContext.getMaxOutputLength()).thenReturn(128L);
-    when(core.getClientContext()).thenReturn(clientContext);
-    when(clientContext.getBucketFactory(true)).thenReturn(bucketFactory);
-    when(bucketFactory.makeBucket(128L)).thenReturn(createdBucket);
+    when(fetchRuntimeSupport.allocateBinaryBlobBucket(128L, true)).thenReturn(createdBucket);
 
     ClientGetter getter =
         createGetter(
@@ -248,11 +243,12 @@ class ClientGetGetterFactoryTest {
             false,
             true,
             true,
-            core);
+            fetchRuntimeSupport);
 
     BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
     assertNotNull(writer);
     assertSame(createdBucket, readField(writer, "out"));
+    verify(fetchRuntimeSupport).allocateBinaryBlobBucket(128L, true);
   }
 
   @Test
@@ -273,11 +269,12 @@ class ClientGetGetterFactoryTest {
             true,
             false,
             false,
-            null);
+            fetchRuntimeSupport);
 
     Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
 
     assertInstanceOf(NullBucket.class, storedReturnBucket);
+    verifyNoInteractions(fetchRuntimeSupport);
   }
 
   @Test
@@ -298,13 +295,14 @@ class ClientGetGetterFactoryTest {
             false,
             false,
             false,
-            null);
+            fetchRuntimeSupport);
 
     Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
     BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
 
     assertSame(returnBucket, storedReturnBucket);
     assertNull(writer);
+    verifyNoInteractions(fetchRuntimeSupport);
   }
 
   @Test
@@ -333,7 +331,7 @@ class ClientGetGetterFactoryTest {
             false,
             false,
             false,
-            null);
+            fetchRuntimeSupport);
 
     ClientGetCallback callback = getter.getClientCallback();
 
@@ -350,29 +348,7 @@ class ClientGetGetterFactoryTest {
     verify(request).onFailure(fetchException);
     verify(request).onResume(context);
     verify(request).getClientDetail(dos, checker);
-  }
-
-  @Test
-  void createGetter_whenBinaryBlobTrueAndBucketProvided_doesNotTouchCore() throws IOException {
-    ClientGet request = mockRequestWithClient();
-    FetchContext fetchContext = mock(FetchContext.class);
-    NodeClientCore core = mock(NodeClientCore.class);
-    Bucket returnBucket = mock(Bucket.class);
-
-    createGetter(
-        request,
-        mock(FreenetURI.class),
-        fetchContext,
-        (short) 1,
-        returnBucket,
-        null,
-        null,
-        false,
-        true,
-        false,
-        core);
-
-    verifyNoInteractions(core);
+    verifyNoInteractions(fetchRuntimeSupport);
   }
 
   private static ClientGetter createGetter(
@@ -386,7 +362,7 @@ class ClientGetGetterFactoryTest {
       boolean discardData,
       boolean binaryBlob,
       boolean persistenceForever,
-      NodeClientCore core)
+      FcpFetchRuntimeSupport fetchRuntimeSupport)
       throws IOException {
     ClientGetterRequest getterRequest =
         ClientGetGetterFactory.createGetterRequest(request, uri, fetchContext, priorityClass);
@@ -394,7 +370,7 @@ class ClientGetGetterFactoryTest {
         new ClientGetterOptions(returnBucket, null, false, initialMetadata, extensionCheck);
     ClientGetGetterFlags flags =
         new ClientGetGetterFlags(discardData, binaryBlob, persistenceForever);
-    return ClientGetGetterFactory.createGetter(getterRequest, options, flags, core);
+    return ClientGetGetterFactory.createGetter(getterRequest, options, flags, fetchRuntimeSupport);
   }
 
   private static HashResult hashFor(HashType type, byte seed) {

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -49,12 +49,11 @@ class FCPConnectionHandlerTest {
   @Mock private RandomnessPort randomnessPort;
 
   private FCPConnectionHandler handler;
-  private Random fastRandom;
 
   @BeforeEach
   void setUp() {
     DeterministicRandomSource randomSource = new DeterministicRandomSource(1234L);
-    fastRandom = new Random(5678L);
+    Random fastRandom = new Random(5678L);
 
     lenient().when(server.getCore()).thenReturn(core);
     lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -32,7 +32,7 @@ class FCPServerTest {
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     when(runtimePorts.execution()).thenReturn(executionPort);
-    when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
+    lenient().when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
     lenient().when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
     lenient().when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
     FcpServerConfig config =
@@ -102,7 +102,7 @@ class FCPServerTest {
     // Arrange
     PersistentRequestRoot root = spy(new PersistentRequestRoot());
     when(runtimePorts.execution()).thenReturn(executionPort);
-    when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
+    lenient().when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -176,6 +176,22 @@ class FCPServerTest {
     // Assert
     assertSame(serverTransferAccess, actual);
     assertNotSame(coreTransferAccess, actual);
+  }
+
+  @Test
+  void fetchRuntimeSupport_whenServerTransferPolicyChanges_readsLatestRuntimePort() {
+    // Arrange
+    FCPServer server = newServer(false, false);
+    FcpFetchRuntimeSupport support = server.fetchRuntimeSupport();
+    TransferAccessPort updatedServerTransferAccess = mock(TransferAccessPort.class);
+    when(runtimePorts.transferAccess()).thenReturn(updatedServerTransferAccess);
+
+    // Act
+    TransferAccessPort actual = support.transferAccess();
+
+    // Assert
+    assertSame(updatedServerTransferAccess, actual);
+    assertNotSame(serverTransferAccess, actual);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -25,6 +25,7 @@ class FCPServerTest {
 
   @Mock private NodeClientCore core;
   @Mock private RuntimePorts runtimePorts;
+  @Mock private RuntimePorts coreRuntimePorts;
   @Mock private ExecutionPort executionPort;
   @Mock private TransferAccessPort serverTransferAccess;
   @Mock private TransferAccessPort coreTransferAccess;
@@ -32,6 +33,8 @@ class FCPServerTest {
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     when(runtimePorts.execution()).thenReturn(executionPort);
     when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
+    lenient().when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
+    lenient().when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -173,6 +176,19 @@ class FCPServerTest {
     // Assert
     assertSame(serverTransferAccess, actual);
     assertNotSame(coreTransferAccess, actual);
+  }
+
+  @Test
+  void messageFetchRuntimeSupport_whenTransferAccessQueried_usesCoreRuntimePorts() {
+    // Arrange
+    FCPServer server = newServer(false, false);
+
+    // Act
+    TransferAccessPort actual = server.messageFetchRuntimeSupport().transferAccess();
+
+    // Assert
+    assertSame(coreTransferAccess, actual);
+    assertNotSame(serverTransferAccess, actual);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -7,6 +7,7 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,9 +26,12 @@ class FCPServerTest {
   @Mock private NodeClientCore core;
   @Mock private RuntimePorts runtimePorts;
   @Mock private ExecutionPort executionPort;
+  @Mock private TransferAccessPort serverTransferAccess;
+  @Mock private TransferAccessPort coreTransferAccess;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     when(runtimePorts.execution()).thenReturn(executionPort);
+    when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -95,6 +99,7 @@ class FCPServerTest {
     // Arrange
     PersistentRequestRoot root = spy(new PersistentRequestRoot());
     when(runtimePorts.execution()).thenReturn(executionPort);
+    when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -141,6 +146,33 @@ class FCPServerTest {
     FCPServer server = newServer(false, false);
 
     assertSame(runtimePorts, server.runtime());
+  }
+
+  @Test
+  void fetchRuntimeSupport_whenQueried_returnsConfiguredAdapter() {
+    // Arrange
+    FCPServer server = newServer(false, false);
+    FcpFetchRuntimeSupport first = server.fetchRuntimeSupport();
+
+    // Act
+    FcpFetchRuntimeSupport second = server.fetchRuntimeSupport();
+
+    // Assert
+    assertNotNull(first);
+    assertSame(first, second);
+  }
+
+  @Test
+  void fetchRuntimeSupport_whenTransferAccessQueried_usesServerRuntimePorts() {
+    // Arrange
+    FCPServer server = newServer(false, false);
+
+    // Act
+    TransferAccessPort actual = server.fetchRuntimeSupport().transferAccess();
+
+    // Assert
+    assertSame(serverTransferAccess, actual);
+    assertNotSame(coreTransferAccess, actual);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -7,7 +7,6 @@ import network.crypta.io.NetworkInterface;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
-import network.crypta.runtime.spi.TransferAccessPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -20,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -39,7 +37,6 @@ class FcpServerConfigRegistrarTest {
     Config config = new Config();
     PersistentRequestRoot root = new PersistentRequestRoot();
     when(runtimePorts.execution()).thenReturn(executionPort);
-    when(runtimePorts.transferAccess()).thenReturn(mock(TransferAccessPort.class));
 
     // Act
     FCPServer server = FcpServerConfigRegistrar.maybeCreate(core, runtimePorts, config, root);
@@ -224,7 +221,6 @@ class FcpServerConfigRegistrarTest {
 
   private FCPServer newServer() {
     when(runtimePorts.execution()).thenReturn(executionPort);
-    when(runtimePorts.transferAccess()).thenReturn(mock(TransferAccessPort.class));
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -7,6 +7,7 @@ import network.crypta.io.NetworkInterface;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -37,6 +39,7 @@ class FcpServerConfigRegistrarTest {
     Config config = new Config();
     PersistentRequestRoot root = new PersistentRequestRoot();
     when(runtimePorts.execution()).thenReturn(executionPort);
+    when(runtimePorts.transferAccess()).thenReturn(mock(TransferAccessPort.class));
 
     // Act
     FCPServer server = FcpServerConfigRegistrar.maybeCreate(core, runtimePorts, config, root);
@@ -221,6 +224,7 @@ class FcpServerConfigRegistrarTest {
 
   private FCPServer newServer() {
     when(runtimePorts.execution()).thenReturn(executionPort);
+    when(runtimePorts.transferAccess()).thenReturn(mock(TransferAccessPort.class));
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.FetchContext;
 import network.crypta.client.FetchResult;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
@@ -47,6 +48,7 @@ class FcpServerPersistentOpsTest {
   @Mock private NodeClientCore core;
 
   @Mock private FCPServer server;
+  @Mock private FcpFetchRuntimeSupport fetchRuntimeSupport;
   @Mock private RuntimePorts runtimePorts;
   @Mock private TransferAccessPort transferAccess;
 
@@ -635,7 +637,12 @@ class FcpServerPersistentOpsTest {
 
   private FcpServerPersistentOps newOps(PersistentRequestRoot root) {
     lenient().when(server.runtime()).thenReturn(runtimePorts);
+    lenient().when(server.fetchRuntimeSupport()).thenReturn(fetchRuntimeSupport);
     lenient().when(runtimePorts.transferAccess()).thenReturn(transferAccess);
+    lenient().when(fetchRuntimeSupport.transferAccess()).thenReturn(transferAccess);
+    lenient()
+        .when(fetchRuntimeSupport.defaultPersistentFetchContext())
+        .thenReturn(mock(FetchContext.class));
     return new FcpServerPersistentOps(server, core, root);
   }
 


### PR DESCRIPTION
## Summary
- add a narrow package-local `FcpFetchRuntimeSupport` seam and a core-backed implementation for the FCP GET path
- route `ClientGet`, `ClientGetFactory`, `ClientGetGetterFactory`, and the GET-specific `FCPServer` wiring through that support without changing `runtime-spi`
- preserve server-owned `TransferAccessPort` behavior for persistent global GET DDA checks, add focused regression coverage, and document the new support types

## Testing
- `./gradlew test --tests 'network.crypta.clients.fcp.FCPServerTest' --tests 'network.crypta.clients.fcp.FcpServerConfigRegistrarTest' --tests 'network.crypta.clients.fcp.FcpServerPersistentOpsTest' --tests 'network.crypta.clients.fcp.ClientGetFactoryTest' --tests 'network.crypta.clients.fcp.ClientGetGetterFactoryTest'`

## Notes
- `runtime-spi` is unchanged
- PUT and USK paths remain untouched in this change set