### PR TITLE
docs(http): Remove stale runtime wording

### DIFF
--- a/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -1789,7 +1789,7 @@ public final class SimpleToadletServer
    * <p>The ticker is shared across push managers and other time-based components. It is owned by
    * the node instance and exposed here for convenience.
    *
-   * @return {@link Ticker} from the node; never {@code null} after the core is set.
+   * @return shared {@link Ticker}; never {@code null} after runtime support is published.
    */
   public Ticker getTicker() {
     return requireRuntimeSupport().ticker();


### PR DESCRIPTION
## Summary
- update `SimpleToadletServer#getTicker()` Javadoc to refer to published runtime support instead of the old core-based wording
- keep the PR scoped to the remaining stale wording in `clients.http`
- make no runtime behavior changes

## Context
The `HttpShellRuntimeSupport` seam and `Node` startup wiring are already present on `develop`. This follow-up only aligns the remaining stale Javadoc with the current seam-based API.

## How to test
- `./gradlew test --tests network.crypta.clients.http.SimpleToadletServerTest`
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupportTest`
- `./gradlew test --tests network.crypta.runtime.services.NodeServicesSubsystemTest`
- `./gradlew test --tests network.crypta.runtime.endpoints.ClientEndpointsTest`
- `rg -n "import network\.crypta\.node\.(Node|NodeClientCore);" src/main/java/network/crypta/clients/http`
