### PR TITLE
build(gradle): Add selective output ownership metadata

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -48,11 +48,14 @@ Use this skill when you need to:
 - `:foundation-config` is the current home for all main `network.crypta.config` and
   `network.crypta.l10n` sources. Their unit tests still live in the root test tree and are run by
   the root project.
-- Selective extractions that still share root output directories rely on leaf-owned stale-root
-  output metadata at `<leaf>/gradle/owned-root-output-patterns.txt`. Update that metadata whenever
-  a leaf starts owning additional main classes/resources that root used to compile/package, or move
-  to a more structural boundary instead. If the split under `network.crypta.support*` keeps
-  growing, prefer a future extraction such as `:foundation-support`.
+- Every extracted internal leaf relies on leaf-owned stale-root-output metadata at
+  `<leaf>/gradle/owned-root-output-patterns.txt`. This is required even for structurally separate
+  package/resource moves, because stale root outputs from earlier builds or branch switches can
+  still shadow leaf outputs while `buildJar` packages root outputs first.
+- Update that metadata whenever a leaf starts owning additional main classes/resources that root
+  used to compile/package. If the split under `network.crypta.support*` keeps growing, prefer a
+  future extraction such as `:foundation-support`, but keep the metadata accurate until the build
+  no longer has that shadowing risk.
 
 ## Architecture overview (by package)
 ### Core network layer (`network.crypta.node`)

--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -48,6 +48,11 @@ Use this skill when you need to:
 - `:foundation-config` is the current home for all main `network.crypta.config` and
   `network.crypta.l10n` sources. Their unit tests still live in the root test tree and are run by
   the root project.
+- Selective extractions that still share root output directories rely on leaf-owned stale-root
+  output metadata at `<leaf>/gradle/owned-root-output-patterns.txt`. Update that metadata whenever
+  a leaf starts owning additional main classes/resources that root used to compile/package, or move
+  to a more structural boundary instead. If the split under `network.crypta.support*` keeps
+  growing, prefer a future extraction such as `:foundation-support`.
 
 ## Architecture overview (by package)
 ### Core network layer (`network.crypta.node`)

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -24,10 +24,13 @@ Use this skill when you need to:
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
 - `:foundation-config` owns the main `network.crypta.config` and `network.crypta.l10n` sources,
   plus the minimal support/node compile closure they currently need.
-- Selective extractions that still leave root and leaf outputs mixed must keep the leaf-owned
-  stale-root-output metadata in sync. When moving additional main classes/resources from root into a
-  leaf without a full structural boundary, update `<leaf>/gradle/owned-root-output-patterns.txt`
-  and validate with `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`.
+- Every extracted internal leaf must keep leaf-owned stale-root-output metadata in sync at
+  `<leaf>/gradle/owned-root-output-patterns.txt`, even for structurally separate package/resource
+  moves. Non-clean builds and branch switches can leave stale root outputs behind, and `buildJar`
+  still packages root outputs before leaf outputs.
+- When moving additional main classes/resources from root into any extracted leaf, update that
+  leaf's `owned-root-output-patterns.txt` and validate with
+  `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`.
 - `:runtime-spi` is the JDK-only runtime/config API leaf. Its focused unit tests still live in the
   root test tree and run through the root build.
 - All tests remain in the root project for now and compile against the leaf subprojects through

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -24,6 +24,10 @@ Use this skill when you need to:
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
 - `:foundation-config` owns the main `network.crypta.config` and `network.crypta.l10n` sources,
   plus the minimal support/node compile closure they currently need.
+- Selective extractions that still leave root and leaf outputs mixed must keep the leaf-owned
+  stale-root-output metadata in sync. When moving additional main classes/resources from root into a
+  leaf without a full structural boundary, update `<leaf>/gradle/owned-root-output-patterns.txt`
+  and validate with `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`.
 - `:runtime-spi` is the JDK-only runtime/config API leaf. Its focused unit tests still live in the
   root test tree and run through the root build.
 - All tests remain in the root project for now and compile against the leaf subprojects through

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ debhelper-build-stamp
 .gradle
 .gradle-home
 gradle
+!*/gradle/
+*/gradle/**
+!*/gradle/owned-root-output-patterns.txt
 /.gradle-user-home
 debian/seednodes.fref
 .idea

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,12 +127,6 @@ data class SelectiveLeafRootOutputOwnership(
       "RootOutputs"
 }
 
-sealed interface InternalLeafRootOutputOwnershipMode {
-  data object RequiresMetadata : InternalLeafRootOutputOwnershipMode
-
-  data class NoRootOutputsToPrune(val reason: String) : InternalLeafRootOutputOwnershipMode
-}
-
 fun parseOwnedRootOutputPatterns(metadataFile: File): List<String> =
   metadataFile.useLines { lines ->
     lines.map(String::trim).filter { it.isNotEmpty() && !it.startsWith("#") }.toList()
@@ -140,67 +134,26 @@ fun parseOwnedRootOutputPatterns(metadataFile: File): List<String> =
 
 val selectiveLeafOwnershipMetadataRelativePath = "gradle/owned-root-output-patterns.txt"
 
-val internalLeafRootOutputOwnershipModes =
-  mapOf(
-    ":foundation-config" to InternalLeafRootOutputOwnershipMode.RequiresMetadata,
-    ":foundation-fs" to
-      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
-        "Owns the structurally separate network.crypta.fs package tree"
-      ),
-    ":foundation-compat" to
-      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
-        "Owns the structurally separate network.crypta.compat package tree"
-      ),
-    ":runtime-spi" to
-      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
-        "Owns the structurally separate network.crypta.runtime.spi package tree"
-      ),
-    ":thirdparty-onion" to
-      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
-        "Owns the structurally separate com.onionnetworks package tree"
-      ),
-    ":thirdparty-legacy" to
-      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
-        "Owns the structurally separate org.bitpedia/org.sevenzip/org.spaceroots package trees"
-      ),
-    ":launcher-desktop" to
-      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
-        "Owns the structurally separate launcher package/resources boundary"
-      ),
-  )
-
-check(internalLeafRootOutputOwnershipModes.keys == internalLeafProjects.map { it.path }.toSet()) {
-  "Every internal leaf project must declare whether it requires owned-root-output metadata or an " +
-    "explicit structural opt-out"
-}
-
-// Selective extractions that still share the root output directories must either move to a more
-// structural boundary or declare leaf-owned stale-root-output metadata under
-// <leaf>/gradle/owned-root-output-patterns.txt. If the network.crypta.support* split keeps
-// growing, prefer a structural extraction such as :foundation-support over expanding pattern lists.
+// Every extracted internal leaf declares leaf-owned stale-root-output metadata under
+// <leaf>/gradle/owned-root-output-patterns.txt. Even structurally separated package moves need this
+// because stale root outputs from earlier builds or branch switches can still shadow leaf outputs
+// when buildJar packages sourceSets.main.output before the leaf outputs.
 val selectiveLeafRootOutputOwnerships =
-  internalLeafProjects.mapNotNull { leaf ->
-    when (internalLeafRootOutputOwnershipModes.getValue(leaf.path)) {
-      InternalLeafRootOutputOwnershipMode.RequiresMetadata -> {
-        val metadataFile =
-          leaf.layout.projectDirectory.file(selectiveLeafOwnershipMetadataRelativePath).asFile
-        if (!metadataFile.isFile) {
-          throw GradleException(
-            "Missing ${relativePath(leaf.projectDir)}/$selectiveLeafOwnershipMetadataRelativePath " +
-              "for ${leaf.path}. Add leaf-owned stale-root-output metadata or switch the leaf to " +
-              "an explicit structural opt-out."
-          )
-        }
-        SelectiveLeafRootOutputOwnership(
-          leaf = leaf,
-          metadataFile = metadataFile,
-          patterns = parseOwnedRootOutputPatterns(metadataFile),
-        )
-      }
-      is InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune -> {
-        null
-      }
+  internalLeafProjects.map { leaf ->
+    val metadataFile =
+      leaf.layout.projectDirectory.file(selectiveLeafOwnershipMetadataRelativePath).asFile
+    if (!metadataFile.isFile) {
+      throw GradleException(
+        "Missing ${relativePath(leaf.projectDir)}/$selectiveLeafOwnershipMetadataRelativePath " +
+          "for ${leaf.path}. Add leaf-owned stale-root-output metadata before extracting root " +
+          "outputs into this leaf."
+      )
     }
+    SelectiveLeafRootOutputOwnership(
+      leaf = leaf,
+      metadataFile = metadataFile,
+      patterns = parseOwnedRootOutputPatterns(metadataFile),
+    )
   }
 
 val verifySelectiveLeafOwnershipMetadata by

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.File
+
 plugins {
   // Apply Gradle 9 convention plugins from the included build
   id("cryptad.java-kotlin-conventions")
@@ -110,66 +112,150 @@ val internalLeafJarNames =
     internalLeafProjects.map { leaf -> "${leaf.name}-${project.version}.jar" }.toSet()
   }
 
-val foundationConfigOwnedRootOutputPatterns =
-  listOf(
-    "network/crypta/config/**",
-    "network/crypta/l10n/**",
-    "network/crypta/node/FSParseException*",
-    "network/crypta/support/Base64*",
-    "network/crypta/support/Fields*",
-    "network/crypta/support/HTMLEncoder*",
-    "network/crypta/support/HTMLEntities*",
-    "network/crypta/support/HTMLNode*",
-    "network/crypta/support/HexUtil*",
-    "network/crypta/support/IllegalBase64Exception*",
-    "network/crypta/support/PriorityAwareExecutor*",
-    "network/crypta/support/SimpleFieldSet*",
-    "network/crypta/support/Ticker*",
-    "network/crypta/support/TimeUtil*",
-    "network/crypta/support/URLDecoder*",
-    "network/crypta/support/URLEncodedFormatException*",
-    "network/crypta/support/URLEncoder*",
-    "network/crypta/support/XMLCharacterClasses*",
-    "network/crypta/support/api/BooleanCallback*",
-    "network/crypta/support/api/IntCallback*",
-    "network/crypta/support/api/LongCallback*",
-    "network/crypta/support/api/ShortCallback*",
-    "network/crypta/support/api/StringArrCallback*",
-    "network/crypta/support/api/StringCallback*",
-    "network/crypta/support/io/AtomicFileMoves*",
-    "network/crypta/support/io/LineReader*",
-    "network/crypta/support/io/LineReadingInputStream*",
-    "network/crypta/support/io/Readers*",
-    "network/crypta/support/io/TooLongException*",
-  )
+data class SelectiveLeafRootOutputOwnership(
+  val leaf: Project,
+  val metadataFile: File,
+  val patterns: List<String>,
+) {
+  val pruneTaskName: String =
+    "prune" +
+      leaf.name.split("-").joinToString(separator = "") { segment ->
+        segment.replaceFirstChar { firstChar ->
+          if (firstChar.isLowerCase()) firstChar.titlecase() else firstChar.toString()
+        }
+      } +
+      "RootOutputs"
+}
 
-val pruneFoundationConfigRootOutputs by
-  tasks.registering(Delete::class) {
+fun parseOwnedRootOutputPatterns(metadataFile: File): List<String> =
+  metadataFile.useLines { lines ->
+    lines.map(String::trim).filter { it.isNotEmpty() && !it.startsWith("#") }.toList()
+  }
+
+val selectiveLeafOwnershipMetadataRelativePath = "gradle/owned-root-output-patterns.txt"
+
+// Selective extractions that still share the root output directories must either move to a more
+// structural boundary or declare leaf-owned stale-root-output metadata under
+// <leaf>/gradle/owned-root-output-patterns.txt. If the network.crypta.support* split keeps
+// growing, prefer a structural extraction such as :foundation-support over expanding pattern lists.
+val selectiveLeafRootOutputOwnerships =
+  internalLeafProjects.mapNotNull { leaf ->
+    val metadataFile =
+      leaf.layout.projectDirectory.file(selectiveLeafOwnershipMetadataRelativePath).asFile
+    if (!metadataFile.isFile) {
+      null
+    } else {
+      SelectiveLeafRootOutputOwnership(
+        leaf = leaf,
+        metadataFile = metadataFile,
+        patterns = parseOwnedRootOutputPatterns(metadataFile),
+      )
+    }
+  }
+
+val verifySelectiveLeafOwnershipMetadata by
+  tasks.registering {
+    group = "verification"
+    description = "Verifies leaf-owned stale-root-output metadata for selective extractions"
+    doLast {
+      val currentOwnerships =
+        selectiveLeafRootOutputOwnerships.map { ownership ->
+          ownership.copy(patterns = parseOwnedRootOutputPatterns(ownership.metadataFile))
+        }
+
+      val emptyMetadataFiles =
+        currentOwnerships.filter { it.patterns.isEmpty() }.map { relativePath(it.metadataFile) }
+      if (emptyMetadataFiles.isNotEmpty()) {
+        throw GradleException(
+          "Selective leaf ownership metadata must not be empty: " +
+            emptyMetadataFiles.sorted().joinToString(", ")
+        )
+      }
+
+      val duplicatePatternsWithinFile =
+        currentOwnerships.mapNotNull { ownership ->
+          val duplicatePatterns =
+            ownership.patterns.groupingBy { it }.eachCount().filterValues { it > 1 }.keys.sorted()
+          if (duplicatePatterns.isEmpty()) {
+            null
+          } else {
+            relativePath(ownership.metadataFile) to duplicatePatterns
+          }
+        }
+      if (duplicatePatternsWithinFile.isNotEmpty()) {
+        throw GradleException(
+          buildString {
+            appendLine("Duplicate patterns found within selective leaf ownership metadata:")
+            duplicatePatternsWithinFile.forEach { (metadataPath, duplicatePatterns) ->
+              appendLine("$metadataPath: ${duplicatePatterns.joinToString(", ")}")
+            }
+          }
+        )
+      }
+
+      val duplicatePatternsAcrossLeaves =
+        currentOwnerships
+          .flatMap { ownership ->
+            ownership.patterns.map { pattern -> pattern to ownership.leaf.path }
+          }
+          .groupBy(keySelector = { it.first }, valueTransform = { it.second })
+          .mapValues { (_, owningLeaves) -> owningLeaves.distinct().sorted() }
+          .filterValues { it.size > 1 }
+      if (duplicatePatternsAcrossLeaves.isNotEmpty()) {
+        throw GradleException(
+          buildString {
+            appendLine("Duplicate patterns claimed by multiple selective leaf projects:")
+            duplicatePatternsAcrossLeaves.toSortedMap().forEach { (pattern, owningLeaves) ->
+              appendLine("$pattern: ${owningLeaves.joinToString(", ")}")
+            }
+          }
+        )
+      }
+    }
+  }
+
+val selectiveLeafRootOutputPruneTasks =
+  selectiveLeafRootOutputOwnerships.associate { ownership ->
+    ownership.leaf.path to
+      tasks.register<Delete>(ownership.pruneTaskName) {
+        description =
+          "Removes stale root outputs for sources extracted into ${ownership.leaf.path} on non-clean builds"
+        dependsOn(verifySelectiveLeafOwnershipMetadata)
+        outputs.upToDateWhen { false }
+        delete(
+          fileTree(layout.buildDirectory.dir("classes/java/main")) {
+            include(*ownership.patterns.toTypedArray())
+          },
+          fileTree(layout.buildDirectory.dir("resources/main")) {
+            include(*ownership.patterns.toTypedArray())
+          },
+        )
+      }
+  }
+
+val pruneFoundationConfigRootOutputs =
+  selectiveLeafRootOutputPruneTasks.getValue(":foundation-config")
+
+val pruneSelectiveLeafRootOutputs by
+  tasks.registering {
     description =
-      "Removes stale root outputs for sources extracted into :foundation-config on non-clean builds"
-    outputs.upToDateWhen { false }
-    delete(
-      fileTree(layout.buildDirectory.dir("classes/java/main")) {
-        include(foundationConfigOwnedRootOutputPatterns)
-      },
-      fileTree(layout.buildDirectory.dir("resources/main")) {
-        include(foundationConfigOwnedRootOutputPatterns)
-      },
-    )
+      "Removes stale root outputs claimed by selectively extracted leaf projects on non-clean builds"
+    dependsOn(verifySelectiveLeafOwnershipMetadata)
+    dependsOn(selectiveLeafRootOutputPruneTasks.values)
   }
 
 internalLeafProjects.forEach { leaf ->
   leaf.extensions.configure<org.sonarqube.gradle.SonarExtension>("sonar") { isSkipProject = true }
 }
 
-tasks.named("copyResourcesToClasses2") { dependsOn(pruneFoundationConfigRootOutputs) }
+tasks.named("copyResourcesToClasses2") { dependsOn(pruneSelectiveLeafRootOutputs) }
 
-tasks.named("compileJava") { dependsOn(pruneFoundationConfigRootOutputs) }
+tasks.named("compileJava") { dependsOn(pruneSelectiveLeafRootOutputs) }
 
-tasks.named("processResources") { dependsOn(pruneFoundationConfigRootOutputs) }
+tasks.named("processResources") { dependsOn(pruneSelectiveLeafRootOutputs) }
 
 tasks.named<org.gradle.jvm.tasks.Jar>("buildJar") {
-  dependsOn(pruneFoundationConfigRootOutputs)
+  dependsOn(pruneSelectiveLeafRootOutputs)
   dependsOn(internalLeafProjects.map { "${it.path}:classes" })
   internalLeafProjects.forEach { leaf ->
     from(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,12 @@ data class SelectiveLeafRootOutputOwnership(
       "RootOutputs"
 }
 
+sealed interface InternalLeafRootOutputOwnershipMode {
+  data object RequiresMetadata : InternalLeafRootOutputOwnershipMode
+
+  data class NoRootOutputsToPrune(val reason: String) : InternalLeafRootOutputOwnershipMode
+}
+
 fun parseOwnedRootOutputPatterns(metadataFile: File): List<String> =
   metadataFile.useLines { lines ->
     lines.map(String::trim).filter { it.isNotEmpty() && !it.startsWith("#") }.toList()
@@ -134,22 +140,66 @@ fun parseOwnedRootOutputPatterns(metadataFile: File): List<String> =
 
 val selectiveLeafOwnershipMetadataRelativePath = "gradle/owned-root-output-patterns.txt"
 
+val internalLeafRootOutputOwnershipModes =
+  mapOf(
+    ":foundation-config" to InternalLeafRootOutputOwnershipMode.RequiresMetadata,
+    ":foundation-fs" to
+      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
+        "Owns the structurally separate network.crypta.fs package tree"
+      ),
+    ":foundation-compat" to
+      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
+        "Owns the structurally separate network.crypta.compat package tree"
+      ),
+    ":runtime-spi" to
+      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
+        "Owns the structurally separate network.crypta.runtime.spi package tree"
+      ),
+    ":thirdparty-onion" to
+      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
+        "Owns the structurally separate com.onionnetworks package tree"
+      ),
+    ":thirdparty-legacy" to
+      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
+        "Owns the structurally separate org.bitpedia/org.sevenzip/org.spaceroots package trees"
+      ),
+    ":launcher-desktop" to
+      InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune(
+        "Owns the structurally separate launcher package/resources boundary"
+      ),
+  )
+
+check(internalLeafRootOutputOwnershipModes.keys == internalLeafProjects.map { it.path }.toSet()) {
+  "Every internal leaf project must declare whether it requires owned-root-output metadata or an " +
+    "explicit structural opt-out"
+}
+
 // Selective extractions that still share the root output directories must either move to a more
 // structural boundary or declare leaf-owned stale-root-output metadata under
 // <leaf>/gradle/owned-root-output-patterns.txt. If the network.crypta.support* split keeps
 // growing, prefer a structural extraction such as :foundation-support over expanding pattern lists.
 val selectiveLeafRootOutputOwnerships =
   internalLeafProjects.mapNotNull { leaf ->
-    val metadataFile =
-      leaf.layout.projectDirectory.file(selectiveLeafOwnershipMetadataRelativePath).asFile
-    if (!metadataFile.isFile) {
-      null
-    } else {
-      SelectiveLeafRootOutputOwnership(
-        leaf = leaf,
-        metadataFile = metadataFile,
-        patterns = parseOwnedRootOutputPatterns(metadataFile),
-      )
+    when (internalLeafRootOutputOwnershipModes.getValue(leaf.path)) {
+      InternalLeafRootOutputOwnershipMode.RequiresMetadata -> {
+        val metadataFile =
+          leaf.layout.projectDirectory.file(selectiveLeafOwnershipMetadataRelativePath).asFile
+        if (!metadataFile.isFile) {
+          throw GradleException(
+            "Missing ${relativePath(leaf.projectDir)}/$selectiveLeafOwnershipMetadataRelativePath " +
+              "for ${leaf.path}. Add leaf-owned stale-root-output metadata or switch the leaf to " +
+              "an explicit structural opt-out."
+          )
+        }
+        SelectiveLeafRootOutputOwnership(
+          leaf = leaf,
+          metadataFile = metadataFile,
+          patterns = parseOwnedRootOutputPatterns(metadataFile),
+        )
+      }
+      is InternalLeafRootOutputOwnershipMode.NoRootOutputsToPrune -> {
+        null
+      }
     }
   }
 

--- a/foundation-compat/gradle/owned-root-output-patterns.txt
+++ b/foundation-compat/gradle/owned-root-output-patterns.txt
@@ -1,0 +1,3 @@
+# Root outputs that must be pruned on non-clean builds because :foundation-compat owns them now.
+
+network/crypta/compat/**

--- a/foundation-config/gradle/owned-root-output-patterns.txt
+++ b/foundation-config/gradle/owned-root-output-patterns.txt
@@ -1,0 +1,33 @@
+# Root outputs that must be pruned on non-clean builds because :foundation-config owns them now.
+# Future selective extractions should either tighten the structural boundary or add/update the
+# relevant leaf-owned metadata file instead of hardcoding patterns in the root build script.
+
+network/crypta/config/**
+network/crypta/l10n/**
+network/crypta/node/FSParseException*
+network/crypta/support/Base64*
+network/crypta/support/Fields*
+network/crypta/support/HTMLEncoder*
+network/crypta/support/HTMLEntities*
+network/crypta/support/HTMLNode*
+network/crypta/support/HexUtil*
+network/crypta/support/IllegalBase64Exception*
+network/crypta/support/PriorityAwareExecutor*
+network/crypta/support/SimpleFieldSet*
+network/crypta/support/Ticker*
+network/crypta/support/TimeUtil*
+network/crypta/support/URLDecoder*
+network/crypta/support/URLEncodedFormatException*
+network/crypta/support/URLEncoder*
+network/crypta/support/XMLCharacterClasses*
+network/crypta/support/api/BooleanCallback*
+network/crypta/support/api/IntCallback*
+network/crypta/support/api/LongCallback*
+network/crypta/support/api/ShortCallback*
+network/crypta/support/api/StringArrCallback*
+network/crypta/support/api/StringCallback*
+network/crypta/support/io/AtomicFileMoves*
+network/crypta/support/io/LineReader*
+network/crypta/support/io/LineReadingInputStream*
+network/crypta/support/io/Readers*
+network/crypta/support/io/TooLongException*

--- a/foundation-fs/gradle/owned-root-output-patterns.txt
+++ b/foundation-fs/gradle/owned-root-output-patterns.txt
@@ -1,0 +1,3 @@
+# Root outputs that must be pruned on non-clean builds because :foundation-fs owns them now.
+
+network/crypta/fs/**

--- a/launcher-desktop/gradle/owned-root-output-patterns.txt
+++ b/launcher-desktop/gradle/owned-root-output-patterns.txt
@@ -1,0 +1,5 @@
+# Root outputs that must be pruned on non-clean builds because :launcher-desktop owns them now.
+
+com/jthemedetecor/**
+network/crypta/launcher/**
+oshi/annotation/**

--- a/runtime-spi/gradle/owned-root-output-patterns.txt
+++ b/runtime-spi/gradle/owned-root-output-patterns.txt
@@ -1,0 +1,3 @@
+# Root outputs that must be pruned on non-clean builds because :runtime-spi owns them now.
+
+network/crypta/runtime/spi/**

--- a/thirdparty-legacy/gradle/owned-root-output-patterns.txt
+++ b/thirdparty-legacy/gradle/owned-root-output-patterns.txt
@@ -1,0 +1,5 @@
+# Root outputs that must be pruned on non-clean builds because :thirdparty-legacy owns them now.
+
+org/bitpedia/**
+org/sevenzip/**
+org/spaceroots/**

--- a/thirdparty-onion/gradle/owned-root-output-patterns.txt
+++ b/thirdparty-onion/gradle/owned-root-output-patterns.txt
@@ -1,0 +1,4 @@
+# Root outputs that must be pruned on non-clean builds because :thirdparty-onion owns them now.
+
+com/onionnetworks/**
+lib/fec.properties


### PR DESCRIPTION
## Summary
- replace the hardcoded `:foundation-config` stale-root-output list with leaf-owned metadata in `foundation-config/gradle/owned-root-output-patterns.txt`
- generate per-leaf prune tasks plus the aggregate `pruneSelectiveLeafRootOutputs` task from metadata while keeping `pruneFoundationConfigRootOutputs` available
- add `verifySelectiveLeafOwnershipMetadata`, the narrow `.gitignore` exception for metadata files, and skill guidance so future selective extractions update the metadata when ownership shifts

## Testing
- `./gradlew spotlessApply`
- `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`
- `./gradlew verifySelectiveLeafOwnershipMetadata compileJava processResources buildJar`
- `./gradlew buildJar`
- manual non-clean sanity check: created fake stale files under `build/classes/java/main/...` and `build/resources/main/...`, reran `./gradlew buildJar`, and confirmed the prune task removed them before packaging
