### PR TITLE
refactor(fcp): Add server runtime support seam

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -715,7 +715,7 @@ public abstract class ClientRequest implements Serializable {
       return;
     }
 
-    server.getCore().getClientContext().jobRunner.setCheckpointASAP();
+    server.serverRuntimeSupport().clientContext().jobRunner.setCheckpointASAP();
 
     PersistentRequestModifiedMessage modifiedMsg =
         buildPersistentRequestModifiedMessage(clientTokenChanged, priorityClassChanged);
@@ -739,7 +739,7 @@ public abstract class ClientRequest implements Serializable {
     }
     priorityClass = newPriorityClass;
     ClientRequester requester = getClientRequest();
-    requester.setPriorityClass(priorityClass, server.getCore().getClientContext());
+    requester.setPriorityClass(priorityClass, server.serverRuntimeSupport().clientContext());
     if (client != null) {
       RequestStatusCache cache = client.getRequestStatusCache();
       if (cache != null) {
@@ -778,6 +778,7 @@ public abstract class ClientRequest implements Serializable {
   @SuppressWarnings("unused")
   public void restartAsync(final FCPServer server, final boolean disableFilterData)
       throws PersistenceDisabledException {
+    FcpServerRuntimeSupport runtimeSupport = server.serverRuntimeSupport();
     synchronized (requestLock()) {
       this.started = false;
     }
@@ -788,9 +789,8 @@ public abstract class ClientRequest implements Serializable {
       }
     }
     if (persistence == Persistence.FOREVER) {
-      server
-          .getCore()
-          .getClientContext()
+      runtimeSupport
+          .clientContext()
           .jobRunner
           .queue(
               (PersistentJob)
@@ -818,7 +818,7 @@ public abstract class ClientRequest implements Serializable {
                 @Override
                 public void run() {
                   try {
-                    restart(server.getCore().getClientContext(), disableFilterData);
+                    restart(runtimeSupport.clientContext(), disableFilterData);
                   } catch (PersistenceDisabledException _) {
                     // Impossible
                   }

--- a/src/main/java/network/crypta/clients/fcp/CoreFcpServerRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/CoreFcpServerRuntimeSupport.java
@@ -1,0 +1,66 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.client.async.ClientContext;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.PersistentTempBucketFactory;
+
+/**
+ * Core-backed implementation of {@link FcpServerRuntimeSupport}.
+ *
+ * <p>This adapter keeps the server-owned FCP infrastructure coupled to a narrow, package-local
+ * contract instead of directly to {@link NodeClientCore}. It is an immutable wrapper over the live
+ * daemon core and delegates each method directly so connection handlers, persistent ops, and the
+ * parser continue to observe the current runtime state.
+ *
+ * <p>Callers typically get a single instance from {@link FCPServer} during server construction and
+ * reuse it for the lifetime of that server. The record does not cache derived state, so every
+ * method reflects the current core-backed factories, context, and persistence status at the time of
+ * the call. That keeps the seam narrow and reversible while still preserving the same operational
+ * behavior that the pre-refactor code saw through direct core access.
+ *
+ * @param core live daemon core backing the owning FCP server
+ */
+record CoreFcpServerRuntimeSupport(NodeClientCore core) implements FcpServerRuntimeSupport {
+
+  /**
+   * Creates a runtime-support adapter backed by the supplied node core.
+   *
+   * <p>The constructor retains the live core reference rather than copying out individual services.
+   * That choice ensures later calls still see the current client context, bucket factories, and
+   * persistence state owned by the daemon. The provided core must therefore already be fully
+   * initialized for normal FCP server operation.
+   *
+   * @param core live daemon core that owns the runtime services exposed through this seam
+   * @throws NullPointerException if {@code core} is {@code null}
+   */
+  CoreFcpServerRuntimeSupport(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  @Override
+  public ClientContext clientContext() {
+    return core.getClientContext();
+  }
+
+  @Override
+  public boolean persistenceDisabled() {
+    return core.killedDatabase();
+  }
+
+  @Override
+  public BucketFactory tempBucketFactory() {
+    return core.getTempBucketFactory();
+  }
+
+  @Override
+  public PersistentTempBucketFactory persistentTempBucketFactory() {
+    return core.getPersistentTempBucketFactory();
+  }
+
+  @Override
+  public void fillSecureRandom(byte[] bytes) {
+    core.getRandom().nextBytes(bytes);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -268,8 +268,9 @@ public class FCPConnectionHandler implements Closeable {
   }
 
   private void notifyLostRequests(ClientRequest[] requests) {
+    ClientContext clientContext = serverClientContext();
     for (ClientRequest request : requests) {
-      request.onLostConnection(server.getCore().getClientContext());
+      request.onLostConnection(clientContext);
     }
   }
 
@@ -281,9 +282,7 @@ public class FCPConnectionHandler implements Closeable {
 
   private void enqueueClientCleanup() {
     try {
-      server
-          .getCore()
-          .getClientContext()
+      serverClientContext()
           .jobRunner
           .queue(
               (PersistentJob)
@@ -697,7 +696,7 @@ public class FCPConnectionHandler implements Closeable {
             return false;
           }
           if (!registerPersistentRequest(request, message.identifier, message.global)) {
-            request.cancel(server.getCore().getClientContext());
+            request.cancel(serverClientContext());
             return false;
           }
           request.start(context);
@@ -803,9 +802,7 @@ public class FCPConnectionHandler implements Closeable {
 
   private void queuePersistentJob(PersistentJob job, String identifier, boolean global) {
     try {
-      server
-          .getCore()
-          .getClientContext()
+      serverClientContext()
           .jobRunner
           .queue(job, NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
     } catch (PersistenceDisabledException _) {
@@ -1005,8 +1002,9 @@ public class FCPConnectionHandler implements Closeable {
       req = requestsByIdentifier.remove(identifier);
     }
     if (req != null) {
-      if (kill) req.cancel(server.getCore().getClientContext());
-      req.requestWasRemoved(server.getCore().getClientContext());
+      ClientContext clientContext = serverClientContext();
+      if (kill) req.cancel(clientContext);
+      req.requestWasRemoved(clientContext);
     }
     return req;
   }
@@ -1025,7 +1023,7 @@ public class FCPConnectionHandler implements Closeable {
     PersistentRequestClient client = global ? server.getGlobalRebootClient() : getRebootClient();
     ClientRequest req = client.getRequest(identifier);
     if (req != null) {
-      client.removeByIdentifier(identifier, true, server, server.getCore().getClientContext());
+      client.removeByIdentifier(identifier, true, server, serverClientContext());
     }
     return req;
   }
@@ -1034,9 +1032,13 @@ public class FCPConnectionHandler implements Closeable {
     PersistentRequestClient client = global ? server.getGlobalForeverClient() : getForeverClient();
     ClientRequest req = client.getRequest(identifier);
     if (req != null) {
-      client.removeByIdentifier(identifier, true, server, server.getCore().getClientContext());
+      client.removeByIdentifier(identifier, true, server, serverClientContext());
     }
     return req;
+  }
+
+  private ClientContext serverClientContext() {
+    return server.serverRuntimeSupport().clientContext();
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPConnectionInputHandler.java
@@ -216,11 +216,12 @@ public class FCPConnectionInputHandler implements Runnable {
     if (LOG.isTraceEnabled()) {
       LOG.trace("Incoming FCP message:\n{}\n{}", messageType, fs);
     }
+    FcpServerRuntimeSupport runtimeSupport = handler.getServer().serverRuntimeSupport();
     return FCPMessage.create(
         messageType,
         fs,
-        handler.getServer().getCore().getTempBucketFactory(),
-        handler.getServer().getCore().getPersistentTempBucketFactory());
+        runtimeSupport.tempBucketFactory(),
+        runtimeSupport.persistentTempBucketFactory());
   }
 
   private boolean readPayloadIfRequired(FCPMessage msg, LineReadingInputStream lis)
@@ -228,7 +229,9 @@ public class FCPConnectionInputHandler implements Runnable {
     if (msg instanceof BaseDataCarryingMessage message) {
       try {
         message.readFrom(
-            lis, handler.getServer().getCore().getTempBucketFactory(), handler.getServer());
+            lis,
+            handler.getServer().serverRuntimeSupport().tempBucketFactory(),
+            handler.getServer());
       } catch (MessageInvalidException e) {
         sendProtocolError(e);
         return false;

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -52,6 +52,7 @@ public class FCPServer implements Runnable, DownloadCache {
   /* It’s not the field that is deprecated, but accessing it directly is. */
   private final NodeClientCore core;
 
+  private final FcpServerRuntimeSupport serverRuntimeSupport;
   private final FcpFetchRuntimeSupport fetchRuntimeSupport;
   private final FcpInsertRuntimeSupport insertRuntimeSupport;
 
@@ -109,6 +110,7 @@ public class FCPServer implements Runnable, DownloadCache {
     this.port = config.port();
     this.enabled = config.enabled();
     this.core = dependencies.core();
+    this.serverRuntimeSupport = new CoreFcpServerRuntimeSupport(core);
     this.runtime = dependencies.runtimePorts();
     this.fetchRuntimeSupport = new CoreFcpFetchRuntimeSupport(core, this.runtime::transferAccess);
     this.insertRuntimeSupport =
@@ -118,7 +120,8 @@ public class FCPServer implements Runnable, DownloadCache {
     this.neverDropAMessage = config.neverDropAMessage();
     this.maxMessageQueueLength = config.maxMessageQueueLength();
     this.listener = new FcpServerListener(this, runtime, config);
-    this.persistentOps = new FcpServerPersistentOps(this, core, dependencies.persistentRoot());
+    this.persistentOps =
+        new FcpServerPersistentOps(this, serverRuntimeSupport, dependencies.persistentRoot());
   }
 
   /**
@@ -735,6 +738,19 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public NodeClientCore getCore() {
     return core;
+  }
+
+  /**
+   * Returns runtime support for server-owned FCP infrastructure concerns.
+   *
+   * <p>This package-local seam keeps connection handling, persistent request plumbing, and inbound
+   * message parsing independent of direct {@link NodeClientCore} access while preserving current
+   * behavior. It is an internal wiring detail of {@code clients.fcp}, not a public server API.
+   *
+   * @return server runtime support backing infrastructure-level FCP operations
+   */
+  FcpServerRuntimeSupport serverRuntimeSupport() {
+    return serverRuntimeSupport;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -21,7 +21,6 @@ import network.crypta.client.async.PersistentJob;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.Base64;
@@ -67,8 +66,8 @@ final class FcpServerPersistentOps implements DownloadCache {
   /** The owning server used for queue coordination and callback wiring. */
   private final FCPServer server;
 
-  /** Client core providing contexts, RNG, and bucket factories. */
-  private final NodeClientCore core;
+  /** Runtime support providing contexts, RNG, and bucket factories. */
+  private final FcpServerRuntimeSupport runtimeSupport;
 
   /** Root registry for forever-persistent clients. */
   private final PersistentRequestRoot persistentRoot;
@@ -83,20 +82,23 @@ final class FcpServerPersistentOps implements DownloadCache {
   private final PersistentRequestClient globalForeverClient;
 
   /**
-   * Creates a persistence helper bound to the provided server, core, and persistent root.
+   * Creates a persistence helper bound to the provided server, runtime support, and persistent
+   * root.
    *
    * <p>The constructor initializes the reboot-client map, wires the forever-global client from the
    * provided root, and allocates the reboot-global client used for temporary persistence. No
    * network operations occur here; the helper is ready for use immediately after construction.
    *
    * @param server owning server used when scheduling global queue operations.
-   * @param core client core supplying contexts, RNG, and storage factories.
+   * @param runtimeSupport runtime support supplying contexts, RNG, and storage factories.
    * @param persistentRoot registry for forever-persistent clients and queues.
    */
   FcpServerPersistentOps(
-      FCPServer server, NodeClientCore core, PersistentRequestRoot persistentRoot) {
+      FCPServer server,
+      FcpServerRuntimeSupport runtimeSupport,
+      PersistentRequestRoot persistentRoot) {
     this.server = server;
-    this.core = core;
+    this.runtimeSupport = runtimeSupport;
     this.persistentRoot = persistentRoot;
     this.rebootClientsByName = new WeakHashMap<>();
     this.globalForeverClient = persistentRoot.globalForeverClient;
@@ -205,7 +207,7 @@ final class FcpServerPersistentOps implements DownloadCache {
    * @throws PersistenceDisabledException when persistence is unavailable or disabled.
    */
   RequestStatus[] getGlobalRequests() throws PersistenceDisabledException {
-    if (core.killedDatabase()) throw new PersistenceDisabledException();
+    if (runtimeSupport.persistenceDisabled()) throw new PersistenceDisabledException();
     List<RequestStatus> v = new ArrayList<>();
     globalRebootClient.addPersistentRequestStatus(v);
     if (globalForeverClient != null) globalForeverClient.addPersistentRequestStatus(v);
@@ -224,10 +226,10 @@ final class FcpServerPersistentOps implements DownloadCache {
    * @throws PersistenceDisabledException when persistence is unavailable or disabled.
    */
   boolean removeGlobalRequestBlocking(final String identifier) throws PersistenceDisabledException {
-    if (!globalRebootClient.removeByIdentifier(identifier, true, server, core.getClientContext())) {
+    if (!globalRebootClient.removeByIdentifier(identifier, true, server, clientContext())) {
       final CountDownLatch done = new CountDownLatch(1);
       final AtomicBoolean success = new AtomicBoolean();
-      core.getClientContext()
+      clientContext()
           .jobRunner
           .queue(
               new PersistentJob() {
@@ -243,7 +245,7 @@ final class FcpServerPersistentOps implements DownloadCache {
                   try {
                     succeeded =
                         globalForeverClient.removeByIdentifier(
-                            identifier, true, server, core.getClientContext());
+                            identifier, true, server, clientContext());
                   } catch (Exception e) {
                     LOG.error("Caught removing identifier {}: {}", identifier, e, e);
                   } finally {
@@ -277,7 +279,7 @@ final class FcpServerPersistentOps implements DownloadCache {
     globalRebootClient.removeAll();
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicBoolean success = new AtomicBoolean();
-    core.getClientContext()
+    clientContext()
         .jobRunner
         .queue(
             new PersistentJob() {
@@ -337,7 +339,7 @@ final class FcpServerPersistentOps implements DownloadCache {
         boolean done;
       }
       final OutputWrapper ow = new OutputWrapper();
-      core.getClientContext()
+      clientContext()
           .jobRunner
           .queue(
               new PersistentJob() {
@@ -399,7 +401,7 @@ final class FcpServerPersistentOps implements DownloadCache {
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicReference<NotAllowedException> notAllowed = new AtomicReference<>();
     final AtomicReference<IOException> ioException = new AtomicReference<>();
-    core.getClientContext()
+    clientContext()
         .jobRunner
         .queue(
             new PersistentJob() {
@@ -511,7 +513,7 @@ final class FcpServerPersistentOps implements DownloadCache {
 
     while (true) {
       byte[] buf = new byte[8];
-      core.getRandom().nextBytes(buf);
+      runtimeSupport.fillSecureRandom(buf);
       String id = FPROXY_PREFIX + Base64.encode(buf);
       PersistentGlobalRequestSpec spec =
           new PersistentGlobalRequestSpec(
@@ -656,11 +658,11 @@ final class FcpServerPersistentOps implements DownloadCache {
   void startBlocking(final ClientRequest req)
       throws IdentifierCollisionException, PersistenceDisabledException {
     if (req.persistence == Persistence.REBOOT) {
-      req.start(core.getClientContext());
+      req.start(clientContext());
     } else {
       final CountDownLatch done = new CountDownLatch(1);
       final AtomicReference<IdentifierCollisionException> collision = new AtomicReference<>();
-      core.getClientContext()
+      clientContext()
           .jobRunner
           .queue(
               new PersistentJob() {
@@ -700,13 +702,13 @@ final class FcpServerPersistentOps implements DownloadCache {
       throws PersistenceDisabledException {
     ClientRequest req = globalRebootClient.getRequest(identifier);
     if (req != null) {
-      req.restart(core.getClientContext(), disableFilterData);
+      req.restart(clientContext(), disableFilterData);
       return true;
     } else {
       final CountDownLatch done = new CountDownLatch(1);
       final AtomicBoolean success = new AtomicBoolean();
       if (LOG.isDebugEnabled()) LOG.debug("Queueing restart of {}", identifier);
-      core.getClientContext()
+      clientContext()
           .jobRunner
           .queue(
               new PersistentJob() {
@@ -761,7 +763,7 @@ final class FcpServerPersistentOps implements DownloadCache {
 
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicReference<FetchResult> resultRef = new AtomicReference<>();
-    core.getClientContext()
+    clientContext()
         .jobRunner
         .queue(
             new PersistentJob() {
@@ -825,7 +827,9 @@ final class FcpServerPersistentOps implements DownloadCache {
 
     Bucket newData = preferred;
     try {
-      if (newData == null) newData = core.getTempBucketFactory().makeBucket(origData.size());
+      if (newData == null) {
+        newData = runtimeSupport.tempBucketFactory().makeBucket(origData.size());
+      }
       BucketTools.copy(origData, newData);
       if (origData.size() != newData.size()) {
         LOG.info("Maybe it disappeared under us?");
@@ -852,7 +856,7 @@ final class FcpServerPersistentOps implements DownloadCache {
       if (newData == null) {
         try {
           if (preferred != null) newData = preferred;
-          else newData = core.getTempBucketFactory().makeBucket(origData.size());
+          else newData = runtimeSupport.tempBucketFactory().makeBucket(origData.size());
           BucketTools.copy(origData, newData);
         } catch (IOException e) {
           LOG.error("Unable to copy data: {}", e, e);
@@ -877,5 +881,9 @@ final class FcpServerPersistentOps implements DownloadCache {
 
   PersistentRequestClient getGlobalRebootClient() {
     return globalRebootClient;
+  }
+
+  private ClientContext clientContext() {
+    return runtimeSupport.clientContext();
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
@@ -1,0 +1,55 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.PersistentTempBucketFactory;
+
+/**
+ * Narrow runtime support seam for server-owned FCP infrastructure.
+ *
+ * <p>This package-local adapter keeps connection handling, persistent request plumbing, and inbound
+ * message parsing independent of direct {@code NodeClientCore} access while preserving the current
+ * runtime behavior. It exposes only the live client context, persistence-availability check, bucket
+ * factories, and secure randomness currently required by the FCP server's infrastructure classes.
+ *
+ * <p>The seam is intentionally local to {@code clients.fcp}. It is not a new shared platform API;
+ * callers should add methods only when a later refactoring needs another demonstrably
+ * server-infrastructure-specific capability.
+ */
+interface FcpServerRuntimeSupport {
+
+  /**
+   * Returns the live client context used for request lifecycle and persistent job work.
+   *
+   * @return current client context backing the owning FCP server
+   */
+  ClientContext clientContext();
+
+  /**
+   * Reports whether forever-persistent storage is currently unavailable.
+   *
+   * @return {@code true} when persistent storage has been disabled or torn down
+   */
+  boolean persistenceDisabled();
+
+  /**
+   * Returns the temporary bucket factory used for non-persistent payloads and cache copies.
+   *
+   * @return temporary bucket factory owned by the current runtime
+   */
+  BucketFactory tempBucketFactory();
+
+  /**
+   * Returns the persistent temporary bucket factory used for forever-persistent inbound payloads.
+   *
+   * @return persistent temporary bucket factory owned by the current runtime
+   */
+  PersistentTempBucketFactory persistentTempBucketFactory();
+
+  /**
+   * Fills the supplied byte array with secure random data from the owning runtime.
+   *
+   * @param bytes destination array to populate with secure random bytes
+   */
+  void fillSecureRandom(byte[] bytes);
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -294,9 +294,13 @@ class ClientGetFactoryTest {
 
   private FCPConnectionHandler newConnectionHandler() {
     FCPServer server = mock(FCPServer.class);
+    FcpServerRuntimeSupport serverRuntimeSupport = mock(FcpServerRuntimeSupport.class);
+    ClientContext clientContext = mock(ClientContext.class);
     Socket socket = mock(Socket.class);
     RuntimePorts handlerRuntimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
+    when(server.serverRuntimeSupport()).thenReturn(serverRuntimeSupport);
+    when(serverRuntimeSupport.clientContext()).thenReturn(clientContext);
     when(server.runtime()).thenReturn(handlerRuntimePorts);
     when(handlerRuntimePorts.randomness()).thenReturn(randomnessPort);
     doAnswer(

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
@@ -1,0 +1,315 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class ClientRequestModifyRequestTest {
+
+  @Test
+  void modifyRequest_whenPriorityAndTokenChange_updatesRequesterCacheAndQueuesMessage() {
+    TrackingJobRunner jobRunner = new TrackingJobRunner();
+    ClientContext context = newContextWithJobRunner(jobRunner);
+    FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
+    when(runtimeSupport.clientContext()).thenReturn(context);
+    FCPServer server = mock(FCPServer.class);
+    when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
+    ClientRequester requester = mock(ClientRequester.class);
+    PersistentRequestClient client =
+        spy(
+            new PersistentRequestClient(
+                "modify", null, true, null, ClientRequest.Persistence.REBOOT, null));
+    DownloadRequestStatus status = newDownloadStatus();
+    requireStatusCache(client).addDownload(status);
+    TestClientRequest request =
+        TestClientRequest.reboot("request-1", (short) 1, "token-a", client, requester);
+
+    request.modifyRequest("token-b", (short) 4, server);
+
+    verify(requester).setPriorityClass((short) 4, context);
+    verify(client).queueClientRequestMessage(any(PersistentRequestModifiedMessage.class), eq(0));
+    assertEquals(1, jobRunner.checkpointRequests);
+    assertEquals(4, request.priorityClass);
+    assertEquals("token-b", request.clientToken);
+    assertEquals(4, status.getPriority());
+
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+    verify(client).queueClientRequestMessage(messageCaptor.capture(), eq(0));
+    PersistentRequestModifiedMessage modified =
+        assertInstanceOf(PersistentRequestModifiedMessage.class, messageCaptor.getValue());
+    assertEquals("request-1", modified.getFieldSet().get("Identifier"));
+    assertEquals("4", modified.getFieldSet().get("PriorityClass"));
+    assertEquals("token-b", modified.getFieldSet().get("ClientToken"));
+  }
+
+  @Test
+  void modifyRequest_whenNothingChanges_skipsCheckpointRequesterAndMessageQueue() {
+    TrackingJobRunner jobRunner = new TrackingJobRunner();
+    ClientContext context = newContextWithJobRunner(jobRunner);
+    FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
+    when(runtimeSupport.clientContext()).thenReturn(context);
+    FCPServer server = mock(FCPServer.class);
+    when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
+    ClientRequester requester = mock(ClientRequester.class);
+    PersistentRequestClient client =
+        spy(
+            new PersistentRequestClient(
+                "modify", null, true, null, ClientRequest.Persistence.REBOOT, null));
+    TestClientRequest request =
+        TestClientRequest.reboot("request-2", (short) 2, "same-token", client, requester);
+
+    request.modifyRequest("same-token", (short) 2, server);
+
+    assertEquals(0, jobRunner.checkpointRequests);
+    verify(requester, never()).setPriorityClass(any(short.class), any(ClientContext.class));
+    verify(client, never()).queueClientRequestMessage(any(FCPMessage.class), eq(0));
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static ClientContext newContextWithJobRunner(PersistentJobRunner jobRunner) {
+    ClientContext context =
+        Mockito.mock(
+            ClientContext.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    try {
+      Field field = ClientContext.class.getDeclaredField("jobRunner");
+      field.setAccessible(true);
+      field.set(context, jobRunner);
+      return context;
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed to set ClientContext.jobRunner", e);
+    }
+  }
+
+  private static RequestStatusCache requireStatusCache(PersistentRequestClient client) {
+    RequestStatusCache cache = client.getRequestStatusCache();
+    if (cache == null) {
+      throw new AssertionError("Expected global client to expose a request status cache");
+    }
+    return cache;
+  }
+
+  private static DownloadRequestStatus newDownloadStatus() {
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            "request-1",
+            ClientRequest.Persistence.REBOOT,
+            false,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 1);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(10, "text/plain", null, null, null, mock(Bucket.class), false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(
+            outcome, null, null, null, mock(FreenetURI.class), false, false);
+    return new DownloadRequestStatus(statusSnapshot, details);
+  }
+
+  private static final class TrackingJobRunner implements PersistentJobRunner {
+    private int checkpointRequests;
+
+    @Override
+    public void queue(PersistentJob persistentJob, int threadPriority) {
+      throw new UnsupportedOperationException("Not used by modifyRequest()");
+    }
+
+    @Override
+    public void queueNormalOrDrop(PersistentJob persistentJob) {
+      throw new UnsupportedOperationException("Not used by modifyRequest()");
+    }
+
+    @Override
+    public void queueInternal(PersistentJob job, int threadPriority) {
+      throw new UnsupportedOperationException("Not used by modifyRequest()");
+    }
+
+    @Override
+    public void queueInternal(PersistentJob job) {
+      throw new UnsupportedOperationException("Not used by modifyRequest()");
+    }
+
+    @Override
+    public void setCheckpointASAP() {
+      checkpointRequests++;
+    }
+
+    @Override
+    public boolean hasLoaded() {
+      return true;
+    }
+
+    @Override
+    public CheckpointLock lock() {
+      return (_, _) -> {};
+    }
+
+    @Override
+    public boolean newSalt() {
+      return false;
+    }
+
+    @Override
+    public boolean shuttingDown() {
+      return false;
+    }
+  }
+
+  private static final class TestClientRequest extends ClientRequest {
+    private final ClientRequester requester;
+
+    private TestClientRequest(ConstructorInit init, ClientRequester requester) {
+      super(init);
+      this.requester = requester;
+    }
+
+    static TestClientRequest reboot(
+        String identifier,
+        short priorityClass,
+        String clientToken,
+        PersistentRequestClient client,
+        ClientRequester requester) {
+      return new TestClientRequest(
+          prepareConstructorInit(
+              new ClientRequestParams(
+                  null, identifier, 0, priorityClass, Persistence.REBOOT, false, clientToken, true),
+              null,
+              client),
+          requester);
+    }
+
+    @Override
+    public void onLostConnection(ClientContext context) {
+      // No-op for focused modifyRequest() testing.
+    }
+
+    @Override
+    public void sendPendingMessages(
+        FCPConnectionOutputHandler handler,
+        String listRequestIdentifier,
+        boolean includeData,
+        boolean onlyData) {
+      // No-op for focused modifyRequest() testing.
+    }
+
+    @Override
+    void register(boolean noTags) {
+      // No-op for focused modifyRequest() testing.
+    }
+
+    @Override
+    protected ClientRequester getClientRequest() {
+      return requester;
+    }
+
+    @Override
+    protected void freeData() {
+      // No-op for focused modifyRequest() testing.
+    }
+
+    @Override
+    public double getSuccessFraction() {
+      return 0;
+    }
+
+    @Override
+    public double getTotalBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getMinBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFetchedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFatalyFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public String getFailureReason(boolean longDescription) {
+      return "failure";
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return true;
+    }
+
+    @Override
+    public void start(ClientContext context) {
+      // No-op for focused modifyRequest() testing.
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return false;
+    }
+
+    @Override
+    public boolean canRestart() {
+      return false;
+    }
+
+    @Override
+    public boolean restart(ClientContext context, boolean disableFilterData) {
+      return false;
+    }
+
+    @Override
+    RequestStatus getStatus() {
+      return null;
+    }
+
+    @Override
+    protected void innerResume(ClientContext context) {
+      // No-op for focused modifyRequest() testing.
+    }
+
+    @Override
+    RequestIdentifier.RequestType getType() {
+      return RequestIdentifier.RequestType.GET;
+    }
+
+    @Override
+    public boolean fullyResumed() {
+      return true;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
@@ -5,7 +5,6 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.PersistentJobRunner;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.PrioRunnable;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -40,11 +39,11 @@ class ClientRequestRestartAsyncTest {
     when(runtimePorts.execution()).thenReturn(executionPort);
     PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
     ClientContext context = newContextWithJobRunner(jobRunner);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getClientContext()).thenReturn(context);
+    FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
+    when(runtimeSupport.clientContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.runtime()).thenReturn(runtimePorts);
-    when(server.getCore()).thenReturn(core);
+    when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
     TestClientRequest request = TestClientRequest.connection();
     request.markStarted();
 
@@ -76,11 +75,11 @@ class ClientRequestRestartAsyncTest {
     when(runtimePorts.execution()).thenReturn(executionPort);
     PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
     ClientContext context = newContextWithJobRunner(jobRunner);
-    NodeClientCore core = mock(NodeClientCore.class);
-    when(core.getClientContext()).thenReturn(context);
+    FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
+    when(runtimeSupport.clientContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.runtime()).thenReturn(runtimePorts);
-    when(server.getCore()).thenReturn(core);
+    when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
     TestClientRequest request = TestClientRequest.forever();
     request.markStarted();
 

--- a/src/test/java/network/crypta/clients/fcp/CoreFcpServerRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CoreFcpServerRuntimeSupportTest.java
@@ -1,0 +1,66 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.RandomSource;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class CoreFcpServerRuntimeSupportTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientContext clientContext;
+  @Mock private TempBucketFactory tempBucketFactory;
+  @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
+  @Mock private RandomSource randomSource;
+
+  @Test
+  void constructor_whenCoreNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new CoreFcpServerRuntimeSupport(null));
+  }
+
+  @Test
+  void clientContext_whenQueried_returnsCoreClientContext() {
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
+
+    assertSame(clientContext, support.clientContext());
+  }
+
+  @Test
+  void persistenceAndBucketFactories_whenQueried_delegateToCore() {
+    when(core.killedDatabase()).thenReturn(true);
+    when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
+    when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
+
+    CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
+
+    assertTrue(support.persistenceDisabled());
+    assertSame(tempBucketFactory, support.tempBucketFactory());
+    assertSame(persistentTempBucketFactory, support.persistentTempBucketFactory());
+  }
+
+  @Test
+  void fillSecureRandom_whenCalled_delegatesToCoreRandomSource() {
+    when(core.getRandom()).thenReturn(randomSource);
+    CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
+    byte[] bytes = new byte[8];
+
+    support.fillSecureRandom(bytes);
+
+    verify(randomSource).nextBytes(bytes);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -13,12 +13,10 @@ import java.util.Random;
 import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.EntropySource;
 import network.crypta.crypt.RandomSource;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,9 +44,8 @@ import static org.mockito.Mockito.when;
 class FCPConnectionHandlerTest {
 
   @Mock private FCPServer server;
-  @Mock private NodeClientCore core;
+  @Mock private FcpServerRuntimeSupport serverRuntimeSupport;
   @Mock private ClientContext clientContext;
-  @Mock private TempBucketFactory tempBucketFactory;
   @Mock private Socket socket;
   @Mock private RuntimePorts runtimePorts;
   @Mock private RandomnessPort randomnessPort;
@@ -61,8 +58,8 @@ class FCPConnectionHandlerTest {
     DeterministicRandomSource randomSource = new DeterministicRandomSource(1234L);
     Random fastRandom = new Random(5678L);
 
-    lenient().when(server.getCore()).thenReturn(core);
-    lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
+    lenient().when(server.serverRuntimeSupport()).thenReturn(serverRuntimeSupport);
+    lenient().when(serverRuntimeSupport.clientContext()).thenReturn(clientContext);
     lenient().when(server.runtime()).thenReturn(runtimePorts);
     lenient().when(server.insertRuntimeSupport()).thenReturn(insertRuntimeSupport);
     lenient().when(runtimePorts.randomness()).thenReturn(randomnessPort);
@@ -129,7 +126,6 @@ class FCPConnectionHandlerTest {
   void removeRequestByIdentifier_whenKillTrue_cancelsAndNotifies() {
     ClientRequest request = mock(ClientRequest.class);
     handler.requestsByIdentifier.put("id", request);
-    when(core.getClientContext()).thenReturn(clientContext);
 
     ClientRequest removed = handler.removeRequestByIdentifier("id", true);
 
@@ -143,7 +139,6 @@ class FCPConnectionHandlerTest {
   void removeRequestByIdentifier_whenKillFalse_onlyNotifies() {
     ClientRequest request = mock(ClientRequest.class);
     handler.requestsByIdentifier.put("id", request);
-    when(core.getClientContext()).thenReturn(clientContext);
 
     ClientRequest removed = handler.removeRequestByIdentifier("id", false);
 

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -13,7 +13,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.runtime.spi.NodeInfoPort;
@@ -31,12 +30,14 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
@@ -213,6 +214,53 @@ class FCPConnectionInputHandlerTest {
   }
 
   @Test
+  void realRun_whenCreatingMessage_usesServerRuntimeSupportBucketFactories() throws Exception {
+    TestContext ctx = createContext(clientHello("One"), message("AfterHello", "EndMessage"));
+    FakeSimpleMessage message = new FakeSimpleMessage();
+    List<String> lines =
+        List.of(
+            "ClientHello",
+            "Name=One",
+            "ExpectedVersion=2.0",
+            "EndMessage",
+            "AfterHello",
+            "EndMessage");
+
+    try (MockedStatic<FCPMessage> mocked = mockFactory(message, "AfterHello")) {
+      withLineSequence(lines, ctx.inputHandler::realRun);
+
+      mocked.verify(
+          () ->
+              FCPMessage.create(
+                  eq("AfterHello"),
+                  any(SimpleFieldSet.class),
+                  same(ctx.bucketFactory),
+                  same(ctx.persistentFactory)));
+    }
+  }
+
+  @Test
+  void realRun_whenReadingDataPayload_usesServerRuntimeSupportTempBucketFactory() throws Exception {
+    FakeDataMessage dataMessage = new FakeDataMessage(null);
+    TestContext ctx = createContext(clientHello("One"), message("StubData", "EndMessage"));
+    List<String> lines =
+        List.of(
+            "ClientHello",
+            "Name=One",
+            "ExpectedVersion=2.0",
+            "EndMessage",
+            "StubData",
+            "EndMessage");
+
+    try (var _ = mockFactory(dataMessage, "StubData")) {
+      withLineSequence(lines, ctx.inputHandler::realRun);
+    }
+
+    assertSame(ctx.bucketFactory, dataMessage.readBucketFactory);
+    assertSame(ctx.server, dataMessage.readServer);
+  }
+
+  @Test
   void realRun_whenHandlerIndicatesClosed_stopsConsumingFurtherMessages() throws Exception {
     AtomicBoolean closed = new AtomicBoolean(false);
     FakeSimpleMessage stopMessage = new FakeSimpleMessage(() -> closed.set(true), null);
@@ -271,7 +319,7 @@ class FCPConnectionInputHandlerTest {
     ctx.handler = mock(FCPConnectionHandler.class);
     ctx.bucketFactory = mock(TempBucketFactory.class);
     ctx.server = mock(FCPServer.class);
-    ctx.core = mock(NodeClientCore.class);
+    ctx.runtimeSupport = mock(FcpServerRuntimeSupport.class);
     ctx.runtimePorts = mock(RuntimePorts.class);
     ctx.nodeInfoPort = mock(NodeInfoPort.class);
     ctx.persistentFactory = mock(PersistentTempBucketFactory.class);
@@ -280,7 +328,7 @@ class FCPConnectionInputHandlerTest {
     when(ctx.handler.getSocket()).thenReturn(ctx.socket);
     when(ctx.socket.getInputStream()).thenReturn(stream);
     when(ctx.handler.getServer()).thenReturn(ctx.server);
-    lenient().when(ctx.server.getCore()).thenReturn(ctx.core);
+    lenient().when(ctx.server.serverRuntimeSupport()).thenReturn(ctx.runtimeSupport);
     lenient().when(ctx.server.runtime()).thenReturn(ctx.runtimePorts);
     lenient().when(ctx.runtimePorts.nodeInfo()).thenReturn(ctx.nodeInfoPort);
     lenient()
@@ -288,8 +336,10 @@ class FCPConnectionInputHandlerTest {
         .thenReturn(
             new NodeGreetingSnapshot(
                 "Cryptad", "v-string", 123, "rev-xyz", false, "descriptor", "ENGLISH"));
-    lenient().when(ctx.core.getTempBucketFactory()).thenReturn(ctx.bucketFactory);
-    lenient().when(ctx.core.getPersistentTempBucketFactory()).thenReturn(ctx.persistentFactory);
+    lenient().when(ctx.runtimeSupport.tempBucketFactory()).thenReturn(ctx.bucketFactory);
+    lenient()
+        .when(ctx.runtimeSupport.persistentTempBucketFactory())
+        .thenReturn(ctx.persistentFactory);
     lenient().when(ctx.handler.isClosed()).thenReturn(false);
     lenient().when(ctx.handler.getConnectionIdentifierUUID()).thenReturn(UUID.randomUUID());
 
@@ -332,7 +382,7 @@ class FCPConnectionInputHandlerTest {
     FCPConnectionInputHandler inputHandler;
     FCPConnectionHandler handler;
     FCPServer server;
-    NodeClientCore core;
+    FcpServerRuntimeSupport runtimeSupport;
     RuntimePorts runtimePorts;
     NodeInfoPort nodeInfoPort;
     Socket socket;
@@ -342,6 +392,8 @@ class FCPConnectionInputHandlerTest {
 
   private static final class FakeDataMessage extends BaseDataCarryingMessage {
     private final MessageInvalidException readFailure;
+    private BucketFactory readBucketFactory;
+    private FCPServer readServer;
 
     FakeDataMessage(MessageInvalidException readFailure) {
       this.readFailure = readFailure;
@@ -350,6 +402,8 @@ class FCPConnectionInputHandlerTest {
     @Override
     public void readFrom(InputStream is, BucketFactory bf, FCPServer server)
         throws MessageInvalidException {
+      readBucketFactory = bf;
+      readServer = server;
       if (readFailure != null) {
         throw readFailure;
       }

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -6,12 +6,15 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.USKManager;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
+import network.crypta.support.io.PersistentTempBucketFactory;
+import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -35,6 +38,9 @@ class FCPServerTest {
   @Mock private ClientContext clientContext;
   @Mock private InsertContext insertContext;
   @Mock private USKManager uskManager;
+  @Mock private TempBucketFactory tempBucketFactory;
+  @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
+  @Mock private RandomSource randomSource;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     when(runtimePorts.execution()).thenReturn(executionPort);
@@ -44,6 +50,9 @@ class FCPServerTest {
     lenient().when(core.getClientContext()).thenReturn(clientContext);
     lenient().when(clientContext.getDefaultPersistentInsertContext()).thenReturn(insertContext);
     lenient().when(core.getUskManager()).thenReturn(uskManager);
+    lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
+    lenient().when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
+    lenient().when(core.getRandom()).thenReturn(randomSource);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -158,6 +167,33 @@ class FCPServerTest {
     FCPServer server = newServer(false, false);
 
     assertSame(runtimePorts, server.runtime());
+  }
+
+  @Test
+  void serverRuntimeSupport_whenQueried_returnsConfiguredAdapter() {
+    FCPServer server = newServer(false, false);
+    FcpServerRuntimeSupport first = server.serverRuntimeSupport();
+
+    FcpServerRuntimeSupport second = server.serverRuntimeSupport();
+
+    assertNotNull(first);
+    assertSame(first, second);
+  }
+
+  @Test
+  void serverRuntimeSupport_whenServicesQueried_delegatesToCore() {
+    when(core.killedDatabase()).thenReturn(true);
+    FCPServer server = newServer(false, false);
+    byte[] bytes = new byte[4];
+
+    FcpServerRuntimeSupport support = server.serverRuntimeSupport();
+
+    assertSame(clientContext, support.clientContext());
+    assertTrue(support.persistenceDisabled());
+    assertSame(tempBucketFactory, support.tempBucketFactory());
+    assertSame(persistentTempBucketFactory, support.persistentTempBucketFactory());
+    support.fillSecureRandom(bytes);
+    verify(randomSource).nextBytes(bytes);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -636,14 +636,16 @@ class FcpServerPersistentOpsTest {
   }
 
   private FcpServerPersistentOps newOps(PersistentRequestRoot root) {
+    FcpServerRuntimeSupport runtimeSupport = new CoreFcpServerRuntimeSupport(core);
     lenient().when(server.runtime()).thenReturn(runtimePorts);
+    lenient().when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
     lenient().when(server.fetchRuntimeSupport()).thenReturn(fetchRuntimeSupport);
     lenient().when(runtimePorts.transferAccess()).thenReturn(transferAccess);
     lenient().when(fetchRuntimeSupport.transferAccess()).thenReturn(transferAccess);
     lenient()
         .when(fetchRuntimeSupport.defaultPersistentFetchContext())
         .thenReturn(mock(FetchContext.class));
-    return new FcpServerPersistentOps(server, core, root);
+    return new FcpServerPersistentOps(server, runtimeSupport, root);
   }
 
   private static void setField(Object target, String fieldName, Object value) throws Exception {


### PR DESCRIPTION
## Summary
- add a package-local `FcpServerRuntimeSupport` seam plus `CoreFcpServerRuntimeSupport` in `clients.fcp`
- wire the new seam into `FCPServer` while keeping `getCore()` as a compatibility shim
- route `FcpServerPersistentOps`, `FCPConnectionHandler`, `FCPConnectionInputHandler`, and `ClientRequest` through the seam for server-owned infrastructure access
- expand FCP tests to cover the new adapter, parser bucket-factory delegation, request lifecycle plumbing, and the full-suite follow-up fallout in `ClientGetFactoryTest`

## Testing
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests *FcpServerPersistentOpsTest --tests *FCPConnectionHandlerTest --tests *FCPConnectionInputHandlerTest --tests *ClientRequestRestartAsyncTest --tests *ModifyPersistentRequestTest --tests *RemovePersistentRequestTest --tests *FCPServerTest`
- `./gradlew test --tests *CoreFcpServerRuntimeSupportTest --tests *FCPServerTest --tests *FCPConnectionInputHandlerTest --tests *ClientRequestModifyRequestTest --tests *ClientRequestRestartAsyncTest --tests *FcpServerPersistentOpsTest`
- `./gradlew test --tests *ClientGetFactoryTest`
- `./gradlew sonarlintFile -Psonarlint.file=src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java`
- `./gradlew test`

## Notes
- this is the PR-48 seam extraction for server-owned FCP infrastructure
- `FCPServer.getCore()` remains in place for untouched call sites in this PR