### PR TITLE
refactor(fcp): Introduce message runtime support adapter

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -346,7 +346,7 @@ public final class AddPeer extends FCPMessage {
       HighLevelSimpleClient client =
           handler
               .getServer()
-              .getCore()
+              .messageRuntimeSupport()
               .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
       return AddPeer.getReferenceFromFreenetURI(refUri, client);
     } catch (MalformedURLException | FetchException _) {

--- a/src/main/java/network/crypta/clients/fcp/CoreFcpMessageRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/CoreFcpMessageRuntimeSupport.java
@@ -1,0 +1,134 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.PeerNode;
+import network.crypta.node.probe.Listener;
+import network.crypta.node.probe.Type;
+
+/**
+ * Core-backed implementation of {@link FcpMessageRuntimeSupport}.
+ *
+ * <p>This adapter wraps a live {@link NodeClientCore} and translates the small message-runtime
+ * contract back into the concrete daemon operations that FCP handlers already relied on before the
+ * seam existed. It is deliberately thin: it keeps no additional state beyond the retained core
+ * reference, performs no protocol branching of its own, and delegates each call immediately to the
+ * same node services that message classes previously navigated to directly.
+ *
+ * <p>That design keeps the cleanup reversible and behavior-preserving. {@link FCPServer} owns one
+ * adapter instance and shares it with message handlers, while tests can substitute the interface
+ * instead of mocking the entire core graph. The adapter should therefore remain focused on direct
+ * delegation rather than becoming a second policy layer.
+ *
+ * <ul>
+ *   <li>Preserves existing core-backed semantics for client creation and peer lookups.
+ *   <li>Delegates feed watching and shutdown to the same node subsystems used before the refactor.
+ *   <li>Starts probes through the live network path without changing UID or callback handling.
+ * </ul>
+ *
+ * @param core live daemon core backing the FCP message paths
+ */
+record CoreFcpMessageRuntimeSupport(NodeClientCore core) implements FcpMessageRuntimeSupport {
+
+  /**
+   * Creates a message-runtime adapter backed by the supplied node core.
+   *
+   * <p>The adapter keeps the reference for its full lifetime and assumes the caller has already
+   * chosen the correct core instance for the surrounding {@link FCPServer}. No defensive wrapping
+   * or lifecycle management is added here because the goal is to preserve the existing runtime path
+   * and only narrow how message code reaches it.
+   *
+   * @param core live daemon core that owns the message-level services exposed through this seam
+   * @throws NullPointerException if {@code core} is {@code null} when the adapter is created
+   */
+  CoreFcpMessageRuntimeSupport(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  /**
+   * Creates a high-level client through the retained node core.
+   *
+   * <p>This implementation forwards directly to {@link NodeClientCore#makeClient(short, boolean,
+   * boolean)} so message handlers receive the same priority, store, and queue behavior they used
+   * before the adapter existed. The method adds no caching or wrapping; it simply returns the live
+   * client created by the underlying core for the current request path.
+   *
+   * @param priorityClass client priority class requested by the message handler
+   * @param forceDontIgnoreStore whether store-visibility behavior should be forced on the client
+   * @param forceMixedQueue whether mixed-queue behavior should be forced on the client
+   * @return live high-level client created by the retained node core
+   */
+  @Override
+  public HighLevelSimpleClient makeClient(
+      short priorityClass, boolean forceDontIgnoreStore, boolean forceMixedQueue) {
+    return core.makeClient(priorityClass, forceDontIgnoreStore, forceMixedQueue);
+  }
+
+  /**
+   * Toggles feed watching through the core's alert manager.
+   *
+   * <p>Enabling registers the supplied handler for feed events, while disabling removes it. The
+   * method deliberately mirrors the previous direct message-to-core behavior and leaves any
+   * idempotency or duplicate-registration handling to the alert manager implementation already used
+   * by the daemon.
+   *
+   * @param handler active connection handler whose feed registration should change
+   * @param enabled whether the handler should be registered or unregistered for feed updates
+   */
+  @Override
+  public void watchFeeds(FCPConnectionHandler handler, boolean enabled) {
+    if (enabled) {
+      core.getAlerts().watch(handler);
+    } else {
+      core.getAlerts().unwatch(handler);
+    }
+  }
+
+  /**
+   * Requests node shutdown through the retained core.
+   *
+   * <p>The implementation delegates to the live node owned by the core and passes the supplied
+   * reason string through unchanged. That preserves the shutdown cause text already expected by
+   * logs, tests, and message handlers that send the protocol reply before triggering the runtime
+   * exit path.
+   *
+   * @param reason shutdown reason to pass through to the node lifecycle
+   */
+  @Override
+  public void shutdownNode(String reason) {
+    core.getNode().exit(reason);
+  }
+
+  /**
+   * Resolves a peer from the node network reachable through the retained core.
+   *
+   * <p>No caching or translation is added here. Callers observe the current peer table at the time
+   * of the lookup and receive {@code null} when the identifier is unknown, allowing message code to
+   * preserve its existing unknown-peer and darknet-only protocol behavior.
+   *
+   * @param nodeIdentifier peer identifier supplied by the message handler
+   * @return matching peer node, or {@code null} when no current peer matches the identifier
+   */
+  @Override
+  public PeerNode findPeer(String nodeIdentifier) {
+    return core.getNode().network().getPeerNode(nodeIdentifier);
+  }
+
+  /**
+   * Starts a probe through the node network associated with the retained core.
+   *
+   * <p>The adapter does not alter probe parameters, generate IDs, or wrap callbacks. It simply
+   * passes the validated hop limit, UID, probe type, and listener to the same runtime path that
+   * message handlers previously called directly, preserving asynchronous probe execution semantics.
+   *
+   * @param hopsToLive probe hop limit to submit to the network
+   * @param uid probe UID selected by the caller for correlation
+   * @param probeType probe type to execute
+   * @param listener callback listener that receives probe results and failures
+   */
+  @Override
+  public void startProbe(byte hopsToLive, long uid, Type probeType, Listener listener) {
+    core.getNode().network().startProbe(hopsToLive, uid, probeType, listener);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -53,6 +53,7 @@ public class FCPServer implements Runnable, DownloadCache {
   private final NodeClientCore core;
 
   private final FcpServerRuntimeSupport serverRuntimeSupport;
+  private final FcpMessageRuntimeSupport messageRuntimeSupport;
   private final FcpFetchRuntimeSupport fetchRuntimeSupport;
   private final FcpInsertRuntimeSupport insertRuntimeSupport;
 
@@ -111,6 +112,7 @@ public class FCPServer implements Runnable, DownloadCache {
     this.enabled = config.enabled();
     this.core = dependencies.core();
     this.serverRuntimeSupport = new CoreFcpServerRuntimeSupport(core);
+    this.messageRuntimeSupport = new CoreFcpMessageRuntimeSupport(core);
     this.runtime = dependencies.runtimePorts();
     this.fetchRuntimeSupport = new CoreFcpFetchRuntimeSupport(core, this.runtime::transferAccess);
     this.insertRuntimeSupport =
@@ -727,17 +729,16 @@ public class FCPServer implements Runnable, DownloadCache {
   }
 
   /**
-   * Exposes the backing {@link NodeClientCore} for callers needing lower-level services.
+   * Returns runtime support for residual message-level FCP infrastructure concerns.
    *
-   * <p>The returned reference is the same instance supplied at construction time. Callers should
-   * avoid mutating shared state on the core directly unless they own the broader node lifecycle. It
-   * is intended for subsystems that need access to shared services such as downloads directories or
-   * persistent storage.
+   * <p>This package-local seam keeps message execution code independent of direct {@link
+   * NodeClientCore} access while preserving the current runtime behavior. It is an internal wiring
+   * detail of {@code clients.fcp}, not a public server API.
    *
-   * @return node client core instance used by this server.
+   * @return message runtime support backing the remaining message-level FCP operations
    */
-  public NodeClientCore getCore() {
-    return core;
+  FcpMessageRuntimeSupport messageRuntimeSupport() {
+    return messageRuntimeSupport;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
@@ -1,0 +1,105 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.PeerNode;
+import network.crypta.node.probe.Listener;
+import network.crypta.node.probe.Type;
+
+/**
+ * Narrow runtime support seam for residual message-level FCP operations.
+ *
+ * <p>This package-local contract gives the remaining message handlers in {@code clients.fcp} a
+ * small, explicit surface for runtime-dependent work that used to reach directly into {@link
+ * network.crypta.node.NodeClientCore}. Typical callers get the adapter from {@link
+ * FCPServer#messageRuntimeSupport()} and immediately delegate one operation such as peer lookup,
+ * shutdown, or probe startup while keeping protocol branching in the message class itself.
+ *
+ * <p>The interface is intentionally local to the FCP package. It is not part of {@code
+ * runtime-spi}, and it is not intended to become a general daemon abstraction. Its job is narrower:
+ * preserve existing node behavior while removing direct core dependencies from message-level
+ * execution paths, so later refactors can adjust server bootstrap and configuration seams without
+ * touching protocol handlers again.
+ *
+ * <ul>
+ *   <li>Exposes only the runtime actions still needed by residual message classes.
+ *   <li>Leaves protocol validation, reply construction, and authorization with the message code.
+ *   <li>Allows tests to substitute the runtime side of those operations without mocking the core.
+ * </ul>
+ *
+ * @see FCPServer#messageRuntimeSupport()
+ * @see CoreFcpMessageRuntimeSupport
+ */
+interface FcpMessageRuntimeSupport {
+
+  /**
+   * Creates a client with the supplied message-level queue and store behavior.
+   *
+   * <p>Implementations should preserve the same queue-selection and store-visibility behavior that
+   * message handlers historically received from the backing node core. Callers typically use this
+   * when a message needs a short-lived high-level client to fetch or inspect a noderef while still
+   * keeping client creation behind a package-local seam. The returned client is live and may hold
+   * node resources, so callers should avoid caching it beyond the handling flow that requested it.
+   *
+   * @param priorityClass client priority class requested by the caller for this operation
+   * @param forceDontIgnoreStore whether the caller requires explicit store-visibility behavior
+   * @param forceMixedQueue whether the caller requires mixed-queue behavior for the created client
+   * @return live high-level client backed by the daemon runtime and configured for the request
+   */
+  HighLevelSimpleClient makeClient(
+      short priorityClass, boolean forceDontIgnoreStore, boolean forceMixedQueue);
+
+  /**
+   * Enables or disables feed watching for a connection handler.
+   *
+   * <p>This hook toggles the handler's registration with the node-side alert or feed subsystem. The
+   * message layer remains responsible for parsing the {@code Enabled} flag and deciding when to
+   * call this method; the adapter only performs the runtime action. Implementations may treat the
+   * call as idempotent if the handler is already in the requested state, matching the underlying
+   * alert manager semantics.
+   *
+   * @param handler active FCP connection handler whose feed registration should change
+   * @param enabled whether watch mode should be enabled for the supplied handler
+   */
+  void watchFeeds(FCPConnectionHandler handler, boolean enabled);
+
+  /**
+   * Requests a node shutdown with the supplied reason.
+   *
+   * <p>Callers invoke this only after message-level authorization and reply ordering have already
+   * been handled. The adapter therefore performs the runtime shutdown action itself and should pass
+   * the supplied reason through unchanged so daemon logs and lifecycle reporting continue to show
+   * the same shutdown cause text as before the seam was introduced.
+   *
+   * @param reason shutdown reason passed through to the node lifecycle machinery
+   */
+  void shutdownNode(String reason);
+
+  /**
+   * Resolves a peer node by its FCP node identifier.
+   *
+   * <p>This lookup is used by message handlers that still need node-level peer routing decisions
+   * but should no longer navigate from the server into the core and network objects directly. A
+   * {@code null} result indicates that no matching peer is currently known and lets the caller keep
+   * its existing protocol behavior for unknown-node replies.
+   *
+   * @param nodeIdentifier peer identifier supplied by the inbound message
+   * @return matching peer node, or {@code null} when the identifier is not currently known
+   */
+  PeerNode findPeer(String nodeIdentifier);
+
+  /**
+   * Starts a probe request using the live node network subsystem.
+   *
+   * <p>The adapter is responsible only for handing the already-validated probe request off to the
+   * runtime. Message code remains responsible for access checks, UID generation, and translating
+   * listener callbacks back into FCP replies. Implementations should begin the probe with the same
+   * hop limit, UID, and probe type supplied by the caller, then forward completion and error events
+   * to the provided listener using the runtime's normal asynchronous behavior.
+   *
+   * @param hopsToLive probe hop limit to submit to the node network
+   * @param uid probe UID chosen by the caller for correlation and reply matching
+   * @param probeType probe type to execute against the live network
+   * @param listener callback listener that receives probe results and failures
+   */
+  void startProbe(byte hopsToLive, long uid, Type probeType, Listener listener);
+}

--- a/src/main/java/network/crypta/clients/fcp/FilterMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/FilterMessage.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * is designed to be instantiated, validated, and consumed entirely on a single thread while the
  * caller holds the relevant protocol connection locks; no shared mutable state escapes the object.
  *
- * <p>Typical callers build a {@code Filter} FCP message prior to uploading content that might trip
+ * <p>Typical callers build a {@code Filter} FCP message before uploading content that might trip
  * safety policies. The reply, {@link FilterResultMessage}, lets the client decide whether to redact
  * data or retry with a safer MIME type before performing irreversible operations such as
  * persistence. Large inputs are streamed through temporary buckets, so the filtering cost is
@@ -78,7 +78,7 @@ public final class FilterMessage extends DataCarryingMessage {
    * that the caller supplied every field required for the chosen data source before executing any
    * disk or network operations.
    *
-   * <p>The constructor consumes lightweight identifiers immediately so that subsequent failures
+   * <p>The constructor consumes lightweight identifiers immediately so that later failures
    * reference the client-provided ID. For {@code DIRECT} payloads it copies length metadata; for
    * {@code DISK} payloads it verifies paths, sets up {@link FileBucket} staging, and derives MIME
    * hints. Callers typically chain this constructor directly from {@code FCPMessage.create} without
@@ -309,8 +309,8 @@ public final class FilterMessage extends DataCarryingMessage {
    *
    * @param handler connection handler responsible for sending replies back over the client's FCP
    *     socket and exposing the server core; must remain valid for the call duration.
-   * @throws MessageInvalidException if the payload bucket is absent or a transient allocation error
-   *     prevents preparing buckets for the filtering process.
+   * @throws MessageInvalidException if the payload bucket is absent, or a transient allocation
+   *     error prevents preparing buckets for the filtering process.
    */
   @Override
   public void run(FCPConnectionHandler handler) throws MessageInvalidException {
@@ -330,7 +330,7 @@ public final class FilterMessage extends DataCarryingMessage {
     try (InputStream input = bucket.getInputStream();
         OutputStream output = resultBucket.getOutputStream()) {
       FilterStatus status =
-          applyFilter(input, output, handler.getServer().getCore().getClientContext());
+          applyFilter(input, output, handler.getServer().serverRuntimeSupport().clientContext());
       resultCharset = status.charset;
       resultMimeType = status.mimeType;
     } catch (UnsafeContentTypeException _) {

--- a/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
@@ -218,9 +218,7 @@ public final class ProbeRequest extends FCPMessage {
     long probeUid = FcpRuntimeAdapters.nextSecureLong(handler.getServer().runtime().randomness());
     handler
         .getServer()
-        .getCore()
-        .getNode()
-        .network()
+        .messageRuntimeSupport()
         .startProbe(hopsToLive, probeUid, probeType, listener);
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
@@ -47,7 +47,7 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
   private final long dataLength;
 
   /**
-   * Creates a new send request from already-validated common routing fields.
+   * Creates a new sending request from already-validated common routing fields.
    *
    * <p>Subclasses should call {@link #parseCommonFields(SimpleFieldSet)} before invoking this
    * constructor so validation errors are surfaced from the subclass constructor rather than this
@@ -127,7 +127,7 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
    */
   @Override
   public void run(FCPConnectionHandler handler) throws MessageInvalidException {
-    PeerNode pn = handler.getServer().getCore().getNode().network().getPeerNode(nodeIdentifier);
+    PeerNode pn = handler.getServer().messageRuntimeSupport().findPeer(nodeIdentifier);
     if (pn == null) {
       FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
       handler.send(msg);
@@ -152,7 +152,7 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
    * actionable details.
    *
    * @param pn darknet peer reference already registered on the node and guaranteed non-null.
-   * @return integer status communicated to the client; semantic range is defined by the subclass.
+   * @return integer status communicated to the client; the subclass defines semantic range.
    * @throws MessageInvalidException if the payload cannot be accepted or violates protocol
    *     invariants enforced by the subclass.
    */

--- a/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
@@ -80,7 +80,7 @@ public class ShutdownMessage extends FCPMessage {
    * Executes the shutdown request by validating access, notifying the client, and exiting the node.
    *
    * <p>The handler must expose full-access privileges; otherwise the method rejects the request
-   * with a {@link MessageInvalidException}. On acceptance it first sends a {@link
+   * with a {@link MessageInvalidException}. On acceptance, it first sends a {@link
    * ProtocolErrorMessage#SHUTTING_DOWN} response so the client can distinguish deliberate shutdown
    * from transport failures, and then calls {@link Node#exit(String)} to terminate the process. The
    * call is synchronous and does not retry; callers should therefore ensure idempotency upstream
@@ -88,8 +88,8 @@ public class ShutdownMessage extends FCPMessage {
    *
    * @param handler connection handler that issued the request; must provide full-access rights or
    *     the call fails with an exception
-   * @throws MessageInvalidException when the connection lacks required privileges or protocol
-   *     validation fails prior to triggering the shutdown
+   * @throws MessageInvalidException when the connection lacks required privileges or protocol,
+   *     validation fails before triggering the shutdown
    */
   @Override
   public void run(FCPConnectionHandler handler) throws MessageInvalidException {
@@ -101,6 +101,6 @@ public class ShutdownMessage extends FCPMessage {
         new ProtocolErrorMessage(
             ProtocolErrorMessage.SHUTTING_DOWN, true, "The node is shutting down", "Node", false);
     handler.send(msg);
-    handler.getServer().getCore().getNode().exit("Received FCP shutdown message");
+    handler.getServer().messageRuntimeSupport().shutdownNode("Received FCP shutdown message");
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/WatchFeedsMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/WatchFeedsMessage.java
@@ -42,7 +42,7 @@ public class WatchFeedsMessage extends FCPMessage {
    * Creates a new message instance from a serialized field set received over FCP.
    *
    * <p>The constructor extracts the {@code Enabled} boolean flag from the provided {@link
-   * SimpleFieldSet}. If the key is absent, watching defaults to enabled so clients that omit the
+   * SimpleFieldSet}. If the key is absent, watching defaults to "enabled" so clients that omit the
    * field still receive alerts. The instance is immutable and may be reused across handler calls,
    * but it is typically constructed per incoming request.
    *
@@ -79,8 +79,7 @@ public class WatchFeedsMessage extends FCPMessage {
    */
   @Override
   public void run(FCPConnectionHandler handler) throws MessageInvalidException {
-    if (enabled) handler.getServer().getCore().getAlerts().watch(handler);
-    else handler.getServer().getCore().getAlerts().unwatch(handler);
+    handler.getServer().messageRuntimeSupport().watchFeeds(handler, enabled);
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -12,6 +12,7 @@ import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
+import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.PeerAddFailureReason;
 import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
@@ -28,6 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,6 +55,8 @@ class AddPeerTest {
   @Mock private Node node;
 
   @Mock private FCPServer server;
+
+  @Mock private FcpMessageRuntimeSupport messageRuntimeSupport;
 
   @Mock private RuntimePorts runtimePorts;
 
@@ -161,6 +166,64 @@ class AddPeerTest {
     StringBuilder result = AddPeer.getReferenceFromFreenetURI(uri, client);
 
     assertEquals("ref-line-1\nref-line-2\n", result.toString());
+  }
+
+  @Test
+  void run_whenUrlUsesCryptaUri_usesMessageRuntimeSupportClient() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.putSingle("URL", "KSK@keyword");
+    AddPeer addPeer = new AddPeer(fs);
+    PeerSnapshot snapshot = peerSnapshot("peer-url");
+    stubPeerPort();
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(handler.getServer()).thenReturn(server);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.add(any(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES))).thenReturn(snapshot);
+
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+
+    try (MockedStatic<AddPeer> mockedAddPeer =
+        Mockito.mockStatic(AddPeer.class, Mockito.CALLS_REAL_METHODS)) {
+      StringBuilder reference = new StringBuilder();
+      reference.append("identity=peer-url\n");
+      mockedAddPeer
+          .when(() -> AddPeer.getReferenceFromFreenetURI(any(FreenetURI.class), eq(client)))
+          .thenReturn(reference);
+      when(messageRuntimeSupport.makeClient(
+              RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true))
+          .thenReturn(client);
+
+      addPeer.run(handler);
+    }
+
+    verify(messageRuntimeSupport)
+        .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+    verify(peerPort).add(any(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
+  }
+
+  @Test
+  void run_whenUrlUsesStandardUrl_readsReferenceWithoutMessageRuntimeSupport(@TempDir Path tempDir)
+      throws Exception {
+    Path file = tempDir.resolve("peer-ref.txt");
+    Files.writeString(file, "identity=peer-file\n", StandardCharsets.UTF_8);
+
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.putSingle("URL", file.toUri().toURL().toString());
+    AddPeer addPeer = new AddPeer(fs);
+    PeerSnapshot snapshot = peerSnapshot("peer-file");
+    stubPeerPort();
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(peerPort.add(any(PeerFieldSet.class), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES)))
+        .thenReturn(snapshot);
+
+    addPeer.run(handler);
+
+    ArgumentCaptor<PeerFieldSet> referenceCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
+    verify(peerPort).add(referenceCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
+    assertEquals("peer-file", referenceCaptor.getValue().directValues().get("identity"));
+    verifyNoInteractions(messageRuntimeSupport);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/CoreFcpMessageRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CoreFcpMessageRuntimeSupportTest.java
@@ -1,0 +1,111 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.PeerNode;
+import network.crypta.node.RequestStarter;
+import network.crypta.node.probe.Listener;
+import network.crypta.node.probe.Type;
+import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.node.useralerts.UserAlertManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class CoreFcpMessageRuntimeSupportTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private HighLevelSimpleClient client;
+  @Mock private UserAlertManager alerts;
+  @Mock private Node node;
+  @Mock private NodeNetworkSubsystem network;
+  @Mock private PeerNode peerNode;
+  @Mock private FCPConnectionHandler handler;
+
+  @Test
+  void constructor_whenCoreNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new CoreFcpMessageRuntimeSupport(null));
+  }
+
+  @Test
+  void makeClient_whenCalled_delegatesToCore() {
+    when(core.makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true))
+        .thenReturn(client);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    HighLevelSimpleClient actual =
+        support.makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+
+    assertSame(client, actual);
+    verify(core).makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+  }
+
+  @Test
+  void watchFeeds_whenEnabledTrue_watchesHandler() {
+    when(core.getAlerts()).thenReturn(alerts);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    support.watchFeeds(handler, true);
+
+    verify(alerts).watch(handler);
+  }
+
+  @Test
+  void watchFeeds_whenEnabledFalse_unwatchesHandler() {
+    when(core.getAlerts()).thenReturn(alerts);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    support.watchFeeds(handler, false);
+
+    verify(alerts).unwatch(handler);
+  }
+
+  @Test
+  void shutdownNode_whenCalled_exitsNode() {
+    when(core.getNode()).thenReturn(node);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    support.shutdownNode("Received FCP shutdown message");
+
+    verify(node).exit("Received FCP shutdown message");
+  }
+
+  @Test
+  void findPeer_whenCalled_returnsPeerNode() {
+    when(core.getNode()).thenReturn(node);
+    when(node.network()).thenReturn(network);
+    when(network.getPeerNode("peer-1")).thenReturn(peerNode);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    PeerNode actual = support.findPeer("peer-1");
+
+    assertSame(peerNode, actual);
+  }
+
+  @Test
+  void startProbe_whenCalled_delegatesToNetwork() {
+    when(core.getNode()).thenReturn(node);
+    when(node.network()).thenReturn(network);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    Listener listener = org.mockito.Mockito.mock(Listener.class);
+    ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+
+    support.startProbe((byte) 5, 42L, Type.BUILD, listener);
+
+    verify(network).startProbe(eq((byte) 5), eq(42L), eq(Type.BUILD), listenerCaptor.capture());
+    assertNotNull(listenerCaptor.getValue());
+    assertSame(listener, listenerCaptor.getValue());
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
@@ -9,6 +10,7 @@ import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -41,6 +43,7 @@ class FCPServerTest {
   @Mock private TempBucketFactory tempBucketFactory;
   @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
   @Mock private RandomSource randomSource;
+  @Mock private HighLevelSimpleClient highLevelSimpleClient;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     when(runtimePorts.execution()).thenReturn(executionPort);
@@ -194,6 +197,32 @@ class FCPServerTest {
     assertSame(persistentTempBucketFactory, support.persistentTempBucketFactory());
     support.fillSecureRandom(bytes);
     verify(randomSource).nextBytes(bytes);
+  }
+
+  @Test
+  void messageRuntimeSupport_whenQueried_returnsConfiguredAdapter() {
+    FCPServer server = newServer(false, false);
+    FcpMessageRuntimeSupport first = server.messageRuntimeSupport();
+
+    FcpMessageRuntimeSupport second = server.messageRuntimeSupport();
+
+    assertNotNull(first);
+    assertSame(first, second);
+  }
+
+  @Test
+  void messageRuntimeSupport_whenMakeClientInvoked_delegatesToCore() {
+    when(core.makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true))
+        .thenReturn(highLevelSimpleClient);
+    FCPServer server = newServer(false, false);
+
+    HighLevelSimpleClient actual =
+        server
+            .messageRuntimeSupport()
+            .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+
+    assertSame(highLevelSimpleClient, actual);
+    verify(core).makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
@@ -14,7 +14,6 @@ import network.crypta.client.filter.ContentFilterCallbacks;
 import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.client.filter.UnsafeContentTypeException;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.BucketFactory;
@@ -186,6 +185,7 @@ class FilterMessageTest {
   }
 
   @Test
+  @SuppressWarnings("resource")
   void run_whenContentFilterSucceeds_sendsResultMessage() throws Exception {
     byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
     FilterMessage message = createDirectMessage("req-run-success", payload);
@@ -230,6 +230,35 @@ class FilterMessageTest {
     } catch (IOException e) {
       fail(e);
     }
+  }
+
+  @Test
+  @SuppressWarnings("resource")
+  void run_whenContentFilterSucceeds_readsClientContextFromServerRuntimeSupport() throws Exception {
+    byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+    FilterMessage message = createDirectMessage("req-run-context", payload);
+
+    ClientContext clientContext = Mockito.mock(ClientContext.class);
+    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
+    FCPServer server = Mockito.mock(FCPServer.class);
+    FcpServerRuntimeSupport runtimeSupport = Mockito.mock(FcpServerRuntimeSupport.class);
+    Mockito.when(handler.getServer()).thenReturn(server);
+    Mockito.when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
+    Mockito.when(runtimeSupport.clientContext()).thenReturn(clientContext);
+
+    try (MockedStatic<ContentFilter> staticFilter = Mockito.mockStatic(ContentFilter.class)) {
+      staticFilter
+          .when(
+              () ->
+                  ContentFilter.filter(
+                      Mockito.any(ContentFilterRequest.class),
+                      Mockito.any(ContentFilterCallbacks.class)))
+          .thenReturn(filterStatusUtf8Text());
+
+      message.run(handler);
+    }
+
+    Mockito.verify(runtimeSupport).clientContext();
   }
 
   @Test
@@ -302,10 +331,10 @@ class FilterMessageTest {
   private FCPConnectionHandler handlerWithContext(ClientContext context) {
     FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
     FCPServer server = Mockito.mock(FCPServer.class);
-    NodeClientCore core = Mockito.mock(NodeClientCore.class);
+    FcpServerRuntimeSupport runtimeSupport = Mockito.mock(FcpServerRuntimeSupport.class);
     Mockito.lenient().when(handler.getServer()).thenReturn(server);
-    Mockito.lenient().when(server.getCore()).thenReturn(core);
-    Mockito.lenient().when(core.getClientContext()).thenReturn(context);
+    Mockito.lenient().when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
+    Mockito.lenient().when(runtimeSupport.clientContext()).thenReturn(context);
     return handler;
   }
 

--- a/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
@@ -3,13 +3,10 @@ package network.crypta.clients.fcp;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.node.FSParseException;
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Probe;
 import network.crypta.node.probe.Type;
-import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
@@ -32,7 +29,6 @@ import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,9 +40,10 @@ class ProbeRequestTest {
   private static final long REQUEST_UID = 4242L;
 
   @Mock private FCPConnectionHandler handler;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private FCPServer server;
+  @Mock private FcpMessageRuntimeSupport messageRuntimeSupport;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RandomnessPort randomnessPort;
 
   @Test
   void constructor_whenTypeUnrecognized_expectMessageInvalidException() {
@@ -107,8 +104,6 @@ class ProbeRequestTest {
       throws MessageInvalidException {
     ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 5));
     when(handler.hasFullAccess()).thenReturn(false);
-    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    when(node.network()).thenReturn(network);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> request.run(handler));
@@ -116,30 +111,24 @@ class ProbeRequestTest {
     assertEquals(ProtocolErrorMessage.ACCESS_DENIED, exception.protocolCode);
     assertEquals("probe-1", exception.ident);
     assertEquals("Probe requires full access.", exception.getMessage());
-    verify(network, never()).startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
+    verify(messageRuntimeSupport, never())
+        .startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
   }
 
   @Test
   void run_whenHtlMissing_usesProbeMaxHtl() throws MessageInvalidException {
     ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, null));
     when(handler.hasFullAccess()).thenReturn(true);
-    FCPServer server = mock(FCPServer.class);
-    RuntimePorts runtimePorts = mock(RuntimePorts.class);
-    RandomnessPort randomnessPort = mock(RandomnessPort.class);
-    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    NodeClientCore core = mock(NodeClientCore.class);
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.getNode()).thenReturn(node);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
-    when(node.network()).thenReturn(network);
     ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
 
     request.run(handler);
 
-    verify(network)
+    verify(messageRuntimeSupport)
         .startProbe(eq(Probe.MAX_HTL), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
     assertNotNull(listenerCaptor.getValue());
   }
@@ -148,23 +137,16 @@ class ProbeRequestTest {
   void run_whenHtlProvided_usesProvidedValue() throws MessageInvalidException {
     ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 12));
     when(handler.hasFullAccess()).thenReturn(true);
-    FCPServer server = mock(FCPServer.class);
-    RuntimePorts runtimePorts = mock(RuntimePorts.class);
-    RandomnessPort randomnessPort = mock(RandomnessPort.class);
-    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    NodeClientCore core = mock(NodeClientCore.class);
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.getNode()).thenReturn(node);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
-    when(node.network()).thenReturn(network);
     ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
 
     request.run(handler);
 
-    verify(network)
+    verify(messageRuntimeSupport)
         .startProbe(eq((byte) 12), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
     assertNotNull(listenerCaptor.getValue());
   }
@@ -370,25 +352,18 @@ class ProbeRequestTest {
 
   private Listener runAndCaptureListener(ProbeRequest request) throws MessageInvalidException {
     when(handler.hasFullAccess()).thenReturn(true);
-    FCPServer server = mock(FCPServer.class);
-    RuntimePorts runtimePorts = mock(RuntimePorts.class);
-    RandomnessPort randomnessPort = mock(RandomnessPort.class);
-    NodeNetworkSubsystem network = mock(NodeNetworkSubsystem.class);
-    NodeClientCore core = mock(NodeClientCore.class);
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.getNode()).thenReturn(node);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
-    when(node.network()).thenReturn(network);
     AtomicReference<Listener> listenerRef = new AtomicReference<>();
     doAnswer(
             invocation -> {
               listenerRef.set(invocation.getArgument(3));
               return null;
             })
-        .when(network)
+        .when(messageRuntimeSupport)
         .startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
 
     request.run(handler);

--- a/src/test/java/network/crypta/clients/fcp/SendTextMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendTextMessageTest.java
@@ -3,19 +3,23 @@ package network.crypta.clients.fcp;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +29,10 @@ class SendTextMessageTest {
   private static final String NODE_IDENTIFIER = "peer-node-1";
 
   @Mock private DarknetPeerNode darknetPeerNode;
+  @Mock private FCPConnectionHandler handler;
+  @Mock private FCPServer server;
+  @Mock private FcpMessageRuntimeSupport messageRuntimeSupport;
+  @Mock private PeerNode peerNode;
 
   @Test
   void getName_whenCalled_returnsSendText() throws MessageInvalidException {
@@ -73,6 +81,59 @@ class SendTextMessageTest {
     assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
     assertEquals("", ex.getMessage());
     verify(darknetPeerNode, never()).sendTextFeed(Mockito.anyString());
+  }
+
+  @Test
+  void run_whenPeerUnknown_sendsUnknownNodeIdentifierMessage() throws Exception {
+    SendTextMessage message = new SendTextMessage(baseFieldSet());
+    when(handler.getServer()).thenReturn(server);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
+    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER)).thenReturn(null);
+    ArgumentCaptor<FCPMessage> sentCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+
+    message.run(handler);
+
+    verify(handler).send(sentCaptor.capture());
+    UnknownNodeIdentifierMessage sent =
+        assertInstanceOf(UnknownNodeIdentifierMessage.class, sentCaptor.getValue());
+    assertEquals(NODE_IDENTIFIER, sent.getFieldSet().get("NodeIdentifier"));
+    assertEquals(IDENTIFIER, sent.getFieldSet().get("Identifier"));
+  }
+
+  @Test
+  void run_whenPeerIsNotDarknet_throwsDarknetOnly() throws Exception {
+    SendTextMessage message = new SendTextMessage(baseFieldSet());
+    when(handler.getServer()).thenReturn(server);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
+    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER)).thenReturn(peerNode);
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
+
+    assertEquals(ProtocolErrorMessage.DARKNET_ONLY, ex.protocolCode);
+    assertEquals("SendText only available for darknet peers", ex.getMessage());
+    assertEquals(IDENTIFIER, ex.ident);
+    verify(handler, never()).send(Mockito.any());
+  }
+
+  @Test
+  void run_whenDarknetPeerResolved_sendsSentPeerMessage() throws Exception {
+    String text = "hello peer";
+    byte[] payload = text.getBytes(StandardCharsets.UTF_8);
+    SendTextMessage message = new SendTextMessage(baseFieldSetWithLength(payload.length));
+    message.bucket = new ArrayBucket(payload);
+    when(handler.getServer()).thenReturn(server);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
+    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+    when(darknetPeerNode.sendTextFeed(text)).thenReturn(123);
+    ArgumentCaptor<FCPMessage> sentCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+
+    message.run(handler);
+
+    verify(handler).send(sentCaptor.capture());
+    SentPeerMessage sent = assertInstanceOf(SentPeerMessage.class, sentCaptor.getValue());
+    assertEquals(IDENTIFIER, sent.clientIdentifier);
+    assertEquals(123, sent.nodeStatus);
   }
 
   private SimpleFieldSet baseFieldSet() {

--- a/src/test/java/network/crypta/clients/fcp/ShutdownMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ShutdownMessageTest.java
@@ -1,7 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,10 +23,7 @@ class ShutdownMessageTest {
 
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
-  @Mock private NodeClientCore core;
-
-  @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
-  private Node node;
+  @Mock private FcpMessageRuntimeSupport messageRuntimeSupport;
 
   @Test
   void getName_whenCalled_returnsShutdownConstant() {
@@ -61,7 +56,6 @@ class ShutdownMessageTest {
     assertNull(thrown.ident);
     assertFalse(thrown.global);
     verify(handler, never()).send(any());
-    verify(node, never()).exit(any(String.class));
   }
 
   @Test
@@ -70,15 +64,14 @@ class ShutdownMessageTest {
     ShutdownMessage message = new ShutdownMessage();
     when(handler.hasFullAccess()).thenReturn(true);
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(core);
-    when(core.getNode()).thenReturn(node);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     ArgumentCaptor<ProtocolErrorMessage> sentMessage =
         ArgumentCaptor.forClass(ProtocolErrorMessage.class);
 
     message.run(handler);
 
     verify(handler).send(sentMessage.capture());
-    verify(node).exit("Received FCP shutdown message");
+    verify(messageRuntimeSupport).shutdownNode("Received FCP shutdown message");
 
     ProtocolErrorMessage protocolError = sentMessage.getValue();
     assertEquals(ProtocolErrorMessage.SHUTTING_DOWN, protocolError.getCode());

--- a/src/test/java/network/crypta/clients/fcp/WatchFeedsMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/WatchFeedsMessageTest.java
@@ -1,7 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.useralerts.UserAlertManager;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,8 +16,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class WatchFeedsMessageTest {
 
-  @Mock private NodeClientCore clientCore;
-  @Mock private UserAlertManager alertManager;
+  @Mock private FcpMessageRuntimeSupport messageRuntimeSupport;
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
 
@@ -60,13 +56,11 @@ class WatchFeedsMessageTest {
     WatchFeedsMessage message = new WatchFeedsMessage(fs);
 
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(clientCore);
-    when(clientCore.getAlerts()).thenReturn(alertManager);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
 
     message.run(handler);
 
-    verify(alertManager).watch(handler);
-    verify(alertManager, never()).unwatch(handler);
+    verify(messageRuntimeSupport).watchFeeds(handler, true);
   }
 
   @Test
@@ -76,13 +70,11 @@ class WatchFeedsMessageTest {
     WatchFeedsMessage message = new WatchFeedsMessage(fs);
 
     when(handler.getServer()).thenReturn(server);
-    when(server.getCore()).thenReturn(clientCore);
-    when(clientCore.getAlerts()).thenReturn(alertManager);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
 
     message.run(handler);
 
-    verify(alertManager).unwatch(handler);
-    verify(alertManager, never()).watch(handler);
+    verify(messageRuntimeSupport).watchFeeds(handler, false);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add a local `clients.fcp` message runtime seam with `FcpMessageRuntimeSupport` and `CoreFcpMessageRuntimeSupport`
- migrate the remaining message-level `getCore()` call sites in `AddPeer`, `ProbeRequest`, `SendPeerMessage`, `ShutdownMessage`, and `WatchFeedsMessage`, and move `FilterMessage` to `serverRuntimeSupport().clientContext()`
- remove `FCPServer.getCore()`, update the affected FCP tests, add focused adapter coverage, and tighten Javadocs for the new seam types

## How to test
- `./gradlew test --tests network.crypta.clients.fcp.AddPeerTest --tests network.crypta.clients.fcp.FilterMessageTest --tests network.crypta.clients.fcp.FCPServerTest --tests network.crypta.clients.fcp.ProbeRequestTest --tests network.crypta.clients.fcp.ShutdownMessageTest --tests network.crypta.clients.fcp.WatchFeedsMessageTest --tests network.crypta.clients.fcp.CoreFcpMessageRuntimeSupportTest --tests network.crypta.clients.fcp.SendTextMessageTest`
- `./gradlew jacocoTestReport`
- `./gradlew -q classes`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main' -sourcepath . -d /tmp/doclint-fcp-message-runtime-support src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java`
- `javadoc -quiet -private -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main' -sourcepath . -d /tmp/doclint-core-fcp-message-runtime-support src/main/java/network/crypta/clients/fcp/CoreFcpMessageRuntimeSupport.java`

## Notes
- this keeps runtime behavior unchanged and limits the change to the residual FCP message-level runtime access cleanup for PR-49
- the full repository test suite was not rerun in this workflow