### PR TITLE
refactor(fcp): Remove residual daemon constant coupling

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -34,7 +34,9 @@ Use this skill when you need to:
     `LegacyDarknetConnectionsPort`, `LegacyDarknetMessagingPort`,
     `LegacyQueuePagePort`, `LegacyQueueDownloadPort`, `LegacyQueueInsertPort`,
     `LegacyQueueMutationPort`, `LegacyQueueSupportPort`, `LegacyQueueCompletionPort`,
-    `LegacySecurityLevelsPort`, and `LegacyFirstTimeWizardPort`.
+    `LegacySecurityLevelsPort`, `LegacyPageChromePort`, `LegacyCoreUpdateActionPort`,
+    `LegacyFirstTimeWizardPort`, `LegacyToadletSymlinkPort`, `LegacyWelcomePagePort`, and
+    `LegacyWelcomeActionPort`.
 - The large cyclic daemon core still lives in the root project:
   `network.crypta.node`, `network.crypta.io`, `network.crypta.client`,
   `network.crypta.clients`, `network.crypta.support`, `network.crypta.config`,
@@ -73,9 +75,14 @@ Use this skill when you need to:
   - `FcpRuntimeAdapters` preserves legacy FCP-local shapes such as `PriorityAwareExecutor` and
     `RandomSource` on top of the SPI.
   - Detached peer-management operations such as `ModifyPeer` now go through `RuntimePorts#peer()`.
+  - Server bootstrap now flows through `FcpServerDependencies` and
+    `CoreFcpServerDependenciesFactory`.
+  - Package-local seams split the remaining daemon-backed work by concern:
+    `FcpServerRuntimeSupport`, `FcpMessageRuntimeSupport`, `FcpFetchRuntimeSupport`, and
+    `FcpInsertRuntimeSupport`.
 - HTTP interface: `network.crypta.clients.http`
-  - The migrated management slices no longer depend directly on live daemon peers or node-info
-    exports for their core data flow.
+  - The migrated management and shell slices no longer depend directly on live daemon peers or
+    node-info exports for their core data flow.
   - `ConfigToadlet` now takes detached configuration export/update capabilities from
     `ConfigPort` through `ConfigToadletRuntimePorts`.
   - `ConnectionsToadlet`, `DarknetConnectionsToadlet`, `OpennetConnectionsToadlet`, and
@@ -86,9 +93,20 @@ Use this skill when you need to:
     `TransferAccessPort`, `DarknetConnectionsPort`, and `DarknetMessagingPort`.
   - `SecurityLevelsToadlet` uses `SecurityLevelsPort` for detached page state, warning HTML, and
     master-password mutation flows.
+  - `PageMaker` reads shared shell status through `PageChromePort`.
+  - `CoreActionToadlet` reaches updater availability, download triggers, and installer-path
+    validation through `CoreUpdateActionPort`.
   - `FirstTimeWizardToadlet` and `FirstTimeWizardNewToadlet` use `FirstTimeWizardPort` for
-    detached snapshot export, validation bounds, bandwidth/security suggestions, and submission
-    handling.
+    detached snapshot export, validation bounds, bandwidth/security suggestions, current-bandwidth
+    rows, and submission handling.
+  - `SymlinkerToadlet` persists aliases through `ToadletSymlinkPort`.
+  - `WelcomeToadlet` splits detached GET state and POST actions across `WelcomePagePort` and
+    `WelcomeActionPort`, bundled in `WelcomeToadletRuntimePorts`.
+  - FProxy and shell bootstrap now have local package-private seams:
+    `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellRuntimeSupport`,
+    `HttpShellFProxyBootstrap`, and `FProxyRegistrarDependencies`.
+  - `BookmarkEditorToadletRuntimePorts` and `FileInsertWizardToadletRuntimePorts` are small
+    page-specific records used to keep constructor surfaces explicit during HTTP wiring.
   - `N2NTMToadlet` uses `DarknetConnectionsPort` and `DarknetMessagingPort` for selected-peer
     lookup, transfer confirmations, and compose/send actions.
 
@@ -98,14 +116,17 @@ Use this skill when you need to:
   `ConfigPort`, `ConnectivityPort`, `ConnectionsPagePort`, `ConnectionsSupportPort`,
   `DarknetConnectionsPort`, `DarknetMessagingPort`, `DiagnosticPort`, `QueueSupportPort`,
   `QueueCompletionPort`, `QueuePagePort`, `QueueDownloadPort`, `QueueInsertPort`,
-  `QueueMutationPort`, `StatisticsPort`, `SecurityLevelsPort`, `FirstTimeWizardPort`,
-  `RequestQueuePort`, `NodeInfoPort`, and `PeerPort`
+  `QueueMutationPort`, `StatisticsPort`, `SecurityLevelsPort`, `PageChromePort`,
+  `CoreUpdateActionPort`, `FirstTimeWizardPort`, `ToadletSymlinkPort`, `WelcomePagePort`,
+  `WelcomeActionPort`, `RequestQueuePort`, `NodeInfoPort`, and `PeerPort`
 - Detached DTOs include config, connectivity, peer, darknet-friends, node-reference, queue,
-  security-level, first-time-wizard, and statistics/report snapshot types such as
+  security-level, shared shell, first-time-wizard, symlinker, welcome-page, and statistics/report
+  snapshot types such as
   `ConfigSnapshot`, `ConfigFieldSet`, `ConfigSection`, `PeerSnapshot`,
   `DarknetConnectionPeerSnapshot`, `DarknetUploadedFile`, `NodeReferenceSnapshot`,
   `QueuePageSnapshot`, `QueuePersistenceStatusSnapshot`, `QueueInsertOutcome`,
-  `SecurityLevelsSnapshot`, and `FirstTimeWizardSnapshot`
+  `SecurityLevelsSnapshot`, `PageChromeSnapshot`, `FirstTimeWizardSnapshot`,
+  `FirstTimeWizardCurrentBandwidthLimits`, `ToadletSymlinkEntry`, and `WelcomePageSnapshot`
 - Root adapters: `network.crypta.node.runtime.LegacyRuntimePorts`,
   `network.crypta.node.runtime.LegacyConfigPort`,
   `network.crypta.node.runtime.LegacyNodeInfoPort`,
@@ -114,6 +135,8 @@ Use this skill when you need to:
   `network.crypta.node.runtime.LegacyConnectionsSupportPort`,
   `network.crypta.node.runtime.LegacyDarknetConnectionsPort`,
   `network.crypta.node.runtime.LegacyDarknetMessagingPort`,
+  `network.crypta.node.runtime.LegacyPageChromePort`,
+  `network.crypta.node.runtime.LegacyCoreUpdateActionPort`,
   `network.crypta.node.runtime.LegacyQueuePagePort`,
   `network.crypta.node.runtime.LegacyQueueDownloadPort`,
   `network.crypta.node.runtime.LegacyQueueInsertPort`,
@@ -121,7 +144,10 @@ Use this skill when you need to:
   `network.crypta.node.runtime.LegacyQueueSupportPort`,
   `network.crypta.node.runtime.LegacyQueueCompletionPort`,
   `network.crypta.node.runtime.LegacySecurityLevelsPort`,
-  `network.crypta.node.runtime.LegacyFirstTimeWizardPort`
+  `network.crypta.node.runtime.LegacyFirstTimeWizardPort`,
+  `network.crypta.node.runtime.LegacyToadletSymlinkPort`,
+  `network.crypta.node.runtime.LegacyWelcomePagePort`,
+  `network.crypta.node.runtime.LegacyWelcomeActionPort`
 
 ### Plugin system (`network.crypta.pluginmanager`)
 - Management: `PluginManager`
@@ -134,7 +160,9 @@ Use this skill when you need to:
   operation (`config()`, `peer()`, `nodeInfo()`, `connectionsPage()`, `connectionsSupport()`,
   `darknetConnections()`, `darknetMessaging()`, `queuePage()`, `queueDownload()`,
   `queueInsert()`, `queueMutation()`, `queueSupport()`, `queueCompletion()`,
-  `securityLevels()`, `firstTimeWizard()`, etc.) instead of traversing daemon internals directly
+  `securityLevels()`, `pageChrome()`, `coreUpdateAction()`, `firstTimeWizard()`,
+  `toadletSymlinks()`, `welcomePage()`, `welcomeAction()`, etc.) instead of traversing daemon
+  internals directly
 
 ### Supporting infrastructure (`network.crypta.support`)
 - Logging, data structures, threading, helpers

--- a/.agents/skills/cryptad-core-updater/SKILL.md
+++ b/.agents/skills/cryptad-core-updater/SKILL.md
@@ -29,6 +29,9 @@ Use this skill when working on:
 - `NodeUpdateManager` now coordinates:
   - `CoreUpdater` for core packages
   - `PluginJarUpdater` for plugins
+- The legacy HTTP updater UI now crosses the runtime boundary through
+  `RuntimePorts#coreUpdateAction()` and `network.crypta.runtime.spi.CoreUpdateActionPort`,
+  implemented in the root daemon by `network.crypta.node.runtime.LegacyCoreUpdateActionPort`.
 - Core updater state surfaces through CorePackage-named APIs:
   - `hasNewCorePackage()`, `newCorePackageVersion()`, `newCorePackageVersionLabel()`
   - `fetchingNewCorePackage()`, `fetchingNewCorePackageVersion()`
@@ -48,6 +51,16 @@ Use this skill when working on:
 - Actions: `download`, `install`, `openStore`
 - UI: alerts panel shows progress percent when available.
   - Failures surface clear retry guidance (non-fatal errors relabel to “Retry”).
+- Request parsing, redirects, `AppEnv` checks, and OS-specific installer or store-launching remain
+  in `network.crypta.node.updater.CoreActionToadlet`.
+- Daemon-backed availability checks, UI-triggered download start, and downloaded-installer
+  containment validation now live behind `CoreUpdateActionPort`.
+
+## Runtime-boundary classes to inspect
+- HTTP/action layer: `network.crypta.node.updater.CoreActionToadlet`
+- SPI contract: `network.crypta.runtime.spi.CoreUpdateActionPort`
+- Root adapter: `network.crypta.node.runtime.LegacyCoreUpdateActionPort`
+- Aggregate runtime entry point: `network.crypta.runtime.spi.RuntimePorts`
 
 ## Platform specifics (selected behaviors)
 - Linux:

--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ Cryptad now uses a partial multi-project Gradle build.
 - `:foundation-fs` owns `network.crypta.fs`.
 - `:foundation-compat` owns `network.crypta.compat`.
 - `:runtime-spi` owns `network.crypta.runtime.spi` and the JDK-only runtime/config boundary used
-  by higher layers, including the migrated FCP peer-management plus the admin-HTTP config,
-  connections, queue, security-levels, and first-time-wizard slices.
+  by higher layers, including detached FCP peer management plus the admin-HTTP config,
+  connectivity, connections, queue, security-levels, shared page-chrome, core-update action,
+  first-time-wizard, symlinker, and welcome-page slices.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
@@ -179,12 +180,19 @@ Cryptad now uses a partial multi-project Gradle build.
 - The large cyclic daemon core remains in the root project for now, and all tests still live there.
 - Higher-level infrastructure now crosses a narrower boundary through
   `network.crypta.runtime.spi.RuntimePorts`, implemented in the root project by
-  `network.crypta.node.runtime.LegacyRuntimePorts`, plus HTTP-local wiring records such as
+  `network.crypta.node.runtime.LegacyRuntimePorts`, plus HTTP-local wiring records and
+  package-local seams such as
+  `network.crypta.clients.http.BookmarkEditorToadletRuntimePorts`,
   `network.crypta.clients.http.ConfigToadletRuntimePorts`,
   `network.crypta.clients.http.ConnectionsToadletRuntimePorts`,
+  `network.crypta.clients.http.FileInsertWizardToadletRuntimePorts`,
   `network.crypta.clients.http.FirstTimeWizardToadletRuntimePorts`,
   `network.crypta.clients.http.QueueToadletRuntimePorts`, and
-  `network.crypta.clients.http.SecurityLevelsToadletRuntimePorts`.
+  `network.crypta.clients.http.SecurityLevelsToadletRuntimePorts`,
+  `network.crypta.clients.http.WelcomeToadletRuntimePorts`,
+  `network.crypta.clients.http.FProxyRuntimeSupport`,
+  `network.crypta.clients.http.HttpShellRuntimeSupport`, and
+  `network.crypta.clients.http.bookmark.BookmarkRuntimeSupport`.
 
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
 `gradle/wrapper/gradle-wrapper.properties`). To also verify the download by checksum, add
@@ -510,19 +518,29 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 - Clients: `network.crypta.client`, FCP (`network.crypta.clients.fcp`), HTTP
   (`network.crypta.clients.http`). FCP now consumes execution, randomness, transfer policy,
   lifecycle, config access, and detached peer mutations through `RuntimePorts` and FCP-local
-  adapters instead of reaching directly into daemon internals for those concerns. The migrated HTTP
-  management/configuration slices now also consume detached runtime ports for config export and
-  persistence, connectivity and friends/strangers page snapshots, add-friend installer metadata,
-  local noderef export, selected-peer actions, queue page/download/insert/mutation/support and
-  completion flows, security-level state and warnings, first-time-wizard snapshot/submission
-  handling, and N2NTM compose/send flows.
+  adapters instead of reaching directly into daemon internals for those concerns. FCP bootstrap now
+  flows through `FcpServerDependencies` and `CoreFcpServerDependenciesFactory`, with package-local
+  seams such as `FcpServerRuntimeSupport`, `FcpMessageRuntimeSupport`,
+  `FcpFetchRuntimeSupport`, and `FcpInsertRuntimeSupport` splitting server-owned, message-owned,
+  GET/fetch, and insert/USK concerns.
+  The migrated HTTP management and shell slices now cross the boundary in two layers:
+  `RuntimePorts` for JDK-only detached runtime state and package-local helpers such as
+  `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellRuntimeSupport`,
+  `HttpShellFProxyBootstrap`, and `FProxyRegistrarDependencies`. Those paths now cover config
+  export and persistence, connectivity and friends/strangers snapshots, selected-peer actions,
+  queue page/download/insert/mutation/support and completion flows, security-level state and
+  warnings, shared page chrome, core-update actions, first-time-wizard snapshots plus current
+  bandwidth limits, symlinker persistence, welcome-page reads/actions, bookmark runtime wiring,
+  and N2NTM compose/send flows.
 - Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and detached DTOs such as
   `RuntimePorts`, `ConfigPort`, `NodeInfoPort`, `PeerPort`, `ConnectionsPagePort`,
   `ConnectionsSupportPort`, `DarknetConnectionsPort`, `DarknetMessagingPort`, `QueuePagePort`,
   `QueueDownloadPort`, `QueueInsertPort`, `QueueMutationPort`, `QueueSupportPort`,
-  `QueueCompletionPort`, `SecurityLevelsPort`, `FirstTimeWizardPort`, `ConfigSnapshot`,
-  `ConfigFieldSet`, `QueuePageSnapshot`, `QueueInsertOutcome`, `SecurityLevelsSnapshot`, and
-  `FirstTimeWizardSnapshot`.
+  `QueueCompletionPort`, `SecurityLevelsPort`, `PageChromePort`, `CoreUpdateActionPort`,
+  `FirstTimeWizardPort`, `ToadletSymlinkPort`, `WelcomePagePort`, `WelcomeActionPort`,
+  `ConfigSnapshot`, `ConfigFieldSet`, `QueuePageSnapshot`, `QueueInsertOutcome`,
+  `SecurityLevelsSnapshot`, `PageChromeSnapshot`, `FirstTimeWizardSnapshot`,
+  `FirstTimeWizardCurrentBandwidthLimits`, `ToadletSymlinkEntry`, and `WelcomePageSnapshot`.
 - Config (`network.crypta.config`): type‑safe persisted configuration retained in the root daemon
   and exposed upstream through `network.crypta.node.runtime.LegacyConfigPort` via
   `RuntimePorts#config()`.

--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.PeerAddFailureReason;
 import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
@@ -347,7 +346,7 @@ public final class AddPeer extends FCPMessage {
           handler
               .getServer()
               .messageRuntimeSupport()
-              .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+              .makeClient(FcpPriorityClasses.IMMEDIATE_SPLITFILE, true, true);
       return AddPeer.getReferenceFromFreenetURI(refUri, client);
     } catch (MalformedURLException | FetchException _) {
       LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urlString);

--- a/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
@@ -10,7 +10,6 @@ import java.util.Locale;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -169,12 +168,10 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
   private ReturnTypeConfig resolveReturnType(SimpleFieldSet fs) throws MessageInvalidException {
     ReturnType parsedType = parseReturnTypeFCP(fs.get("ReturnType"));
     return switch (parsedType) {
-      case DIRECT ->
-          new ReturnTypeConfig(parsedType, null, RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS);
-      case NONE -> new ReturnTypeConfig(parsedType, null, RequestStarter.PREFETCH_PRIORITY_CLASS);
+      case DIRECT -> new ReturnTypeConfig(parsedType, null, FcpPriorityClasses.IMMEDIATE_SPLITFILE);
+      case NONE -> new ReturnTypeConfig(parsedType, null, FcpPriorityClasses.PREFETCH);
       case DISK ->
-          new ReturnTypeConfig(
-              parsedType, initDiskFile(fs), RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS);
+          new ReturnTypeConfig(parsedType, initDiskFile(fs), FcpPriorityClasses.BULK_SPLITFILE);
       default ->
           throw new MessageInvalidException(
               ProtocolErrorMessage.MESSAGE_PARSE_ERROR, "Unknown return-type", identifier, global);
@@ -261,15 +258,15 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
     }
     try {
       short parsed = Short.parseShort(priorityString);
-      if (!RequestStarter.isValidPriorityClass(parsed)) {
+      if (!FcpPriorityClasses.isValid(parsed)) {
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_FIELD,
             "Invalid priority class "
                 + parsed
                 + " - range is "
-                + RequestStarter.PAUSED_PRIORITY_CLASS
+                + FcpPriorityClasses.PAUSED
                 + " to "
-                + RequestStarter.MAXIMUM_PRIORITY_CLASS,
+                + FcpPriorityClasses.MAXIMUM,
             identifier,
             global);
       }
@@ -347,7 +344,7 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
    *
    * <p>Even though the value is always {@link #NAME}, this indirection keeps the {@link
    * BaseDataCarryingMessage} contract satisfied and enables instrumentation hooks that inspect
-   * names before executing a handler. The method is pure and side effect free, allowing it to be
+   * names before executing a handler. The method is pure and side-effect-free, allowing it to be
    * invoked repeatedly when tracing or metrics systems need to tag outgoing responses.
    *
    * @return literal {@code ClientGet} so dispatchers map field sets consistently.
@@ -360,11 +357,11 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
   /**
    * Delegates processing to the provided connection handler for execution on the node.
    *
-   * <p>The handler typically schedules the request with {@link RequestStarter}, causing the node to
-   * retrieve or stream data according to the persistence and return type captured inside this
-   * message. Callers should only invoke this method once per instance; repeated calls would enqueue
-   * redundant work and potentially exceed resource quotas because the message carries immutable
-   * identifiers and client tokens.
+   * <p>The handler typically schedules the request through the node's fetch pipeline, causing the
+   * node to retrieve or stream data according to the persistence and return type captured inside
+   * this message. Callers should only invoke this method once per instance; repeated calls would
+   * enqueue redundant work and potentially exceed resource quotas because the message carries
+   * immutable identifiers and client tokens.
    *
    * @param handler active connection handler orchestrating ClientGet lifecycle and status relays.
    */
@@ -381,7 +378,7 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
    * rely on datastore durability instead. External callers can consult this helper when determining
    * whether to materialize temporary buckets or bypass caching for highly transient transfers.
    *
-   * @return true to mirror into client cache, false to stream directly.
+   * @return true to mirror into the client cache, false to stream directly.
    */
   public boolean shouldWriteToClientCache() {
     return writeToClientCache;
@@ -406,7 +403,7 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
   }
 
   /**
-   * Reads optional initial metadata that may accompany the literal message body.
+   * Reads optional initial metadata that may come with the literal message body.
    *
    * <p>The implementation allocates a {@link Bucket} sized exactly to {@link
    * #initialMetadataLength} and streams bytes from the provided {@link InputStream}. Because the

--- a/src/main/java/network/crypta/clients/fcp/ClientHelloMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientHelloMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.support.SimpleFieldSet;
 
@@ -117,8 +116,7 @@ public final class ClientHelloMessage extends FCPMessage {
    * so it focuses on the happy path: fetching greeting metadata from the runtime SPI, building a
    * node response using the handler's connection UUID, and dispatching it over the same channel.
    * After the response leaves, the handler remembers the client name so future log lines can refer
-   * to it even if the socket closes unexpectedly. The {@link Node} parameter is currently unused
-   * but retained for parity with other {@link FCPMessage} hooks.
+   * to it even if the socket closes unexpectedly.
    *
    * <pre>{@code
    * ClientHelloMessage hello = ...;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
@@ -7,8 +7,6 @@ import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
-import network.crypta.node.RequestStarter;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.compress.Compressor.COMPRESSOR_TYPE;
@@ -19,11 +17,10 @@ import network.crypta.support.compress.InvalidCompressionCodecException;
  *
  * <p>This abstract container centralizes the parsing and validation shared by {@link
  * ClientPutDiskDirMessage} and {@link ClientPutComplexDirMessage}. A node controller builds an
- * instance from an inbound {@link SimpleFieldSet} and hands it to {@link RequestStarter}, which
- * turns the embedded metadata into the actual insert pipeline. The message spells out the target
- * {@link FreenetURI}, retry envelope, splitfile compatibility mode, compression hints, and
- * persistence knobs expected by the storage layer so that both directory flavors remain
- * interoperable.
+ * instance from an inbound {@link SimpleFieldSet} and hands it to the insert pipeline. The message
+ * spells out the target {@link FreenetURI}, retry envelope, splitfile compatibility mode,
+ * compression hints, and persistence knobs expected by the storage layer so that both directory
+ * flavors remain interoperable.
  *
  * <p>All fields are populated during construction, and the type is effectively immutable afterward,
  * which lets callers hand references across worker threads without additional synchronization. The
@@ -109,9 +106,9 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
 
   /**
    * Signals whether cacheable blocks should be forked into independent inserts while obeying the
-   * node's {@link Node#FORK_ON_CACHEABLE_DEFAULT} policy. Callers read this flag to decide if a
-   * cache hit should spawn separate background persistence work or remain in-band with the parent
-   * request, allowing UI clients to trade extra bandwidth for faster convergence on popular data.
+   * node's default cache-forking policy. Callers read this flag to decide if a cache hit should
+   * spawn separate background persistence work or remain in-band with the parent request, allowing
+   * UI clients to trade extra bandwidth for faster convergence on popular data.
    */
   public final boolean forkOnCacheable;
 
@@ -247,7 +244,7 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
     if (fs.get("ForkOnCacheable") != null) {
       return fs.getBoolean("ForkOnCacheable", false);
     }
-    return Node.FORK_ON_CACHEABLE_DEFAULT;
+    return FcpInsertDefaults.FORK_ON_CACHEABLE_DEFAULT;
   }
 
   /**
@@ -378,19 +375,19 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
       throws MessageInvalidException {
     String priorityString = fs.get("PriorityClass");
     if (priorityString == null) {
-      return RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
+      return FcpPriorityClasses.IMMEDIATE_SPLITFILE;
     }
     try {
       short parsed = Short.parseShort(priorityString);
-      if (!RequestStarter.isValidPriorityClass(parsed))
+      if (!FcpPriorityClasses.isValid(parsed))
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_FIELD,
             "Invalid priority class "
                 + parsed
                 + " - range is "
-                + RequestStarter.PAUSED_PRIORITY_CLASS
+                + FcpPriorityClasses.PAUSED
                 + " to "
-                + RequestStarter.MAXIMUM_PRIORITY_CLASS,
+                + FcpPriorityClasses.MAXIMUM,
             identifier,
             global);
       return parsed;

--- a/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
@@ -10,8 +10,6 @@ import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.Node;
-import network.crypta.node.RequestStarter;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
@@ -161,7 +159,7 @@ public final class ClientPutMessage extends DataCarryingMessage {
     compressorDescriptor = parseCompressorDescriptor(fs.get("Codecs"), identifier, global);
     if (fs.get("ForkOnCacheable") != null)
       forkOnCacheable = fs.getBoolean("ForkOnCacheable", false);
-    else forkOnCacheable = Node.FORK_ON_CACHEABLE_DEFAULT;
+    else forkOnCacheable = FcpInsertDefaults.FORK_ON_CACHEABLE_DEFAULT;
     extraInsertsSingleBlock =
         fs.getInt("ExtraInsertsSingleBlock", HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK);
     extraInsertsSplitfileHeaderBlock =
@@ -272,19 +270,19 @@ public final class ClientPutMessage extends DataCarryingMessage {
   private static short parsePriorityClass(String priorityString, String identifier, boolean global)
       throws MessageInvalidException {
     if (priorityString == null) {
-      return RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS;
+      return FcpPriorityClasses.IMMEDIATE_SPLITFILE;
     }
     try {
       short parsed = Short.parseShort(priorityString);
-      if (!RequestStarter.isValidPriorityClass(parsed)) {
+      if (!FcpPriorityClasses.isValid(parsed)) {
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_FIELD,
             "Invalid priority class "
                 + parsed
                 + " - range is "
-                + RequestStarter.PAUSED_PRIORITY_CLASS
+                + FcpPriorityClasses.PAUSED
                 + " to "
-                + RequestStarter.MAXIMUM_PRIORITY_CLASS,
+                + FcpPriorityClasses.MAXIMUM,
             identifier,
             global);
       }
@@ -499,10 +497,9 @@ public final class ClientPutMessage extends DataCarryingMessage {
    * Initiates processing of this insert request by delegating to the connection handler.
    *
    * <p>The method is invoked on the handler thread after any payload bucket has been populated so
-   * that {@link DataCarryingMessage} invariants already hold. It forwards this instance, together
-   * with the owning {@link Node}, to {@link FCPConnectionHandler#startClientPut(ClientPutMessage)}
-   * so the handler can enforce quotas, schedule insert workers, or emit late validation errors to
-   * the client.
+   * that {@link DataCarryingMessage} invariants already hold. It forwards this instance to {@link
+   * FCPConnectionHandler#startClientPut(ClientPutMessage)} so the handler can enforce quotas,
+   * schedule insert workers, or emit late validation errors to the client.
    *
    * @param handler connection handler that accepted the message and coordinates streaming
    *     back-pressure

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -15,7 +15,6 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.node.PrioRunnable;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
-import network.crypta.node.RequestStarter;
 import network.crypta.support.io.NativeThread;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
@@ -525,10 +524,10 @@ public abstract class ClientRequest implements Serializable {
   /**
    * Returns the current priority class used for scheduling this request.
    *
-   * <p>Priority classes are defined by {@link RequestStarter} and influence how quickly the node
+   * <p>Priority classes follow the FCP-local protocol defaults and influence how quickly the node
    * allocates bandwidth and other resources compared to other queued requests.
    *
-   * @return priority class value in the range defined by {@link RequestStarter}
+   * @return priority class value in the range defined by {@link FcpPriorityClasses}
    */
   public short getPriority() {
     return priorityClass;
@@ -973,8 +972,7 @@ public abstract class ClientRequest implements Serializable {
     int verbosity = dis.readInt();
     long startupTime = dis.readLong();
     short priorityClass = dis.readShort();
-    if (priorityClass < RequestStarter.MAXIMUM_PRIORITY_CLASS
-        || priorityClass > RequestStarter.PAUSED_PRIORITY_CLASS)
+    if (!FcpPriorityClasses.isValid(priorityClass))
       throw new StorageFormatException("Bogus priority");
     String clientToken = dis.readBoolean() ? dis.readUTF() : null;
     boolean finished = dis.readBoolean();

--- a/src/main/java/network/crypta/clients/fcp/DisconnectMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/DisconnectMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -21,7 +20,7 @@ import network.crypta.support.SimpleFieldSet;
  *
  * <ul>
  *   <li>Preserves explicit shutdown semantics rather than relying on TCP FIN/RST heuristics.
- *   <li>Helps {@link Node} enforce connection quotas by guaranteeing {@code close()} is invoked.
+ *   <li>Helps the server enforce connection quotas by guaranteeing {@code close()} is invoked.
  * </ul>
  *
  * @author <a href="mailto:bombe@freenetproject.org">David ‘Bombe’ Roden</a>
@@ -85,9 +84,8 @@ public class DisconnectMessage extends FCPMessage {
    *
    * <p>Calling this method is idempotent with respect to protocol semantics: on the first
    * invocation the handler closes its socket, cancels queued state, and notifies observers, while
-   * later calls simply operate on an already-closed channel. The {@link Node} reference is supplied
-   * for parity with other messages yet remains unused, emphasizing that the logic lives entirely in
-   * the connection layer.
+   * later calls simply operate on an already-closed channel. The logic lives entirely in the
+   * connection layer.
    *
    * <pre>{@code
    * // Example: proactively terminate a misbehaving client

--- a/src/main/java/network/crypta/clients/fcp/ExpectedDataLength.java
+++ b/src/main/java/network/crypta/clients/fcp/ExpectedDataLength.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -8,8 +7,8 @@ import network.crypta.support.SimpleFieldSet;
  * implementation.
  *
  * <p>This lightweight message informs a connected client about the byte length that the node
- * anticipates for a specific identifier. It is typically sent while a download is still in progress
- * so that UI layers can prepare disk space, update progress meters, or judge whether the transfer
+ * expects for a specific identifier. It is typically sent while a download is still in progress so
+ * that UI layers can prepare disk space, update progress meters, or judge whether the transfer
  * should continue. Instances are immutable; the identifier, global flag, and data length captured
  * in the constructor remain fixed for the life of the object, allowing the message to be safely
  * shared across threads provided callers do not mutate the returned {@link SimpleFieldSet}.
@@ -34,14 +33,14 @@ public class ExpectedDataLength extends FCPMessage {
   /**
    * Creates a new immutable descriptor for a future payload length.
    *
-   * <p>The constructor simply stores the provided metadata without validation so callers are
+   * <p>The constructor simply stores the provided metadata without validation, so callers are
    * responsible for ensuring the identifier matches ongoing requests and that {@code dataLength}
    * reflects the best estimate currently available. Because the values are stored verbatim they can
    * represent either optimistic or pessimistic projections depending on the upstream calculation.
    *
    * @param identifier unique token provided by the client; must not be {@code null}.
    * @param global whether the message relates to a global request or a per-connection context.
-   * @param dataLength anticipated payload size in bytes as reported by upstream logic.
+   * @param dataLength expected payload size in bytes as reported by upstream logic.
    */
   ExpectedDataLength(String identifier, boolean global, long dataLength) {
     this.messageIdentifier = identifier;
@@ -91,7 +90,7 @@ public class ExpectedDataLength extends FCPMessage {
    * Execution hook for inbound command handling; this implementation performs no action.
    *
    * <p>The message type is informational-only, so the server-side handler intentionally abstains
-   * from altering connection state or interacting with the {@link Node}. Implementations that treat
+   * from altering the connection state or touching daemon internals. Implementations that treat
    * this message as a notification should intercept it earlier in the pipeline. Invoking this
    * method is safe and idempotent on any thread because the body contains no shared state access.
    *

--- a/src/main/java/network/crypta/clients/fcp/FcpInsertDefaults.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpInsertDefaults.java
@@ -1,0 +1,28 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Holds FCP-local default values for insert-related message parsing.
+ *
+ * <p>This helper keeps ordinary {@code clients.fcp} message classes from depending directly on
+ * daemon-owned types when they only need stable protocol defaults. The values defined here are
+ * intentionally duplicated from the daemon layer and verified by parity tests, so cleanup work can
+ * reduce compile-time coupling without altering runtime behavior. Callers treat this class as a
+ * read-only constants holder during request parsing, serialization, and validation.
+ *
+ * <p>The type is package-private because the constants are an internal detail of the FCP message
+ * package rather than a general daemon API. It has no mutable state, performs no I/O, and is safe
+ * for concurrent access from parser and handler threads.
+ */
+final class FcpInsertDefaults {
+  /**
+   * Default value used when an FCP insert request omits the {@code ForkOnCacheable} field.
+   *
+   * <p>A value of {@code true} preserves the daemon's current behavior for cacheable inserts while
+   * allowing message classes such as {@code ClientPutMessage} and {@code ClientPutDirMessage} to
+   * avoid a direct dependency on daemon-owned constants.
+   */
+  static final boolean FORK_ON_CACHEABLE_DEFAULT = true;
+
+  /** Prevents instantiation of this constants-only helper type. */
+  private FcpInsertDefaults() {}
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpPeerNoteTypes.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpPeerNoteTypes.java
@@ -1,0 +1,27 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Defines peer-note type identifiers used by FCP message parsing and response generation.
+ *
+ * <p>This package-private helper lets ordinary FCP message classes refer to stable peer-note type
+ * values without importing daemon-owned classes solely for numeric constants. The values are kept
+ * deliberately small and local to the package because they are part of the FCP wire contract rather
+ * than a broader runtime SPI. Parity tests pin these constants to the daemon's current values, so
+ * drift is caught during test runs instead of during protocol handling.
+ *
+ * <p>The class is immutable and stateless. Callers such as {@code ListPeerNotesMessage} and {@code
+ * ModifyPeerNote} use it only when validating requests or constructing outbound note messages.
+ */
+final class FcpPeerNoteTypes {
+  /**
+   * Numeric peer-note type used for a node operator's private darknet comment.
+   *
+   * <p>This is the only peer-note type currently consumed by the ordinary FCP peer-note messages in
+   * this package. It maps to the private comment text returned by {@code PeerNote} responses and
+   * accepted by note-modification requests.
+   */
+  static final int PRIVATE_DARKNET_COMMENT = 1;
+
+  /** Prevents instantiation of this constants-only helper type. */
+  private FcpPeerNoteTypes() {}
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpPriorityClasses.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpPriorityClasses.java
@@ -1,0 +1,75 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Defines the priority-class values used by ordinary FCP message and request classes.
+ *
+ * <p>The constants in this helper mirror the daemon-owned request-starter priorities that have
+ * historically been referenced directly from parser and message code. Keeping the values local to
+ * {@code clients.fcp} reduces compile-time coupling while preserving the existing wire-level
+ * behavior and scheduler semantics. A dedicated parity test verifies that the numeric values here
+ * stay aligned with the daemon layer, so this cleanup does not silently change default request
+ * ordering.
+ *
+ * <p>The class is package-private, immutable, and safe for concurrent use. It exists only to
+ * support FCP message parsing, defaulting, serialization, and validation in classes such as {@code
+ * ClientGetMessage}, {@code ClientPutMessage}, and {@code ModifyPersistentRequest}.
+ */
+final class FcpPriorityClasses {
+  /**
+   * Priority used for latency-sensitive splitfile work that should begin immediately.
+   *
+   * <p>FCP request parsers use this as the default for direct fetches and inserts where the legacy
+   * daemon behavior favored prompt processing over background batching.
+   */
+  static final short IMMEDIATE_SPLITFILE = 2;
+
+  /**
+   * Priority used for background fetch activity that should avoid competing with direct user work.
+   *
+   * <p>This value is typically chosen for requests such as {@code ReturnType=none}, where the
+   * caller wants the node to warm data in the background rather than stream it back immediately.
+   */
+  static final short PREFETCH = 5;
+
+  /**
+   * Priority used for bulk splitfile work that is expected to run behind interactive traffic.
+   *
+   * <p>Directory inserts and disk-oriented fetch flows commonly default to this value, so large
+   * background transfers do not take precedence over more urgent requests.
+   */
+  static final short BULK_SPLITFILE = 4;
+
+  /**
+   * Lowest numeric priority value accepted by the FCP layer.
+   *
+   * <p>Priority validation treats this constant as the inclusive lower bound when checking whether
+   * a parsed {@code PriorityClass} value can be handed to the scheduler.
+   */
+  static final short MAXIMUM = 0;
+
+  /**
+   * Highest numeric priority value accepted by the FCP layer.
+   *
+   * <p>Priority validation treats this constant as the inclusive upper bound. Values above this
+   * threshold are rejected during message parsing before any request is queued.
+   */
+  static final short PAUSED = 6;
+
+  /** Prevents instantiation of this constants-only helper type. */
+  private FcpPriorityClasses() {}
+
+  /**
+   * Determines whether a parsed FCP priority class lies within the accepted inclusive range.
+   *
+   * <p>This helper centralizes the boundary check used by multiple request and message parsers. It
+   * does not normalize or remap values; callers remain responsible for producing protocol errors
+   * when this method returns {@code false}.
+   *
+   * @param priorityClass priority value parsed from an inbound FCP field set
+   * @return {@code true} when {@code priorityClass} is between {@link #MAXIMUM} and {@link
+   *     #PAUSED}, inclusive; {@code false} otherwise
+   */
+  static boolean isValid(short priorityClass) {
+    return priorityClass >= MAXIMUM && priorityClass <= PAUSED;
+  }
+}

--- a/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -21,7 +21,6 @@ import network.crypta.client.async.PersistentJob;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.Base64;
 import network.crypta.support.api.Bucket;
@@ -624,7 +623,7 @@ final class FcpServerPersistentOps implements DownloadCache {
             spec.persistRebootOnly(),
             spec.identifier(),
             Integer.MAX_VALUE,
-            RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS,
+            FcpPriorityClasses.BULK_SPLITFILE,
             spec.returnFilename(),
             null,
             false,

--- a/src/main/java/network/crypta/clients/fcp/GetConfig.java
+++ b/src/main/java/network/crypta/clients/fcp/GetConfig.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import java.util.EnumSet;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.ConfigSection;
 import network.crypta.support.SimpleFieldSet;
 
@@ -105,8 +104,9 @@ public class GetConfig extends FCPMessage {
    * raising a {@link MessageInvalidException} describing the access denial. When authorized, it
    * requests the selected configuration sections from the runtime SPI and constructs a {@link
    * ConfigData} response from the returned snapshot. The response is streamed via the provided
-   * handler without mutating the {@link Node}. Invocations are single-shot per instance; repeated
-   * calls would resend identical configuration data until the connection closes.
+   * handler without mutating the live daemon configuration directly. Invocations are single-shot
+   * per instance; repeated calls would resend identical configuration data until the connection
+   * closes.
    *
    * @param handler connection context responsible for permission checks and outbound delivery; must
    *     not be {@code null} and must expose full access for the call to proceed.

--- a/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ListPeerNotesMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
@@ -123,7 +122,7 @@ public class ListPeerNotesMessage extends FCPMessage {
           new PeerNote(
               nodeIdentifier,
               noteText,
-              Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT,
+              FcpPeerNoteTypes.PRIVATE_DARKNET_COMMENT,
               requestIdentifier));
       handler.send(new EndListPeerNotesMessage(nodeIdentifier, requestIdentifier));
     } catch (UnknownPeerException _) {

--- a/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPeerNote.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.FSParseException;
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.UnknownPeerException;
@@ -159,7 +158,7 @@ public class ModifyPeerNote extends FCPMessage {
           e);
       return;
     }
-    if (peerNoteType != Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT) {
+    if (peerNoteType != FcpPeerNoteTypes.PRIVATE_DARKNET_COMMENT) {
       FCPMessage msg = new UnknownPeerNoteTypeMessage(peerNoteType, requestIdentifier);
       handler.send(msg);
       return;

--- a/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ModifyPersistentRequest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.RequestQueuePort;
 import network.crypta.runtime.spi.RequestQueuePriority;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -58,15 +57,15 @@ public final class ModifyPersistentRequest extends FCPMessage {
     if (prio != null) {
       try {
         priorityClass = Short.parseShort(prio);
-        if (!RequestStarter.isValidPriorityClass(priorityClass))
+        if (!FcpPriorityClasses.isValid(priorityClass))
           throw new MessageInvalidException(
               ProtocolErrorMessage.INVALID_FIELD,
               "Invalid priority class "
                   + priorityClass
                   + " - range is "
-                  + RequestStarter.PAUSED_PRIORITY_CLASS
+                  + FcpPriorityClasses.PAUSED
                   + " to "
-                  + RequestStarter.MAXIMUM_PRIORITY_CLASS,
+                  + FcpPriorityClasses.MAXIMUM,
               requestIdentifier,
               global);
       } catch (NumberFormatException e) {

--- a/src/main/java/network/crypta/clients/fcp/RemovePeer.java
+++ b/src/main/java/network/crypta/clients/fcp/RemovePeer.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.runtime.spi.RemovedPeerSnapshot;
 import network.crypta.runtime.spi.UnknownPeerException;
 import network.crypta.support.SimpleFieldSet;
@@ -29,7 +28,6 @@ import network.crypta.support.SimpleFieldSet;
  *
  * @see PeerRemoved
  * @see UnknownNodeIdentifierMessage
- * @see Node
  */
 public class RemovePeer extends FCPMessage {
 

--- a/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/ShutdownMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -14,11 +13,11 @@ import network.crypta.support.SimpleFieldSet;
  * partially trusted connections cannot terminate the process unexpectedly.
  *
  * <p>Shutdown proceeds synchronously within the handler call: after an acknowledgment error message
- * is queued to the client, the node exits its process via {@link Node#exit(String)}. The class is
- * immutable and thread-safe; instances are stateless and may be reused across requests, though the
- * surrounding protocol usually allocates a fresh instance per inbound frame. Use this type when you
- * need a minimal, declarative way to signal server termination over FCP rather than invoking
- * out-of-band administration hooks.
+ * is queued to the client, the server requests node termination through the message runtime
+ * support. The class is immutable and thread-safe; instances are stateless and may be reused across
+ * requests, though the surrounding protocol usually allocates a fresh instance per inbound frame.
+ * Use this type when you need a minimal, declarative way to signal server termination over FCP
+ * rather than invoking out-of-band administration hooks.
  *
  * <ul>
  *   <li>Responsibilities: identify the shutdown intent and delegate execution to the node.
@@ -82,9 +81,9 @@ public class ShutdownMessage extends FCPMessage {
    * <p>The handler must expose full-access privileges; otherwise the method rejects the request
    * with a {@link MessageInvalidException}. On acceptance, it first sends a {@link
    * ProtocolErrorMessage#SHUTTING_DOWN} response so the client can distinguish deliberate shutdown
-   * from transport failures, and then calls {@link Node#exit(String)} to terminate the process. The
+   * from transport failures, and then asks the message runtime support to terminate the node. The
    * call is synchronous and does not retry; callers should therefore ensure idempotency upstream
-   * because repeated invocations will request exit repeatedly once authorization passes.
+   * because repeated invocations will request shutdown repeatedly once authorization passes.
    *
    * @param handler connection handler that issued the request; must provide full-access rights or
    *     the call fails with an exception

--- a/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.net.MalformedURLException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
-import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -82,7 +81,7 @@ public final class SubscribeUSKMessage extends FCPMessage {
     this.dontPoll = fs.getBoolean("DontPoll", false);
     if (!dontPoll) this.sparsePoll = fs.getBoolean("SparsePoll", false);
     else sparsePoll = false;
-    prio = fs.getShort("PriorityClass", RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS);
+    prio = fs.getShort("PriorityClass", FcpPriorityClasses.BULK_SPLITFILE);
     prioProgress = fs.getShort("PriorityClassProgress", (short) Math.max(0, prio - 1));
     realTimeFlag = fs.getBoolean("RealTimeFlag", false);
     ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -32,7 +31,7 @@ import network.crypta.support.SimpleFieldSet;
 public class SubscribedUSKMessage extends FCPMessage {
 
   /**
-   * Canonical FCP identifier used on the wire for this message type so routers and handlers can
+   * Canonical FCP identifier used on the wire for this message type, so routers and handlers can
    * recognize acknowledgement payloads.
    */
   public static final String NAME = "SubscribedUSK";
@@ -66,7 +65,7 @@ public class SubscribedUSKMessage extends FCPMessage {
    * <p>The resulting {@link SimpleFieldSet} always includes the original {@code Identifier}, the
    * canonical {@code URI} derived from {@link SubscribeUSKMessage#key}, and the {@code DontPoll}
    * boolean that instructs the node to avoid proactive polling. Each invocation returns a fresh
-   * field set, ensuring callers can adjust or discard the structure without affecting subsequent
+   * field set, ensuring callers can adjust or discard the structure without affecting further
    * messages. The method does not perform null checks because the constructor already expects a
    * fully parsed request.
    *
@@ -108,7 +107,7 @@ public class SubscribedUSKMessage extends FCPMessage {
    * toward the node. Because the message is designed to flow only from server to client, the method
    * immediately throws {@link MessageInvalidException} with a descriptive explanation so callers
    * can surface the misuse to their users. The behavior is intentionally non-recoverable and does
-   * not mutate either the {@link FCPConnectionHandler} or the {@link Node} instance.
+   * not mutate the {@link FCPConnectionHandler}.
    *
    * @param handler active FCP connection context that attempted to process the message; not
    *     modified by this method.

--- a/src/main/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/SubscribedUSKRoundFinishedMessage.java
@@ -1,19 +1,18 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
  * Notifies an FCP client that a subscribed USK polling round has completed for a given subscription
  * identifier.
  *
- * <p>This message is emitted by the node after it has finished probing the requested update
- * sequence key (USK) for newer editions. Clients typically subscribe using the higher-level USK
- * subscription commands and receive this message to learn that the current polling interval has
- * reached its natural end, regardless of whether fresh data was discovered. The message is
- * intentionally lightweight: it only echoes the identifier provided at subscription time so the
- * client can correlate the lifecycle of concurrent subscriptions without holding additional state
- * inside the protocol layer.
+ * <p>The node emits this message after it has finished probing the requested update sequence key
+ * (USK) for newer editions. Clients typically subscribe using the higher-level USK subscription
+ * commands and receive this message to learn that the current polling interval has reached its
+ * natural end, regardless of whether fresh data was discovered. The message is intentionally
+ * lightweight: it only echoes the identifier provided at subscription time so the client can
+ * correlate the lifecycle of concurrent subscriptions without holding additional state inside the
+ * protocol layer.
  *
  * <p>Responsibilities and notable behaviors:
  *
@@ -87,8 +86,8 @@ public class SubscribedUSKRoundFinishedMessage extends FCPMessage {
    * <p>The FCP framework still requires a {@code run} implementation for completeness, so the
    * method remains to satisfy the contract but signals misuse via an {@link
    * UnsupportedOperationException} at runtime. Implementations that invoke this method should treat
-   * such calls as programming errors or protocol violations. No state is modified and no
-   * interaction with {@link Node} occurs before the exception is thrown.
+   * such calls as programming errors or protocol violations. No state is modified before the
+   * exception is thrown.
    *
    * @param handler connection handler associated with the subscription; never used because the
    *     method aborts immediately.

--- a/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
+++ b/src/main/java/network/crypta/clients/fcp/TestDdaRequestMessage.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.Node;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -72,9 +71,9 @@ public final class TestDdaRequestMessage extends FCPMessage {
    * handler does not receive nonsensical work items.
    *
    * @param fs field set containing Directory, WantReadDirectory, and WantWriteDirectory entries
-   *     from client.
-   * @throws MessageInvalidException If required directory is missing, empty, or both access flags
-   *     false.
+   *     from the client.
+   * @throws MessageInvalidException If the required directory is missing, empty, or both, access
+   *     flags false.
    */
   public TestDdaRequestMessage(SimpleFieldSet fs) throws MessageInvalidException {
     requestedDirectory = fs.get(DIRECTORY);
@@ -123,8 +122,9 @@ public final class TestDdaRequestMessage extends FCPMessage {
    * handlers.
    *
    * <p>The value is constant for every instance and matches {@link #NAME}, allowing dispatchers or
-   * tests to compare names without constructing additional field sets. The method is side effect
-   * free and threads can call it repeatedly without synchronization because the value is immutable.
+   * tests to compare names without constructing additional field sets. The method is
+   * side-effect-free, and threads can call it repeatedly without synchronization because the value
+   * is immutable.
    *
    * @return Message name constant identifying a TestDDARequest on the wire protocol.
    */
@@ -138,15 +138,14 @@ public final class TestDdaRequestMessage extends FCPMessage {
    *
    * <p>The method delegates to {@link FCPConnectionHandler#enqueueDDACheck(String, boolean,
    * boolean)} to perform path validation and spawn a {@link DdaCheckJob}. It then wraps the job in
-   * a {@link TestDdaReplyMessage} and sends it back over the same connection. The {@link Node}
-   * argument is accepted for interface compatibility but is not used directly. Callers should pass
-   * a handler that can manage filesystem permissions; this method does not retry and will propagate
+   * a {@link TestDdaReplyMessage} and sends it back over the same connection. Callers should pass a
+   * handler that can manage filesystem permissions; this method does not retry and will propagate
    * validation errors as {@link MessageInvalidException}.
    *
    * @param handler connection-scoped handler responsible for scheduling DDA checks and sending
    *     replies synchronously.
-   * @throws MessageInvalidException if handler rejects the directory or if validation fails during
-   *     enqueueing.
+   * @throws MessageInvalidException if the handler rejects the directory or if validation fails
+   *     during enqueueing.
    */
   @Override
   public void run(FCPConnectionHandler handler) throws MessageInvalidException {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetMessageTest.java
@@ -127,6 +127,59 @@ class ClientGetMessageTest {
   }
 
   @Test
+  void constructor_whenPriorityClassMissingAndReturnTypeDirect_usesImmediateSplitfilePriority()
+      throws MessageInvalidException {
+    ClientGetMessage message = new ClientGetMessage(baseFieldSet());
+
+    assertEquals(FcpPriorityClasses.IMMEDIATE_SPLITFILE, message.priorityClass);
+  }
+
+  @Test
+  void constructor_whenPriorityClassMissingAndReturnTypeNone_usesPrefetchPriority()
+      throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putOverwrite("ReturnType", ReturnType.NONE.name());
+
+    ClientGetMessage message = new ClientGetMessage(fs);
+
+    assertEquals(FcpPriorityClasses.PREFETCH, message.priorityClass);
+  }
+
+  @Test
+  void constructor_whenPriorityClassMissingAndReturnTypeDisk_usesBulkSplitfilePriority(
+      @TempDir Path tempDir) throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putOverwrite("ReturnType", ReturnType.DISK.name());
+    fs.putSingle("Filename", tempDir.resolve("download.bin").toString());
+
+    ClientGetMessage message = new ClientGetMessage(fs);
+
+    assertEquals(FcpPriorityClasses.BULK_SPLITFILE, message.priorityClass);
+  }
+
+  @Test
+  void constructor_whenPriorityClassOutOfRange_throwsInvalidField() {
+    short invalidPriorityClass = (short) (FcpPriorityClasses.PAUSED + 1);
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("PriorityClass", Short.toString(invalidPriorityClass));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientGetMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Invalid priority class "
+                    + invalidPriorityClass
+                    + " - range is "
+                    + FcpPriorityClasses.PAUSED
+                    + " to "
+                    + FcpPriorityClasses.MAXIMUM));
+  }
+
+  @Test
   void getFieldSet_whenCalled_containsCoreValues() throws MessageInvalidException {
     ClientGetMessage message = new ClientGetMessage(baseFieldSet());
 

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
@@ -78,6 +78,36 @@ class ClientPutDiskDirMessageTest {
   }
 
   @Test
+  void constructor_whenPriorityClassMissing_usesInsertDefaults() throws MessageInvalidException {
+    ClientPutDiskDirMessage message = newMessage(tempDir);
+
+    assertEquals(FcpPriorityClasses.IMMEDIATE_SPLITFILE, message.priorityClass);
+    assertEquals(FcpInsertDefaults.FORK_ON_CACHEABLE_DEFAULT, message.forkOnCacheable);
+  }
+
+  @Test
+  void constructor_whenPriorityClassOutOfRange_expectInvalidField() {
+    short invalidPriorityClass = (short) (FcpPriorityClasses.PAUSED + 1);
+    SimpleFieldSet fs = baseFieldSet();
+    fs.putSingle("Filename", tempDir.toAbsolutePath().toString());
+    fs.putSingle("PriorityClass", Short.toString(invalidPriorityClass));
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> new ClientPutDiskDirMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, ex.protocolCode);
+    assertTrue(
+        ex.getMessage()
+            .contains(
+                "Invalid priority class "
+                    + invalidPriorityClass
+                    + " - range is "
+                    + FcpPriorityClasses.PAUSED
+                    + " to "
+                    + FcpPriorityClasses.MAXIMUM));
+  }
+
+  @Test
   void run_whenUploadNotAllowed_expectAccessDenied() throws Exception {
     when(transferAccess.allowUploadFrom(any())).thenReturn(false);
     ClientPutDiskDirMessage message = newMessage(tempDir);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutMessageTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -103,8 +102,7 @@ class ClientPutMessageTest {
     assertEquals(10L, serialized.getLong("DataLength", -1));
     assertTrue(serialized.getBoolean("GetCHKOnly", false));
     assertEquals(
-        RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS,
-        serialized.getShort("PriorityClass", (short) -1));
+        FcpPriorityClasses.IMMEDIATE_SPLITFILE, serialized.getShort("PriorityClass", (short) -1));
     assertEquals("connection", serialized.get("Persistence"));
     assertTrue(serialized.getBoolean("DontCompress", false));
     assertEquals("GZIP", serialized.get("Codecs"));
@@ -190,6 +188,50 @@ class ClientPutMessageTest {
     ClientPutMessage message = newDirectMessage("put-length", 99L);
 
     assertEquals(99L, message.dataLength());
+  }
+
+  @Test
+  void constructor_whenForkOnCacheableMissing_usesInsertDefault() throws MessageInvalidException {
+    ClientPutMessage message = newDirectMessage("put-fork-default", 12L);
+
+    assertEquals(FcpInsertDefaults.FORK_ON_CACHEABLE_DEFAULT, message.forkOnCacheable);
+  }
+
+  @Test
+  void constructor_whenForkOnCacheableProvided_usesExplicitValue() throws MessageInvalidException {
+    SimpleFieldSet fs = baseFieldSet("put-fork-explicit");
+    fs.putSingle("UploadFrom", "direct");
+    fs.put("DataLength", 12L);
+    fs.put("ForkOnCacheable", false);
+
+    ClientPutMessage message = new ClientPutMessage(fs);
+
+    assertFalse(message.forkOnCacheable);
+  }
+
+  @Test
+  void constructor_whenPriorityClassOutOfRange_throwsInvalidField() {
+    short invalidPriorityClass = (short) (FcpPriorityClasses.PAUSED + 1);
+    SimpleFieldSet fs = baseFieldSet("put-invalid-priority");
+    fs.putSingle("UploadFrom", "direct");
+    fs.put("DataLength", 5L);
+    fs.putSingle("PriorityClass", Short.toString(invalidPriorityClass));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> new ClientPutMessage(fs));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals("put-invalid-priority", exception.ident);
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "Invalid priority class "
+                    + invalidPriorityClass
+                    + " - range is "
+                    + FcpPriorityClasses.PAUSED
+                    + " to "
+                    + FcpPriorityClasses.MAXIMUM));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FcpProtocolDefaultsParityTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpProtocolDefaultsParityTest.java
@@ -1,0 +1,61 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.node.Node;
+import network.crypta.node.RequestStarter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class FcpProtocolDefaultsParityTest {
+
+  @Test
+  void priorityConstants_whenComparedToRequestStarter_matchDaemonValues() {
+    assertEquals(
+        RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, FcpPriorityClasses.IMMEDIATE_SPLITFILE);
+    assertEquals(RequestStarter.PREFETCH_PRIORITY_CLASS, FcpPriorityClasses.PREFETCH);
+    assertEquals(RequestStarter.BULK_SPLITFILE_PRIORITY_CLASS, FcpPriorityClasses.BULK_SPLITFILE);
+    assertEquals(RequestStarter.MAXIMUM_PRIORITY_CLASS, FcpPriorityClasses.MAXIMUM);
+    assertEquals(RequestStarter.PAUSED_PRIORITY_CLASS, FcpPriorityClasses.PAUSED);
+  }
+
+  @Test
+  void insertDefaults_whenComparedToNode_matchDaemonValues() {
+    assertEquals(Node.FORK_ON_CACHEABLE_DEFAULT, FcpInsertDefaults.FORK_ON_CACHEABLE_DEFAULT);
+  }
+
+  @Test
+  void peerNoteTypes_whenComparedToNode_matchDaemonValues() {
+    assertEquals(
+        Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, FcpPeerNoteTypes.PRIVATE_DARKNET_COMMENT);
+  }
+
+  @Test
+  void isValid_whenCheckingBoundaryValues_matchesRequestStarterBehavior() {
+    short belowMinimum = (short) (FcpPriorityClasses.MAXIMUM - 1);
+    short aboveMaximum = (short) (FcpPriorityClasses.PAUSED + 1);
+    short inRange = FcpPriorityClasses.IMMEDIATE_SPLITFILE;
+
+    assertFalse(FcpPriorityClasses.isValid(belowMinimum));
+    assertTrue(FcpPriorityClasses.isValid(FcpPriorityClasses.MAXIMUM));
+    assertTrue(FcpPriorityClasses.isValid(inRange));
+    assertTrue(FcpPriorityClasses.isValid(FcpPriorityClasses.PAUSED));
+    assertFalse(FcpPriorityClasses.isValid(aboveMaximum));
+
+    assertEquals(
+        RequestStarter.isValidPriorityClass(belowMinimum),
+        FcpPriorityClasses.isValid(belowMinimum));
+    assertEquals(
+        RequestStarter.isValidPriorityClass(FcpPriorityClasses.MAXIMUM),
+        FcpPriorityClasses.isValid(FcpPriorityClasses.MAXIMUM));
+    assertEquals(RequestStarter.isValidPriorityClass(inRange), FcpPriorityClasses.isValid(inRange));
+    assertEquals(
+        RequestStarter.isValidPriorityClass(FcpPriorityClasses.PAUSED),
+        FcpPriorityClasses.isValid(FcpPriorityClasses.PAUSED));
+    assertEquals(
+        RequestStarter.isValidPriorityClass(aboveMaximum),
+        FcpPriorityClasses.isValid(aboveMaximum));
+  }
+}


### PR DESCRIPTION
## Summary
- add FCP-local helper classes for residual priority, insert-default, and peer-note protocol constants in `network.crypta.clients.fcp`
- replace the remaining direct `Node` and `RequestStarter` usages in ordinary FCP message/request classes, including parity coverage and focused unit-test coverage for the new local default paths
- refresh `README.md` and the `cryptad-architecture` / `cryptad-core-updater` skills to match the runtime-seam and runtime-spi changes that landed after `0fc31339`

## How to test
- `./gradlew test --tests '*ClientGetMessageTest' --tests '*ClientPutMessageTest' --tests '*ClientPutDiskDirMessageTest'`
- `./gradlew test`
- `./gradlew compileJava`

## Commit history
- `refactor(fcp): Remove residual daemon constant coupling`
- `docs(repo): Refresh runtime seam architecture notes`