### PR TITLE
refactor(client): Decouple persistent-request seam

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientBaseCallback.java
+++ b/src/main/java/network/crypta/client/async/ClientBaseCallback.java
@@ -13,7 +13,7 @@ import network.crypta.support.io.ResumeFailedException;
  * requests and can therefore re‑establish any necessary persistent state after a restart.
  *
  * <p>When the node restarts, {@link #onResume(ClientContext)} is invoked so the client can
- * re-register with the persistence infrastructure (for example {@code PersistentRequestRoot},
+ * re-register with the persistence infrastructure (for example, the persistent-request coordinator,
  * persistent temporary buckets, or trackers) before normal processing continues. The returned
  * {@link #getRequestClient()} value is consulted by the schedulers to group related work and apply
  * per‑client limits, persistence, and real‑time flags. Implementations should be lightweight and
@@ -36,14 +36,14 @@ public interface ClientBaseCallback {
    * Resumes a persistent request after a node restart.
    *
    * <p>This method is invoked during node recovery so the client can re-register any durable
-   * resources and state needed by the request, such as entries under {@code PersistentRequestRoot},
+   * resources and state needed by the request, such as persistent-request coordinator entries,
    * persistent temporary buckets, or file trackers. Implementations should treat repeated calls as
    * safe and avoid expensive work unless required to restore correctness. Heavy I/O or long‑running
-   * computations should be minimized to keep startup responsive.
+   * computations should be minimized to keep the startup responsive.
    *
-   * @param context Non-null execution context providing access to schedulers, persistence roots,
+   * @param context Non-null execution context providing access to schedulers, persistence services,
    *     bucket factories, file trackers, and other services necessary to reattach state.
-   * @throws network.crypta.support.io.ResumeFailedException If persisted state is missing,
+   * @throws network.crypta.support.io.ResumeFailedException If the persisted state is missing,
    *     incompatible, or corrupt such that the request cannot be safely resumed by this client.
    */
   void onResume(ClientContext context) throws ResumeFailedException;

--- a/src/main/java/network/crypta/client/async/ClientContext.java
+++ b/src/main/java/network/crypta/client/async/ClientContext.java
@@ -6,9 +6,9 @@ import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
 import network.crypta.crypt.CryptoResumeContext;
 import network.crypta.crypt.MasterSecret;
@@ -169,8 +169,8 @@ public class ClientContext implements CryptoResumeContext {
    */
   public final MemoryLimitedJobRunner memoryLimitedJobRunner;
 
-  /** Root for persistent request coordination, including recovery across restarts. */
-  public final PersistentRequestRoot persistentRoot;
+  /** Coordinator for persistent request ownership, including recovery across restarts. */
+  public final PersistentRequestCoordinator persistentRequestCoordinator;
 
   private final FetchContext defaultPersistentFetchContext;
   private final InsertContext defaultPersistentInsertContext;
@@ -235,7 +235,7 @@ public class ClientContext implements CryptoResumeContext {
     this.linkFilterExceptionProvider = services.linkFilterExceptionProvider();
     this.memoryLimitedJobRunner = runtime.memoryLimitedJobRunner();
     this.tempRAFFactory = rafFactories.tempRAFFactory();
-    this.persistentRoot = services.persistentRoot();
+    this.persistentRequestCoordinator = services.persistentRequestCoordinator();
     this.dummyJobRunner = new DummyJobRunner(mainExecutorInternal, this);
     this.defaultPersistentFetchContext = defaults.defaultPersistentFetchContext();
     this.defaultPersistentInsertContext = defaults.defaultPersistentInsertContext();

--- a/src/main/java/network/crypta/client/async/ClientContextServices.java
+++ b/src/main/java/network/crypta/client/async/ClientContextServices.java
@@ -1,7 +1,7 @@
 package network.crypta.client.async;
 
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.node.ClientContextResources;
 import network.crypta.support.compress.RealCompressor;
 
@@ -15,7 +15,7 @@ import network.crypta.support.compress.RealCompressor;
  * @param uskManager manager for USK coordination and updates
  * @param compressor compressor implementation used in client pipelines
  * @param checker datastore checker used for verification work
- * @param persistentRoot persistent request root for durable request coordination
+ * @param persistentRequestCoordinator persistent request coordinator for durable request ownership
  * @param linkFilterExceptionProvider provider for link filter exceptions
  */
 public record ClientContextServices(
@@ -23,5 +23,5 @@ public record ClientContextServices(
     USKManager uskManager,
     RealCompressor compressor,
     DatastoreChecker checker,
-    PersistentRequestRoot persistentRoot,
+    PersistentRequestCoordinator persistentRequestCoordinator,
     LinkFilterExceptionProvider linkFilterExceptionProvider) {}

--- a/src/main/java/network/crypta/client/async/package-info.java
+++ b/src/main/java/network/crypta/client/async/package-info.java
@@ -45,8 +45,8 @@
  * <ul>
  *   <li>Uses node‑level request senders and failure tracking; see {@link
  *       network.crypta.node.FailureTable} for related back‑off decisions.
- *   <li>Exposes progress and lifecycle to client interfaces, including the FCP layer (for example,
- *       {@link network.crypta.clients.fcp.PersistentRequestClient}).
+ *   <li>Exposes progress and lifecycle to client interfaces, including the FCP layer and the
+ *       client-owned persistent-request seam.
  * </ul>
  */
 package network.crypta.client.async;

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestClientHandle.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestClientHandle.java
@@ -1,0 +1,20 @@
+package network.crypta.client.async.persistence;
+
+/**
+ * Opaque reference to the runtime-owned owner that backs a durable client request.
+ *
+ * <p>The client layer uses this marker interface to remember which runtime-owned client, queue, or
+ * session currently owns a persistent request. The handle deliberately exposes no behavioral API.
+ * That keeps {@code network.crypta.client.async} independent of endpoint-specific owner types while
+ * still allowing startup wiring to return a stable token that can be passed back through the
+ * persistence seam. Implementations are free to represent the handle with an existing runtime
+ * object, a lightweight wrapper, or another identity-bearing type, as long as callers can treat it
+ * as opaque and implementation-specific.
+ *
+ * <p>Handles are typically obtained from {@link PersistentRequestCoordinator} when a request is
+ * first created or when a saved request is reattached during node startup. Callers should not
+ * serialize, inspect, or downcast a handle outside the runtime package that created it.
+ *
+ * @see PersistentRequestCoordinator
+ */
+public interface PersistentRequestClientHandle {}

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestClientHandle.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestClientHandle.java
@@ -7,13 +7,15 @@ package network.crypta.client.async.persistence;
  * session currently owns a persistent request. The handle deliberately exposes no behavioral API.
  * That keeps {@code network.crypta.client.async} independent of endpoint-specific owner types while
  * still allowing startup wiring to return a stable token that can be passed back through the
- * persistence seam. Implementations are free to represent the handle with an existing runtime
- * object, a lightweight wrapper, or another identity-bearing type, as long as callers can treat it
- * as opaque and implementation-specific.
+ * persistence seam. The client layer must treat the handle as opaque and implementation-specific.
+ * Runtime code that creates the handle may still downcast or adapt it within that same runtime
+ * implementation when reconnecting request state to protocol-specific queues and callbacks.
  *
  * <p>Handles are typically obtained from {@link PersistentRequestCoordinator} when a request is
  * first created or when a saved request is reattached during node startup. Callers should not
- * serialize, inspect, or downcast a handle outside the runtime package that created it.
+ * serialize, inspect, or downcast a handle outside the runtime implementation that created it. The
+ * current FCP-backed coordinator returns {@code PersistentRequestClient} instances for that local
+ * runtime use.
  *
  * @see PersistentRequestCoordinator
  */

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestCoordinator.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestCoordinator.java
@@ -1,0 +1,57 @@
+package network.crypta.client.async.persistence;
+
+/**
+ * Coordinates the client-layer handoff between durable request handles and runtime-owned owners.
+ *
+ * <p>This interface is the narrow seam that lets {@code network.crypta.client.async} create or
+ * recover persistent requests without importing protocol-specific owner registries. Startup wiring
+ * provides an implementation from the active runtime package. The client layer then uses that
+ * implementation only to resolve an opaque owner handle for a new persistent request or to reattach
+ * a reloaded request to the owner that should resume it.
+ *
+ * <p>The contract stays intentionally small. It does not expose request catalogs, queue mutation
+ * primitives, or transport callbacks. Those details remain in the runtime implementation so the
+ * client package can preserve existing checkpoint and restart behavior while avoiding a direct
+ * dependency on endpoint-specific types.
+ *
+ * @see PersistentRequestClientHandle
+ * @see PersistentRequestHandle
+ */
+public interface PersistentRequestCoordinator {
+
+  /**
+   * Returns an opaque owner handle for a persistent request, creating the owner if needed.
+   *
+   * <p>Callers use this when they need the runtime-owned client or queue that should back a newly
+   * created durable request. Implementations may reuse an existing owner, create one lazily, or
+   * normalize the supplied identity to a canonical runtime object. When {@code global} is {@code
+   * true}, implementations may ignore {@code clientName} and resolve the shared global owner
+   * instead.
+   *
+   * @param global whether the request belongs to the runtime's global persistent queue rather than
+   *     a named client-specific owner
+   * @param clientName durable client name used for non-global ownership lookup; ignored or
+   *     implementation-defined when {@code global} is {@code true}
+   * @return opaque handle for the runtime-owned client or queue that should own the request
+   */
+  PersistentRequestClientHandle getOrCreateClientHandle(boolean global, String clientName);
+
+  /**
+   * Reattaches a reloaded persistent request to its runtime-owned owner and returns that owner.
+   *
+   * <p>This method is used during restart and recovery flows after the durable request object has
+   * been reconstructed from serialized state or compact recovery data. Implementations should bind
+   * the request to the correct owner, restore whatever owner-side bookkeeping is required for later
+   * callbacks, and return the same opaque handle shape used for newly created requests.
+   *
+   * @param request durable request handle that has been reconstructed and is ready to be attached
+   *     to runtime-owned ownership state
+   * @param global whether the request should resume under the runtime's global persistent queue
+   * @param clientName durable client name used for non-global owner lookup during resume
+   * @return opaque handle for the runtime-owned owner that now backs the resumed request
+   * @throws IllegalArgumentException if the supplied request handle is incompatible with the
+   *     implementation performing the resuming
+   */
+  PersistentRequestClientHandle resumePersistentRequest(
+      PersistentRequestHandle request, boolean global, String clientName);
+}

--- a/src/main/java/network/crypta/client/async/persistence/PersistentRequestCoordinator.java
+++ b/src/main/java/network/crypta/client/async/persistence/PersistentRequestCoordinator.java
@@ -12,7 +12,9 @@ package network.crypta.client.async.persistence;
  * <p>The contract stays intentionally small. It does not expose request catalogs, queue mutation
  * primitives, or transport callbacks. Those details remain in the runtime implementation so the
  * client package can preserve existing checkpoint and restart behavior while avoiding a direct
- * dependency on endpoint-specific types.
+ * dependency on endpoint-specific types. Any runtime-local adaptation from the opaque handle back
+ * to protocol-specific owner state remains the responsibility of the runtime code that supplied the
+ * coordinator.
  *
  * @see PersistentRequestClientHandle
  * @see PersistentRequestHandle

--- a/src/main/java/network/crypta/client/async/persistence/package-info.java
+++ b/src/main/java/network/crypta/client/async/persistence/package-info.java
@@ -4,14 +4,17 @@
  * <p>This package defines the narrow seam that {@code network.crypta.client.async} uses to
  * checkpoint, deduplicate, and recover durable requests without depending directly on a concrete
  * endpoint implementation such as FCP. The types here are owned by the client layer because the
- * persistence coordinator needs stable concepts that survive protocol refactors: a request handle,
- * a byte-compatible identifier, a catalog for live requests, and a codec for compact recovery
- * records.
+ * persistence coordinator needs stable concepts that survive protocol refactors: an opaque client
+ * handle, a request handle, a byte-compatible identifier, a catalog for live requests, and a codec
+ * for compact recovery records.
  *
  * <p>The seam is intentionally small. It preserves the existing identifier layout and restart
  * behavior so runtime-owned adapters can continue to bridge legacy request types without widening
  * {@code runtime-spi}. In practice, startup wiring provides an adapter implementation, the client
  * layer performs save and load orchestration locally, and endpoint packages remain responsible only
- * for listing requests and reconstructing protocol-specific state.
+ * for listing requests and reconstructing protocol-specific state. The primary bridge types are
+ * {@link network.crypta.client.async.persistence.PersistentRequestHandle}, {@link
+ * network.crypta.client.async.persistence.PersistentRequestClientHandle}, and {@link
+ * network.crypta.client.async.persistence.PersistentRequestCoordinator}.
  */
 package network.crypta.client.async.persistence;

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -297,6 +297,20 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
         : handler.getRebootClient();
   }
 
+  /**
+   * Reconstitutes the FCP-local persistent owner from the client-owned seam handle.
+   *
+   * <p>{@code ClientRequest} is an FCP runtime type, so it still needs the concrete {@link
+   * PersistentRequestClient} in order to obtain low-level request clients during deserialization
+   * and resume. The client layer never performs this cast; it remains local to the FCP
+   * implementation and therefore expects the active FCP coordinator to return the matching runtime
+   * handle shape.
+   *
+   * @param handle opaque persistent-request client handle returned by the configured coordinator
+   * @return FCP persistent client that owns this request during recovery and resume
+   * @throws IllegalStateException if the configured coordinator returns a handle that is
+   *     incompatible with the FCP runtime implementation
+   */
   private static PersistentRequestClient requirePersistentRequestClient(
       PersistentRequestClientHandle handle) {
     if (handle instanceof PersistentRequestClient client) {

--- a/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -10,6 +10,7 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 import network.crypta.crypt.ChecksumChecker;
@@ -294,6 +295,15 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
     return persistenceType2 == Persistence.FOREVER
         ? handler.getForeverClient()
         : handler.getRebootClient();
+  }
+
+  private static PersistentRequestClient requirePersistentRequestClient(
+      PersistentRequestClientHandle handle) {
+    if (handle instanceof PersistentRequestClient client) {
+      return client;
+    }
+    throw new IllegalStateException(
+        "Persistent request client handle is not a PersistentRequestClient: " + handle);
   }
 
   /**
@@ -976,7 +986,9 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
     // We can't wait until onResume() to get the client, because it may be used in the
     // constructors.
     PersistentRequestClient client =
-        context.persistentRoot.makeClient(reqID.globalQueue, reqID.clientName);
+        requirePersistentRequestClient(
+            context.persistentRequestCoordinator.getOrCreateClientHandle(
+                reqID.globalQueue, reqID.clientName));
     RequestClient lowLevelClient = client.lowLevelClient(realTime);
     return new PersistentState(
         realTime,
@@ -998,19 +1010,23 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * <p>This method is invoked by the owning {@link ClientRequester} immediately after the request
    * has been read from persistent storage. It recreates transient collaborators such as the {@link
    * PersistentRequestClient}, low-level {@link RequestClient} and any subclass state via {@link
-   * #innerResume(ClientContext)} before registering the request with the persistent root again.
+   * #innerResume(ClientContext)} before registering the request with the persistent-request
+   * coordinator again.
    *
-   * @param context client context that provides access to persistent roots and utility factories
+   * @param context client context that provides access to the persistent-request coordinator and
+   *     utility factories
    * @throws ResumeFailedException if the request cannot be reattached to the runtime environment
    */
   @Override
   public final void onResume(ClientContext context) throws ResumeFailedException {
-    client = context.persistentRoot.makeClient(global, clientName);
+    client =
+        requirePersistentRequestClient(
+            context.persistentRequestCoordinator.getOrCreateClientHandle(global, clientName));
     lowLevelClient = client.lowLevelClient(realTime);
     innerResume(context);
     ClientRequester req = getClientRequest();
     if (req != null) req.onResume(context); // Can legally be null.
-    context.persistentRoot.resume(this, global, clientName);
+    context.persistentRequestCoordinator.resumePersistentRequest(this, global, clientName);
   }
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -9,6 +9,7 @@ import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.ListPersistentRequestsMessage.PersistentListJob;
 import network.crypta.clients.fcp.ListPersistentRequestsMessage.TransientListJob;
@@ -50,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * @see FCPConnectionHandler
  * @see RequestStatusCache
  */
-public final class PersistentRequestClient {
+public final class PersistentRequestClient implements PersistentRequestClientHandle {
   private static final Logger LOG = LoggerFactory.getLogger(PersistentRequestClient.class);
 
   /**

--- a/src/main/java/network/crypta/clients/fcp/PersistentRequestRoot.java
+++ b/src/main/java/network/crypta/clients/fcp/PersistentRequestRoot.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import network.crypta.client.async.persistence.PersistentRequestClientHandle;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,8 +27,8 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>During client login, call {@link #registerForeverClient(String, FCPConnectionHandler)} to
  *       reuse or create the durable client context.
- *   <li>On resume, call {@link #resume(ClientRequest, boolean, String)} to attach a reloaded
- *       request to its owning client.
+ *   <li>On resume, call {@link #resumePersistentRequest(PersistentRequestHandle, boolean, String)}
+ *       to attach a reloaded request to its owning client.
  *   <li>Periodically call {@link #maybeUnregisterClient(PersistentRequestClient)} to release empty,
  *       non-global clients.
  * </ul>
@@ -37,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * @see PersistentRequestClient
  * @see ClientRequest
  */
-public class PersistentRequestRoot {
+public class PersistentRequestRoot implements PersistentRequestCoordinator {
   private static final Logger LOG = LoggerFactory.getLogger(PersistentRequestRoot.class);
 
   final PersistentRequestClient globalForeverClient;
@@ -60,13 +63,13 @@ public class PersistentRequestRoot {
   }
 
   /**
-   * Obtain a persistent client, creating it if missing, and bind it to the provided connection.
+   * Get a persistent client, creating it if missing, and bind it to the provided connection.
    *
    * <p>This method is idempotent per {@code name} and safe to call concurrently from multiple
    * threads. It keeps the global registry synchronized while looking up or inserting the client,
    * then associates the optional {@link FCPConnectionHandler} outside the lock to avoid blocking
    * other lookups. The returned client remains valid even if the handler later disconnects; callers
-   * should ensure subsequent request operations honor that lifecycle.
+   * should ensure later request operations honor that lifecycle.
    *
    * @param name stable client identifier used as the registry key; must not be blank or null.
    * @param handler connection used to deliver replies and state callbacks; may be {@code null} when
@@ -93,7 +96,7 @@ public class PersistentRequestRoot {
    *
    * <p>The registry is not mutated when the client does not yet exist; in that case the method
    * returns {@code null} so callers can decide whether to register a new client or reject the
-   * request. When a handler is supplied the method updates the client outside the synchronized
+   * request. When a handler is supplied, the method updates the client outside the synchronized
    * block, keeping lock contention low while still ensuring consistent lookup semantics.
    *
    * @param name registry key that identifies the persistent client to fetch; must match the value
@@ -118,8 +121,8 @@ public class PersistentRequestRoot {
    *
    * <p>This helper prevents the client map from accumulating inactive entries after requests have
    * been canceled or completed. The global queue client is never removed. Callers should invoke
-   * this after request teardown to keep memory usage predictable; the method itself performs a
-   * cheap state check and synchronized removal.
+   * this after request teardown to keep memory usage predictable; the method itself performs an
+   * inexpensive state check and synchronized removal.
    *
    * @param client persistent client to consider for removal; ignored when {@code null} or when the
    *     instance represents the shared global queue.
@@ -136,11 +139,11 @@ public class PersistentRequestRoot {
    * Collect all currently tracked persistent requests across the global queue and per-client queues
    * in registration order.
    *
-   * <p>The returned array is a snapshot; subsequent request additions or removals are not
-   * reflected. The method delegates to {@link PersistentRequestClient#addPersistentRequests(List,
-   * boolean)} for each client and therefore includes only requests marked as persistent. Consumers
-   * should not mutate the returned request objects unless they hold the appropriate synchronization
-   * required by {@link PersistentRequestClient}.
+   * <p>The returned array is a snapshot; later request additions or removals are not reflected. The
+   * method delegates to {@link PersistentRequestClient#addPersistentRequests(List, boolean)} for
+   * each client and therefore includes only requests marked as persistent. Consumers should not
+   * mutate the returned request objects unless they hold the appropriate synchronization required
+   * by {@link PersistentRequestClient}.
    *
    * @return array of persistent requests currently registered in the node; may be empty but never
    *     {@code null}.
@@ -151,6 +154,17 @@ public class PersistentRequestRoot {
     for (PersistentRequestClient client : clients.values())
       client.addPersistentRequests(requests, true);
     return requests.toArray(new ClientRequest[0]);
+  }
+
+  @Override
+  public PersistentRequestClientHandle getOrCreateClientHandle(boolean global, String clientName) {
+    return makeClient(global, clientName);
+  }
+
+  @Override
+  public PersistentRequestClientHandle resumePersistentRequest(
+      PersistentRequestHandle request, boolean global, String clientName) {
+    return resume(requireClientRequest(request), global, clientName);
   }
 
   PersistentRequestClient resume(ClientRequest clientRequest, boolean global, String clientName) {
@@ -172,7 +186,7 @@ public class PersistentRequestRoot {
    *
    * <p>The lookup first resolves the owning client (global queue or named client) and then queries
    * the client for the request by its identifier. The method holds the registry lock only during
-   * client resolution, allowing concurrent lookups to proceed. It does not verify request state
+   * client resolution, allowing concurrent lookups to proceed. It does not verify the request state
    * beyond existence; callers must perform further validation if they need status or ownership
    * checks.
    *
@@ -200,5 +214,16 @@ public class PersistentRequestRoot {
    */
   public PersistentRequestClient getGlobalForeverClient() {
     return globalForeverClient;
+  }
+
+  private static ClientRequest requireClientRequest(PersistentRequestHandle request) {
+    if (request == null) {
+      throw new IllegalArgumentException("Persistent request handle must not be null");
+    }
+    if (request instanceof ClientRequest clientRequest) {
+      return clientRequest;
+    }
+    throw new IllegalArgumentException(
+        "Persistent request handle is not a ClientRequest: " + request.getClass().getName());
   }
 }

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -9,9 +9,9 @@ import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
 import network.crypta.crypt.CryptoResumeContext;
 import network.crypta.crypt.MasterSecret;
@@ -90,7 +90,8 @@ class ClientContextTest {
     fileRAFPersistent = mock(FileRandomAccessBufferFactory.class);
     RealCompressor realCompressor = mock(RealCompressor.class);
     DatastoreChecker datastoreChecker = mock(DatastoreChecker.class);
-    PersistentRequestRoot persistentRoot = mock(PersistentRequestRoot.class);
+    PersistentRequestCoordinator persistentRequestCoordinator =
+        mock(PersistentRequestCoordinator.class);
     MasterSecret cryptoSecretTransient = mock(MasterSecret.class);
     LinkFilterExceptionProvider linkFilterExceptionProvider =
         mock(LinkFilterExceptionProvider.class);
@@ -156,7 +157,7 @@ class ClientContextTest {
                 uskManager,
                 realCompressor,
                 datastoreChecker,
-                persistentRoot,
+                persistentRequestCoordinator,
                 linkFilterExceptionProvider),
             new ClientContextDefaults(defaultFetchCtx, defaultInsertCtx, config));
 

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
@@ -1,0 +1,602 @@
+package network.crypta.clients.fcp;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.persistence.PersistentRequestClientHandle;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.node.RequestClient;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class ClientRequestTest {
+
+  @Test
+  void
+      prepareConstructorInit_whenConnectionPersistenceWithoutHandler_expectFallbackRequestClient() {
+    ClientRequestParams params =
+        new ClientRequestParams(
+            null,
+            "connection-fallback",
+            3,
+            (short) 2,
+            ClientRequest.Persistence.CONNECTION,
+            true,
+            "token",
+            false);
+
+    TestClientRequest request =
+        new TestClientRequest(ClientRequest.prepareConstructorInit(params, null), null);
+
+    assertFalse(request.isPersistent());
+    assertFalse(request.isPersistentForever());
+    assertNull(request.getClient());
+    assertTrue(request.getRequestClient().realTimeFlag());
+    assertFalse(request.getRequestClient().persistent());
+    assertEquals("connection-fallback", request.getIdentifier());
+  }
+
+  @Test
+  void prepareConstructorInit_whenConnectionPersistenceWithHandler_expectHandlerRequestClient() {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    RequestClient lowLevelClient = mock(RequestClient.class);
+    when(handler.connectionRequestClient(true)).thenReturn(lowLevelClient);
+
+    ClientRequestParams params =
+        new ClientRequestParams(
+            null,
+            "connection-handler",
+            5,
+            (short) 1,
+            ClientRequest.Persistence.CONNECTION,
+            true,
+            null,
+            false);
+
+    TestClientRequest request =
+        new TestClientRequest(ClientRequest.prepareConstructorInit(params, handler, null), null);
+
+    assertSame(lowLevelClient, request.getRequestClient());
+    assertNull(request.getClient());
+    verify(handler).connectionRequestClient(true);
+  }
+
+  @Test
+  void
+      prepareConstructorInit_whenGlobalForeverPersistent_expectMaxVerbosityAndPersistentIdentifiers() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    TestClientRequest request =
+        TestClientRequest.forever(
+            "global-request",
+            7,
+            (short) 4,
+            "token-a",
+            true,
+            true,
+            root.getGlobalForeverClient(),
+            null);
+
+    RequestIdentifier identifier = request.getRequestIdentifier();
+    PersistentRequestIdentifier persistentIdentifier = request.getPersistentRequestIdentifier();
+
+    assertTrue(request.isPersistent());
+    assertTrue(request.isPersistentForever());
+    assertEquals(Integer.MAX_VALUE, request.verbosityValue());
+    assertTrue(identifier.globalQueue);
+    assertNull(identifier.clientName);
+    assertEquals("global-request", identifier.identifier);
+    assertEquals(RequestIdentifier.RequestType.GET, identifier.type);
+    assertTrue(persistentIdentifier.isGlobalQueue());
+    assertNull(persistentIdentifier.clientName());
+    assertEquals("global-request", persistentIdentifier.identifier());
+  }
+
+  @Test
+  void getRequestIdentifier_whenConnectionPersistence_expectIllegalStateException() {
+    TestClientRequest request =
+        new TestClientRequest(
+            ClientRequest.prepareConstructorInit(
+                new ClientRequestParams(
+                    null,
+                    "connection-id",
+                    0,
+                    (short) 1,
+                    ClientRequest.Persistence.CONNECTION,
+                    false,
+                    null,
+                    false),
+                null),
+            null);
+
+    assertThrows(IllegalStateException.class, request::getRequestIdentifier);
+  }
+
+  @Test
+  void applyDiagnosticIdentifier_whenRequesterPresent_expectPrefixedIdentifierAssigned() {
+    ClientRequester requester = mock(ClientRequester.class);
+    TestClientRequest request =
+        new TestClientRequest(
+            ClientRequest.prepareConstructorInit(
+                new ClientRequestParams(
+                    null,
+                    "diag-id",
+                    0,
+                    (short) 1,
+                    ClientRequest.Persistence.CONNECTION,
+                    false,
+                    null,
+                    false),
+                null),
+            null);
+
+    request.applyDiagnosticIdentifierTo(requester);
+
+    assertEquals("fcp:diag-id", request.diagnosticIdentifierValue());
+    verify(requester).setExternalRequestIdentifier("fcp:diag-id");
+  }
+
+  @Test
+  void cancel_whenRequesterPresent_expectRequesterCancelledAndDataFreed() {
+    ClientRequester requester = mock(ClientRequester.class);
+    ClientContext context = mock(ClientContext.class);
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    TestClientRequest request =
+        TestClientRequest.forever(
+            "cancel-id",
+            0,
+            (short) 1,
+            null,
+            false,
+            false,
+            root.registerForeverClient("cancel-client", null),
+            requester);
+
+    request.cancel(context);
+
+    verify(requester).cancel(context);
+    assertEquals(1, request.freeDataCalls());
+  }
+
+  @Test
+  void onShutdown_whenRequesterPresent_expectDelegatesToRequester() {
+    ClientRequester requester = mock(ClientRequester.class);
+    ClientContext context = mock(ClientContext.class);
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    TestClientRequest request =
+        TestClientRequest.forever(
+            "shutdown-id",
+            0,
+            (short) 1,
+            null,
+            false,
+            false,
+            root.registerForeverClient("shutdown-client", null),
+            requester);
+
+    request.onShutdown(context);
+
+    verify(requester).onShutdown(context);
+  }
+
+  @Test
+  void getClientDetail_whenPersistenceNotForever_expectNoOutput() throws IOException {
+    TestClientRequest request =
+        new TestClientRequest(
+            ClientRequest.prepareConstructorInit(
+                new ClientRequestParams(
+                    null,
+                    "non-persistent",
+                    0,
+                    (short) 1,
+                    ClientRequest.Persistence.CONNECTION,
+                    false,
+                    null,
+                    false),
+                null),
+            null);
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    request.getClientDetail(new DataOutputStream(buffer), mock(ChecksumChecker.class));
+
+    assertEquals(0, buffer.size());
+  }
+
+  @Test
+  void persistentDetailConstructor_whenRoundTripped_expectRestoresPersistentState()
+      throws IOException, StorageFormatException {
+    PersistentRequestRoot originalRoot = new PersistentRequestRoot();
+    TestClientRequest original =
+        TestClientRequest.forever(
+            "roundtrip-id",
+            9,
+            (short) 4,
+            "roundtrip-token",
+            false,
+            true,
+            originalRoot.registerForeverClient("roundtrip-client", null),
+            null);
+    original.markFinished();
+
+    PersistentRequestRoot resumedRoot = new PersistentRequestRoot();
+    PersistentRequestClient resumedClient =
+        resumedRoot.registerForeverClient("roundtrip-client", null);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "roundtrip-client")).thenReturn(resumedClient);
+    ClientContext context = newContextWithCoordinator(coordinator);
+
+    TestClientRequest restored =
+        new TestClientRequest(
+            new DataInputStream(new ByteArrayInputStream(serializeClientDetail(original))),
+            original.getRequestIdentifier(),
+            context,
+            null);
+
+    assertEquals("roundtrip-id", restored.getIdentifier());
+    assertEquals(4, restored.getPriority());
+    assertEquals("roundtrip-token", restored.clientTokenValue());
+    assertTrue(restored.hasFinished());
+    assertSame(resumedClient, restored.getClient());
+    assertSame(resumedClient.lowLevelClient(true), restored.getRequestClient());
+    verify(coordinator).getOrCreateClientHandle(false, "roundtrip-client");
+  }
+
+  @Test
+  void
+      persistentDetailConstructor_whenCoordinatorReturnsIncompatibleHandle_expectIllegalStateException()
+          throws IOException {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    TestClientRequest original =
+        TestClientRequest.forever(
+            "bad-handle-id",
+            1,
+            (short) 2,
+            null,
+            false,
+            false,
+            root.registerForeverClient("bad-handle-client", null),
+            null);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "bad-handle-client"))
+        .thenReturn(new OpaqueHandle());
+    ClientContext context = newContextWithCoordinator(coordinator);
+    byte[] clientDetail = serializeClientDetail(original);
+    RequestIdentifier requestIdentifier = original.getRequestIdentifier();
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(clientDetail));
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> new TestClientRequest(input, requestIdentifier, context, null));
+  }
+
+  @Test
+  void persistentDetailConstructor_whenPriorityInvalid_expectStorageFormatException()
+      throws IOException {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    TestClientRequest original =
+        TestClientRequest.forever(
+            "bad-priority-id",
+            1,
+            (short) 2,
+            null,
+            false,
+            false,
+            root.registerForeverClient("bad-priority-client", null),
+            null);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "bad-priority-client"))
+        .thenReturn(root.registerForeverClient("bad-priority-client", null));
+    ClientContext context = newContextWithCoordinator(coordinator);
+    byte[] invalidDetail = rewritePriorityToInvalidValue(serializeClientDetail(original));
+    RequestIdentifier requestIdentifier = original.getRequestIdentifier();
+    DataInputStream input = new DataInputStream(new ByteArrayInputStream(invalidDetail));
+
+    assertThrows(
+        StorageFormatException.class,
+        () -> new TestClientRequest(input, requestIdentifier, context, null));
+  }
+
+  @Test
+  void onResume_whenCoordinatorReturnsIncompatibleHandle_expectIllegalStateException() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    TestClientRequest request =
+        TestClientRequest.forever(
+            "resume-bad-handle",
+            0,
+            (short) 1,
+            null,
+            false,
+            false,
+            root.registerForeverClient("resume-client", null),
+            mock(ClientRequester.class));
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "resume-client"))
+        .thenReturn(new OpaqueHandle());
+    ClientContext context = newContextWithCoordinator(coordinator);
+
+    assertThrows(IllegalStateException.class, () -> request.onResume(context));
+  }
+
+  @Test
+  void onResume_whenRequesterPresent_expectInnerResumeRequesterAndCoordinator()
+      throws ResumeFailedException {
+    ClientRequester requester = mock(ClientRequester.class);
+    PersistentRequestRoot originalRoot = new PersistentRequestRoot();
+    TestClientRequest request =
+        TestClientRequest.forever(
+            "resume-ok",
+            0,
+            (short) 1,
+            null,
+            false,
+            false,
+            originalRoot.registerForeverClient("resume-client", null),
+            requester);
+    PersistentRequestRoot resumedRoot = new PersistentRequestRoot();
+    PersistentRequestClient resumedClient =
+        resumedRoot.registerForeverClient("resume-client", null);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "resume-client")).thenReturn(resumedClient);
+    when(coordinator.resumePersistentRequest(request, false, "resume-client"))
+        .thenReturn(resumedClient);
+    ClientContext context = newContextWithCoordinator(coordinator);
+
+    request.onResume(context);
+
+    InOrder inOrder = inOrder(coordinator, requester);
+    inOrder.verify(coordinator).getOrCreateClientHandle(false, "resume-client");
+    inOrder.verify(requester).onResume(context);
+    inOrder.verify(coordinator).resumePersistentRequest(request, false, "resume-client");
+    assertSame(context, request.innerResumeContext());
+    assertSame(resumedClient, request.getClient());
+    assertSame(resumedClient.lowLevelClient(false), request.getRequestClient());
+  }
+
+  private static byte[] serializeClientDetail(TestClientRequest request) throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    try (DataOutputStream out = new DataOutputStream(buffer)) {
+      request.getClientDetail(out, mock(ChecksumChecker.class));
+    }
+    return buffer.toByteArray();
+  }
+
+  private static byte[] rewritePriorityToInvalidValue(byte[] source) throws IOException {
+    try (DataInputStream input = new DataInputStream(new ByteArrayInputStream(source));
+        ByteArrayOutputStream outputBuffer = new ByteArrayOutputStream();
+        DataOutputStream output = new DataOutputStream(outputBuffer)) {
+      output.writeLong(input.readLong());
+      output.writeInt(input.readInt());
+      RequestIdentifier identifier = new RequestIdentifier(input);
+      identifier.writeTo(output);
+      output.writeBoolean(input.readBoolean());
+      output.writeInt(input.readInt());
+      output.writeLong(input.readLong());
+      output.writeShort((short) -1);
+      boolean hasClientToken = input.readBoolean();
+      output.writeBoolean(hasClientToken);
+      if (hasClientToken) {
+        output.writeUTF(input.readUTF());
+      }
+      output.writeBoolean(input.readBoolean());
+      return outputBuffer.toByteArray();
+    }
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static ClientContext newContextWithCoordinator(PersistentRequestCoordinator coordinator) {
+    ClientContext context = mock(ClientContext.class);
+    try {
+      Field field = ClientContext.class.getDeclaredField("persistentRequestCoordinator");
+      field.setAccessible(true);
+      field.set(context, coordinator);
+      return context;
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed to set ClientContext.persistentRequestCoordinator", e);
+    }
+  }
+
+  private static final class OpaqueHandle implements PersistentRequestClientHandle {}
+
+  private static final class TestClientRequest extends ClientRequest {
+    private final ClientRequester requester;
+    private ClientContext innerResumeContext;
+    private int freeDataCalls;
+
+    private TestClientRequest(ConstructorInit init, ClientRequester requester) {
+      super(init);
+      this.requester = requester;
+    }
+
+    private TestClientRequest(
+        DataInputStream input,
+        RequestIdentifier requestIdentifier,
+        ClientContext context,
+        ClientRequester requester)
+        throws IOException, StorageFormatException {
+      super(input, requestIdentifier, context);
+      this.requester = requester;
+    }
+
+    static TestClientRequest forever(
+        String identifier,
+        int verbosity,
+        short priorityClass,
+        String clientToken,
+        boolean global,
+        boolean realTime,
+        PersistentRequestClient client,
+        ClientRequester requester) {
+      return new TestClientRequest(
+          ClientRequest.prepareConstructorInit(
+              new ClientRequestParams(
+                  null,
+                  identifier,
+                  verbosity,
+                  priorityClass,
+                  Persistence.FOREVER,
+                  realTime,
+                  clientToken,
+                  global),
+              null,
+              client),
+          requester);
+    }
+
+    int verbosityValue() {
+      return verbosity;
+    }
+
+    String clientTokenValue() {
+      return clientToken;
+    }
+
+    int freeDataCalls() {
+      return freeDataCalls;
+    }
+
+    ClientContext innerResumeContext() {
+      return innerResumeContext;
+    }
+
+    String diagnosticIdentifierValue() {
+      return diagnosticIdentifier();
+    }
+
+    void applyDiagnosticIdentifierTo(ClientRequester requester) {
+      applyDiagnosticIdentifier(requester);
+    }
+
+    void markFinished() {
+      finished = true;
+    }
+
+    @Override
+    public void onLostConnection(ClientContext context) {
+      // No-op for focused ClientRequest base-class tests.
+    }
+
+    @Override
+    public void sendPendingMessages(
+        FCPConnectionOutputHandler handler,
+        String listRequestIdentifier,
+        boolean includeData,
+        boolean onlyData) {
+      // No-op for focused ClientRequest base-class tests.
+    }
+
+    @Override
+    void register(boolean noTags) {
+      // Registration is outside this test's scope.
+    }
+
+    @Override
+    protected ClientRequester getClientRequest() {
+      return requester;
+    }
+
+    @Override
+    protected void freeData() {
+      freeDataCalls++;
+    }
+
+    @Override
+    public double getSuccessFraction() {
+      return 0;
+    }
+
+    @Override
+    public double getTotalBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getMinBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFetchedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public double getFatalyFailedBlocks() {
+      return 0;
+    }
+
+    @Override
+    public String getFailureReason(boolean longDescription) {
+      return "failure";
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return true;
+    }
+
+    @Override
+    public void start(ClientContext context) {
+      // Start behavior is outside this test's scope.
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return false;
+    }
+
+    @Override
+    public boolean canRestart() {
+      return true;
+    }
+
+    @Override
+    public boolean restart(ClientContext context, boolean disableFilterData) {
+      return false;
+    }
+
+    @Override
+    RequestStatus getStatus() {
+      return null;
+    }
+
+    @Override
+    protected void innerResume(ClientContext context) {
+      innerResumeContext = context;
+    }
+
+    @Override
+    RequestIdentifier.RequestType getType() {
+      return RequestIdentifier.RequestType.GET;
+    }
+
+    @Override
+    public boolean fullyResumed() {
+      return true;
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
@@ -2,6 +2,8 @@ package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.persistence.PersistentRequestClientHandle;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -128,10 +130,32 @@ class PersistentRequestRootTest {
     TestClientRequest request =
         new TestClientRequest(root.getGlobalForeverClient(), "id-1", true, true, true);
 
-    root.resume(request, true, "ignored-name");
+    PersistentRequestClientHandle resumed =
+        root.resumePersistentRequest(request, true, "ignored-name");
 
     assertTrue(root.hasRequest(new RequestIdentifier(true, null, "id-1", RequestType.GET)));
     assertNull(root.getForeverClient("ignored-name", null));
+    assertSame(root.getGlobalForeverClient(), resumed);
+  }
+
+  @Test
+  void getOrCreateClientHandle_whenNamedClient_returnsPersistentClientHandle() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestClient expected = root.registerForeverClient("clientA", null);
+
+    PersistentRequestClientHandle handle = root.getOrCreateClientHandle(false, "clientA");
+
+    assertSame(expected, handle);
+  }
+
+  @Test
+  void resumePersistentRequest_whenHandleIsNotClientRequest_rejectsHandle() {
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    PersistentRequestHandle handle = org.mockito.Mockito.mock(PersistentRequestHandle.class);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> root.resumePersistentRequest(handle, false, "clientA"));
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
@@ -405,20 +405,10 @@ class NodeClientPersistenceTest {
         () -> assertSame(cryptoSecretTransient, context.cryptoSecretTransient),
         () -> assertSame(config, context.getConfig()),
         () -> assertSame(executor, context.getMainExecutor()),
-        () -> assertSame(fileRafTransient, context.getFileRandomAccessBufferFactory(false)),
         () ->
-            assertInstanceOf(
-                DiskSpaceCheckingRandomAccessBufferFactory.class,
-                context.getFileRandomAccessBufferFactory(true)),
-        () -> assertSame(persistentRafFactory, context.getRandomAccessBufferFactory(true)));
-    ArgumentCaptor<PersistentRequestCatalog> catalogCaptor =
-        ArgumentCaptor.forClass(PersistentRequestCatalog.class);
-    ArgumentCaptor<PersistentRequestRecoveryCodec> recoveryCodecCaptor =
-        ArgumentCaptor.forClass(PersistentRequestRecoveryCodec.class);
-    verify(clientLayerPersister)
-        .configurePersistenceAdapters(catalogCaptor.capture(), recoveryCodecCaptor.capture());
-    assertInstanceOf(CoreFcpPersistentRequestCatalog.class, catalogCaptor.getValue());
-    assertInstanceOf(FcpPersistentRequestRecoveryCodec.class, recoveryCodecCaptor.getValue());
+            assertContextPersistentStorageFactories(
+                context, fileRafTransient, persistentRafFactory));
+    assertPersistenceAdaptersConfigured(clientLayerPersister);
   }
 
   @Test
@@ -469,7 +459,7 @@ class NodeClientPersistenceTest {
             mock(InsertContext.class));
     ClientContext context = persistence.createClientContext(node, params);
 
-    PersistentRequestRoot root = context.persistentRoot;
+    PersistentRequestRoot root = (PersistentRequestRoot) context.persistentRequestCoordinator;
     PersistentRequestClient client = root.registerForeverClient("client", null);
     ClientRequest request = mock(ClientRequest.class);
     when(request.hasFinished()).thenReturn(false);
@@ -529,6 +519,29 @@ class NodeClientPersistenceTest {
     SubConfig nodeConfig = mock(SubConfig.class);
     when(nodeConfig.getString("clientThrottleFile")).thenReturn(throttleFile.getAbsolutePath());
     return nodeConfig;
+  }
+
+  private static void assertContextPersistentStorageFactories(
+      ClientContext context,
+      FileRandomAccessBufferFactory fileRafTransient,
+      MaybeEncryptedRandomAccessBufferFactory persistentRafFactory) {
+    assertSame(fileRafTransient, context.getFileRandomAccessBufferFactory(false));
+    assertInstanceOf(
+        DiskSpaceCheckingRandomAccessBufferFactory.class,
+        context.getFileRandomAccessBufferFactory(true));
+    assertSame(persistentRafFactory, context.getRandomAccessBufferFactory(true));
+  }
+
+  private static void assertPersistenceAdaptersConfigured(
+      ClientLayerPersister clientLayerPersister) {
+    ArgumentCaptor<PersistentRequestCatalog> catalogCaptor =
+        ArgumentCaptor.forClass(PersistentRequestCatalog.class);
+    ArgumentCaptor<PersistentRequestRecoveryCodec> recoveryCodecCaptor =
+        ArgumentCaptor.forClass(PersistentRequestRecoveryCodec.class);
+    verify(clientLayerPersister)
+        .configurePersistenceAdapters(catalogCaptor.capture(), recoveryCodecCaptor.capture());
+    assertInstanceOf(CoreFcpPersistentRequestCatalog.class, catalogCaptor.getValue());
+    assertInstanceOf(FcpPersistentRequestRecoveryCodec.class, recoveryCodecCaptor.getValue());
   }
 
   private static Node newNode(Ticker ticker, File runDir) {


### PR DESCRIPTION
## Summary
- add the client-owned `PersistentRequestCoordinator` and `PersistentRequestClientHandle` seam for durable request ownership
- wire `ClientContext` and `ClientContextServices` through the seam, and bridge `PersistentRequestRoot` / `ClientRequest` through the existing FCP runtime types
- update seam-facing docs and Javadoc, plus the focused persistence tests and the `NodeClientPersistenceTest` assertion extraction

## Validation
- `rg -n '^import network\.crypta\.clients\.fcp\.' src/main/java/network/crypta/client -g'*.java'`
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests 'network.crypta.client.async.ClientContextTest' --tests 'network.crypta.runtime.endpoints.NodeClientPersistenceTest' --tests 'network.crypta.clients.fcp.PersistentRequestRootTest' --tests 'network.crypta.clients.fcp.ClientRequestRestartAsyncTest' --tests 'network.crypta.clients.fcp.ClientGetPersistenceIOTest'`

Structural grep returned no matches under `src/main/java/network/crypta/client`.
