### PR TITLE
refactor(runtime-bootstrap): Move startup CLI and logging glue

### DIFF
--- a/build-logic/spotbugs-exclude-test.xml
+++ b/build-logic/spotbugs-exclude-test.xml
@@ -44,7 +44,7 @@
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP2"/>
-    <Class name="~network\.crypta\.node\.NodeCliTest\$.*\$\$inlined\$assertThrows\$1"/>
+    <Class name="~network\.crypta\.runtime\.bootstrap\.NodeCliTest\$.*\$\$inlined\$assertThrows\$1"/>
     <Method name="&lt;init&gt;"/>
   </Match>
   <Match>
@@ -195,12 +195,12 @@
   </Match>
   <Match>
     <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
-    <Class name="network.crypta.node.NodeCliTest"/>
+    <Class name="network.crypta.runtime.bootstrap.NodeCliTest"/>
     <Method name="config_file_flag_overrides_positional"/>
   </Match>
   <Match>
     <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
-    <Class name="network.crypta.node.NodeCliTest"/>
+    <Class name="network.crypta.runtime.bootstrap.NodeCliTest"/>
     <Method name="explicitConfigFile_whenPositionalProvided_expectPositionalValue"/>
   </Match>
   <Match>

--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -1214,7 +1214,7 @@
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
-    <Class name="network.crypta.node.LoggingConfigHandler"/>
+    <Class name="network.crypta.runtime.bootstrap.LoggingConfigHandler"/>
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
@@ -1230,7 +1230,7 @@
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
-    <Class name="network.crypta.node.NodeCli"/>
+    <Class name="network.crypta.runtime.bootstrap.NodeCli"/>
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>

--- a/src/main/java/network/crypta/node/NodeStarter.java
+++ b/src/main/java/network/crypta/node/NodeStarter.java
@@ -28,6 +28,8 @@ import network.crypta.fs.AppDirs;
 import network.crypta.fs.AppEnv;
 import network.crypta.fs.Resolved;
 import network.crypta.fs.ServiceDirs;
+import network.crypta.runtime.bootstrap.LoggingConfigHandler;
+import network.crypta.runtime.bootstrap.NodeCli;
 import network.crypta.runtime.core.SSL;
 import network.crypta.support.JVMVersion;
 import network.crypta.support.Logging;

--- a/src/main/java/network/crypta/runtime/bootstrap/LoggingConfigHandler.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/LoggingConfigHandler.java
@@ -1,4 +1,4 @@
-package network.crypta.node;
+package network.crypta.runtime.bootstrap;
 
 import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Level;

--- a/src/main/java/network/crypta/runtime/bootstrap/NodeCli.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/NodeCli.java
@@ -1,4 +1,4 @@
-package network.crypta.node;
+package network.crypta.runtime.bootstrap;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import network.crypta.fs.Dirs;
+import network.crypta.node.Version;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;

--- a/src/main/java/network/crypta/runtime/bootstrap/package-info.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/package-info.java
@@ -1,9 +1,9 @@
 /**
  * Startup bootstrap and config wiring helpers for early node initialization.
  *
- * <p>This package groups the neutral runtime helpers that prepare program directories, random
- * sources, and node configuration callbacks during startup. The classes remain part of the daemon
- * runtime and preserve their existing behavior, but they are not part of the routing, storage, or
- * message kernel.
+ * <p>This package groups the neutral runtime helpers that handle CLI parsing, startup logging
+ * configuration, program-directory setup, and early bootstrap/config wiring during daemon startup.
+ * The classes remain part of the daemon runtime and preserve their existing behavior, but they are
+ * not part of the routing, storage, or message kernel.
  */
 package network.crypta.runtime.bootstrap;

--- a/src/test/java/network/crypta/runtime/bootstrap/LoggingConfigHandlerTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/LoggingConfigHandlerTest.java
@@ -1,4 +1,4 @@
-package network.crypta.node;
+package network.crypta.runtime.bootstrap;
 
 import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Level;

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeCliTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeCliTest.java
@@ -1,4 +1,4 @@
-package network.crypta.node;
+package network.crypta.runtime.bootstrap;
 
 import java.io.File;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- move `NodeCli` and `LoggingConfigHandler` from `network.crypta.node` to `network.crypta.runtime.bootstrap`
- move the package-local `NodeCliTest` and `LoggingConfigHandlerTest` classes to the matching bootstrap test package, and update `NodeStarter` imports
- expand `runtime.bootstrap` package documentation and update SpotBugs excludes to the relocated FQCNs

## Testing
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests 'network.crypta.runtime.bootstrap.NodeCliTest' --tests 'network.crypta.runtime.bootstrap.LoggingConfigHandlerTest' --tests 'network.crypta.node.NodeStarterTest' --tests 'network.crypta.runtime.bootstrap.NodeBootstrapTest' --tests 'network.crypta.runtime.bootstrap.NodeConfigManagerTest'`
- `./gradlew spotbugsMain spotbugsTest`