### PR TITLE
refactor(fcp): Introduce insert and USK runtime seam

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -18,7 +18,6 @@ import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.InsertRequestParams;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.ResumeFailedException;
@@ -118,7 +117,7 @@ public final class ClientPut extends ClientPutBase {
    *     {@code null} and should be consistent with the request type.
    * @param upload upload payload metadata describing source and content hints; must not be {@code
    *     null} and should include a readable bucket if required.
-   * @param core owning {@link NodeClientCore} providing policies, factories, and scheduler hooks;
+   * @param server owning server providing insert runtime support, policies, and scheduler hooks;
    *     must not be {@code null}.
    * @throws IdentifierCollisionException when the chosen identifier already exists in persistence.
    * @throws NotAllowedException when the configured upload source violates server-side policy.
@@ -126,17 +125,15 @@ public final class ClientPut extends ClientPutBase {
    * @throws IOException when filesystem or bucket reads fail during preparation.
    */
   public ClientPut(
-      FcpInsertRequest request,
-      FcpInsertOptions options,
-      ClientPutUpload upload,
-      NodeClientCore core)
+      FcpInsertRequest request, FcpInsertOptions options, ClientPutUpload upload, FCPServer server)
       throws IdentifierCollisionException,
           NotAllowedException,
           MetadataUnresolvedException,
           IOException {
+    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
     ClientRequestParams requestParams =
         new ClientRequestParams(
-            checkEmptySSK(request.uri(), upload.targetFilename(), core.getClientContext()),
+            checkEmptySSK(request.uri(), upload.targetFilename(), runtimeSupport.clientContext()),
             ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
             request.verbosity(),
             request.priorityClass(),
@@ -150,7 +147,7 @@ public final class ClientPut extends ClientPutBase {
         options,
         null,
         request.client(),
-        core,
+        runtimeSupport,
         derivePublicURI(requestParams.uri()));
     UploadFrom uploadFromType = upload.uploadFromType();
     File uploadOrigFilename = upload.origFilename();
@@ -160,7 +157,7 @@ public final class ClientPut extends ClientPutBase {
 
     if (uploadFromType == UploadFrom.DISK) {
       ClientPutDiskUploadValidator.validatePersistentDiskUpload(
-          core.getRuntimePorts().transferAccess(), uploadOrigFilename);
+          runtimeSupport.transferAccess(), uploadOrigFilename);
     }
 
     this.binaryBlob = upload.binaryBlob();
@@ -175,7 +172,12 @@ public final class ClientPut extends ClientPutBase {
     if (LOG.isDebugEnabled()) LOG.debug(PERSISTENT_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
     PreparedData preparedData =
         ClientPutPreparedDataFactory.prepareForPersistentUpload(
-            uploadFrom, cm, tempData, upload.redirectTarget(), core, isPersistentForever());
+            uploadFrom,
+            cm,
+            tempData,
+            upload.redirectTarget(),
+            runtimeSupport,
+            isPersistentForever());
     this.data = preparedData.bucket();
     this.clientMetadata = cm;
     this.targetURI = preparedData.targetUri();
@@ -211,8 +213,8 @@ public final class ClientPut extends ClientPutBase {
    *     rights; must not be {@code null} and should represent the active socket.
    * @param message parsed {@link ClientPutMessage} containing payload descriptors and metadata;
    *     must not be {@code null} and should already have validated field syntax.
-   * @param server owning server providing {@link NodeClientCore} accessors and capability checks;
-   *     must not be {@code null}.
+   * @param server owning server providing insert runtime support and capability checks; must not be
+   *     {@code null}.
    * @throws IdentifierCollisionException if another request on the connection already uses the
    *     identifier.
    * @throws MessageInvalidException when client supplied fields (hashes, MIME, permissions) are
@@ -221,6 +223,7 @@ public final class ClientPut extends ClientPutBase {
    */
   public ClientPut(FCPConnectionHandler handler, ClientPutMessage message, FCPServer server)
       throws IdentifierCollisionException, MessageInvalidException, IOException {
+    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
     FcpInsertOptions options =
         new FcpInsertOptions(
             new FcpInsertBehaviorOptions(
@@ -241,7 +244,7 @@ public final class ClientPut extends ClientPutBase {
             message.overrideSplitfileCryptoKey);
     ClientRequestParams requestParams =
         new ClientRequestParams(
-            checkEmptySSK(message.uri, message.targetFilename, server.getCore().getClientContext()),
+            checkEmptySSK(message.uri, message.targetFilename, runtimeSupport.clientContext()),
             ensureConnectionIdentifierAvailable(handler, message),
             message.verbosity,
             message.priorityClass,
@@ -249,9 +252,15 @@ public final class ClientPut extends ClientPutBase {
             options.realTimeFlag(),
             message.clientToken,
             message.global);
-    super(requestParams, null, options, handler, server, derivePublicURI(requestParams.uri()));
+    super(
+        requestParams,
+        null,
+        options,
+        handler,
+        runtimeSupport,
+        derivePublicURI(requestParams.uri()));
     binaryBlob = message.binaryBlob;
-    TransferAccessPort transferAccess = server.getCore().getRuntimePorts().transferAccess();
+    TransferAccessPort transferAccess = runtimeSupport.transferAccess();
 
     DiskUploadContext diskContext =
         ClientPutDiskUploadValidator.validateDiskUpload(
@@ -274,7 +283,7 @@ public final class ClientPut extends ClientPutBase {
     ClientMetadata cm = new ClientMetadata(mimeType);
     PreparedData preparedData =
         ClientPutPreparedDataFactory.prepareForMessage(
-            message, cm, server, isPersistentForever(), uploadFrom, identifier, global);
+            message, cm, runtimeSupport, isPersistentForever(), uploadFrom, identifier, global);
     this.data = preparedData.bucket();
     this.clientMetadata = cm;
     this.targetURI = preparedData.targetUri();

--- a/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -23,7 +23,6 @@ import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.StartedCompressionEvent;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,19 +188,19 @@ public abstract class ClientPutBase extends ClientRequest
    * @param charset optional declared source charset; unsupported values trigger warnings only
    * @param options insert tuning options covering retries, compression, and caching behavior
    * @param handler owning connection handler responsible for queuing outbound replies
-   * @param server server providing node context, bucket factories, and persistent insert defaults
+   * @param runtimeSupport insert runtime support providing contexts and bucket factories
    * @param publicURI precomputed request URI corresponding to {@code requestParams.uri()}
    */
-  protected ClientPutBase(
+  ClientPutBase(
       ClientRequestParams requestParams,
       String charset,
       FcpInsertOptions options,
       FCPConnectionHandler handler,
-      FCPServer server,
+      FcpInsertRuntimeSupport runtimeSupport,
       FreenetURI publicURI) {
     super(prepareConstructorInit(requestParams, handler));
     warnIfUnsupportedCharset(charset);
-    ctx = server.getCore().getClientContext().getDefaultPersistentInsertContext();
+    ctx = runtimeSupport.defaultPersistentInsertContext();
     ctx.setGetCHKOnly(options.getCHKOnly());
     ctx.setDontCompress(options.dontCompress());
     ctx.getEventProducer().addEventListener(this);
@@ -256,30 +255,31 @@ public abstract class ClientPutBase extends ClientRequest
    * disk or migrating between schedulers.
    *
    * <p>The constructor receives a fully resolved persistent client handle and reuses the
-   * persistence-aware {@link InsertContext} provided by {@link NodeClientCore}. It mirrors the
-   * connection-bound constructor but skips server-specific bookkeeping, allowing REST API callers
-   * or resuming jobs to bypass socket handlers entirely while preserving the same configuration
-   * surface.
+   * persistence-aware {@link InsertContext} provided by the insert runtime support seam. It mirrors
+   * the connection-bound constructor but skips server-specific bookkeeping, allowing REST API
+   * callers or resuming jobs to bypass socket handlers entirely while preserving the same
+   * configuration surface.
    *
    * @param requestParams request metadata including URI, identifiers, and scheduling flags
    * @param charset optional charset hint that influences metadata generation when meaningful
    * @param options insert tuning options that should persist across restarts
    * @param handler connection handler for immediate responses during the resume handshake
    * @param client persistent request owner used to enqueue outbound messages after resumption
-   * @param core node core used to get shared factories and contexts for resumed jobs
+   * @param runtimeSupport insert runtime support used to get shared factories and contexts for
+   *     resumed jobs
    * @param publicURI precomputed request URI corresponding to {@code requestParams.uri()}
    */
-  protected ClientPutBase(
+  ClientPutBase(
       ClientRequestParams requestParams,
       String charset,
       FcpInsertOptions options,
       FCPConnectionHandler handler,
       PersistentRequestClient client,
-      NodeClientCore core,
+      FcpInsertRuntimeSupport runtimeSupport,
       FreenetURI publicURI) {
     super(prepareConstructorInit(requestParams, handler, client));
     warnIfUnsupportedCharset(charset);
-    ctx = core.getClientContext().getDefaultPersistentInsertContext();
+    ctx = runtimeSupport.defaultPersistentInsertContext();
     ctx.setGetCHKOnly(options.getCHKOnly());
     ctx.setDontCompress(options.dontCompress());
     ctx.getEventProducer().addEventListener(this);

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -24,7 +24,6 @@ import network.crypta.client.async.ManifestPutterParams;
 import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.ManifestElement;
 import network.crypta.support.io.FileBucket;
 import network.crypta.support.io.ResumeFailedException;
@@ -119,6 +118,7 @@ public final class ClientPutDir extends ClientPutBase {
       boolean wasDiskPut,
       FCPServer server)
       throws MalformedURLException, TooManyFilesInsertException {
+    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
     FcpInsertOptions options =
         new FcpInsertOptions(
             new FcpInsertBehaviorOptions(
@@ -142,7 +142,7 @@ public final class ClientPutDir extends ClientPutBase {
             checkEmptySSK(
                 message.uri,
                 message.targetFilename != null ? message.targetFilename : "site",
-                server.getCore().getClientContext()),
+                runtimeSupport.clientContext()),
             message.identifier,
             message.verbosity,
             message.priorityClass,
@@ -150,7 +150,13 @@ public final class ClientPutDir extends ClientPutBase {
             options.realTimeFlag(),
             message.clientToken,
             message.global);
-    super(requestParams, null, options, handler, server, derivePublicURI(requestParams.uri()));
+    super(
+        requestParams,
+        null,
+        options,
+        handler,
+        runtimeSupport,
+        derivePublicURI(requestParams.uri()));
     // debug level captured via LOG.isDebugEnabled()
     this.wasDiskPut = wasDiskPut;
     this.overrideSplitfileCryptoKey = message.overrideSplitfileCryptoKey;
@@ -162,7 +168,7 @@ public final class ClientPutDir extends ClientPutBase {
     this.manifestElements.putAll(manifestElements);
 
     this.defaultName = message.defaultName;
-    makePutter(server.getCore().getClientContext());
+    makePutter(runtimeSupport.clientContext());
     if (putter != null) {
       numberOfFiles = putter.countFiles();
       totalSize = putter.totalSize();
@@ -183,8 +189,7 @@ public final class ClientPutDir extends ClientPutBase {
    * the request is registered with a {@link PersistentRequestClient}. The constructor immediately
    * counts files and bytes, so progress meters have deterministic totals, and it captures the
    * optional override splitfile key for callers who precompute keys. After construction, invoke
-   * {@link #start(ClientContext)} to stream blocks while leveraging the provided {@link
-   * NodeClientCore}.
+   * {@link #start(ClientContext)} to stream blocks while leveraging the provided {@link FCPServer}.
    *
    * <pre>{@code
    * var request =
@@ -215,7 +220,7 @@ public final class ClientPutDir extends ClientPutBase {
    * @param defaultName default manifest document served when consumers fetch the directory.
    * @param allowUnreadableFiles true to skip unreadable entries instead of aborting immediately.
    * @param includeHiddenFiles true to include filesystem entries marked hidden by the OS.
-   * @param core node client core providing context services and cryptographic settings.
+   * @param server owning server providing insert runtime support and cryptographic settings.
    * @throws FileNotFoundException if unreadable files are encountered while not permitted.
    * @throws MalformedURLException if the URI cannot be parsed, normalized, or validated.
    * @throws TooManyFilesInsertException if the directory exceeds the configured file limit.
@@ -227,11 +232,12 @@ public final class ClientPutDir extends ClientPutBase {
       String defaultName,
       boolean allowUnreadableFiles,
       boolean includeHiddenFiles,
-      NodeClientCore core)
+      FCPServer server)
       throws FileNotFoundException, MalformedURLException, TooManyFilesInsertException {
+    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
     ClientRequestParams requestParams =
         new ClientRequestParams(
-            checkEmptySSK(request.uri(), "site", core.getClientContext()),
+            checkEmptySSK(request.uri(), "site", runtimeSupport.clientContext()),
             request.identifier(),
             request.verbosity(),
             request.priorityClass(),
@@ -245,14 +251,14 @@ public final class ClientPutDir extends ClientPutBase {
         options,
         null,
         request.client(),
-        core,
+        runtimeSupport,
         derivePublicURI(requestParams.uri()));
     wasDiskPut = true;
     this.overrideSplitfileCryptoKey = options.overrideSplitfileCryptoKey();
     // debug level captured via LOG.isDebugEnabled()
     this.manifestElements = makeDiskDirManifest(dir, "", allowUnreadableFiles, includeHiddenFiles);
     this.defaultName = defaultName;
-    makePutter(core.getClientContext());
+    makePutter(runtimeSupport.clientContext());
     if (putter != null) {
       numberOfFiles = putter.countFiles();
       totalSize = putter.totalSize();

--- a/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
@@ -529,8 +529,7 @@ public final class ClientPutMessage extends DataCarryingMessage {
   RandomAccessBucket createBucket(BucketFactory bf, long length, FCPServer server)
       throws IOException, PersistenceDisabledException {
     if (persistence == Persistence.FOREVER) {
-      if (server.getCore().killedDatabase()) throw new PersistenceDisabledException();
-      return server.getCore().getPersistentTempBucketFactory().makeBucket(length);
+      return server.insertRuntimeSupport().allocatePersistentUploadBucket(length);
     } else {
       return super.createBucket(bf, length, server);
     }

--- a/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
@@ -6,7 +6,6 @@ import network.crypta.client.Metadata.DocumentType;
 import network.crypta.client.Metadata;
 import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.RandomAccessBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +57,8 @@ final class ClientPutPreparedDataFactory {
    * @param data bucket holding the raw upload payload; must not be {@code null}.
    * @param redirectTarget redirect target URI used when {@code uploadFrom} is redirect; may be
    *     {@code null} when unused.
-   * @param core node core providing the persistent bucket factory; must not be {@code null}.
+   * @param runtimeSupport insert runtime support providing the bucket factory; must not be {@code
+   *     null}.
    * @param persistentForever whether to use a forever-persistent bucket factory.
    * @return a {@link PreparedData} bundle describing the bucket to insert and redirect metadata.
    * @throws MetadataUnresolvedException when redirect metadata cannot serialize.
@@ -69,14 +69,14 @@ final class ClientPutPreparedDataFactory {
       ClientMetadata metadata,
       RandomAccessBucket data,
       FreenetURI redirectTarget,
-      NodeClientCore core,
+      FcpInsertRuntimeSupport runtimeSupport,
       boolean persistentForever)
       throws MetadataUnresolvedException, IOException {
     if (uploadFrom == ClientPutBase.UploadFrom.REDIRECT) {
       Metadata redirectMetadata =
           new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
       RandomAccessBucket redirectData =
-          redirectMetadata.toBucket(core.getClientContext().getBucketFactory(persistentForever));
+          redirectMetadata.toBucket(runtimeSupport.bucketFactory(persistentForever));
       return new PreparedData(redirectData, true, redirectTarget);
     }
     return new PreparedData(data, false, null);
@@ -92,7 +92,8 @@ final class ClientPutPreparedDataFactory {
    *
    * @param message parsed FCP message containing the data bucket; must not be {@code null}.
    * @param metadata client metadata attached to the upload; must not be {@code null}.
-   * @param server server instance providing access to the node core; must not be {@code null}.
+   * @param runtimeSupport insert runtime support providing bucket allocation; must not be {@code
+   *     null}.
    * @param persistentForever whether to use a forever-persistent bucket factory.
    * @param uploadFrom upload source describing whether this is a redirect or direct upload.
    * @param identifier request identifier used for error reporting; must not be {@code null}.
@@ -104,7 +105,7 @@ final class ClientPutPreparedDataFactory {
   static PreparedData prepareForMessage(
       ClientPutMessage message,
       ClientMetadata metadata,
-      FCPServer server,
+      FcpInsertRuntimeSupport runtimeSupport,
       boolean persistentForever,
       ClientPutBase.UploadFrom uploadFrom,
       String identifier,
@@ -118,8 +119,7 @@ final class ClientPutPreparedDataFactory {
           new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
       try {
         RandomAccessBucket redirectData =
-            metadataDoc.toBucket(
-                server.getCore().getClientContext().getBucketFactory(persistentForever));
+            metadataDoc.toBucket(runtimeSupport.bucketFactory(persistentForever));
         return new PreparedData(redirectData, true, redirectTarget);
       } catch (MetadataUnresolvedException e) {
         throw new MessageInvalidException(

--- a/src/main/java/network/crypta/clients/fcp/CoreFcpInsertRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/CoreFcpInsertRuntimeSupport.java
@@ -1,0 +1,85 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Supplier;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.USKManager;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+
+/**
+ * Core-backed implementation of {@link FcpInsertRuntimeSupport}.
+ *
+ * <p>This adapter is the insert/USK assembly seam between {@code clients.fcp} and the broader
+ * daemon runtime. It keeps insert-specific wiring local to this package by translating the small
+ * set of insert dependencies into direct delegations on the wrapped {@link NodeClientCore} plus the
+ * transfer-access policy supplier used for upload validation. The adapter is immutable after
+ * construction and observes the live daemon state on each call.
+ *
+ * @param core live daemon core used for insert contexts, bucket allocation, and USK subscriptions
+ * @param transferAccessSupplier live transfer-policy lookup used for upload DDA checks; callers
+ *     typically bind this to {@code core.getRuntimePorts().transferAccess()} to preserve legacy
+ *     insert validation behavior
+ */
+record CoreFcpInsertRuntimeSupport(
+    NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier)
+    implements FcpInsertRuntimeSupport {
+
+  /**
+   * Creates an insert-runtime adapter over the supplied live daemon services.
+   *
+   * <p>The adapter does not snapshot state. Later calls continue to observe the current client
+   * context, bucket factories, USK manager, and transfer policy exposed by the wrapped core and the
+   * supplied transfer-policy lookup. Callers usually construct one instance per {@link FCPServer}
+   * and reuse it for all insert and USK request assembly in that server.
+   *
+   * @param core live daemon core providing insert contexts, persistent bucket factories, and USK
+   *     services for the FCP insert path
+   * @param transferAccessSupplier live transfer-policy lookup that should stay aligned with the
+   *     legacy insert validation policy while requests are being created
+   */
+  CoreFcpInsertRuntimeSupport(
+      NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier) {
+    this.core = Objects.requireNonNull(core);
+    this.transferAccessSupplier = Objects.requireNonNull(transferAccessSupplier);
+  }
+
+  @Override
+  public ClientContext clientContext() {
+    return core.getClientContext();
+  }
+
+  @Override
+  public InsertContext defaultPersistentInsertContext() {
+    return core.getClientContext().getDefaultPersistentInsertContext();
+  }
+
+  @Override
+  public TransferAccessPort transferAccess() {
+    return Objects.requireNonNull(transferAccessSupplier.get());
+  }
+
+  @Override
+  public BucketFactory bucketFactory(boolean persistentForever) {
+    return core.getClientContext().getBucketFactory(persistentForever);
+  }
+
+  @Override
+  public RandomAccessBucket allocatePersistentUploadBucket(long length)
+      throws IOException, PersistenceDisabledException {
+    if (core.killedDatabase()) {
+      throw new PersistenceDisabledException();
+    }
+    return core.getPersistentTempBucketFactory().makeBucket(length);
+  }
+
+  @Override
+  public USKManager uskManager() {
+    return core.getUskManager();
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -10,6 +10,7 @@ import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
@@ -579,7 +580,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(server.getCore().getClientContext());
+    request.start(server.insertRuntimeSupport().clientContext());
   }
 
   private void startRebootClientPut(ClientPutMessage message) {
@@ -591,7 +592,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(server.getCore().getClientContext());
+    request.start(server.insertRuntimeSupport().clientContext());
   }
 
   private void startForeverClientPut(ClientPutMessage message) {
@@ -660,16 +661,17 @@ public class FCPConnectionHandler implements Closeable {
       return;
     }
     RegistrationResult registration = registerConnectionScopedRequest(message.identifier, request);
+    ClientContext clientContext = server.insertRuntimeSupport().clientContext();
     if (registration == RegistrationResult.DUPLICATE) {
-      request.cancel(server.getCore().getClientContext());
+      request.cancel(clientContext);
       handleIdentifierCollision(message.identifier, message.global);
       return;
     }
     if (registration == RegistrationResult.CLOSED) {
-      request.cancel(server.getCore().getClientContext());
+      request.cancel(clientContext);
       return;
     }
-    request.start(server.getCore().getClientContext());
+    request.start(clientContext);
   }
 
   private void startRebootClientPutDir(
@@ -678,11 +680,12 @@ public class FCPConnectionHandler implements Closeable {
     if (request == null) {
       return;
     }
+    ClientContext clientContext = server.insertRuntimeSupport().clientContext();
     if (!registerPersistentRequest(request, message.identifier, message.global)) {
-      request.cancel(server.getCore().getClientContext());
+      request.cancel(clientContext);
       return;
     }
-    request.start(server.getCore().getClientContext());
+    request.start(clientContext);
   }
 
   private void startForeverClientPutDir(

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -53,6 +53,7 @@ public class FCPServer implements Runnable, DownloadCache {
   private final NodeClientCore core;
 
   private final FcpFetchRuntimeSupport fetchRuntimeSupport;
+  private final FcpInsertRuntimeSupport insertRuntimeSupport;
 
   private final RuntimePorts runtime;
 
@@ -110,6 +111,8 @@ public class FCPServer implements Runnable, DownloadCache {
     this.core = dependencies.core();
     this.runtime = dependencies.runtimePorts();
     this.fetchRuntimeSupport = new CoreFcpFetchRuntimeSupport(core, this.runtime::transferAccess);
+    this.insertRuntimeSupport =
+        new CoreFcpInsertRuntimeSupport(core, () -> core.getRuntimePorts().transferAccess());
     this.assumeDownloadDDAIsAllowed = config.assumeDownloadDDAAllowed();
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();
@@ -747,6 +750,22 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   FcpFetchRuntimeSupport fetchRuntimeSupport() {
     return fetchRuntimeSupport;
+  }
+
+  /**
+   * Returns the package-local runtime support used by the FCP insert and USK path.
+   *
+   * <p>This seam keeps put request construction, upload bucket allocation, and USK subscription
+   * wiring independent of direct {@link NodeClientCore} access while preserving current runtime
+   * behavior. Insert validation historically consulted the core runtime's transfer policy for both
+   * live message puts and queued local-file inserts, so this seam keeps upload checks aligned with
+   * {@code core.getRuntimePorts()}. It is package-private because it is an internal wiring detail
+   * of {@code clients.fcp}, not a public server API.
+   *
+   * @return insert runtime support backing put construction and USK subscriptions
+   */
+  FcpInsertRuntimeSupport insertRuntimeSupport() {
+    return insertRuntimeSupport;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertRuntimeSupport.java
@@ -1,0 +1,107 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.USKManager;
+import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+
+/**
+ * Narrow runtime support seam for the FCP insert and USK subscription path.
+ *
+ * <p>This package-local adapter keeps insert request creation, upload bucket allocation, and USK
+ * subscription wiring independent of direct {@code NodeClientCore} access while preserving the
+ * current runtime behavior. It exposes only the insert-specific services needed by {@link
+ * ClientPutBase}, {@link ClientPut}, {@link ClientPutDir}, {@link ClientPutPreparedDataFactory},
+ * {@link ClientPutMessage}, and {@link SubscribeUSK}: the live {@link ClientContext}, the default
+ * persistent {@link InsertContext}, transfer-policy checks, bucket factories, forever-persistent
+ * upload allocation, and the {@link USKManager}.
+ *
+ * <p>Typical call paths get one instance from {@link FCPServer} and thread it through request
+ * constructors while they normalize URIs, validate disk access, allocate temporary buckets, and
+ * register USK listeners. The seam is intentionally small and local to {@code clients.fcp}. It is
+ * not a general FCP runtime facade and does not widen {@code runtime-spi}; callers should add new
+ * methods only when a later refactoring needs a demonstrably insert- or USK-specific seam.
+ *
+ * <p>Implementations are expected to be lightweight adapters over live daemon services rather than
+ * detached snapshots. Callers therefore treat returned collaborators as the current runtime state
+ * and should not assume ownership of shared resources beyond the normal contracts of the underlying
+ * types.
+ */
+interface FcpInsertRuntimeSupport {
+
+  /**
+   * Returns the live client context used to start, resume, or validate insert requests.
+   *
+   * <p>Insert assembly uses this context when it needs request-level defaults that still depend on
+   * the live daemon, for example, generating placeholder SSKs or starting the resulting putter from
+   * {@link FCPConnectionHandler}. Implementations should return the current context in effect for
+   * the owning node rather than a cached copy.
+   *
+   * @return current client context backing FCP insert operations
+   */
+  ClientContext clientContext();
+
+  /**
+   * Returns the default persistent insert context template for new put requests.
+   *
+   * <p>Callers typically get this baseline once during request construction and immediately tune
+   * retries, compression, caching, and compatibility flags for the specific insert being assembled.
+   * The returned context should therefore match the daemon's current persistent insert defaults.
+   *
+   * @return persistent insert context defaults supplied by the daemon runtime
+   */
+  InsertContext defaultPersistentInsertContext();
+
+  /**
+   * Returns the transfer-access policy used for upload validation and DDA checks.
+   *
+   * <p>Disk-backed inserts consult this policy before accepting local files or directories. Keeping
+   * the lookup behind the seam preserves the legacy allow/deny behavior while removing direct core
+   * access from the insert request classes.
+   *
+   * @return transfer policy for disk-upload validation
+   */
+  TransferAccessPort transferAccess();
+
+  /**
+   * Returns the bucket factory appropriate for the requested persistence class.
+   *
+   * <p>Insert helpers use this when they need to synthesize metadata buckets, especially for
+   * redirect uploads that must follow the same persistence rules as the surrounding request.
+   *
+   * @param persistentForever whether the request persists forever
+   * @return bucket factory aligned with the insert persistence mode
+   */
+  BucketFactory bucketFactory(boolean persistentForever);
+
+  /**
+   * Allocates a forever-persistent upload bucket for inbound FCP payloads.
+   *
+   * <p>This is used by the live message path when the client requests {@code FOREVER} persistence
+   * and the server must stage upload bytes in the persistent temporary bucket store.
+   * Implementations should throw rather than silently downgrade when the persistent store is
+   * unavailable.
+   *
+   * @param length expected payload length
+   * @return newly allocated persistent upload bucket
+   * @throws IOException if the underlying bucket factory cannot allocate the bucket
+   * @throws PersistenceDisabledException if forever-persistent uploads are unavailable
+   */
+  RandomAccessBucket allocatePersistentUploadBucket(long length)
+      throws IOException, PersistenceDisabledException;
+
+  /**
+   * Returns the live USK manager used by subscription flows.
+   *
+   * <p>{@link SubscribeUSK} uses the returned manager to register, poll, and later remove USK
+   * subscriptions. The seam does not abstract USK behavior further; it only provides the concrete
+   * manager instance needed by the existing FCP subscription workflow.
+   *
+   * @return current USK manager backing FCP subscriptions
+   */
+  USKManager uskManager();
+}

--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
@@ -5,15 +5,14 @@ import network.crypta.client.async.USKCallback;
 import network.crypta.client.async.USKFoundEdition;
 import network.crypta.client.async.USKProgressCallback;
 import network.crypta.keys.USK;
-import network.crypta.node.NodeClientCore;
 
 /**
  * Bridges an FCP client subscription to the node's USK manager.
  *
  * <p>This helper wires a {@link SubscribeUSKMessage} received over FCP into the asynchronous USK
- * subscription facilities provided by {@link NodeClientCore}. It registers itself as the {@link
- * USKProgressCallback} so that progress, network activity, and discovered editions are fed back to
- * the originating {@link FCPConnectionHandler}. Instances are intentionally lightweight and
+ * subscription facilities provided by the insert runtime support seam. It registers itself as the
+ * {@link USKProgressCallback} so that progress, network activity, and discovered editions are fed
+ * back to the originating {@link FCPConnectionHandler}. Instances are intentionally lightweight and
  * short-lived: they register with the node on construction and can be removed via {@link
  * #unsubscribe()} when the client disconnects or no longer requires updates.
  *
@@ -38,7 +37,7 @@ import network.crypta.node.NodeClientCore;
 public final class SubscribeUSK implements USKProgressCallback {
   final FCPConnectionHandler handler;
   final String clientIdentifier;
-  final NodeClientCore core;
+  final FcpInsertRuntimeSupport runtimeSupport;
   final boolean dontPoll;
   final short prio;
   final short prioProgress;
@@ -54,32 +53,36 @@ public final class SubscribeUSK implements USKProgressCallback {
    * additional initialization is required after construction.
    *
    * @param message parsed FCP subscribe request containing keys, flags, and priorities; never null.
-   * @param core node client core that owns the USK manager and executes polling logic.
+   * @param runtimeSupport insert runtime support that owns the USK manager and polling logic.
    * @param handler connection handler used to emit FCP responses back to the requesting client.
    * @throws IdentifierCollisionException if the identifier already exists on this handler and
    *     cannot be reused for another subscription.
    */
-  public SubscribeUSK(
-      SubscribeUSKMessage message, NodeClientCore core, FCPConnectionHandler handler)
+  SubscribeUSK(
+      SubscribeUSKMessage message,
+      FcpInsertRuntimeSupport runtimeSupport,
+      FCPConnectionHandler handler)
       throws IdentifierCollisionException {
     this.handler = handler;
     this.dontPoll = message.dontPoll;
     this.clientIdentifier = message.clientIdentifier;
-    this.core = core;
+    this.runtimeSupport = runtimeSupport;
     this.usk = message.key;
     prio = message.prio;
     prioProgress = message.prioProgress;
     handler.addUSKSubscription(clientIdentifier, this);
     if (!message.dontPoll && message.sparsePoll)
       toUnsub =
-          core.getUskManager()
+          runtimeSupport
+              .uskManager()
               .subscribeSparse(
                   message.key,
                   this,
                   message.ignoreUSKDatehints,
                   handler.getRebootClient().lowLevelClient(message.realTimeFlag));
     else {
-      core.getUskManager()
+      runtimeSupport
+          .uskManager()
           .subscribe(
               message.key,
               this,
@@ -104,7 +107,7 @@ public final class SubscribeUSK implements USKProgressCallback {
   public void onFoundEdition(USKFoundEdition foundEdition) {
     USK key = foundEdition.key();
     if (handler.isClosed()) {
-      core.getUskManager().unsubscribe(key, toUnsub);
+      runtimeSupport.uskManager().unsubscribe(key, toUnsub);
       return;
     }
     FCPMessage msg =
@@ -154,7 +157,7 @@ public final class SubscribeUSK implements USKProgressCallback {
    * calls.
    */
   public void unsubscribe() {
-    core.getUskManager().unsubscribe(usk, toUnsub);
+    runtimeSupport.uskManager().unsubscribe(usk, toUnsub);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
@@ -33,7 +33,7 @@ public final class SubscribeUSKMessage extends FCPMessage {
 
   /**
    * Message name sent over FCP to denote a USK subscription request. Constant value is stable
-   * across releases so client implementations can rely on it when constructing field sets or
+   * across releases, so client implementations can rely on it when constructing field sets or
    * parsing incoming traffic without hard-coding multiple variants.
    */
   public static final String NAME = "SubscribeUSK";
@@ -141,7 +141,7 @@ public final class SubscribeUSKMessage extends FCPMessage {
   @Override
   public void run(FCPConnectionHandler handler) throws MessageInvalidException {
     try {
-      new SubscribeUSK(this, handler.getServer().getCore(), handler);
+      new SubscribeUSK(this, handler.getServer().insertRuntimeSupport(), handler);
     } catch (IdentifierCollisionException _) {
       handler.send(new IdentifierCollisionMessage(clientIdentifier, false));
       return;

--- a/src/main/java/network/crypta/node/runtime/LegacyQueueInsertPort.java
+++ b/src/main/java/network/crypta/node/runtime/LegacyQueueInsertPort.java
@@ -351,7 +351,7 @@ public final class LegacyQueueInsertPort implements QueueInsertPort {
             null,
             request.filenameForKey(),
             false),
-        core);
+        fcpServer);
   }
 
   ClientPut createLocalFileClientPut(
@@ -372,7 +372,7 @@ public final class LegacyQueueInsertPort implements QueueInsertPort {
             null,
             request.targetFilename(),
             false),
-        core);
+        fcpServer);
   }
 
   ClientPutDir createLocalDirectoryPut(
@@ -386,7 +386,7 @@ public final class LegacyQueueInsertPort implements QueueInsertPort {
         null,
         false,
         false,
-        core);
+        fcpServer);
   }
 
   private FCPServer fcpServer() throws RequestQueueUnavailableException {

--- a/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
@@ -1,0 +1,382 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.InsertContext;
+import network.crypta.client.InsertContextOptions;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.InsertException;
+import network.crypta.client.async.BaseClientPutter;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.events.ExpectedHashesEvent;
+import network.crypta.client.events.FinishedCompressionEvent;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.client.events.SplitfileProgressCounts;
+import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
+import network.crypta.client.events.StartedCompressionEvent;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.clients.fcp.RequestIdentifier.RequestType;
+import network.crypta.crypt.HashResult;
+import network.crypta.crypt.HashType;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientPutBaseTest {
+
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FcpInsertRuntimeSupport runtimeSupport;
+  @Mock private ClientContext clientContext;
+  @Mock private PersistentRequestClient persistentClient;
+  @Mock private RequestStatusCache cache;
+  @Mock private Bucket generatedMetadata;
+
+  @Test
+  void uploadFromGetByCode_whenValidCodeProvided_returnsMatchingEnum() {
+    assertSame(ClientPutBase.UploadFrom.DIRECT, ClientPutBase.UploadFrom.getByCode(0));
+    assertSame(ClientPutBase.UploadFrom.DISK, ClientPutBase.UploadFrom.getByCode(1));
+    assertSame(ClientPutBase.UploadFrom.REDIRECT, ClientPutBase.UploadFrom.getByCode(2));
+  }
+
+  @Test
+  void uploadFromGetByCode_whenCodeUnknown_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> ClientPutBase.UploadFrom.getByCode(99));
+  }
+
+  @Test
+  void constructor_whenConnectionScoped_appliesInsertOptionsToRuntimeContext() {
+    InsertContext insertContext = newInsertContext();
+    when(runtimeSupport.defaultPersistentInsertContext()).thenReturn(insertContext);
+    ClientRequestParams params = newRequestParams("conn-id", Persistence.CONNECTION);
+
+    TestClientPutBase request =
+        new TestClientPutBase(
+            params, "bad[", newOptions(), handler, runtimeSupport, mock(FreenetURI.class));
+
+    assertSame(insertContext, request.ctx);
+    assertTrue(insertContext.isGetCHKOnly());
+    assertTrue(insertContext.isDontCompress());
+    assertEquals(5, insertContext.getMaxInsertRetries());
+    assertTrue(insertContext.isCanWriteClientCache());
+    assertEquals("GZIP", insertContext.getCompressorDescriptor());
+    assertTrue(insertContext.isLocalRequestOnly());
+    assertTrue(insertContext.isEarlyEncode());
+    assertTrue(insertContext.isIgnoreUSKDatehints());
+  }
+
+  @Test
+  void constructor_whenPersistentScoped_appliesInsertOptionsToRuntimeContext() {
+    InsertContext insertContext = newInsertContext();
+    when(runtimeSupport.defaultPersistentInsertContext()).thenReturn(insertContext);
+    ClientRequestParams params = newRequestParams("persistent-id", Persistence.REBOOT);
+    PersistentRequestClient client =
+        new PersistentRequestClient("client-a", null, false, null, Persistence.REBOOT, null);
+
+    TestClientPutBase request =
+        new TestClientPutBase(
+            params, null, newOptions(), null, client, runtimeSupport, mock(FreenetURI.class));
+
+    assertSame(insertContext, request.ctx);
+    assertTrue(insertContext.isGetCHKOnly());
+    assertEquals(CompatibilityMode.latest(), insertContext.getCompatibilityMode());
+    assertEquals(2, insertContext.getExtraInsertsSingleBlock());
+    assertEquals(3, insertContext.getExtraInsertsSplitfileHeaderBlock());
+  }
+
+  @Test
+  void onSuccess_whenConnectionScoped_freesDataSendsSuccessAndNotifiesClient() throws Exception {
+    TestClientPutBase request = new TestClientPutBase();
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    BaseClientPutter state = mock(BaseClientPutter.class);
+    FreenetURI generatedUri = mock(FreenetURI.class);
+    setField(ClientRequest.class, request, "identifier", "success-id");
+    setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
+    setField(ClientRequest.class, request, "origHandler", handler);
+    setField(ClientRequest.class, request, "client", client);
+    setField(ClientPutBase.class, request, "generatedURI", generatedUri);
+
+    request.onSuccess(state);
+
+    assertTrue((boolean) getClientRequestField(request, "started"));
+    assertTrue((boolean) getClientRequestField(request, "finished"));
+    assertTrue(request.succeeded);
+    assertEquals(1, request.freeDataCalls);
+    verify(handler).finishedClientRequest(request);
+    verify(handler).send(any(PutSuccessfulMessage.class));
+    verify(client).notifySuccess(request);
+  }
+
+  @Test
+  void onFailure_whenConnectionScoped_freesDataSendsFailureAndNotifiesClient() throws Exception {
+    TestClientPutBase request = new TestClientPutBase();
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    BaseClientPutter state = mock(BaseClientPutter.class);
+    InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
+    setField(ClientRequest.class, request, "identifier", "failure-id");
+    setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
+    setField(ClientRequest.class, request, "origHandler", handler);
+    setField(ClientRequest.class, request, "client", client);
+
+    request.onFailure(failure, state);
+
+    assertTrue((boolean) getClientRequestField(request, "started"));
+    assertTrue((boolean) getClientRequestField(request, "finished"));
+    assertEquals(1, request.freeDataCalls);
+    assertInstanceOf(PutFailedMessage.class, request.getFailureMessage());
+    verify(handler).finishedClientRequest(request);
+    verify(handler).send(any(PutFailedMessage.class));
+    verify(client).notifyFailure(request);
+  }
+
+  @Test
+  void receive_whenVerboseEventsArrive_updatesProgressCacheAndCompressionHooks() throws Exception {
+    TestClientPutBase request = new TestClientPutBase();
+    when(persistentClient.getRequestStatusCache()).thenReturn(cache);
+    setField(ClientRequest.class, request, "identifier", "event-id");
+    setField(ClientRequest.class, request, "persistence", Persistence.REBOOT);
+    setField(ClientRequest.class, request, "client", persistentClient);
+    setField(ClientRequest.class, request, "verbosity", 1 | 8 | 512);
+
+    SplitfileProgressEvent progressEvent =
+        new SplitfileProgressEvent(
+            new SplitfileProgressCounts(10, 4, 2, 1, 3, 1, true),
+            new SplitfileProgressTimestamps(
+                Instant.ofEpochMilli(1000), Instant.ofEpochMilli(2000)));
+    ExpectedHashesEvent hashesEvent =
+        new ExpectedHashesEvent(
+            new HashResult[] {
+              new HashResult(HashType.SHA256, new byte[HashType.SHA256.hashLength])
+            });
+
+    request.receive(progressEvent, clientContext);
+    request.receive(new StartedCompressionEvent(COMPRESSOR_TYPE.GZIP), clientContext);
+    request.receive(new FinishedCompressionEvent(1, 25L, 10L), clientContext);
+    request.receive(hashesEvent, clientContext);
+
+    verify(cache).updateStatus("event-id", progressEvent);
+    verify(persistentClient, never()).notifySuccess(any());
+    verify(persistentClient, never()).notifyFailure(any());
+    verify(persistentClient, times(4)).queueClientRequestMessage(any(FCPMessage.class), anyInt());
+    assertEquals(1, request.startCompressingCalls);
+    assertEquals(1, request.stopCompressingCalls);
+    assertInstanceOf(ExpectedHashes.class, request.getProgressMessageSnapshot());
+  }
+
+  @Test
+  void requestWasRemoved_whenForeverPersistent_clearsTransientStateAndQueuesRemoval()
+      throws Exception {
+    TestClientPutBase request = new TestClientPutBase();
+    FreenetURI generatedUri = mock(FreenetURI.class);
+    PutFailedMessage failure =
+        new PutFailedMessage(
+            new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null),
+            "remove-id",
+            false);
+    setField(ClientRequest.class, request, "identifier", "remove-id");
+    setField(ClientRequest.class, request, "persistence", Persistence.FOREVER);
+    setField(ClientRequest.class, request, "client", persistentClient);
+    setField(ClientPutBase.class, request, "generatedURI", generatedUri);
+    setField(ClientPutBase.class, request, "putFailedMessage", failure);
+    setField(ClientPutBase.class, request, "progressMessage", new StaticFcpMessage("Progress"));
+    setField(ClientPutBase.class, request, "generatedMetadata", generatedMetadata);
+    setField(ClientRequest.class, request, "finished", true);
+
+    request.requestWasRemoved(clientContext);
+
+    verify(persistentClient)
+        .queueClientRequestMessage(any(PersistentRequestRemovedMessage.class), eq(0));
+    verify(generatedMetadata).free();
+    assertEquals(1, request.freeDataCalls);
+    assertNull(request.getFailureMessage());
+    assertNull(request.getGeneratedURI());
+    assertNull(request.getProgressMessageSnapshot());
+  }
+
+  private static ClientRequestParams newRequestParams(String identifier, Persistence persistence) {
+    return new ClientRequestParams(
+        mock(FreenetURI.class), identifier, 7, (short) 4, persistence, true, "token-1", false);
+  }
+
+  private static FcpInsertOptions newOptions() {
+    return new FcpInsertOptions(
+        new FcpInsertBehaviorOptions(true, true, true, 5, true, true, true),
+        new FcpInsertTuningOptions(true, true, "GZIP", 2, 3, CompatibilityMode.COMPAT_CURRENT),
+        null);
+  }
+
+  private static InsertContext newInsertContext() {
+    return new InsertContext(
+        InsertContextOptions.builder()
+            .retryLimits(1, 0)
+            .splitfileSegmentLimits(1, 1)
+            .clientOptions(new SimpleEventProducer(), true, false, false)
+            .compressorDescriptor(null)
+            .redundancy(0, 0)
+            .compatibility(CompatibilityMode.COMPAT_CURRENT)
+            .build());
+  }
+
+  private static void setField(Class<?> owner, Object target, String name, Object value)
+      throws ReflectiveOperationException {
+    Field field = owner.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Object getClientRequestField(Object target, String name)
+      throws ReflectiveOperationException {
+    Field field = ClientRequest.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static final class StaticFcpMessage extends FCPMessage {
+    private final String name;
+
+    private StaticFcpMessage(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public SimpleFieldSet getFieldSet() {
+      SimpleFieldSet fieldSet = new SimpleFieldSet(true);
+      fieldSet.putSingle("Name", name);
+      return fieldSet;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public void run(FCPConnectionHandler handler) {
+      // No-op test message.
+    }
+  }
+
+  private static final class TestClientPutBase extends ClientPutBase {
+    private final FCPMessage tagMessage = new StaticFcpMessage("PersistentTag");
+    private int freeDataCalls;
+    private int startCompressingCalls;
+    private int stopCompressingCalls;
+
+    private TestClientPutBase(
+        ClientRequestParams requestParams,
+        String charset,
+        FcpInsertOptions options,
+        FCPConnectionHandler handler,
+        FcpInsertRuntimeSupport runtimeSupport,
+        FreenetURI publicURI) {
+      super(requestParams, charset, options, handler, runtimeSupport, publicURI);
+    }
+
+    private TestClientPutBase(
+        ClientRequestParams requestParams,
+        String charset,
+        FcpInsertOptions options,
+        FCPConnectionHandler handler,
+        PersistentRequestClient client,
+        FcpInsertRuntimeSupport runtimeSupport,
+        FreenetURI publicURI) {
+      super(requestParams, charset, options, handler, client, runtimeSupport, publicURI);
+    }
+
+    private TestClientPutBase() {}
+
+    @Override
+    void register(boolean noTags) {
+      // Registration is irrelevant for these base-class unit tests.
+    }
+
+    @Override
+    protected ClientRequester getClientRequest() {
+      return null;
+    }
+
+    @Override
+    protected void freeData() {
+      freeDataCalls++;
+    }
+
+    @Override
+    public void start(ClientContext context) {
+      // The test double never schedules real network work.
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return succeeded;
+    }
+
+    @Override
+    public boolean canRestart() {
+      return false;
+    }
+
+    @Override
+    public boolean restart(ClientContext context, boolean disableFilterData) {
+      return false;
+    }
+
+    @Override
+    RequestStatus getStatus() {
+      return null;
+    }
+
+    @Override
+    protected void innerResume(ClientContext context) {
+      // No-op for test double.
+    }
+
+    @Override
+    RequestType getType() {
+      return RequestType.PUT;
+    }
+
+    @Override
+    public boolean fullyResumed() {
+      return true;
+    }
+
+    @Override
+    protected void onStopCompressing() {
+      stopCompressingCalls++;
+    }
+
+    @Override
+    protected void onStartCompressing() {
+      startCompressingCalls++;
+    }
+
+    @Override
+    protected FCPMessage persistentTagMessage() {
+      return tagMessage;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
@@ -8,6 +8,7 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ContainerInserter;
+import network.crypta.client.async.ManifestPutter;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.SplitfileProgressTimestamps;
@@ -28,11 +29,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
@@ -132,6 +135,56 @@ class ClientPutDirTest {
   }
 
   @Test
+  void start_whenPersistentRequestStarts_updatesCacheAndQueuesTag() throws Exception {
+    ClientPutDir putDir = spy(newClientPutDir());
+    ManifestPutter putter = mock(ManifestPutter.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    FCPMessage tagMessage = mock(FCPMessage.class);
+    ClientContext context = mock(ClientContext.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    doReturn(tagMessage).when(putDir).persistentTagMessage();
+    setField(ClientPutDir.class, putDir, "putter", putter);
+    setField(ClientRequest.class, putDir, "identifier", "dir-start");
+    setField(ClientRequest.class, putDir, "persistence", ClientRequest.Persistence.REBOOT);
+    setField(ClientRequest.class, putDir, "client", client);
+
+    putDir.start(context);
+
+    verify(putter).start(context);
+    verify(cache).updateStarted("dir-start", true);
+    verify(client).queueClientRequestMessage(tagMessage, 0);
+    assertTrue((boolean) getField(ClientRequest.class, putDir, "started"));
+  }
+
+  @Test
+  void start_whenAlreadyStarted_doesNothing() throws Exception {
+    ClientPutDir putDir = newClientPutDir();
+    ManifestPutter putter = mock(ManifestPutter.class);
+    setField(ClientPutDir.class, putDir, "putter", putter);
+    setField(ClientRequest.class, putDir, "started", true);
+
+    putDir.start(mock(ClientContext.class));
+
+    verify(putter, never()).start(any());
+  }
+
+  @Test
+  void start_whenPutterThrowsInsertException_invokesOnFailure() throws Exception {
+    ClientPutDir putDir = spy(newClientPutDir());
+    ManifestPutter putter = mock(ManifestPutter.class);
+    InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
+    doThrow(failure).when(putter).start(any());
+    setField(ClientPutDir.class, putDir, "putter", putter);
+    setField(ClientRequest.class, putDir, "persistence", ClientRequest.Persistence.REBOOT);
+    setField(ClientRequest.class, putDir, "client", persistentRequestClient);
+
+    putDir.start(mock(ClientContext.class));
+
+    verify(putDir).onFailure(failure, null);
+  }
+
+  @Test
   void innerResume_whenManifestPresent_delegatesToContainerInserter() throws Exception {
     ClientPutDir putDir = newClientPutDir();
     Map<String, Object> manifest = new HashMap<>();
@@ -175,6 +228,28 @@ class ClientPutDirTest {
     assertEquals(RequestType.PUTDIR, newClientPutDir().getType());
   }
 
+  @Test
+  void requestWasRemoved_whenForeverPersistence_clearsPutter() throws Exception {
+    ClientPutDir putDir = newClientPutDir();
+    ManifestPutter putter = mock(ManifestPutter.class);
+    setField(ClientPutDir.class, putDir, "putter", putter);
+    setField(ClientRequest.class, putDir, "persistence", ClientRequest.Persistence.FOREVER);
+    setField(ClientRequest.class, putDir, "client", persistentRequestClient);
+    setField(ClientRequest.class, putDir, "finished", true);
+
+    putDir.requestWasRemoved(mock(ClientContext.class));
+
+    assertNull(getField(ClientPutDir.class, putDir, "putter"));
+    verify(persistentRequestClient)
+        .queueClientRequestMessage(any(PersistentRequestRemovedMessage.class), anyInt());
+    verify(putter, never()).cancel(any());
+  }
+
+  @Test
+  void fullyResumed_alwaysReturnsFalse() {
+    assertFalse(newClientPutDir().fullyResumed());
+  }
+
   private static ClientPutDir newClientPutDir() {
     return new ClientPutDir();
   }
@@ -195,6 +270,13 @@ class ClientPutDirTest {
   private static Object getManifestElements(ClientPutDir target)
       throws ReflectiveOperationException {
     return MANIFEST_ELEMENTS_FIELD.get(target);
+  }
+
+  private static Object getField(Class<?> owner, Object target, String name)
+      throws ReflectiveOperationException {
+    Field field = owner.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
   }
 
   private static final Field MANIFEST_ELEMENTS_FIELD;

--- a/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
@@ -5,13 +5,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
-import network.crypta.support.io.PersistentTempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -130,15 +128,12 @@ class ClientPutMessageTest {
     ClientPutMessage message = newForeverMessage("put-forever", 64L);
     BucketFactory transientFactory = Mockito.mock(BucketFactory.class);
     FCPServer server = Mockito.mock(FCPServer.class);
-    NodeClientCore core = Mockito.mock(NodeClientCore.class);
-    PersistentTempBucketFactory persistentFactory = Mockito.mock(PersistentTempBucketFactory.class);
+    FcpInsertRuntimeSupport runtimeSupport = Mockito.mock(FcpInsertRuntimeSupport.class);
 
-    Mockito.when(server.getCore()).thenReturn(core);
-    Mockito.when(core.killedDatabase()).thenReturn(false);
-    Mockito.when(core.getPersistentTempBucketFactory()).thenReturn(persistentFactory);
+    Mockito.when(server.insertRuntimeSupport()).thenReturn(runtimeSupport);
 
     try (RandomAccessBucket expectedBucket = Mockito.mock(RandomAccessBucket.class)) {
-      Mockito.when(persistentFactory.makeBucket(64L)).thenReturn(expectedBucket);
+      Mockito.when(runtimeSupport.allocatePersistentUploadBucket(64L)).thenReturn(expectedBucket);
 
       try (RandomAccessBucket bucket = message.createBucket(transientFactory, 64L, server)) {
         assertSame(expectedBucket, bucket);
@@ -149,14 +144,17 @@ class ClientPutMessageTest {
 
   @Test
   void createBucket_whenPersistentForeverAndDatabaseKilled_expectPersistenceDisabled()
-      throws MessageInvalidException {
+      throws Exception {
     ClientPutMessage message = newForeverMessage("put-forever-disabled", 16L);
     BucketFactory transientFactory = Mockito.mock(BucketFactory.class);
     FCPServer server = Mockito.mock(FCPServer.class);
-    NodeClientCore core = Mockito.mock(NodeClientCore.class);
+    FcpInsertRuntimeSupport runtimeSupport = Mockito.mock(FcpInsertRuntimeSupport.class);
 
-    Mockito.when(server.getCore()).thenReturn(core);
-    Mockito.when(core.killedDatabase()).thenReturn(true);
+    Mockito.when(server.insertRuntimeSupport()).thenReturn(runtimeSupport);
+    //noinspection resource
+    Mockito.doThrow(new PersistenceDisabledException())
+        .when(runtimeSupport)
+        .allocatePersistentUploadBucket(16L);
 
     assertThrows(
         PersistenceDisabledException.class,
@@ -165,7 +163,6 @@ class ClientPutMessageTest {
             fail("PersistenceDisabledException expected before bucket allocation");
           }
         });
-    Mockito.verify(core, Mockito.never()).getPersistentTempBucketFactory();
     Mockito.verifyNoInteractions(transientFactory);
   }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPreparedDataFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPreparedDataFactoryTest.java
@@ -2,9 +2,7 @@ package network.crypta.clients.fcp;
 
 import java.io.IOException;
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.async.ClientContext;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
@@ -42,7 +40,7 @@ class ClientPutPreparedDataFactoryTest {
             metadata,
             bucket,
             null,
-            mock(NodeClientCore.class),
+            mock(FcpInsertRuntimeSupport.class),
             false);
 
     assertSame(bucket, prepared.bucket());
@@ -55,15 +53,13 @@ class ClientPutPreparedDataFactoryTest {
     ClientMetadata metadata = new ClientMetadata("text/plain");
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     FreenetURI target = new FreenetURI(VALID_CHK);
-    ClientContext context = mock(ClientContext.class);
-    NodeClientCore core = mock(NodeClientCore.class);
+    FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
 
-    when(core.getClientContext()).thenReturn(context);
-    when(context.getBucketFactory(true)).thenReturn(new ArrayBucketFactory());
+    when(runtimeSupport.bucketFactory(true)).thenReturn(new ArrayBucketFactory());
 
     PreparedData prepared =
         ClientPutPreparedDataFactory.prepareForPersistentUpload(
-            ClientPutBase.UploadFrom.REDIRECT, metadata, bucket, target, core, true);
+            ClientPutBase.UploadFrom.REDIRECT, metadata, bucket, target, runtimeSupport, true);
 
     assertNotNull(prepared.bucket());
     assertNotSame(bucket, prepared.bucket());
@@ -77,19 +73,22 @@ class ClientPutPreparedDataFactoryTest {
     //noinspection resource
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     FreenetURI target = new FreenetURI(VALID_CHK);
-    ClientContext context = mock(ClientContext.class);
-    NodeClientCore core = mock(NodeClientCore.class);
+    FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
     BucketFactory bucketFactory = mock(BucketFactory.class);
 
-    when(core.getClientContext()).thenReturn(context);
-    when(context.getBucketFactory(false)).thenReturn(bucketFactory);
+    when(runtimeSupport.bucketFactory(false)).thenReturn(bucketFactory);
     when(bucketFactory.makeBucket(-1)).thenThrow(new IOException("fail"));
 
     assertThrows(
         IOException.class,
         () ->
             ClientPutPreparedDataFactory.prepareForPersistentUpload(
-                ClientPutBase.UploadFrom.REDIRECT, metadata, bucket, target, core, false));
+                ClientPutBase.UploadFrom.REDIRECT,
+                metadata,
+                bucket,
+                target,
+                runtimeSupport,
+                false));
   }
 
   @Test
@@ -102,7 +101,7 @@ class ClientPutPreparedDataFactoryTest {
         ClientPutPreparedDataFactory.prepareForMessage(
             message,
             new ClientMetadata("text/plain"),
-            mock(FCPServer.class),
+            mock(FcpInsertRuntimeSupport.class),
             false,
             ClientPutBase.UploadFrom.DIRECT,
             "id",
@@ -118,19 +117,15 @@ class ClientPutPreparedDataFactoryTest {
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.REDIRECT, VALID_CHK);
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     message.bucket = bucket;
-    ClientContext context = mock(ClientContext.class);
-    NodeClientCore core = mock(NodeClientCore.class);
-    FCPServer server = mock(FCPServer.class);
+    FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
 
-    when(server.getCore()).thenReturn(core);
-    when(core.getClientContext()).thenReturn(context);
-    when(context.getBucketFactory(true)).thenReturn(new ArrayBucketFactory());
+    when(runtimeSupport.bucketFactory(true)).thenReturn(new ArrayBucketFactory());
 
     PreparedData prepared =
         ClientPutPreparedDataFactory.prepareForMessage(
             message,
             new ClientMetadata("text/plain"),
-            server,
+            runtimeSupport,
             true,
             ClientPutBase.UploadFrom.REDIRECT,
             "id",

--- a/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
@@ -30,11 +30,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -185,6 +188,61 @@ class ClientPutTest {
   }
 
   @Test
+  void register_whenPersistentAndTagsRequested_registersAndQueuesTagMessage() throws Exception {
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    FCPMessage tagMessage = mock(FCPMessage.class);
+    ClientPut put = spy(clientPut);
+    setField(ClientRequest.class, put, "persistence", Persistence.FOREVER);
+    setField(ClientRequest.class, put, "client", client);
+    doReturn(tagMessage).when(put).persistentTagMessage();
+
+    put.register(false);
+
+    verify(client).register(put);
+    verify(client).queueClientRequestMessage(tagMessage, 0);
+  }
+
+  @Test
+  void start_whenPersistentRequestStarts_updatesCacheAndQueuesTag() throws Exception {
+    ClientPutter putter = mock(ClientPutter.class);
+    ClientContext context = mock(ClientContext.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    FCPMessage tagMessage = mock(FCPMessage.class);
+    ClientPut put = spy(clientPut);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(ClientPut.class, put, "putter", putter);
+    setField(ClientRequest.class, put, "identifier", "start-id");
+    setField(ClientRequest.class, put, "persistence", Persistence.REBOOT);
+    setField(ClientRequest.class, put, "client", client);
+    doReturn(tagMessage).when(put).persistentTagMessage();
+
+    put.start(context);
+
+    verify(putter).start(false, context);
+    verify(client).queueClientRequestMessage(tagMessage, 0);
+    verify(cache).updateStarted("start-id", true);
+    assertTrue((boolean) getField(ClientRequest.class, put, "started"));
+  }
+
+  @Test
+  void start_whenPutterThrowsInsertException_invokesOnFailure() throws Exception {
+    ClientPutter putter = mock(ClientPutter.class);
+    ClientContext context = mock(ClientContext.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
+    ClientPut put = spy(clientPut);
+    setField(ClientPut.class, put, "putter", putter);
+    setField(ClientRequest.class, put, "persistence", Persistence.REBOOT);
+    setField(ClientRequest.class, put, "client", client);
+    doThrow(failure).when(putter).start(false, context);
+
+    put.start(context);
+
+    verify(put).onFailure(failure, null);
+  }
+
+  @Test
   void innerResume_whenBucketPresent_delegatesToBucket() throws Exception {
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     setField(ClientPut.class, clientPut, "data", bucket);
@@ -292,6 +350,38 @@ class ClientPutTest {
 
     assertFalse(restarted);
     verify(spyPut).onFailure(failure, null);
+  }
+
+  @Test
+  void setVarsRestart_whenClientHasCache_updatesCompressionStatus() throws Exception {
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(ClientRequest.class, clientPut, "client", client);
+
+    clientPut.setVarsRestart();
+
+    verify(cache).updateCompressionStatus("test-id", COMPRESS_STATE.WAITING);
+    assertFalse((boolean) getField(ClientRequest.class, clientPut, "started"));
+    assertNull(getField(ClientPutBase.class, clientPut, "putFailedMessage"));
+    assertNull(getField(ClientPutBase.class, clientPut, "progressMessage"));
+  }
+
+  @Test
+  void requestWasRemoved_whenForeverPersistence_clearsPutter() throws Exception {
+    ClientPutter putter = mock(ClientPutter.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    setField(ClientPut.class, clientPut, "putter", putter);
+    setField(ClientRequest.class, clientPut, "persistence", Persistence.FOREVER);
+    setField(ClientRequest.class, clientPut, "client", client);
+    setField(ClientRequest.class, clientPut, "finished", true);
+
+    clientPut.requestWasRemoved(mock(ClientContext.class));
+
+    assertNull(getField(ClientPut.class, clientPut, "putter"));
+    verify(client)
+        .queueClientRequestMessage(Mockito.any(PersistentRequestRemovedMessage.class), eq(0));
+    verifyNoInteractions(putter);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/CoreFcpInsertRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CoreFcpInsertRuntimeSupportTest.java
@@ -1,0 +1,72 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class CoreFcpInsertRuntimeSupportTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientContext clientContext;
+  @Mock private TransferAccessPort transferAccess;
+  @Mock private BucketFactory bucketFactory;
+  @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
+  @Mock private RandomAccessBucket bucket;
+
+  @Test
+  void bucketFactory_whenPersistenceFlagProvided_returnsClientContextFactory() {
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(clientContext.getBucketFactory(true)).thenReturn(bucketFactory);
+    CoreFcpInsertRuntimeSupport support =
+        new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
+
+    BucketFactory actual = support.bucketFactory(true);
+
+    assertSame(bucketFactory, actual);
+    verify(clientContext).getBucketFactory(true);
+  }
+
+  @Test
+  void allocatePersistentUploadBucket_whenDatabaseKilled_throwsPersistenceDisabledException() {
+    when(core.killedDatabase()).thenReturn(true);
+    CoreFcpInsertRuntimeSupport support =
+        new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
+
+    //noinspection resource
+    assertThrows(
+        PersistenceDisabledException.class, () -> support.allocatePersistentUploadBucket(64L));
+    verifyNoInteractions(persistentTempBucketFactory);
+  }
+
+  @Test
+  void allocatePersistentUploadBucket_whenDatabaseAvailable_returnsPersistentBucket()
+      throws Exception {
+    when(core.killedDatabase()).thenReturn(false);
+    when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
+    when(persistentTempBucketFactory.makeBucket(128L)).thenReturn(bucket);
+    CoreFcpInsertRuntimeSupport support =
+        new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
+
+    RandomAccessBucket actual = support.allocatePersistentUploadBucket(128L);
+
+    assertSame(bucket, actual);
+    //noinspection resource
+    verify(persistentTempBucketFactory).makeBucket(128L);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.EntropySource;
@@ -15,12 +17,14 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -47,6 +52,7 @@ class FCPConnectionHandlerTest {
   @Mock private Socket socket;
   @Mock private RuntimePorts runtimePorts;
   @Mock private RandomnessPort randomnessPort;
+  @Mock private FcpInsertRuntimeSupport insertRuntimeSupport;
 
   private FCPConnectionHandler handler;
 
@@ -58,7 +64,9 @@ class FCPConnectionHandlerTest {
     lenient().when(server.getCore()).thenReturn(core);
     lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
     lenient().when(server.runtime()).thenReturn(runtimePorts);
+    lenient().when(server.insertRuntimeSupport()).thenReturn(insertRuntimeSupport);
     lenient().when(runtimePorts.randomness()).thenReturn(randomnessPort);
+    lenient().when(insertRuntimeSupport.clientContext()).thenReturn(clientContext);
     lenient()
         .doAnswer(
             invocation -> {
@@ -259,6 +267,81 @@ class FCPConnectionHandlerTest {
 
     assertFalse(client.realTimeFlag());
     assertFalse(client.persistent());
+  }
+
+  @Test
+  void startClientPut_whenConnectionPersistence_startsWithInsertRuntimeContext() throws Exception {
+    ClientPutMessage message = newClientPutMessage("put-connection", "connection");
+
+    try (MockedConstruction<ClientPut> ignored = mockConstruction(ClientPut.class)) {
+      handler.startClientPut(message);
+
+      ClientPut request = ignored.constructed().getFirst();
+      verify(request).start(clientContext);
+    }
+  }
+
+  @Test
+  void startClientPut_whenRebootPersistence_startsWithInsertRuntimeContext() throws Exception {
+    ClientPutMessage message = newClientPutMessage("put-reboot", "reboot");
+
+    try (MockedConstruction<ClientPut> ignored = mockConstruction(ClientPut.class)) {
+      handler.startClientPut(message);
+
+      ClientPut request = ignored.constructed().getFirst();
+      verify(request).register(false);
+      verify(request).start(clientContext);
+    }
+  }
+
+  @Test
+  void startClientPutDir_whenConnectionPersistence_startsWithInsertRuntimeContext(
+      @TempDir Path tempDir) throws Exception {
+    ClientPutDiskDirMessage message = newClientPutDirMessage(tempDir, "connection");
+    Map<String, Object> buckets = new HashMap<>();
+
+    try (MockedConstruction<ClientPutDir> ignored = mockConstruction(ClientPutDir.class)) {
+      handler.startClientPutDir(message, buckets, true);
+
+      ClientPutDir request = ignored.constructed().getFirst();
+      verify(request).start(clientContext);
+    }
+  }
+
+  @Test
+  void startClientPutDir_whenRebootPersistence_startsWithInsertRuntimeContext(@TempDir Path tempDir)
+      throws Exception {
+    ClientPutDiskDirMessage message = newClientPutDirMessage(tempDir, "reboot");
+    Map<String, Object> buckets = new HashMap<>();
+
+    try (MockedConstruction<ClientPutDir> ignored = mockConstruction(ClientPutDir.class)) {
+      handler.startClientPutDir(message, buckets, true);
+
+      ClientPutDir request = ignored.constructed().getFirst();
+      verify(request).register(false);
+      verify(request).start(clientContext);
+    }
+  }
+
+  private static ClientPutMessage newClientPutMessage(String identifier, String persistence)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", identifier);
+    fs.putSingle("URI", "CHK@");
+    fs.putSingle("UploadFrom", "direct");
+    fs.put("DataLength", 4L);
+    fs.putSingle("Persistence", persistence);
+    return new ClientPutMessage(fs);
+  }
+
+  private static ClientPutDiskDirMessage newClientPutDirMessage(Path dir, String persistence)
+      throws MessageInvalidException {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle("Identifier", "dir-id");
+    fs.putSingle("URI", "KSK@site");
+    fs.putSingle("Filename", dir.toString());
+    fs.putSingle("Persistence", persistence);
+    return new ClientPutDiskDirMessage(fs);
   }
 
   private static final class DeterministicRandomSource extends RandomSource {

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -1,7 +1,10 @@
 package network.crypta.clients.fcp;
 
+import network.crypta.client.InsertContext;
 import network.crypta.client.async.CacheFetchResult;
+import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.USKManager;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
@@ -29,12 +32,18 @@ class FCPServerTest {
   @Mock private ExecutionPort executionPort;
   @Mock private TransferAccessPort serverTransferAccess;
   @Mock private TransferAccessPort coreTransferAccess;
+  @Mock private ClientContext clientContext;
+  @Mock private InsertContext insertContext;
+  @Mock private USKManager uskManager;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     when(runtimePorts.execution()).thenReturn(executionPort);
     lenient().when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
     lenient().when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
     lenient().when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
+    lenient().when(core.getClientContext()).thenReturn(clientContext);
+    lenient().when(clientContext.getDefaultPersistentInsertContext()).thenReturn(insertContext);
+    lenient().when(core.getUskManager()).thenReturn(uskManager);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -192,6 +201,50 @@ class FCPServerTest {
     // Assert
     assertSame(updatedServerTransferAccess, actual);
     assertNotSame(serverTransferAccess, actual);
+  }
+
+  @Test
+  void insertRuntimeSupport_whenQueried_returnsConfiguredAdapter() {
+    FCPServer server = newServer(false, false);
+    FcpInsertRuntimeSupport first = server.insertRuntimeSupport();
+
+    FcpInsertRuntimeSupport second = server.insertRuntimeSupport();
+
+    assertNotNull(first);
+    assertSame(first, second);
+  }
+
+  @Test
+  void insertRuntimeSupport_whenTransferAccessQueried_usesCoreRuntimePorts() {
+    FCPServer server = newServer(false, false);
+
+    TransferAccessPort actual = server.insertRuntimeSupport().transferAccess();
+
+    assertSame(coreTransferAccess, actual);
+    assertNotSame(serverTransferAccess, actual);
+  }
+
+  @Test
+  void insertRuntimeSupport_whenCoreTransferPolicyChanges_readsLatestCoreRuntimePort() {
+    FCPServer server = newServer(false, false);
+    FcpInsertRuntimeSupport support = server.insertRuntimeSupport();
+    TransferAccessPort updatedCoreTransferAccess = mock(TransferAccessPort.class);
+    when(coreRuntimePorts.transferAccess()).thenReturn(updatedCoreTransferAccess);
+
+    TransferAccessPort actual = support.transferAccess();
+
+    assertSame(updatedCoreTransferAccess, actual);
+    assertNotSame(coreTransferAccess, actual);
+  }
+
+  @Test
+  void insertRuntimeSupport_whenContextServicesQueried_delegatesToCore() {
+    FCPServer server = newServer(false, false);
+    FcpInsertRuntimeSupport support = server.insertRuntimeSupport();
+
+    assertSame(clientContext, support.clientContext());
+    assertSame(insertContext, support.defaultPersistentInsertContext());
+    assertSame(uskManager, support.uskManager());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.USKManager;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
@@ -36,7 +35,7 @@ class SubscribeUSKMessageTest {
       "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,"
           + "3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
 
-  @Mock private NodeClientCore nodeClientCore;
+  @Mock private FcpInsertRuntimeSupport runtimeSupport;
   @Mock private USKManager uskManager;
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
@@ -138,8 +137,8 @@ class SubscribeUSKMessageTest {
     SubscribeUSKMessage message = new SubscribeUSKMessage(baseFields());
 
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(nodeClientCore);
-    when(nodeClientCore.getUskManager()).thenReturn(uskManager);
+    when(server.insertRuntimeSupport()).thenReturn(runtimeSupport);
+    when(runtimeSupport.uskManager()).thenReturn(uskManager);
     doNothing().when(uskManager).subscribe(any(), any(), anyBoolean(), anyBoolean(), any());
 
     message.run(handler);
@@ -154,7 +153,7 @@ class SubscribeUSKMessageTest {
   @Test
   void run_whenIdentifierCollides_sendsIdentifierCollisionMessage() throws Exception {
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(nodeClientCore);
+    when(server.insertRuntimeSupport()).thenReturn(runtimeSupport);
     doThrow(new IdentifierCollisionException())
         .when(handler)
         .addUSKSubscription(any(), any(SubscribeUSK.class));
@@ -178,7 +177,7 @@ class SubscribeUSKMessageTest {
     lenient().when(handler.getRebootClient()).thenReturn(rebootClient);
     lenient().when(rebootClient.lowLevelClient(false)).thenReturn(requestClient);
     lenient().when(handler.getServer()).thenReturn(server);
-    lenient().when(server.getCore()).thenReturn(nodeClientCore);
+    lenient().when(server.insertRuntimeSupport()).thenReturn(runtimeSupport);
     doNothing().when(handler).addUSKSubscription(any(), any(SubscribeUSK.class));
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -7,7 +7,6 @@ import network.crypta.client.async.USKFoundEditionProgress;
 import network.crypta.client.async.USKManager;
 import network.crypta.client.async.USKSparseProxyCallback;
 import network.crypta.keys.USK;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,7 @@ class SubscribeUSKTest {
   private static final String TEST_USK =
       "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/";
 
-  @Mock private NodeClientCore core;
+  @Mock private FcpInsertRuntimeSupport runtimeSupport;
   @Mock private USKManager uskManager;
   @Mock private FCPConnectionHandler handler;
   @Mock private PersistentRequestClient persistentRequestClient;
@@ -52,7 +51,7 @@ class SubscribeUSKTest {
     when(uskManager.subscribeSparse(eq(message.key), any(), eq(true), eq(requestClient)))
         .thenReturn(sparseProxyCallback);
 
-    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
     verify(handler).addUSKSubscription("id-sparse", subscription);
     verify(persistentRequestClient).lowLevelClient(true);
@@ -71,7 +70,7 @@ class SubscribeUSKTest {
         buildSubscribeUSKMessage("id-poll", false, false, (short) 6, (short) 5, false, false);
     mockCommonBehavior();
 
-    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
     verify(handler).addUSKSubscription("id-poll", subscription);
     verify(persistentRequestClient).lowLevelClient(false);
@@ -89,7 +88,7 @@ class SubscribeUSKTest {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-closed", true, false, (short) 2, (short) 1, false, false);
     mockCommonBehavior();
-    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
     when(handler.isClosed()).thenReturn(true);
 
     subscription.onFoundEdition(
@@ -107,7 +106,7 @@ class SubscribeUSKTest {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-open", true, false, (short) 3, (short) 1, false, false);
     mockCommonBehavior();
-    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
     when(handler.isClosed()).thenReturn(false);
 
     subscription.onFoundEdition(
@@ -135,7 +134,7 @@ class SubscribeUSKTest {
         buildSubscribeUSKMessage("id-prio", true, false, (short) 9, (short) 2, false, false);
     mockCommonBehavior();
 
-    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
     assertEquals(9, subscription.getPollingPriorityNormal());
     assertEquals(2, subscription.getPollingPriorityProgress());
@@ -146,7 +145,7 @@ class SubscribeUSKTest {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-send", true, false, (short) 1, (short) 0, false, false);
     mockCommonBehavior();
-    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
     subscription.onSendingToNetwork(clientContext);
 
@@ -163,7 +162,7 @@ class SubscribeUSKTest {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-round", true, false, (short) 1, (short) 0, false, false);
     mockCommonBehavior();
-    SubscribeUSK subscription = new SubscribeUSK(message, core, handler);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
     subscription.onRoundFinished(clientContext);
 
@@ -176,7 +175,7 @@ class SubscribeUSKTest {
   }
 
   private void mockCommonBehavior() {
-    when(core.getUskManager()).thenReturn(uskManager);
+    when(runtimeSupport.uskManager()).thenReturn(uskManager);
     when(handler.getRebootClient()).thenReturn(persistentRequestClient);
     when(persistentRequestClient.lowLevelClient(anyBoolean())).thenReturn(requestClient);
     lenient().when(requestClient.persistent()).thenReturn(false);


### PR DESCRIPTION
## Summary
- implement PR-47 by adding a package-local `FcpInsertRuntimeSupport` seam and a core-backed `CoreFcpInsertRuntimeSupport` adapter in `clients.fcp`
- route `ClientPut`, `ClientPutDir`, `ClientPutPreparedDataFactory`, `ClientPutMessage`, `SubscribeUSK`, `SubscribeUSKMessage`, `FCPConnectionHandler`, and `LegacyQueueInsertPort` through the new seam instead of direct `NodeClientCore` access on the insert and USK path
- preserve legacy insert disk-validation behavior by keeping transfer-access checks aligned with `core.getRuntimePorts().transferAccess()`, and update the focused FCP tests plus Javadoc for the new seam files

## How to test
- `./gradlew test --tests *FCPServerTest --tests *ClientPutPreparedDataFactoryTest --tests *ClientPutMessageTest --tests *SubscribeUSKTest --tests *SubscribeUSKMessageTest --tests *FCPConnectionHandlerTest --tests *ClientPutTest --tests *ClientPutDirTest`
- `javadoc -quiet -private -Xdoclint:all -classpath "build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main" -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/fcp/FcpInsertRuntimeSupport.java`
- `javadoc -quiet -private -Xdoclint:all -classpath "build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main" -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/clients/fcp/CoreFcpInsertRuntimeSupport.java`
