### PR TITLE
refactor(fcp): Decouple FCP bootstrap from NodeClientCore

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/CoreFcpServerDependenciesFactory.java
+++ b/src/main/java/network/crypta/clients/fcp/CoreFcpServerDependenciesFactory.java
@@ -1,0 +1,78 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+
+/**
+ * Builds the core-backed dependency bundle used by FCP server bootstrap.
+ *
+ * <p>This factory is intentionally local to {@code clients.fcp}. Callers use it at the bootstrap
+ * boundary, typically from node startup code such as {@code NodeClientPersistence}, to translate
+ * the remaining {@link NodeClientCore}-backed services into the narrow package-local seams that
+ * {@link FCPServer} accepts. That keeps the server constructor and configuration registrar free of
+ * direct daemon-core references while preserving the runtime behavior that older code paths
+ * expected.
+ *
+ * <p>The factory is stateless and creates one fresh {@link FcpServerDependencies} bundle per call.
+ * Each bundle contains lightweight adapters over live daemon services rather than detached
+ * snapshots, so later requests still observe the current transfer-access policy, client context,
+ * and persistence state exposed by the node.
+ *
+ * <ul>
+ *   <li>Builds server-owned runtime support for listener, persistence, and connection plumbing.
+ *   <li>Builds message-path runtime support for residual FCP protocol handlers.
+ *   <li>Preserves the intentional split between server-owned and core-owned transfer policy
+ *       lookups.
+ * </ul>
+ *
+ * @see FCPServer
+ * @see FcpServerDependencies
+ */
+public final class CoreFcpServerDependenciesFactory {
+  private CoreFcpServerDependenciesFactory() {}
+
+  /**
+   * Builds the full dependency bundle required by {@link FCPServer}.
+   *
+   * <p>This method preserves the transfer-policy split introduced by the FCP decoupling work.
+   * Normal server-owned fetch support reads transfer access from the supplied {@code runtimePorts},
+   * because those flows are owned by the surrounding server runtime. Message fetch and insert
+   * support continue to consult {@code core.getRuntimePorts().transferAccess()}, matching the
+   * legacy behavior for inbound message handling and upload validation. The returned bundle is
+   * ready to pass directly into {@link FCPServer#maybeCreate(FcpServerDependencies,
+   * network.crypta.config.Config)} or the package-local server constructor.
+   *
+   * @param core live daemon core that backs the remaining core-owned FCP runtime seams
+   * @param runtimePorts runtime SPI bridge used by server-owned FCP infrastructure and fetch flows
+   * @param persistentRoot persistence root used to resolve global clients and durable request state
+   * @return fully built dependency bundle that wires {@link FCPServer} without storing the core
+   * @throws NullPointerException if {@code core}, {@code runtimePorts}, or {@code persistentRoot}
+   *     is {@code null}
+   */
+  public static FcpServerDependencies create(
+      NodeClientCore core, RuntimePorts runtimePorts, PersistentRequestRoot persistentRoot) {
+    NodeClientCore nonNullCore = Objects.requireNonNull(core);
+    RuntimePorts nonNullRuntimePorts = Objects.requireNonNull(runtimePorts);
+    PersistentRequestRoot nonNullPersistentRoot = Objects.requireNonNull(persistentRoot);
+
+    FcpServerRuntimeSupport serverRuntimeSupport = new CoreFcpServerRuntimeSupport(nonNullCore);
+    FcpMessageRuntimeSupport messageRuntimeSupport = new CoreFcpMessageRuntimeSupport(nonNullCore);
+    FcpFetchRuntimeSupport fetchRuntimeSupport =
+        new CoreFcpFetchRuntimeSupport(nonNullCore, nonNullRuntimePorts::transferAccess);
+    FcpFetchRuntimeSupport messageFetchRuntimeSupport =
+        new CoreFcpFetchRuntimeSupport(
+            nonNullCore, () -> nonNullCore.getRuntimePorts().transferAccess());
+    FcpInsertRuntimeSupport insertRuntimeSupport =
+        new CoreFcpInsertRuntimeSupport(
+            nonNullCore, () -> nonNullCore.getRuntimePorts().transferAccess());
+    return new FcpServerDependencies(
+        nonNullRuntimePorts,
+        nonNullPersistentRoot,
+        serverRuntimeSupport,
+        messageRuntimeSupport,
+        fetchRuntimeSupport,
+        messageFetchRuntimeSupport,
+        insertRuntimeSupport);
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -10,7 +10,6 @@ import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.config.Config;
 import network.crypta.io.AllowedHosts;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.Bucket;
 
@@ -49,12 +48,10 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   public static final int DEFAULT_FCP_PORT = 9481;
 
-  /* It’s not the field that is deprecated, but accessing it directly is. */
-  private final NodeClientCore core;
-
   private final FcpServerRuntimeSupport serverRuntimeSupport;
   private final FcpMessageRuntimeSupport messageRuntimeSupport;
   private final FcpFetchRuntimeSupport fetchRuntimeSupport;
+  private final FcpFetchRuntimeSupport messageFetchRuntimeSupport;
   private final FcpInsertRuntimeSupport insertRuntimeSupport;
 
   private final RuntimePorts runtime;
@@ -110,13 +107,12 @@ public class FCPServer implements Runnable, DownloadCache {
     this.allowedHostsFullAccess = new AllowedHosts(config.allowedHostsFullAccess());
     this.port = config.port();
     this.enabled = config.enabled();
-    this.core = dependencies.core();
-    this.serverRuntimeSupport = new CoreFcpServerRuntimeSupport(core);
-    this.messageRuntimeSupport = new CoreFcpMessageRuntimeSupport(core);
     this.runtime = dependencies.runtimePorts();
-    this.fetchRuntimeSupport = new CoreFcpFetchRuntimeSupport(core, this.runtime::transferAccess);
-    this.insertRuntimeSupport =
-        new CoreFcpInsertRuntimeSupport(core, () -> core.getRuntimePorts().transferAccess());
+    this.serverRuntimeSupport = dependencies.serverRuntimeSupport();
+    this.messageRuntimeSupport = dependencies.messageRuntimeSupport();
+    this.fetchRuntimeSupport = dependencies.fetchRuntimeSupport();
+    this.messageFetchRuntimeSupport = dependencies.messageFetchRuntimeSupport();
+    this.insertRuntimeSupport = dependencies.insertRuntimeSupport();
     this.assumeDownloadDDAIsAllowed = config.assumeDownloadDDAAllowed();
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();
@@ -124,57 +120,6 @@ public class FCPServer implements Runnable, DownloadCache {
     this.listener = new FcpServerListener(this, runtime, config);
     this.persistentOps =
         new FcpServerPersistentOps(this, serverRuntimeSupport, dependencies.persistentRoot());
-  }
-
-  /**
-   * Constructs a server instance wired to the provided node components and policy flags.
-   *
-   * <p>This convenience overload packages the raw parameters into {@link FcpServerConfig} and
-   * {@link FcpServerDependencies}, then delegates to the primary constructor. It captures immutable
-   * configuration such as the bind address, allowlists, port, and persistence roots; runtime
-   * toggles only adjust the dedicated mutable fields. It does not bind sockets or start background
-   * threads, so callers must invoke {@link #maybeStart()} to begin accepting connections.
-   *
-   * @param ipToBindTo textual bind address; {@code 0.0.0.0} listens on all interfaces.
-   * @param allowedHosts comma-separated allowlist enforced for standard FCP sockets.
-   * @param allowedHostsFullAccess allowlist used for privileged operations that bypass client-side
-   *     restrictions.
-   * @param port TCP port number for the FCP listener, in the host byte order.
-   * @param core node client core exposing persistence, download directories, and cache factories.
-   * @param runtime runtime SPI bridge for infrastructure code that avoids daemon internals.
-   * @param isEnabled whether networked FCP should start.
-   * @param assumeDDADownloadAllowed flag to treat download DDA as preapproved globally.
-   * @param assumeDDAUploadAllowed flag to treat upload DDA as preapproved globally.
-   * @param neverDropAMessage whether outbound queues retain messages under backpressure.
-   * @param maxMessageQueueLength maximum messages buffered per connection before applying limits.
-   * @param persistentRoot persistence root used to access global clients and caches.
-   */
-  @SuppressWarnings("java:S107")
-  public FCPServer(
-      String ipToBindTo,
-      String allowedHosts,
-      String allowedHostsFullAccess,
-      int port,
-      NodeClientCore core,
-      RuntimePorts runtime,
-      boolean isEnabled,
-      boolean assumeDDADownloadAllowed,
-      boolean assumeDDAUploadAllowed,
-      boolean neverDropAMessage,
-      int maxMessageQueueLength,
-      PersistentRequestRoot persistentRoot) {
-    this(
-        new FcpServerConfig(
-            ipToBindTo,
-            allowedHosts,
-            allowedHostsFullAccess,
-            port,
-            isEnabled,
-            assumeDDADownloadAllowed,
-            assumeDDAUploadAllowed,
-            neverDropAMessage,
-            maxMessageQueueLength),
-        new FcpServerDependencies(core, runtime, persistentRoot));
   }
 
   /**
@@ -221,18 +166,15 @@ public class FCPServer implements Runnable, DownloadCache {
    * <p>This factory wires the FCP-related settings into the {@code fcp} configuration subtree and
    * constructs the server with immutable values derived from that configuration. It does not start
    * network listeners; callers still invoke {@link #maybeStart()} at the appropriate lifecycle
-   * point. The returned server is fully wired to the supplied client core and persistence root, so
-   * it can immediately serve FCP traffic once started.
+   * point. The returned server is fully wired to the supplied dependencies, so it can immediately
+   * serve FCP traffic once started.
    *
-   * @param core client core used for persistence and endpoint access.
-   * @param runtime runtime SPI bridge used by infrastructure code inside the server.
+   * @param dependencies prebuilt FCP runtime and persistence dependencies.
    * @param config configuration registry where the {@code fcp} subsection is registered.
-   * @param root persistence root used to back global request queues.
    * @return configured server instance ready to be started by the caller.
    */
-  public static FCPServer maybeCreate(
-      NodeClientCore core, RuntimePorts runtime, Config config, PersistentRequestRoot root) {
-    return FcpServerConfigRegistrar.maybeCreate(core, runtime, config, root);
+  public static FCPServer maybeCreate(FcpServerDependencies dependencies, Config config) {
+    return FcpServerConfigRegistrar.maybeCreate(dependencies, config);
   }
 
   /**
@@ -731,9 +673,9 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Returns runtime support for residual message-level FCP infrastructure concerns.
    *
-   * <p>This package-local seam keeps message execution code independent of direct {@link
-   * NodeClientCore} access while preserving the current runtime behavior. It is an internal wiring
-   * detail of {@code clients.fcp}, not a public server API.
+   * <p>This package-local seam keeps message execution code independent of direct daemon-core
+   * access while preserving the current runtime behavior. It is an internal wiring detail of {@code
+   * clients.fcp}, not a public server API.
    *
    * @return message runtime support backing the remaining message-level FCP operations
    */
@@ -745,8 +687,8 @@ public class FCPServer implements Runnable, DownloadCache {
    * Returns runtime support for server-owned FCP infrastructure concerns.
    *
    * <p>This package-local seam keeps connection handling, persistent request plumbing, and inbound
-   * message parsing independent of direct {@link NodeClientCore} access while preserving current
-   * behavior. It is an internal wiring detail of {@code clients.fcp}, not a public server API.
+   * message parsing independent of direct daemon-core access while preserving current behavior. It
+   * is an internal wiring detail of {@code clients.fcp}, not a public server API.
    *
    * @return server runtime support backing infrastructure-level FCP operations
    */
@@ -757,8 +699,8 @@ public class FCPServer implements Runnable, DownloadCache {
   /**
    * Returns the package-local runtime support used by the FCP GET/fetch path.
    *
-   * <p>This seam keeps fetch request construction and getter setup independent of direct {@link
-   * NodeClientCore} access while preserving current runtime behavior. This accessor is used for the
+   * <p>This seam keeps fetch request construction and getter setup independent of direct
+   * daemon-core access while preserving current runtime behavior. This accessor is used for the
    * server-owned persistent/global GET flow, so its transfer policy stays aligned with {@link
    * #runtime()}. It is package-private because it is an internal wiring detail of {@code
    * clients.fcp}, not a public server API.
@@ -773,11 +715,11 @@ public class FCPServer implements Runnable, DownloadCache {
    * Returns the package-local runtime support used by the FCP insert and USK path.
    *
    * <p>This seam keeps put request construction, upload bucket allocation, and USK subscription
-   * wiring independent of direct {@link NodeClientCore} access while preserving current runtime
-   * behavior. Insert validation historically consulted the core runtime's transfer policy for both
-   * live message puts and queued local-file inserts, so this seam keeps upload checks aligned with
-   * {@code core.getRuntimePorts()}. It is package-private because it is an internal wiring detail
-   * of {@code clients.fcp}, not a public server API.
+   * wiring independent of direct daemon-core access while preserving current runtime behavior.
+   * Insert validation historically consulted the core runtime's transfer policy for both live
+   * message puts and queued local-file inserts, so this seam keeps upload checks aligned with the
+   * core runtime ports. It is package-private because it is an internal wiring detail of {@code
+   * clients.fcp}, not a public server API.
    *
    * @return insert runtime support backing put construction and USK subscriptions
    */
@@ -796,7 +738,7 @@ public class FCPServer implements Runnable, DownloadCache {
    * @return fetch runtime support that uses the core runtime's transfer policy for message flows
    */
   FcpFetchRuntimeSupport messageFetchRuntimeSupport() {
-    return new CoreFcpFetchRuntimeSupport(core, () -> core.getRuntimePorts().transferAccess());
+    return messageFetchRuntimeSupport;
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerConfigRegistrar.java
@@ -8,8 +8,6 @@ import network.crypta.config.SubConfig;
 import network.crypta.crypt.SSL;
 import network.crypta.io.NetworkInterface;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
-import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.IntCallback;
 import network.crypta.support.api.StringCallback;
@@ -19,18 +17,18 @@ import network.crypta.support.api.StringCallback;
  *
  * <p>This helper centralizes the wiring between the {@code fcp} {@link SubConfig} and the runtime
  * components that back the FCP listener and request lifecycle. It installs callbacks for mutable
- * configuration values (such as bind address and allowed hosts), preserves the immutable defaults
- * captured in {@link FcpServerConfig}, and creates the server instance that other subsystems use.
- * The method is typically invoked during node startup or endpoint initialization and is expected to
- * run once per process. It performs no network binding or background thread creation; callers still
- * invoke {@link FCPServer#maybeStart()} to begin accepting connections.
+ * configuration values, preserves the configured defaults until the server is available, and
+ * creates the server instance that other subsystems use. The method is typically invoked during
+ * node startup or endpoint initialization and is expected to run once per process. It performs no
+ * network binding or background thread creation; callers still invoke {@link
+ * FCPServer#maybeStart()} to begin accepting connections.
  *
  * <p>Responsibilities include:
  *
  * <ul>
  *   <li>Registering the {@code fcp} option set with deterministic ordering and defaults.
- *   <li>Binding config callbacks that guard runtime changes and apply validation.
- *   <li>Building the {@link FCPServer} with dependencies from the node client core.
+ *   <li>Binding config callbacks directly to the created {@link FCPServer}.
+ *   <li>Building the server with the already-constructed dependency bundle.
  * </ul>
  *
  * @see FCPServer
@@ -38,6 +36,11 @@ import network.crypta.support.api.StringCallback;
  * @see FcpServerListener
  */
 final class FcpServerConfigRegistrar {
+  private static final String ENABLED_OPTION = "enabled";
+  private static final String BIND_TO_OPTION = "bindTo";
+  private static final String ALLOWED_HOSTS_OPTION = "allowedHosts";
+  private static final String ALLOWED_HOSTS_FULL_ACCESS_OPTION = "allowedHostsFullAccess";
+
   /** Creates a registrar utility; instances are not used. */
   private FcpServerConfigRegistrar() {}
 
@@ -45,57 +48,64 @@ final class FcpServerConfigRegistrar {
    * Registers the FCP sub-configuration and returns a fully wired {@link FCPServer} instance.
    *
    * <p>The method creates (or retrieves) a {@link SubConfig} named {@code fcp}, registers all FCP
-   * options with their defaults, and attaches callbacks that enforce non-mutable fields such as the
-   * port and SSL toggle. If SSL support is available, the persisted SSL value is applied to the
-   * listener state; otherwise the setting remains disabled until restart. After building the {@link
-   * FcpServerConfig} and dependency container, the returned server is created and the config is
-   * marked initialized so later user changes trigger callbacks.
+   * options with their defaults, and attaches callbacks that guard runtime changes. If SSL support
+   * is available, the persisted SSL value is applied to the listener state; otherwise the setting
+   * remains disabled until restart. After building the {@link FcpServerConfig} and server
+   * dependency bundle, the returned server is created and the config is marked initialized so later
+   * user changes trigger callbacks.
    *
-   * <pre>{@code
-   * Config config = new Config();
-   * FCPServer server = FcpServerConfigRegistrar.maybeCreate(core, runtimePorts, config, root);
-   * server.maybeStart();
-   * }</pre>
-   *
-   * @param core client core used for endpoint access and persisted settings lookups.
-   * @param runtimePorts runtime SPI bridge passed to the created server.
+   * @param dependencies pre-built runtime and persistence dependencies for the server.
    * @param config root configuration registry where the {@code fcp} subsection is registered.
-   * @param root persistent request root used to wire global request queues.
    * @return configured {@link FCPServer} instance ready for {@link FCPServer#maybeStart()}.
    */
-  static FCPServer maybeCreate(
-      NodeClientCore core, RuntimePorts runtimePorts, Config config, PersistentRequestRoot root) {
+  static FCPServer maybeCreate(FcpServerDependencies dependencies, Config config) {
     SubConfig fcpConfig = config.createSubConfig("fcp");
     short sortOrder = 0;
+
+    FCPEnabledCallback enabledCallback = new FCPEnabledCallback(false);
     fcpConfig.register(
-        "enabled",
+        ENABLED_OPTION,
         true,
         new Option.Meta(sortOrder++, true, false, "FcpServer.isEnabled", "FcpServer.isEnabledLong"),
-        new FCPEnabledCallback(core));
+        enabledCallback);
+    enabledCallback.setInitialEnabled(fcpConfig.getBoolean(ENABLED_OPTION));
+
     fcpConfig.register(
         "ssl",
         false,
         new Option.Meta(sortOrder++, true, true, "FcpServer.ssl", "FcpServer.sslLong"),
         new FCPSSLCallback());
+    FCPPortNumberCallback portCallback = new FCPPortNumberCallback(FCPServer.DEFAULT_FCP_PORT);
     fcpConfig.register(
         "port",
         FCPServer.DEFAULT_FCP_PORT /* anagram of 1984, and 1000 up from the old number */,
         new Option.Meta(2, true, true, "FcpServer.portNumber", "FcpServer.portNumberLong"),
-        new FCPPortNumberCallback(core),
+        portCallback,
         false);
+    portCallback.setInitialPort(fcpConfig.getInt("port"));
+
+    FCPBindtoCallback bindToCallback = new FCPBindtoCallback(NetworkInterface.DEFAULT_BIND_TO);
     fcpConfig.register(
-        "bindTo",
+        BIND_TO_OPTION,
         NetworkInterface.DEFAULT_BIND_TO,
         new Option.Meta(sortOrder++, true, true, "FcpServer.bindTo", "FcpServer.bindToLong"),
-        new FCPBindtoCallback(core));
+        bindToCallback);
+    bindToCallback.setInitialBindTo(fcpConfig.getString(BIND_TO_OPTION));
+
+    FCPAllowedHostsCallback allowedHostsCallback =
+        new FCPAllowedHostsCallback(NetworkInterface.DEFAULT_BIND_TO);
     fcpConfig.register(
-        "allowedHosts",
+        ALLOWED_HOSTS_OPTION,
         NetworkInterface.DEFAULT_BIND_TO,
         new Option.Meta(
             sortOrder++, true, true, "FcpServer.allowedHosts", "FcpServer.allowedHostsLong"),
-        new FCPAllowedHostsCallback(core));
+        allowedHostsCallback);
+    allowedHostsCallback.setInitialAllowedHosts(fcpConfig.getString(ALLOWED_HOSTS_OPTION));
+
+    FCPAllowedHostsFullAccessCallback allowedHostsFullAccessCallback =
+        new FCPAllowedHostsFullAccessCallback(NetworkInterface.DEFAULT_BIND_TO);
     fcpConfig.register(
-        "allowedHostsFullAccess",
+        ALLOWED_HOSTS_FULL_ACCESS_OPTION,
         NetworkInterface.DEFAULT_BIND_TO,
         new Option.Meta(
             sortOrder++,
@@ -103,7 +113,9 @@ final class FcpServerConfigRegistrar {
             true,
             "FcpServer.allowedHostsFullAccess",
             "FcpServer.allowedHostsFullAccessLong"),
-        new FCPAllowedHostsFullAccessCallback(core));
+        allowedHostsFullAccessCallback);
+    allowedHostsFullAccessCallback.setInitialAllowedHostsFullAccess(
+        fcpConfig.getString(ALLOWED_HOSTS_FULL_ACCESS_OPTION));
 
     AssumeDDADownloadIsAllowedCallback cb4 = new AssumeDDADownloadIsAllowedCallback();
     AssumeDDAUploadIsAllowedCallback cb5 = new AssumeDDAUploadIsAllowedCallback();
@@ -157,22 +169,26 @@ final class FcpServerConfigRegistrar {
 
     FcpServerConfig serverConfig =
         new FcpServerConfig(
-            fcpConfig.getString("bindTo"),
-            fcpConfig.getString("allowedHosts"),
-            fcpConfig.getString("allowedHostsFullAccess"),
+            fcpConfig.getString(BIND_TO_OPTION),
+            fcpConfig.getString(ALLOWED_HOSTS_OPTION),
+            fcpConfig.getString(ALLOWED_HOSTS_FULL_ACCESS_OPTION),
             fcpConfig.getInt("port"),
-            fcpConfig.getBoolean("enabled"),
+            fcpConfig.getBoolean(ENABLED_OPTION),
             fcpConfig.getBoolean("assumeDownloadDDAIsAllowed"),
             fcpConfig.getBoolean("assumeUploadDDAIsAllowed"),
             fcpConfig.getBoolean("neverDropAMessage"),
             fcpConfig.getInt("maxMessageQueueLength"));
-    FcpServerDependencies dependencies = new FcpServerDependencies(core, runtimePorts, root);
     FCPServer fcp = new FCPServer(serverConfig, dependencies);
 
-    cb4.server = fcp;
-    cb5.server = fcp;
-    cb6.server = fcp;
-    cb7.server = fcp;
+    portCallback.bind(fcp);
+    enabledCallback.bind(fcp);
+    bindToCallback.bind(fcp);
+    allowedHostsCallback.bind(fcp);
+    allowedHostsFullAccessCallback.bind(fcp);
+    cb4.bind(fcp);
+    cb5.bind(fcp);
+    cb6.bind(fcp);
+    cb7.bind(fcp);
 
     fcpConfig.finishedInitialization();
     return fcp;
@@ -180,22 +196,24 @@ final class FcpServerConfigRegistrar {
 
   /** Callback that exposes the read-only FCP port configuration. */
   static class FCPPortNumberCallback extends IntCallback {
+    private int initialPort;
+    private FCPServer server;
 
-    /** Node core used to access the active endpoint configuration. */
-    private final NodeClientCore node;
+    FCPPortNumberCallback(int initialPort) {
+      this.initialPort = initialPort;
+    }
 
-    /**
-     * Creates a callback bound to the provided node client core.
-     *
-     * @param node client core supplying the current endpoint configuration.
-     */
-    FCPPortNumberCallback(NodeClientCore node) {
-      this.node = node;
+    void setInitialPort(int initialPort) {
+      this.initialPort = initialPort;
+    }
+
+    void bind(FCPServer server) {
+      this.server = server;
     }
 
     @Override
     public Integer get() {
-      return node.getEndpoints().getFCPServer().port;
+      return server == null ? initialPort : server.port;
     }
 
     @Override
@@ -213,22 +231,24 @@ final class FcpServerConfigRegistrar {
 
   /** Callback that exposes the read-only enabled flag for networked FCP. */
   static class FCPEnabledCallback extends BooleanCallback {
+    private boolean initialEnabled;
+    private FCPServer server;
 
-    /** Node core used to access the endpoint state for the enabled flag. */
-    final NodeClientCore node;
+    FCPEnabledCallback(boolean initialEnabled) {
+      this.initialEnabled = initialEnabled;
+    }
 
-    /**
-     * Creates a callback bound to the provided node client core.
-     *
-     * @param node client core supplying the current endpoint configuration.
-     */
-    FCPEnabledCallback(NodeClientCore node) {
-      this.node = node;
+    void setInitialEnabled(boolean initialEnabled) {
+      this.initialEnabled = initialEnabled;
+    }
+
+    void bind(FCPServer server) {
+      this.server = server;
     }
 
     @Override
     public Boolean get() {
-      return node.getEndpoints().getFCPServer().enabled;
+      return server == null ? initialEnabled : server.enabled;
     }
 
     @Override
@@ -247,7 +267,6 @@ final class FcpServerConfigRegistrar {
 
   /** Callback that reports and guards the SSL enablement flag for FCP. */
   static class FCPSSLCallback extends BooleanCallback {
-
     /** Creates a callback instance for SSL configuration handling. */
     FCPSSLCallback() {}
 
@@ -286,33 +305,41 @@ final class FcpServerConfigRegistrar {
 
   /** Callback that exposes the bind address and updates the listener when modified. */
   static class FCPBindtoCallback extends StringCallback {
+    private String initialBindTo;
+    private FCPServer server;
 
-    /** Node core used to resolve the active FCP server instance. */
-    final NodeClientCore node;
+    FCPBindtoCallback(String initialBindTo) {
+      this.initialBindTo = initialBindTo;
+    }
 
-    /**
-     * Creates a callback bound to the provided node client core.
-     *
-     * @param node client core supplying the current endpoint configuration.
-     */
-    FCPBindtoCallback(NodeClientCore node) {
-      this.node = node;
+    void setInitialBindTo(String initialBindTo) {
+      this.initialBindTo = initialBindTo;
+    }
+
+    void bind(FCPServer server) {
+      this.server = server;
+      server.listener().updateBindTo(initialBindTo);
+      server.bindTo = initialBindTo;
     }
 
     @Override
     public String get() {
-      return node.getEndpoints().getFCPServer().bindTo;
+      return server == null ? initialBindTo : server.bindTo;
     }
 
     @Override
     public void set(String val) throws InvalidConfigValueException {
+      if (server == null) {
+        initialBindTo = val;
+        return;
+      }
       String oldValue = get();
       if (!val.equals(oldValue)) {
-        FCPServer server = node.getEndpoints().getFCPServer();
+        FCPServer currentServer = server;
 
-        String[] failedAddresses = server.listener().setBindTo(val, true);
+        String[] failedAddresses = currentServer.listener().setBindTo(val, true);
         if (failedAddresses != null) {
-          server.listener().setBindTo(oldValue, true);
+          currentServer.listener().setBindTo(oldValue, true);
           throw new InvalidConfigValueException(
               NodeL10n.getBase()
                   .getString(
@@ -321,40 +348,44 @@ final class FcpServerConfigRegistrar {
                       Arrays.toString(failedAddresses)));
         }
 
-        server.listener().setBindTo(val, true);
-        server.listener().updateBindTo(val);
-        server.bindTo = val;
+        currentServer.listener().updateBindTo(val);
+        currentServer.bindTo = val;
+        initialBindTo = val;
       }
     }
   }
 
   /** Callback that reads or updates the allowed-hosts list for the FCP listener. */
   static class FCPAllowedHostsCallback extends StringCallback {
+    private String initialAllowedHosts;
+    private FCPServer server;
 
-    /** Node core used to resolve the active FCP server instance. */
-    private final NodeClientCore node;
+    FCPAllowedHostsCallback(String initialAllowedHosts) {
+      this.initialAllowedHosts = initialAllowedHosts;
+    }
 
-    /**
-     * Creates a callback bound to the provided node client core.
-     *
-     * @param node client core supplying the current endpoint configuration.
-     */
-    public FCPAllowedHostsCallback(NodeClientCore node) {
-      this.node = node;
+    void setInitialAllowedHosts(String initialAllowedHosts) {
+      this.initialAllowedHosts = initialAllowedHosts;
+    }
+
+    void bind(FCPServer server) {
+      this.server = server;
+      server.listener().setAllowedHosts(initialAllowedHosts);
     }
 
     @Override
     public String get() {
-      FCPServer server = node.getEndpoints().getFCPServer();
-      if (server == null) return NetworkInterface.DEFAULT_BIND_TO;
-      return server.listener().getAllowedHosts();
+      return server == null ? initialAllowedHosts : server.listener().getAllowedHosts();
     }
 
     @Override
     public void set(String val) throws InvalidConfigValueException {
       if (!val.equals(get())) {
         try {
-          node.getEndpoints().getFCPServer().listener().setAllowedHosts(val);
+          if (server != null) {
+            server.listener().setAllowedHosts(val);
+          }
+          initialAllowedHosts = val;
         } catch (IllegalArgumentException e) {
           throw new InvalidConfigValueException(e);
         }
@@ -364,28 +395,37 @@ final class FcpServerConfigRegistrar {
 
   /** Callback that manages the full-access allowlist for privileged operations. */
   static class FCPAllowedHostsFullAccessCallback extends StringCallback {
-    /** Node core used to resolve the active FCP server instance. */
-    private final NodeClientCore node;
+    private String initialAllowedHostsFullAccess;
+    private FCPServer server;
 
-    /**
-     * Creates a callback bound to the provided node client core.
-     *
-     * @param node client core supplying the current endpoint configuration.
-     */
-    public FCPAllowedHostsFullAccessCallback(NodeClientCore node) {
-      this.node = node;
+    FCPAllowedHostsFullAccessCallback(String initialAllowedHostsFullAccess) {
+      this.initialAllowedHostsFullAccess = initialAllowedHostsFullAccess;
+    }
+
+    void setInitialAllowedHostsFullAccess(String initialAllowedHostsFullAccess) {
+      this.initialAllowedHostsFullAccess = initialAllowedHostsFullAccess;
+    }
+
+    void bind(FCPServer server) {
+      this.server = server;
+      server.getAllowedHostsFullAccess().setAllowedHosts(initialAllowedHostsFullAccess);
     }
 
     @Override
     public String get() {
-      return node.getEndpoints().getFCPServer().getAllowedHostsFullAccess().getAllowedHosts();
+      return server == null
+          ? initialAllowedHostsFullAccess
+          : server.getAllowedHostsFullAccess().getAllowedHosts();
     }
 
     @Override
     public void set(String val) throws InvalidConfigValueException {
       if (!val.equals(get())) {
         try {
-          node.getEndpoints().getFCPServer().getAllowedHostsFullAccess().setAllowedHosts(val);
+          if (server != null) {
+            server.getAllowedHostsFullAccess().setAllowedHosts(val);
+          }
+          initialAllowedHostsFullAccess = val;
         } catch (IllegalArgumentException e) {
           throw new InvalidConfigValueException(e);
         }
@@ -400,6 +440,10 @@ final class FcpServerConfigRegistrar {
 
     /** Creates a callback instance for download DDA defaults. */
     AssumeDDADownloadIsAllowedCallback() {}
+
+    void bind(FCPServer server) {
+      this.server = server;
+    }
 
     @Override
     public Boolean get() {
@@ -421,6 +465,10 @@ final class FcpServerConfigRegistrar {
     /** Creates a callback instance for upload DDA defaults. */
     AssumeDDAUploadIsAllowedCallback() {}
 
+    void bind(FCPServer server) {
+      this.server = server;
+    }
+
     @Override
     public Boolean get() {
       return server.assumeUploadDDAIsAllowed;
@@ -441,6 +489,10 @@ final class FcpServerConfigRegistrar {
     /** Creates a callback instance for queue retention defaults. */
     NeverDropAMessageCallback() {}
 
+    void bind(FCPServer server) {
+      this.server = server;
+    }
+
     @Override
     public Boolean get() {
       return server.neverDropAMessage;
@@ -460,6 +512,10 @@ final class FcpServerConfigRegistrar {
 
     /** Creates a callback instance for queue length defaults. */
     MaxMessageQueueLengthCallback() {}
+
+    void bind(FCPServer server) {
+      this.server = server;
+    }
 
     @Override
     public Integer get() {

--- a/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
@@ -1,14 +1,28 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
- * Core node services required to construct an {@link FCPServer}.
+ * Bootstrap dependency bundle required to construct an {@link FCPServer}.
  *
- * @param core node client core exposing persistence, download directories, and cache factories.
- * @param runtimePorts runtime SPI bridge for infrastructure code that avoids daemon internals.
- * @param persistentRoot persistence root used to access global clients and caches.
+ * <p>This record carries the already-built runtime seams used by the server and its listeners. The
+ * bundle is intentionally free of direct {@link network.crypta.node.NodeClientCore} access so
+ * server construction can stay isolated from the broader daemon core once the support adapters are
+ * created.
+ *
+ * @param runtimePorts runtime SPI bridge used by server-owned infrastructure
+ * @param persistentRoot persistence root used to access global clients and caches
+ * @param serverRuntimeSupport server-owned runtime seam for persistent ops and connection handling
+ * @param messageRuntimeSupport residual message-path runtime seam
+ * @param fetchRuntimeSupport GET/fetch runtime seam for server-owned request flows
+ * @param messageFetchRuntimeSupport GET/fetch runtime seam for inbound message request flows
+ * @param insertRuntimeSupport insert/USK runtime seam for server-owned request flows
  */
 public record FcpServerDependencies(
-    NodeClientCore core, RuntimePorts runtimePorts, PersistentRequestRoot persistentRoot) {}
+    RuntimePorts runtimePorts,
+    PersistentRequestRoot persistentRoot,
+    FcpServerRuntimeSupport serverRuntimeSupport,
+    FcpMessageRuntimeSupport messageRuntimeSupport,
+    FcpFetchRuntimeSupport fetchRuntimeSupport,
+    FcpFetchRuntimeSupport messageFetchRuntimeSupport,
+    FcpInsertRuntimeSupport insertRuntimeSupport) {}

--- a/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.fcp;
 
+import java.io.IOException;
 import java.net.Socket;
+import java.util.Objects;
 import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -53,6 +55,9 @@ final class FcpServerListener implements Runnable {
   /** Executor adapter expected by the legacy network-interface factories. */
   private final PriorityAwareExecutor executor;
 
+  /** Factory used to build short-lived interfaces for pre-start bind validation. */
+  private final ValidationInterfaceFactory validationInterfaceFactory;
+
   /** TCP port to bind when creating the network interface. */
   private final int port;
 
@@ -82,9 +87,32 @@ final class FcpServerListener implements Runnable {
    * @param config snapshot of listener configuration values at construction time.
    */
   FcpServerListener(FCPServer server, RuntimePorts runtime, FcpServerConfig config) {
+    this(server, runtime, config, FcpServerListener::createValidationInterface);
+  }
+
+  /**
+   * Creates a listener with an explicit factory for pre-start bind validation.
+   *
+   * <p>This overload exists so tests can supply deterministic validation interfaces without
+   * touching the real network stack. Production callers should use {@link
+   * #FcpServerListener(FCPServer, RuntimePorts, FcpServerConfig)}.
+   *
+   * @param server the owning server that constructs connection handlers for clients.
+   * @param runtime runtime SPI bridge supplying execution and lifecycle state used by the
+   *     accept-loop.
+   * @param config snapshot of listener configuration values at construction time.
+   * @param validationInterfaceFactory factory for temporary interfaces used to validate pre-start
+   *     bind changes.
+   */
+  FcpServerListener(
+      FCPServer server,
+      RuntimePorts runtime,
+      FcpServerConfig config,
+      ValidationInterfaceFactory validationInterfaceFactory) {
     this.server = server;
     this.runtime = runtime;
     this.executor = FcpRuntimeAdapters.priorityAwareExecutor(runtime);
+    this.validationInterfaceFactory = Objects.requireNonNull(validationInterfaceFactory);
     this.port = config.port();
     this.enabled = config.enabled();
     this.allowedHosts = config.allowedHosts();
@@ -119,25 +147,64 @@ final class FcpServerListener implements Runnable {
   }
 
   /**
-   * Applies a new bind address to the active {@link NetworkInterface}, or caches it for startup.
+   * Applies a new bind address to the active {@link NetworkInterface}, or validates it for startup.
    *
-   * <p>If the listener has not yet created its {@link NetworkInterface}, this method records the
-   * provided bind string and reports success so configuration callbacks can accept pre-start
-   * updates. Once the interface exists, it forwards the raw bind string to {@link
-   * NetworkInterface#setBindTo(String, boolean)} and returns any failed addresses.
+   * <p>If the listener has not yet created its {@link NetworkInterface}, this method validates the
+   * provided bind string against a short-lived interface instance before caching it. Invalid
+   * addresses are returned to the caller and are not retained. Once the interface exists, the
+   * method forwards the raw bind string to {@link NetworkInterface#setBindTo(String, boolean)} and
+   * returns any failed addresses.
    *
    * @param value comma-separated bind addresses or {@code null} to use defaults.
-   * @param update whether to update acceptors immediately for the new bindings.
+   * @param ignoreUnbindableIp6 whether IPv6 bind failures should be ignored when validating or
+   *     applying the new bindings.
    * @return array of failed addresses, or {@code null} when all bindings succeed.
    */
   @SuppressWarnings({"SameParameterValue", "java:S1168"})
-  String[] setBindTo(String value, boolean update) {
+  String[] setBindTo(String value, boolean ignoreUnbindableIp6) {
     NetworkInterface netIface = networkInterface;
     if (netIface == null) {
+      return validatePreStartBindTo(value, ignoreUnbindableIp6);
+    }
+    return netIface.setBindTo(value, ignoreUnbindableIp6);
+  }
+
+  @SuppressWarnings("java:S1168")
+  private String[] validatePreStartBindTo(String value, boolean ignoreUnbindableIp6) {
+    NetworkInterface validationInterface =
+        validationInterfaceFactory.create(port, allowedHosts, executor);
+    String[] failedAddresses = validationInterface.setBindTo(value, ignoreUnbindableIp6);
+    boolean closed = closeValidationInterface(validationInterface, value);
+    if (failedAddresses == null && closed) {
       bindTo = value;
       return null;
     }
-    return netIface.setBindTo(value, update);
+    return failedAddresses == null ? validationFailure(value) : failedAddresses;
+  }
+
+  private boolean closeValidationInterface(NetworkInterface validationInterface, String value) {
+    try {
+      validationInterface.close();
+      return true;
+    } catch (IOException e) {
+      LOG.warn("Failed to close temporary FCP bind validator for {}:{}", value, port, e);
+      return false;
+    }
+  }
+
+  private static String[] validationFailure(String value) {
+    return new String[] {normalizeBindTo(value)};
+  }
+
+  private static String normalizeBindTo(String value) {
+    return value == null || value.isEmpty() ? NetworkInterface.DEFAULT_BIND_TO : value;
+  }
+
+  private static NetworkInterface createValidationInterface(
+      int port, String allowedHosts, PriorityAwareExecutor executor) {
+    return ssl
+        ? new ValidationSslNetworkInterface(port, allowedHosts, executor)
+        : new ValidationNetworkInterface(port, allowedHosts, executor);
   }
 
   /**
@@ -260,5 +327,24 @@ final class FcpServerListener implements Runnable {
     Socket s = networkInterface.accept();
     FCPConnectionHandler ch = new FCPConnectionHandler(s, server);
     ch.start();
+  }
+
+  @FunctionalInterface
+  interface ValidationInterfaceFactory {
+    NetworkInterface create(int port, String allowedHosts, PriorityAwareExecutor executor);
+  }
+
+  private static final class ValidationNetworkInterface extends NetworkInterface {
+    private ValidationNetworkInterface(
+        int port, String allowedHosts, PriorityAwareExecutor executor) {
+      super(port, allowedHosts, executor);
+    }
+  }
+
+  private static final class ValidationSslNetworkInterface extends SSLNetworkInterface {
+    private ValidationSslNetworkInterface(
+        int port, String allowedHosts, PriorityAwareExecutor executor) {
+      super(port, allowedHosts, executor);
+    }
   }
 }

--- a/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
@@ -19,8 +19,9 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * thread, dispatching sockets to {@link FCPConnectionHandler} instances. Runtime lifecycle and
  * execution concerns are consumed through {@link RuntimePorts} so the listener does not depend on
  * daemon executor implementations directly. Configuration updates such as {@link
- * #updateBindTo(String)} and {@link #setAllowedHosts(String)} are delegated to the underlying
- * interface when available, while SSL mode is tracked via static flag accessors.
+ * #updateBindTo(String)}, {@link #setBindTo(String, boolean)}, and {@link #setAllowedHosts(String)}
+ * are delegated to the underlying interface when available and otherwise cached for later startup,
+ * while SSL mode is tracked via static flag accessors.
  *
  * <p>The listener is intentionally conservative about re-binding: it caches the created interface
  * and only creates a new one once per instance. Shutdown handling relies on the Tanuki Wrapper
@@ -118,19 +119,25 @@ final class FcpServerListener implements Runnable {
   }
 
   /**
-   * Delegates to the underlying {@link NetworkInterface} to update binding addresses.
+   * Applies a new bind address to the active {@link NetworkInterface}, or caches it for startup.
    *
-   * <p>This method assumes a listener has already been started and will throw a {@link
-   * NullPointerException} if the interface has not been initialized. It forwards the raw bind
-   * string to {@link NetworkInterface#setBindTo(String, boolean)} and returns any failed addresses.
+   * <p>If the listener has not yet created its {@link NetworkInterface}, this method records the
+   * provided bind string and reports success so configuration callbacks can accept pre-start
+   * updates. Once the interface exists, it forwards the raw bind string to {@link
+   * NetworkInterface#setBindTo(String, boolean)} and returns any failed addresses.
    *
    * @param value comma-separated bind addresses or {@code null} to use defaults.
    * @param update whether to update acceptors immediately for the new bindings.
    * @return array of failed addresses, or {@code null} when all bindings succeed.
    */
-  @SuppressWarnings("SameParameterValue")
+  @SuppressWarnings({"SameParameterValue", "java:S1168"})
   String[] setBindTo(String value, boolean update) {
-    return networkInterface.setBindTo(value, update);
+    NetworkInterface netIface = networkInterface;
+    if (netIface == null) {
+      bindTo = value;
+      return null;
+    }
+    return netIface.setBindTo(value, update);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerListener.java
@@ -59,7 +59,7 @@ final class FcpServerListener implements Runnable {
   private final boolean enabled;
 
   /** Allowed-hosts filter string provided at initialization time. */
-  private final String allowedHosts;
+  private String allowedHosts;
 
   /** Current bind address string used when initializing the interface. */
   private String bindTo;
@@ -146,29 +146,36 @@ final class FcpServerListener implements Runnable {
   }
 
   /**
-   * Returns the allowed-hosts string from the active interface, or the default when absent.
+   * Returns the allowed-hosts string from the active interface, or the configured value when
+   * absent.
    *
-   * <p>If the listener has not yet created its {@link NetworkInterface}, this method returns {@link
-   * NetworkInterface#DEFAULT_BIND_TO} to preserve legacy behavior during configuration discovery.
+   * <p>If the listener has not yet created its {@link NetworkInterface}, this method returns the
+   * listener's configured allowlist value so configuration callbacks can expose the current
+   * in-memory setting before the socket is active.
    *
-   * @return current allowlist string, or the default bind list when no interface exists.
+   * @return current allowlist string, or the configured value when no interface exists.
    */
   String getAllowedHosts() {
     NetworkInterface netIface = networkInterface;
-    return netIface == null ? NetworkInterface.DEFAULT_BIND_TO : netIface.getAllowedHosts();
+    return netIface == null ? allowedHosts : netIface.getAllowedHosts();
   }
 
   /**
-   * Applies a new allowed-hosts string to the active network interface.
+   * Applies a new allowed-hosts string to the active network interface and caches it for future
+   * binds.
    *
-   * <p>The method assumes the listener has been initialized and delegates to {@link
-   * NetworkInterface#setAllowedHosts(String)}. It does not validate the input beyond the interface
-   * implementation.
+   * <p>The method caches the value even when the interface has not yet been created, so later
+   * listener initialization sees the latest configured allowlist. When the interface is active, it
+   * delegates to {@link NetworkInterface#setAllowedHosts(String)}.
    *
    * @param value new allowlist string for filtering inbound connections.
    */
   void setAllowedHosts(String value) {
-    networkInterface.setAllowedHosts(value);
+    this.allowedHosts = value;
+    NetworkInterface netIface = networkInterface;
+    if (netIface != null) {
+      netIface.setAllowedHosts(value);
+    }
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/node/NodeClientPersistence.java
@@ -9,6 +9,7 @@ import network.crypta.client.async.ClientContextRuntime;
 import network.crypta.client.async.ClientContextServices;
 import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.CoreFcpServerDependenciesFactory;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Option;
@@ -253,10 +254,9 @@ public final class NodeClientPersistence {
   /**
    * Creates the FCP server configured for this node and client core.
    *
-   * <p>The server is constructed via {@link FCPServer#maybeCreate(NodeClientCore, RuntimePorts,
-   * network.crypta.config.Config, PersistentRequestRoot)} and shares this instance's persistent
-   * request root so durable requests can be managed consistently across reconnections. This method
-   * performs no side effects beyond the delegation.
+   * <p>The server is constructed via a local dependency bundle, so the remaining core-backed
+   * runtime adapters stay localized to the FCP bootstrap seam. It shares this instance's persistent
+   * request root so durable requests can be managed consistently across reconnections.
    *
    * @param node node instance supplying configuration and shared services.
    * @param core client core used by the FCP server for callbacks.
@@ -264,7 +264,9 @@ public final class NodeClientPersistence {
    * @return the configured FCP server instance from {@code maybeCreate}.
    */
   public FCPServer createFcpServer(Node node, NodeClientCore core, RuntimePorts runtimePorts) {
-    return FCPServer.maybeCreate(core, runtimePorts, node.getConfig(), persistentRoot);
+    return FCPServer.maybeCreate(
+        CoreFcpServerDependenciesFactory.create(core, runtimePorts, persistentRoot),
+        node.getConfig());
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/CoreFcpServerDependenciesFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CoreFcpServerDependenciesFactoryTest.java
@@ -1,0 +1,112 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class CoreFcpServerDependenciesFactoryTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private RuntimePorts coreRuntimePorts;
+  @Mock private TransferAccessPort serverTransferAccess;
+  @Mock private TransferAccessPort coreTransferAccess;
+
+  @Test
+  void create_whenCoreNull_expectNullPointerException() {
+    // Arrange
+    PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+
+    // Act & Assert
+    assertThrows(
+        NullPointerException.class,
+        () -> CoreFcpServerDependenciesFactory.create(null, runtimePorts, persistentRoot));
+  }
+
+  @Test
+  void create_whenRuntimePortsNull_expectNullPointerException() {
+    // Arrange
+    PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+
+    // Act & Assert
+    assertThrows(
+        NullPointerException.class,
+        () -> CoreFcpServerDependenciesFactory.create(core, null, persistentRoot));
+  }
+
+  @Test
+  void create_whenPersistentRootNull_expectNullPointerException() {
+    // Act & Assert
+    assertThrows(
+        NullPointerException.class,
+        () -> CoreFcpServerDependenciesFactory.create(core, runtimePorts, null));
+  }
+
+  @Test
+  void create_whenCalled_expectBundleRetainsProvidedDependencies() {
+    // Arrange
+    PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+
+    // Act
+    FcpServerDependencies dependencies =
+        CoreFcpServerDependenciesFactory.create(core, runtimePorts, persistentRoot);
+
+    // Assert
+    assertSame(runtimePorts, dependencies.runtimePorts());
+    assertSame(persistentRoot, dependencies.persistentRoot());
+    assertNotNull(dependencies.serverRuntimeSupport());
+    assertNotNull(dependencies.messageRuntimeSupport());
+    assertNotNull(dependencies.fetchRuntimeSupport());
+    assertNotNull(dependencies.messageFetchRuntimeSupport());
+    assertNotNull(dependencies.insertRuntimeSupport());
+  }
+
+  @Test
+  void create_whenTransferAccessQueried_expectSupportsUseExpectedRuntimePorts() {
+    // Arrange
+    PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+    when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
+    when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
+    when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
+    FcpServerDependencies dependencies =
+        CoreFcpServerDependenciesFactory.create(core, runtimePorts, persistentRoot);
+
+    // Act & Assert
+    assertSame(serverTransferAccess, dependencies.fetchRuntimeSupport().transferAccess());
+    assertSame(coreTransferAccess, dependencies.messageFetchRuntimeSupport().transferAccess());
+    assertSame(coreTransferAccess, dependencies.insertRuntimeSupport().transferAccess());
+  }
+
+  @Test
+  void create_whenTransferPoliciesChange_expectSupportsReadLiveRuntimePorts() {
+    // Arrange
+    PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+    TransferAccessPort updatedServerTransferAccess = mock(TransferAccessPort.class);
+    TransferAccessPort updatedCoreTransferAccess = mock(TransferAccessPort.class);
+    when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
+    when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
+    when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
+    FcpServerDependencies dependencies =
+        CoreFcpServerDependenciesFactory.create(core, runtimePorts, persistentRoot);
+    when(runtimePorts.transferAccess()).thenReturn(updatedServerTransferAccess);
+    when(coreRuntimePorts.transferAccess()).thenReturn(updatedCoreTransferAccess);
+
+    // Act & Assert
+    assertSame(updatedServerTransferAccess, dependencies.fetchRuntimeSupport().transferAccess());
+    assertSame(
+        updatedCoreTransferAccess, dependencies.messageFetchRuntimeSupport().transferAccess());
+    assertSame(updatedCoreTransferAccess, dependencies.insertRuntimeSupport().transferAccess());
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -46,16 +46,6 @@ class FCPServerTest {
   @Mock private HighLevelSimpleClient highLevelSimpleClient;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
-    when(runtimePorts.execution()).thenReturn(executionPort);
-    lenient().when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
-    lenient().when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
-    lenient().when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
-    lenient().when(core.getClientContext()).thenReturn(clientContext);
-    lenient().when(clientContext.getDefaultPersistentInsertContext()).thenReturn(insertContext);
-    lenient().when(core.getUskManager()).thenReturn(uskManager);
-    lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
-    lenient().when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
-    lenient().when(core.getRandom()).thenReturn(randomSource);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -67,8 +57,21 @@ class FCPServerTest {
             assumeUploadAllowed,
             false,
             10);
-    return new FCPServer(
-        config, new FcpServerDependencies(core, runtimePorts, new PersistentRequestRoot()));
+    return new FCPServer(config, newDependencies(new PersistentRequestRoot()));
+  }
+
+  private FcpServerDependencies newDependencies(PersistentRequestRoot root) {
+    when(runtimePorts.execution()).thenReturn(executionPort);
+    lenient().when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
+    lenient().when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
+    lenient().when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
+    lenient().when(core.getClientContext()).thenReturn(clientContext);
+    lenient().when(clientContext.getDefaultPersistentInsertContext()).thenReturn(insertContext);
+    lenient().when(core.getUskManager()).thenReturn(uskManager);
+    lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
+    lenient().when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
+    lenient().when(core.getRandom()).thenReturn(randomSource);
+    return CoreFcpServerDependenciesFactory.create(core, runtimePorts, root);
   }
 
   @Test
@@ -124,6 +127,8 @@ class FCPServerTest {
     PersistentRequestRoot root = spy(new PersistentRequestRoot());
     when(runtimePorts.execution()).thenReturn(executionPort);
     lenient().when(runtimePorts.transferAccess()).thenReturn(serverTransferAccess);
+    lenient().when(core.getRuntimePorts()).thenReturn(coreRuntimePorts);
+    lenient().when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -135,7 +140,7 @@ class FCPServerTest {
             false,
             false,
             10);
-    FCPServer server = new FCPServer(config, new FcpServerDependencies(core, runtimePorts, root));
+    FCPServer server = new FCPServer(config, newDependencies(root));
     PersistentRequestClient forever = root.registerForeverClient("forever", null);
 
     // Act

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.lang.reflect.Field;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.SubConfig;
@@ -192,6 +193,22 @@ class FcpServerConfigRegistrarTest {
   }
 
   @Test
+  void maybeCreate_whenBindToUpdatedBeforeStart_expectPendingListenerValueUpdated()
+      throws Exception {
+    // Arrange
+    Config config = new Config();
+    FCPServer server = FcpServerConfigRegistrar.maybeCreate(newDependencies(), config);
+    SubConfig subConfig = config.get("fcp");
+
+    // Act
+    assertDoesNotThrow(() -> subConfig.getOption("bindTo").setValue("0.0.0.0"));
+
+    // Assert
+    assertEquals("0.0.0.0", server.bindTo);
+    assertEquals("0.0.0.0", getListenerBindTo(server.listener()));
+  }
+
+  @Test
   void fcpAllowedHostsFullAccessCallback_whenBeforeBind_expectInitialValue() {
     // Arrange
     FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback callback =
@@ -302,6 +319,12 @@ class FcpServerConfigRegistrarTest {
       return new FCPServer(config, dependencies);
     }
     return new TestServer(config, dependencies, listenerOverride);
+  }
+
+  private String getListenerBindTo(FcpServerListener listener) throws Exception {
+    Field bindToField = FcpServerListener.class.getDeclaredField("bindTo");
+    bindToField.setAccessible(true);
+    return (String) bindToField.get(listener);
   }
 
   private static final class TestServer extends FCPServer {

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -19,6 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -35,11 +41,7 @@ class FcpServerConfigRegistrarTest {
   void maybeCreate_whenDefaults_expectConfiguredServerAndInitializedSubConfig() {
     // Arrange
     Config config = new Config();
-    PersistentRequestRoot root = new PersistentRequestRoot();
-    when(runtimePorts.execution()).thenReturn(executionPort);
-
-    // Act
-    FCPServer server = FcpServerConfigRegistrar.maybeCreate(core, runtimePorts, config, root);
+    FCPServer server = FcpServerConfigRegistrar.maybeCreate(newDependencies(), config);
     SubConfig subConfig = config.get("fcp");
 
     // Assert
@@ -61,37 +63,47 @@ class FcpServerConfigRegistrarTest {
   }
 
   @Test
-  void fcpPortNumberCallback_whenValueUnchanged_expectNoException() {
+  void fcpPortNumberCallback_whenBeforeBind_expectInitialValue() {
     // Arrange
-    FCPServer server = newServer();
-    when(core.getEndpoints().getFCPServer()).thenReturn(server);
     FcpServerConfigRegistrar.FCPPortNumberCallback callback =
-        new FcpServerConfigRegistrar.FCPPortNumberCallback(core);
+        new FcpServerConfigRegistrar.FCPPortNumberCallback(FCPServer.DEFAULT_FCP_PORT);
 
     // Act & Assert
-    assertEquals(server.port, callback.get());
-    assertDoesNotThrow(() -> callback.set(server.port));
+    assertEquals(FCPServer.DEFAULT_FCP_PORT, callback.get());
+    assertDoesNotThrow(() -> callback.set(FCPServer.DEFAULT_FCP_PORT));
   }
 
   @Test
-  void fcpPortNumberCallback_whenValueChanged_expectInvalidConfigValueException() {
+  void fcpPortNumberCallback_whenBoundAndValueChanged_expectInvalidConfigValueException() {
     // Arrange
-    FCPServer server = newServer();
-    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FCPServer server = newServer(null);
     FcpServerConfigRegistrar.FCPPortNumberCallback callback =
-        new FcpServerConfigRegistrar.FCPPortNumberCallback(core);
+        new FcpServerConfigRegistrar.FCPPortNumberCallback(FCPServer.DEFAULT_FCP_PORT);
+    callback.bind(server);
 
     // Act & Assert
+    assertEquals(server.port, callback.get());
     assertThrows(InvalidConfigValueException.class, () -> callback.set(server.port + 1));
   }
 
   @Test
-  void fcpEnabledCallback_whenValueUnchanged_expectNoException() {
+  void fcpEnabledCallback_whenBeforeBind_expectInitialValue() {
     // Arrange
-    FCPServer server = newServer();
-    when(core.getEndpoints().getFCPServer()).thenReturn(server);
     FcpServerConfigRegistrar.FCPEnabledCallback callback =
-        new FcpServerConfigRegistrar.FCPEnabledCallback(core);
+        new FcpServerConfigRegistrar.FCPEnabledCallback(true);
+
+    // Act & Assert
+    assertTrue(callback.get());
+    assertDoesNotThrow(() -> callback.set(true));
+  }
+
+  @Test
+  void fcpEnabledCallback_whenBound_expectLiveServerValue() {
+    // Arrange
+    FCPServer server = newServer(null);
+    FcpServerConfigRegistrar.FCPEnabledCallback callback =
+        new FcpServerConfigRegistrar.FCPEnabledCallback(true);
+    callback.bind(server);
 
     // Act & Assert
     assertEquals(server.enabled, callback.get());
@@ -111,57 +123,106 @@ class FcpServerConfigRegistrarTest {
   }
 
   @Test
-  void fcpAllowedHostsCallback_whenServerMissing_expectDefaultBind() {
+  void fcpAllowedHostsCallback_whenBeforeBind_expectInitialValue() {
     // Arrange
-    when(core.getEndpoints().getFCPServer()).thenReturn(null);
     FcpServerConfigRegistrar.FCPAllowedHostsCallback callback =
-        new FcpServerConfigRegistrar.FCPAllowedHostsCallback(core);
+        new FcpServerConfigRegistrar.FCPAllowedHostsCallback(NetworkInterface.DEFAULT_BIND_TO);
 
     // Act & Assert
     assertEquals(NetworkInterface.DEFAULT_BIND_TO, callback.get());
   }
 
   @Test
-  void fcpAllowedHostsCallback_whenValueUnchanged_expectNoException() {
+  void fcpAllowedHostsCallback_whenBoundAndValueChanged_expectListenerUpdated() {
     // Arrange
-    FCPServer server = newServer();
-    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerListener listener = mock(FcpServerListener.class);
+    final String[] allowedHosts = {NetworkInterface.DEFAULT_BIND_TO};
+    doAnswer(
+            invocation -> {
+              allowedHosts[0] = invocation.getArgument(0);
+              return null;
+            })
+        .when(listener)
+        .setAllowedHosts(anyString());
+    when(listener.getAllowedHosts()).thenAnswer(_ -> allowedHosts[0]);
+
+    FCPServer server = newServer(listener);
     FcpServerConfigRegistrar.FCPAllowedHostsCallback callback =
-        new FcpServerConfigRegistrar.FCPAllowedHostsCallback(core);
+        new FcpServerConfigRegistrar.FCPAllowedHostsCallback(NetworkInterface.DEFAULT_BIND_TO);
+    callback.bind(server);
 
-    // Act & Assert
-    assertDoesNotThrow(() -> callback.set(NetworkInterface.DEFAULT_BIND_TO));
+    // Act
+    assertDoesNotThrow(() -> callback.set("127.0.0.1,192.168.0.1"));
+
+    // Assert
+    assertEquals("127.0.0.1,192.168.0.1", callback.get());
+    verify(listener).setAllowedHosts("127.0.0.1,192.168.0.1");
   }
 
   @Test
-  void fcpBindToCallback_whenGetCalled_expectServerBindTo() {
+  void fcpBindToCallback_whenBeforeBind_expectInitialValue() {
     // Arrange
-    FCPServer server = newServer();
-    when(core.getEndpoints().getFCPServer()).thenReturn(server);
     FcpServerConfigRegistrar.FCPBindtoCallback callback =
-        new FcpServerConfigRegistrar.FCPBindtoCallback(core);
+        new FcpServerConfigRegistrar.FCPBindtoCallback("127.0.0.1");
 
     // Act & Assert
-    assertEquals(server.bindTo, callback.get());
+    assertEquals("127.0.0.1", callback.get());
   }
 
   @Test
-  void fcpAllowedHostsFullAccessCallback_whenValueUnchanged_expectNoException() {
+  void fcpBindToCallback_whenBoundAndValueChanged_expectServerUpdated() {
     // Arrange
-    FCPServer server = newServer();
-    when(core.getEndpoints().getFCPServer()).thenReturn(server);
+    FcpServerListener listener = mock(FcpServerListener.class);
+    doNothing().when(listener).updateBindTo(anyString());
+    when(listener.setBindTo(anyString(), eq(true))).thenReturn(null);
+
+    FCPServer server = newServer(listener);
+    server.bindTo = "127.0.0.1";
+    FcpServerConfigRegistrar.FCPBindtoCallback callback =
+        new FcpServerConfigRegistrar.FCPBindtoCallback("127.0.0.1");
+    callback.bind(server);
+
+    // Act
+    assertDoesNotThrow(() -> callback.set("0.0.0.0"));
+
+    // Assert
+    assertEquals("0.0.0.0", server.bindTo);
+    verify(listener).setBindTo("0.0.0.0", true);
+    verify(listener).updateBindTo("0.0.0.0");
+  }
+
+  @Test
+  void fcpAllowedHostsFullAccessCallback_whenBeforeBind_expectInitialValue() {
+    // Arrange
     FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback callback =
-        new FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback(core);
+        new FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback(
+            NetworkInterface.DEFAULT_BIND_TO);
 
     // Act & Assert
-    assertEquals(server.allowedHostsFullAccess.getAllowedHosts(), callback.get());
-    assertDoesNotThrow(() -> callback.set(server.allowedHostsFullAccess.getAllowedHosts()));
+    assertEquals(NetworkInterface.DEFAULT_BIND_TO, callback.get());
+  }
+
+  @Test
+  void fcpAllowedHostsFullAccessCallback_whenBoundAndValueChanged_expectServerUpdated() {
+    // Arrange
+    FCPServer server = newServer(null);
+    FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback callback =
+        new FcpServerConfigRegistrar.FCPAllowedHostsFullAccessCallback(
+            NetworkInterface.DEFAULT_BIND_TO);
+    callback.bind(server);
+
+    // Act
+    assertDoesNotThrow(() -> callback.set("127.0.0.1,192.168.0.1"));
+
+    // Assert
+    assertEquals("127.0.0.1,192.168.0.1", callback.get());
+    assertEquals("127.0.0.1,192.168.0.1", server.allowedHostsFullAccess.getAllowedHosts());
   }
 
   @Test
   void assumeDDADownloadIsAllowedCallback_whenSet_expectServerUpdated() {
     // Arrange
-    FCPServer server = newServer();
+    FCPServer server = newServer(null);
     FcpServerConfigRegistrar.AssumeDDADownloadIsAllowedCallback callback =
         new FcpServerConfigRegistrar.AssumeDDADownloadIsAllowedCallback();
     callback.server = server;
@@ -176,7 +237,7 @@ class FcpServerConfigRegistrarTest {
   @Test
   void assumeDDAUploadIsAllowedCallback_whenSet_expectServerUpdated() {
     // Arrange
-    FCPServer server = newServer();
+    FCPServer server = newServer(null);
     FcpServerConfigRegistrar.AssumeDDAUploadIsAllowedCallback callback =
         new FcpServerConfigRegistrar.AssumeDDAUploadIsAllowedCallback();
     callback.server = server;
@@ -191,7 +252,7 @@ class FcpServerConfigRegistrarTest {
   @Test
   void neverDropAMessageCallback_whenSet_expectServerUpdated() {
     // Arrange
-    FCPServer server = newServer();
+    FCPServer server = newServer(null);
     FcpServerConfigRegistrar.NeverDropAMessageCallback callback =
         new FcpServerConfigRegistrar.NeverDropAMessageCallback();
     callback.server = server;
@@ -206,7 +267,7 @@ class FcpServerConfigRegistrarTest {
   @Test
   void maxMessageQueueLengthCallback_whenSet_expectServerUpdated() {
     // Arrange
-    FCPServer server = newServer();
+    FCPServer server = newServer(null);
     FcpServerConfigRegistrar.MaxMessageQueueLengthCallback callback =
         new FcpServerConfigRegistrar.MaxMessageQueueLengthCallback();
     callback.server = server;
@@ -219,8 +280,12 @@ class FcpServerConfigRegistrarTest {
     assertEquals(42, callback.get());
   }
 
-  private FCPServer newServer() {
+  private FcpServerDependencies newDependencies() {
     when(runtimePorts.execution()).thenReturn(executionPort);
+    return CoreFcpServerDependenciesFactory.create(core, runtimePorts, new PersistentRequestRoot());
+  }
+
+  private FCPServer newServer(FcpServerListener listenerOverride) {
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
@@ -232,7 +297,25 @@ class FcpServerConfigRegistrarTest {
             false,
             false,
             10);
-    return new FCPServer(
-        config, new FcpServerDependencies(core, runtimePorts, new PersistentRequestRoot()));
+    FcpServerDependencies dependencies = newDependencies();
+    if (listenerOverride == null) {
+      return new FCPServer(config, dependencies);
+    }
+    return new TestServer(config, dependencies, listenerOverride);
+  }
+
+  private static final class TestServer extends FCPServer {
+    private final FcpServerListener listener;
+
+    private TestServer(
+        FcpServerConfig config, FcpServerDependencies dependencies, FcpServerListener listener) {
+      super(config, dependencies);
+      this.listener = listener;
+    }
+
+    @Override
+    FcpServerListener listener() {
+      return listener;
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerConfigRegistrarTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import java.lang.reflect.Field;
 import network.crypta.config.Config;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.SubConfig;
@@ -25,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -193,19 +193,27 @@ class FcpServerConfigRegistrarTest {
   }
 
   @Test
-  void maybeCreate_whenBindToUpdatedBeforeStart_expectPendingListenerValueUpdated()
-      throws Exception {
+  void fcpBindToCallback_whenListenerRejectsValue_expectInvalidConfigValueException() {
     // Arrange
-    Config config = new Config();
-    FCPServer server = FcpServerConfigRegistrar.maybeCreate(newDependencies(), config);
-    SubConfig subConfig = config.get("fcp");
+    FcpServerListener listener = mock(FcpServerListener.class);
+    doNothing().when(listener).updateBindTo(anyString());
+    when(listener.setBindTo("0.0.0.0", true)).thenReturn(new String[] {"0.0.0.0"});
+    when(listener.setBindTo("127.0.0.1", true)).thenReturn(null);
+    FCPServer server = newServer(listener);
+    server.bindTo = "127.0.0.1";
+    FcpServerConfigRegistrar.FCPBindtoCallback callback =
+        new FcpServerConfigRegistrar.FCPBindtoCallback("127.0.0.1");
+    callback.bind(server);
 
-    // Act
-    assertDoesNotThrow(() -> subConfig.getOption("bindTo").setValue("0.0.0.0"));
+    // Act & Assert
+    assertThrows(InvalidConfigValueException.class, () -> callback.set("0.0.0.0"));
 
     // Assert
-    assertEquals("0.0.0.0", server.bindTo);
-    assertEquals("0.0.0.0", getListenerBindTo(server.listener()));
+    assertEquals("127.0.0.1", server.bindTo);
+    assertEquals("127.0.0.1", callback.get());
+    verify(listener).setBindTo("0.0.0.0", true);
+    verify(listener).setBindTo("127.0.0.1", true);
+    verify(listener, never()).updateBindTo("0.0.0.0");
   }
 
   @Test
@@ -319,12 +327,6 @@ class FcpServerConfigRegistrarTest {
       return new FCPServer(config, dependencies);
     }
     return new TestServer(config, dependencies, listenerOverride);
-  }
-
-  private String getListenerBindTo(FcpServerListener listener) throws Exception {
-    Field bindToField = FcpServerListener.class.getDeclaredField("bindTo");
-    bindToField.setAccessible(true);
-    return (String) bindToField.get(listener);
   }
 
   private static final class TestServer extends FCPServer {

--- a/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
@@ -135,6 +135,19 @@ class FcpServerListenerTest {
   }
 
   @Test
+  void setBindTo_whenNetworkInterfaceMissing_expectValueCachedForFutureStart() throws Exception {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+
+    // Act
+    String[] result = listener.setBindTo("0.0.0.0", true);
+
+    // Assert
+    assertNull(result);
+    assertEquals("0.0.0.0", getBindTo(listener));
+  }
+
+  @Test
   void updateBindTo_whenInvoked_expectFieldUpdated() throws Exception {
     // Arrange
     FcpServerListener listener = newListener(true);
@@ -185,6 +198,7 @@ class FcpServerListenerTest {
 
     // Act
     try (var networkInterfaceMock = mockStatic(NetworkInterface.class)) {
+      //noinspection resource
       networkInterfaceMock
           .when(
               () ->

--- a/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
@@ -135,9 +135,16 @@ class FcpServerListenerTest {
   }
 
   @Test
-  void setBindTo_whenNetworkInterfaceMissing_expectValueCachedForFutureStart() throws Exception {
+  void setBindTo_whenValidationSucceedsBeforeStart_expectValueCachedForFutureStart()
+      throws Exception {
     // Arrange
-    FcpServerListener listener = newListener(true);
+    NetworkInterface validationInterface = mock(NetworkInterface.class);
+    when(validationInterface.setBindTo("0.0.0.0", true)).thenReturn(null);
+    FcpServerListener listener =
+        newListener(
+            true,
+            NetworkInterface.DEFAULT_BIND_TO,
+            (ignoredPort, ignoredAllowedHosts, ignoredExecutor) -> validationInterface);
 
     // Act
     String[] result = listener.setBindTo("0.0.0.0", true);
@@ -145,6 +152,28 @@ class FcpServerListenerTest {
     // Assert
     assertNull(result);
     assertEquals("0.0.0.0", getBindTo(listener));
+    verify(validationInterface).close();
+  }
+
+  @Test
+  void setBindTo_whenValidationFailsBeforeStart_expectValueRejectedAndNotCached() throws Exception {
+    // Arrange
+    NetworkInterface validationInterface = mock(NetworkInterface.class);
+    String[] failed = new String[] {"0.0.0.0"};
+    when(validationInterface.setBindTo("0.0.0.0", true)).thenReturn(failed);
+    FcpServerListener listener =
+        newListener(
+            true,
+            NetworkInterface.DEFAULT_BIND_TO,
+            (ignoredPort, ignoredAllowedHosts, ignoredExecutor) -> validationInterface);
+
+    // Act
+    String[] result = listener.setBindTo("0.0.0.0", true);
+
+    // Assert
+    assertArrayEquals(failed, result);
+    assertEquals("127.0.0.1", getBindTo(listener));
+    verify(validationInterface).close();
   }
 
   @Test
@@ -280,6 +309,13 @@ class FcpServerListenerTest {
   }
 
   private FcpServerListener newListener(boolean enabled, String allowedHosts) {
+    return newListener(enabled, allowedHosts, null);
+  }
+
+  private FcpServerListener newListener(
+      boolean enabled,
+      String allowedHosts,
+      FcpServerListener.ValidationInterfaceFactory validationInterfaceFactory) {
     FcpServerListener.setSslEnabled(false);
     when(runtimePorts.execution()).thenReturn(executionPort);
     FcpServerConfig config =
@@ -293,7 +329,10 @@ class FcpServerListenerTest {
             false,
             false,
             10);
-    return new FcpServerListener(server, runtimePorts, config);
+    if (validationInterfaceFactory == null) {
+      return new FcpServerListener(server, runtimePorts, config);
+    }
+    return new FcpServerListener(server, runtimePorts, config, validationInterfaceFactory);
   }
 
   private void setNetworkInterface(FcpServerListener listener, NetworkInterface value)

--- a/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerListenerTest.java
@@ -20,6 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -50,7 +54,7 @@ class FcpServerListenerTest {
   }
 
   @Test
-  void getAllowedHosts_whenNetworkInterfaceMissing_expectDefaultBind() {
+  void getAllowedHosts_whenNetworkInterfaceMissing_expectConfiguredHosts() {
     // Arrange
     FcpServerListener listener = newListener(true);
 
@@ -59,6 +63,18 @@ class FcpServerListenerTest {
 
     // Assert
     assertEquals(NetworkInterface.DEFAULT_BIND_TO, allowedHosts);
+  }
+
+  @Test
+  void getAllowedHosts_whenConfiguredAndNetworkInterfaceMissing_expectConfiguredHosts() {
+    // Arrange
+    FcpServerListener listener = newListener(true, "127.0.0.1");
+
+    // Act
+    String allowedHosts = listener.getAllowedHosts();
+
+    // Assert
+    assertEquals("127.0.0.1", allowedHosts);
   }
 
   @Test
@@ -88,6 +104,18 @@ class FcpServerListenerTest {
 
     // Assert
     verify(networkInterface).setAllowedHosts("127.0.0.1");
+  }
+
+  @Test
+  void setAllowedHosts_whenNetworkInterfaceMissing_expectValueCachedForFutureReads() {
+    // Arrange
+    FcpServerListener listener = newListener(true);
+
+    // Act
+    listener.setAllowedHosts("127.0.0.1");
+
+    // Assert
+    assertEquals("127.0.0.1", listener.getAllowedHosts());
   }
 
   @Test
@@ -141,6 +169,35 @@ class FcpServerListenerTest {
 
     // Act
     listener.maybeStart();
+
+    // Assert
+    assertSame(networkInterface, getNetworkInterface(listener));
+  }
+
+  @Test
+  void maybeStart_whenAllowedHostsUpdatedBeforeStart_expectInterfaceCreatedWithUpdatedHosts()
+      throws Exception {
+    // Arrange
+    FcpServerListener.setSslEnabled(false);
+    FcpServerListener listener = newListener(true);
+    NetworkInterface networkInterface = mock(NetworkInterface.class);
+    listener.setAllowedHosts("127.0.0.1");
+
+    // Act
+    try (var networkInterfaceMock = mockStatic(NetworkInterface.class)) {
+      networkInterfaceMock
+          .when(
+              () ->
+                  NetworkInterface.create(anyInt(), anyString(), anyString(), any(), anyBoolean()))
+          .thenAnswer(
+              invocation -> {
+                assertEquals(FCPServer.DEFAULT_FCP_PORT, invocation.<Integer>getArgument(0));
+                assertEquals("127.0.0.1", invocation.getArgument(2));
+                return networkInterface;
+              });
+
+      listener.maybeStart();
+    }
 
     // Assert
     assertSame(networkInterface, getNetworkInterface(listener));
@@ -205,11 +262,16 @@ class FcpServerListenerTest {
   }
 
   private FcpServerListener newListener(boolean enabled) {
+    return newListener(enabled, NetworkInterface.DEFAULT_BIND_TO);
+  }
+
+  private FcpServerListener newListener(boolean enabled, String allowedHosts) {
+    FcpServerListener.setSslEnabled(false);
     when(runtimePorts.execution()).thenReturn(executionPort);
     FcpServerConfig config =
         new FcpServerConfig(
             "127.0.0.1",
-            NetworkInterface.DEFAULT_BIND_TO,
+            allowedHosts,
             NetworkInterface.DEFAULT_BIND_TO,
             FCPServer.DEFAULT_FCP_PORT,
             enabled,

--- a/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/node/NodeClientPersistenceTest.java
@@ -11,7 +11,9 @@ import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.USKManager;
 import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.CoreFcpServerDependenciesFactory;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpServerDependencies;
 import network.crypta.clients.fcp.PersistentRequestClient;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.clients.http.SimpleToadletServer;
@@ -476,24 +478,31 @@ class NodeClientPersistenceTest {
     NodeClientCore core = mock(NodeClientCore.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     FCPServer expected = mock(FCPServer.class);
+    FcpServerDependencies dependencies = mock(FcpServerDependencies.class);
 
     // Act
-    try (MockedStatic<FCPServer> fcpServerMock = mockStatic(FCPServer.class)) {
-      fcpServerMock
+    try (MockedStatic<CoreFcpServerDependenciesFactory> factoryMock =
+            mockStatic(CoreFcpServerDependenciesFactory.class);
+        MockedStatic<FCPServer> fcpServerMock = mockStatic(FCPServer.class)) {
+      factoryMock
           .when(
               () ->
-                  FCPServer.maybeCreate(
-                      eq(core), eq(runtimePorts), eq(config), any(PersistentRequestRoot.class)))
+                  CoreFcpServerDependenciesFactory.create(
+                      eq(core), eq(runtimePorts), any(PersistentRequestRoot.class)))
+          .thenReturn(dependencies);
+      fcpServerMock
+          .when(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)))
           .thenReturn(expected);
 
       FCPServer result = persistence.createFcpServer(node, core, runtimePorts);
 
       // Assert
       assertSame(expected, result);
-      fcpServerMock.verify(
+      factoryMock.verify(
           () ->
-              FCPServer.maybeCreate(
-                  eq(core), eq(runtimePorts), eq(config), any(PersistentRequestRoot.class)));
+              CoreFcpServerDependenciesFactory.create(
+                  eq(core), eq(runtimePorts), any(PersistentRequestRoot.class)));
+      fcpServerMock.verify(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)));
     }
   }
 


### PR DESCRIPTION
## Summary

Implements repository PR-50 for the FCP bootstrap/config seam.

- add `CoreFcpServerDependenciesFactory` to build the FCP dependency bundle from `NodeClientCore`, `RuntimePorts`, and `PersistentRequestRoot`
- refactor `FcpServerDependencies` into a pure bootstrap bundle and update `FCPServer` to consume prebuilt runtime support instead of storing `NodeClientCore`
- bind `FcpServerConfigRegistrar` callbacks directly to the created `FCPServer`, including pre-bind fallback behavior for port, enabled, bind, and allowed-host settings
- update `NodeClientPersistence.createFcpServer(...)` to construct the dependency bundle before creating the server
- extend the FCP tests to cover the new factory wiring and the listener/config callback bootstrap behavior

## Testing

- `./gradlew test`

## Notes

- `CoreFcpServerDependenciesFactory.java` Javadoc was expanded and verified with `javadoc -quiet -Xdoclint:all` against the Gradle-derived main compile classpath.
