### PR TITLE
refactor(runtime): Remove HTTP shim, refresh docs

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -49,19 +49,26 @@ Use this skill when you need to:
     resources
 - The runtime boundary is split intentionally:
   - `:runtime-spi` exposes small JDK-only ports and immutable config DTOs.
-  - The root project implements those ports in `network.crypta.node.runtime.LegacyRuntimePorts`
-    plus per-slice adapters such as `LegacyConfigPort`, `LegacyNodeInfoPort`, `LegacyPeerPort`,
-    `LegacyConnectionsPagePort`, `LegacyConnectionsSupportPort`,
-    `LegacyDarknetConnectionsPort`, `LegacyDarknetMessagingPort`,
-    `LegacyQueuePagePort`, `LegacyQueueDownloadPort`, `LegacyQueueInsertPort`,
-    `LegacyQueueMutationPort`, `LegacyQueueSupportPort`, `LegacyQueueCompletionPort`,
-    `LegacySecurityLevelsPort`, `LegacyPageChromePort`, `LegacyCoreUpdateActionPort`,
-    `LegacyFirstTimeWizardPort`, `LegacyToadletSymlinkPort`, `LegacyWelcomePagePort`, and
-    `LegacyWelcomeActionPort`.
+  - The root project implements those ports across `network.crypta.runtime.core` and
+    `network.crypta.runtime.admin`. The runtime nucleus lives in
+    `network.crypta.runtime.core.LegacyRuntimePorts` plus core adapters such as
+    `LegacyConfigPort`, `LegacyConnectivityPort`, `LegacyNodeInfoPort`, `LegacyPeerPort`,
+    `LegacyRequestQueuePort`, `LegacySecurityLevelsPort`, and `LegacyCoreUpdateActionPort`.
+    Page-oriented adapters such as `LegacyConnectionsPagePort`,
+    `LegacyConnectionsSupportPort`, `LegacyDarknetConnectionsPort`,
+    `LegacyDarknetMessagingPort`, `LegacyQueuePagePort`, `LegacyQueueDownloadPort`,
+    `LegacyQueueInsertPort`, `LegacyQueueMutationPort`, `LegacyQueueSupportPort`,
+    `LegacyQueueCompletionPort`, `LegacyPageChromePort`, `LegacyDiagnosticPort`,
+    `LegacyStatisticsPort`, `LegacyFirstTimeWizardPort`, `LegacyToadletSymlinkPort`,
+    `LegacyWelcomePagePort`, and `LegacyWelcomeActionPort` now live in
+    `network.crypta.runtime.admin`.
 - The large cyclic daemon core still lives in the root project:
   most of `network.crypta.node`, the daemon-coupled transport/socket/filter side of
-  `network.crypta.io.comm`, `network.crypta.client`, `network.crypta.clients`,
-  `network.crypta.node.runtime`, the remaining daemon-coupled support code, and
+  `network.crypta.io.comm`, `network.crypta.client`, `network.crypta.clients`, the
+  `network.crypta.runtime.bootstrap`, `network.crypta.runtime.core`,
+  `network.crypta.runtime.admin`, `network.crypta.runtime.alerts`,
+  `network.crypta.runtime.endpoints`, `network.crypta.runtime.services`, and
+  `network.crypta.runtime.updater` families, the remaining daemon-coupled support code, and
   `network.crypta.tools`.
 - The wire split is intentionally narrow:
   `:interop-wire` owns the message/schema nucleus, while root keeps `MessageCore`,
@@ -86,7 +93,17 @@ Use this skill when you need to:
 - Peer management: `PeerNode`, `PeerManager`
 - Network transport: `PacketSender`, `FNPPacketMangler`
 - Request orchestration: `RequestStarter`, `RequestScheduler`
-- Updates: `NodeUpdateManager`
+- Updates now bootstrap through `network.crypta.runtime.updater.NodeUpdateManager`
+
+### Runtime orchestration packages (`network.crypta.runtime.*`)
+- Startup/CLI/config bootstrap: `network.crypta.runtime.bootstrap`
+  (`NodeStarter`, `NodeBootstrap`, `NodeCli`, `NodeConfigManager`, `LoggingConfigHandler`)
+- Runtime SPI nucleus and daemon-backed core adapters: `network.crypta.runtime.core`
+- Page-oriented admin/runtime adapters: `network.crypta.runtime.admin`
+- Operator-facing alerts: `network.crypta.runtime.alerts`
+- Endpoint bootstrap glue for FCP/HTTP/TMCI: `network.crypta.runtime.endpoints`
+- Service coordination: `network.crypta.runtime.services`
+- Core/plugin update subsystem: `network.crypta.runtime.updater`
 
 ### Content storage (`network.crypta.store`)
 - Storage abstractions: `FreenetStore`
@@ -97,7 +114,7 @@ Use this skill when you need to:
 - Neutral contracts `BlockMetadata`, `GetPubkey`, and `StorableBlock` live in
   `:foundation-store-contracts`, along with the store-maintenance alert seam in
   `network.crypta.store.alerts`.
-- Root-owned runtime/UI integration remains in `network.crypta.node.runtime`, for example
+- Root-owned runtime/UI integration now lives in `network.crypta.runtime.alerts`, for example
   `UserAlertManagerStoreAlertSink`.
 
 ### Cryptography (`network.crypta.crypt`)
@@ -120,7 +137,7 @@ Use this skill when you need to:
   `network.crypta.node.VersionParseException`, `network.crypta.node.probe.Error`,
   `network.crypta.node.probe.Type`, and `network.crypta.support.Serializer`.
 - Root keeps transport-facing code such as `PeerContext`, `MessageCore`, filters, packet/socket
-  handlers, and runtime helpers like `network.crypta.node.runtime.SSL`.
+  handlers, and runtime helpers like `network.crypta.runtime.core.SSL`.
 
 ### Client APIs
 - High-level client: `network.crypta.client`
@@ -182,27 +199,16 @@ Use this skill when you need to:
   `QueuePageSnapshot`, `QueuePersistenceStatusSnapshot`, `QueueInsertOutcome`,
   `SecurityLevelsSnapshot`, `PageChromeSnapshot`, `FirstTimeWizardSnapshot`,
   `FirstTimeWizardCurrentBandwidthLimits`, `ToadletSymlinkEntry`, and `WelcomePageSnapshot`
-- Root adapters: `network.crypta.node.runtime.LegacyRuntimePorts`,
-  `network.crypta.node.runtime.LegacyConfigPort`,
-  `network.crypta.node.runtime.LegacyNodeInfoPort`,
-  `network.crypta.node.runtime.LegacyPeerPort`,
-  `network.crypta.node.runtime.LegacyConnectionsPagePort`,
-  `network.crypta.node.runtime.LegacyConnectionsSupportPort`,
-  `network.crypta.node.runtime.LegacyDarknetConnectionsPort`,
-  `network.crypta.node.runtime.LegacyDarknetMessagingPort`,
-  `network.crypta.node.runtime.LegacyPageChromePort`,
-  `network.crypta.node.runtime.LegacyCoreUpdateActionPort`,
-  `network.crypta.node.runtime.LegacyQueuePagePort`,
-  `network.crypta.node.runtime.LegacyQueueDownloadPort`,
-  `network.crypta.node.runtime.LegacyQueueInsertPort`,
-  `network.crypta.node.runtime.LegacyQueueMutationPort`,
-  `network.crypta.node.runtime.LegacyQueueSupportPort`,
-  `network.crypta.node.runtime.LegacyQueueCompletionPort`,
-  `network.crypta.node.runtime.LegacySecurityLevelsPort`,
-  `network.crypta.node.runtime.LegacyFirstTimeWizardPort`,
-  `network.crypta.node.runtime.LegacyToadletSymlinkPort`,
-  `network.crypta.node.runtime.LegacyWelcomePagePort`,
-  `network.crypta.node.runtime.LegacyWelcomeActionPort`
+- Root adapters in `network.crypta.runtime.core`: `LegacyRuntimePorts`, `LegacyConfigPort`,
+  `LegacyConnectivityPort`, `LegacyNodeInfoPort`, `LegacyPeerPort`, `LegacyRequestQueuePort`,
+  `LegacySecurityLevelsPort`, and `LegacyCoreUpdateActionPort`
+- Root adapters in `network.crypta.runtime.admin`: `LegacyConnectionsPagePort`,
+  `LegacyConnectionsSupportPort`, `LegacyDarknetConnectionsPort`,
+  `LegacyDarknetMessagingPort`, `LegacyDiagnosticPort`, `LegacyStatisticsPort`,
+  `LegacyPageChromePort`, `LegacyQueuePagePort`, `LegacyQueueDownloadPort`,
+  `LegacyQueueInsertPort`, `LegacyQueueMutationPort`, `LegacyQueueSupportPort`,
+  `LegacyQueueCompletionPort`, `LegacyFirstTimeWizardPort`, `LegacyToadletSymlinkPort`,
+  `LegacyWelcomePagePort`, and `LegacyWelcomeActionPort`
 
 ### Plugin system (`network.crypta.pluginmanager`)
 - Management: `PluginManager`

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -103,7 +103,7 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew compileJava compileTestJava`
 
 ## Run tasks
-- Run daemon entrypoint (`NodeStarter`):
+- Run daemon entrypoint (`network.crypta.runtime.bootstrap.NodeStarter`):
   - `./gradlew run`
 - Pass daemon CLI args:
   - `./gradlew run --args="--help"`

--- a/.agents/skills/cryptad-core-updater/SKILL.md
+++ b/.agents/skills/cryptad-core-updater/SKILL.md
@@ -31,7 +31,7 @@ Use this skill when working on:
   - `PluginJarUpdater` for plugins
 - The legacy HTTP updater UI now crosses the runtime boundary through
   `RuntimePorts#coreUpdateAction()` and `network.crypta.runtime.spi.CoreUpdateActionPort`,
-  implemented in the root daemon by `network.crypta.node.runtime.LegacyCoreUpdateActionPort`.
+  implemented in the root daemon by `network.crypta.runtime.core.LegacyCoreUpdateActionPort`.
 - Core updater state surfaces through CorePackage-named APIs:
   - `hasNewCorePackage()`, `newCorePackageVersion()`, `newCorePackageVersionLabel()`
   - `fetchingNewCorePackage()`, `fetchingNewCorePackageVersion()`
@@ -52,14 +52,16 @@ Use this skill when working on:
 - UI: alerts panel shows progress percent when available.
   - Failures surface clear retry guidance (non-fatal errors relabel to “Retry”).
 - Request parsing, redirects, `AppEnv` checks, and OS-specific installer or store-launching remain
-  in `network.crypta.node.updater.CoreActionToadlet`.
+  in `network.crypta.runtime.updater.CoreActionToadlet`.
 - Daemon-backed availability checks, UI-triggered download start, and downloaded-installer
   containment validation now live behind `CoreUpdateActionPort`.
 
 ## Runtime-boundary classes to inspect
-- HTTP/action layer: `network.crypta.node.updater.CoreActionToadlet`
+- HTTP/action layer: `network.crypta.runtime.updater.CoreActionToadlet`
+- Updater coordinator/state: `network.crypta.runtime.updater.NodeUpdateManager`
+- Core package downloader: `network.crypta.runtime.updater.CoreUpdater`
 - SPI contract: `network.crypta.runtime.spi.CoreUpdateActionPort`
-- Root adapter: `network.crypta.node.runtime.LegacyCoreUpdateActionPort`
+- Root adapter: `network.crypta.runtime.core.LegacyCoreUpdateActionPort`
 - Aggregate runtime entry point: `network.crypta.runtime.spi.RuntimePorts`
 
 ## Platform specifics (selected behaviors)

--- a/.agents/skills/cryptad-runtime-debugging/SKILL.md
+++ b/.agents/skills/cryptad-runtime-debugging/SKILL.md
@@ -77,7 +77,11 @@ Read `Thread.print -l` in this order:
 Typical Cryptad packages to inspect after a dump:
 
 - `network.crypta.node` for peer management, packet sending, announcers, and schedulers
-- `network.crypta.node.updater` for updater state, CoreUpdater, and NodeUpdateManager
+- `network.crypta.runtime.updater` for updater state, CoreUpdater, CoreActionToadlet, and
+  NodeUpdateManager
+- `network.crypta.runtime.endpoints` and `network.crypta.runtime.admin` for FCP/HTTP/TMCI
+  bootstrap glue and page-oriented runtime adapters
+- `network.crypta.runtime.alerts` for alert lifecycles and operator-facing state propagation
 - `network.crypta.clients.http` for stuck HTTP handlers and rendered pages
 - `network.crypta.client.async` for fetcher and callback interactions
 - `network.crypta.support` for pooled threads, timers, and executor behavior
@@ -99,8 +103,8 @@ where
 where all
 locals
 print <expression>
-stop in network.crypta.node.updater.NodeUpdateManager.hasNewCorePackage
-clear network.crypta.node.updater.NodeUpdateManager.hasNewCorePackage
+stop in network.crypta.runtime.updater.NodeUpdateManager.hasNewCorePackage
+clear network.crypta.runtime.updater.NodeUpdateManager.hasNewCorePackage
 cont
 exit
 ```

--- a/README.md
+++ b/README.md
@@ -200,7 +200,10 @@ Cryptad now uses a partial multi-project Gradle build.
   resources.
 - The large cyclic daemon core remains in the root project for now, and all tests still live
   there. The root still owns daemon-coupled transport/socket code in `network.crypta.io.comm`,
-  runtime adapters and helpers under `network.crypta.runtime.core`, and the remaining
+  runtime package families such as `network.crypta.runtime.bootstrap`,
+  `network.crypta.runtime.core`, `network.crypta.runtime.admin`,
+  `network.crypta.runtime.alerts`, `network.crypta.runtime.endpoints`,
+  `network.crypta.runtime.services`, and `network.crypta.runtime.updater`, plus the remaining
   daemon-coupled support/UI wiring.
 - Higher-level infrastructure now crosses a narrower boundary through
   `network.crypta.runtime.spi.RuntimePorts`, the minimal wire-side `MessageSource` seam used by
@@ -215,7 +218,8 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.clients.http.SecurityLevelsToadletRuntimePorts`,
   `network.crypta.clients.http.WelcomeToadletRuntimePorts`,
   `network.crypta.clients.http.FProxyRuntimeSupport`,
-  `network.crypta.clients.http.HttpShellRuntimeSupport`, and
+  `network.crypta.clients.http.HttpShellRuntimeSupport`,
+  `network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport`, and
   `network.crypta.clients.http.bookmark.BookmarkRuntimeSupport`.
 
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
@@ -545,8 +549,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 
 - Build/module layout:
   - Root project `:cryptad` remains the daemon/application build and still owns the strongly
-    coupled core packages, all tests, packaging/runtime tasks, and the current
-    `LegacyRuntimePorts` bridge into the runtime SPI.
+    coupled core packages, all tests, packaging/runtime tasks, and the runtime package families
+    that now sit under `network.crypta.runtime.*` in the root project.
   - Leaf subprojects are `:foundation-support`, `:foundation-store`,
     `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
     `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:runtime-spi`,
@@ -593,11 +597,24 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `ConfigSnapshot`, `ConfigFieldSet`, `QueuePageSnapshot`, `QueueInsertOutcome`,
   `SecurityLevelsSnapshot`, `PageChromeSnapshot`, `FirstTimeWizardSnapshot`,
   `FirstTimeWizardCurrentBandwidthLimits`, `ToadletSymlinkEntry`, and `WelcomePageSnapshot`.
+- Runtime package families (`network.crypta.runtime.*`): `runtime.bootstrap` owns startup and CLI
+  wiring such as `NodeStarter`, `NodeBootstrap`, `NodeCli`, and `NodeConfigManager`;
+  `runtime.core` owns the runtime SPI nucleus such as `LegacyRuntimePorts`,
+  `LegacyConfigPort`, `LegacyConnectivityPort`, `LegacyNodeInfoPort`, `LegacyPeerPort`,
+  `LegacyRequestQueuePort`, `LegacySecurityLevelsPort`, and `LegacyCoreUpdateActionPort`;
+  `runtime.admin` owns page-oriented adapters such as `LegacyConnectionsPagePort`,
+  `LegacyQueuePagePort`, `LegacyPageChromePort`, `LegacyFirstTimeWizardPort`, and
+  `LegacyWelcomePagePort`; `runtime.alerts` owns operator-facing alerts and
+  `UserAlertManagerStoreAlertSink`; `runtime.endpoints` owns FCP/HTTP/TMCI bootstrap glue such as
+  `ClientEndpoints`, `NodeClientCoreInit`, `NodeClientPersistence`, and the HTTP-local runtime
+  adapters in `runtime.endpoints.http`; `runtime.services` owns `NodeServicesSubsystem`; and
+  `runtime.updater` owns `NodeUpdateManager`, `CoreUpdater`, and `CoreActionToadlet`.
 - Config + localization leaf (`:foundation-config`): `network.crypta.config`,
   `network.crypta.l10n`, and the main l10n properties. Its public APIs re-export
   `:foundation-support` and `:foundation-fs` where config surfaces expose `SimpleFieldSet` or
   filesystem-facing types. Higher layers should still prefer `RuntimePorts#config()` and the root
-  `LegacyConfigPort` bridge instead of reaching through daemon internals.
+  `network.crypta.runtime.core.LegacyConfigPort` bridge instead of reaching through daemon
+  internals.
 - Support foundation leaf (`:foundation-support`): stable generic support, support-api,
   support-io, support-compress, support-math, and transport-IP classes plus
   `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,

--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -30,11 +30,9 @@ import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.PrioRunnable;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.core.SSL;
-import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.HTMLNode;
@@ -54,19 +52,19 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * endpoints to browsers and local tools. It wires configuration callbacks, constructs the network
  * interface, and manages registration of individual {@link Toadlet} handlers. Typical lifecycle:
  * construct the server with the node configuration, publish runtime support through {@link
- * #setCore(NodeClientCore)} or {@link #setRuntimeSupport(HttpShellRuntimeSupport)} once the daemon
- * is ready, start the listener, and invoke {@link #finishStart()} after startup housekeeping
- * completes. The server keeps track of theme selection, panic button visibility, gateway mode, and
- * access controls. It also delegates bookmark management, push managers, and theme overrides to the
- * HTTP-local runtime adapter and supporting helper classes.
+ * #setRuntimeSupport(HttpShellRuntimeSupport)} once the daemon is ready, start the listener, and
+ * invoke {@link #finishStart()} after startup housekeeping completes. The server keeps track of
+ * theme selection, panic button visibility, gateway mode, and access controls. It also delegates
+ * bookmark management, push managers, and theme overrides to the HTTP-local runtime adapter and
+ * supporting helper classes.
  *
  * <p>Concurrency: the network listener and request handling threads read shared state such as the
  * {@link #runtimeSupport} reference, panic flags, and theme settings. The runtime support reference
- * is published through a volatile write-in {@link #setCore(NodeClientCore)} or {@link
- * #setRuntimeSupport(HttpShellRuntimeSupport)} so request threads see it once set. Mutability: most
- * configuration is thread-safe via synchronized blocks or volatile fields; URL registration is
- * guarded by the server monitor. Extended configuration callbacks are invoked on the configuration
- * thread; request handlers run on the executor.
+ * is published through a volatile write-in {@link #setRuntimeSupport(HttpShellRuntimeSupport)} so
+ * request threads see it once set. Mutability: most configuration is thread-safe via synchronized
+ * blocks or volatile fields; URL registration is guarded by the server monitor. Extended
+ * configuration callbacks are invoked on the configuration thread; request handlers run on the
+ * executor.
  *
  * <ul>
  *   <li>Responsibilities: bind sockets, dispatch toadlets, surface configuration, and relay alerts.
@@ -75,7 +73,6 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * </ul>
  *
  * @see Toadlet
- * @see NodeClientCore
  * @see network.crypta.clients.http.FProxyToadlet
  */
 public final class SimpleToadletServer
@@ -455,15 +452,14 @@ public final class SimpleToadletServer
   }
 
   /**
-   * Builds the FProxy runtime structures once the core is ready.
+   * Builds the FProxy runtime structures once runtime support is ready.
    *
-   * <p>Call this after {@link #setCore(NodeClientCore)} or {@link
-   * #setRuntimeSupport(HttpShellRuntimeSupport)} and before accepting requests to install bookmark
-   * handling, interval push scheduling, and UI registration against the active node. This method is
-   * idempotent; later calls are ignored after the first successful invocation. It captures the
-   * current runtime support reference, wires the push managers to the shared {@link Ticker},
-   * assembles the daemon-only root FProxy collaborators, and delegates to {@link FProxyRegistrar}
-   * for the remaining HTTP shell registration.
+   * <p>Call this after {@link #setRuntimeSupport(HttpShellRuntimeSupport)} and before accepting
+   * requests to install bookmark handling, interval push scheduling, and UI registration against
+   * the active node. This method is idempotent; later calls are ignored after the first successful
+   * invocation. It captures the current runtime support reference, wires the push managers to the
+   * shared {@link Ticker}, assembles the daemon-only root FProxy collaborators, and delegates to
+   * {@link FProxyRegistrar} for the remaining HTTP shell registration.
    */
   public void createFproxy() {
     synchronized (this) {
@@ -492,23 +488,19 @@ public final class SimpleToadletServer
   }
 
   /**
-   * Publishes the initialized node core to request handlers through the HTTP-local runtime adapter.
+   * Publishes the initialized HTTP runtime adapter to request handlers.
    *
-   * <p>This compatibility shim wraps the supplied core in {@link
-   * network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport}. The runtime support
-   * reference is written with volatile semantics, so listener threads see it after startup. Call
-   * this exactly once, immediately after the node finishes constructing its {@link NodeClientCore},
-   * and before invoking {@link #createFproxy()} or {@link #start()}. When the runtime support
-   * exposes runtime SPI ports, this method also late-injects the detached page-chrome port into the
-   * shared {@link PageMaker}. Passing {@code null} leaves the server unable to service requests.
+   * <p>The runtime support reference is written with volatile semantics, so listener threads see it
+   * after startup. Call this exactly once, immediately after daemon bootstrap finishes creating the
+   * adapter, and before invoking {@link #createFproxy()} or {@link #start()}. When the runtime
+   * support exposes runtime SPI ports, this method also late-injects the detached page-chrome port
+   * into the shared {@link PageMaker}. Passing {@code null} leaves the server unable to service
+   * requests.
    *
-   * @param core fully constructed {@link NodeClientCore}; must not be {@code null}.
+   * @param runtimeSupport fully constructed runtime adapter; may be {@code null} during tests that
+   *     intentionally exercise uninitialized behavior
    */
-  public void setCore(NodeClientCore core) {
-    setRuntimeSupport(core == null ? null : new CoreHttpShellRuntimeSupport(core));
-  }
-
-  void setRuntimeSupport(HttpShellRuntimeSupport runtimeSupport) {
+  public void setRuntimeSupport(HttpShellRuntimeSupport runtimeSupport) {
     this.runtimeSupport = runtimeSupport;
     RuntimePorts runtimePorts = runtimeSupport == null ? null : runtimeSupport.runtimePorts();
     pageMaker.setPageChromePort(runtimePorts == null ? null : runtimePorts.pageChrome());
@@ -521,8 +513,8 @@ public final class SimpleToadletServer
    * callbacks, and defers expensive wiring (runtime support assignment, network listener startup)
    * to later calls. It seeds random sources, sets the initial access control list, and records
    * whether the server should start enabled. The {@link #runtimeSupport} is left {@code null};
-   * callers must invoke {@link #setCore(NodeClientCore)} or {@link
-   * #setRuntimeSupport(HttpShellRuntimeSupport)} before servicing requests.
+   * callers must invoke {@link #setRuntimeSupport(HttpShellRuntimeSupport)} before servicing
+   * requests.
    *
    * @param fproxyConfig configuration subsection containing fproxy.* keys that drive listener
    *     options, theme settings, limits, and ACLs; must be non-null.
@@ -538,7 +530,7 @@ public final class SimpleToadletServer
       throws InvalidConfigValueException {
 
     this.executor = executor;
-    this.runtimeSupport = null; // setCore() or setRuntimeSupport() will be called later.
+    this.runtimeSupport = null; // setRuntimeSupport() will be called later.
     this.random = new SecureRandom();
 
     int configItemOrder = registerInitialOptions(fproxyConfig);
@@ -1220,11 +1212,12 @@ public final class SimpleToadletServer
    * Removes the temporary startup toadlet once the node is ready.
    *
    * <p>Calling this method unregisters the startup handler that served initial setup pages and
-   * clears its reference for garbage collection. It must only be invoked after {@link #setCore} and
-   * after startup has progressed far enough that the main toadlets are available.
+   * clears its reference for garbage collection. It must only be invoked after {@link
+   * #setRuntimeSupport(HttpShellRuntimeSupport)} and after startup has progressed far enough that
+   * the main toadlets are available.
    */
   public void removeStartupToadlet() {
-    // setCore() must have been called first. It is in fact called much earlier on.
+    // setRuntimeSupport() must have been called first. It is in fact called much earlier on.
     synchronized (this) {
       unregister(startupToadlet);
       // Ready to be GCed
@@ -1257,11 +1250,11 @@ public final class SimpleToadletServer
   /**
    * Starts the HTTP listener thread if it has been initialized.
    *
-   * <p>Callers should ensure {@link #setCore(NodeClientCore)} or {@link
-   * #setRuntimeSupport(HttpShellRuntimeSupport)} and {@link #createFproxy()} have completed before
-   * invoking this method. When {@link #myThread} is non-null, the network interface is lazily
-   * created and the thread is started, logging the bind address and port. This call is idempotent
-   * when {@link #myThread} is already {@code null} or the thread has previously been started.
+   * <p>Callers should ensure {@link #setRuntimeSupport(HttpShellRuntimeSupport)} and {@link
+   * #createFproxy()} have completed before invoking this method. When {@link #myThread} is
+   * non-null, the network interface is lazily created and the thread is started, logging the bind
+   * address and port. This call is idempotent when {@link #myThread} is already {@code null} or the
+   * thread has previously been started.
    */
   @SuppressWarnings("java:S106")
   public void start() {
@@ -1546,8 +1539,8 @@ public final class SimpleToadletServer
    *
    * <p>The alert manager surfaces node warnings and informational banners to the UI and handles
    * their dismissal state. When runtime support has not yet been assigned this method returns
-   * {@code null}; callers should therefore wait until after {@link #setCore(NodeClientCore)} or
-   * {@link #setRuntimeSupport(HttpShellRuntimeSupport)} is invoked.
+   * {@code null}; callers should therefore wait until after {@link
+   * #setRuntimeSupport(HttpShellRuntimeSupport)} is invoked.
    *
    * @return active {@link UserAlertManager}, or {@code null} when unavailable.
    */
@@ -1800,23 +1793,6 @@ public final class SimpleToadletServer
    */
   public Ticker getTicker() {
     return requireRuntimeSupport().ticker();
-  }
-
-  /**
-   * Returns the currently bound node core when runtime support is core-backed.
-   *
-   * <p>This compatibility accessor is retained for callers that still expect a {@link
-   * NodeClientCore}. When the server was initialized with a non-core-backed runtime adapter, this
-   * method returns {@code null}.
-   *
-   * @return {@link NodeClientCore} instance or {@code null} when unset.
-   */
-  public NodeClientCore getCore() {
-    HttpShellRuntimeSupport runtimeSupportRef = this.runtimeSupport;
-    if (runtimeSupportRef instanceof CoreHttpShellRuntimeSupport(NodeClientCore core)) {
-      return core;
-    }
-    return null;
   }
 
   private HttpShellRuntimeSupport requireRuntimeSupport() {

--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -42,6 +42,7 @@ import network.crypta.runtime.bootstrap.NodeBootstrap;
 import network.crypta.runtime.bootstrap.NodeConfigManager;
 import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
+import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.Fields;
 import network.crypta.support.HexUtil;
@@ -224,7 +225,7 @@ public final class Node implements TimeSkewDetectorCallback {
   /** Node-reference directory (node identity, peers, etc.) */
   private final ProgramDirectory nodeDir;
 
-  /** Config directory (l10n overrides, etc) */
+  /** Config directory (l10n overrides, etc.) */
   final ProgramDirectory cfgDir;
 
   /** User data directory (bookmarks, download lists, etc.) */
@@ -705,7 +706,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
             storage.getDatabaseKey(),
             persistentSecret);
     services.setClientCore(clientCoreLocal);
-    services.toadlets().setCore(clientCoreLocal);
+    services.toadlets().setRuntimeSupport(new CoreHttpShellRuntimeSupport(clientCoreLocal));
 
     services.registerJvmVersionAlertIfNeeded();
 

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -18,6 +18,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.endpoints.ClientEndpoints;
+import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.endpoints.http.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -123,7 +124,7 @@ class SimpleToadletServerTest {
     when(core.getNode().network().ticker()).thenReturn(ticker);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     when(client.getFetchContext()).thenReturn(fetchContext);
-    server.setCore(core);
+    server.setRuntimeSupport(new CoreHttpShellRuntimeSupport(core));
 
     AtomicInteger registrarCalls = new AtomicInteger();
     AtomicReference<FProxyRegistrarDependencies> dependenciesRef = new AtomicReference<>();


### PR DESCRIPTION
## Summary

- remove the final `NodeClientCore` compatibility shim from `SimpleToadletServer` and publish HTTP bootstrap wiring only through `HttpShellRuntimeSupport`
- switch `Node` startup to `setRuntimeSupport(new CoreHttpShellRuntimeSupport(...))` and update the affected HTTP test to use the same seam
- refresh `README.md` and the affected `.agents/skills` files so they describe the current `network.crypta.runtime.*` package layout and updater/debugging entry points

## How to test

```bash
./gradlew test --tests network.crypta.clients.http.SimpleToadletServerTest
./gradlew compileJava compileTestJava
./gradlew test --tests network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupportTest
./gradlew test --tests network.crypta.runtime.services.NodeServicesSubsystemTest
./gradlew test --tests network.crypta.runtime.endpoints.ClientEndpointsTest
rg -n "import network\.crypta\.node\.(Node|NodeClientCore);" src/main/java/network/crypta/clients/http
```
