### PR TITLE
refactor(support): Introduce persistent filename contract

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientContext.java
+++ b/src/main/java/network/crypta/client/async/ClientContext.java
@@ -29,6 +29,7 @@ import network.crypta.support.io.FileRandomAccessBufferFactory;
 import network.crypta.support.io.FilenameGenerator;
 import network.crypta.support.io.NativeThread;
 import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentFilenameGenerator;
 import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.TempBucketFactory;
 
@@ -294,12 +295,12 @@ public class ClientContext implements CryptoResumeContext {
   }
 
   /**
-   * Returns the filename generator for persistent artifacts.
+   * Returns the filename contract for persistent artifacts.
    *
-   * @return the persistent filename generator
+   * @return the persistent filename contract
    */
   @Override
-  public FilenameGenerator getPersistentFilenameGenerator() {
+  public PersistentFilenameGenerator getPersistentFilenameGenerator() {
     return persistentFG;
   }
 

--- a/src/main/java/network/crypta/support/api/ResumeContext.java
+++ b/src/main/java/network/crypta/support/api/ResumeContext.java
@@ -1,8 +1,8 @@
 package network.crypta.support.api;
 
 import java.util.Random;
-import network.crypta.support.io.FilenameGenerator;
 import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentFilenameGenerator;
 
 /**
  * Narrow runtime view used to reconnect persisted bucket and buffer state after restart.
@@ -34,15 +34,15 @@ public interface ResumeContext {
   Random fastWeakRandom();
 
   /**
-   * Returns the filename generator for persistent artifacts.
+   * Returns the persistent filename contract for persistent artifacts.
    *
-   * <p>Resumed file-backed components use this generator to recover or allocate the stable file
-   * paths associated with persistent temporary storage. The generator should reflect the persistent
-   * storage namespace for the current process, not any transient scratch area.
+   * <p>Resumed file-backed components use this contract to recover or allocate the stable file
+   * paths associated with persistent temporary storage. The implementation should reflect the
+   * persistent storage namespace for the current process, not any transient scratch area.
    *
-   * @return the filename generator that manages persistent artifact naming for resumed state
+   * @return the persistent filename resolver used for resumed state
    */
-  FilenameGenerator getPersistentFilenameGenerator();
+  PersistentFilenameGenerator getPersistentFilenameGenerator();
 
   /**
    * Returns the tracker responsible for persistent temporary files.

--- a/src/main/java/network/crypta/support/io/FilenameGenerator.java
+++ b/src/main/java/network/crypta/support/io/FilenameGenerator.java
@@ -36,7 +36,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
  *
  * @author toad
  */
-public final class FilenameGenerator {
+public final class FilenameGenerator implements PersistentFilenameGenerator {
   private static final Logger LOG = LoggerFactory.getLogger(FilenameGenerator.class);
 
   private final Random random;
@@ -53,7 +53,7 @@ public final class FilenameGenerator {
    * <p>If {@code dir} is {@code null}, the system temporary directory specified by the {@code
    * java.io.tmpdir} system property is used. The directory is canonicalized before use. When {@code
    * wipeFiles} is {@code true}, existing files in the directory whose names start with {@code
-   * prefix} are deleted on best-effort basis. On Windows the match is case-insensitive.
+   * prefix} are deleted on a best-effort basis. On Windows the match is case-insensitive.
    *
    * <p>Security: uniqueness is enforced by {@link File#createNewFile()} to avoid time-of-check to
    * time-of-use races. Callers can supply a stronger {@link Random} implementation if desired.
@@ -176,7 +176,7 @@ public final class FilenameGenerator {
   }
 
   /**
-   * Resolves the file path corresponding to an identifier, without creating the file.
+   * Resolves the file path corresponding to an identifier without creating the file.
    *
    * <p>The identifier is encoded as a lower-case hexadecimal string via {@link
    * Long#toHexString(long)} and prefixed with the generator's prefix. The returned {@link File} may
@@ -186,6 +186,7 @@ public final class FilenameGenerator {
    *     associated with this generator's namespace
    * @return the file path under the configured temporary directory
    */
+  @Override
   public File getFilename(long id) {
     return new File(tmpDir, prefix + Long.toHexString(id));
   }
@@ -240,6 +241,7 @@ public final class FilenameGenerator {
    * @param id identifier to use when constructing the target file name
    * @return the destination file if the move succeeded; otherwise the original file
    */
+  @Override
   public File maybeMove(File file, long id) {
     if (matches(file)) return file;
     File newFile = getFilename(id);

--- a/src/main/java/network/crypta/support/io/PersistentFileTracker.java
+++ b/src/main/java/network/crypta/support/io/PersistentFileTracker.java
@@ -17,7 +17,8 @@ import java.io.File;
  *   <li>Schedule actual deletion of resources implementing {@link DelayedFree} only after the
  *       transaction recording their deletion has been durably persisted, to avoid data loss on
  *       unclean shutdowns.
- *   <li>Provide access to the persistent temporary directory and its {@link FilenameGenerator}.
+ *   <li>Provide access to the persistent temporary directory and its {@link
+ *       PersistentFilenameGenerator}.
  * </ul>
  *
  * <p>This interface also extends {@link DiskSpaceChecker}; implementations should use the same
@@ -85,9 +86,9 @@ public interface PersistentFileTracker extends DiskSpaceChecker {
   File dir();
 
   /**
-   * Returns the filename generator bound to the persistent temporary directory.
+   * Returns the persistent filename contract bound to the persistent temporary directory.
    *
-   * @return the generator used for naming and migration of temp files
+   * @return the contract used for naming and migration of temp files
    */
-  FilenameGenerator getGenerator();
+  PersistentFilenameGenerator getGenerator();
 }

--- a/src/main/java/network/crypta/support/io/PersistentFilenameGenerator.java
+++ b/src/main/java/network/crypta/support/io/PersistentFilenameGenerator.java
@@ -1,0 +1,50 @@
+package network.crypta.support.io;
+
+import java.io.File;
+
+/**
+ * Contract for resolving and relocating persistent temporary files.
+ *
+ * <p>Persistence-oriented code uses this interface to recover the stable file path associated with
+ * a persisted identifier and to reconcile that path with the current on-disk layout after restart
+ * or directory moves. The contract is intentionally narrow: it exposes only the operations needed
+ * by the generic resume and persistence surface and avoids coupling callers to any concrete
+ * filename generation strategy.
+ *
+ * <p>Typical callers are persistent buckets, pooled file buffers, and resume helpers that need to
+ * reopen or relocate files created in an earlier process. Those callers should treat the interface
+ * as a path-resolution contract, not as a general-purpose temp-file factory. Implementations may
+ * keep a richer internal state, but cross-boundary APIs should rely only on this minimal surface,
+ * so generic support code can move independently of the concrete filename generator implementation.
+ */
+public interface PersistentFilenameGenerator {
+
+  /**
+   * Returns the file associated with the supplied persistent identifier.
+   *
+   * <p>The returned path is stable for the current persistent filename namespace. It may already
+   * exist because a previous run created the file, or it may merely describe the location where
+   * resume code should recreate an empty file before continuing. Callers should not infer anything
+   * about file ownership beyond the identifier-to-path mapping exposed here.
+   *
+   * @param id persistent identifier whose stable backing-file path should be resolved
+   * @return the file currently associated with {@code id} in this namespace
+   */
+  File getFilename(long id);
+
+  /**
+   * Reconciles a stored file path with the current persistent filename namespace.
+   *
+   * <p>If the supplied file already belongs to the current namespace, implementations may return it
+   * unchanged. If the namespace has moved or the persisted path is stale, implementations may move
+   * the file into the expected location or otherwise recover the file that should now back the
+   * supplied identifier. Callers typically invoke this during resume after validating that some
+   * on-disk file still exists and before re-registering it with persistent tracking.
+   *
+   * @param file file to reconcile against the current namespace; must not be {@code null}
+   * @param id persistent identifier used to derive the expected current file path
+   * @return the file that resume code should use after reconciliation completes
+   * @throws ResumeFailedException if the stored file cannot be recovered into the current namespace
+   */
+  File maybeMove(File file, long id) throws ResumeFailedException;
+}

--- a/src/main/java/network/crypta/support/io/PersistentTempBucketFactory.java
+++ b/src/main/java/network/crypta/support/io/PersistentTempBucketFactory.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * <p>The deletion lifecycle is coordinated with persistence: buckets are freed only after the
  * transaction recording their deletion is durably committed. The factory is recreated on startup
  * and relies on callers to re-register their files, which prevents reuse after an unclean shutdown.
- * This class is thread-safe; it synchronizes around mutable state and uses a dedicated lock for
+ * This class is thread-safe; it synchronizes around the mutable state and uses a dedicated lock for
  * encryption settings.
  *
  * <p><strong>Notable behaviors:</strong>
@@ -41,9 +41,9 @@ public final class PersistentTempBucketFactory implements BucketFactory, Persist
   private static final Logger LOG = LoggerFactory.getLogger(PersistentTempBucketFactory.class);
 
   /**
-   * Original contents of directory. This used to be used to delete any files that we can't account
-   * for. However, at the moment we do not support garbage collection for non-blob persistent temp
-   * files. When we implement it, it will probably not use this structure.
+   * Original contents of the directory. This used to be used to delete any files that we can't
+   * account for. However, at the moment we do not support garbage collection for non-blob
+   * persistent temp files. When we implement it, it will probably not use this structure.
    */
   private HashSet<File> originalFiles;
 
@@ -56,7 +56,7 @@ public final class PersistentTempBucketFactory implements BucketFactory, Persist
   public final FilenameGenerator fg;
 
   /**
-   * Buckets to free. When buckets are freed, we write them to this list, and delete the files
+   * Buckets to free. When buckets are freed, we write them to this list and delete the files
    * *after* the transaction recording the buckets being deleted hits the disk.
    */
   private final ArrayList<DelayedFree> bucketsToFree;
@@ -294,16 +294,16 @@ public final class PersistentTempBucketFactory implements BucketFactory, Persist
   }
 
   /**
-   * Returns the filename generator responsible for persistent temp file naming.
+   * Returns the filename contract responsible for persistent temp file naming.
    *
-   * <p>The generator exposes the current directory and prefix and can relocate files when the
-   * tracked directory changes. Callers should not mutate its configuration directly and should rely
-   * on the factory methods to create new filenames.
+   * <p>The contract exposes the current directory and prefix through this factory and can relocate
+   * files when the tracked directory changes. Callers should not mutate its configuration directly
+   * and should rely on the factory methods to create new filenames.
    *
-   * @return the filename generator used by this factory.
+   * @return the filename contract used by this factory.
    */
   @Override
-  public FilenameGenerator getGenerator() {
+  public PersistentFilenameGenerator getGenerator() {
     return fg;
   }
 

--- a/src/main/java/network/crypta/support/io/PersistentTempFileBucket.java
+++ b/src/main/java/network/crypta/support/io/PersistentTempFileBucket.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Persistent, file-backed temporary bucket that survives process restarts.
+ * Persistent, file-backed temporary bucket that survives the process restarts.
  *
  * <p>This bucket stores its data in the persistent temp directory and is designed to be resumed
  * after a node restart. Unlike plain {@link TempFileBucket}, it never registers files with {@link
@@ -41,27 +41,30 @@ public class PersistentTempFileBucket extends TempFileBucket implements Serializ
    * Creates a persistent temp bucket for the given filename id.
    *
    * @param id stable identifier used by {@link FilenameGenerator} to derive the backing file name
-   * @param generator filename generator for locating/migrating the file
-   * @param tracker persistent file tracker providing disk-space checks and registration on resume
+   * @param generator filename contract for locating/migrating the file
+   * @param tracker a persistent file tracker providing disk-space checks and registration on resume
    */
   public PersistentTempFileBucket(
-      long id, FilenameGenerator generator, PersistentFileTracker tracker) {
+      long id, PersistentFilenameGenerator generator, PersistentFileTracker tracker) {
     this(id, generator, tracker, true);
   }
 
   /**
-   * Constructs a persistent temp bucket with explicit delete-on-free policy.
+   * Constructs a persistent temp bucket with an explicit delete-on-free policy.
    *
    * <p>Subclasses call this to create either a normal bucket ({@code deleteOnFree=true}) or a
    * shadow/read-only view ({@code deleteOnFree=false}).
    *
    * @param id stable identifier used by the generator
-   * @param generator filename generator for locating/migrating the file
+   * @param generator filename contract for locating/migrating the file
    * @param tracker persistent file tracker for disk checks and registration
    * @param deleteOnFree whether {@link #free()} deletes the backing file
    */
   protected PersistentTempFileBucket(
-      long id, FilenameGenerator generator, PersistentFileTracker tracker, boolean deleteOnFree) {
+      long id,
+      PersistentFilenameGenerator generator,
+      PersistentFileTracker tracker,
+      boolean deleteOnFree) {
     super(id, generator, deleteOnFree);
     this.tracker = tracker;
   }
@@ -104,7 +107,7 @@ public class PersistentTempFileBucket extends TempFileBucket implements Serializ
    * {@link BufferedOutputStream} with the same internal buffer size used for disk-space checks.
    *
    * @return a buffered output stream for writing the bucket contents
-   * @throws IOException if opening the underlying stream fails or the bucket is read-only/freed
+   * @throws IOException if opening the underlying stream fails, or the bucket is read-only/freed
    */
   @Override
   public OutputStream getOutputStream() throws IOException {
@@ -140,7 +143,7 @@ public class PersistentTempFileBucket extends TempFileBucket implements Serializ
      * resolve the generator and file location, then wire the tracker and register the file so it
      * is not collected during persistent-temp cleanup.
      *
-     * @param context resume context providing {@link PersistentFileTracker}
+     * @param context the resume context providing {@link PersistentFileTracker}
      * @throws ResumeFailedException if the backing file cannot be located or validated
      */
     super.innerResume(context);
@@ -195,7 +198,8 @@ public class PersistentTempFileBucket extends TempFileBucket implements Serializ
   }
 
   // Subclasses that add fields should override equals/hashCode. The tracker is transient and not
-  // part of logical identity; delegate to super to preserve TempFileBucket's equality semantics.
+  // part of logical identity; delegate to super class to preserve TempFileBucket's equality
+  // semantics.
   @Override
   public boolean equals(Object obj) {
     return super.equals(obj);

--- a/src/main/java/network/crypta/support/io/PooledFileRandomAccessBuffer.java
+++ b/src/main/java/network/crypta/support/io/PooledFileRandomAccessBuffer.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * while holding a pool lock throws {@link IllegalStateException}.
  *
  * <p>Serialization/resume: a compact descriptor can be written with {@link #storeTo} and restored
- * via the {@linkplain #PooledFileRandomAccessBuffer(DataInputStream, FilenameGenerator,
+ * via the {@linkplain #PooledFileRandomAccessBuffer(DataInputStream, PersistentFilenameGenerator,
  * PersistentFileTracker) persistence constructor}. {@link #onResume(ResumeContext)} validates and
  * re-registers persistent-temp files.
  *
@@ -629,18 +629,20 @@ public final class PooledFileRandomAccessBuffer
    * Reconstruct a buffer from a descriptor written by {@link #storeTo}.
    *
    * <p>Caller must consume {@link #MAGIC} before invoking this constructor; this method validates
-   * {@link #VERSION}. For persistent-temp files, the file may be moved by {@link FilenameGenerator}
-   * during resume.
+   * {@link #VERSION}. For persistent-temp files, the file may be moved by {@link
+   * PersistentFilenameGenerator} during resume.
    *
    * @param dis source stream positioned after {@link #MAGIC}
-   * @param fg filename generator for persistent-temp resolution
+   * @param fg filename contract for persistent-temp resolution
    * @param persistentFileTracker tracker used to (re)register files during resume
    * @throws StorageFormatException if the version or stored values are invalid
    * @throws IOException on I/O errors
    * @throws ResumeFailedException if the file is missing and cannot be recovered
    */
   PooledFileRandomAccessBuffer(
-      DataInputStream dis, FilenameGenerator fg, PersistentFileTracker persistentFileTracker)
+      DataInputStream dis,
+      PersistentFilenameGenerator fg,
+      PersistentFileTracker persistentFileTracker)
       throws StorageFormatException, IOException, ResumeFailedException {
     int version = dis.readInt();
     if (version != VERSION) throw new StorageFormatException("Bad version");

--- a/src/main/java/network/crypta/support/io/TempFileBucket.java
+++ b/src/main/java/network/crypta/support/io/TempFileBucket.java
@@ -15,8 +15,8 @@ import org.slf4j.LoggerFactory;
 /**
  * File-backed, non-persistent temporary bucket implementation.
  *
- * <p>This bucket stores data in a file located by a {@link FilenameGenerator}. Instances start
- * empty and, by design, operate directly on an already-existing file path (see {@link
+ * <p>This bucket stores data in a file located by a {@link PersistentFilenameGenerator}. Instances
+ * start empty and, by design, operate directly on an already-existing file path (see {@link
  * #tempFileAlreadyExists()}). Reads and writes are coordinated by the {@link BaseFileBucket}
  * superclass.
  *
@@ -49,11 +49,11 @@ public class TempFileBucket extends BaseFileBucket implements Bucket, Serializab
    */
   @Serial private static final long serialVersionUID = 1L;
 
-  /** Stable identifier used by {@link FilenameGenerator} to derive the file path. */
+  /** Stable identifier used by the filename contract to derive the file path. */
   long filenameID;
 
-  /** Non-serializable generator reattached on resume in persistent subclasses. */
-  protected transient FilenameGenerator generator;
+  /** Non-serializable filename contract reattached on resume in persistent subclasses. */
+  protected transient PersistentFilenameGenerator generator;
 
   /** When {@code true}, write operations are disallowed. */
   private volatile boolean readOnly;
@@ -74,9 +74,9 @@ public class TempFileBucket extends BaseFileBucket implements Bucket, Serializab
    * the lifetime of the JVM and can cause memory growth.
    *
    * @param id identifier used by the generator to compute the file path
-   * @param generator filename generator; must be non-null
+   * @param generator filename contract; must be non-null
    */
-  public TempFileBucket(long id, FilenameGenerator generator) {
+  public TempFileBucket(long id, PersistentFilenameGenerator generator) {
     // Using deleteOnExit() for temp files retains entries for JVM lifetime and risks memory leaks.
     this(id, generator, true);
   }
@@ -88,10 +88,10 @@ public class TempFileBucket extends BaseFileBucket implements Bucket, Serializab
    * shadows ({@code deleteOnFree=false}).
    *
    * @param id stable identifier used by the generator
-   * @param generator filename generator for locating the file; must be non-null
+   * @param generator filename contract for locating the file; must be non-null
    * @param deleteOnFree whether {@link #free()} deletes the underlying file
    */
-  protected TempFileBucket(long id, FilenameGenerator generator, boolean deleteOnFree) {
+  protected TempFileBucket(long id, PersistentFilenameGenerator generator, boolean deleteOnFree) {
     super(generator.getFilename(id), false, false, true);
     this.filenameID = id;
     this.generator = generator;
@@ -157,10 +157,10 @@ public class TempFileBucket extends BaseFileBucket implements Bucket, Serializab
    *
    * <p>This method updates {@link #generator} from {@link
    * ResumeContext#getPersistentFilenameGenerator()}, verifies the backing file exists (creating it
-   * if necessary), and relocates it using {@link FilenameGenerator#maybeMove(File, long)} when the
-   * generator's directory has changed.
+   * if necessary), and relocates it using {@link PersistentFilenameGenerator#maybeMove(File, long)}
+   * when the filename namespace has changed.
    *
-   * @param context client context providing a persistent {@link FilenameGenerator}
+   * @param context client context providing a persistent filename contract
    * @throws ResumeFailedException if the file is missing and cannot be created
    */
   protected void innerResume(ResumeContext context) throws ResumeFailedException {

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -30,6 +30,7 @@ import network.crypta.support.io.FileRandomAccessBufferFactory;
 import network.crypta.support.io.FilenameGenerator;
 import network.crypta.support.io.NativeThread;
 import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentFilenameGenerator;
 import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -277,6 +278,13 @@ class ClientContextTest {
     assertSame(
         ctx.getPersistentFilenameGenerator(), resumeContext.getPersistentFilenameGenerator());
     assertSame(ctx.getPersistentFileTracker(), resumeContext.getPersistentFileTracker());
+  }
+
+  @Test
+  void getPersistentFilenameGenerator_whenCalled_returnsPersistentFilenameGeneratorContract() {
+    PersistentFilenameGenerator persistentFilenameGenerator = ctx.getPersistentFilenameGenerator();
+
+    assertSame(ctx.persistentFG, persistentFilenameGenerator);
   }
 
   @Test

--- a/src/test/java/network/crypta/support/io/PersistentTempBucketFactoryTest.java
+++ b/src/test/java/network/crypta/support/io/PersistentTempBucketFactoryTest.java
@@ -258,4 +258,21 @@ class PersistentTempBucketFactoryTest {
     // Assert
     assertTrue(factory.isEncrypting());
   }
+
+  @Test
+  void getGenerator_whenViewedThroughTracker_returnsPersistentFilenameGeneratorContract()
+      throws Exception {
+    // Arrange
+    PersistentTempBucketFactory factory =
+        new PersistentTempBucketFactory(tempDir.toFile(), PREFIX, seededSecureRandom(14L), false);
+    //noinspection UnnecessaryLocalVariable
+    PersistentFileTracker tracker = factory;
+    long id = 0x14L;
+
+    // Act
+    PersistentFilenameGenerator generator = tracker.getGenerator();
+
+    // Assert
+    assertEquals(factory.fg.getFilename(id), generator.getFilename(id));
+  }
 }

--- a/src/test/java/network/crypta/support/io/PersistentTempFileBucketTest.java
+++ b/src/test/java/network/crypta/support/io/PersistentTempFileBucketTest.java
@@ -18,6 +18,7 @@ import network.crypta.client.async.ClientContextServices;
 import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.node.ClientContextResources;
 import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.api.ResumeContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -74,6 +76,7 @@ class PersistentTempFileBucketTest {
     return new AutoFree(bucket);
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class AutoFree implements AutoCloseable {
     private final PersistentTempFileBucket bucket;
 
@@ -105,7 +108,7 @@ class PersistentTempFileBucketTest {
           os,
           "Unbuffered stream must be DiskSpaceCheckingOutputStream");
 
-      // Sanity: write exactly threshold bytes to trigger a single check
+      // Sanity: exactly write threshold bytes to trigger a single check
       byte[] buf = new byte[PersistentTempFileBucket.BUFFER_SIZE];
       os.write(buf);
       os.close();
@@ -122,7 +125,7 @@ class PersistentTempFileBucketTest {
     when(trackerMock.checkDiskSpace(any(), anyInt(), anyInt())).thenReturn(true);
     PersistentTempFileBucket bucket = new PersistentTempFileBucket(id, generator, trackerMock);
     try (var _ = autoClose(bucket)) {
-      // Act & Assert: BufferedOutputStream wraps unbuffered disk-space checking stream.
+      // Act & Assert: BufferedOutputStream wraps an unbuffered disk-space checking stream.
       try (OutputStream os = bucket.getOutputStream()) {
         assertInstanceOf(
             BufferedOutputStream.class, os, "getOutputStream() should return a buffered stream");
@@ -160,7 +163,7 @@ class PersistentTempFileBucketTest {
   void write_whenLengthBelowThreshold_doesNotCallChecker() throws Exception {
     // Arrange
     long id = generator.makeRandomFilename();
-    // No stubbing needed; should not be called at all
+    // No stubbing needed; it should not be called at all
     PersistentTempFileBucket bucket = new PersistentTempFileBucket(id, generator, trackerMock);
     try (var _ = autoClose(bucket)) {
       // Act
@@ -190,7 +193,7 @@ class PersistentTempFileBucketTest {
             "Should throw when disk space checker rejects write at threshold");
       }
 
-      // File should exist but be empty (the write never reaches the underlying stream)
+      // File should exist but be empty (the writing never reaches the underlying stream)
       assertTrue(file.exists(), "File should exist after stream creation");
       assertEquals(0L, file.length(), "File length should remain zero on failed write");
     }
@@ -257,7 +260,7 @@ class PersistentTempFileBucketTest {
                   tempDir.toFile(), "ctx-", seededSecureRandom(3), false));
 
       // Rebuild context with ptbfSpy to ensure persistentFileTracker is our spy and persistentFG is
-      // generator
+      // the generator
       context =
           new ClientContext(
               0L,
@@ -280,6 +283,38 @@ class PersistentTempFileBucketTest {
 
       // Assert: factory registers the file
       verify(ptbfSpy, times(1)).register(generator.getFilename(id));
+    }
+  }
+
+  @Test
+  void innerResume_whenResumeContextProvidesPersistentFilenameGenerator_registersRelocatedFile()
+      throws Exception {
+    // Arrange
+    long id = 0x77L;
+    File original = tempDir.resolve("stored.tmp").toFile();
+    assertTrue(original.createNewFile(), "Setup should create the stored file");
+    PersistentFilenameGenerator initialGenerator = mock(PersistentFilenameGenerator.class);
+    when(initialGenerator.getFilename(id)).thenReturn(original);
+    PersistentTempFileBucket bucket =
+        new PersistentTempFileBucket(id, initialGenerator, trackerMock);
+
+    try (var _ = autoClose(bucket)) {
+      File relocated = tempDir.resolve("relocated.tmp").toFile();
+      assertTrue(relocated.createNewFile(), "Setup should create the relocated file");
+      PersistentFilenameGenerator resumedGenerator = mock(PersistentFilenameGenerator.class);
+      when(resumedGenerator.maybeMove(original, id)).thenReturn(relocated);
+      PersistentFileTracker resumedTracker = mock(PersistentFileTracker.class);
+      ResumeContext context = mock(ResumeContext.class);
+      when(context.getPersistentFilenameGenerator()).thenReturn(resumedGenerator);
+      when(context.getPersistentFileTracker()).thenReturn(resumedTracker);
+
+      // Act
+      bucket.innerResume(context);
+
+      // Assert
+      assertEquals(relocated, bucket.getFile());
+      verify(resumedGenerator, times(1)).maybeMove(original, id);
+      verify(resumedTracker, times(1)).register(relocated);
     }
   }
 

--- a/src/test/java/network/crypta/support/io/PooledFileRandomAccessBufferTest.java
+++ b/src/test/java/network/crypta/support/io/PooledFileRandomAccessBufferTest.java
@@ -1,7 +1,12 @@
 package network.crypta.support.io;
 
-import java.io.*;
-
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.stream.Stream;
@@ -15,11 +20,22 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
+import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @Tag("unit")
 @SuppressWarnings("java:S100") // Keep method_whenCondition_expectOutcome naming per project style
@@ -359,7 +375,7 @@ class PooledFileRandomAccessBufferTest {
         assertEquals(PooledFileRandomAccessBuffer.MAGIC, dis.readInt());
         try (PooledFileRandomAccessBuffer copy =
             new PooledFileRandomAccessBuffer(
-                dis, mock(FilenameGenerator.class), mock(PersistentFileTracker.class))) {
+                dis, mock(PersistentFilenameGenerator.class), mock(PersistentFileTracker.class))) {
 
           // Assert
           assertEquals(orig.size(), copy.size());
@@ -377,8 +393,8 @@ class PooledFileRandomAccessBufferTest {
     long tempId = 0xABCDL;
     ByteArrayOutputStream baos = getByteArrayOutputStream(original, tempId);
 
-    // Prepare mocks: original does not exist; generator resolves a different existing file
-    FilenameGenerator fg = mock(FilenameGenerator.class);
+    // Prepare mocks: the original does not exist; the generator resolves a different existing file
+    PersistentFilenameGenerator fg = mock(PersistentFilenameGenerator.class);
     PersistentFileTracker tracker = mock(PersistentFileTracker.class);
     File moved = new File(tempDir, "tmp-" + Long.toHexString(tempId));
     Files.write(moved.toPath(), new byte[0]); // ensure it exists
@@ -391,10 +407,37 @@ class PooledFileRandomAccessBufferTest {
 
         // Assert
         verify(tracker, times(1)).register(moved);
-        assertNotNull(p.file);
-        assertEquals(moved.getCanonicalPath(), p.file.getCanonicalPath());
+        File actualFile = requireNonNull(p.file, "restored file");
+        assertEquals(moved.getCanonicalPath(), actualFile.getCanonicalPath());
       }
     }
+  }
+
+  @Test
+  void load_whenPersistentTempFileExists_usesPersistentFilenameGeneratorContract()
+      throws Exception {
+    // Arrange
+    File existing = new File(tempDir, "existing-persistent.bin");
+    Files.write(existing.toPath(), new byte[0]);
+    long tempId = 0x4242L;
+    ByteArrayOutputStream baos = getByteArrayOutputStream(existing, tempId);
+    PersistentFilenameGenerator fg = mock(PersistentFilenameGenerator.class);
+    PersistentFileTracker tracker = mock(PersistentFileTracker.class);
+    when(fg.maybeMove(existing, tempId)).thenReturn(existing);
+
+    // Act
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      assertEquals(PooledFileRandomAccessBuffer.MAGIC, dis.readInt());
+      try (PooledFileRandomAccessBuffer p = new PooledFileRandomAccessBuffer(dis, fg, tracker)) {
+
+        // Assert
+        File actualFile = requireNonNull(p.file, "restored file");
+        assertEquals(existing.getCanonicalPath(), actualFile.getCanonicalPath());
+      }
+    }
+
+    verify(fg, times(1)).maybeMove(existing, tempId);
+    verifyNoInteractions(tracker);
   }
 
   private static @NotNull ByteArrayOutputStream getByteArrayOutputStream(File original, long tempId)
@@ -434,7 +477,7 @@ class PooledFileRandomAccessBufferTest {
       dos.writeBoolean(false);
     }
 
-    FilenameGenerator fg = mock(FilenameGenerator.class);
+    PersistentFilenameGenerator fg = mock(PersistentFilenameGenerator.class);
     when(fg.getFilename(tempId)).thenReturn(new File(tempDir, "absent-" + tempId));
     when(fg.maybeMove(org.mockito.ArgumentMatchers.any(File.class), anyLong()))
         .thenAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/network/crypta/support/io/TempFileBucketTest.java
+++ b/src/test/java/network/crypta/support/io/TempFileBucketTest.java
@@ -17,6 +17,7 @@ import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.node.ClientContextResources;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.api.ResumeContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -163,7 +164,7 @@ class TempFileBucketTest extends BucketTestBase {
         TempFileBucket shadowBucket = (TempFileBucket) shadow;
         assertTrue(shadowBucket.isReadOnly(), "Shadow must be read-only");
       }
-      // Shadow closed; file should still exist
+      // Shadow closed; the file should still exist
       assertTrue(file.exists(), "Shadow.close() must not delete the file");
     }
     File file2 = gen.getFilename(id);
@@ -198,7 +199,7 @@ class TempFileBucketTest extends BucketTestBase {
 
   @Test
   void innerResume_whenFileIsNull_setsGeneratorAndEnsuresFileExists() throws Exception {
-    // Arrange: construct a bucket as if deserialized from an old format (file is null)
+    // Arrange: construct a bucket as if deserialized from an old format (the file is null)
     long id = 0xabcdeL;
     FilenameGenerator gen =
         new FilenameGenerator(seededSecureRandom(8), false, tempDir.toFile(), "tfb-");
@@ -268,8 +269,39 @@ class TempFileBucketTest extends BucketTestBase {
       // Act
       bucket.innerResume(context);
 
-      // Assert: maybeMove must be invoked for non-null file path
+      // Assert: maybeMove must be invoked for a non-null file path
       verify(spyGen, times(1)).maybeMove(any(File.class), Mockito.eq(id));
+    }
+  }
+
+  @Test
+  void innerResume_whenResumeContextExposesPersistentFilenameGenerator_usesInterfaceContract()
+      throws Exception {
+    // Arrange
+    long id = 0x55L;
+    File original = tempDir.resolve("original.tmp").toFile();
+    assertTrue(original.createNewFile(), "Setup should create the original file");
+
+    PersistentFilenameGenerator initialGenerator = Mockito.mock(PersistentFilenameGenerator.class);
+    Mockito.when(initialGenerator.getFilename(id)).thenReturn(original);
+
+    try (TempFileBucket bucket = new TempFileBucket(id, initialGenerator)) {
+      File relocated = tempDir.resolve("relocated.tmp").toFile();
+      assertTrue(relocated.createNewFile(), "Setup should create the relocated file");
+
+      PersistentFilenameGenerator resumedGenerator =
+          Mockito.mock(PersistentFilenameGenerator.class);
+      Mockito.when(resumedGenerator.maybeMove(original, id)).thenReturn(relocated);
+
+      ResumeContext context = Mockito.mock(ResumeContext.class);
+      Mockito.when(context.getPersistentFilenameGenerator()).thenReturn(resumedGenerator);
+
+      // Act
+      bucket.innerResume(context);
+
+      // Assert
+      assertEquals(relocated, bucket.getFile());
+      Mockito.verify(resumedGenerator, times(1)).maybeMove(original, id);
     }
   }
 
@@ -359,7 +391,7 @@ class TempFileBucketTest extends BucketTestBase {
     long id = 0x12345L;
     FilenameGenerator gen =
         new FilenameGenerator(seededSecureRandom(18), false, tempDir.toFile(), "tfb-");
-    // emulate deserialized state: generator set but file is null
+    // emulate deserialized state: generator set, but the file is null
     try (TempFileBucket bucket = new TempFileBucket()) {
       bucket.filenameID = id;
       bucket.generator = gen;


### PR DESCRIPTION
## Summary
- add `PersistentFilenameGenerator` as the narrow cross-boundary contract for persistent filename lookup and relocation
- update the generic resume and persistence APIs to return that contract instead of exposing `FilenameGenerator` directly
- wire the temp-file resume implementations and `ClientContext` through the interface boundary while keeping behavior unchanged and adding focused unit coverage
- refresh Javadocs on the touched support-layer types to describe the contract rather than the concrete implementation
- keep this as a pure in-root dependency-prep change with no module/source moves, no `settings.gradle.kts` changes, and no owned-output or build-guardrail edits

## How to test
- `./gradlew test --tests 'network.crypta.client.async.ClientContextTest' --tests 'network.crypta.support.io.PersistentTempBucketFactoryTest' --tests 'network.crypta.support.io.TempFileBucketTest' --tests 'network.crypta.support.io.PersistentTempFileBucketTest' --tests 'network.crypta.support.io.PooledFileRandomAccessBufferTest'`
- `./gradlew test --tests 'network.crypta.support.io.PooledFileRandomAccessBufferTest'`
- `./gradlew test`
