### PR TITLE
refactor(crypto-keys): Remove extraction blockers

### DIFF
--- a/src/main/java/network/crypta/client/InsertUriChecks.java
+++ b/src/main/java/network/crypta/client/InsertUriChecks.java
@@ -1,0 +1,43 @@
+package network.crypta.client;
+
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Validates insert-target URIs at the client layer.
+ *
+ * <p>This adapter keeps insert-specific policy checks close to the client APIs that actually
+ * perform inserts. The corresponding {@link FreenetURI} type stays focused on key parsing and key
+ * transformations, while insert-specific failure reporting remains in {@code network.crypta.client}
+ * where {@link InsertException} and {@link InsertExceptionMode} already define the public error
+ * surface.
+ *
+ * <p>The current helper set is intentionally small. Callers use these methods immediately before
+ * constructing insert jobs or accepting operator-provided target URIs, which keeps validation
+ * consistent across HTTP, FCP, and asynchronous client flows without reintroducing a keys-to-client
+ * dependency.
+ */
+public final class InsertUriChecks {
+
+  /** Prevents instantiation of this comments-only validation utility. */
+  private InsertUriChecks() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  /**
+   * Verifies that the URI does not contain meta strings.
+   *
+   * <p>Insert requests accept a concrete key target, not a URI with additional meta-string path
+   * components. When such components are present, the method throws the same client-layer exception
+   * and mode that legacy insert validation used, so higher layers keep their existing behavior and
+   * error handling.
+   *
+   * @param uri insert target to validate before starting client-side insert work
+   * @throws InsertException if the URI carries meta strings that inserts do not support
+   */
+  public static void checkInsertURI(FreenetURI uri) throws InsertException {
+    if (uri.hasMetaStrings()) {
+      throw new InsertException(InsertExceptionMode.META_STRINGS_NOT_SUPPORTED, uri);
+    }
+  }
+}

--- a/src/main/java/network/crypta/client/async/ClientPutter.java
+++ b/src/main/java/network/crypta/client/async/ClientPutter.java
@@ -9,6 +9,7 @@ import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
+import network.crypta.client.InsertUriChecks;
 import network.crypta.client.Metadata;
 import network.crypta.client.events.SendingToNetworkEvent;
 import network.crypta.client.events.SplitfileProgressCounts;
@@ -231,7 +232,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
     if (LOG.isDebugEnabled()) LOG.debug("Insert start requested: {} target={}", this, targetURI);
     final byte cryptoAlgorithm = selectCryptoAlgorithm();
     try {
-      targetURI.checkInsertURI();
+      InsertUriChecks.checkInsertURI(targetURI);
       final boolean randomiseKeys = randomiseSplitfileKeys(targetURI, ctx);
       if (data == null)
         throw new InsertException(InsertExceptionMode.BUCKET_ERROR, "No data to insert", null);

--- a/src/main/java/network/crypta/client/async/SingleFileInserter.java
+++ b/src/main/java/network/crypta/client/async/SingleFileInserter.java
@@ -15,6 +15,7 @@ import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
+import network.crypta.client.InsertUriChecks;
 import network.crypta.client.Metadata.DocumentType;
 import network.crypta.client.Metadata;
 import network.crypta.client.MetadataRedirectTarget;
@@ -866,7 +867,7 @@ class SingleFileInserter implements ClientPutState, Serializable {
     if (uri == null) {
       throw new InsertException(InsertExceptionMode.INVALID_URI, "Null key type", null);
     }
-    uri.checkInsertURI(); // will throw an exception if needed
+    InsertUriChecks.checkInsertURI(uri);
 
     if (uri.getKeyType().equals("USK")) {
       try {

--- a/src/main/java/network/crypta/clients/http/Toadlet.java
+++ b/src/main/java/network/crypta/clients/http/Toadlet.java
@@ -16,6 +16,7 @@ import network.crypta.client.FetchWaiter;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertBlock;
 import network.crypta.client.InsertException;
+import network.crypta.client.InsertUriChecks;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.RequestClient;
@@ -198,7 +199,8 @@ public abstract class Toadlet {
    *     <p>Override this function to return something else for invisible Toadlets as explained
    *     above.
    */
-  public Toadlet showAsToadlet(ToadletContext context) {
+  @SuppressWarnings("java:S1172")
+  public Toadlet showAsToadlet(@SuppressWarnings("unused") ToadletContext context) {
     return resolveLegacyShowAsToadlet();
   }
 
@@ -333,7 +335,7 @@ public abstract class Toadlet {
   FreenetURI insert(InsertBlock insert, String filenameHint) throws InsertException {
     // For now, just run it blocking.
     FreenetURI desiredURI = Objects.requireNonNull(insert.desiredURI, "InsertBlock.desiredURI");
-    desiredURI.checkInsertURI();
+    InsertUriChecks.checkInsertURI(desiredURI);
     return getClientImpl().insert(insert, false, filenameHint);
   }
 

--- a/src/main/java/network/crypta/crypt/AEADCryptBucket.java
+++ b/src/main/java/network/crypta/crypt/AEADCryptBucket.java
@@ -16,7 +16,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import network.crypta.client.async.ClientContext;
-import network.crypta.node.NodeStarter;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.BucketTools;
 import network.crypta.support.io.FilenameGenerator;
@@ -94,7 +93,7 @@ public final class AEADCryptBucket implements Bucket, Serializable {
       throw new IOException("Read only");
     }
     OutputStream os = underlying.getOutputStreamUnbuffered();
-    return AEADOutputStream.createAES(os, key, NodeStarter.getGlobalSecureRandom());
+    return AEADOutputStream.createAES(os, key, CryptoRandoms.shared());
   }
 
   /**
@@ -275,6 +274,7 @@ public final class AEADCryptBucket implements Bucket, Serializable {
   private static final String FIELD_READONLY = "readOnly";
 
   @Serial
+  @SuppressWarnings("unused") // Used reflectively by Java serialization.
   private static final ObjectStreamField[] serialPersistentFields = {
     new ObjectStreamField(FIELD_UNDERLYING, Bucket.class),
     new ObjectStreamField(FIELD_KEY, byte[].class),
@@ -283,7 +283,6 @@ public final class AEADCryptBucket implements Bucket, Serializable {
 
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
-    assert serialPersistentFields.length > 0;
     // Write fields using the default field block. Include the underlying only when it is
     // Serializable; otherwise fail fast to avoid silently dropping data.
     ObjectOutputStream.PutField fields = out.putFields();

--- a/src/main/java/network/crypta/crypt/BucketInputStreams.java
+++ b/src/main/java/network/crypta/crypt/BucketInputStreams.java
@@ -1,0 +1,105 @@
+package network.crypta.crypt;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import network.crypta.support.api.Bucket;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Creates input-stream views over {@link Bucket} instances for crypt-layer consumers.
+ *
+ * <p>The helper mirrors the long-lived client-side bucket wrapper, but keeps the ownership and
+ * cleanup behavior inside {@code network.crypta.crypt}. Callers obtain a conventional {@link
+ * InputStream} over bucket contents while the wrapper takes responsibility for releasing the bucket
+ * when the stream is closed, which reduces leak-prone manual cleanup at checksum and decryption
+ * call sites.
+ *
+ * <p>This class does not change bucket semantics. It only centralizes a common lifecycle pattern:
+ * open the bucket stream once, read through the wrapper, then close the wrapper so the underlying
+ * bucket is freed exactly at the point the caller is done with the bytes.
+ */
+public final class BucketInputStreams {
+
+  /** Prevents instantiation of this stream-wrapping utility. */
+  private BucketInputStreams() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  /**
+   * Opens the bucket's input stream and frees the bucket when the returned stream is closed.
+   *
+   * <p>The returned wrapper reads directly from {@link Bucket#getInputStream()} and adds only the
+   * cleanup policy. Callers should use the wrapper in a try-with-resources block and should not
+   * attempt to free the bucket separately after the stream has been handed off here.
+   *
+   * @param bucket source bucket whose contents should be exposed as a stream
+   * @return stream over the bucket contents that frees the bucket on successful close
+   * @throws IOException if the bucket cannot provide an input stream for reading
+   */
+  public static InputStream openAndFreeOnClose(Bucket bucket) throws IOException {
+    return new ReadBucketAndFreeInputStream(bucket.getInputStream(), bucket);
+  }
+
+  /** Stream wrapper that couples bucket reads with bucket cleanup on close. */
+  private static final class ReadBucketAndFreeInputStream extends FilterInputStream {
+
+    /** Bucket to free after the wrapped stream closes successfully. */
+    private final Bucket bucket;
+
+    /**
+     * Creates a wrapper around an already-open bucket stream.
+     *
+     * @param in underlying stream returned by the bucket
+     * @param bucket bucket that owns the underlying stream contents
+     */
+    private ReadBucketAndFreeInputStream(InputStream in, Bucket bucket) {
+      super(in);
+      this.bucket = bucket;
+    }
+
+    /**
+     * Reads bytes into a portion of the array from the wrapped stream.
+     *
+     * <p>This override forwards directly to the underlying stream to avoid the default single-byte
+     * read loop in {@link FilterInputStream}, which can be inefficient for larger transfers.
+     *
+     * @param buf destination byte array which receives data; must not be {@code null}
+     * @param offset start offset within {@code buf}
+     * @param length maximum number of bytes to read
+     * @return the number of bytes read, or {@code -1} at end of stream
+     * @throws IOException if an I/O error occurs while reading from the underlying stream
+     */
+    @Override
+    public int read(byte @NotNull [] buf, int offset, int length) throws IOException {
+      return in.read(buf, offset, length);
+    }
+
+    /**
+     * Reads bytes into the entire array from the wrapped stream.
+     *
+     * @param buf destination byte array to fill with data; must not be {@code null}
+     * @return the number of bytes read, or {@code -1} when no more data is available
+     * @throws IOException if an I/O error occurs while reading from the underlying stream
+     */
+    @Override
+    public int read(byte @NotNull [] buf) throws IOException {
+      return read(buf, 0, buf.length);
+    }
+
+    /**
+     * Closes the wrapped stream and frees the associated bucket.
+     *
+     * <p>The implementation closes the underlying stream first and frees the bucket only after that
+     * close succeeds. If stream closure fails, the {@link IOException} is propagated and the bucket
+     * is left untouched so callers do not silently lose the original close failure.
+     *
+     * @throws IOException if closing the underlying stream fails
+     */
+    @Override
+    public void close() throws IOException {
+      in.close();
+      bucket.free();
+    }
+  }
+}

--- a/src/main/java/network/crypta/crypt/ChecksumChecker.java
+++ b/src/main/java/network/crypta/crypt/ChecksumChecker.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import network.crypta.client.async.ReadBucketAndFreeInputStream;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.NonClosingOutputStream;
@@ -220,7 +219,7 @@ public abstract class ChecksumChecker {
     try (OutputStream os = bucket.getOutputStream()) {
       copyAndStripChecksum(dis, os, length);
     }
-    return ReadBucketAndFreeInputStream.create(bucket);
+    return BucketInputStreams.openAndFreeOnClose(bucket);
   }
 
   public void writeAndChecksum(OutputStream os, byte[] buf, int offset, int length)

--- a/src/main/java/network/crypta/crypt/CryptoRandoms.java
+++ b/src/main/java/network/crypta/crypt/CryptoRandoms.java
@@ -1,0 +1,63 @@
+package network.crypta.crypt;
+
+import java.security.SecureRandom;
+
+/**
+ * Exposes the shared process-wide source of cryptographic randomness.
+ *
+ * <p>The shared {@link SecureRandom} is initialized lazily and force-seeded on first use. Node
+ * bootstrap warms the same singleton via {@code NodeStarter.getGlobalSecureRandom()} so that
+ * callers still pay any entropy blocking cost during startup instead of during later cryptographic
+ * operations.
+ *
+ * <p>This class exists so crypt-layer code can depend on a stable helper inside {@code
+ * network.crypta.crypt} instead of reaching up into startup code. The lifecycle is still
+ * coordinated with bootstrap: the first call creates the singleton, eagerly seeds it by producing a
+ * small block of random bytes, and then publishes the fully initialized instance for the rest of
+ * the process lifetime.
+ */
+public final class CryptoRandoms {
+  /** Prevents instantiation of this singleton access utility. */
+  private CryptoRandoms() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  /**
+   * Returns the shared process-wide {@link SecureRandom} instance.
+   *
+   * <p>The instance is created lazily on first use and seeded eagerly before being published.
+   * Repeated calls return the same object, so callers share one process-wide randomness source
+   * rather than creating their own per-operation generators.
+   *
+   * @return shared secure random source for cryptographic operations in this JVM
+   */
+  public static SecureRandom shared() {
+    return Holder.SHARED;
+  }
+
+  /** Holds the lazily initialized singleton and the private seeding routine used to create it. */
+  private static final class Holder {
+    /** Shared {@link SecureRandom} instance after eager self-seeding completes. */
+    private static final SecureRandom SHARED = forceSeeding(new SecureRandom());
+
+    /** Prevents instantiation of the lazy-holder helper. */
+    private Holder() {
+      throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Forces the candidate random source to perform its initial self-seeding work immediately.
+     *
+     * <p>The method reads a small block of random bytes before the instance is published. That
+     * keeps any startup-time entropy blocking at initialization time instead of deferring it to the
+     * first later encryption, key-generation, or certificate-generation call.
+     *
+     * @param secureRandom random source being prepared for shared process-wide use
+     * @return the same random source after eager seeding has completed
+     */
+    private static SecureRandom forceSeeding(SecureRandom secureRandom) {
+      secureRandom.nextBytes(new byte[16]);
+      return secureRandom;
+    }
+  }
+}

--- a/src/main/java/network/crypta/crypt/KeyGenUtils.java
+++ b/src/main/java/network/crypta/crypt/KeyGenUtils.java
@@ -17,7 +17,6 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import network.crypta.node.NodeStarter;
 import network.crypta.support.Fields;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
@@ -73,7 +72,7 @@ public final class KeyGenUtils {
     int dotPos = version.indexOf('.');
     int dashPos = version.indexOf('-');
     int end = version.length();
-    if (dotPos > -1 && dotPos < end) {
+    if (dotPos > -1) {
       end = dotPos;
     }
     if (dashPos > -1 && dashPos < end) {
@@ -315,7 +314,7 @@ public final class KeyGenUtils {
    */
   private static byte[] genRandomBytes(int length) {
     byte[] randBytes = new byte[length];
-    NodeStarter.getGlobalSecureRandom().nextBytes(randBytes);
+    CryptoRandoms.shared().nextBytes(randBytes);
     return randBytes;
   }
 

--- a/src/main/java/network/crypta/crypt/SSL.java
+++ b/src/main/java/network/crypta/crypt/SSL.java
@@ -26,7 +26,6 @@ import javax.net.ssl.SSLContext;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
-import network.crypta.node.NodeStarter;
 import network.crypta.support.api.BooleanCallback;
 import network.crypta.support.api.IntCallback;
 import network.crypta.support.api.StringCallback;
@@ -382,7 +381,7 @@ public class SSL {
 
     // Generate a key pair.
     KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGORITHM, "BC");
-    keyPairGenerator.initialize(KEY_SIZE, NodeStarter.getGlobalSecureRandom());
+    keyPairGenerator.initialize(KEY_SIZE, CryptoRandoms.shared());
     KeyPair keyPair = keyPairGenerator.generateKeyPair();
 
     // Build a certificate.

--- a/src/main/java/network/crypta/keys/ChkKeySizes.java
+++ b/src/main/java/network/crypta/keys/ChkKeySizes.java
@@ -1,0 +1,21 @@
+package network.crypta.keys;
+
+import network.crypta.crypt.KeyType;
+
+/**
+ * Defines CHK-specific key sizes in the keys package.
+ *
+ * <p>This package-private helper keeps CHK byte-count decisions close to the code that validates
+ * and allocates CHK crypto material. The values are still derived from shared cryptographic
+ * definitions rather than hard-coded magic numbers, but callers no longer need to depend on
+ * unrelated node-layer constants just to ask how many bytes an AES-256 CHK key requires.
+ */
+final class ChkKeySizes {
+  /** Number of bytes required for CHK AES-256 crypto keys. */
+  static final int AES_256_BYTES = KeyType.AES_256.keySize / Byte.SIZE;
+
+  /** Prevents instantiation of this constants-only helper. */
+  private ChkKeySizes() {
+    throw new IllegalStateException("Utility class");
+  }
+}

--- a/src/main/java/network/crypta/keys/ClientCHKBlock.java
+++ b/src/main/java/network/crypta/keys/ClientCHKBlock.java
@@ -18,7 +18,6 @@ import network.crypta.crypt.UnsupportedCipherException;
 import network.crypta.crypt.Util;
 import network.crypta.crypt.ciphers.Rijndael;
 import network.crypta.keys.Key.Compressed;
-import network.crypta.node.Node;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.compress.InvalidCompressionCodecException;
@@ -224,7 +223,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
       throw new CHKDecodeException("Unsupported cipher", e);
     }
     byte[] cryptoKey = key.cryptoKey;
-    if (cryptoKey.length < Node.SYMMETRIC_KEY_LENGTH)
+    if (cryptoKey.length < ChkKeySizes.AES_256_BYTES)
       throw new CHKDecodeException("Crypto key too short");
     cipher.initialize(key.cryptoKey);
     byte[] zeroIv = new byte[PCFBMode.lengthIV(cipher)];
@@ -266,7 +265,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     long times = Long.MAX_VALUE;
     byte[] input = new byte[1024];
     byte[] output = new byte[hmac.getMacLength()];
-    byte[] key = new byte[Node.SYMMETRIC_KEY_LENGTH];
+    byte[] key = new byte[ChkKeySizes.AES_256_BYTES];
     final String algo = hmac.getAlgorithm();
     hmac.init(new SecretKeySpec(key, algo));
     // warm-up
@@ -300,7 +299,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     try {
       final String algo = HMAC_SHA256;
       final Provider sun = JceLoader.getSunJCE();
-      SecretKeySpec dummyKey = new SecretKeySpec(new byte[Node.SYMMETRIC_KEY_LENGTH], algo);
+      SecretKeySpec dummyKey = new SecretKeySpec(new byte[ChkKeySizes.AES_256_BYTES], algo);
       Mac hmac = Mac.getInstance(algo);
       hmac.init(dummyKey); // resolve provider
       hmac = safeSelectPreferredHmac(hmac, sun, dummyKey);
@@ -342,7 +341,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     byte[] data = block.data;
     byte[] hash = Arrays.copyOfRange(headers, 2, 2 + 32);
     byte[] cryptoKey = key.cryptoKey;
-    if (cryptoKey.length < Node.SYMMETRIC_KEY_LENGTH)
+    if (cryptoKey.length < ChkKeySizes.AES_256_BYTES)
       throw new CHKDecodeException("Crypto key too short");
     try {
       Cipher cipher = Cipher.getInstance("AES/CTR/NOPADDING", Rijndael.getAesCtrProvider());
@@ -404,7 +403,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
     byte[] data = block.data;
     byte[] hash = Arrays.copyOfRange(headers, 2, 2 + 32);
     byte[] cryptoKey = key.cryptoKey;
-    if (cryptoKey.length < Node.SYMMETRIC_KEY_LENGTH)
+    if (cryptoKey.length < ChkKeySizes.AES_256_BYTES)
       throw new CHKDecodeException("Crypto key too short");
     Rijndael aes;
     try {
@@ -457,7 +456,7 @@ public class ClientCHKBlock implements ClientKeyBlock {
    *
    * @param data the block payload, exactly {@link CHKBlock#DATA_LENGTH} bytes.
    * @param cryptoKey optional encryption key; when non-null it must be {@link
-   *     Node#SYMMETRIC_KEY_LENGTH} bytes.
+   *     ChkKeySizes#AES_256_BYTES} bytes.
    * @param cryptoAlgorithm algorithm selector; one of {@link Key#ALGO_AES_PCFB_256_SHA256} or
    *     {@link Key#ALGO_AES_CTR_256_SHA256}.
    * @return the encoded client block.

--- a/src/main/java/network/crypta/keys/FreenetURI.java
+++ b/src/main/java/network/crypta/keys/FreenetURI.java
@@ -21,8 +21,6 @@ import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import network.crypta.client.InsertException.InsertExceptionMode;
-import network.crypta.client.InsertException;
 import network.crypta.support.Base64;
 import network.crypta.support.Fields;
 import network.crypta.support.IllegalBase64Exception;
@@ -655,6 +653,7 @@ public final class FreenetURI implements Comparable<FreenetURI>, Serializable {
    *
    * <p>Not intended for direct use.
    */
+  @SuppressWarnings("unused")
   FreenetURI() {
     // For serialization only.
     this.metaStr = null;
@@ -1236,24 +1235,6 @@ public final class FreenetURI implements Comparable<FreenetURI>, Serializable {
   public FreenetURI setRoutingKey(byte[] newRoutingKey) {
     return new FreenetURI(
         keyType, docName, metaStr, newRoutingKey, cryptoKey, extra, suggestedEdition);
-  }
-
-  /**
-   * Throw an InsertException if we have any meta-strings. They are not valid for inserts, you must
-   * insert a directory to create a directory structure.
-   */
-  public void checkInsertURI() throws InsertException {
-    if (metaStr != null && metaStr.length > 0)
-      throw new InsertException(InsertExceptionMode.META_STRINGS_NOT_SUPPORTED, this);
-  }
-
-  /**
-   * Throw an InsertException if the argument has any meta-strings. They are not valid for inserts,
-   * you must insert a directory to create a directory structure.
-   */
-  @SuppressWarnings("unused")
-  public static void checkInsertURIOrThrow(FreenetURI uri) throws InsertException {
-    uri.checkInsertURI();
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -20,6 +20,7 @@ import network.crypta.config.FreenetFilePersistentConfig;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
+import network.crypta.crypt.CryptoRandoms;
 import network.crypta.crypt.JceLoader;
 import network.crypta.crypt.RandomSource;
 import network.crypta.crypt.SSL;
@@ -138,6 +139,7 @@ public class NodeStarter implements WrapperListener {
 
     // Initialize RNG, defaulting to Yarrow if none supplied.
     RandomSource random = randomSource != null ? randomSource : new Yarrow();
+    getGlobalSecureRandom();
 
     if (enablePlug) {
       startKeepAlivePlugThread();
@@ -402,20 +404,15 @@ public class NodeStarter implements WrapperListener {
   }
 
   /**
-   * Returns a lazily initialized process-wide {@link SecureRandom} and ensures it seeds eagerly.
+   * Returns the process-wide {@link SecureRandom} shared with {@link CryptoRandoms}.
+   *
+   * <p>Node bootstrap calls this during startup so the shared instance is force-seeded before later
+   * cryptographic operations use it.
    *
    * @return shared {@link SecureRandom} instance
    */
-  public static synchronized SecureRandom getGlobalSecureRandom() {
-    if (globalSecureRandom == null) {
-      globalSecureRandom = new SecureRandom();
-      forceSecureRandomSeeding(globalSecureRandom);
-    }
-    return globalSecureRandom;
-  }
-
-  private static void forceSecureRandomSeeding(SecureRandom secureRandom) {
-    secureRandom.nextBytes(new byte[16]); // Force it to seed itself so it blocks now, not later.
+  public static SecureRandom getGlobalSecureRandom() {
+    return CryptoRandoms.shared();
   }
 
   /**
@@ -534,6 +531,7 @@ public class NodeStarter implements WrapperListener {
     WrapperManager.signalStarting(500000);
 
     startKeepAliveNativePlugThread();
+    getGlobalSecureRandom();
 
     initSSL(cfg);
 
@@ -1265,9 +1263,6 @@ public class NodeStarter implements WrapperListener {
   private static boolean isTestingVM;
   private static boolean isStarted;
   private static Thread nativeKeepAlivePlugThread;
-
-  /** Static instance of SecureRandom, as opposed to Node's copy. @see getSecureRandom() */
-  private static SecureRandom globalSecureRandom;
 
   private Node node;
 }

--- a/src/test/java/network/crypta/client/InsertUriChecksTest.java
+++ b/src/test/java/network/crypta/client/InsertUriChecksTest.java
@@ -1,0 +1,35 @@
+package network.crypta.client;
+
+import java.util.Random;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class InsertUriChecksTest {
+
+  @Test
+  void checkInsertURI_whenMetaStringsPresent_throwsMetaStringsNotSupported() {
+    FreenetURI uri = FreenetURI.generateRandomCHK(new Random(1)).pushMetaString("file");
+
+    InsertException ex =
+        assertThrows(InsertException.class, () -> InsertUriChecks.checkInsertURI(uri));
+    assertEquals(InsertExceptionMode.META_STRINGS_NOT_SUPPORTED, ex.getMode());
+    assertEquals(uri, ex.getUri());
+  }
+
+  @Test
+  void checkInsertURI_whenMetaStringsAbsent_passes() {
+    assertDoesNotThrow(() -> InsertUriChecks.checkInsertURI(FreenetURI.EMPTY_CHK_URI));
+  }
+
+  @Test
+  void checkInsertURI_whenUriIsNull_throwsNullPointerException() {
+    //noinspection DataFlowIssue
+    assertThrows(NullPointerException.class, () -> InsertUriChecks.checkInsertURI(null));
+  }
+}

--- a/src/test/java/network/crypta/crypt/BucketInputStreamsTest.java
+++ b/src/test/java/network/crypta/crypt/BucketInputStreamsTest.java
@@ -1,0 +1,141 @@
+package network.crypta.crypt;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import network.crypta.support.api.Bucket;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"java:S100", "java:S5778", "EmptyTryBlock"})
+@ExtendWith(MockitoExtension.class)
+class BucketInputStreamsTest {
+
+  @Test
+  void openAndFreeOnClose_whenBucketProvidesStream_readDelegatesAndReturnsData() throws Exception {
+    byte[] src = new byte[] {0, 1, 2, 3, 4, 5};
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getInputStream()).thenReturn(new ByteArrayInputStream(src));
+
+    try (InputStream is = BucketInputStreams.openAndFreeOnClose(bucket)) {
+      byte[] buf = new byte[4];
+      int read = is.read(buf, 1, 2);
+
+      assertEquals(2, read);
+      assertArrayEquals(new byte[] {0, 0, 1, 0}, buf);
+    }
+  }
+
+  @Test
+  void openAndFreeOnClose_whenUsingArrayOverload_doesNotFallBackToSingleByteRead()
+      throws Exception {
+    class NoSingleByteReadInputStream extends InputStream {
+      private final byte[] data;
+      private int pos = 0;
+
+      NoSingleByteReadInputStream(byte[] data) {
+        this.data = data;
+      }
+
+      @Override
+      public int read() {
+        throw new IllegalStateException("single-byte read() must not be used");
+      }
+
+      @Override
+      public int read(byte @NotNull [] b, int off, int len) {
+        if (pos >= data.length) return -1;
+        int n = Math.min(len, data.length - pos);
+        System.arraycopy(data, pos, b, off, n);
+        pos += n;
+        return n;
+      }
+    }
+
+    byte[] src = new byte[] {10, 11, 12, 13, 14};
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getInputStream()).thenReturn(new NoSingleByteReadInputStream(src));
+
+    try (InputStream is = BucketInputStreams.openAndFreeOnClose(bucket)) {
+      byte[] buf1 = new byte[3];
+      int r1 = is.read(buf1);
+      assertEquals(3, r1);
+      assertArrayEquals(new byte[] {10, 11, 12}, buf1);
+
+      byte[] buf2 = new byte[4];
+      int r2 = is.read(buf2, 1, 3);
+      assertEquals(2, r2);
+      assertArrayEquals(new byte[] {0, 13, 14, 0}, buf2);
+    }
+  }
+
+  @Test
+  void openAndFreeOnClose_whenCalled_closesStreamThenFreesBucketInOrder() throws Exception {
+    InputStream underlying = mock(InputStream.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getInputStream()).thenReturn(underlying);
+
+    try (var _ = BucketInputStreams.openAndFreeOnClose(bucket)) {
+      // no-op
+    }
+
+    InOrder order = inOrder(underlying, bucket);
+    order.verify(underlying, times(1)).close();
+    order.verify(bucket, times(1)).free();
+  }
+
+  @Test
+  void openAndFreeOnClose_whenUnderlyingCloseThrows_propagatesAndDoesNotFree() throws Exception {
+    InputStream underlying = mock(InputStream.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getInputStream()).thenReturn(underlying);
+    doThrow(new IOException("boom")).when(underlying).close();
+
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> {
+              try (var _ = BucketInputStreams.openAndFreeOnClose(bucket)) {
+                // no-op
+              }
+            });
+    assertEquals("boom", ex.getMessage());
+    verify(bucket, times(0)).free();
+  }
+
+  @Test
+  void openAndFreeOnClose_whenBucketOpenThrows_propagatesAndDoesNotFree() throws Exception {
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getInputStream()).thenThrow(new IOException("boom"));
+
+    IOException ex =
+        assertThrows(IOException.class, () -> BucketInputStreams.openAndFreeOnClose(bucket));
+
+    assertEquals("boom", ex.getMessage());
+    verify(bucket, times(0)).free();
+  }
+
+  @Test
+  void openAndFreeOnClose_withNullBucket_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          try (var _ = BucketInputStreams.openAndFreeOnClose(null)) {
+            // no-op
+          }
+        });
+  }
+}

--- a/src/test/java/network/crypta/crypt/CryptoRandomsTest.java
+++ b/src/test/java/network/crypta/crypt/CryptoRandomsTest.java
@@ -1,0 +1,25 @@
+package network.crypta.crypt;
+
+import java.security.SecureRandom;
+import network.crypta.node.NodeStarter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@SuppressWarnings("java:S100")
+class CryptoRandomsTest {
+  @Test
+  void shared_whenCalledTwice_expectSameInstance() {
+    SecureRandom first = CryptoRandoms.shared();
+    SecureRandom second = CryptoRandoms.shared();
+
+    assertNotNull(first);
+    assertSame(first, second);
+  }
+
+  @Test
+  void shared_whenComparedWithNodeStarter_expectSameInstance() {
+    assertSame(CryptoRandoms.shared(), NodeStarter.getGlobalSecureRandom());
+  }
+}

--- a/src/test/java/network/crypta/keys/ClientCHKBlockTest.java
+++ b/src/test/java/network/crypta/keys/ClientCHKBlockTest.java
@@ -3,7 +3,6 @@ package network.crypta.keys;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
-import network.crypta.node.Node;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.ArrayBucketFactory;
@@ -166,8 +165,8 @@ class ClientCHKBlockTest {
     ClientCHK goodKey = good.getClientKey();
     byte[] routing = goodKey.getRoutingKey();
     byte[] extra = goodKey.getExtra();
-    // Use a deterministic short key: length SYMMETRIC_KEY_LENGTH - 1
-    byte[] shortKey = Arrays.copyOf(goodKey.getCryptoKey(), Node.SYMMETRIC_KEY_LENGTH - 1);
+    // Use a deterministic short key: length AES_256_BYTES - 1
+    byte[] shortKey = Arrays.copyOf(goodKey.getCryptoKey(), ChkKeySizes.AES_256_BYTES - 1);
     ClientCHK shortClientKey = new ClientCHK(routing, shortKey, extra);
 
     ClientCHKBlock forged = forgeBlock(good, shortClientKey);
@@ -247,7 +246,8 @@ class ClientCHKBlockTest {
   @Test
   void encodeNew_throwsOnWrongAlgorithm() {
     byte[] data = new byte[CHKBlock.DATA_LENGTH];
-    byte[] encKey = new byte[Node.SYMMETRIC_KEY_LENGTH];
+    assertEquals(32, ChkKeySizes.AES_256_BYTES);
+    byte[] encKey = new byte[ChkKeySizes.AES_256_BYTES];
     MessageDigest md = network.crypta.crypt.SHA256.getMessageDigest();
     ClientCHKEncodeParams params =
         new ClientCHKEncodeParams(
@@ -266,7 +266,7 @@ class ClientCHKBlockTest {
     for (int i = 0; i < data.length; i++) data[i] = (byte) (i & 0xFF);
     byte[] original = data.clone();
     MessageDigest md = network.crypta.crypt.SHA256.getMessageDigest();
-    byte[] encKey = new byte[Node.SYMMETRIC_KEY_LENGTH];
+    byte[] encKey = new byte[ChkKeySizes.AES_256_BYTES];
     ClientCHKBlock.innerEncode(
         new ClientCHKEncodeParams(
             new ClientCHKEncodePayload(data, /* dataLength= */ 123, md, encKey),

--- a/src/test/java/network/crypta/keys/FreenetURITest.java
+++ b/src/test/java/network/crypta/keys/FreenetURITest.java
@@ -13,7 +13,6 @@ import java.util.Random;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -314,12 +313,11 @@ class FreenetURITest {
   }
 
   @Test
-  @SuppressWarnings("java:S1612")
-  void checkInsertURI_throwsWhenMetaStringsPresent() {
+  void hasMetaStrings_reportsPresenceOfMetaStrings() {
     FreenetURI uri = FreenetURI.generateRandomCHK(new Random(1)).pushMetaString("file");
-    // Disambiguate overloaded methods by using explicit lambdas
-    assertThrows(network.crypta.client.InsertException.class, uri::checkInsertURI);
-    assertDoesNotThrow(FreenetURI.EMPTY_CHK_URI::checkInsertURI);
+
+    assertTrue(uri.hasMetaStrings());
+    assertFalse(FreenetURI.EMPTY_CHK_URI.hasMetaStrings());
   }
 
   @Test

--- a/src/test/java/network/crypta/node/NodeStarterTest.java
+++ b/src/test/java/network/crypta/node/NodeStarterTest.java
@@ -4,10 +4,15 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import network.crypta.config.PersistentConfig;
+import network.crypta.config.SubConfig;
+import network.crypta.crypt.CryptoRandoms;
 import network.crypta.crypt.DummyRandomSource;
 import network.crypta.crypt.RandomSource;
+import network.crypta.crypt.SSL;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.NativeThread;
@@ -183,6 +188,55 @@ class NodeStarterTest {
       assertEquals(1, nativeThreadCtor.constructed().size());
       wm.verify(() -> WrapperManager.signalStarting(500000), times(1));
       wm.verify(() -> WrapperManager.stop(expectedExitCode), times(0));
+    }
+  }
+
+  @Test
+  void start_whenBootstrapping_warmsSharedRandomBeforeInitializingSsl()
+      throws ReflectiveOperationException, java.io.IOException {
+    File tmpDir = createStandaloneTempDir("node-starter-rng-order-");
+    NodeStarter ns = newNodeStarterViaReflection();
+    int expectedExitCode = NodeInitException.EXIT_COULD_NOT_START_UPDATER;
+    String[] args = startupArgs(tmpDir);
+    SecureRandom sharedRandom = new SecureRandom();
+    List<String> calls = new ArrayList<>();
+
+    try (MockedStatic<WrapperManager> wm = Mockito.mockStatic(WrapperManager.class);
+        MockedStatic<CryptoRandoms> cryptoRandoms = Mockito.mockStatic(CryptoRandoms.class);
+        MockedStatic<SSL> ssl = Mockito.mockStatic(SSL.class);
+        MockedConstruction<NativeThread> nativeThreadCtor =
+            Mockito.mockConstruction(NativeThread.class);
+        MockedConstruction<Node> nodeCtor =
+            Mockito.mockConstruction(
+                Node.class,
+                (mock, _) ->
+                    Mockito.doThrow(new NodeInitException(expectedExitCode, "simulated startup"))
+                        .when(mock)
+                        .start(false))) {
+      wm.when(WrapperManager::isControlledByNativeWrapper).thenReturn(false);
+      cryptoRandoms
+          .when(CryptoRandoms::shared)
+          .thenAnswer(
+              _ -> {
+                calls.add("random");
+                return sharedRandom;
+              });
+      ssl.when(() -> SSL.init(Mockito.any(SubConfig.class)))
+          .thenAnswer(
+              _ -> {
+                calls.add("ssl");
+                return null;
+              });
+
+      Integer result = ns.start(args);
+
+      assertEquals(expectedExitCode, result);
+      assertEquals(1, nodeCtor.constructed().size());
+      assertEquals(1, nativeThreadCtor.constructed().size());
+      assertTrue(calls.contains("random"));
+      assertTrue(calls.contains("ssl"));
+      assertTrue(calls.indexOf("random") < calls.indexOf("ssl"));
+      cryptoRandoms.verify(CryptoRandoms::shared, times(1));
     }
   }
 
@@ -387,7 +441,6 @@ class NodeStarterTest {
   private static void resetNodeStarterStatics() throws ReflectiveOperationException {
     clearStaticBoolean("isStarted");
     clearStaticBoolean("isTestingVM");
-    clearStaticObject("globalSecureRandom");
     clearStaticObject("nodestarter_osgi");
   }
 


### PR DESCRIPTION
## Summary

- add crypt-local `CryptoRandoms` and `BucketInputStreams` helpers so `crypt/keys` no longer depend directly on `NodeStarter` or `ReadBucketAndFreeInputStream`
- move insert URI validation into `InsertUriChecks`, update client call sites, and remove the deprecated `FreenetURI` insert-validation shims
- replace the `Node.SYMMETRIC_KEY_LENGTH` dependency in `ClientCHKBlock`, preserve bootstrap RNG warming in `NodeStarter`, and update tests plus Javadoc for the new helpers

## Testing

- `./gradlew test`
- `javadoc -quiet -private -Xdoclint:all` on:
  - `src/main/java/network/crypta/client/InsertUriChecks.java`
  - `src/main/java/network/crypta/crypt/BucketInputStreams.java`
  - `src/main/java/network/crypta/crypt/CryptoRandoms.java`
  - `src/main/java/network/crypta/keys/ChkKeySizes.java`
