### PR TITLE
refactor(client): Remove remaining runtime imports

### DIFF
--- a/src/main/java/network/crypta/client/async/ClientContext.java
+++ b/src/main/java/network/crypta/client/async/ClientContext.java
@@ -6,6 +6,8 @@ import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.alerts.ClientAlert;
+import network.crypta.client.async.alerts.ClientAlertSink;
 import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
@@ -15,8 +17,6 @@ import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.RequestScheduler;
 import network.crypta.node.RequestStarterGroup;
-import network.crypta.runtime.alerts.UserAlert;
-import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.support.DummyJobRunner;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
@@ -74,7 +74,7 @@ public class ClientContext implements CryptoResumeContext {
   private ClientRequestScheduler chkFetchSchedulerRT;
   private ClientRequestScheduler sskInsertSchedulerRT;
   private ClientRequestScheduler chkInsertSchedulerRT;
-  private UserAlertManager alerts;
+  private ClientAlertSink alerts;
 
   private final PriorityAwareExecutor mainExecutorInternal;
 
@@ -244,14 +244,14 @@ public class ClientContext implements CryptoResumeContext {
   }
 
   /**
-   * Initializes request schedulers and user-alert manager after construction. This is expected to
-   * be called during node startup once {@link RequestStarterGroup} is created.
+   * Initializes request schedulers and alert posting after construction. This is expected to be
+   * called during node startup once {@link RequestStarterGroup} is created.
    *
    * @param starters Group of request schedulers for CHK/SSK fetch/insert in bulk and real-time
    *     modes.
-   * @param alerts User alert manager for surfacing notifications to end users.
+   * @param alerts Sink for surfacing client-layer notifications to operator-facing surfaces.
    */
-  public void init(RequestStarterGroup starters, UserAlertManager alerts) {
+  public void init(RequestStarterGroup starters, ClientAlertSink alerts) {
     this.sskFetchSchedulerBulk = starters.sskFetchSchedulerBulk;
     this.chkFetchSchedulerBulk = starters.chkFetchSchedulerBulk;
     this.sskInsertSchedulerBulk = starters.sskPutSchedulerBulk;
@@ -473,17 +473,17 @@ public class ClientContext implements CryptoResumeContext {
   }
 
   /**
-   * Posts a user-facing alert. When the alert manager is not yet available, the alert is scheduled
-   * to be posted as soon as initialization completes.
+   * Posts a client-layer alert. When the alert sink is not yet available, the alert is scheduled to
+   * be posted as soon as initialization completes.
    *
-   * @param alert The alert to register; must be a non-null instance.
+   * @param alert The alert to post; must be a non-null instance.
    */
-  public void postUserAlert(final UserAlert alert) {
+  public void postUserAlert(final ClientAlert alert) {
     if (alerts == null) {
       // Wait until after startup
-      ticker.queueTimedJob(() -> alerts.register(alert), "Post alert", 0L, false, false);
+      ticker.queueTimedJob(() -> alerts.post(alert), "Post alert", 0L, false, false);
     } else {
-      alerts.register(alert);
+      alerts.post(alert);
     }
   }
 

--- a/src/main/java/network/crypta/client/async/HealingDecisionSupplier.java
+++ b/src/main/java/network/crypta/client/async/HealingDecisionSupplier.java
@@ -1,8 +1,8 @@
 package network.crypta.client.async;
 
 import java.util.function.Supplier;
+import network.crypta.crypt.CryptoRandoms;
 import network.crypta.node.Location;
-import network.crypta.runtime.bootstrap.NodeStarter;
 
 /**
  * Supplies decisions that determine whether the node should perform a healing insert for a given
@@ -11,14 +11,14 @@ import network.crypta.runtime.bootstrap.NodeStarter;
  * <p>This helper focuses healing on the fraction of the keyspace from which the node would most
  * plausibly receive traffic if it were one of the long-distance peers of a real inserter. In
  * opennet deployments, blindly healing every key can be indistinguishable from user inserts to an
- * adversarial neighbor and therefore leaks behavior. By specializing healing so that it resembles
- * normal request forwarding, we reduce this risk while still contributing meaningfully to network
- * health.
+ * adversarial neighbor and therefore leaks behavior. By specializing in healing so that it
+ * resembles normal request forwarding, we reduce this risk while still contributing meaningfully to
+ * network health.
  *
  * <p>The decision policy is distance-aware. Keys closer to the node's own location are healed with
  * higher probability using a continuous function of distance; far-away keys are healed at a low
  * fixed rate. This mirrors typical routing patterns, reduces the number of hops taken by healing
- * inserts, and helps limit unnecessary load.
+ * inserts, and helps limit an unnecessary load.
  *
  * <p>Thread-safety: Instances are immutable after construction provided the suppliers given at
  * creation are themselves thread-safe and side effect free. Callers may reuse a single instance
@@ -34,8 +34,8 @@ public class HealingDecisionSupplier {
    * opennet enablement, and a cryptographically strong random source.
    *
    * <p>The {@code currentNodeLocation} and {@code isOpennetEnabled} suppliers are invoked for each
-   * decision. The random source is derived from the globally shared secure RNG used by the node
-   * runtime so that probabilities are stable and unbiased.
+   * decision. The random source is derived from the shared cryptographic RNG so that probabilities
+   * are stable and unbiased.
    *
    * @param currentNodeLocation provides the node's keyspace location in {@code [0.0, 1.0)}; values
    *     outside this range are treated as implementation-defined and should be avoided.
@@ -47,7 +47,7 @@ public class HealingDecisionSupplier {
 
     this.currentNodeLocation = currentNodeLocation;
     this.isOpennetEnabled = isOpennetEnabled;
-    randomNumberSupplier = NodeStarter.getGlobalSecureRandom()::nextDouble;
+    randomNumberSupplier = CryptoRandoms.shared()::nextDouble;
   }
 
   HealingDecisionSupplier(
@@ -63,7 +63,7 @@ public class HealingDecisionSupplier {
   /**
    * Decides whether to heal for the provided key location.
    *
-   * <p>When opennet is disabled the decision allows healing unconditionally, reflecting the lower
+   * <p>When opennet is disabled, the decision allows healing unconditionally, reflecting the lower
    * exposure to Sybil-style observation on darknet. When opennet is enabled, the decision applies a
    * distance-sensitive probability so that healing resembles ordinary routing: nearby keys are more
    * likely to be healed, and far-away keys are allowed with a low fixed chance. The
@@ -99,14 +99,14 @@ public class HealingDecisionSupplier {
    *
    * <p>When a key is close to our location, we use a continuous function depending on the distance
    * to choose a probability. The closer to our node, the higher the probability of healing. As a
-   * side effect this reduces the hops healing inserts take, reducing the overall load on the
+   * side effect, this reduces the hops healing inserts take, reducing the overall load on the
    * network.
    *
    * <p>The continuous function is gauged to accept 50% of the keys close to our node: a peak at our
    * own location for which the area below the curve between 0 and 0.1 sums up to 0.5.
    *
    * <p>Close keys are those in our 20% of the keyspace: the ones that would reach us if we were one
-   * of 5 long distance peers of a peer node. These are the keys for which we are most likely to be
+   * of 5 long-distance peers of a peer node. These are the keys for which we are most likely to be
    * the best next hop when seen from the originator.
    */
   private static boolean shouldHealBlock(
@@ -120,7 +120,7 @@ public class HealingDecisionSupplier {
       double randomToPower4 = Math.pow(randomBetweenZeroAndOne, 4);
       return distanceToNodeLocation < randomToPower4;
     } else {
-      // if the key is a long distance key for us, heal it with 10% probability: it is unlikely that
+      // if the key is a long-distance key for us, heal it with 10% probability: it is unlikely that
       // this would have reached us. Setting this to 0 could amplify a keyspace takeover attack.
       return randomBetweenZeroAndOne > 0.9;
     }

--- a/src/main/java/network/crypta/client/async/alerts/ClientAlert.java
+++ b/src/main/java/network/crypta/client/async/alerts/ClientAlert.java
@@ -1,0 +1,18 @@
+package network.crypta.client.async.alerts;
+
+/**
+ * Marks an alert value that can cross the client-layer alert seam.
+ *
+ * <p>This interface is intentionally empty. Client code only needs a stable type that says "this
+ * object is safe to hand to the alert sink" without taking a direct dependency on runtime-owned
+ * alert implementations. The concrete alert model, rendering, and operator-facing registration
+ * remain on the runtime side of the boundary.
+ *
+ * <p>Typical call flow is straightforward: client-layer code creates or receives an implementation,
+ * passes it to {@link ClientAlertSink#post(ClientAlert)}, and relies on the owning runtime adapter
+ * to validate and route it. Implementations should generally behave like immutable notification
+ * values because they may be queued briefly during startup before the sink is ready.
+ *
+ * @see ClientAlertSink
+ */
+public interface ClientAlert {}

--- a/src/main/java/network/crypta/client/async/alerts/ClientAlertSink.java
+++ b/src/main/java/network/crypta/client/async/alerts/ClientAlertSink.java
@@ -1,0 +1,29 @@
+package network.crypta.client.async.alerts;
+
+/**
+ * Receives client-layer alerts and hands them to the owning alert subsystem.
+ *
+ * <p>This is the active half of the client-owned seam. Client code depends on this interface, so it
+ * can emit operator-visible notifications without importing runtime-specific alert managers or UI
+ * types. Implementations decide how alerts are validated, queued, or translated before they reach
+ * the concrete alert system.
+ *
+ * <p>Callers typically get a sink during startup wiring and reuse it for the lifetime of a {@code
+ * ClientContext}. Implementations may forward immediately, buffer briefly, or reject alert types
+ * they do not understand. The contract is intentionally small so the client layer stays decoupled
+ * from alert rendering concerns.
+ */
+@FunctionalInterface
+public interface ClientAlertSink {
+
+  /**
+   * Posts an alert to the owning alert system.
+   *
+   * <p>Implementations should treat this as a handoff point rather than a request to render the
+   * alert directly. The sink may forward immediately, enqueue the alert for later processing, or
+   * reject values that do not belong to the concrete alert model behind the seam.
+   *
+   * @param alert alert emitted from client-layer code and ready for sink-specific handling
+   */
+  void post(ClientAlert alert);
+}

--- a/src/main/java/network/crypta/client/async/alerts/package-info.java
+++ b/src/main/java/network/crypta/client/async/alerts/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Defines the client-owned alert seam used by asynchronous client code.
+ *
+ * <p>This package exists for one narrow purpose: let code under {@code network.crypta.client.async}
+ * emit operator-facing alerts without importing runtime-owned alert classes directly. The package
+ * provides a marker interface for alert values and a sink interface for posting them. That keeps
+ * the dependency direction clean while preserving the existing runtime alert pipeline.
+ *
+ * <p>The seam is intentionally small. It does not define rendering, formatting, persistence, or
+ * transport behavior. Runtime code remains responsible for those concerns, typically through a
+ * small adapter that validates the neutral client-layer alert and forwards it into the concrete
+ * {@code UserAlertManager} infrastructure.
+ */
+package network.crypta.client.async.alerts;

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -22,6 +22,7 @@ import network.crypta.keys.Key;
 import network.crypta.keys.NodeSSK;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
 import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.core.LegacyRuntimePorts;
 import network.crypta.runtime.endpoints.ClientEndpoints;
@@ -358,7 +359,7 @@ public final class NodeClientCore implements Persistable {
     requestStarters = createRequestStarters(node, portNumber, init, throttleFS);
     transfers = new NodeClientCoreTransfers(this);
 
-    clientContext.init(requestStarters, alerts);
+    clientContext.init(requestStarters, new UserAlertManagerClientAlertSink(alerts));
 
     setupSecretAndInitStorage(databaseKey, persistentSecret);
 

--- a/src/main/java/network/crypta/runtime/alerts/UserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/UserAlert.java
@@ -1,12 +1,13 @@
 package network.crypta.runtime.alerts;
 
+import network.crypta.client.async.alerts.ClientAlert;
 import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.support.HTMLNode;
 
 /**
  * Describes a user-facing alert emitted by the node and consumed by UI surfaces and external
- * clients. Implementations provide human-readable text (plain and optionally HTML), priority,
- * lifecycle hooks, and metadata used for de-duplication and feeds. Alerts may be dismissible by the
+ * clients. Implementations provide human-readable text (plain and optional HTML), priority,
+ * lifecycle hooks, and metadata used for deduplication and feeds. Alerts may be dismissible by the
  * end user or persist until programmatically unregistered by the producer.
  *
  * <p>Typical usage in consumers follows this pattern: check {@link #isValid()} under appropriate
@@ -29,11 +30,11 @@ import network.crypta.support.HTMLNode;
  * @see network.crypta.runtime.alerts.UserAlertManager
  * @see network.crypta.clients.fcp.FeedMessage
  */
-public interface UserAlert {
+public interface UserAlert extends ClientAlert {
 
   /**
    * Indicates whether the alert is user-dismissible. Non-dismissible alerts remain visible until
-   * their producer unregisters them or marks them invalid. User interfaces may hide the dismiss
+   * their producer unregisters them or marks them invalid. User interfaces may hide the dismissed
    * affordance when this returns {@code false} and show a specific button label otherwise.
    *
    * @return {@code true} when a user action can dismiss the alert; {@code false} when the alert
@@ -53,7 +54,7 @@ public interface UserAlert {
   /**
    * Returns the full content of the alert as plain text. This text must be safe to render without
    * HTML interpretation and should contain all details necessary for a user who cannot render HTML.
-   * Lines may be separated by newlines; callers are free to wrap as needed for display.
+   * Newlines may separate lines; callers are free to wrap as needed for display.
    *
    * @return plain-text body of the alert; non-null, suitable for text-only renderers and feeds.
    */
@@ -92,7 +93,7 @@ public interface UserAlert {
   /**
    * Reports whether the alert is currently valid and should be shown. Callers that consume multiple
    * fields from an alert are encouraged to synchronize on the alert instance, check this flag, and
-   * then read the remaining fields to obtain a consistent snapshot for rendering.
+   * then read the remaining fields to get a consistent snapshot for rendering.
    *
    * @return {@code true} if the alert remains relevant and should be displayed; {@code false}
    *     otherwise.

--- a/src/main/java/network/crypta/runtime/alerts/UserAlertManagerClientAlertSink.java
+++ b/src/main/java/network/crypta/runtime/alerts/UserAlertManagerClientAlertSink.java
@@ -1,0 +1,59 @@
+package network.crypta.runtime.alerts;
+
+import java.util.Objects;
+import network.crypta.client.async.alerts.ClientAlert;
+import network.crypta.client.async.alerts.ClientAlertSink;
+
+/**
+ * Adapts the client-owned alert seam to the runtime {@link UserAlertManager}.
+ *
+ * <p>This adapter is the runtime-side bridge for the new client alert seam. Client code posts the
+ * neutral {@link ClientAlert} marker through {@link ClientAlertSink}; this class performs the
+ * runtime-specific check that the value is actually a {@link UserAlert} and then forwards it to the
+ * existing {@link UserAlertManager}. Keeping that knowledge here preserves the existing alert
+ * manager behavior without leaking runtime-owned types back into the client layer.
+ *
+ * <p>The class is stateless apart from its manager reference and is safe to reuse wherever the same
+ * {@link UserAlertManager} instance should receive client-originated alerts. Unsupported alert
+ * implementations are rejected immediately, so type mismatches fail at the boundary instead of
+ * being silently ignored.
+ */
+public final class UserAlertManagerClientAlertSink implements ClientAlertSink {
+  private final UserAlertManager userAlertManager;
+
+  /**
+   * Creates an adapter that forwards runtime user alerts to the given manager.
+   *
+   * <p>Callers usually construct this once during node startup and pass it into {@code
+   * ClientContext.init(...)}. The adapter keeps a direct reference to the manager and does not add
+   * buffering, synchronization, or translation beyond the alert type check performed in {@link
+   * #post(ClientAlert)}.
+   *
+   * @param userAlertManager runtime alert manager that should receive forwarded client alerts and
+   *     must not be {@code null}
+   * @throws NullPointerException if the supplied runtime alert manager is {@code null}
+   */
+  public UserAlertManagerClientAlertSink(UserAlertManager userAlertManager) {
+    this.userAlertManager = Objects.requireNonNull(userAlertManager, "userAlertManager");
+  }
+
+  /**
+   * Posts a client-layer alert to the runtime manager when it is a runtime {@link UserAlert}.
+   *
+   * <p>This method enforces the boundary contract for the runtime side of the seam. A {@link
+   * UserAlert} is forwarded unchanged to {@link UserAlertManager#register(UserAlert)} so the
+   * existing runtime alert lifecycle remains intact. Any other {@link ClientAlert}, including
+   * {@code null}, is rejected immediately because this adapter only knows how to register runtime
+   * user alerts.
+   *
+   * @param alert client-layer alert to validate and forward to the runtime alert manager
+   * @throws IllegalArgumentException if {@code alert} is {@code null} or not a {@link UserAlert}
+   */
+  @Override
+  public void post(ClientAlert alert) {
+    if (!(alert instanceof UserAlert userAlert)) {
+      throw new IllegalArgumentException("alert must be a UserAlert");
+    }
+    userAlertManager.register(userAlert);
+  }
+}

--- a/src/test/java/network/crypta/client/async/ClientContextTest.java
+++ b/src/test/java/network/crypta/client/async/ClientContextTest.java
@@ -9,6 +9,8 @@ import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.alerts.ClientAlert;
+import network.crypta.client.async.alerts.ClientAlertSink;
 import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
@@ -17,8 +19,6 @@ import network.crypta.crypt.CryptoResumeContext;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.ClientContextResources;
-import network.crypta.runtime.alerts.UserAlert;
-import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.support.DummyJobRunner;
 import network.crypta.support.MemoryLimitedJobRunner;
 import network.crypta.support.PriorityAwareExecutor;
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -168,23 +169,47 @@ class ClientContextTest {
   }
 
   @Test
-  void init_whenCalled_setsAlertsUsedByPostUserAlert() {
-    UserAlertManager alerts = mock(UserAlertManager.class);
-    // We don't need actual schedulers here; a mock is fine (fields read as null)
+  void init_whenCalled_setsSchedulersAndUsesConfiguredAlertSink() {
+    ClientAlertSink alerts = mock(ClientAlertSink.class);
+    ClientRequestScheduler sskFetchBulk = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler chkFetchBulk = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler sskInsertBulk = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler chkInsertBulk = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler sskFetchRT = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler chkFetchRT = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler sskInsertRT = mock(ClientRequestScheduler.class);
+    ClientRequestScheduler chkInsertRT = mock(ClientRequestScheduler.class);
     network.crypta.node.RequestStarterGroup starters =
         mock(network.crypta.node.RequestStarterGroup.class);
+    setField(starters, "sskFetchSchedulerBulk", sskFetchBulk);
+    setField(starters, "chkFetchSchedulerBulk", chkFetchBulk);
+    setField(starters, "sskPutSchedulerBulk", sskInsertBulk);
+    setField(starters, "chkPutSchedulerBulk", chkInsertBulk);
+    setField(starters, "sskFetchSchedulerRT", sskFetchRT);
+    setField(starters, "chkFetchSchedulerRT", chkFetchRT);
+    setField(starters, "sskPutSchedulerRT", sskInsertRT);
+    setField(starters, "chkPutSchedulerRT", chkInsertRT);
 
     ctx.init(starters, alerts);
 
-    UserAlert alert = mock(UserAlert.class);
+    assertSame(sskFetchBulk, ctx.getSskFetchScheduler(false));
+    assertSame(chkFetchBulk, ctx.getChkFetchScheduler(false));
+    assertSame(sskInsertBulk, ctx.getSskInsertScheduler(false));
+    assertSame(chkInsertBulk, ctx.getChkInsertScheduler(false));
+    assertSame(sskFetchRT, ctx.getSskFetchScheduler(true));
+    assertSame(chkFetchRT, ctx.getChkFetchScheduler(true));
+    assertSame(sskInsertRT, ctx.getSskInsertScheduler(true));
+    assertSame(chkInsertRT, ctx.getChkInsertScheduler(true));
+
+    ClientAlert alert = mock(ClientAlert.class);
     ctx.postUserAlert(alert);
-    verify(alerts, times(1)).register(alert);
+    verify(alerts, times(1)).post(alert);
   }
 
   @Test
   void postUserAlert_whenAlertsNull_schedulesAndRunsLater() {
     // Ensure alerts are null (do not call init())
-    UserAlert alert = mock(UserAlert.class);
+    ClientAlert alert = mock(ClientAlert.class);
     ctx.postUserAlert(alert);
 
     FakeTicker fakeTicker = (FakeTicker) ticker;
@@ -193,11 +218,25 @@ class ClientContextTest {
     assertNotNull(fakeTicker.lastJob);
 
     // Set alerts, then run the queued job
-    UserAlertManager alerts = mock(UserAlertManager.class);
+    ClientAlertSink alerts = mock(ClientAlertSink.class);
     setField(ctx, "alerts", alerts);
     fakeTicker.runLast();
 
-    verify(alerts, times(1)).register(alert);
+    verify(alerts, times(1)).post(alert);
+  }
+
+  @Test
+  void postUserAlert_whenAlertsAlreadyInitialized_postsImmediatelyWithoutQueueing() {
+    ClientAlertSink alerts = mock(ClientAlertSink.class);
+    ClientAlert alert = mock(ClientAlert.class);
+    FakeTicker fakeTicker = (FakeTicker) ticker;
+    setField(ctx, "alerts", alerts);
+
+    ctx.postUserAlert(alert);
+
+    verify(alerts, times(1)).post(alert);
+    assertNull(fakeTicker.lastJob);
+    assertNull(fakeTicker.lastName);
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/HealingDecisionSupplierTest.java
+++ b/src/test/java/network/crypta/client/async/HealingDecisionSupplierTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class HealingDecisionSupplierTest {
@@ -117,6 +118,29 @@ class HealingDecisionSupplierTest {
 
     // Assert
     assertThat("Darknet should always heal", result, Matchers.equalTo(true));
+  }
+
+  @Test
+  void shouldHeal_whenOpennetDisabled_currentNodeLocationSupplierNotInvoked() {
+    Supplier<Double> nodeLocationThrowing =
+        () -> {
+          throw new AssertionError(
+              "Node location supplier must not be called when opennet is disabled");
+        };
+    HealingDecisionSupplier supplier =
+        new HealingDecisionSupplier(nodeLocationThrowing, () -> false, () -> 0.2);
+
+    boolean result = supplier.shouldHeal(0.33);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void shouldHeal_whenOpennetSupplierReturnsNull_throwsNullPointerException() {
+    HealingDecisionSupplier supplier =
+        new HealingDecisionSupplier(() -> 0.25, () -> null, () -> 0.2);
+
+    assertThrows(NullPointerException.class, () -> supplier.shouldHeal(0.33));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
@@ -38,6 +38,7 @@ import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueCompletionPort;
@@ -334,7 +335,7 @@ class QueueToadletPostDownloadTest {
     when(network.executor()).thenReturn(executor);
 
     ClientContext context = createClientContext();
-    context.init(starters, alerts);
+    context.init(starters, new UserAlertManagerClientAlertSink(alerts));
     when(core.getClientContext()).thenReturn(context);
 
     when(fcp.getGlobalRequest(anyString())).thenReturn(null);

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
@@ -36,6 +36,7 @@ import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueBrowserUploadInsertRequest;
@@ -339,7 +340,7 @@ class QueueToadletPostInsertTest {
     when(network.executor()).thenReturn(executor);
 
     ClientContext context = createClientContext();
-    context.init(starters, alerts);
+    context.init(starters, new UserAlertManagerClientAlertSink(alerts));
     when(core.getClientContext()).thenReturn(context);
 
     when(fcp.getGlobalRequest(anyString())).thenReturn(null);

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
@@ -35,6 +35,7 @@ import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
 import network.crypta.runtime.spi.QueueCompletionPort;
@@ -309,7 +310,7 @@ class QueueToadletPostMutationTest {
     when(network.executor()).thenReturn(executor);
 
     ClientContext context = createClientContext();
-    context.init(starters, alerts);
+    context.init(starters, new UserAlertManagerClientAlertSink(alerts));
     when(core.getClientContext()).thenReturn(context);
 
     when(fcp.getGlobalRequest(anyString())).thenReturn(null);

--- a/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
@@ -38,6 +38,7 @@ import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarterGroup;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -285,7 +286,7 @@ class QueueToadletRecommendTest {
     when(network.darknetConnections()).thenReturn(new DarknetPeerNode[0]);
 
     ClientContext context = createClientContext();
-    context.init(starters, alerts);
+    context.init(starters, new UserAlertManagerClientAlertSink(alerts));
     when(core.getClientContext()).thenReturn(context);
 
     when(fcp.getGlobalRequest(anyString())).thenReturn(null);

--- a/src/test/java/network/crypta/runtime/alerts/UserAlertManagerClientAlertSinkTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/UserAlertManagerClientAlertSinkTest.java
@@ -1,0 +1,48 @@
+package network.crypta.runtime.alerts;
+
+import network.crypta.client.async.alerts.ClientAlert;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@SuppressWarnings("java:S100")
+class UserAlertManagerClientAlertSinkTest {
+
+  @Test
+  void constructor_whenUserAlertManagerNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new UserAlertManagerClientAlertSink(null));
+  }
+
+  @Test
+  void post_whenUserAlert_forwardsToUserAlertManager() {
+    UserAlertManager userAlertManager = mock(UserAlertManager.class);
+    UserAlertManagerClientAlertSink sink = new UserAlertManagerClientAlertSink(userAlertManager);
+    UserAlert alert = mock(UserAlert.class);
+
+    sink.post(alert);
+
+    verify(userAlertManager).register(alert);
+  }
+
+  @Test
+  void post_whenClientAlertIsNotUserAlert_throwsIllegalArgumentException() {
+    UserAlertManager userAlertManager = mock(UserAlertManager.class);
+    UserAlertManagerClientAlertSink sink = new UserAlertManagerClientAlertSink(userAlertManager);
+    ClientAlert alert = new ClientAlert() {};
+
+    assertThrows(IllegalArgumentException.class, () -> sink.post(alert));
+    verifyNoInteractions(userAlertManager);
+  }
+
+  @Test
+  void post_whenClientAlertIsNull_throwsIllegalArgumentException() {
+    UserAlertManager userAlertManager = mock(UserAlertManager.class);
+    UserAlertManagerClientAlertSink sink = new UserAlertManagerClientAlertSink(userAlertManager);
+
+    assertThrows(IllegalArgumentException.class, () -> sink.post(null));
+    verifyNoInteractions(userAlertManager);
+  }
+}


### PR DESCRIPTION
## Summary
- replace `HealingDecisionSupplier`'s default RNG source with `CryptoRandoms.shared()` so client main code no longer depends on `NodeStarter`
- add the client-owned `network.crypta.client.async.alerts` seam and a runtime `UserAlertManagerClientAlertSink` adapter, then wire `ClientContext` and `NodeClientCore` through it
- update focused unit tests, HTTP compile-call sites, and Javadocs for the new seam and adapter

## How to test
- `./gradlew test --tests 'network.crypta.client.async.ClientContextTest' --tests 'network.crypta.client.async.HealingDecisionSupplierTest' --tests 'network.crypta.runtime.alerts.UserAlertManagerClientAlertSinkTest'`
- `./gradlew test`
- `rg -n '^import network\.crypta\.runtime\.' src/main/java/network/crypta/client`

## Notes
- the import scan above should return no matches for `src/main/java/network/crypta/client/**`
- new alert-seam Javadocs were checked with `javadoc -Xdoclint:all`, and the package docs were checked with `javac -Xdoclint:all -Werror`