### PR TITLE
refactor(client): Decouple ClientLayerPersister from FCP

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientLayerPersister.java
+++ b/src/main/java/network/crypta/client/async/ClientLayerPersister.java
@@ -21,9 +21,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import network.crypta.clients.fcp.ClientRequest;
-import network.crypta.clients.fcp.RequestIdentifier;
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.crypt.AEADVerificationFailedException;
 import network.crypta.crypt.CRCChecksumChecker;
 import network.crypta.crypt.ChecksumChecker;
@@ -31,7 +34,6 @@ import network.crypta.crypt.ChecksumFailedException;
 import network.crypta.node.DatabaseKey;
 import network.crypta.node.MasterKeysWrongPasswordException;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -66,8 +68,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
  * current variant and proceeds to the next to maximize recovery.
  *
  * <ul>
- *   <li>Responsibilities: checkpoint active requests, rotate files, restore and (if needed) restart
- *       requests.
+ *   <li>Responsibilities: checkpoint active requests, rotate files, restore, and (if needed)
+ *       restart requests.
  *   <li>Threading: inherits periodic checkpointing from {@link PersistentJobRunnerImpl}; most
  *       lifecyle methods synchronize on an internal monitor to maintain invariants.
  *   <li>Trade-offs: favors durability and orderly recovery over minimal metadata size.
@@ -81,8 +83,9 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
 
   static final long INTERVAL = MINUTES.toMillis(10);
   private final Node node; // Needed for bandwidth stats putter
-  private final NodeClientCore clientCore;
   private final PersistentTempBucketFactory persistentTempFactory;
+  private PersistentRequestCatalog persistentRequestCatalog;
+  private PersistentRequestRecoveryCodec persistentRequestRecoveryCodec;
 
   /**
    * Needed for temporary storage when writing objects. Some of them might be big, e.g., site
@@ -125,8 +128,6 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
    *     provided {@code executor} to preserve ordering and avoid thread proliferation.
    * @param node parent node instance used for I/O statistics and contextual operations during
    *     checkpointing and recovery; expected to outlive this persister.
-   * @param core client core used as the authoritative source of persistent requests to save and as
-   *     the target for resuming or restarting requests after a successful load.
    * @param persistentTempFactory factory that tracks delayed frees and provides buckets scheduled
    *     for post-checkpoint cleanup; only its lifecycle hooks are invoked during saves/loads.
    * @param tempBucketFactory factory for short-lived buckets used to stage checksummed
@@ -138,13 +139,11 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
       PriorityAwareExecutor executor,
       Ticker ticker,
       Node node,
-      NodeClientCore core,
       PersistentTempBucketFactory persistentTempFactory,
       TempBucketFactory tempBucketFactory,
       PersistentStatsPutter stats) {
     super(executor, ticker, INTERVAL);
     this.node = node;
-    this.clientCore = core;
     this.persistentTempFactory = persistentTempFactory;
     this.tempBucketFactory = tempBucketFactory;
     this.checker = new CRCChecksumChecker();
@@ -161,17 +160,31 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
       PriorityAwareExecutor executor,
       Ticker ticker,
       Node node,
-      NodeClientCore core,
       PersistentTempBucketFactory persistentTempFactory,
       TempBucketFactory tempBucketFactory) {
     this(
         executor,
         ticker,
         node,
-        core,
         persistentTempFactory,
         tempBucketFactory,
         new PersistentStatsPutter());
+  }
+
+  /**
+   * Installs the persistent-request catalog and fallback recovery codec used by this persister.
+   *
+   * <p>Callers should configure both adapters before starting or loading the persister, so request
+   * enumeration, duplicate detection, and recovery all use the runtime-owned bridge for the active
+   * protocol implementation.
+   *
+   * @param catalog catalog used to list and deduplicate persistent requests
+   * @param recoveryCodec codec used to restart requests from compact recovery data
+   */
+  public void configurePersistenceAdapters(
+      PersistentRequestCatalog catalog, PersistentRequestRecoveryCodec recoveryCodec) {
+    persistentRequestCatalog = Objects.requireNonNull(catalog);
+    persistentRequestRecoveryCodec = Objects.requireNonNull(recoveryCodec);
   }
 
   private void loadAllVariants(
@@ -270,7 +283,7 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
   }
 
   private ResumeOutcome resumeOne(PartiallyLoadedRequest partial) {
-    ClientRequest req = partial.request;
+    PersistentRequestHandle req = partial.request;
     try {
       req.onResume(getClientContext());
       if (partial.status == RequestLoadStatus.RESTORED_FULLY
@@ -299,9 +312,9 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
    * required. When {@code noWrite} is {@code true}, all existing variants are deleted and future
    * checkpoints are disabled for the lifetime of the instance.
    *
-   * <p>On load, corrupted variants are skipped and backups are probed to maximize recovery. After a
-   * successful load, the method schedules an early checkpoint so the later state is captured
-   * quickly.
+   * <p>On loading, corrupted variants are skipped and backups are probed to maximize recovery.
+   * After a successful load, the method schedules an early checkpoint so the later state is
+   * captured quickly.
    *
    * <pre>{@code
    * // Example: load and enable encrypted persistence
@@ -498,10 +511,11 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     FAILED
   }
 
-  private record PartiallyLoadedRequest(ClientRequest request, RequestLoadStatus status) {}
+  private record PartiallyLoadedRequest(
+      PersistentRequestHandle request, RequestLoadStatus status) {}
 
   private static class PartialLoad {
-    private final Map<RequestIdentifier, PartiallyLoadedRequest> partiallyLoadedRequests =
+    private final Map<PersistentRequestIdentifier, PartiallyLoadedRequest> partiallyLoadedRequests =
         new HashMap<>();
 
     private byte[] salt;
@@ -517,13 +531,15 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
      *     necessary.
      */
     void addPartiallyLoadedRequest(
-        RequestIdentifier reqID, ClientRequest request, RequestLoadStatus status) {
+        PersistentRequestIdentifier reqID,
+        PersistentRequestHandle request,
+        RequestLoadStatus status) {
       if (reqID == null) {
         if (request == null) {
           somethingFailed = true;
           return;
         } else {
-          reqID = request.getRequestIdentifier();
+          reqID = request.getPersistentRequestIdentifier();
         }
       }
       PartiallyLoadedRequest old = partiallyLoadedRequests.get(reqID);
@@ -682,7 +698,7 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     }
     if (latest) {
       try {
-        // Only read stats/buckets from the latest version (client.dat not client.dat.bak).
+        // Only read stats/buckets from the latest version (client.dat, not client.dat.bak).
         readStatsAndBuckets(ois, length);
       } catch (Exception t) {
         LOG.error("Failed to restore stats and delete old temp files: {}", t, t);
@@ -707,10 +723,10 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
   private void processSingleRequest(
       ObjectInputStream ois, long length, boolean noSerialize, PartialLoad loaded)
       throws IOException {
-    RequestIdentifier reqID = readRequestIdentifier(ois);
+    PersistentRequestIdentifier reqID = readRequestIdentifier(ois);
     if (alreadyPresent(reqID, ois, length)) return;
 
-    ClientRequest request = maybeReadSerialized(ois, length, noSerialize, reqID, loaded);
+    PersistentRequestHandle request = maybeReadSerialized(ois, length, noSerialize, reqID, loaded);
     if (request == null || LOG.isDebugEnabled()) {
       maybeRecoverFromRecoveryData(ois, length, reqID, loaded, request);
     } else {
@@ -718,9 +734,9 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     }
   }
 
-  private boolean alreadyPresent(RequestIdentifier reqID, ObjectInputStream ois, long length)
-      throws IOException {
-    if (reqID != null && getClientContext().persistentRoot.hasRequest(reqID)) {
+  private boolean alreadyPresent(
+      PersistentRequestIdentifier reqID, ObjectInputStream ois, long length) throws IOException {
+    if (reqID != null && requirePersistentRequestCatalog().hasRequest(reqID)) {
       LOG.warn("Not reading request because already have it");
       skipChecksummedObject(ois, length); // Request itself
       skipChecksummedObject(ois, length); // Recovery data
@@ -729,11 +745,11 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     return false;
   }
 
-  private ClientRequest maybeReadSerialized(
+  private PersistentRequestHandle maybeReadSerialized(
       ObjectInputStream ois,
       long length,
       boolean noSerialize,
-      RequestIdentifier reqID,
+      PersistentRequestIdentifier reqID,
       PartialLoad loaded)
       throws IOException {
     if (noSerialize) {
@@ -742,9 +758,10 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
       return null;
     }
     try {
-      ClientRequest request = (ClientRequest) readChecksummedObject(ois, length);
+      PersistentRequestHandle request =
+          asPersistentRequestHandle(readChecksummedObject(ois, length));
       if (request != null && reqID != null) {
-        if (!reqID.sameIdentifier(request.getRequestIdentifier())) {
+        if (!reqID.sameIdentifier(request.getPersistentRequestIdentifier())) {
           LOG.error("Request does not match request identifier, discarding");
           return null;
         } else {
@@ -762,14 +779,14 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
   }
 
   @SuppressWarnings("UnusedReturnValue")
-  private ClientRequest maybeRecoverFromRecoveryData(
+  private PersistentRequestHandle maybeRecoverFromRecoveryData(
       ObjectInputStream ois,
       long length,
-      RequestIdentifier reqID,
+      PersistentRequestIdentifier reqID,
       PartialLoad loaded,
-      ClientRequest current) {
+      PersistentRequestHandle current) {
     try {
-      ClientRequest restored = readRequestFromRecoveryData(ois, length, reqID);
+      PersistentRequestHandle restored = readRequestFromRecoveryData(ois, length, reqID);
       if (current == null && restored != null) {
         boolean loadedFully = restored.fullyResumed();
         loaded.addPartiallyLoadedRequest(
@@ -872,17 +889,17 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
       oos.writeLong(MAGIC);
       oos.writeInt(VERSION);
       checker.writeAndChecksum(oos, salt);
-      ClientRequest[] requests = getRequests();
+      PersistentRequestHandle[] requests = getRequests();
       if (shutdown) {
-        for (ClientRequest req : requests) {
+        for (PersistentRequestHandle req : requests) {
           if (req == null) continue;
           callOnShutdown(req);
         }
       }
       oos.writeInt(requests.length);
-      for (ClientRequest req : requests) {
+      for (PersistentRequestHandle req : requests) {
         // Write the request identifier so we can skip reading the request if we already have it.
-        writeRequestIdentifier(oos, req.getRequestIdentifier());
+        writeRequestIdentifier(oos, req.getPersistentRequestIdentifier());
         // Write the actual request.
         writeChecksummedObject(oos, req, req.toString());
         // Write recovery data. This is just enough to restart the request from scratch,
@@ -903,7 +920,7 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     }
   }
 
-  private void callOnShutdown(ClientRequest req) {
+  private void callOnShutdown(PersistentRequestHandle req) {
     try {
       req.onShutdown(getClientContext());
     } catch (Exception t) {
@@ -911,10 +928,11 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     }
   }
 
-  private void writeRecoveryData(ObjectOutputStream os, ClientRequest req) throws IOException {
+  private void writeRecoveryData(ObjectOutputStream os, PersistentRequestHandle req)
+      throws IOException {
     PrependLengthOutputStream oos = checker.checksumWriterWithLengthNoClose(os, tempBucketFactory);
     try (DataOutputStream dos = new DataOutputStream(new NonClosingOutputStream(oos))) {
-      req.getClientDetail(dos, checker);
+      req.writeRecoveryData(dos, checker);
     } catch (Exception e) {
       LOG.error("Unable to write recovery data stream for {}: {}", req, e, e);
       if (oos != null) oos.abort();
@@ -923,12 +941,14 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     }
   }
 
-  private ClientRequest readRequestFromRecoveryData(
-      ObjectInputStream is, long totalLength, RequestIdentifier reqID)
+  private PersistentRequestHandle readRequestFromRecoveryData(
+      ObjectInputStream is, long totalLength, PersistentRequestIdentifier reqID)
       throws IOException, ChecksumFailedException, StorageFormatException {
     InputStream tmp = checker.checksumReaderWithLength(is, this.tempBucketFactory, totalLength);
     try (DataInputStream dis = new DataInputStream(tmp)) {
-      ClientRequest request = ClientRequest.restartFrom(dis, reqID, getClientContext(), checker);
+      PersistentRequestHandle request =
+          requirePersistentRequestRecoveryCodec()
+              .restartFrom(dis, reqID, getClientContext(), checker);
       tmp = null;
       return request;
     } catch (Exception t) {
@@ -973,8 +993,20 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     FileUtil.skipFully(is, length + checker.checksumLength());
   }
 
-  private ClientRequest[] getRequests() {
-    return clientCore.getPersistentRequests();
+  private PersistentRequestHandle asPersistentRequestHandle(Object request) {
+    if (request == null) {
+      return null;
+    }
+    if (request instanceof PersistentRequestHandle persistentRequestHandle) {
+      return persistentRequestHandle;
+    }
+    throw new IllegalStateException(
+        "Serialized persistent request does not implement PersistentRequestHandle: "
+            + request.getClass().getName());
+  }
+
+  private PersistentRequestHandle[] getRequests() {
+    return requirePersistentRequestCatalog().getPersistentRequests();
   }
 
   @Override
@@ -982,7 +1014,7 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     return newSalt;
   }
 
-  private RequestIdentifier readRequestIdentifier(DataInput is) throws IOException {
+  private PersistentRequestIdentifier readRequestIdentifier(DataInput is) throws IOException {
     short length = is.readShort();
     if (length <= 0) return null;
     byte[] buf = new byte[length];
@@ -996,7 +1028,7 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     }
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(buf));
     try {
-      return new RequestIdentifier(dis);
+      return new PersistentRequestIdentifier(dis);
     } catch (IOException e) {
       LOG.error(
           "Failed to parse RequestIdentifier in spite of valid checksum (probably a bug): {}",
@@ -1006,7 +1038,8 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     }
   }
 
-  private void writeRequestIdentifier(DataOutput os, RequestIdentifier req) throws IOException {
+  private void writeRequestIdentifier(DataOutput os, PersistentRequestIdentifier req)
+      throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     OutputStream oos = checker.checksumWriter(baos);
     DataOutputStream dos = new DataOutputStream(oos);
@@ -1015,6 +1048,16 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
     byte[] buf = baos.toByteArray();
     os.writeShort(buf.length - checker.checksumLength());
     os.write(buf);
+  }
+
+  private PersistentRequestCatalog requirePersistentRequestCatalog() {
+    return Objects.requireNonNull(
+        persistentRequestCatalog, "Persistent request catalog not configured");
+  }
+
+  private PersistentRequestRecoveryCodec requirePersistentRequestRecoveryCodec() {
+    return Objects.requireNonNull(
+        persistentRequestRecoveryCodec, "Persistent request recovery codec not configured");
   }
 
   /**

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestCatalog.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestCatalog.java
@@ -1,0 +1,40 @@
+package network.crypta.client.async.persistence;
+
+/**
+ * Provides access to the currently registered durable requests.
+ *
+ * <p>The catalog is the read-only view that {@code ClientLayerPersister} needs from the runtime at
+ * checkpoint and restart time. It exposes a stable snapshot of requests that should be written to
+ * disk and a duplicate-detection query that lets startup skip requests already reconstructed by an
+ * earlier load step.
+ *
+ * <p>Implementations are typically thin adapters over endpoint-specific registries. They should
+ * avoid side effects, return a point-in-time snapshot rather than a live view, and preserve the
+ * runtime's existing notion of request identity so restart semantics remain unchanged.
+ */
+public interface PersistentRequestCatalog {
+
+  /**
+   * Returns a snapshot of the current persistent requests.
+   *
+   * <p>The returned array should represent the requests that are eligible for durable checkpointing
+   * at the time of the call. Callers may iterate it immediately and should not assume that later
+   * runtime changes, such as newly queued requests or completions, will be reflected in the same
+   * array instance.
+   *
+   * @return array containing the currently checkpointable persistent requests; never {@code null}
+   */
+  PersistentRequestHandle[] getPersistentRequests();
+
+  /**
+   * Returns whether a request with the given identifier is already registered.
+   *
+   * <p>This method supports duplicate detection during startup replay. Implementations should use
+   * the same queue and identifier semantics that the runtime uses for live request lookups so the
+   * client layer does not accidentally restart a request that is already attached to the node.
+   *
+   * @param identifier stable persistent-request identifier describing the request being checked
+   * @return {@code true} when a matching durable request is already present in the runtime
+   */
+  boolean hasRequest(PersistentRequestIdentifier identifier);
+}

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestHandle.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestHandle.java
@@ -1,0 +1,112 @@
+package network.crypta.client.async.persistence;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.support.io.ResumeFailedException;
+
+/**
+ * Minimal durable-request contract used by {@code ClientLayerPersister}.
+ *
+ * <p>Implementations expose only the lifecycle and recovery operations that the client-layer
+ * persister needs to save and restore durable requests. The contract is deliberately narrower than
+ * any endpoint-specific request API: it does not expose protocol messages, request queues, or UI
+ * state. That keeps persistence control flow in {@code network.crypta.client.async} while letting
+ * runtime-owned adapters decide how a concrete request is enumerated, resumed, canceled, or
+ * restarted.
+ *
+ * <p>A typical lifecycle is: list handles from {@link PersistentRequestCatalog}, write their
+ * identifiers and recovery data during a checkpoint, deserialize or rebuild them during startup,
+ * invoke {@link #onResume(ClientContext)}, and then call {@link #start(ClientContext)} when the
+ * restored request should continue running. Implementations should remain robust when these hooks
+ * are invoked after partial failures or repeated startup attempts.
+ */
+public interface PersistentRequestHandle {
+
+  /**
+   * Returns the stable identifier used for duplicate detection and recovery.
+   *
+   * <p>The returned identifier must remain stable for the lifetime of the durable request and must
+   * use the same queue and request-type semantics that the runtime expects during restart. The
+   * persister writes it ahead of any serialized state so the startup can avoid rebuilding requests
+   * that are already present.
+   *
+   * @return immutable persistent-request identifier for this durable request instance
+   */
+  PersistentRequestIdentifier getPersistentRequestIdentifier();
+
+  /**
+   * Reattaches this request to the live runtime context after deserialization or restart.
+   *
+   * <p>This hook gives the implementation a chance to recreate transient collaborators, reconnect
+   * to schedulers, and re-register itself with runtime-owned request registries before further work
+   * resumes. It may be invoked after either Java deserialization or compact recovery-data
+   * reconstruction.
+   *
+   * @param context client runtime context that provides schedulers, registries, and storage
+   *     services needed during resume
+   * @throws ResumeFailedException if the request cannot be safely reattached to the running node
+   */
+  void onResume(ClientContext context) throws ResumeFailedException;
+
+  /**
+   * Starts the request after successful recovery.
+   *
+   * <p>Implementations are responsible for creating the underlying work item, scheduling it on the
+   * appropriate queues, and updating any status caches. This method may be called again after a
+   * restart request but should avoid duplicating work when already running.
+   *
+   * @param context client runtime context used to schedule the request and attach any new work to
+   *     the node
+   */
+  void start(ClientContext context);
+
+  /**
+   * Cancels the request after a failed resuming or restart.
+   *
+   * <p>The persister calls this after a restore path has failed badly enough that the partially
+   * reconstructed request should not remain registered. Implementations should release runtime
+   * resources and propagate cancellation to any underlying requester when one exists.
+   *
+   * @param context client runtime context used to propagate cancellation and release resources
+   */
+  void cancel(ClientContext context);
+
+  /**
+   * Gives the request one final chance to flush state before persistence during shutdown.
+   *
+   * <p>This hook runs only on shutdown-triggered checkpoints. Implementations can use it to push
+   * transient state into fields that are persisted normally, or to ask nested requesters to flush
+   * state that improves restart quality.
+   *
+   * @param context client runtime context available during the node shutdown save path
+   */
+  void onShutdown(ClientContext context);
+
+  /**
+   * Writes compact recovery data that can rebuild the request when Java serialization fails.
+   *
+   * <p>The record written here should contain only the minimum durable information needed to
+   * reconstruct or restart the request when the regular serialized form cannot be read. The
+   * persister wraps this stream with length framing and checksums, so implementations should focus
+   * on request-specific payload layout rather than outer framing.
+   *
+   * @param dos destination stream for the request-specific recovery payload
+   * @param checker checksum helper supplied by the persistence layer for request-specific restart
+   *     logic
+   * @throws IOException if the request cannot write its recovery payload to the supplied stream
+   */
+  void writeRecoveryData(DataOutputStream dos, ChecksumChecker checker) throws IOException;
+
+  /**
+   * Returns whether recovery restored the request fully without restarting underlying work.
+   *
+   * <p>Implementations can use this to distinguish fast resumes that reused on-disk state from
+   * slower fallback paths that reconstructed work from compact recovery data.
+   *
+   * @return {@code true} when the request resumed fully from stored state without a restart-style
+   *     rebuild
+   */
+  boolean fullyResumed();
+}

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestIdentifier.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestIdentifier.java
@@ -1,0 +1,217 @@
+package network.crypta.client.async.persistence;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * Immutable identifier for a durable client request.
+ *
+ * <p>This value object records the minimum identity needed to find, deduplicate, and restart a
+ * durable request. It captures queue scope, client ownership for non-global queues, a stable
+ * request identifier string, and the request category that restart logic should apply. Instances
+ * are immutable and safe to retain across checkpoint, load, and adapter boundaries.
+ *
+ * <p>The binary layout intentionally matches the legacy FCP {@code RequestIdentifier} format so
+ * existing persistence files remain byte-compatible. Equality includes the request type because the
+ * persisted record does, while {@link #sameIdentifier(PersistentRequestIdentifier)} compares only
+ * queue scope, client name, and stable identifier string for duplicate detection during startup.
+ */
+public final class PersistentRequestIdentifier {
+
+  /**
+   * Stable request categories embedded in the persistence-file identifier record.
+   *
+   * <p>The short code assigned to each constant is part of the durable on-disk format and therefore
+   * must remain stable across refactoring.
+   */
+  public enum RequestType {
+    /** Durable fetch request that resumes or restarts download-oriented logic. */
+    GET((short) 0),
+    /** Durable single-item insert request that restarts upload-oriented logic. */
+    PUT((short) 1),
+    /** Durable directory insert request that restarts manifest-oriented upload logic. */
+    PUTDIR((short) 2);
+
+    private final short code;
+
+    RequestType(short code) {
+      this.code = code;
+    }
+
+    short code() {
+      return code;
+    }
+
+    private static RequestType fromCode(short code) throws IOException {
+      for (RequestType type : values()) {
+        if (type.code == code) {
+          return type;
+        }
+      }
+      throw new IOException("Bogus type");
+    }
+  }
+
+  static final int MAGIC = 0x25ebd38d;
+  static final short VERSION = 1;
+
+  private final boolean globalQueue;
+  private final String clientName;
+  private final String identifier;
+  private final RequestType type;
+
+  /**
+   * Creates an identifier from explicit queue, client, and request-type components.
+   *
+   * <p>Callers typically use this constructor when adapting an endpoint-owned request identifier
+   * into the client-owned persistence seam. For global queues, {@code clientName} is ignored and
+   * may be {@code null}. For named queues, callers should pass the stable client name that the
+   * runtime uses to locate the owning durable request set.
+   *
+   * @param globalQueue {@code true} when the request belongs to the node-global durable queue
+   * @param clientName stable client name for non-global queues; ignored for global queues
+   * @param identifier stable request identifier within the selected queue
+   * @param type durable request category used during restart and equality checks
+   */
+  public PersistentRequestIdentifier(
+      boolean globalQueue, String clientName, String identifier, RequestType type) {
+    this.globalQueue = globalQueue;
+    this.clientName = clientName;
+    this.identifier = identifier;
+    this.type = type;
+  }
+
+  /**
+   * Reconstructs an identifier from its byte-compatible on-disk form.
+   *
+   * <p>The input must be positioned at the start of an identifier record written by {@link
+   * #writeTo(DataOutput)} or by the legacy FCP identifier codec. The constructor validates the
+   * magic, version, queue layout, and request-type code before exposing the decoded value.
+   *
+   * @param input data source positioned at the start of the identifier record
+   * @throws IOException if the record is truncated, malformed, or uses an unknown format version
+   */
+  public PersistentRequestIdentifier(DataInput input) throws IOException {
+    int magic = input.readInt();
+    if (magic != MAGIC) {
+      throw new IOException("Bad magic");
+    }
+    short version = input.readShort();
+    if (version != VERSION) {
+      throw new IOException("Bad version");
+    }
+    globalQueue = input.readBoolean();
+    clientName = globalQueue ? null : input.readUTF();
+    identifier = input.readUTF();
+    type = RequestType.fromCode(input.readShort());
+  }
+
+  /**
+   * Writes this identifier using the stable persistence-file layout.
+   *
+   * <p>The encoded form is intentionally byte-compatible with the legacy FCP identifier layout, so
+   * existing persistence files can still be read during incremental decoupling work. Callers should
+   * treat the output as versioned binary metadata rather than a general-purpose serialization
+   * format.
+   *
+   * @param output destination that receives the encoded identifier record
+   * @throws IOException if the identifier cannot be written to the destination
+   */
+  public void writeTo(DataOutput output) throws IOException {
+    output.writeInt(MAGIC);
+    output.writeShort(VERSION);
+    output.writeBoolean(globalQueue);
+    if (!globalQueue) {
+      output.writeUTF(clientName);
+    }
+    output.writeUTF(identifier);
+    output.writeShort(type.code());
+  }
+
+  /**
+   * Returns whether another identifier targets the same queued request, ignoring the request type.
+   *
+   * <p>This comparison is used for duplicate detection during startup replay. It deliberately
+   * ignores the request type because the runtime's existing duplicate semantics are based on queue
+   * ownership and stable identifier string rather than on the specific restart codec.
+   *
+   * @param other candidate identifier to compare against this identifier
+   * @return {@code true} when queue scope, client, and stable identifier string all match
+   */
+  public boolean sameIdentifier(PersistentRequestIdentifier other) {
+    if (globalQueue != other.globalQueue) {
+      return false;
+    }
+    if (!globalQueue && !clientName.equals(other.clientName)) {
+      return false;
+    }
+    return identifier.equals(other.identifier);
+  }
+
+  /**
+   * Returns whether the identifier belongs to the global queue.
+   *
+   * @return {@code true} when this identifier targets the node-global durable queue
+   */
+  public boolean isGlobalQueue() {
+    return globalQueue;
+  }
+
+  /**
+   * Returns the client name for non-global queues.
+   *
+   * @return stable non-global client name, or {@code null} when this identifier is global
+   */
+  public String clientName() {
+    return clientName;
+  }
+
+  /**
+   * Returns the stable request identifier string.
+   *
+   * @return stable queue-local identifier string used for lookup and duplicate detection
+   */
+  public String identifier() {
+    return identifier;
+  }
+
+  /**
+   * Returns the request type stored with the identifier.
+   *
+   * @return durable request category that restart logic should apply to this request
+   */
+  public RequestType type() {
+    return type;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((clientName == null) ? 0 : clientName.hashCode());
+    result = prime * result + (globalQueue ? 1231 : 1237);
+    result = prime * result + ((identifier == null) ? 0 : identifier.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof PersistentRequestIdentifier other)) {
+      return false;
+    }
+    if (globalQueue != other.globalQueue) {
+      return false;
+    }
+    if (!globalQueue && !clientName.equals(other.clientName)) {
+      return false;
+    }
+    if (!identifier.equals(other.identifier)) {
+      return false;
+    }
+    return type == other.type;
+  }
+}

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestRecoveryCodec.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestRecoveryCodec.java
@@ -1,0 +1,48 @@
+package network.crypta.client.async.persistence;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
+
+/**
+ * Restarts durable requests from compact recovery records.
+ *
+ * <p>The recovery codec isolates endpoint-specific restart logic from the client-layer persistence
+ * flow. {@code ClientLayerPersister} owns the framing, checksum handling, duplicate detection, and
+ * overall fallback policy, while implementations of this interface know how to turn a compact
+ * request-specific payload back into a live durable request for a particular runtime endpoint.
+ *
+ * <p>Keeping this seam separate from {@link PersistentRequestHandle} lets the client layer remain
+ * stable while runtime adapters evolve independently. A codec may return {@code null} when a
+ * particular durable request type cannot be restarted from compact data and should instead be
+ * treated as unrecoverable.
+ */
+public interface PersistentRequestRecoveryCodec {
+
+  /**
+   * Restarts a request from a compact recovery-data stream.
+   *
+   * <p>The supplied stream contains only the request-specific payload inside the outer persistence
+   * framing. Implementations may validate that payload against the durable identifier, reconstruct
+   * the endpoint-owned request state, and attach the result to the live runtime context. They
+   * should not consume bytes beyond the current request record.
+   *
+   * @param dis input positioned at the start of the request-specific compact recovery payload
+   * @param identifier durable request identifier describing the request to recover
+   * @param context live client runtime context that will own the restarted request
+   * @param checker checksum helper available for request-specific restart logic when needed
+   * @return recovered request, or {@code null} when this codec cannot restart the request type
+   * @throws StorageFormatException if the compact recovery payload is malformed or inconsistent
+   * @throws IOException if the recovery payload cannot be read from the stream
+   * @throws ResumeFailedException if restart cannot attach the recovered request to the runtime
+   */
+  PersistentRequestHandle restartFrom(
+      DataInputStream dis,
+      PersistentRequestIdentifier identifier,
+      ClientContext context,
+      ChecksumChecker checker)
+      throws StorageFormatException, IOException, ResumeFailedException;
+}

--- a/src/main/java/network/crypta/client/async/persistence/package-info.java
+++ b/src/main/java/network/crypta/client/async/persistence/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Client-owned persistence contracts for durable async request recovery.
+ *
+ * <p>This package defines the narrow seam that {@code network.crypta.client.async} uses to
+ * checkpoint, deduplicate, and recover durable requests without depending directly on a concrete
+ * endpoint implementation such as FCP. The types here are owned by the client layer because the
+ * persistence coordinator needs stable concepts that survive protocol refactors: a request handle,
+ * a byte-compatible identifier, a catalog for live requests, and a codec for compact recovery
+ * records.
+ *
+ * <p>The seam is intentionally small. It preserves the existing identifier layout and restart
+ * behavior so runtime-owned adapters can continue to bridge legacy request types without widening
+ * {@code runtime-spi}. In practice, startup wiring provides an adapter implementation, the client
+ * layer performs save and load orchestration locally, and endpoint packages remain responsible only
+ * for listing requests and reconstructing protocol-specific state.
+ */
+package network.crypta.client.async.persistence;

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -10,6 +10,8 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.PrioRunnable;
@@ -48,7 +50,7 @@ import static network.crypta.clients.fcp.RequestIdentifier.RequestType.GET;
  * @see PersistentRequestClient
  * @see ClientRequester
  */
-public abstract class ClientRequest implements Serializable {
+public abstract class ClientRequest implements Serializable, PersistentRequestHandle {
   private static final Logger LOG = LoggerFactory.getLogger(ClientRequest.class);
 
   /**
@@ -96,10 +98,10 @@ public abstract class ClientRequest implements Serializable {
    */
   protected String clientToken;
 
-  /** Timestamp : startup time */
+  /** Timestamp: startup time */
   protected final long startupTime;
 
-  /** Timestamp : completion time */
+  /** Timestamp: completion time */
   protected volatile long completionTime;
 
   /**
@@ -322,7 +324,7 @@ public abstract class ClientRequest implements Serializable {
    * job or be canceled outright. This callback is invoked on a node worker thread and should return
    * quickly.
    *
-   * @param context client context providing access to schedulers, queues and persistent roots
+   * @param context client context providing access to schedulers, queues, and persistent roots
    */
   public abstract void onLostConnection(ClientContext context);
 
@@ -410,6 +412,7 @@ public abstract class ClientRequest implements Serializable {
    *
    * @param context client context used when propagating the cancellation into the core node
    */
+  @Override
   public void cancel(ClientContext context) {
     ClientRequester cr = getClientRequest();
     // It might have been finished on startup.
@@ -633,17 +636,6 @@ public abstract class ClientRequest implements Serializable {
    */
   @SuppressWarnings("unused")
   public abstract boolean isTotalFinalized();
-
-  /**
-   * Starts the request if it has not already been started.
-   *
-   * <p>Implementations are responsible for creating the underlying {@link ClientRequester},
-   * scheduling it on the appropriate queues, and updating any status caches. This method may be
-   * called again after a restart request but should avoid duplicating work when already running.
-   *
-   * @param context client context providing access to schedulers, factories, and persistent roots
-   */
-  public abstract void start(ClientContext context);
 
   /** Indicates whether {@link #start(ClientContext)} has been invoked for this request. */
   protected boolean started;
@@ -918,6 +910,11 @@ public abstract class ClientRequest implements Serializable {
     dos.writeBoolean(finished);
   }
 
+  @Override
+  public void writeRecoveryData(DataOutputStream dos, ChecksumChecker checker) throws IOException {
+    getClientDetail(dos, checker);
+  }
+
   /**
    * Reconstructs a persistent {@code ClientRequest} instance from the compact client-detail
    * encoding written by {@link #getClientDetail(DataOutputStream, ChecksumChecker)}.
@@ -1006,6 +1003,7 @@ public abstract class ClientRequest implements Serializable {
    * @param context client context that provides access to persistent roots and utility factories
    * @throws ResumeFailedException if the request cannot be reattached to the runtime environment
    */
+  @Override
   public final void onResume(ClientContext context) throws ResumeFailedException {
     client = context.persistentRoot.makeClient(global, clientName);
     lowLevelClient = client.lowLevelClient(realTime);
@@ -1055,6 +1053,11 @@ public abstract class ClientRequest implements Serializable {
     return new RequestIdentifier(global, clientName, identifier, getType());
   }
 
+  @Override
+  public PersistentRequestIdentifier getPersistentRequestIdentifier() {
+    return getRequestIdentifier().toPersistentRequestIdentifier();
+  }
+
   abstract RequestIdentifier.RequestType getType();
 
   /**
@@ -1083,17 +1086,6 @@ public abstract class ClientRequest implements Serializable {
   }
 
   /**
-   * Returns whether the original fetch was resumed entirely from stored data.
-   *
-   * <p>Subclasses use this to differentiate between fast restarts that reuse an existing splitfile
-   * layout and slower paths that have to reconstruct state from scratch. The value may be used for
-   * diagnostics or user-facing status messages.
-   *
-   * @return {@code true} when the request resumed from existing data without restarting work
-   */
-  public abstract boolean fullyResumed();
-
-  /**
    * Called just before the node performs its final writing during shutdown.
    *
    * <p>Subclasses can override this hook to flush any outstanding state to disk or perform
@@ -1102,6 +1094,7 @@ public abstract class ClientRequest implements Serializable {
    *
    * @param context client context giving access to persistence mechanisms used during shutdown
    */
+  @Override
   public void onShutdown(ClientContext context) {
     ClientRequester request = getClientRequest();
     if (request != null) request.onShutdown(context);

--- a/src/main/java/network/crypta/clients/fcp/RequestIdentifier.java
+++ b/src/main/java/network/crypta/clients/fcp/RequestIdentifier.java
@@ -3,6 +3,7 @@ package network.crypta.clients.fcp;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 
 /**
  * Immutable handle that uniquely identifies a client request in the FCP bridge and carries enough
@@ -102,7 +103,7 @@ public final class RequestIdentifier {
    * version short, queue flag, optional UTF client name, UTF identifier, and request-type code.
    *
    * @param dis data source positioned at the start of the serialized identifier.
-   * @throws IOException if the magic or version differ, type is invalid, or input fails.
+   * @throws IOException if the magic or version differ, the type is invalid, or input fails.
    */
   public RequestIdentifier(DataInput dis) throws IOException {
     int magic = dis.readInt();
@@ -136,8 +137,8 @@ public final class RequestIdentifier {
 
   /**
    * Determines whether another identifier represents the same queued request while deliberately
-   * ignoring {@link #type}. Use this when de-duplicating enqueue attempts that should coalesce
-   * based on queue scope, client name, and stable identifier string.
+   * ignoring {@link #type}. Use this when deduplicating enqueue attempts that should coalesce based
+   * on queue scope, client name, and stable identifier string.
    *
    * @param other candidate identifier compared by queue flag, client name, and identifier string.
    * @return {@code true} when queue scope and identifier match, even if request types differ.
@@ -146,6 +147,31 @@ public final class RequestIdentifier {
     if (globalQueue != other.globalQueue) return false;
     if (!globalQueue && !clientName.equals(other.clientName)) return false;
     return identifier.equals(other.identifier);
+  }
+
+  /**
+   * Converts this legacy FCP identifier to the client-owned persistence identifier.
+   *
+   * @return equivalent client-owned identifier with the same byte-compatible field values
+   */
+  public PersistentRequestIdentifier toPersistentRequestIdentifier() {
+    return new PersistentRequestIdentifier(
+        globalQueue, clientName, identifier, toPersistentRequestType(type));
+  }
+
+  /**
+   * Rebuilds an FCP identifier from the client-owned persistence identifier.
+   *
+   * @param identifier client-owned identifier to convert
+   * @return equivalent FCP request identifier
+   */
+  public static RequestIdentifier fromPersistentRequestIdentifier(
+      PersistentRequestIdentifier identifier) {
+    return new RequestIdentifier(
+        identifier.isGlobalQueue(),
+        identifier.clientName(),
+        identifier.identifier(),
+        fromPersistentRequestType(identifier.type()));
   }
 
   /** Hash code aligned with {@link #equals(Object)}; omits {@link #type} by design. */
@@ -165,7 +191,7 @@ public final class RequestIdentifier {
    * base identifier string, and {@link #type}. Suitable for maps and sets that must distinguish
    * between different request categories.
    *
-   * @param obj other object, expected to be another {@code RequestIdentifier}.
+   * @param obj the other object, expected to be another {@code RequestIdentifier}.
    * @return {@code true} when all significant fields match; {@code false} otherwise.
    */
   @Override
@@ -177,5 +203,22 @@ public final class RequestIdentifier {
     if (!globalQueue && !clientName.equals(other.clientName)) return false;
     if (!identifier.equals(other.identifier)) return false;
     return type == other.type;
+  }
+
+  private static PersistentRequestIdentifier.RequestType toPersistentRequestType(RequestType type) {
+    return switch (type) {
+      case GET -> PersistentRequestIdentifier.RequestType.GET;
+      case PUT -> PersistentRequestIdentifier.RequestType.PUT;
+      case PUTDIR -> PersistentRequestIdentifier.RequestType.PUTDIR;
+    };
+  }
+
+  private static RequestType fromPersistentRequestType(
+      PersistentRequestIdentifier.RequestType type) {
+    return switch (type) {
+      case GET -> RequestType.GET;
+      case PUT -> RequestType.PUT;
+      case PUTDIR -> RequestType.PUTDIR;
+    };
   }
 }

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -286,7 +286,6 @@ public final class NodeClientCore implements Persistable {
             node.network().executor(),
             node.network().ticker(),
             node,
-            this,
             persistentTempBucketFactory,
             tempBucketFactory);
 

--- a/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
@@ -8,6 +8,8 @@ import network.crypta.client.async.ClientContextRafFactories;
 import network.crypta.client.async.ClientContextRuntime;
 import network.crypta.client.async.ClientContextServices;
 import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.PersistentRequestRoot;
@@ -21,7 +23,9 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeInitException;
 import network.crypta.node.Persistable;
+import network.crypta.runtime.endpoints.fcp.CoreFcpPersistentRequestCatalog;
 import network.crypta.runtime.endpoints.fcp.CoreFcpServerDependenciesFactory;
+import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestRecoveryCodec;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.Ticker;
@@ -63,6 +67,10 @@ import network.crypta.support.io.TempBucketFactory;
 public final class NodeClientPersistence {
   private final ConfigurablePersister persister;
   private final PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+  private final PersistentRequestCatalog persistentRequestCatalog =
+      new CoreFcpPersistentRequestCatalog(persistentRoot);
+  private final PersistentRequestRecoveryCodec persistentRequestRecoveryCodec =
+      new FcpPersistentRequestRecoveryCodec();
   private DiskSpaceCheckingRandomAccessBufferFactory diskChecker;
   private MaybeEncryptedRandomAccessBufferFactory persistentRafFactory;
   private final int sortOrderAfter;
@@ -305,6 +313,9 @@ public final class NodeClientPersistence {
    */
   public ClientContext createClientContext(Node node, ClientContextInitParams params) {
     DiskSpaceCheckingRandomAccessBufferFactory checker = requireDiskChecker();
+    params
+        .clientLayerPersister()
+        .configurePersistenceAdapters(persistentRequestCatalog, persistentRequestRecoveryCodec);
     NodeClientCoreInit init = params.init();
     ClientContextRuntime runtime =
         new ClientContextRuntime(

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/CoreFcpPersistentRequestCatalog.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/CoreFcpPersistentRequestCatalog.java
@@ -1,0 +1,47 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.util.Objects;
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.clients.fcp.RequestIdentifier;
+
+/**
+ * Runtime-owned adapter that exposes FCP persistent requests through the client-owned catalog seam.
+ *
+ * <p>This adapter keeps durable-request enumeration and duplicate detection under runtime ownership
+ * while exposing only the narrow client-owned catalog contract. It reuses the existing {@link
+ * PersistentRequestRoot} registry and FCP request-identifier semantics, so the client-layer
+ * persister can checkpoint and skip duplicates without importing FCP types directly.
+ *
+ * <p>The implementation is intentionally thin. It delegates snapshot creation to the live FCP
+ * registry and converts client-owned identifiers back into legacy FCP identifiers only for lookup.
+ * That preserves the existing queue and request-name semantics during the first phase of the
+ * decoupling work.
+ */
+public final class CoreFcpPersistentRequestCatalog implements PersistentRequestCatalog {
+  private final PersistentRequestRoot persistentRoot;
+
+  /**
+   * Creates a catalog adapter backed by the shared FCP persistent-request registry.
+   *
+   * @param persistentRoot shared FCP request root used for enumeration and duplicate lookups
+   */
+  public CoreFcpPersistentRequestCatalog(PersistentRequestRoot persistentRoot) {
+    this.persistentRoot = Objects.requireNonNull(persistentRoot);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PersistentRequestHandle[] getPersistentRequests() {
+    return persistentRoot.getPersistentRequests();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean hasRequest(PersistentRequestIdentifier identifier) {
+    return persistentRoot.hasRequest(
+        RequestIdentifier.fromPersistentRequestIdentifier(Objects.requireNonNull(identifier)));
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestRecoveryCodec.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestRecoveryCodec.java
@@ -1,0 +1,48 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
+import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.RequestIdentifier;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
+
+/**
+ * Runtime-owned adapter that restarts FCP persistent requests through the client-owned seam.
+ *
+ * <p>This codec bridges the client-owned recovery contract back to the existing FCP restart path.
+ * It converts the client-owned durable identifier into the legacy FCP identifier type and then
+ * delegates reconstruction to {@link ClientRequest#restartFrom(DataInputStream, RequestIdentifier,
+ * ClientContext, ChecksumChecker)}. The adapter stays stateless, so startup wiring can reuse a
+ * single instance without coordinating additional caches or configuration.
+ */
+public final class FcpPersistentRequestRecoveryCodec implements PersistentRequestRecoveryCodec {
+
+  /**
+   * Creates a stateless adapter for FCP compact-recovery records.
+   *
+   * <p>The adapter carries no mutable state and is safe to reuse for repeated startup and recovery
+   * attempts.
+   */
+  public FcpPersistentRequestRecoveryCodec() {
+    // Explicit for Javadoc coverage of the public API; the adapter is intentionally stateless.
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PersistentRequestHandle restartFrom(
+      DataInputStream dis,
+      PersistentRequestIdentifier identifier,
+      ClientContext context,
+      ChecksumChecker checker)
+      throws StorageFormatException, IOException, ResumeFailedException {
+    RequestIdentifier requestIdentifier =
+        RequestIdentifier.fromPersistentRequestIdentifier(identifier);
+    return ClientRequest.restartFrom(dis, requestIdentifier, context, checker);
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
@@ -3,7 +3,7 @@
  *
  * <p>This package adapts daemon- and runtime-backed services to the narrow runtime-support seams
  * defined in {@code network.crypta.clients.fcp}. The types here exist to keep remaining {@code
- * NodeClientCore}-backed FCP bootstrap wiring under runtime ownership while preserving the current
- * protocol behavior and without widening {@code runtime-spi}.
+ * NodeClientCore}-backed FCP bootstrap and persistence-bridge wiring under runtime ownership while
+ * preserving the current protocol behavior and without widening {@code runtime-spi}.
  */
 package network.crypta.runtime.endpoints.fcp;

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -133,7 +133,6 @@ class ClientContextTest {
                     mainExecutor,
                     ticker,
                     null,
-                    null,
                     persistentTempBucketFactory,
                     tempBucketFactory,
                     null),

--- a/src/test/java/network/crypta/client/async/ClientLayerPersisterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientLayerPersisterTest.java
@@ -11,12 +11,14 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.io.StreamCorruptedException;
-import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.crypt.AEADVerificationFailedException;
 import network.crypta.io.comm.IOStatisticCollector;
 import network.crypta.node.MasterKeysWrongPasswordException;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -57,7 +59,6 @@ class ClientLayerPersisterTest {
   @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
   Node node;
 
-  @Mock NodeClientCore core;
   @Mock PersistentTempBucketFactory persistentTempBucketFactory;
   @Mock TempBucketFactory tempBucketFactory;
   @Mock RequestStarterGroup requestStarters;
@@ -65,8 +66,6 @@ class ClientLayerPersisterTest {
   private ClientLayerPersister newPersister() {
     PriorityAwareExecutor exec = new InlineExecutor();
     Ticker ticker = new InlineTicker(exec);
-
-    when(core.getPersistentRequests()).thenReturn(new ClientRequest[0]);
 
     // Stats reading during save()
     when(node.network().collector()).thenReturn(new IOStatisticCollector());
@@ -82,14 +81,20 @@ class ClientLayerPersisterTest {
       throw new RuntimeException(e);
     }
 
-    return new ClientLayerPersister(
-        exec,
-        ticker,
-        node,
-        core,
-        persistentTempBucketFactory,
-        tempBucketFactory,
-        new PersistentStatsPutter());
+    ClientLayerPersister persister =
+        new ClientLayerPersister(
+            exec,
+            ticker,
+            node,
+            persistentTempBucketFactory,
+            tempBucketFactory,
+            new PersistentStatsPutter());
+    PersistentRequestCatalog catalog = mock(PersistentRequestCatalog.class);
+    when(catalog.getPersistentRequests()).thenReturn(new PersistentRequestHandle[0]);
+    when(catalog.hasRequest(any(PersistentRequestIdentifier.class))).thenReturn(false);
+    PersistentRequestRecoveryCodec recoveryCodec = mock(PersistentRequestRecoveryCodec.class);
+    persister.configurePersistenceAdapters(catalog, recoveryCodec);
+    return persister;
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/persistence/PersistentRequestIdentifierTest.java
+++ b/src/test/java/network/crypta/client/async/persistence/PersistentRequestIdentifierTest.java
@@ -1,0 +1,160 @@
+package network.crypta.client.async.persistence;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class PersistentRequestIdentifierTest {
+
+  @Test
+  void writeToAndConstructor_whenNonGlobalQueue_roundTripsFields() throws IOException {
+    // Arrange
+    PersistentRequestIdentifier original =
+        new PersistentRequestIdentifier(
+            false, "client-a", "request-1", PersistentRequestIdentifier.RequestType.PUT);
+
+    // Act
+    PersistentRequestIdentifier restored = roundTrip(original);
+
+    // Assert
+    assertEquals(original, restored);
+    assertFalse(restored.isGlobalQueue());
+    assertEquals("client-a", restored.clientName());
+    assertEquals("request-1", restored.identifier());
+    assertEquals(PersistentRequestIdentifier.RequestType.PUT, restored.type());
+  }
+
+  @Test
+  void writeToAndConstructor_whenGlobalQueue_roundTripsFields() throws IOException {
+    // Arrange
+    PersistentRequestIdentifier original =
+        new PersistentRequestIdentifier(
+            true, null, "global-request", PersistentRequestIdentifier.RequestType.GET);
+
+    // Act
+    PersistentRequestIdentifier restored = roundTrip(original);
+
+    // Assert
+    assertEquals(original, restored);
+    assertTrue(restored.isGlobalQueue());
+    assertNull(restored.clientName());
+    assertEquals("global-request", restored.identifier());
+    assertEquals(PersistentRequestIdentifier.RequestType.GET, restored.type());
+  }
+
+  @Test
+  void sameIdentifier_whenTypeDiffers_expectTrueAndEqualsFalse() {
+    // Arrange
+    PersistentRequestIdentifier first =
+        new PersistentRequestIdentifier(
+            false, "client-a", "shared-id", PersistentRequestIdentifier.RequestType.GET);
+    PersistentRequestIdentifier second =
+        new PersistentRequestIdentifier(
+            false, "client-a", "shared-id", PersistentRequestIdentifier.RequestType.PUTDIR);
+
+    // Act
+    boolean sameIdentifier = first.sameIdentifier(second);
+
+    // Assert
+    assertTrue(sameIdentifier);
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  void sameIdentifier_whenClientDiffers_expectFalse() {
+    // Arrange
+    PersistentRequestIdentifier first =
+        new PersistentRequestIdentifier(
+            false, "client-a", "shared-id", PersistentRequestIdentifier.RequestType.GET);
+    PersistentRequestIdentifier second =
+        new PersistentRequestIdentifier(
+            false, "client-b", "shared-id", PersistentRequestIdentifier.RequestType.GET);
+
+    // Act
+    boolean sameIdentifier = first.sameIdentifier(second);
+
+    // Assert
+    assertFalse(sameIdentifier);
+  }
+
+  @Test
+  void constructor_whenMagicInvalid_throwsIOException() throws IOException {
+    // Arrange
+    byte[] payload =
+        rawBytes(
+            PersistentRequestIdentifier.MAGIC + 1, PersistentRequestIdentifier.VERSION, (short) 0);
+
+    // Act & Assert
+    assertThrows(IOException.class, () -> readIdentifier(payload));
+  }
+
+  @Test
+  void constructor_whenVersionInvalid_throwsIOException() throws IOException {
+    // Arrange
+    byte[] payload =
+        rawBytes(
+            PersistentRequestIdentifier.MAGIC,
+            (short) (PersistentRequestIdentifier.VERSION + 1),
+            (short) 0);
+
+    // Act & Assert
+    assertThrows(IOException.class, () -> readIdentifier(payload));
+  }
+
+  @Test
+  void constructor_whenTypeInvalid_throwsIOException() throws IOException {
+    // Arrange
+    byte[] payload =
+        rawBytes(
+            PersistentRequestIdentifier.MAGIC,
+            PersistentRequestIdentifier.VERSION,
+            Short.MAX_VALUE);
+
+    // Act & Assert
+    assertThrows(IOException.class, () -> readIdentifier(payload));
+  }
+
+  private static PersistentRequestIdentifier roundTrip(PersistentRequestIdentifier identifier)
+      throws IOException {
+    byte[] payload = writeBytes(identifier);
+    return readIdentifier(payload);
+  }
+
+  private static byte[] writeBytes(PersistentRequestIdentifier identifier) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      identifier.writeTo(dos);
+    }
+    return baos.toByteArray();
+  }
+
+  private static PersistentRequestIdentifier readIdentifier(byte[] payload) throws IOException {
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(payload))) {
+      return new PersistentRequestIdentifier(dis);
+    }
+  }
+
+  private static byte[] rawBytes(int magic, short version, short typeCode) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(magic);
+      dos.writeShort(version);
+      dos.writeBoolean(false);
+      dos.writeUTF("client-a");
+      dos.writeUTF("request-1");
+      dos.writeShort(typeCode);
+    }
+    return baos.toByteArray();
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/CoreFcpPersistentRequestCatalogTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CoreFcpPersistentRequestCatalogTest.java
@@ -1,0 +1,199 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.runtime.endpoints.fcp.CoreFcpPersistentRequestCatalog;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class CoreFcpPersistentRequestCatalogTest {
+
+  @Test
+  void getPersistentRequests_whenRootContainsRequests_expectReturnsSnapshot() {
+    // Arrange
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient globalClient = root.getGlobalForeverClient();
+    PersistentRequestClient namedClient = root.registerForeverClient("client-a", null);
+    TestClientRequest globalRequest =
+        new TestClientRequest(globalClient, "global-id", true, RequestIdentifier.RequestType.GET);
+    TestClientRequest namedRequest =
+        new TestClientRequest(namedClient, "client-id", false, RequestIdentifier.RequestType.PUT);
+    globalClient.resume(globalRequest);
+    namedClient.resume(namedRequest);
+    CoreFcpPersistentRequestCatalog catalog = new CoreFcpPersistentRequestCatalog(root);
+
+    // Act
+    PersistentRequestHandle[] requests = catalog.getPersistentRequests();
+
+    // Assert
+    assertArrayEquals(new PersistentRequestHandle[] {globalRequest, namedRequest}, requests);
+  }
+
+  @Test
+  void hasRequest_whenIdentifierMatchesExpectTrueEvenWhenTypeDiffers() {
+    // Arrange
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient client = root.registerForeverClient("client-a", null);
+    client.resume(
+        new TestClientRequest(client, "shared-id", false, RequestIdentifier.RequestType.PUT));
+    CoreFcpPersistentRequestCatalog catalog = new CoreFcpPersistentRequestCatalog(root);
+    PersistentRequestIdentifier lookupIdentifier =
+        new PersistentRequestIdentifier(
+            false, "client-a", "shared-id", PersistentRequestIdentifier.RequestType.GET);
+
+    // Act
+    boolean present = catalog.hasRequest(lookupIdentifier);
+
+    // Assert
+    assertTrue(present);
+  }
+
+  @Test
+  void hasRequest_whenIdentifierMissing_expectFalse() {
+    // Arrange
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    CoreFcpPersistentRequestCatalog catalog = new CoreFcpPersistentRequestCatalog(root);
+    PersistentRequestIdentifier lookupIdentifier =
+        new PersistentRequestIdentifier(
+            false, "client-a", "missing-id", PersistentRequestIdentifier.RequestType.GET);
+
+    // Act
+    boolean present = catalog.hasRequest(lookupIdentifier);
+
+    // Assert
+    assertFalse(present);
+  }
+
+  private static final class TestClientRequest extends ClientRequest {
+    private final RequestIdentifier.RequestType type;
+
+    TestClientRequest(
+        PersistentRequestClient client,
+        String identifier,
+        boolean global,
+        RequestIdentifier.RequestType type) {
+      super(
+          prepareConstructorInit(
+              new ClientRequestParams(
+                  null, identifier, 0, (short) 0, Persistence.FOREVER, false, null, global),
+              null,
+              client));
+      this.type = type;
+    }
+
+    @Override
+    public void onLostConnection(ClientContext context) {
+      // No-op: connection lifecycle is irrelevant for this adapter test.
+    }
+
+    @Override
+    public void sendPendingMessages(
+        FCPConnectionOutputHandler handler,
+        String listRequestIdentifier,
+        boolean includeData,
+        boolean onlyData) {
+      // No-op: message replay is outside this test's scope.
+    }
+
+    @Override
+    void register(boolean noTags) {
+      // No-op: the client registry is exercised directly in the test.
+    }
+
+    @Override
+    protected ClientRequester getClientRequest() {
+      return null;
+    }
+
+    @Override
+    protected void freeData() {
+      // No-op: the stub never allocates buffers.
+    }
+
+    @Override
+    public double getSuccessFraction() {
+      return 0;
+    }
+
+    @Override
+    public double getTotalBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getMinBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFetchedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFatalyFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public String getFailureReason(boolean longDescription) {
+      return "";
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return true;
+    }
+
+    @Override
+    public void start(ClientContext context) {
+      // No-op: startup mechanics are not part of catalog behavior.
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return false;
+    }
+
+    @Override
+    public boolean canRestart() {
+      return false;
+    }
+
+    @Override
+    public boolean restart(ClientContext context, boolean disableFilterData) {
+      return false;
+    }
+
+    @Override
+    RequestStatus getStatus() {
+      return null;
+    }
+
+    @Override
+    protected void innerResume(ClientContext context) {
+      // No-op: runtime reattachment is not exercised here.
+    }
+
+    @Override
+    RequestIdentifier.RequestType getType() {
+      return type;
+    }
+
+    @Override
+    public boolean fullyResumed() {
+      return true;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/RequestIdentifierTest.java
+++ b/src/test/java/network/crypta/clients/fcp/RequestIdentifierTest.java
@@ -5,8 +5,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -79,6 +81,34 @@ class RequestIdentifierTest {
   }
 
   @Test
+  void persistentConversion_whenRoundTripped_preservesFields() {
+    RequestIdentifier original =
+        new RequestIdentifier(false, "clientA", "identifier-1", RequestIdentifier.RequestType.PUT);
+
+    PersistentRequestIdentifier persistent = original.toPersistentRequestIdentifier();
+    RequestIdentifier restored = RequestIdentifier.fromPersistentRequestIdentifier(persistent);
+
+    assertEquals(original, restored);
+    assertTrue(
+        persistent.sameIdentifier(
+            new PersistentRequestIdentifier(
+                false, "clientA", "identifier-1", PersistentRequestIdentifier.RequestType.GET)));
+  }
+
+  @Test
+  void persistentIdentifierWriteTo_whenComparedWithLegacyEncoding_matchesBytes()
+      throws IOException {
+    RequestIdentifier original =
+        new RequestIdentifier(false, "clientA", "identifier-1", RequestIdentifier.RequestType.PUT);
+
+    byte[] legacyBytes = writeBytes(original);
+    byte[] persistentBytes = writeBytes(original.toPersistentRequestIdentifier());
+
+    assertEquals(legacyBytes.length, persistentBytes.length);
+    assertArrayEquals(legacyBytes, persistentBytes);
+  }
+
+  @Test
   void constructor_whenMagicInvalid_throwsIOException() throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try (DataOutputStream dos = new DataOutputStream(baos)) {
@@ -137,5 +167,21 @@ class RequestIdentifierTest {
     try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
       return new RequestIdentifier(dis);
     }
+  }
+
+  private byte[] writeBytes(RequestIdentifier identifier) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      identifier.writeTo(dos);
+    }
+    return baos.toByteArray();
+  }
+
+  private byte[] writeBytes(PersistentRequestIdentifier identifier) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      identifier.writeTo(dos);
+    }
+    return baos.toByteArray();
   }
 }

--- a/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
@@ -11,6 +11,8 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.USKManager;
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.FcpServerDependencies;
@@ -28,7 +30,9 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeInitException;
 import network.crypta.node.Persistable;
+import network.crypta.runtime.endpoints.fcp.CoreFcpPersistentRequestCatalog;
 import network.crypta.runtime.endpoints.fcp.CoreFcpServerDependenciesFactory;
+import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestRecoveryCodec;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
@@ -407,6 +411,14 @@ class NodeClientPersistenceTest {
                 DiskSpaceCheckingRandomAccessBufferFactory.class,
                 context.getFileRandomAccessBufferFactory(true)),
         () -> assertSame(persistentRafFactory, context.getRandomAccessBufferFactory(true)));
+    ArgumentCaptor<PersistentRequestCatalog> catalogCaptor =
+        ArgumentCaptor.forClass(PersistentRequestCatalog.class);
+    ArgumentCaptor<PersistentRequestRecoveryCodec> recoveryCodecCaptor =
+        ArgumentCaptor.forClass(PersistentRequestRecoveryCodec.class);
+    verify(clientLayerPersister)
+        .configurePersistenceAdapters(catalogCaptor.capture(), recoveryCodecCaptor.capture());
+    assertInstanceOf(CoreFcpPersistentRequestCatalog.class, catalogCaptor.getValue());
+    assertInstanceOf(FcpPersistentRequestRecoveryCodec.class, recoveryCodecCaptor.getValue());
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestRecoveryCodecTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestRecoveryCodecTest.java
@@ -1,0 +1,58 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.RequestIdentifier;
+import network.crypta.crypt.ChecksumChecker;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+@SuppressWarnings("java:S100")
+class FcpPersistentRequestRecoveryCodecTest {
+
+  @Test
+  void restartFrom_whenCalled_expectDelegatesToClientRequestUsingConvertedIdentifier()
+      throws Exception {
+    // Arrange
+    FcpPersistentRequestRecoveryCodec codec = new FcpPersistentRequestRecoveryCodec();
+    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+    PersistentRequestIdentifier persistentIdentifier =
+        new PersistentRequestIdentifier(
+            false, "client-a", "request-1", PersistentRequestIdentifier.RequestType.PUTDIR);
+    RequestIdentifier requestIdentifier =
+        RequestIdentifier.fromPersistentRequestIdentifier(persistentIdentifier);
+    ClientContext context = mock(ClientContext.class);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ClientRequest expectedRequest = mock(ClientRequest.class);
+
+    // Act
+    try (MockedStatic<ClientRequest> clientRequestMock = mockStatic(ClientRequest.class)) {
+      clientRequestMock
+          .when(
+              () ->
+                  ClientRequest.restartFrom(
+                      same(dis), eq(requestIdentifier), same(context), same(checker)))
+          .thenReturn(expectedRequest);
+
+      PersistentRequestHandle restored =
+          codec.restartFrom(dis, persistentIdentifier, context, checker);
+
+      // Assert
+      assertSame(expectedRequest, restored);
+      clientRequestMock.verify(
+          () ->
+              ClientRequest.restartFrom(
+                  same(dis), eq(requestIdentifier), same(context), same(checker)));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a client-owned persistence seam under `network.crypta.client.async.persistence` for durable request handles, identifiers, catalogs, and recovery codecs
- refactor `ClientLayerPersister` to depend on that seam instead of `clients.fcp`, and bridge back to FCP with thin runtime-owned adapters wired from `NodeClientPersistence`
- extend coverage with focused identifier and adapter tests, strengthen persistence wiring assertions, and clean up Javadoc for the newly added main-source types

## How to test
- `./gradlew compileJava`
- `./gradlew test`
- `rg -n "^import network\.crypta\.clients\.fcp\." src/main/java/network/crypta/client -g'*.java'`

## Notes
- the remaining direct `client -> clients.fcp` imports are the expected `PersistentRequestRoot` references in `ClientContext` and `ClientContextServices`
- this keeps the request-id encoding byte-compatible and does not widen `runtime-spi`