### PR TITLE
fix(core): Centralize low-level helper APIs

### DIFF
--- a/src/main/java/network/crypta/clients/http/TranslationToadlet.java
+++ b/src/main/java/network/crypta/clients/http/TranslationToadlet.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.l10n.TranslationPaths;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet.KeyIterator;
@@ -49,7 +50,7 @@ public class TranslationToadlet extends Toadlet {
    * emitting navigation, links back to the translation UI. The trailing slash is intentional to
    * align with other in-UI links that append query parameters directly without adding a separator.
    */
-  public static final String TOADLET_URL = "/translation/";
+  public static final String TOADLET_URL = TranslationPaths.TOADLET_URL;
 
   private static final String PARAM_TO_TRANSLATE_ONLY = "toTranslateOnly";
   private static final String PARAM_GET_OVERRIDE_FILE = "getOverrideTranslationFile";

--- a/src/main/java/network/crypta/config/ConfigExitCodes.java
+++ b/src/main/java/network/crypta/config/ConfigExitCodes.java
@@ -1,0 +1,25 @@
+package network.crypta.config;
+
+/**
+ * Defines process exit codes that originate in configuration and wrapper handling.
+ *
+ * <p>This class gives low-level configuration code a stable place to reference shared numeric exit
+ * statuses without depending on broader startup exception types. Keep constants here when the same
+ * exit status must be reused by wrapper editing, config persistence, or other early-boot paths that
+ * may run before the full node stack is available.
+ *
+ * <p>The values are process-level contracts rather than user-facing settings. Callers should treat
+ * them as stable identifiers that may be surfaced by launch scripts, service managers, or wrapper
+ * tooling when startup fails before the daemon becomes operational.
+ *
+ * @see network.crypta.node.NodeInitException
+ */
+public final class ConfigExitCodes {
+  /**
+   * Exit status used when generated or edited {@code wrapper.conf} is invalid and startup cannot
+   * safely continue with that file in place.
+   */
+  public static final int BROKE_WRAPPER_CONF = 28;
+
+  private ConfigExitCodes() {}
+}

--- a/src/main/java/network/crypta/config/FilePersistentConfig.java
+++ b/src/main/java/network/crypta/config/FilePersistentConfig.java
@@ -8,7 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.AtomicFileMoves;
 import network.crypta.support.io.LineReadingInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -239,7 +239,7 @@ public class FilePersistentConfig extends PersistentConfig {
    *
    * <p>Callers must hold {@link #storeSync}. The method serializes the export from {@link
    * #exportFieldSet()} to {@link #tempFilename} (including {@link #header} when provided), then
-   * moves it over {@link #filename} via {@link FileUtil#moveTo(File, File)}.
+   * moves it over {@link #filename} via {@link AtomicFileMoves#moveTo(File, File)}.
    *
    * @throws IOException if writing or moving the file fails
    */
@@ -254,7 +254,7 @@ public class FilePersistentConfig extends PersistentConfig {
         fs.writeToBigBuffer(fos);
       }
     }
-    FileUtil.moveTo(tempFilename, filename);
+    AtomicFileMoves.moveTo(tempFilename, filename);
   }
 
   /** Completes initialization and performs any deferred store. */

--- a/src/main/java/network/crypta/config/WrapperConfig.java
+++ b/src/main/java/network/crypta/config/WrapperConfig.java
@@ -11,8 +11,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import network.crypta.node.NodeInitException;
-import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -58,7 +56,8 @@ public class WrapperConfig {
       LOG.info("Cannot alter properties: wrapper.conf not writable");
       return false;
     }
-    if (!FileUtil.getCanonicalFile(f).getParentFile().canWrite()) {
+    File parent = canonicalOrAbsolute(f).getParentFile();
+    if (parent == null || !parent.canWrite()) {
       LOG.info("Cannot alter properties: parent dir not writable");
       return false; // Can we create a file to rename over wrapper.conf?
     }
@@ -198,9 +197,17 @@ public class WrapperConfig {
                 + " boot until you get a new wrapper.conf!\n"
                 + "The old config file is saved in {} and it should be renamed to wrapper.conf",
             oldOldConfig);
-        System.exit(NodeInitException.EXIT_BROKE_WRAPPER_CONF);
+        System.exit(ConfigExitCodes.BROKE_WRAPPER_CONF);
       }
     }
     return true;
+  }
+
+  private static File canonicalOrAbsolute(File file) {
+    try {
+      return file.getAbsoluteFile().getCanonicalFile();
+    } catch (IOException _) {
+      return file.getAbsoluteFile();
+    }
   }
 }

--- a/src/main/java/network/crypta/l10n/BaseL10n.java
+++ b/src/main/java/network/crypta/l10n/BaseL10n.java
@@ -14,10 +14,9 @@ import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
-import network.crypta.clients.http.TranslationToadlet;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.AtomicFileMoves;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -579,7 +578,7 @@ public final class BaseL10n {
         this.translationOverride.writeToBigBuffer(fos);
       }
 
-      FileUtil.moveTo(tempFile, finalFile);
+      AtomicFileMoves.moveTo(tempFile, finalFile);
       LOG.info("Override file saved successfully!");
     } catch (IOException e) {
       LOG.error("Error while saving the translation override: {}", e.getMessage(), e);
@@ -690,7 +689,7 @@ public final class BaseL10n {
    *
    * @param key Key to search for.
    * @return Text node with the resolved value; if the key is missing, returns a node prompting
-   *     translation with a link to {@link TranslationToadlet}.
+   *     translation with a link to {@link TranslationPaths#TOADLET_URL}.
    */
   public HTMLNode getHTMLNode(String key) {
     return getHTMLNode(key, null, null);
@@ -715,7 +714,7 @@ public final class BaseL10n {
     if (patterns != null) translationField.addChild("#", getDefaultString(key, patterns, values));
     else translationField.addChild("#", getDefaultString(key));
     translationField
-        .addChild("a", "href", TranslationToadlet.TOADLET_URL + "?translate=" + key)
+        .addChild("a", "href", TranslationPaths.TOADLET_URL + "?translate=" + key)
         .addChild("small", " (translate it in your native language!)");
 
     return translationField;

--- a/src/main/java/network/crypta/l10n/TranslationPaths.java
+++ b/src/main/java/network/crypta/l10n/TranslationPaths.java
@@ -1,0 +1,25 @@
+package network.crypta.l10n;
+
+/**
+ * Centralizes canonical translation-related UI paths shared across the localization stack.
+ *
+ * <p>Use this class when code outside the HTTP toadlet needs to build links, placeholders, or
+ * diagnostics that point at the translation interface. Keeping the path in one location avoids
+ * duplicating string literals between HTTP handlers, localization helpers, and tests, which helps
+ * preserve link stability when the UI route changes.
+ *
+ * <p>The constants are intentionally narrow in scope: this is a route catalog, not a registry of
+ * translation behavior or permissions. Callers still perform their own access checks and
+ * query-parameter validation.
+ *
+ * @see network.crypta.clients.http.TranslationToadlet
+ */
+public final class TranslationPaths {
+  /**
+   * Canonical route for the translation toadlet, including the trailing slash expected by callers
+   * that append query parameters directly.
+   */
+  public static final String TOADLET_URL = "/translation/";
+
+  private TranslationPaths() {}
+}

--- a/src/main/java/network/crypta/node/NodeInitException.java
+++ b/src/main/java/network/crypta/node/NodeInitException.java
@@ -1,11 +1,12 @@
 package network.crypta.node;
 
 import java.io.Serial;
+import network.crypta.config.ConfigExitCodes;
 
 /**
  * Reports an early node startup failure with an associated process exit code.
  *
- * <p>Throw this exception when initialization cannot proceed and the launcher or wrapper should
+ * <p>Throw this exception when initialization cannot proceed, and the launcher or wrapper should
  * terminate the JVM with a deterministic exit status. Use one of the {@code EXIT_*} constants to
  * classify the failure. The chosen code is also exposed via {@link #exitCode} for programmatic
  * handling. Instances are immutable and thread-safe.
@@ -26,12 +27,14 @@ public class NodeInitException extends Exception {
   public static final int EXIT_COULD_NOT_START_UPDATER = 21;
 
   /** TMCI (text-mode control interface) fails to start. */
+  @SuppressWarnings("unused")
   public static final int EXIT_COULD_NOT_START_TMCI = 19;
 
   /** FProxy HTTP service fails to start. */
   public static final int EXIT_COULD_NOT_START_FPROXY = 18;
 
   /** FCP (client protocol) service fails to start. */
+  @SuppressWarnings("unused")
   public static final int EXIT_COULD_NOT_START_FCP = 17;
 
   /** Node directory is invalid, inaccessible, or not writable. */
@@ -49,14 +52,14 @@ public class NodeInitException extends Exception {
   /** Binding the USM port fails (already in use or permissions). */
   public static final int EXIT_COULD_NOT_BIND_USM = 9;
 
-  /** Other store-related initialization error not covered by specific codes. */
+  /** Other store-related initialization error which is not covered by specific codes. */
   public static final int EXIT_STORE_OTHER = 3;
 
   /** Upper bound for node-specific exit codes (not itself an exit value). */
   public static final int EXIT_NODE_UPPER_LIMIT = 1024;
 
   /** Generated or edited {@code wrapper.conf} is invalid. */
-  public static final int EXIT_BROKE_WRAPPER_CONF = 28;
+  public static final int EXIT_BROKE_WRAPPER_CONF = ConfigExitCodes.BROKE_WRAPPER_CONF;
 
   /** Creation or update of {@code master.keys} fails (e.g., I/O error). */
   public static final int EXIT_CANT_WRITE_MASTER_KEYS = 30;

--- a/src/main/java/network/crypta/support/io/AtomicFileMoves.java
+++ b/src/main/java/network/crypta/support/io/AtomicFileMoves.java
@@ -1,0 +1,177 @@
+package network.crypta.support.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Performs best-effort file replacement with an atomic-first strategy for low-level persistence
+ * code.
+ *
+ * <p>Use this helper when code needs to publish a fully written temporary file over an existing
+ * target without pulling in broader daemon utilities. The class first asks the filesystem for an
+ * atomic move, then falls back to a bounded replace-existing retry loop. That behavior matches the
+ * needs of config and localization persistence, where callers prefer a complete replacement over
+ * partial in-place writes but must still cope with platforms that do not support atomic rename.
+ *
+ * <p>This helper is stateless and thread-safe. It does not fsync, coordinate locking between
+ * processes, or guarantee recovery after all retries fail. Callers remain responsible for creating
+ * the temporary file, choosing an appropriate directory, and reacting to a {@code false} result.
+ *
+ * <ul>
+ *   <li>Prefers atomic replacement when the platform supports it.
+ *   <li>Falls back to replace-existing moves with bounded backoff.
+ *   <li>Preserves interruption if retry sleep is cut short.
+ * </ul>
+ *
+ * @see network.crypta.config.FilePersistentConfig
+ * @see network.crypta.l10n.BaseL10n
+ */
+public final class AtomicFileMoves {
+  private static final Logger LOG = LoggerFactory.getLogger(AtomicFileMoves.class);
+
+  private static final int REPLACE_MOVE_MAX_ATTEMPTS = 5;
+  private static final long REPLACE_MOVE_BASE_BACKOFF_MILLIS = 50;
+  private static final long REPLACE_MOVE_MAX_BACKOFF_MILLIS = 400;
+
+  private AtomicFileMoves() {}
+
+  /**
+   * Moves a file to a destination path while allowing replacement of an existing target.
+   *
+   * <p>This convenience overload delegates to {@link #moveTo(File, File, boolean)} with {@code
+   * overwrite} enabled. It fits the common Cryptad pattern of writing a fresh temporary file and
+   * then publishing it over the previous config or override file in one step. The method returns
+   * {@code false} when both the atomic move and every retrying fallback path fail.
+   *
+   * @param orig file that already contains the complete replacement contents
+   * @param dest destination path that should receive the replacement file
+   * @return {@code true} when the move succeeds; {@code false} when all supported strategies fail
+   */
+  public static boolean moveTo(File orig, File dest) {
+    return moveTo(orig, dest, true);
+  }
+
+  /**
+   * Moves a file to a destination path, optionally refusing to replace an existing target.
+   *
+   * <p>The method first attempts an atomic move so readers either observe the old file or the new
+   * file, never an in-place partial write. When the platform rejects that operation, the code falls
+   * back to replace-existing moves with bounded retries and exponential backoff. If {@code
+   * overwrite} is {@code false} and the destination already exists, the method returns {@code
+   * false} immediately without touching either path.
+   *
+   * @param orig file that should be moved or renamed into place
+   * @param dest destination path that should receive {@code orig}
+   * @param overwrite whether an existing destination may be replaced in place
+   * @return {@code true} if the move succeeds; {@code false} if replacement is disallowed or the
+   *     move still fails after the fallback strategy is exhausted
+   */
+  public static boolean moveTo(File orig, File dest, boolean overwrite) {
+    if (!overwrite && dest.exists()) {
+      return false;
+    }
+    Path source = orig.toPath();
+    Path target = dest.toPath();
+    if (tryAtomicMove(source, target, orig, dest)) {
+      return true;
+    }
+    return moveWithReplaceRetries(source, target, orig, dest);
+  }
+
+  private static boolean tryAtomicMove(Path source, Path target, File orig, File dest) {
+    try {
+      Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+      return true;
+    } catch (AtomicMoveNotSupportedException | FileAlreadyExistsException e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Atomic move unavailable for {} -> {}: {}", orig, dest, e.toString());
+      }
+    } catch (IOException e) {
+      if (LOG.isWarnEnabled()) {
+        LOG.warn(
+            "Atomic move failed for {} -> {}, retrying non-atomically: {}",
+            orig,
+            dest,
+            e.toString());
+      }
+    }
+    return false;
+  }
+
+  private static boolean moveWithReplaceRetries(Path source, Path target, File orig, File dest) {
+    IOException lastFailure = null;
+    for (int attempt = 1; attempt <= REPLACE_MOVE_MAX_ATTEMPTS; attempt++) {
+      try {
+        Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        return true;
+      } catch (IOException e) {
+        lastFailure = e;
+        if (attempt == 1) {
+          LOG.warn(
+              "Replace-existing move failed for {} -> {} (attempt {}/{}), retrying: {}",
+              orig,
+              dest,
+              attempt,
+              REPLACE_MOVE_MAX_ATTEMPTS,
+              e.toString());
+        } else if (attempt < REPLACE_MOVE_MAX_ATTEMPTS && LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Replace-existing move retry failed for {} -> {} (attempt {}/{}): {}",
+              orig,
+              dest,
+              attempt,
+              REPLACE_MOVE_MAX_ATTEMPTS,
+              e.toString());
+        }
+        if (attempt == REPLACE_MOVE_MAX_ATTEMPTS) {
+          break;
+        }
+        if (!sleepBeforeReplaceMoveRetry(orig, dest, attempt)) {
+          return false;
+        }
+      }
+    }
+    LOG.error(
+        "Replace-existing move failed for {} -> {} after {} attempts: {}",
+        orig,
+        dest,
+        REPLACE_MOVE_MAX_ATTEMPTS,
+        lastFailure,
+        lastFailure);
+    return false;
+  }
+
+  private static boolean sleepBeforeReplaceMoveRetry(File orig, File dest, int attempt) {
+    long backoffMillis = retryBackoffMillis(attempt);
+    try {
+      Thread.sleep(backoffMillis);
+      return true;
+    } catch (InterruptedException interrupted) {
+      Thread.currentThread().interrupt();
+      LOG.error(
+          "Interrupted while retrying replace-existing move for {} -> {} (attempt {}/{}).",
+          orig,
+          dest,
+          attempt,
+          REPLACE_MOVE_MAX_ATTEMPTS,
+          interrupted);
+      return false;
+    }
+  }
+
+  private static long retryBackoffMillis(int failedAttempt) {
+    long backoff = REPLACE_MOVE_BASE_BACKOFF_MILLIS;
+    int shifts = failedAttempt - 1;
+    if (shifts > 0) {
+      backoff <<= Math.min(shifts, 30);
+    }
+    return Math.min(backoff, REPLACE_MOVE_MAX_BACKOFF_MILLIS);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/TranslationToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/TranslationToadletTest.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.l10n.TranslationPaths;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
@@ -66,6 +67,12 @@ class TranslationToadletTest {
   @Test
   void path_returnsTranslationUrl() {
     assertEquals(TranslationToadlet.TOADLET_URL, toadlet.path());
+  }
+
+  @Test
+  void translationUrlConstants_shareCanonicalPath() {
+    assertEquals("/translation/", TranslationPaths.TOADLET_URL);
+    assertEquals(TranslationPaths.TOADLET_URL, TranslationToadlet.TOADLET_URL);
   }
 
   @Test

--- a/src/test/java/network/crypta/config/WrapperConfigTest.java
+++ b/src/test/java/network/crypta/config/WrapperConfigTest.java
@@ -1,13 +1,16 @@
 package network.crypta.config;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import network.crypta.node.NodeInitException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -29,7 +32,7 @@ class WrapperConfigTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    // Clear static overrides map to avoid cross-test pollution
+    // Clear static overrides the map to avoid cross-test pollution
     Field f = WrapperConfig.class.getDeclaredField("overrides");
     f.setAccessible(true);
     @SuppressWarnings("unchecked")
@@ -77,7 +80,7 @@ class WrapperConfigTest {
     Map<String, String> map = (Map<String, String>) f.get(null);
     map.put("my.prop", "override");
 
-    // Also mock WrapperManager to prove override takes precedence
+    // Also, mock WrapperManager to prove override takes precedence
     try (MockedStatic<WrapperManager> mocked = Mockito.mockStatic(WrapperManager.class)) {
       Properties props = new Properties();
       props.setProperty("my.prop", "fromWrapper");
@@ -162,6 +165,26 @@ class WrapperConfigTest {
   }
 
   @Test
+  void canonicalOrAbsolute_whenCanonicalLookupFails_returnsAbsoluteFile() throws Exception {
+    // Arrange
+    Method method = WrapperConfig.class.getDeclaredMethod("canonicalOrAbsolute", File.class);
+    method.setAccessible(true);
+    File file = new FailingCanonicalFile("wrapper/wrapper.conf");
+
+    // Act
+    File resolved = (File) method.invoke(null, file);
+
+    // Assert
+    assertEquals(file.getAbsoluteFile(), resolved);
+  }
+
+  @Test
+  void configExitCodes_whenBrokeWrapperConf_constantStaysAtTwentyEight() {
+    assertEquals(28, ConfigExitCodes.BROKE_WRAPPER_CONF);
+    assertEquals(ConfigExitCodes.BROKE_WRAPPER_CONF, NodeInitException.EXIT_BROKE_WRAPPER_CONF);
+  }
+
+  @Test
   @Tag("io")
   void setWrapperProperty_whenPropertyExists_updatesValueAndKeepsReload() throws Exception {
     // Arrange: wrapper/wrapper.conf exists with the target property and reload flag present
@@ -184,7 +207,7 @@ class WrapperConfigTest {
     // Assert
     assertTrue(ok);
     String content = Files.readString(conf, StandardCharsets.UTF_8);
-    // Ensure updated exactly once and reload flag preserved exactly once
+    // Ensure updated exactly once and the reload flag preserved exactly once
     assertTrue(content.contains("my.key=new"));
     assertFalse(content.contains("my.key=old"));
 
@@ -206,7 +229,7 @@ class WrapperConfigTest {
   @Test
   @Tag("io")
   void setWrapperProperty_whenMissingProperty_appendsPropertyAndReload() throws Exception {
-    // Arrange: wrapper.conf without the target property and without reload flag
+    // Arrange: wrapper.conf without the target property and without a reload flag
     Path wrapper = repoRoot().resolve("wrapper");
     Files.createDirectories(wrapper);
     Path conf = wrapper.resolve("wrapper.conf");
@@ -254,5 +277,23 @@ class WrapperConfigTest {
     assertTrue(content.contains("top.level=ok"));
     assertTrue(
         content.toLowerCase(Locale.ROOT).contains("wrapper.restart.reload_configuration=true"));
+  }
+
+  private static final class FailingCanonicalFile extends File {
+    private static final long serialVersionUID = 1L;
+
+    FailingCanonicalFile(String pathname) {
+      super(pathname);
+    }
+
+    @Override
+    public File getAbsoluteFile() {
+      return new FailingCanonicalFile(super.getAbsolutePath());
+    }
+
+    @Override
+    public File getCanonicalFile() throws IOException {
+      throw new IOException("canonicalization failed");
+    }
   }
 }

--- a/src/test/java/network/crypta/l10n/BaseL10nTest.java
+++ b/src/test/java/network/crypta/l10n/BaseL10nTest.java
@@ -1,6 +1,7 @@
 package network.crypta.l10n;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -493,6 +494,23 @@ class BaseL10nTest {
     assertEquals("Sane", l10n.getString("test.sanity"));
     l10n.setOverride(" test.sanity ", " Sane ");
     assertFalse(l10n.isOverridden("test.sanity"));
+  }
+
+  @Test
+  void setOverride_whenNewValue_expectPersistedOverrideFile(@TempDir Path tmp) throws Exception {
+    BaseL10n l10n =
+        new BaseL10n(
+            "network/crypta/l10n/",
+            "crypta.l10n.${lang}.test.properties",
+            tmp.resolve("crypta.l10n.${lang}.override.properties").toString(),
+            LANGUAGE.ENGLISH);
+
+    l10n.setOverride("new.override", "Value");
+
+    Path overrideFile = tmp.resolve("crypta.l10n.en.override.properties");
+    assertTrue(Files.exists(overrideFile));
+    assertEquals(
+        "Value", SimpleFieldSet.readFrom(overrideFile.toFile(), false, false).get("new.override"));
   }
 
   @Test

--- a/src/test/java/network/crypta/node/NodeInitExceptionTest.java
+++ b/src/test/java/network/crypta/node/NodeInitExceptionTest.java
@@ -1,0 +1,25 @@
+package network.crypta.node;
+
+import network.crypta.config.ConfigExitCodes;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("java:S100")
+class NodeInitExceptionTest {
+
+  @Test
+  void constructor_whenUsingWrapperConfigExitCode_preservesCodeAndMessage() {
+    // Arrange
+    int exitCode = NodeInitException.EXIT_BROKE_WRAPPER_CONF;
+    String message = "broken wrapper";
+
+    // Act
+    NodeInitException exception = new NodeInitException(exitCode, message);
+
+    // Assert
+    assertEquals(ConfigExitCodes.BROKE_WRAPPER_CONF, exitCode);
+    assertEquals(exitCode, exception.exitCode);
+    assertEquals("broken wrapper (" + exitCode + ')', exception.getMessage());
+  }
+}

--- a/src/test/java/network/crypta/support/io/AtomicFileMovesTest.java
+++ b/src/test/java/network/crypta/support/io/AtomicFileMovesTest.java
@@ -1,0 +1,220 @@
+package network.crypta.support.io;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+@SuppressWarnings("java:S100")
+class AtomicFileMovesTest {
+
+  @Test
+  @DisplayName("moveTo_whenAtomicMoveSupported_expectTrue")
+  void moveTo_whenAtomicMoveSupported_expectTrue(@TempDir Path tmp) throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from.bin");
+    Path dst = tmp.resolve("to.bin");
+    Files.write(src, List.of("x"));
+
+    try (MockedStatic<Files> files = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.ATOMIC_MOVE)))
+          .then(_ -> dst);
+
+      // Act
+      boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile());
+
+      // Assert
+      assertTrue(ok);
+    }
+  }
+
+  @Test
+  @DisplayName("moveTo_whenAtomicNotSupported_thenFallbackSucceeds_expectTrue")
+  void moveTo_whenAtomicNotSupported_thenFallbackSucceeds_expectTrue(@TempDir Path tmp)
+      throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from2.bin");
+    Path dst = tmp.resolve("to2.bin");
+    Files.write(src, List.of("y"));
+
+    try (MockedStatic<Files> files = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.ATOMIC_MOVE)))
+          .thenThrow(new java.nio.file.AtomicMoveNotSupportedException("a", "b", "nope"));
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.REPLACE_EXISTING)))
+          .then(_ -> dst);
+
+      // Act
+      boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile());
+
+      // Assert
+      assertTrue(ok);
+    }
+  }
+
+  @Test
+  @DisplayName("moveTo_whenAtomicMoveThrowsIOException_thenFallbackSucceeds_expectTrue")
+  void moveTo_whenAtomicMoveThrowsIOException_thenFallbackSucceeds_expectTrue(@TempDir Path tmp)
+      throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from-io.bin");
+    Path dst = tmp.resolve("to-io.bin");
+    Files.write(src, List.of("io"));
+
+    try (MockedStatic<Files> files = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.ATOMIC_MOVE)))
+          .thenThrow(new IOException("transient-atomic-failure"));
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.REPLACE_EXISTING)))
+          .then(_ -> dst);
+
+      // Act
+      boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile());
+
+      // Assert
+      assertTrue(ok);
+    }
+  }
+
+  @Test
+  @DisplayName("moveTo_whenAtomicMoveSeesExistingTarget_thenFallbackReplaces_expectTrue")
+  void moveTo_whenAtomicMoveSeesExistingTarget_thenFallbackReplaces_expectTrue(@TempDir Path tmp)
+      throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from-existing.bin");
+    Path dst = tmp.resolve("to-existing.bin");
+    Files.write(src, List.of("fresh"));
+    Files.write(dst, List.of("stale"));
+
+    try (MockedStatic<Files> files = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.ATOMIC_MOVE)))
+          .thenThrow(new FileAlreadyExistsException(src.toString(), dst.toString(), "exists"));
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.REPLACE_EXISTING)))
+          .then(_ -> dst);
+
+      // Act
+      boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile());
+
+      // Assert
+      assertTrue(ok);
+    }
+  }
+
+  @Test
+  @DisplayName("moveTo_whenFallbackFailsAllRetries_expectFalse")
+  void moveTo_whenFallbackFailsAllRetries_expectFalse(@TempDir Path tmp) throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from-fail.bin");
+    Path dst = tmp.resolve("to-fail.bin");
+    Files.write(src, List.of("fail"));
+
+    try (MockedStatic<Files> files = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.ATOMIC_MOVE)))
+          .thenThrow(new java.nio.file.AtomicMoveNotSupportedException("a", "b", "nope"));
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.REPLACE_EXISTING)))
+          .thenThrow(new IOException("locked-1"))
+          .thenThrow(new IOException("locked-2"))
+          .thenThrow(new IOException("locked-3"))
+          .thenThrow(new IOException("locked-4"))
+          .thenThrow(new IOException("locked-5"));
+
+      // Act
+      boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile());
+
+      // Assert
+      assertFalse(ok);
+      files.verify(() -> Files.move(src, dst, StandardCopyOption.REPLACE_EXISTING), times(5));
+    }
+  }
+
+  @Test
+  @DisplayName("moveTo_whenRetrySleepInterrupted_expectFalseAndPreservesInterrupt")
+  void moveTo_whenRetrySleepInterrupted_expectFalseAndPreservesInterrupt(@TempDir Path tmp)
+      throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from-interrupted.bin");
+    Path dst = tmp.resolve("to-interrupted.bin");
+    Files.write(src, List.of("interrupt"));
+
+    try (MockedStatic<Files> files = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.ATOMIC_MOVE)))
+          .thenThrow(new java.nio.file.AtomicMoveNotSupportedException("a", "b", "nope"));
+      files
+          .when(() -> Files.move(eq(src), eq(dst), eq(StandardCopyOption.REPLACE_EXISTING)))
+          .thenThrow(new IOException("locked"));
+
+      Thread.currentThread().interrupt();
+      try {
+        // Act
+        boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile());
+
+        // Assert
+        assertFalse(ok);
+        assertTrue(Thread.currentThread().isInterrupted());
+        files.verify(() -> Files.move(src, dst, StandardCopyOption.REPLACE_EXISTING), times(1));
+      } finally {
+        boolean clearedInterrupt = Thread.interrupted();
+        if (clearedInterrupt) {
+          assertFalse(Thread.currentThread().isInterrupted());
+        }
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("moveTo_overwriteFalseAndDestExists_expectFalse")
+  void moveTo_overwriteFalseAndDestExists_expectFalse(@TempDir Path tmp) throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from4.bin");
+    Path dst = tmp.resolve("to4.bin");
+    Files.write(src, List.of("1"));
+    Files.write(dst, List.of("2"));
+
+    // Act
+    boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile(), false);
+
+    // Assert
+    assertFalse(ok);
+  }
+
+  @Test
+  @DisplayName("moveTo_whenDestinationExists_replacesExistingContent")
+  void moveTo_whenDestinationExists_replacesExistingContent(@TempDir Path tmp) throws Exception {
+    // Arrange
+    Path src = tmp.resolve("from-replace.bin");
+    Path dst = tmp.resolve("to-replace.bin");
+    Files.writeString(src, "new-content");
+    Files.writeString(dst, "old-content");
+
+    // Act
+    boolean ok = AtomicFileMoves.moveTo(src.toFile(), dst.toFile());
+
+    // Assert
+    assertTrue(ok);
+    assertFalse(Files.exists(src));
+    assertTrue(Files.exists(dst));
+    assertEquals("new-content", Files.readString(dst));
+  }
+}


### PR DESCRIPTION
## Summary
- add shared low-level helpers for atomic file replacement, wrapper exit codes, and translation URLs
- update config, wrapper, l10n, and HTTP code to use the new helpers instead of higher-level dependencies
- expand focused unit coverage and add doclint-clean Javadoc for the newly added helper classes

## How to test
- `./gradlew spotlessApply`
- `./gradlew test --tests 'network.crypta.support.io.AtomicFileMovesTest' --tests 'network.crypta.config.WrapperConfigTest' --tests 'network.crypta.l10n.BaseL10nTest' --tests 'network.crypta.clients.http.TranslationToadletTest' --tests 'network.crypta.config.FilePersistentConfigTest' --tests 'network.crypta.node.NodeInitExceptionTest'`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/config/ConfigExitCodes.java`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/l10n/TranslationPaths.java`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:/root/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/2.0.17/d9e58ac9c7779ba3bf8142aff6c830617a7fe60f/slf4j-api-2.0.17.jar' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/support/io/AtomicFileMoves.java`

## Notes
- `.github/pull_request_template.md` was not present in this repository checkout.
- I did not run the full test suite in this PR flow; the verification above is the focused set for the changed files.