### PR TITLE
refactor(crypt): Decouple ResumeContext from MasterSecret

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientContext.java
+++ b/src/main/java/network/crypta/client/async/ClientContext.java
@@ -10,6 +10,7 @@ import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
+import network.crypta.crypt.CryptoResumeContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.RequestScheduler;
@@ -62,7 +63,7 @@ import network.crypta.support.io.TempBucketFactory;
  * @see ClientRequestScheduler
  * @see RequestScheduler
  */
-public class ClientContext implements ResumeContext {
+public class ClientContext implements CryptoResumeContext {
 
   private ClientRequestScheduler sskFetchSchedulerBulk;
   private ClientRequestScheduler chkFetchSchedulerBulk;
@@ -77,12 +78,12 @@ public class ClientContext implements ResumeContext {
   private final PriorityAwareExecutor mainExecutorInternal;
 
   /**
-   * We need to be able to suspend execution of jobs changing persistent state in order to write it
-   * to disk consistently. Also, some jobs may want to request immediate serialization.
+   * We need to be able to suspend execution of jobs changing persistent state to write it to disk
+   * consistently. Also, some jobs may want to request immediate serialization.
    */
   public final PersistentJobRunner jobRunner;
 
-  /** Strong, cryptographic RNG used for IDs, nonces, and protocol randomness. Thread-safe. */
+  /** Strong, cryptographic RNG used for IDs, nonce, and protocol randomness. Thread-safe. */
   public final RandomSource random;
 
   /**
@@ -92,8 +93,8 @@ public class ClientContext implements ResumeContext {
   public final ArchiveManager archiveManager;
 
   /**
-   * Factory for temporary buckets that persist on disk across restarts. Use when request state must
-   * survive crashes or shutdowns, such as persistent inserts or fetch retries.
+   * Factory for temporary buckets that persist on disk across restarts. Use when the request state
+   * must survive crashes or shutdowns, such as persistent inserts or fetch retries.
    */
   public final PersistentTempBucketFactory persistentBucketFactory;
 
@@ -113,7 +114,7 @@ public class ClientContext implements ResumeContext {
 
   /**
    * Produces lockable random-access buffers for data that must persist. Use for persistent request
-   * pipelines where intermediate state needs to be crash-safe.
+   * pipelines where the intermediate state needs to be crash-safe.
    */
   public final LockableRandomAccessBufferFactory persistentRAFFactory;
 
@@ -127,8 +128,8 @@ public class ClientContext implements ResumeContext {
   public final USKManager uskManager;
 
   /**
-   * Fast but weak PRNG for non-cryptographic use (e.g., jitter, randomized backoff). Do not use for
-   * secrets or key material. Thread-confined unless otherwise documented by callers.
+   * Fast but weak PRNG for non-cryptographic use (e.g., jitter, randomized backoff). Do not use it
+   * for secrets or key material. Thread-confined unless otherwise documented by callers.
    */
   public final Random fastWeakRandomSource;
 
@@ -161,7 +162,7 @@ public class ClientContext implements ResumeContext {
   private DownloadCache downloadCache;
 
   /**
-   * Used for memory intensive jobs such as in-RAM FEC decodes. Some of these jobs may do disk I/O,
+   * Used for memory-intensive jobs such as in-RAM FEC decoding. Some of these jobs may do disk I/O,
    * and we don't guarantee to serialize them. The new splitfile code does FEC decode entirely in
    * memory, which saves a lot of seeks and improves robustness.
    */
@@ -185,7 +186,7 @@ public class ClientContext implements ResumeContext {
 
   /**
    * Transient version of the PersistentJobRunner, just starts stuff immediately. Helpful for
-   * avoiding having two different API's, e.g. in SplitFileFetcherStorage.
+   * avoiding having two different APIs, e.g., in SplitFileFetcherStorage.
    */
   PersistentJobRunner dummyJobRunner;
 
@@ -195,7 +196,7 @@ public class ClientContext implements ResumeContext {
    * Creates a new client context wiring together schedulers, storage factories, crypto state, and
    * supporting services used by getters and putters.
    *
-   * @param bootID Monotonic identifier for this process instance; remains constant until restart
+   * @param bootID Monotonic identifier for this process instance, remains constant until restart
    *     and can be used to disambiguate ephemeral artifacts.
    * @param runtime Runtime executors, schedulers, and randomness sources used by the client layer.
    * @param storageFactories Storage factories and filename generators for transient and persistent
@@ -448,7 +449,7 @@ public class ClientContext implements ResumeContext {
    * Get the temporary bucket factory appropriate for a request.
    *
    * @param persistent If true, get the persistent temporary bucket factory. This creates buckets
-   *     which persist across restarts of the node. If false, get the temporary bucket factory,
+   *     which persist across the restarts of the node. If false, get the temporary bucket factory,
    *     which creates buckets which will be deleted once the node is restarted.
    * @return The appropriate {@link BucketFactory} for the {@code persistent} setting.
    */
@@ -458,7 +459,7 @@ public class ClientContext implements ResumeContext {
   }
 
   /**
-   * Get the RequestScheduler responsible for the given key type. This is used to queue low level
+   * Get the RequestScheduler responsible for the given key type. This is used to queue low-level
    * requests.
    *
    * @param ssk If true, get the SSK request scheduler. If false, get the CHK request scheduler.
@@ -488,8 +489,8 @@ public class ClientContext implements ResumeContext {
   /**
    * Sets the download cache reference used by client requests that support caching.
    *
-   * @param cache Cache implementation to use for subsequent downloads; may be {@code null} to
-   *     disable caching.
+   * @param cache Cache implementation to use for later downloads; may be {@code null} to disable
+   *     caching.
    */
   public void setDownloadCache(DownloadCache cache) {
     this.downloadCache = cache;
@@ -527,8 +528,8 @@ public class ClientContext implements ResumeContext {
   /**
    * Returns the job runner appropriate for the persistence mode.
    *
-   * @param persistent {@code true} to obtain the persistence-serializing runner; {@code false} for
-   *     the transient runner that starts work immediately.
+   * @param persistent {@code true} to get the persistence-serializing runner; {@code false} for the
+   *     transient runner that starts work immediately.
    * @return The {@link PersistentJobRunner} matching the requested mode.
    */
   public PersistentJobRunner getJobRunner(boolean persistent) {
@@ -570,7 +571,7 @@ public class ClientContext implements ResumeContext {
   /**
    * Returns the main priority-aware executor for client-layer tasks.
    *
-   * @return The executor used for general client scheduling outside of persistence serialization.
+   * @return The executor used for general client scheduling outside persistence serialization.
    */
   public PriorityAwareExecutor getMainExecutor() {
     return mainExecutorInternal;
@@ -589,7 +590,7 @@ public class ClientContext implements ResumeContext {
   /**
    * Updates the tracker responsible for persistent files created by client requests.
    *
-   * @param tracker New persistent file tracker to use for subsequent operations.
+   * @param tracker New persistent file tracker to use for later operations.
    */
   public void setPersistentFileTracker(PersistentFileTracker tracker) {
     this.persistentFileTracker = tracker;

--- a/src/main/java/network/crypta/crypt/CryptoResumeContext.java
+++ b/src/main/java/network/crypta/crypt/CryptoResumeContext.java
@@ -1,0 +1,37 @@
+package network.crypta.crypt;
+
+import network.crypta.support.api.ResumeContext;
+
+/**
+ * Crypto-specific resume context for persisted encrypted state.
+ *
+ * <p>This extension narrows where the persistent crypto state is exposed during resume. Generic
+ * persistence code such as file-backed buckets, trackers, and filename generators can continue to
+ * depend on {@link ResumeContext} alone. Encrypted buckets and buffers can then explicitly require
+ * the additional secret material they need. They use that material to rebuild the transient cipher
+ * state after deserialization or process restart.
+ *
+ * <p>Typical callers receive this view only inside persistence-oriented {@code onResume(...)}
+ * paths. Implementations should keep the contract small and stable: it exists to reconnect
+ * encrypted persistent objects to the process-local master secret, not to widen resume code into a
+ * general crypto service locator. That separation keeps support-layer APIs free of direct crypto
+ * coupling while preserving the existing resume behavior for encrypted storage wrappers.
+ *
+ * @see ResumeContext
+ */
+public interface CryptoResumeContext extends ResumeContext {
+
+  /**
+   * Returns the master secret used to re-establish a persistent encrypted state.
+   *
+   * <p>Encrypted buckets and buffers use this secret to derive the runtime keys, nonces, and other
+   * transient cryptographic material that is intentionally not serialized with persistent state.
+   * Implementations may return {@code null} when persistent encryption is unavailable or disabled.
+   * Callers are expected to treat that as part of their own resume contract rather than assuming
+   * that a usable secret is always present.
+   *
+   * @return the process-local master secret for persistent encrypted state, or {@code null} when
+   *     persistent encryption is not configured for the current runtime
+   */
+  MasterSecret getPersistentMasterSecret();
+}

--- a/src/main/java/network/crypta/crypt/CryptoResumeContexts.java
+++ b/src/main/java/network/crypta/crypt/CryptoResumeContexts.java
@@ -1,0 +1,41 @@
+package network.crypta.crypt;
+
+import network.crypta.support.api.ResumeContext;
+import network.crypta.support.io.ResumeFailedException;
+
+/**
+ * Internal helpers for resolving crypto-specific resume state.
+ *
+ * <p>This utility keeps the cast from {@link ResumeContext} to {@link CryptoResumeContext} in one
+ * package-local place so encrypted resume callers can fail consistently when they are invoked with
+ * a generic support-layer context. That keeps the public resume signatures unchanged while making
+ * the crypto dependency explicit at the point where encrypted state is actually reconstructed.
+ *
+ * <p>The helper is intentionally small. It does not add fallback behavior or alternate secret
+ * lookup rules; it only validates that the caller supplied the crypto-aware resume contract needed
+ * by encrypted persistent storage.
+ */
+final class CryptoResumeContexts {
+
+  /** Prevents instantiation of this utility holder. */
+  private CryptoResumeContexts() {}
+
+  /**
+   * Returns the crypto-aware resume context required by encrypted persistent storage.
+   *
+   * <p>Encrypted buckets and buffers call this during resume when they need access to the
+   * persistent master secret. If the supplied context only implements the generic support-layer
+   * contract, resume cannot safely rebuild the encrypted state, so this method fails with a
+   * deterministic {@link ResumeFailedException}.
+   *
+   * @param context generic resume context supplied to an encrypted {@code onResume(...)} path
+   * @return the same context, narrowed to {@link CryptoResumeContext} for crypto-specific access
+   * @throws ResumeFailedException when the supplied context does not expose crypto resume services
+   */
+  static CryptoResumeContext require(ResumeContext context) throws ResumeFailedException {
+    if (context instanceof CryptoResumeContext cryptoContext) {
+      return cryptoContext;
+    }
+    throw new ResumeFailedException("Encrypted persistent state requires a CryptoResumeContext");
+  }
+}

--- a/src/main/java/network/crypta/crypt/EncryptedRandomAccessBucket.java
+++ b/src/main/java/network/crypta/crypt/EncryptedRandomAccessBucket.java
@@ -486,15 +486,16 @@ public final class EncryptedRandomAccessBucket implements RandomAccessBucket, Se
    * Reinitializes after process resume/deserialization.
    *
    * <p>Resumes the underlying bucket first, then refreshes cryptographic material using the
-   * context's persistent master secret.
+   * persistent master secret exposed by the supplied {@link CryptoResumeContext}.
    *
-   * @param context resume context providing the persistent master secret.
+   * @param context resume context; encrypted state requires it to implement {@link
+   *     CryptoResumeContext}.
    * @throws ResumeFailedException if the underlying bucket fails to resume.
    */
   @Override
   public void onResume(ResumeContext context) throws ResumeFailedException {
     underlying.onResume(context);
-    this.masterKey = context.getPersistentMasterSecret();
+    this.masterKey = CryptoResumeContexts.require(context).getPersistentMasterSecret();
     baseSetup(masterKey);
   }
 

--- a/src/main/java/network/crypta/crypt/EncryptedRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/crypt/EncryptedRandomAccessBuffer.java
@@ -54,7 +54,7 @@ import org.bouncycastle.crypto.params.ParametersWithIV;
  * <p>Persistence: instances can be stored and restored via {@link #storeTo(DataOutputStream)} and
  * {@link #create(DataInputStream, FilenameGenerator, PersistentFileTracker, MasterSecret)}; an
  * {@link #onResume(ResumeContext)} call re-derives transient crypto state from the master secret
- * and validates the header.
+ * supplied by a {@link CryptoResumeContext} and validates the header.
  *
  * @author unixninja92 Suggested {@link EncryptedRandomAccessBufferType} to use: ChaCha128
  */
@@ -460,8 +460,8 @@ public final class EncryptedRandomAccessBuffer implements LockableRandomAccessBu
   /**
    * Recreates transient crypto state after deserialization or process restart.
    *
-   * <p>Derives keys from the persistent master secret in {@code context}, verifies the header, and
-   * initializes the stream ciphers.
+   * <p>Derives keys from the persistent master secret exposed by the supplied {@link
+   * CryptoResumeContext}, verifies the header, and initializes the stream ciphers.
    *
    * @throws ResumeFailedException If I/O or cryptographic initialization fails.
    */
@@ -469,7 +469,7 @@ public final class EncryptedRandomAccessBuffer implements LockableRandomAccessBu
   public void onResume(ResumeContext context) throws ResumeFailedException {
     underlyingBuffer.onResume(context);
     try {
-      setup(context.getPersistentMasterSecret(), false);
+      setup(CryptoResumeContexts.require(context).getPersistentMasterSecret(), false);
     } catch (IOException e) {
       throw new ResumeFailedException(
           new IOException("Disk I/O error resuming EncryptedRandomAccessBuffer", e));

--- a/src/main/java/network/crypta/support/api/ResumeContext.java
+++ b/src/main/java/network/crypta/support/api/ResumeContext.java
@@ -1,7 +1,6 @@
 package network.crypta.support.api;
 
 import java.util.Random;
-import network.crypta.crypt.MasterSecret;
 import network.crypta.support.io.FilenameGenerator;
 import network.crypta.support.io.PersistentFileTracker;
 
@@ -9,15 +8,16 @@ import network.crypta.support.io.PersistentFileTracker;
  * Narrow runtime view used to reconnect persisted bucket and buffer state after restart.
  *
  * <p>This interface exists for persistence-oriented components such as buckets, random-access
- * buffers, and encrypted wrappers that must rebuild transient runtime state after deserialization
- * or checkpoint restore. Callers use it from {@code onResume(...)} paths to reacquire only the
- * collaborators that remain meaningful across restarts. That keeps these storage-layer types from
- * depending directly on the larger client runtime surface.
+ * buffers, and other non-crypto persistence helpers that must rebuild the transient runtime state
+ * after deserialization or checkpoint restore. Callers use it from {@code onResume(...)} paths to
+ * reacquire only the collaborators that remain meaningful across restarts. That keeps these
+ * storage-layer types from depending directly on the larger client runtime surface.
  *
  * <p>The contract is intentionally small. Implementations should expose stable persistence helpers
  * only and avoid widening this type into a general execution context. Consumers should treat the
  * returned objects as process-local resume aids, not as permission to reach into unrelated client
- * behavior.
+ * behavior. Crypto-specific resume state belongs on a narrower extension, so this support-layer API
+ * stays free of direct crypto coupling.
  */
 public interface ResumeContext {
 
@@ -54,17 +54,4 @@ public interface ResumeContext {
    * @return the persistent file tracker used for resumed file lifecycle management
    */
   PersistentFileTracker getPersistentFileTracker();
-
-  /**
-   * Returns the master secret used to re-establish persistent encrypted state.
-   *
-   * <p>Encrypted persistent buckets and buffers use this secret to reconstruct their runtime
-   * cryptographic state after reload. Implementations may return {@code null} when persistent
-   * encryption is unavailable or disabled, and callers are expected to handle that case according
-   * to their own resume contract.
-   *
-   * @return the master secret for persistent encrypted state, or {@code null} when none is
-   *     configured
-   */
-  MasterSecret getPersistentMasterSecret();
 }

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -13,6 +13,7 @@ import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
+import network.crypta.crypt.CryptoResumeContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.ClientContextResources;
@@ -190,7 +191,7 @@ class ClientContextTest {
     assertEquals(0L, fakeTicker.lastOffset);
     assertNotNull(fakeTicker.lastJob);
 
-    // Set alerts then run the queued job
+    // Set alerts, then run the queued job
     UserAlertManager alerts = mock(UserAlertManager.class);
     setField(ctx, "alerts", alerts);
     fakeTicker.runLast();
@@ -266,7 +267,7 @@ class ClientContextTest {
   }
 
   @Test
-  void asResumeContext_whenViewedThroughInterface_exposesPersistentObjects() {
+  void asResumeContext_whenViewedThroughInterface_exposesGenericPersistentObjects() {
     MasterSecret secret = mock(MasterSecret.class);
     ctx.setPersistentMasterSecret(secret);
 
@@ -276,7 +277,16 @@ class ClientContextTest {
     assertSame(
         ctx.getPersistentFilenameGenerator(), resumeContext.getPersistentFilenameGenerator());
     assertSame(ctx.getPersistentFileTracker(), resumeContext.getPersistentFileTracker());
-    assertSame(secret, resumeContext.getPersistentMasterSecret());
+  }
+
+  @Test
+  void asCryptoResumeContext_whenViewedThroughInterface_exposesPersistentMasterSecret() {
+    MasterSecret secret = mock(MasterSecret.class);
+    ctx.setPersistentMasterSecret(secret);
+
+    CryptoResumeContext cryptoResumeContext = ctx;
+
+    assertSame(secret, cryptoResumeContext.getPersistentMasterSecret());
   }
 
   @Test

--- a/src/test/java/network/crypta/crypt/EncryptedRandomAccessBucketTest.java
+++ b/src/test/java/network/crypta/crypt/EncryptedRandomAccessBucketTest.java
@@ -25,6 +25,7 @@ import network.crypta.node.ClientContextResources;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.LockableRandomAccessBuffer;
 import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.api.ResumeContext;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.BucketTestBase;
 import network.crypta.support.io.BucketTools;
@@ -308,7 +309,7 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
     int ivLen = types[0].encryptType.ivSize; // bytes
     int keyLen = types[0].encryptKey.keySize >> 3; // bytes
     int macOffset = ivLen + keyLen;
-    raw[macOffset + 3] ^= 0x20; // flip a bit inside MAC region
+    raw[macOffset + 3] ^= 0x20; // flip a bit inside the MAC region
     ArrayBucket corrupted = new ArrayBucket(raw);
 
     EncryptedRandomAccessBucket corruptedBucket =
@@ -345,11 +346,30 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
       os.write(payload);
     }
     // Swap to a different master secret via ClientContext mock
-    ClientContext ctx = Mockito.mock(ClientContext.class);
+    CryptoResumeContext ctx = Mockito.mock(CryptoResumeContext.class);
     Mockito.when(ctx.getPersistentMasterSecret()).thenReturn(new MasterSecret());
     bucket.onResume(ctx);
     // Now the MAC/key derivation won't match the header; reading must fail
     assertThrows(IOException.class, bucket::getInputStreamUnbuffered);
+    bucket.free();
+  }
+
+  @Test
+  void onResume_whenResumeContextIsNotCrypto_expectResumeFailedException() throws Exception {
+    ArrayBucket underlying = new ArrayBucket();
+    EncryptedRandomAccessBucket bucket =
+        new EncryptedRandomAccessBucket(types[0], underlying, secret);
+    byte[] payload = new byte[] {10, 20, 30, 40};
+    try (OutputStream os = bucket.getOutputStream()) {
+      os.write(payload);
+    }
+    ResumeContext context = Mockito.mock(ResumeContext.class);
+
+    ResumeFailedException exception =
+        assertThrows(ResumeFailedException.class, () -> bucket.onResume(context));
+
+    assertEquals(
+        "Encrypted persistent state requires a CryptoResumeContext", exception.getMessage());
     bucket.free();
   }
 
@@ -374,16 +394,7 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
     try (DataOutputStream dos = new DataOutputStream(baos)) {
       erab.storeTo(dos);
     }
-    ClientContext context =
-        new ClientContext(
-            0,
-            new ClientContextRuntime(null, null, null, null, null, r, null),
-            new ClientContextStorageFactories(null, null, null, null, null, null, null),
-            new ClientContextRafFactories(null, null),
-            new ClientContextServices(
-                new ClientContextResources(null, null), null, null, null, null, null),
-            new ClientContextDefaults(null, null, null));
-    context.setPersistentMasterSecret(secret);
+    ClientContext context = createPersistentClientContext(r);
     EncryptedRandomAccessBucket restored;
     try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
       restored =
@@ -423,16 +434,7 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
     try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
       oos.writeObject(erab);
     }
-    ClientContext context =
-        new ClientContext(
-            0,
-            new ClientContextRuntime(null, null, null, null, null, r, null),
-            new ClientContextStorageFactories(null, null, null, null, null, null, null),
-            new ClientContextRafFactories(null, null),
-            new ClientContextServices(
-                new ClientContextResources(null, null), null, null, null, null, null),
-            new ClientContextDefaults(null, null, null));
-    context.setPersistentMasterSecret(secret);
+    ClientContext context = createPersistentClientContext(r);
     EncryptedRandomAccessBucket restored;
     try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         ObjectInputStream ois = new ObjectInputStream(dis)) {
@@ -476,16 +478,7 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
     try (ObjectInputStream ois =
         new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
       EncryptedRandomAccessBucket restored = (EncryptedRandomAccessBucket) ois.readObject();
-      ClientContext context =
-          new ClientContext(
-              0,
-              new ClientContextRuntime(null, null, null, null, null, r, null),
-              new ClientContextStorageFactories(null, null, null, null, null, null, null),
-              new ClientContextRafFactories(null, null),
-              new ClientContextServices(
-                  new ClientContextResources(null, null), null, null, null, null, null),
-              new ClientContextDefaults(null, null, null));
-      context.setPersistentMasterSecret(secret);
+      ClientContext context = createPersistentClientContext(r);
       restored.onResume(context);
       assertEquals(buf.length, restored.size());
       assertEquals(erab, restored);
@@ -506,6 +499,20 @@ class EncryptedRandomAccessBucketTest extends BucketTestBase {
   @Override
   protected void freeBucket(Bucket bucket) {
     bucket.free();
+  }
+
+  private ClientContext createPersistentClientContext(Random random) {
+    ClientContext context =
+        new ClientContext(
+            0,
+            new ClientContextRuntime(null, null, null, null, null, random, null),
+            new ClientContextStorageFactories(null, null, null, null, null, null, null),
+            new ClientContextRafFactories(null, null),
+            new ClientContextServices(
+                new ClientContextResources(null, null), null, null, null, null, null),
+            new ClientContextDefaults(null, null, null));
+    context.setPersistentMasterSecret(secret);
+    return context;
   }
 
   private static final MasterSecret secret = new MasterSecret();

--- a/src/test/java/network/crypta/crypt/EncryptedRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/crypt/EncryptedRandomAccessBufferTest.java
@@ -11,8 +11,8 @@ import java.io.ObjectOutputStream;
 import java.util.Locale;
 import java.util.Random;
 import java.util.stream.Stream;
-import network.crypta.client.async.ClientContext;
 import network.crypta.support.api.LockableRandomAccessBuffer;
+import network.crypta.support.api.ResumeContext;
 import network.crypta.support.io.BucketTools;
 import network.crypta.support.io.DelayedFree;
 import network.crypta.support.io.FileRandomAccessBuffer;
@@ -26,15 +26,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Unit tests for {@link EncryptedRandomAccessBuffer}.
  *
  * <p>Strategy: - Use in-memory or file-backed underlying RAFs with deterministic {@link
- * MasterSecret}. - Verify header handling (new vs existing), bounds, close semantics, resume
+ * MasterSecret}. - Verify header handling (new vs. existing), bounds, close semantics, resume
  * behavior, and persistence round-trips via {@link BucketTools#restoreRAFFrom}.
  */
 @SuppressWarnings("java:S100")
@@ -91,7 +95,7 @@ class EncryptedRandomAccessBufferTest {
   @MethodSource("types")
   @DisplayName("constructor_whenExistingAndBadMagic_expectIOException")
   void constructor_whenExistingAndBadMagic_expectIOException(EncryptedRandomAccessBufferType type) {
-    // Arrange: header area is zeroed -> bad magic
+    // Arrange: the header area is zeroed -> bad magic
     try (LockableRandomAccessBuffer underlying =
         new network.crypta.support.io.ByteArrayRandomAccessBuffer(type.headerLen + 10)) {
       assertThrows(
@@ -220,7 +224,7 @@ class EncryptedRandomAccessBufferTest {
           new EncryptedRandomAccessBuffer(type, underlying, secret, true);
       first.pwrite(0, data, 0, data.length);
 
-      // Act: reopen over same underlying with newFile=false
+      // Act: reopen over the same underlying with newFile=false
       try (EncryptedRandomAccessBuffer reopened =
           new EncryptedRandomAccessBuffer(type, underlying, secret, false)) {
         byte[] out = new byte[payload];
@@ -288,7 +292,7 @@ class EncryptedRandomAccessBufferTest {
       for (int i = 0; i < data.length; i++) data[i] = (byte) (i + 7);
       raf.pwrite(0, data, 0, data.length);
 
-      ClientContext ctx = Mockito.mock(ClientContext.class);
+      CryptoResumeContext ctx = Mockito.mock(CryptoResumeContext.class);
       Mockito.when(ctx.getPersistentMasterSecret()).thenReturn(secret);
 
       // Act
@@ -313,10 +317,31 @@ class EncryptedRandomAccessBufferTest {
             new EncryptedRandomAccessBuffer(type, underlying, deterministicSecret(), true)) {
       raf.pwrite(0, new byte[payload], 0, payload);
 
-      ClientContext ctx = Mockito.mock(ClientContext.class);
+      CryptoResumeContext ctx = Mockito.mock(CryptoResumeContext.class);
       Mockito.when(ctx.getPersistentMasterSecret()).thenReturn(new MasterSecret(new byte[64]));
 
       assertThrows(ResumeFailedException.class, () -> raf.onResume(ctx));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("types")
+  @DisplayName("onResume_whenResumeContextIsNotCrypto_expectResumeFailedException")
+  void onResume_whenResumeContextIsNotCrypto_expectResumeFailedException(
+      EncryptedRandomAccessBufferType type) throws Exception {
+    int payload = 8;
+    try (LockableRandomAccessBuffer underlying =
+            new network.crypta.support.io.ByteArrayRandomAccessBuffer(type.headerLen + payload);
+        EncryptedRandomAccessBuffer raf =
+            new EncryptedRandomAccessBuffer(type, underlying, deterministicSecret(), true)) {
+      raf.pwrite(0, new byte[payload], 0, payload);
+      ResumeContext context = Mockito.mock(ResumeContext.class);
+
+      ResumeFailedException exception =
+          assertThrows(ResumeFailedException.class, () -> raf.onResume(context));
+
+      assertEquals(
+          "Encrypted persistent state requires a CryptoResumeContext", exception.getMessage());
     }
   }
 
@@ -357,7 +382,7 @@ class EncryptedRandomAccessBufferTest {
   @DisplayName("storeTo_and_restoreRAFFrom_roundTrip_expectReadable")
   void storeTo_and_restoreRAFFrom_roundTrip_expectReadable(EncryptedRandomAccessBufferType type)
       throws Exception {
-    // Arrange underlying file-backed buffer so it can be restored from stream
+    // Arrange the underlying file-backed buffer so it can be restored from the stream
     File file = new File(tmpDir, "underlying.dat");
     int payload = 200;
     try (FileRandomAccessBuffer fab =
@@ -502,7 +527,7 @@ class EncryptedRandomAccessBufferTest {
           EncryptedRandomAccessBuffer restored = (EncryptedRandomAccessBuffer) ois.readObject()) {
         assertNotNull(restored);
         // Supply persistent secret and verify readability
-        ClientContext ctx = Mockito.mock(ClientContext.class);
+        CryptoResumeContext ctx = Mockito.mock(CryptoResumeContext.class);
         Mockito.when(ctx.getPersistentMasterSecret()).thenReturn(secret);
         restored.onResume(ctx);
 
@@ -544,7 +569,7 @@ class EncryptedRandomAccessBufferTest {
 
       try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes));
           EncryptedRandomAccessBuffer restored = (EncryptedRandomAccessBuffer) ois.readObject()) {
-        ClientContext ctx = Mockito.mock(ClientContext.class);
+        CryptoResumeContext ctx = Mockito.mock(CryptoResumeContext.class);
         Mockito.when(ctx.getPersistentMasterSecret()).thenReturn(secret);
         restored.onResume(ctx);
         byte[] out = new byte[payload];


### PR DESCRIPTION
## Summary

- introduce `CryptoResumeContext` and a small crypto-local helper so encrypted resume paths can explicitly require persistent crypto state
- remove `MasterSecret` from the generic `support.api.ResumeContext` contract and move `ClientContext` onto the crypto-specific extension
- update encrypted resume call sites, tests, and Javadocs so the support-layer API stays crypto-free while behavior remains unchanged

## How to test

- `./gradlew compileJava`
- `./gradlew testClasses`
- `./gradlew buildJar`
- `./gradlew test --tests '*ClientContextTest' --tests '*EncryptedRandomAccessBufferTest' --tests '*EncryptedRandomAccessBucketTest'`
- `./gradlew test`

## Notes

- no module extraction or source moves
- no ownership metadata changes
- no stale-output prune/verify guardrail changes