### PR TITLE
build(gradle): Generalize selective output pruning

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -48,14 +48,14 @@ Use this skill when you need to:
 - `:foundation-config` is the current home for all main `network.crypta.config` and
   `network.crypta.l10n` sources. Their unit tests still live in the root test tree and are run by
   the root project.
-- Every extracted internal leaf relies on leaf-owned stale-root-output metadata at
-  `<leaf>/gradle/owned-root-output-patterns.txt`. This is required even for structurally separate
-  package/resource moves, because stale root outputs from earlier builds or branch switches can
-  still shadow leaf outputs while `buildJar` packages root outputs first.
+- Every extracted internal leaf relies on leaf-owned aggregated-output metadata at
+  `<leaf>/gradle/owned-output-patterns.txt`. This is required even for structurally separate
+  package/resource moves, because stale non-owner aggregated outputs from earlier builds or branch
+  switches can still shadow leaf outputs while `buildJar` packages aggregated main outputs first.
 - Update that metadata whenever a leaf starts owning additional main classes/resources that root
   used to compile/package. If the split under `network.crypta.support*` keeps growing, prefer a
   future extraction such as `:foundation-support`, but keep the metadata accurate until the build
-  no longer has that shadowing risk.
+  no longer has that stale non-owner aggregated output shadowing risk.
 
 ## Architecture overview (by package)
 ### Core network layer (`network.crypta.node`)

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -24,12 +24,12 @@ Use this skill when you need to:
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
 - `:foundation-config` owns the main `network.crypta.config` and `network.crypta.l10n` sources,
   plus the minimal support/node compile closure they currently need.
-- Every extracted internal leaf must keep leaf-owned stale-root-output metadata in sync at
-  `<leaf>/gradle/owned-root-output-patterns.txt`, even for structurally separate package/resource
-  moves. Non-clean builds and branch switches can leave stale root outputs behind, and `buildJar`
-  still packages root outputs before leaf outputs.
+- Every extracted internal leaf must keep leaf-owned aggregated-output metadata in sync at
+  `<leaf>/gradle/owned-output-patterns.txt`, even for structurally separate package/resource
+  moves. Non-clean builds and branch switches can leave stale non-owner aggregated outputs behind,
+  and `buildJar` still packages aggregated main outputs before leaf outputs.
 - When moving additional main classes/resources from root into any extracted leaf, update that
-  leaf's `owned-root-output-patterns.txt` and validate with
+  leaf's `owned-output-patterns.txt` and validate with
   `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`.
 - `:runtime-spi` is the JDK-only runtime/config API leaf. Its focused unit tests still live in the
   root test tree and run through the root build.

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ debhelper-build-stamp
 gradle
 !*/gradle/
 */gradle/**
-!*/gradle/owned-root-output-patterns.txt
+!*/gradle/owned-output-patterns.txt
 /.gradle-user-home
 debian/seednodes.fref
 .idea

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -280,22 +280,17 @@ val sharedSelectiveLeafPruneTaskNames =
     "test",
     "jacocoTestReport",
     "jacocoTestCoverageVerification",
+    "sonar",
+    "sonarqube",
+    "sonarResolver",
+    "sonarlintFile",
+    "sonarlintMain",
+    "sonarlintTest",
   )
 
 val rootSelectiveLeafPruneTaskNames =
   sharedSelectiveLeafPruneTaskNames +
-    setOf(
-      "copyResourcesToClasses2",
-      "buildJar",
-      "run",
-      "runLauncher",
-      "printDirs",
-      "sonar",
-      "sonarResolver",
-      "sonarlintFile",
-      "sonarlintMain",
-      "sonarlintTest",
-    )
+    setOf("copyResourcesToClasses2", "buildJar", "run", "runLauncher", "printDirs")
 
 internalLeafProjects.forEach { leaf ->
   leaf.wireSelectiveLeafOutputPruning(pruneSelectiveLeafOutputs, sharedSelectiveLeafPruneTaskNames)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,12 @@ val internalLeafJarNames =
     internalLeafProjects.map { leaf -> "${leaf.name}-${project.version}.jar" }.toSet()
   }
 
-data class SelectiveLeafRootOutputOwnership(
+data class AggregatedMainOutputProducer(val project: Project) {
+  val mainClassesDir = project.layout.buildDirectory.dir("classes/java/main")
+  val mainResourcesDir = project.layout.buildDirectory.dir("resources/main")
+}
+
+data class SelectiveLeafOutputOwnership(
   val leaf: Project,
   val metadataFile: File,
   val patterns: List<String>,
@@ -124,53 +129,58 @@ data class SelectiveLeafRootOutputOwnership(
           if (firstChar.isLowerCase()) firstChar.titlecase() else firstChar.toString()
         }
       } +
-      "RootOutputs"
+      "OwnedOutputsFromNonOwners"
 }
 
-fun parseOwnedRootOutputPatterns(metadataFile: File): List<String> =
+fun parseOwnedOutputPatterns(metadataFile: File): List<String> =
   metadataFile.useLines { lines ->
     lines.map(String::trim).filter { it.isNotEmpty() && !it.startsWith("#") }.toList()
   }
 
-val selectiveLeafOwnershipMetadataRelativePath = "gradle/owned-root-output-patterns.txt"
+val selectiveLeafOwnershipMetadataRelativePath = "gradle/owned-output-patterns.txt"
 
-// Every extracted internal leaf declares leaf-owned stale-root-output metadata under
-// <leaf>/gradle/owned-root-output-patterns.txt. Even structurally separated package moves need this
-// because stale root outputs from earlier builds or branch switches can still shadow leaf outputs
-// when buildJar packages sourceSets.main.output before the leaf outputs.
-val selectiveLeafRootOutputOwnerships =
+val aggregatedMainOutputProducers =
+  (listOf(project) + internalLeafProjects).map(::AggregatedMainOutputProducer)
+
+// Every extracted internal leaf declares aggregated main-output ownership metadata under
+// <leaf>/gradle/owned-output-patterns.txt. Structurally separated root -> leaf and leaf -> leaf
+// moves need this because stale outputs can survive in root or old leaf build directories on
+// non-clean builds or branch switches, while root packaging/runtime aggregation still consumes the
+// root main output and every internal leaf main output.
+val selectiveLeafOutputOwnerships =
   internalLeafProjects.map { leaf ->
     val metadataFile =
       leaf.layout.projectDirectory.file(selectiveLeafOwnershipMetadataRelativePath).asFile
     if (!metadataFile.isFile) {
       throw GradleException(
         "Missing ${relativePath(leaf.projectDir)}/$selectiveLeafOwnershipMetadataRelativePath " +
-          "for ${leaf.path}. Add leaf-owned stale-root-output metadata before extracting root " +
-          "outputs into this leaf."
+          "for ${leaf.path}. Add leaf-owned aggregated main-output ownership metadata before " +
+          "extracting root or leaf outputs into this leaf."
       )
     }
-    SelectiveLeafRootOutputOwnership(
+    SelectiveLeafOutputOwnership(
       leaf = leaf,
       metadataFile = metadataFile,
-      patterns = parseOwnedRootOutputPatterns(metadataFile),
+      patterns = parseOwnedOutputPatterns(metadataFile),
     )
   }
 
 val verifySelectiveLeafOwnershipMetadata by
   tasks.registering {
     group = "verification"
-    description = "Verifies leaf-owned stale-root-output metadata for selective extractions"
+    description =
+      "Verifies leaf-owned aggregated main-output ownership metadata for selective extractions"
     doLast {
       val currentOwnerships =
-        selectiveLeafRootOutputOwnerships.map { ownership ->
-          ownership.copy(patterns = parseOwnedRootOutputPatterns(ownership.metadataFile))
+        selectiveLeafOutputOwnerships.map { ownership ->
+          ownership.copy(patterns = parseOwnedOutputPatterns(ownership.metadataFile))
         }
 
       val emptyMetadataFiles =
         currentOwnerships.filter { it.patterns.isEmpty() }.map { relativePath(it.metadataFile) }
       if (emptyMetadataFiles.isNotEmpty()) {
         throw GradleException(
-          "Selective leaf ownership metadata must not be empty: " +
+          "Selective leaf aggregated main-output ownership metadata must not be empty: " +
             emptyMetadataFiles.sorted().joinToString(", ")
         )
       }
@@ -188,7 +198,9 @@ val verifySelectiveLeafOwnershipMetadata by
       if (duplicatePatternsWithinFile.isNotEmpty()) {
         throw GradleException(
           buildString {
-            appendLine("Duplicate patterns found within selective leaf ownership metadata:")
+            appendLine(
+              "Duplicate patterns found within selective leaf aggregated main-output ownership metadata:"
+            )
             duplicatePatternsWithinFile.forEach { (metadataPath, duplicatePatterns) ->
               appendLine("$metadataPath: ${duplicatePatterns.joinToString(", ")}")
             }
@@ -207,7 +219,9 @@ val verifySelectiveLeafOwnershipMetadata by
       if (duplicatePatternsAcrossLeaves.isNotEmpty()) {
         throw GradleException(
           buildString {
-            appendLine("Duplicate patterns claimed by multiple selective leaf projects:")
+            appendLine(
+              "Duplicate aggregated main-output ownership patterns claimed by multiple selective leaf projects:"
+            )
             duplicatePatternsAcrossLeaves.toSortedMap().forEach { (pattern, owningLeaves) ->
               appendLine("$pattern: ${owningLeaves.joinToString(", ")}")
             }
@@ -217,48 +231,81 @@ val verifySelectiveLeafOwnershipMetadata by
     }
   }
 
-val selectiveLeafRootOutputPruneTasks =
-  selectiveLeafRootOutputOwnerships.associate { ownership ->
+fun ownedOutputTreesFor(producer: AggregatedMainOutputProducer, patterns: List<String>) =
+  listOf(
+    fileTree(producer.mainClassesDir) { include(*patterns.toTypedArray()) },
+    fileTree(producer.mainResourcesDir) { include(*patterns.toTypedArray()) },
+  )
+
+val selectiveLeafOutputPruneTasks =
+  selectiveLeafOutputOwnerships.associate { ownership ->
     ownership.leaf.path to
       tasks.register<Delete>(ownership.pruneTaskName) {
+        val staleOutputTrees =
+          aggregatedMainOutputProducers
+            .filter { producer -> producer.project != ownership.leaf }
+            .flatMap { producer -> ownedOutputTreesFor(producer, ownership.patterns) }
         description =
-          "Removes stale root outputs for sources extracted into ${ownership.leaf.path} on non-clean builds"
+          "Removes stale non-owner aggregated main outputs for paths owned by ${ownership.leaf.path} on non-clean builds"
         dependsOn(verifySelectiveLeafOwnershipMetadata)
         outputs.upToDateWhen { false }
-        delete(
-          fileTree(layout.buildDirectory.dir("classes/java/main")) {
-            include(*ownership.patterns.toTypedArray())
-          },
-          fileTree(layout.buildDirectory.dir("resources/main")) {
-            include(*ownership.patterns.toTypedArray())
-          },
-        )
+        delete(staleOutputTrees)
       }
   }
 
-val pruneFoundationConfigRootOutputs =
-  selectiveLeafRootOutputPruneTasks.getValue(":foundation-config")
-
-val pruneSelectiveLeafRootOutputs by
+val pruneSelectiveLeafOutputs by
   tasks.registering {
     description =
-      "Removes stale root outputs claimed by selectively extracted leaf projects on non-clean builds"
+      "Removes stale aggregated main outputs claimed by selectively extracted leaf projects on non-clean builds"
     dependsOn(verifySelectiveLeafOwnershipMetadata)
-    dependsOn(selectiveLeafRootOutputPruneTasks.values)
+    dependsOn(selectiveLeafOutputPruneTasks.values)
   }
 
+fun Project.wireSelectiveLeafOutputPruning(
+  pruneTask: TaskProvider<out Task>,
+  taskNames: Set<String>,
+) {
+  tasks.matching { task -> task.name in taskNames }.configureEach { dependsOn(pruneTask) }
+}
+
+val sharedSelectiveLeafPruneTaskNames =
+  setOf(
+    "compileJava",
+    "processResources",
+    "classes",
+    "jar",
+    "compileTestJava",
+    "processTestResources",
+    "testClasses",
+    "test",
+    "jacocoTestReport",
+    "jacocoTestCoverageVerification",
+  )
+
+val rootSelectiveLeafPruneTaskNames =
+  sharedSelectiveLeafPruneTaskNames +
+    setOf(
+      "copyResourcesToClasses2",
+      "buildJar",
+      "run",
+      "runLauncher",
+      "printDirs",
+      "sonar",
+      "sonarResolver",
+      "sonarlintFile",
+      "sonarlintMain",
+      "sonarlintTest",
+    )
+
 internalLeafProjects.forEach { leaf ->
+  leaf.wireSelectiveLeafOutputPruning(pruneSelectiveLeafOutputs, sharedSelectiveLeafPruneTaskNames)
   leaf.extensions.configure<org.sonarqube.gradle.SonarExtension>("sonar") { isSkipProject = true }
 }
 
-tasks.named("copyResourcesToClasses2") { dependsOn(pruneSelectiveLeafRootOutputs) }
-
-tasks.named("compileJava") { dependsOn(pruneSelectiveLeafRootOutputs) }
-
-tasks.named("processResources") { dependsOn(pruneSelectiveLeafRootOutputs) }
+project.wireSelectiveLeafOutputPruning(pruneSelectiveLeafOutputs, rootSelectiveLeafPruneTaskNames)
 
 tasks.named<org.gradle.jvm.tasks.Jar>("buildJar") {
-  dependsOn(pruneSelectiveLeafRootOutputs)
+  dependsOn(pruneSelectiveLeafOutputs)
   dependsOn(internalLeafProjects.map { "${it.path}:classes" })
   internalLeafProjects.forEach { leaf ->
     from(

--- a/foundation-compat/gradle/owned-output-patterns.txt
+++ b/foundation-compat/gradle/owned-output-patterns.txt
@@ -1,0 +1,3 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :foundation-compat owns them now.
+
+network/crypta/compat/**

--- a/foundation-compat/gradle/owned-root-output-patterns.txt
+++ b/foundation-compat/gradle/owned-root-output-patterns.txt
@@ -1,3 +1,0 @@
-# Root outputs that must be pruned on non-clean builds because :foundation-compat owns them now.
-
-network/crypta/compat/**

--- a/foundation-config/gradle/owned-output-patterns.txt
+++ b/foundation-config/gradle/owned-output-patterns.txt
@@ -1,6 +1,7 @@
-# Root outputs that must be pruned on non-clean builds because :foundation-config owns them now.
+# Aggregated main outputs that must be pruned on non-clean builds because :foundation-config owns them now.
 # Future selective extractions should either tighten the structural boundary or add/update the
-# relevant leaf-owned metadata file instead of hardcoding patterns in the root build script.
+# relevant leaf-owned metadata file instead of hardcoding aggregated main-output ownership in the
+# root build script.
 
 network/crypta/config/**
 network/crypta/l10n/**

--- a/foundation-fs/gradle/owned-output-patterns.txt
+++ b/foundation-fs/gradle/owned-output-patterns.txt
@@ -1,0 +1,3 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :foundation-fs owns them now.
+
+network/crypta/fs/**

--- a/foundation-fs/gradle/owned-root-output-patterns.txt
+++ b/foundation-fs/gradle/owned-root-output-patterns.txt
@@ -1,3 +1,0 @@
-# Root outputs that must be pruned on non-clean builds because :foundation-fs owns them now.
-
-network/crypta/fs/**

--- a/launcher-desktop/gradle/owned-output-patterns.txt
+++ b/launcher-desktop/gradle/owned-output-patterns.txt
@@ -1,0 +1,5 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :launcher-desktop owns them now.
+
+com/jthemedetecor/**
+network/crypta/launcher/**
+oshi/annotation/**

--- a/launcher-desktop/gradle/owned-root-output-patterns.txt
+++ b/launcher-desktop/gradle/owned-root-output-patterns.txt
@@ -1,5 +1,0 @@
-# Root outputs that must be pruned on non-clean builds because :launcher-desktop owns them now.
-
-com/jthemedetecor/**
-network/crypta/launcher/**
-oshi/annotation/**

--- a/runtime-spi/gradle/owned-output-patterns.txt
+++ b/runtime-spi/gradle/owned-output-patterns.txt
@@ -1,0 +1,3 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :runtime-spi owns them now.
+
+network/crypta/runtime/spi/**

--- a/runtime-spi/gradle/owned-root-output-patterns.txt
+++ b/runtime-spi/gradle/owned-root-output-patterns.txt
@@ -1,3 +1,0 @@
-# Root outputs that must be pruned on non-clean builds because :runtime-spi owns them now.
-
-network/crypta/runtime/spi/**

--- a/thirdparty-legacy/gradle/owned-output-patterns.txt
+++ b/thirdparty-legacy/gradle/owned-output-patterns.txt
@@ -1,0 +1,5 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :thirdparty-legacy owns them now.
+
+org/bitpedia/**
+org/sevenzip/**
+org/spaceroots/**

--- a/thirdparty-legacy/gradle/owned-root-output-patterns.txt
+++ b/thirdparty-legacy/gradle/owned-root-output-patterns.txt
@@ -1,5 +1,0 @@
-# Root outputs that must be pruned on non-clean builds because :thirdparty-legacy owns them now.
-
-org/bitpedia/**
-org/sevenzip/**
-org/spaceroots/**

--- a/thirdparty-onion/gradle/owned-output-patterns.txt
+++ b/thirdparty-onion/gradle/owned-output-patterns.txt
@@ -1,0 +1,4 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :thirdparty-onion owns them now.
+
+com/onionnetworks/**
+lib/fec.properties

--- a/thirdparty-onion/gradle/owned-root-output-patterns.txt
+++ b/thirdparty-onion/gradle/owned-root-output-patterns.txt
@@ -1,4 +1,0 @@
-# Root outputs that must be pruned on non-clean builds because :thirdparty-onion owns them now.
-
-com/onionnetworks/**
-lib/fec.properties


### PR DESCRIPTION
## Summary
- generalize selective leaf ownership from root-only output pruning to all aggregated main-output producers
- rename leaf ownership metadata to `owned-output-patterns.txt` and keep duplicate/empty ownership verification
- prune matching paths from every non-owner root or leaf main output before compile, packaging, runtime, test, JaCoCo, and Sonar consumers

## How to test
- `./gradlew verifySelectiveLeafOwnershipMetadata`
- `./gradlew verifySelectiveLeafOwnershipMetadata :foundation-config:classes buildJar`
- `./gradlew --dry-run test run :foundation-config:assemble`
- `./gradlew --dry-run sonar sonarlintMain`
- create fake `network/crypta/config/**` files under the root and `foundation-fs` build outputs, run `./gradlew pruneFoundationConfigOwnedOutputsFromNonOwners`, and confirm the stale files are removed

## Notes
- This is a build-only PR; it does not move support/config/crypto/store sources.
- Explicit `*:jar` invocation is still blocked by the existing `cryptad.buildjar` guard, so the leaf `jar` path was validated via `:foundation-config:assemble --dry-run` instead.