### PR TITLE
refactor(runtime-alerts): Add user-alert feed seam

### DIFF
--- a/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
@@ -491,8 +491,8 @@ public final class NodeStorageSubsystem {
         }
 
         @Override
-        public network.crypta.clients.fcp.FCPMessage getFCPMessage() {
-          return new network.crypta.clients.fcp.FeedMessage(
+        public network.crypta.runtime.alerts.feed.UserAlertFeedEvent getFeedEvent() {
+          return new network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent(
               getTitle(), getShortText(), getText(), getPriorityClass(), getUpdatedTime());
         }
 

--- a/src/main/java/network/crypta/runtime/alerts/AbstractUserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/AbstractUserAlert.java
@@ -1,13 +1,13 @@
 package network.crypta.runtime.alerts;
 
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.FeedMessage;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 
 /**
  * Abstract base implementation of a {@link UserAlert} that centralizes common storage and
  * boilerplate for user-facing alerts. Subclasses provide human-readable content (plain and optional
- * HTML), and may override behavior such as dismissal handling, validity updates, and feed
+ * HTML) and may override behavior such as dismissal handling, validity updates, and feed
  * serialization.
  *
  * <p>Usage typically follows a read-mostly pattern: producers construct an alert and register it
@@ -26,8 +26,7 @@ import network.crypta.support.HTMLNode;
  *       <ul>
  *         <li>Capture title, short/long text, and optional HTML fragment.
  *         <li>Track severity and default dismissal behavior.
- *         <li>Provide an {@link network.crypta.clients.fcp.FCPMessage FCP} representation for
- *             remote subscribers.
+ *         <li>Provide a runtime-owned feed representation for remote subscribers.
  *       </ul>
  * </ul>
  *
@@ -80,7 +79,7 @@ public abstract class AbstractUserAlert implements UserAlert {
    * contained values after construction. Callers may pass {@code null} for the {@code body} when a
    * subclass overrides content accessors.
    *
-   * @param userCanDismiss whether a user interface should offer a dismiss control; when set to
+   * @param userCanDismiss whether a user interface should offer a Dismiss control; when set to
    *     {@code false}, only producers should unregister or invalidate the alert.
    * @param title localized, succinct title suitable for list headers and notification banners; may
    *     be {@code null} if subclasses override {@link #getTitle()}.
@@ -205,8 +204,8 @@ public abstract class AbstractUserAlert implements UserAlert {
   }
 
   @Override
-  public FCPMessage getFCPMessage() {
-    return new FeedMessage(
+  public UserAlertFeedEvent getFeedEvent() {
+    return new BasicUserAlertFeedEvent(
         getTitle(), getShortText(), getText(), getPriorityClass(), getUpdatedTime());
   }
 
@@ -226,8 +225,7 @@ public abstract class AbstractUserAlert implements UserAlert {
    */
   public record Body(String text, String shortText, HTMLNode htmlText) {
     /**
-     * Factory method for convenience when constructing a {@link Body} with the three content
-     * components.
+     * Factory method for convenience when constructing a {@link Body} with the three content parts.
      *
      * @param text full, plain-text body; may be {@code null}.
      * @param shortText compact summary for constrained UI; may be {@code null}.
@@ -242,9 +240,9 @@ public abstract class AbstractUserAlert implements UserAlert {
   /**
    * Encapsulates dismissal-related options for an alert.
    *
-   * <p>The button text is intended for direct display and should be localized. The unregister flag
-   * indicates whether a dismissal should also remove the alert from its manager, rather than just
-   * marking it invalid.
+   * <p>The button text is intended for direct display and should be localized. The unregistered
+   * flag indicates whether a dismissal should also remove the alert from its manager, rather than
+   * just marking it invalid.
    *
    * @param dismissButtonText localized label to show on the dismiss action; may be {@code null} to
    *     use a default or omit the label entirely.

--- a/src/main/java/network/crypta/runtime/alerts/BookmarkFeedUserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/BookmarkFeedUserAlert.java
@@ -2,18 +2,19 @@ package network.crypta.runtime.alerts;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import network.crypta.clients.fcp.BookmarkFeed;
-import network.crypta.clients.fcp.N2NFeedMessageParams;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.runtime.alerts.feed.BookmarkUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.NodeToNodeFeedMetadata;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 
 /**
  * User alert that conveys a bookmark suggestion received from a peer via a node-to-node message.
- * The alert presents both a human-readable summary and a structured payload suitable for
- * programmatic consumption (FCP {@link network.crypta.clients.fcp.BookmarkFeed}).
+ * The alert presents both a human-readable summary and a structured runtime-owned feed payload
+ * suitable for programmatic consumption.
  *
  * <p>Instances are created when a remote peer shares a bookmark entry, typically containing a name,
  * an optional description, and a {@link FreenetURI}. The alert renders a short title, a plain-text
@@ -29,7 +30,8 @@ import network.crypta.support.HTMLNode;
  * <ul>
  *   <li>Renders localized text using {@link NodeL10n} keys scoped to this alert.
  *   <li>Generates an HTML node tree for rich presentation, including bookmark actions.
- *   <li>Exposes an FCP representation via {@link #getFCPMessage()} for client protocols.
+ *   <li>Exposes a runtime-owned feed representation via {@link #getFeedEvent()} for downstream
+ *       protocols.
  * </ul>
  *
  * <pre>{@code
@@ -37,7 +39,7 @@ import network.crypta.support.HTMLNode;
  * var context = new NodeToNodeAlertContext(peer, fileNo, composed, sent, received);
  * var alert = new BookmarkFeedUserAlert(context, name, desc, true, uri);
  * HTMLNode view = alert.getHTMLText();
- * BookmarkFeed fcp = alert.getFCPMessage();
+ * BookmarkUserAlertFeedEvent feedEvent = (BookmarkUserAlertFeedEvent) alert.getFeedEvent();
  * }</pre>
  *
  * @see AbstractUserAlert
@@ -119,7 +121,7 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
    * peer’s display name, the bookmark URI, and the optional description when provided. Newlines in
    * the description are preserved to keep author-intended formatting. This output is
    * audience-focused and primarily intended for display; consumers that need structured data should
-   * prefer {@link #getFCPMessage()} instead of parsing this text. The method does not alter the
+   * prefer {@link #getFeedEvent()} instead of parsing this text. The method does not alter the
    * object state and can be called multiple times without side effects.
    *
    * @return a human-readable, plain-text body with stable keys and values; never {@code null},
@@ -216,8 +218,8 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
       start = idx + 1;
     }
     lines.add(text.substring(start));
-    while (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
-      lines.remove(lines.size() - 1);
+    while (!lines.isEmpty() && lines.getLast().isEmpty()) {
+      lines.removeLast();
     }
     return lines.toArray(new String[0]);
   }
@@ -239,27 +241,26 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
   }
 
   /**
-   * Returns an FCP {@link BookmarkFeed} message equivalent to the current alert content. The
-   * returned object carries the same title, text, priority, timestamps, and bookmark details used
-   * by the UI, enabling remote clients to process or display the alert consistently.
+   * Returns a runtime-owned feed event equivalent to the current alert content. The returned object
+   * carries the same title, text, priority, timestamps, and bookmark details used by the UI,
+   * enabling downstream clients to process or display the alert consistently.
    *
-   * @return a new {@link BookmarkFeed} instance encapsulating this alert’s data; the caller gains
-   *     full ownership of the returned object.
+   * @return a new feed event encapsulating this alert’s data; the caller gains full ownership of
+   *     the returned object.
    */
   @Override
-  public BookmarkFeed getFCPMessage() {
-    N2NFeedMessageParams params =
-        new N2NFeedMessageParams(
-            getTitle(),
-            getShortText(),
-            getText(),
-            getPriorityClass(),
-            getUpdatedTime(),
-            sourceNodeName,
-            composed,
-            sent,
-            received);
-    return new BookmarkFeed(params, name, uri, description, hasAnActivelink);
+  public UserAlertFeedEvent getFeedEvent() {
+    return new BookmarkUserAlertFeedEvent(
+        getTitle(),
+        getShortText(),
+        getText(),
+        getPriorityClass(),
+        getUpdatedTime(),
+        getMetadata(),
+        name,
+        uri,
+        description,
+        hasAnActivelink);
   }
 
   /**
@@ -275,5 +276,9 @@ public class BookmarkFeedUserAlert extends AbstractUserAlert implements NodeToNo
     DarknetPeerNode pn = (DarknetPeerNode) peerRef.get();
     if (pn != null) sourceNodeName = pn.getName();
     return true;
+  }
+
+  private NodeToNodeFeedMetadata getMetadata() {
+    return new NodeToNodeFeedMetadata(sourceNodeName, composed, sent, received);
   }
 }

--- a/src/main/java/network/crypta/runtime/alerts/DatastoreTooSmallAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/DatastoreTooSmallAlert.java
@@ -1,12 +1,12 @@
 package network.crypta.runtime.alerts;
 
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.FeedMessage;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigException;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.Version;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.io.DatastoreUtil;
 
@@ -324,16 +324,16 @@ public class DatastoreTooSmallAlert implements UserAlert {
   }
 
   /**
-   * Produces an FCP feed message containing the alert content for consumption by FCP clients.
+   * Produces a runtime-owned feed event containing the alert content for subscribed clients.
    *
    * <p>The message includes the title, summary, full text, priority, and an updated timestamp. The
    * content is generated on demand and reflects the current configuration.
    *
-   * @return a new {@link FCPMessage} describing this alert; never {@code null}.
+   * @return a new feed event describing this alert; never {@code null}.
    */
   @Override
-  public FCPMessage getFCPMessage() {
-    return new FeedMessage(
+  public UserAlertFeedEvent getFeedEvent() {
+    return new BasicUserAlertFeedEvent(
         getTitle(), getShortText(), getText(), getPriorityClass(), getUpdatedTime());
   }
 }

--- a/src/main/java/network/crypta/runtime/alerts/DiskSpaceUserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/DiskSpaceUserAlert.java
@@ -1,10 +1,10 @@
 package network.crypta.runtime.alerts;
 
 import java.io.File;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.FeedMessage;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
  * @see NodeClientCore
  * @see UserAlert
  * @see HTMLNode
- * @see FCPMessage
  * @author toad
  */
 public class DiskSpaceUserAlert implements UserAlert {
@@ -49,16 +48,16 @@ public class DiskSpaceUserAlert implements UserAlert {
     /** Everything is OK. */
     OK,
     /**
-     * Not enough space to start persistent requests: Space on persistent-temp-* < long term limit.
+     * Not enough space to start persistent requests: Space on persistent-temp-* < long-term limit.
      */
     PERSISTENT,
     /**
-     * Not enough space to start transient requests, finish persistent requests or do anything much:
-     * Space on temp-* < short term limit
+     * Not enough space to start transient requests, finish persistent requests, or do anything
+     * much: Space on temp-* < short-term limit
      */
     TRANSIENT,
     /**
-     * Not enough space to complete persistent requests: Space on persistent-temp-* < short term
+     * Not enough space to complete persistent requests: Space on persistent-temp-* < short-term
      * limit.
      */
     PERSISTENT_COMPLETION;
@@ -228,7 +227,7 @@ public class DiskSpaceUserAlert implements UserAlert {
    *
    * <p>An alert is considered valid when a recent evaluation determined that free space is below
    * one of the configured thresholds. The result is cached for a short interval; callers should be
-   * prepared for the return value to change after subsequent evaluations.
+   * prepared for the return value to change after further evaluations.
    *
    * @return {@code true} when a short‑term, long‑term, or completion threshold is breached; {@code
    *     false} otherwise
@@ -282,8 +281,8 @@ public class DiskSpaceUserAlert implements UserAlert {
   /**
    * Callback invoked when the alert is dismissed; no additional action is required.
    *
-   * <p>Disk‑space status is re‑checked independently on subsequent cycles, so there is nothing to
-   * clean up locally when the current banner is hidden.
+   * <p>Disk‑space status is re‑checked independently on later cycles, so there is nothing to clean
+   * up locally when the current banner is hidden.
    */
   @Override
   public void onDismiss() {
@@ -317,25 +316,25 @@ public class DiskSpaceUserAlert implements UserAlert {
   }
 
   /**
-   * Produces an {@link FCPMessage} describing the alert for feed consumers.
+   * Produces a runtime-owned feed event describing the alert for feed consumers.
    *
    * <p>The message carries the title, short text, full text, priority class, and the last updated
    * timestamp so remote clients can present and sort entries consistently. The payload contains no
    * filesystem paths beyond the directory name string already included in the text.
    *
-   * @return an immutable FCP message representing the current alert state
+   * @return an immutable feed event representing the current alert state
    */
   @Override
-  public FCPMessage getFCPMessage() {
-    return new FeedMessage(
+  public UserAlertFeedEvent getFeedEvent() {
+    return new BasicUserAlertFeedEvent(
         getTitle(), getShortText(), getText(), getPriorityClass(), getUpdatedTime());
   }
 
   /**
    * Returns the timestamp (milliseconds since epoch) of the last status evaluation.
    *
-   * <p>The value is updated whenever the alert re‑evaluates disk space and may lag behind current
-   * wall‑clock time by up to the internal caching interval.
+   * <p>The value is updated whenever the alert re‑evaluates disk space and may lag behind the
+   * current wall‑clock time by up to the internal caching interval.
    *
    * @return the last evaluation time in milliseconds, suitable for sorting or freshness checks
    */

--- a/src/main/java/network/crypta/runtime/alerts/DownloadFeedUserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/DownloadFeedUserAlert.java
@@ -2,13 +2,13 @@ package network.crypta.runtime.alerts;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.N2NFeedMessageParams;
-import network.crypta.clients.fcp.URIFeedMessage;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.runtime.alerts.feed.NodeToNodeFeedMetadata;
+import network.crypta.runtime.alerts.feed.UriUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -34,11 +34,10 @@ import network.crypta.support.HTMLNode;
  *   <li>Title and text are localized via {@link NodeL10n} using resource keys scoped to this class.
  *   <li>HTML output is minimal and safe for embedding in simple views; it deliberately avoids
  *       arbitrary markup beyond line breaks and a link to the URI.
- *   <li>Conversion to FCP is provided by {@link #getFCPMessage()} using {@link URIFeedMessage} for
+ *   <li>Conversion to a runtime-owned feed event is provided by {@link #getFeedEvent()} for
  *       downstream clients.
  * </ul>
  *
- * @see URIFeedMessage
  * @see NodeToNodeMessageUserAlert
  */
 public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNodeMessageUserAlert {
@@ -82,9 +81,9 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
    * Returns a localized, human-readable title summarizing the announcement source.
    *
    * <p>The title interpolates the peer name into a localized resource string. It is intended for
-   * compact UIs such as notification lists where a short, readable label is preferred over the full
-   * text body. The value is computed on each call rather than cached, so recent name changes can be
-   * reflected after {@link #isValid()} refreshes the peer name.
+   * compact UIs such as notification lists where a short, readable label is preferred over the
+   * full-text body. The value is computed on each call rather than cached, so recent name changes
+   * can be reflected after {@link #isValid()} refreshes the peer name.
    *
    * @return a non-{@code null} localized title including the source peer name; suitable for short
    *     labels and summaries
@@ -182,8 +181,8 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
       start = idx + 1;
     }
     lines.add(text.substring(start));
-    while (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
-      lines.remove(lines.size() - 1);
+    while (!lines.isEmpty() && lines.getLast().isEmpty()) {
+      lines.removeLast();
     }
     return lines.toArray(new String[0]);
   }
@@ -211,28 +210,25 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
   }
 
   /**
-   * Converts this alert into an FCP message for clients.
+   * Converts this alert into a runtime-owned feed event for clients.
    *
-   * <p>The returned {@link URIFeedMessage} includes the localized title, short and long text,
-   * priority class, update time, peer name, the provided timestamps, target URI, and description.
-   * No additional transformation is applied beyond field mapping.
+   * <p>The returned event includes the localized title, short and long text, priority class, update
+   * time, peer name, the provided timestamps, target URI, and description. No additional
+   * transformation is applied beyond field mapping.
    *
-   * @return a non-{@code null} {@link FCPMessage} conveying this alert to FCP consumers
+   * @return a non-{@code null} feed event conveying this alert to subscribed consumers
    */
   @Override
-  public FCPMessage getFCPMessage() {
-    N2NFeedMessageParams params =
-        new N2NFeedMessageParams(
-            getTitle(),
-            getShortText(),
-            getText(),
-            getPriorityClass(),
-            getUpdatedTime(),
-            sourceNodeName,
-            composed,
-            sent,
-            received);
-    return new URIFeedMessage(params, uri, description);
+  public UserAlertFeedEvent getFeedEvent() {
+    return new UriUserAlertFeedEvent(
+        getTitle(),
+        getShortText(),
+        getText(),
+        getPriorityClass(),
+        getUpdatedTime(),
+        getMetadata(),
+        uri,
+        description);
   }
 
   /**
@@ -249,5 +245,9 @@ public class DownloadFeedUserAlert extends AbstractUserAlert implements NodeToNo
     DarknetPeerNode pn = (DarknetPeerNode) peerRef.get();
     if (pn != null) sourceNodeName = pn.getName();
     return true;
+  }
+
+  private NodeToNodeFeedMetadata getMetadata() {
+    return new NodeToNodeFeedMetadata(sourceNodeName, composed, sent, received);
   }
 }

--- a/src/main/java/network/crypta/runtime/alerts/DroppedOldPeersUserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/DroppedOldPeersUserAlert.java
@@ -7,10 +7,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.FeedMessage;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.PeerTooOldException;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,17 +21,17 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This alert accumulates the display names of peers that were rejected due to an older
  * encryption protocol or build, along with the highest observed incompatible build number and its
- * build date. It renders human‑readable text and simple HTML content, and it can also be serialized
- * into an {@code FCP} {@link network.crypta.clients.fcp.FCPMessage} to notify external clients.
+ * build date. It renders human-readable text and simple HTML content, and it can also be serialized
+ * into a runtime-owned feed event to notify external clients.
  *
  * <p>Typical usage: create an instance early in peer loading, call {@link #add(PeerTooOldException,
  * String)} for each incompatible peer, and, if non‑empty, register the alert with the system alert
  * service. The instance is mutable while peers are being processed; once registered and shown to
- * users it is usually treated as immutable.
+ * users, it is usually treated as immutable.
  *
  * <ul>
  *   <li>Not thread‑safe: update it from a single thread.
- *   <li>Displays a filename where references to dropped peers are persisted by callers.
+ *   <li>Displays a filename where callers persist references to dropped peers.
  *   <li>Emits a critical‑priority alert intended to be user‑dismissible.
  * </ul>
  */
@@ -75,11 +75,11 @@ public class DroppedOldPeersUserAlert implements UserAlert {
    *
    * <p>When {@code name} is {@code null}, the peer is recorded as {@code (unknown name)}; otherwise
    * the name is stored quoted to make UI rendering unambiguous. The alert tracks the maximum build
-   * number observed across all adds and uses the corresponding build date for titles.
+   * number observed across all adding and uses the corresponding build date for titles.
    *
    * <p>This method logs an error‑level summary about the rejection. It does not throw.
    *
-   * @param e details about the version mismatch including the other node's build number and date;
+   * @param e details about the version mismatch, including the other node's build number and date,
    *     must be non‑null.
    * @param name display name of the peer, or {@code null} when unknown; empty strings are allowed
    *     and will be quoted.
@@ -239,7 +239,7 @@ public class DroppedOldPeersUserAlert implements UserAlert {
    */
   @Override
   public void isValid(boolean validity) {
-    // Ignore, will be unregistered on dismiss.
+    // Ignore, will be unregistered on dismissing.
   }
 
   /** {@inheritDoc} */
@@ -277,16 +277,16 @@ public class DroppedOldPeersUserAlert implements UserAlert {
   }
 
   /**
-   * Serializes the alert into an FCP feed message.
+   * Serializes the alert into a runtime-owned feed event.
    *
-   * <p>The returned message contains the title, short text, full text bytes length, priority class,
+   * <p>The returned message contains the title, short text, full-text bytes length, priority class,
    * and the creation time as the updated time. The message does not include attachments.
    *
-   * @return a new {@code Feed} message conveying the alert; safe to send to external clients.
+   * @return a new feed event conveying the alert; safe to send to external clients.
    */
   @Override
-  public FCPMessage getFCPMessage() {
-    return new FeedMessage(
+  public UserAlertFeedEvent getFeedEvent() {
+    return new BasicUserAlertFeedEvent(
         getTitle(), getShortText(), getText(), getPriorityClass(), getUpdatedTime());
   }
 

--- a/src/main/java/network/crypta/runtime/alerts/N2NTMUserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/N2NTMUserAlert.java
@@ -7,12 +7,12 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Locale;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.N2NFeedMessageParams;
-import network.crypta.clients.fcp.TextFeedMessage;
 import network.crypta.io.comm.PeerContext;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.runtime.alerts.feed.NodeToNodeFeedMetadata;
+import network.crypta.runtime.alerts.feed.TextUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -22,8 +22,8 @@ import network.crypta.support.HTMLNode;
  * path (composed, sent, and received). It also carries lightweight identity information about the
  * source darknet peer and a reference to the originating {@link PeerContext}. The alert exposes
  * multiple readouts tailored to different front-ends: a localized plain-text title and body, a
- * concise short text for summaries, an {@link HTMLNode} fragment for HTML renderers, and an {@link
- * FCPMessage} view for programmatic consumption via FCP.
+ * concise short text for summaries, an {@link HTMLNode} fragment for HTML renderers, and a
+ * runtime-owned feed-event view for programmatic consumption.
  *
  * <p>Instances are mostly immutable after construction. The only mutable parts are the cached
  * {@code sourceNodeName} and {@code sourcePeer} strings, which may be refreshed opportunistically
@@ -226,8 +226,8 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
       start = idx + 1;
     }
     lines.add(text.substring(start));
-    while (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
-      lines.remove(lines.size() - 1);
+    while (!lines.isEmpty() && lines.getLast().isEmpty()) {
+      lines.removeLast();
     }
     return lines.toArray(new String[0]);
   }
@@ -246,27 +246,24 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
   }
 
   /**
-   * Returns an FCP representation of this alert for consumption by external clients.
+   * Returns a runtime-owned feed-event representation of this alert for consumption by external
+   * clients.
    *
-   * <p>The returned {@link TextFeedMessage} mirrors the data shown in the UI: title, short text,
-   * full text, priority, update time, peer name, timestamps, and the raw message body.
+   * <p>The returned event mirrors the data shown in the UI: title, short text, full text, priority,
+   * update time, peer name, timestamps, and the raw message body.
    *
-   * @return a non-null {@link FCPMessage} describing the alert contents
+   * @return a non-null feed event describing the alert contents
    */
   @Override
-  public FCPMessage getFCPMessage() {
-    N2NFeedMessageParams params =
-        new N2NFeedMessageParams(
-            getTitle(),
-            getShortText(),
-            getText(),
-            getPriorityClass(),
-            getUpdatedTime(),
-            sourceNodeName,
-            composedTime,
-            sentTime,
-            receivedTime);
-    return new TextFeedMessage(params, messageText);
+  public UserAlertFeedEvent getFeedEvent() {
+    return new TextUserAlertFeedEvent(
+        getTitle(),
+        getShortText(),
+        getText(),
+        getPriorityClass(),
+        getUpdatedTime(),
+        getMetadata(),
+        messageText);
   }
 
   /**
@@ -350,5 +347,9 @@ public class N2NTMUserAlert extends AbstractUserAlert implements NodeToNodeMessa
       sourcePeer = pn.getPeer().toString();
     }
     return true;
+  }
+
+  private NodeToNodeFeedMetadata getMetadata() {
+    return new NodeToNodeFeedMetadata(sourceNodeName, composedTime, sentTime, receivedTime);
   }
 }

--- a/src/main/java/network/crypta/runtime/alerts/StoringUserEvent.java
+++ b/src/main/java/network/crypta/runtime/alerts/StoringUserEvent.java
@@ -2,17 +2,18 @@ package network.crypta.runtime.alerts;
 
 import java.util.Iterator;
 import java.util.Map;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.FeedMessage;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 
 /**
  * Base class for user alerts that keep a live collection of related, dismissible events.
  *
  * <p>This type stores events in a shared {@link Map} and provides common behavior to render a
- * combined HTML view, emit an FCP feed message, and coordinate dismissal. Subclasses typically add
- * the domain-specific fields that describe a single event and implement {@link #getEventText()} and
- * {@link #getEventHTMLText()} to produce textual and structured HTML representations respectively.
+ * combined HTML view, emit a runtime-owned feed event, and coordinate dismissal. Subclasses
+ * typically add the domain-specific fields that describe a single event and implement {@link
+ * #getEventText()} and {@link #getEventHTMLText()} to produce textual and structured HTML
+ * representations respectively.
  *
  * <p>The backing collection is supplied by the caller and is not copied. This class synchronizes on
  * that map when iterating and mutating it, so all accesses performed here are serialized against
@@ -28,13 +29,12 @@ import network.crypta.support.HTMLNode;
  *
  * <ul>
  *   <li>Aggregates HTML for all stored events in the order reported by the map.
- *   <li>Builds a minimal {@code FeedMessage} from the plain-text representation.
+ *   <li>Builds a minimal feed event from the plain-text representation.
  *   <li>Removes all events on dismissing, invoking per-event cleanup hooks.
  * </ul>
  *
  * @param <T> the concrete subtype, enabling type-safe storage of homogeneous events
  * @see AbstractUserEvent
- * @see network.crypta.clients.fcp.FCPMessage
  * @see network.crypta.support.HTMLNode
  */
 public abstract class StoringUserEvent<T extends StoringUserEvent<T>> extends AbstractUserEvent {
@@ -77,12 +77,12 @@ public abstract class StoringUserEvent<T extends StoringUserEvent<T>> extends Ab
   }
 
   /**
-   * Returns the plain-text representation for this single stored event instance.
+   * Returns the plain-text representation for this single-stored event instance.
    *
    * <p>Implementations should return a human-readable description suitable for logs, feed entries,
    * and other plain-text channels. The text should not contain HTML markup and should be reasonably
    * concise to fit compact UI surfaces. The returned value is used as the title and body in the
-   * generated {@code FeedMessage}.
+   * generated feed event.
    *
    * @return descriptive text for this event instance; never includes HTML tags
    */
@@ -122,12 +122,12 @@ public abstract class StoringUserEvent<T extends StoringUserEvent<T>> extends Ab
   /**
    * {@inheritDoc}
    *
-   * <p>This implementation builds a minimal {@link FeedMessage} using the same text for the
-   * subject, summary, and body. Priority and update time are taken from this event’s metadata.
+   * <p>This implementation builds a minimal feed event using the same text for the subject,
+   * summary, and body. Priority and update time are taken from this event’s metadata.
    */
   @Override
-  public FCPMessage getFCPMessage() {
-    return new FeedMessage(
+  public UserAlertFeedEvent getFeedEvent() {
+    return new BasicUserAlertFeedEvent(
         getEventText(), getEventText(), getEventText(), getPriorityClass(), getUpdatedTime());
   }
 

--- a/src/main/java/network/crypta/runtime/alerts/UserAlert.java
+++ b/src/main/java/network/crypta/runtime/alerts/UserAlert.java
@@ -1,7 +1,7 @@
 package network.crypta.runtime.alerts;
 
 import network.crypta.client.async.alerts.ClientAlert;
-import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -24,11 +24,10 @@ import network.crypta.support.HTMLNode;
  *   <li>Plain and HTML bodies: {@link #getText()} and {@link #getHTMLText()}.
  *   <li>Dismissal behavior: {@link #userCanDismiss()}, {@link #onDismiss()}, and {@link
  *       #shouldUnregisterOnDismiss()}.
- *   <li>External propagation: {@link #getFCPMessage()} for FCP subscribers.
+ *   <li>External propagation: {@link #getFeedEvent()} for feed subscribers.
  * </ul>
  *
  * @see network.crypta.runtime.alerts.UserAlertManager
- * @see network.crypta.clients.fcp.FeedMessage
  */
 public interface UserAlert extends ClientAlert {
 
@@ -155,13 +154,13 @@ public interface UserAlert extends ClientAlert {
   boolean isEventNotification();
 
   /**
-   * Produces the message that will be sent to subscribers of the FCP feed that mirrors user alerts
-   * for remote clients. Implementations should populate the message with the same values exposed by
-   * this interface so consumers observe consistent data across protocols.
+   * Produces the runtime-owned feed event that will be sent to subscribers watching user alerts.
+   * Implementations should populate the event with the same values exposed by this interface so
+   * downstream transport adapters can mirror alert behavior consistently.
    *
-   * @return an FCP message describing this alert for subscribing FCP clients; never {@code null}.
+   * @return a runtime-owned feed event describing this alert; never {@code null}.
    */
-  FCPMessage getFCPMessage();
+  UserAlertFeedEvent getFeedEvent();
 
   /**
    * Returns the moment the alert was last updated, expressed as milliseconds since the Unix epoch

--- a/src/main/java/network/crypta/runtime/alerts/UserAlertManager.java
+++ b/src/main/java/network/crypta/runtime/alerts/UserAlertManager.java
@@ -24,9 +24,9 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.alerts.feed.UserAlertFeedSubscriber;
 import network.crypta.support.Base64;
 import network.crypta.support.HTMLNode;
 import org.slf4j.Logger;
@@ -47,8 +47,8 @@ import static java.util.Arrays.stream;
  *
  * <p>Concurrency: registration and state updates synchronize on internal collections, while
  * subscriber notifications are dispatched asynchronously to avoid blocking alert updates. The
- * manager is mutable and not thread-safe for external iteration; call {@link #getAlerts()} to
- * obtain a stable array.
+ * manager is mutable and not thread-safe for external iteration; call {@link #getAlerts()} to get a
+ * stable array.
  *
  * <p>Responsibilities include:
  *
@@ -77,13 +77,13 @@ public class UserAlertManager implements Comparator<UserAlert> {
   // No point keeping them sorted as some alerts can change priority.
   private final Set<UserAlert> alerts;
   private final NodeClientCore core;
-  private final Set<FCPConnectionHandler> subscribers;
+  private final Set<UserAlertFeedSubscriber> subscribers;
   private final Map<UserEvent.Type, UserEvent> events;
   private final Set<UserEvent.Type> unregisteredEventTypes;
   private long lastUpdated;
 
   /**
-   * Creates a manager bound to the given core and initializes empty alert state.
+   * Creates a manager bound to the given core and initializes an empty alert state.
    *
    * <p>The manager stores alerts in mutable collections, tracks the most recent update time, and
    * prepares to notify FCP subscribers asynchronously. Callers should typically construct this once
@@ -125,7 +125,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    * Registers an event alert, replacing any previously registered event of the same type.
    *
    * <p>Events are treated specially: only the newest {@link UserEvent} for a given type is kept in
-   * the alerts list. If the event type has been permanently unregistered, this call is ignored.
+   * the alert list. If the event type has been permanently unregistered, this call is ignored.
    * Registration updates the timestamp and sends an asynchronous FCP notification to subscribers.
    *
    * @param event the event to register; its type determines replacement behavior
@@ -155,8 +155,8 @@ public class UserAlertManager implements Comparator<UserAlert> {
         .getMainExecutor()
         .execute(
             () -> {
-              for (FCPConnectionHandler subscriber : subscribers)
-                subscriber.send(alert.getFCPMessage());
+              for (UserAlertFeedSubscriber subscriber : subscribers)
+                subscriber.send(alert.getFeedEvent());
             },
             "UserAlertManager callback executor");
   }
@@ -236,7 +236,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    *
    * <p>The returned array is a stable snapshot at the time of call and is sorted using the manager
    * comparator. It is safe for callers to iterate without holding locks, but the snapshot will not
-   * reflect subsequent registrations or dismissals. Callers should not mutate or retain elements
+   * reflect later registrations or dismissals. Callers should not mutate or retain elements
    * expecting live updates.
    *
    * @return a newly allocated array sorted by alert priority and recency
@@ -266,7 +266,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
   @Override
   public int compare(UserAlert a0, UserAlert a1) {
     if (a0 == a1)
-      return 0; // common case, also we should be consistent with == even with proxyuseralert's
+      return 0; // the common case, also we should be consistent with == even with proxyuseralert's
     int priorityComparison = Short.compare(a0.getPriorityClass(), a1.getPriorityClass());
     if (priorityComparison != 0) {
       return priorityComparison;
@@ -300,7 +300,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    *
    * <p>This convenience overload delegates to {@link #createAlerts(boolean)} with {@code
    * showOnlyErrors=true}. It is commonly used by status views that want to avoid rendering
-   * lower-severity information, while still providing a consistent HTML structure.
+   * lower-severity information while still providing a consistent HTML structure.
    *
    * @return an HTML node containing error-level alerts, or an empty marker node
    */
@@ -357,7 +357,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    *
    * <p>The generated node includes CSS classes based on the alert priority class, the localized
    * title as a header, and the full HTML body from the alert. If the alert is dismissable, a
-   * standard dismiss form is appended. This method does not catch exceptions from the alert
+   * standard dismission form is appended. This method does not catch exceptions from the alert
    * implementation; callers should guard if failures must not propagate.
    *
    * @param userAlert the alert to render; must be non-null and already validated
@@ -377,12 +377,12 @@ public class UserAlertManager implements Comparator<UserAlert> {
   }
 
   /**
-   * Builds a dismiss button form for a given alert.
+   * Builds a Dismiss button form for a given alert.
    *
-   * <p>If the alert can be dismissed, this method generates a form that posts to the alerts
-   * endpoint with the alert hash code and form password. An optional redirect target can be
-   * provided to return users to the originating page after dismissal. Non-dismissable alerts return
-   * an empty container.
+   * <p>If the alert can be dismissed, this method generates a form that posts to the alert endpoint
+   * with the alert hash code and form password. An optional redirect target can be provided to
+   * return users to the originating page after dismissal. Non-dismissable alerts return an empty
+   * container.
    *
    * @param userAlert the alert whose dismissal form should be generated
    * @param redirectToAfterDisable optional redirect target after dismissal, or {@code null}
@@ -556,13 +556,13 @@ public class UserAlertManager implements Comparator<UserAlert> {
    * Registers a subscriber and immediately sends the current valid alerts.
    *
    * <p>The subscriber is added to the internal subscriber set and then receives a snapshot of all
-   * valid alerts via asynchronous FCP callbacks. The snapshot is taken at execution time on the
+   * valid alerts via asynchronous feed callbacks. The snapshot is taken at execution time on the
    * executor, so it reflects the state at that moment. Registering the same subscriber multiple
-   * times is safe because the set de-duplicates entries.
+   * times is safe because the set deduplicates entries.
    *
-   * @param subscriber the FCP connection that should receive alert notifications
+   * @param subscriber the feed subscriber that should receive alert notifications
    */
-  public void watch(final FCPConnectionHandler subscriber) {
+  public void watch(final UserAlertFeedSubscriber subscriber) {
     subscribers.add(subscriber);
     // Run off-thread, because of locking, and because client
     // callbacks may take some time
@@ -571,10 +571,9 @@ public class UserAlertManager implements Comparator<UserAlert> {
         .execute(
             () -> {
               for (UserAlert alert : getAlerts())
-                if (alert.isValid()) subscriber.send(alert.getFCPMessage());
+                if (alert.isValid()) subscriber.send(alert.getFeedEvent());
             },
             "UserAlertManager callback executor");
-    subscribers.add(subscriber);
   }
 
   /**
@@ -583,9 +582,9 @@ public class UserAlertManager implements Comparator<UserAlert> {
    * <p>This method removes the subscriber from the internal set. It does not attempt to cancel any
    * in-flight asynchronous notifications already queued on the executor.
    *
-   * @param subscriber the FCP connection to remove from the subscriber list
+   * @param subscriber the feed subscriber to remove from the subscriber list
    */
-  public void unwatch(FCPConnectionHandler subscriber) {
+  public void unwatch(UserAlertFeedSubscriber subscriber) {
     subscribers.remove(subscriber);
   }
 
@@ -597,7 +596,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
   /**
    * Builds an Atom feed document containing the current alerts.
    *
-   * <p>The feed uses the provided start URI as the base for links to the alerts page and is updated
+   * <p>The feed uses the provided start URI as the base for links to the alert page and is updated
    * with the most recent alert timestamp. Each valid alert becomes a feed entry containing its
    * title, summary, and full text. The generated XML is intended for lightweight status polling and
    * does not include pagination or history beyond the current alert snapshot.
@@ -664,6 +663,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static class XmlBuilder implements ElementBuilder {
 
     @Override

--- a/src/main/java/network/crypta/runtime/alerts/feed/BasicUserAlertFeedEvent.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/BasicUserAlertFeedEvent.java
@@ -1,0 +1,51 @@
+package network.crypta.runtime.alerts.feed;
+
+import java.util.Objects;
+
+/**
+ * Immutable runtime-side snapshot of the common fields shared by user-alert feed events.
+ *
+ * <p>This record is the smallest transport-neutral representation of an alert that still carries
+ * the text shown to operators and external clients. Runtime alert implementations construct it when
+ * they need only the basic header, summary, body text, priority class, and update timestamp.
+ * Higher-level feed variants such as bookmark or URI announcements build on the same shape by
+ * adding node-to-node metadata and payload-specific fields.
+ *
+ * <p>The record is intentionally simple: it owns only runtime concepts, it does not reference FCP
+ * classes, and it is safe to hand across subsystem boundaries without additional locking or
+ * copying. The {@code text} field is required because downstream feed bridges encode it as the
+ * primary payload body.
+ *
+ * @param header short one-line title shown most prominently when clients render the alert
+ * @param shortText secondary summary line that gives clients a concise preview of the alert
+ * @param text full alert body text that downstream bridges encode into the feed payload
+ * @param priorityClass numeric severity or priority class preserved from the originating alert
+ * @param updatedTime epoch-millisecond timestamp describing when the originating alert last changed
+ * @see BookmarkUserAlertFeedEvent
+ * @see UriUserAlertFeedEvent
+ * @see TextUserAlertFeedEvent
+ */
+public record BasicUserAlertFeedEvent(
+    String header, String shortText, String text, short priorityClass, long updatedTime)
+    implements UserAlertFeedEvent {
+
+  /**
+   * Creates a runtime-owned basic feed event snapshot.
+   *
+   * <p>The constructor performs only the validation needed to keep downstream encoding predictable.
+   * It accepts nullable {@code header} and {@code shortText} values because existing alerts may
+   * omit one or both summaries, but it requires a non-null body text because the feed bridge always
+   * serializes the main text payload.
+   *
+   * @param header short one-line title shown most prominently when clients render the alert
+   * @param shortText secondary summary line that gives clients a concise preview of the alert
+   * @param text full alert body text that downstream bridges encode into the feed payload
+   * @param priorityClass numeric severity or priority class preserved from the originating alert
+   * @param updatedTime epoch-millisecond timestamp describing when the originating alert last
+   *     changed
+   * @throws NullPointerException if {@code text} is {@code null} and the payload would be undefined
+   */
+  public BasicUserAlertFeedEvent {
+    Objects.requireNonNull(text, "text");
+  }
+}

--- a/src/main/java/network/crypta/runtime/alerts/feed/BookmarkUserAlertFeedEvent.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/BookmarkUserAlertFeedEvent.java
@@ -1,0 +1,69 @@
+package network.crypta.runtime.alerts.feed;
+
+import java.util.Objects;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Immutable runtime-side feed event for bookmark recommendations.
+ *
+ * <p>This variant extends the common alert text fields with the data needed to preserve existing
+ * bookmark feed behavior when the FCP bridge later encodes the event. It carries the bookmark
+ * title, target URI, optional descriptive text, and the node-to-node provenance metadata that tells
+ * clients which darknet peer produced the recommendation and when the message moved through the
+ * system.
+ *
+ * <p>The record does not perform URI normalization or text transformation. Callers are expected to
+ * provide values that already reflect current alert behavior so the downstream bridge can recreate
+ * the exact message layout it used before the seam was introduced.
+ *
+ * @param header short one-line title shown most prominently when clients render the alert
+ * @param shortText secondary summary line that gives clients a concise preview of the alert
+ * @param text full alert body text that downstream bridges encode into the feed payload
+ * @param priorityClass numeric severity or priority class preserved from the originating alert
+ * @param updatedTime epoch-millisecond timestamp describing when the originating alert last changed
+ * @param metadata source-node name and compose/send/receive timestamps for the recommendation
+ * @param bookmarkTitle display title for the recommended bookmark entry
+ * @param uri target {@link FreenetURI} for the bookmark suggestion
+ * @param description optional human-readable description associated with the bookmark
+ * @param hasActiveLink whether the originating alert exposed the bookmark as an active link
+ * @see NodeToNodeFeedMetadata
+ */
+public record BookmarkUserAlertFeedEvent(
+    String header,
+    String shortText,
+    String text,
+    short priorityClass,
+    long updatedTime,
+    NodeToNodeFeedMetadata metadata,
+    String bookmarkTitle,
+    FreenetURI uri,
+    String description,
+    boolean hasActiveLink)
+    implements UserAlertFeedEvent {
+
+  /**
+   * Creates a runtime-owned bookmark feed event snapshot.
+   *
+   * <p>The constructor keeps validation narrow so that it mirrors the existing alert behavior
+   * closely. Provenance metadata and the target URI are required because downstream FCP message
+   * types always rely on them, while the descriptive text may be absent when the originating alert
+   * did not include any additional explanation.
+   *
+   * @param header short one-line title shown most prominently when clients render the alert
+   * @param shortText secondary summary line that gives clients a concise preview of the alert
+   * @param text full alert body text that downstream bridges encode into the feed payload
+   * @param priorityClass numeric severity or priority class preserved from the originating alert
+   * @param updatedTime epoch-millisecond timestamp describing when the originating alert last
+   *     changed
+   * @param metadata source-node name and compose/send/receive timestamps for the recommendation
+   * @param bookmarkTitle display title for the recommended bookmark entry
+   * @param uri target {@link FreenetURI} for the bookmark suggestion
+   * @param description optional human-readable description associated with the bookmark
+   * @param hasActiveLink whether the originating alert exposed the bookmark as an active link
+   * @throws NullPointerException if {@code metadata} or {@code uri} is {@code null}
+   */
+  public BookmarkUserAlertFeedEvent {
+    Objects.requireNonNull(metadata, "metadata");
+    Objects.requireNonNull(uri, "uri");
+  }
+}

--- a/src/main/java/network/crypta/runtime/alerts/feed/NodeToNodeFeedMetadata.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/NodeToNodeFeedMetadata.java
@@ -1,0 +1,22 @@
+package network.crypta.runtime.alerts.feed;
+
+/**
+ * Immutable runtime-owned provenance metadata for node-to-node feed events.
+ *
+ * <p>This record carries the peer-facing source node name together with the timestamps that
+ * describe when a node-to-node message was composed, sent, and received. Runtime alerts use it to
+ * preserve the same timing and origin information that existing FCP feed messages already expose.
+ * Keeping the metadata in a small standalone record lets runtime code describe provenance without
+ * depending on any transport-specific container.
+ *
+ * <p>The timestamp values are passed through without interpretation. Callers may use sentinel
+ * values such as {@code -1} when a particular time is unknown, and transport bridges remain
+ * responsible for deciding how those sentinel values appear on the wire.
+ *
+ * @param sourceNodeName human-readable node name associated with the originating peer message
+ * @param composed epoch milliseconds when the originating peer composed the message, if known
+ * @param sent epoch milliseconds when the originating peer transmitted the message, if known
+ * @param received epoch milliseconds when the local node received the message, if known
+ */
+public record NodeToNodeFeedMetadata(
+    String sourceNodeName, long composed, long sent, long received) {}

--- a/src/main/java/network/crypta/runtime/alerts/feed/TextUserAlertFeedEvent.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/TextUserAlertFeedEvent.java
@@ -1,0 +1,60 @@
+package network.crypta.runtime.alerts.feed;
+
+import java.util.Objects;
+
+/**
+ * Immutable runtime-side feed event for node-to-node text messages.
+ *
+ * <p>This variant is used for alerts that expose a normal rendered alert body and also need to keep
+ * the original text-message payload available for downstream transport encoding. The common fields
+ * describe what operators see in the alert UI, while {@code messageText} preserves the raw
+ * node-to-node message content that FCP clients have historically received in a dedicated payload
+ * bucket.
+ *
+ * <p>The raw message text may be {@code null}. That behavior is deliberate because the legacy alert
+ * path already allowed empty or absent node-to-node text payloads, and the seam keeps that contract
+ * intact so the FCP bridge can continue emitting the same zero-length bucket behavior.
+ *
+ * @param header short one-line title shown most prominently when clients render the alert
+ * @param shortText secondary summary line that gives clients a concise preview of the alert
+ * @param text full alert body text that downstream bridges encode into the feed payload
+ * @param priorityClass numeric severity or priority class preserved from the originating alert
+ * @param updatedTime epoch-millisecond timestamp describing when the originating alert last changed
+ * @param metadata source-node name and compose/send/receive timestamps for the text message
+ * @param messageText raw text payload carried by the node-to-node message, which may be {@code
+ *     null}
+ * @see NodeToNodeFeedMetadata
+ */
+public record TextUserAlertFeedEvent(
+    String header,
+    String shortText,
+    String text,
+    short priorityClass,
+    long updatedTime,
+    NodeToNodeFeedMetadata metadata,
+    String messageText)
+    implements UserAlertFeedEvent {
+
+  /**
+   * Creates a runtime-owned text-message feed event snapshot.
+   *
+   * <p>The constructor requires provenance metadata because downstream node-to-node feed encoders
+   * always emit those fields. It does not require a non-null {@code messageText}; callers may pass
+   * {@code null} when the originating alert had no raw node-to-node message body beyond the main
+   * rendered text.
+   *
+   * @param header short one-line title shown most prominently when clients render the alert
+   * @param shortText secondary summary line that gives clients a concise preview of the alert
+   * @param text full alert body text that downstream bridges encode into the feed payload
+   * @param priorityClass numeric severity or priority class preserved from the originating alert
+   * @param updatedTime epoch-millisecond timestamp describing when the originating alert last
+   *     changed
+   * @param metadata source-node name and compose/send/receive timestamps for the text message
+   * @param messageText raw text payload carried by the node-to-node message, which may be {@code
+   *     null}
+   * @throws NullPointerException if {@code metadata} is {@code null}
+   */
+  public TextUserAlertFeedEvent {
+    Objects.requireNonNull(metadata, "metadata");
+  }
+}

--- a/src/main/java/network/crypta/runtime/alerts/feed/UriUserAlertFeedEvent.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/UriUserAlertFeedEvent.java
@@ -1,0 +1,62 @@
+package network.crypta.runtime.alerts.feed;
+
+import java.util.Objects;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Immutable runtime-side feed event for URI and download announcements.
+ *
+ * <p>This variant models alerts that recommend or announce a specific {@link FreenetURI}. It keeps
+ * the common alert presentation fields together with the announced URI, optional descriptive text,
+ * and the node-to-node provenance metadata required by the existing FCP feed protocol. Runtime
+ * alerts use it when they want to remain transport-neutral but still preserve the exact data shape
+ * that downstream FCP clients expect.
+ *
+ * <p>The record is intentionally descriptive rather than behavioral. It does not attempt to fetch,
+ * validate, or rewrite the URI, and it leaves any sentinel handling for unknown timestamps to the
+ * transport bridge that converts it into a protocol message.
+ *
+ * @param header short one-line title shown most prominently when clients render the alert
+ * @param shortText secondary summary line that gives clients a concise preview of the alert
+ * @param text full alert body text that downstream bridges encode into the feed payload
+ * @param priorityClass numeric severity or priority class preserved from the originating alert
+ * @param updatedTime epoch-millisecond timestamp describing when the originating alert last changed
+ * @param metadata source-node name and compose/send/receive timestamps for the announcement
+ * @param uri announced {@link FreenetURI} that clients may display or follow
+ * @param description optional human-readable description paired with the announced URI
+ * @see NodeToNodeFeedMetadata
+ */
+public record UriUserAlertFeedEvent(
+    String header,
+    String shortText,
+    String text,
+    short priorityClass,
+    long updatedTime,
+    NodeToNodeFeedMetadata metadata,
+    FreenetURI uri,
+    String description)
+    implements UserAlertFeedEvent {
+
+  /**
+   * Creates a runtime-owned URI feed event snapshot.
+   *
+   * <p>The constructor validates only the fields that downstream protocol encoding always requires.
+   * The provenance metadata and URI must be present, while the description may be omitted when the
+   * originating alert had no separate descriptive text to send.
+   *
+   * @param header short one-line title shown most prominently when clients render the alert
+   * @param shortText secondary summary line that gives clients a concise preview of the alert
+   * @param text full alert body text that downstream bridges encode into the feed payload
+   * @param priorityClass numeric severity or priority class preserved from the originating alert
+   * @param updatedTime epoch-millisecond timestamp describing when the originating alert last
+   *     changed
+   * @param metadata source-node name and compose/send/receive timestamps for the announcement
+   * @param uri announced {@link FreenetURI} that clients may display or follow
+   * @param description optional human-readable description paired with the announced URI
+   * @throws NullPointerException if {@code metadata} or {@code uri} is {@code null}
+   */
+  public UriUserAlertFeedEvent {
+    Objects.requireNonNull(metadata, "metadata");
+    Objects.requireNonNull(uri, "uri");
+  }
+}

--- a/src/main/java/network/crypta/runtime/alerts/feed/UserAlertFeedEvent.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/UserAlertFeedEvent.java
@@ -1,0 +1,20 @@
+package network.crypta.runtime.alerts.feed;
+
+/**
+ * Marker interface for immutable runtime-owned user-alert feed events.
+ *
+ * <p>This interface defines the transport-neutral alert feed seam owned by {@code
+ * network.crypta.runtime.alerts}. Concrete event records capture the data that alert producers want
+ * to publish without depending on FCP message classes or connection handlers. The runtime can
+ * therefore notify subscribers in a stable, testable format while endpoint packages remain
+ * responsible for any protocol-specific encoding.
+ *
+ * <p>Implementations are expected to behave as plain data carriers. They should not perform I/O,
+ * hold mutable state, or encode transport-specific behavior.
+ *
+ * @see BasicUserAlertFeedEvent
+ * @see BookmarkUserAlertFeedEvent
+ * @see UriUserAlertFeedEvent
+ * @see TextUserAlertFeedEvent
+ */
+public interface UserAlertFeedEvent {}

--- a/src/main/java/network/crypta/runtime/alerts/feed/UserAlertFeedSubscriber.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/UserAlertFeedSubscriber.java
@@ -1,0 +1,28 @@
+package network.crypta.runtime.alerts.feed;
+
+/**
+ * Runtime-owned sink for user-alert feed events.
+ *
+ * <p>{@link network.crypta.runtime.alerts.UserAlertManager} uses this interface to publish alerts
+ * without knowing which endpoint or protocol is listening. Implementations are typically
+ * lightweight adapters around a concrete delivery mechanism such as FCP, but the runtime itself
+ * only depends on the act of sending an immutable {@link UserAlertFeedEvent}.
+ *
+ * <p>Implementations should define clear equality and lifecycle semantics when callers use them as
+ * watch or unwatch keys.
+ */
+public interface UserAlertFeedSubscriber {
+  /**
+   * Delivers one runtime-owned feed event to the subscriber.
+   *
+   * <p>The caller supplies an immutable event snapshot and expects the implementation to encode or
+   * forward it using its own transport-specific rules. Implementations may reject unsupported or
+   * malformed events by throwing a runtime exception, but they should not mutate the supplied
+   * object.
+   *
+   * @param event immutable runtime-owned event snapshot to deliver to the subscriber
+   * @throws NullPointerException if the implementation requires a non-null event and {@code event}
+   *     is {@code null}
+   */
+  void send(UserAlertFeedEvent event);
+}

--- a/src/main/java/network/crypta/runtime/alerts/feed/package-info.java
+++ b/src/main/java/network/crypta/runtime/alerts/feed/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Runtime-owned alert feed seam.
+ *
+ * <p>This package holds the immutable event and subscriber types that let {@code
+ * network.crypta.runtime.alerts} publish user-alert feed updates without depending on any specific
+ * endpoint protocol. The types here intentionally describe runtime concepts only: alert text,
+ * bookmark or URI payloads, node-to-node provenance metadata, and the minimal subscriber callback
+ * used by {@code UserAlertManager}.
+ *
+ * <p>Protocol-specific encoding stays outside this package. That split lets the runtime own alert
+ * semantics and tests while endpoint packages, such as the FCP bridge, remain responsible for wire
+ * names, bucket layouts, and transport lifecycle.
+ */
+package network.crypta.runtime.alerts.feed;

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/CoreFcpMessageRuntimeSupport.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/CoreFcpMessageRuntimeSupport.java
@@ -82,9 +82,9 @@ record CoreFcpMessageRuntimeSupport(NodeClientCore core) implements FcpMessageRu
   @Override
   public void watchFeeds(FCPConnectionHandler handler, boolean enabled) {
     if (enabled) {
-      core.getAlerts().watch(handler);
+      core.getAlerts().watch(new FcpUserAlertFeedSubscriber(handler));
     } else {
-      core.getAlerts().unwatch(handler);
+      core.getAlerts().unwatch(new FcpUserAlertFeedSubscriber(handler));
     }
   }
 

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedMessageFactory.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedMessageFactory.java
@@ -1,0 +1,132 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.util.Objects;
+import network.crypta.clients.fcp.BookmarkFeed;
+import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.clients.fcp.FeedMessage;
+import network.crypta.clients.fcp.N2NFeedMessageParams;
+import network.crypta.clients.fcp.TextFeedMessage;
+import network.crypta.clients.fcp.URIFeedMessage;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.BookmarkUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.NodeToNodeFeedMetadata;
+import network.crypta.runtime.alerts.feed.TextUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UriUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
+
+/**
+ * Converts runtime-owned alert feed events into concrete FCP feed message instances.
+ *
+ * <p>This factory is the narrow bridge between the transport-neutral alert seam in {@code
+ * network.crypta.runtime.alerts.feed} and the long-standing FCP message classes under {@code
+ * network.crypta.clients.fcp}. Its main job is to recreate the same message kinds, header fields,
+ * bucket payloads, and node-to-node metadata that the old direct alert implementations emitted
+ * before the seam was introduced.
+ *
+ * <p>The factory is stateless and thread-safe. Callers typically invoke {@link #create} immediately
+ * before sending a message on an FCP connection. Unsupported event types fail fast with {@link
+ * IllegalArgumentException} so new runtime event shapes do not silently disappear on the protocol
+ * boundary.
+ *
+ * @see FcpUserAlertFeedSubscriber
+ * @see UserAlertFeedEvent
+ */
+public final class FcpUserAlertFeedMessageFactory {
+  private FcpUserAlertFeedMessageFactory() {}
+
+  /**
+   * Converts one runtime-owned feed event into the matching concrete FCP message type.
+   *
+   * <p>The mapping is shape-based and preserves legacy behavior. Basic alerts become {@link
+   * FeedMessage}, bookmark recommendations become {@link BookmarkFeed}, URI announcements become
+   * {@link URIFeedMessage}, and node-to-node text messages become {@link TextFeedMessage}. The
+   * method does not mutate the supplied event and allocates a fresh FCP message instance for each
+   * invocation.
+   *
+   * @param event immutable runtime-owned feed event snapshot to encode for FCP delivery
+   * @return a new FCP message instance whose fields and payload layout match the event shape
+   * @throws NullPointerException if {@code event} is {@code null}
+   * @throws IllegalArgumentException if the event type is not one of the supported runtime feed
+   *     variants
+   */
+  public static FCPMessage create(UserAlertFeedEvent event) {
+    Objects.requireNonNull(event, "event");
+    return switch (event) {
+      case BookmarkUserAlertFeedEvent bookmarkEvent -> createBookmarkFeed(bookmarkEvent);
+      case TextUserAlertFeedEvent textEvent -> createTextFeed(textEvent);
+      case UriUserAlertFeedEvent uriEvent -> createUriFeed(uriEvent);
+      case BasicUserAlertFeedEvent basicEvent -> createBasicFeed(basicEvent);
+      default ->
+          throw new IllegalArgumentException(
+              "Unsupported user-alert feed event type: " + event.getClass());
+    };
+  }
+
+  private static FeedMessage createBasicFeed(BasicUserAlertFeedEvent event) {
+    return new FeedMessage(
+        event.header(),
+        event.shortText(),
+        event.text(),
+        event.priorityClass(),
+        event.updatedTime());
+  }
+
+  private static BookmarkFeed createBookmarkFeed(BookmarkUserAlertFeedEvent event) {
+    return new BookmarkFeed(
+        createNodeToNodeParams(
+            event.header(),
+            event.shortText(),
+            event.text(),
+            event.priorityClass(),
+            event.updatedTime(),
+            event.metadata()),
+        event.bookmarkTitle(),
+        event.uri(),
+        event.description(),
+        event.hasActiveLink());
+  }
+
+  private static URIFeedMessage createUriFeed(UriUserAlertFeedEvent event) {
+    return new URIFeedMessage(
+        createNodeToNodeParams(
+            event.header(),
+            event.shortText(),
+            event.text(),
+            event.priorityClass(),
+            event.updatedTime(),
+            event.metadata()),
+        event.uri(),
+        event.description());
+  }
+
+  private static TextFeedMessage createTextFeed(TextUserAlertFeedEvent event) {
+    return new TextFeedMessage(
+        createNodeToNodeParams(
+            event.header(),
+            event.shortText(),
+            event.text(),
+            event.priorityClass(),
+            event.updatedTime(),
+            event.metadata()),
+        event.messageText());
+  }
+
+  private static N2NFeedMessageParams createNodeToNodeParams(
+      String header,
+      String shortText,
+      String text,
+      short priorityClass,
+      long updatedTime,
+      NodeToNodeFeedMetadata metadata) {
+    return new N2NFeedMessageParams(
+        header,
+        shortText,
+        text,
+        priorityClass,
+        updatedTime,
+        metadata.sourceNodeName(),
+        metadata.composed(),
+        metadata.sent(),
+        metadata.received());
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedSubscriber.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedSubscriber.java
@@ -1,0 +1,57 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.util.Objects;
+import network.crypta.clients.fcp.FCPConnectionHandler;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedSubscriber;
+
+/**
+ * FCP-side subscriber adapter for runtime-owned user-alert feed events.
+ *
+ * <p>This record wraps an {@link FCPConnectionHandler} and implements the runtime-owned {@link
+ * UserAlertFeedSubscriber} interface so {@code UserAlertManager} can publish feed events without
+ * depending on FCP types directly. When it receives a runtime event, it delegates encoding to
+ * {@link FcpUserAlertFeedMessageFactory} and then sends the resulting protocol message on the
+ * wrapped connection.
+ *
+ * <p>Because this type is a record, equality and hashing are tied to the wrapped handler instance.
+ * That makes it suitable as a stable watch or unwatch key when FCP runtime wiring recreates the
+ * adapter around the same connection handler.
+ *
+ * @param handler active FCP connection handler that receives encoded feed messages
+ */
+public record FcpUserAlertFeedSubscriber(FCPConnectionHandler handler)
+    implements UserAlertFeedSubscriber {
+
+  /**
+   * Creates a subscriber adapter bound to one FCP connection.
+   *
+   * <p>The adapter does not own the lifecycle of the wrapped handler. Callers remain responsible
+   * for registering, unregistering, and closing the connection itself. The constructor validates
+   * only that a handler reference is present, so the later feed delivery does not fail with an
+   * ambiguous null dereference.
+   *
+   * @param handler active FCP connection handler that receives encoded feed messages
+   * @throws NullPointerException if {@code handler} is {@code null}
+   */
+  public FcpUserAlertFeedSubscriber {
+    Objects.requireNonNull(handler, "handler");
+  }
+
+  /**
+   * Sends one runtime-owned feed event through the wrapped FCP connection.
+   *
+   * <p>This method first converts the event into the matching FCP message type and then passes the
+   * encoded message to {@link FCPConnectionHandler#send(network.crypta.clients.fcp.FCPMessage)}.
+   * The call is synchronous with respect to the wrapped handler invocation and preserves the same
+   * event-to-message mapping as the legacy direct alert code path.
+   *
+   * @param event immutable runtime-owned feed event snapshot to encode and deliver
+   * @throws NullPointerException if {@code event} is {@code null}
+   * @throws IllegalArgumentException if the event type is not supported by the FCP bridge
+   */
+  @Override
+  public void send(UserAlertFeedEvent event) {
+    handler.send(FcpUserAlertFeedMessageFactory.create(event));
+  }
+}

--- a/src/test/java/network/crypta/clients/http/UserAlertsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/UserAlertsToadletTest.java
@@ -3,11 +3,11 @@ package network.crypta.clients.http;
 import java.net.URI;
 import javax.naming.SizeLimitExceededException;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.runtime.alerts.AbstractNodeToNodeFileOfferUserAlert;
 import network.crypta.runtime.alerts.NodeToNodeMessageUserAlert;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
@@ -338,7 +338,7 @@ class UserAlertsToadletTest {
     }
 
     @Override
-    public FCPMessage getFCPMessage() {
+    public UserAlertFeedEvent getFeedEvent() {
       return null;
     }
 
@@ -435,7 +435,7 @@ class UserAlertsToadletTest {
     }
 
     @Override
-    public FCPMessage getFCPMessage() {
+    public UserAlertFeedEvent getFeedEvent() {
       return null;
     }
 

--- a/src/test/java/network/crypta/node/IPDetectorManagerTest.java
+++ b/src/test/java/network/crypta/node/IPDetectorManagerTest.java
@@ -14,6 +14,7 @@ import network.crypta.compat.PortForwardProvider;
 import network.crypta.io.AddressTracker.Status;
 import network.crypta.io.comm.Peer;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.PriorityAwareExecutor;
@@ -359,7 +360,7 @@ class IPDetectorManagerTest {
           }
 
           @Override
-          public network.crypta.clients.fcp.FCPMessage getFCPMessage() {
+          public UserAlertFeedEvent getFeedEvent() {
             return null;
           }
 

--- a/src/test/java/network/crypta/runtime/alerts/BookmarkFeedUserAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/BookmarkFeedUserAlertTest.java
@@ -4,19 +4,15 @@ import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import network.crypta.clients.fcp.BookmarkFeed;
-import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.runtime.alerts.feed.BookmarkUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
@@ -211,7 +207,7 @@ class BookmarkFeedUserAlertTest {
   }
 
   @Test
-  void getFCPMessage_whenPopulated_expectBookmarkFeedWithFields() throws MalformedURLException {
+  void getFeedEvent_whenPopulated_expectBookmarkFeedWithFields() throws MalformedURLException {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Frank");
@@ -226,37 +222,29 @@ class BookmarkFeedUserAlertTest {
 
     long updatedTime = alert.getUpdatedTime();
     String expectedTitle = alert.getTitle();
-    String expectedShort = alert.getShortText();
-    int expectedPriority = alert.getPriorityClass();
     int descriptionLen = description.getBytes(StandardCharsets.UTF_8).length;
 
     // Act
-    FCPMessage msg = alert.getFCPMessage();
-
-    // Assert basic type
-    BookmarkFeed bMsg = assertInstanceOf(BookmarkFeed.class, msg);
-    assertEquals("BookmarkFeed", bMsg.getName());
+    BookmarkUserAlertFeedEvent event = (BookmarkUserAlertFeedEvent) alert.getFeedEvent();
 
     // Assert fields present and correct
-    SimpleFieldSet fs = bMsg.getFieldSet();
-    assertEquals(expectedTitle, fs.get("Header"));
-    assertEquals(expectedShort, fs.get("ShortText"));
-    assertEquals(Integer.toString(expectedPriority), fs.get("PriorityClass"));
-    assertEquals(Long.toString(updatedTime), fs.get("UpdatedTime"));
-    assertEquals("Frank", fs.get("SourceNodeName"));
-    assertEquals(uri.toString(), fs.get("URI"));
-    assertEquals(name, fs.get("Name"));
-    assertEquals("false", fs.get("HasAnActivelink"));
-    assertEquals(Integer.toString(descriptionLen), fs.get("DescriptionLength"));
-    // composed was set, sent omitted (-1), received set
-    assertEquals(Long.toString(123L), fs.get("TimeComposed"));
-    assertNull(fs.get("TimeSent"));
-    assertEquals(Long.toString(789L), fs.get("TimeReceived"));
+    assertEquals(expectedTitle, event.header());
+    assertEquals(alert.getShortText(), event.shortText());
+    assertEquals(alert.getText(), event.text());
+    assertEquals(alert.getPriorityClass(), event.priorityClass());
+    assertEquals(updatedTime, event.updatedTime());
+    assertEquals("Frank", event.metadata().sourceNodeName());
+    assertEquals(123L, event.metadata().composed());
+    assertEquals(-1L, event.metadata().sent());
+    assertEquals(789L, event.metadata().received());
+    assertEquals(name, event.bookmarkTitle());
+    assertEquals(uri, event.uri());
+    assertEquals(description, event.description());
+    assertEquals(hasAnActivelink, event.hasActiveLink());
 
-    // DataLength is the sum of bucket sizes; at least check it's >= text length + description
-    // length
+    // The feed event preserves the alert's textual content and bookmark payload.
     int textLen = alert.getText().getBytes(StandardCharsets.UTF_8).length;
-    int dataLen = Integer.parseInt(fs.get("DataLength"));
-    assertEquals(textLen + descriptionLen, dataLen);
+    assertEquals(textLen, event.text().getBytes(StandardCharsets.UTF_8).length);
+    assertEquals(descriptionLen, event.description().getBytes(StandardCharsets.UTF_8).length);
   }
 }

--- a/src/test/java/network/crypta/runtime/alerts/DatastoreTooSmallAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/DatastoreTooSmallAlertTest.java
@@ -1,16 +1,14 @@
 package network.crypta.runtime.alerts;
 
 import java.nio.file.Path;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.FeedMessage;
 import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.Version;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 
@@ -52,42 +49,18 @@ class DatastoreTooSmallAlertTest {
   private void registerSizeOptions(long storeSizeBytes, long clientCacheBytes, long slashdotBytes) {
     // Register the three size options (as sizes)
     nodeConfig.register(
-        "storeSize",
-        storeSizeBytes,
-        new Option.Meta(0, false, true, "", ""),
-        (network.crypta.config.LongCallback) null,
-        true);
+        "storeSize", storeSizeBytes, new Option.Meta(0, false, true, "", ""), null, true);
     nodeConfig.register(
-        "clientCacheSize",
-        clientCacheBytes,
-        new Option.Meta(0, false, true, "", ""),
-        (network.crypta.config.LongCallback) null,
-        true);
+        "clientCacheSize", clientCacheBytes, new Option.Meta(0, false, true, "", ""), null, true);
     nodeConfig.register(
-        "slashdotCacheSize",
-        slashdotBytes,
-        new Option.Meta(0, false, true, "", ""),
-        (network.crypta.config.LongCallback) null,
-        true);
+        "slashdotCacheSize", slashdotBytes, new Option.Meta(0, false, true, "", ""), null, true);
 
     // Also required by DATASTORE_SIZE._setDatastoreSize but not directly used here; harmless to
     // set.
+    nodeConfig.register("inputBandwidthLimit", 0, new Option.Meta(0, false, true, "", ""), null);
+    nodeConfig.register("outputBandwidthLimit", 0, new Option.Meta(0, false, true, "", ""), null);
     nodeConfig.register(
-        "inputBandwidthLimit",
-        0,
-        new Option.Meta(0, false, true, "", ""),
-        (network.crypta.config.IntCallback) null);
-    nodeConfig.register(
-        "outputBandwidthLimit",
-        0,
-        new Option.Meta(0, false, true, "", ""),
-        (network.crypta.config.IntCallback) null);
-    nodeConfig.register(
-        "slashdotCacheLifetime",
-        0L,
-        new Option.Meta(0, false, true, "", ""),
-        (network.crypta.config.LongCallback) null,
-        false);
+        "slashdotCacheLifetime", 0L, new Option.Meta(0, false, true, "", ""), null, false);
   }
 
   private void registerDismissed(String initial) {
@@ -98,10 +71,7 @@ class DatastoreTooSmallAlertTest {
       initVal = 0;
     }
     nodeConfig.register(
-        "datastoreTooSmallDismissed",
-        initVal,
-        new Option.Meta(0, false, true, "", ""),
-        (network.crypta.config.IntCallback) null);
+        "datastoreTooSmallDismissed", initVal, new Option.Meta(0, false, true, "", ""), null);
   }
 
   private static long expectedCurrentGiB(long store, long client, long slashdot) {
@@ -245,21 +215,18 @@ class DatastoreTooSmallAlertTest {
   }
 
   @Test
-  void getFCPMessage_whenCalled_containsTitleShortTextAndTime() {
+  void getFeedEvent_whenCalled_containsTitleShortTextAndTime() {
     registerSizeOptions(1 * GIB, 0, 0);
     registerDismissed("0");
     DatastoreTooSmallAlert alert = new DatastoreTooSmallAlert(core);
 
-    FCPMessage msg = alert.getFCPMessage();
-    assertInstanceOf(FeedMessage.class, msg, "Expected FeedMessage implementation");
+    BasicUserAlertFeedEvent event = (BasicUserAlertFeedEvent) alert.getFeedEvent();
+    assertEquals(alert.getTitle(), event.header());
+    assertEquals(alert.getShortText(), event.shortText());
+    assertEquals(alert.getText(), event.text());
+    assertEquals(UserAlert.WARNING, event.priorityClass());
 
-    SimpleFieldSet fs = msg.getFieldSet();
-    assertEquals(alert.getTitle(), fs.get("Header"));
-    assertEquals(alert.getShortText(), fs.get("ShortText"));
-    int pc = Integer.parseInt(fs.get("PriorityClass"));
-    assertEquals(UserAlert.WARNING, pc);
-
-    long updated = Long.parseLong(fs.get("UpdatedTime"));
+    long updated = event.updatedTime();
     long now = System.currentTimeMillis();
     // Within a reasonable bound of 'now'
     assertTrue(updated <= now && updated > now - 10_000L, "Updated time should be recent");

--- a/src/test/java/network/crypta/runtime/alerts/DiskSpaceUserAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/DiskSpaceUserAlertTest.java
@@ -1,12 +1,10 @@
 package network.crypta.runtime.alerts;
 
 import java.io.File;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.FeedMessage;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -14,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,11 +56,7 @@ class DiskSpaceUserAlertTest {
 
     lenient().when(core.getTempDir()).thenReturn(tempDir);
 
-    if (persistentDirOrNull == null) {
-      lenient().when(core.getPersistentTempDir()).thenReturn(null);
-    } else {
-      lenient().when(core.getPersistentTempDir()).thenReturn(persistentDirOrNull);
-    }
+    lenient().when(core.getPersistentTempDir()).thenReturn(persistentDirOrNull);
     return new DiskSpaceUserAlert(core);
   }
 
@@ -182,7 +175,7 @@ class DiskSpaceUserAlertTest {
   }
 
   @Test
-  void getFCPMessage_containsExpectedFields_andUpdatedTimeMatches() {
+  void getFeedEvent_containsExpectedFields_andUpdatedTimeMatches() {
     long shortLimit = 2_000L;
     long longLimit = 10_000L;
     File temp = new FakeFile("/tmp/temp-space", shortLimit - 1); // TRANSIENT
@@ -193,18 +186,16 @@ class DiskSpaceUserAlertTest {
     long updated = alert.getUpdatedTime();
     assertTrue(updated > 0);
 
-    FCPMessage msg = alert.getFCPMessage();
-    assertInstanceOf(FeedMessage.class, msg);
-    SimpleFieldSet fs = msg.getFieldSet();
+    BasicUserAlertFeedEvent event = (BasicUserAlertFeedEvent) alert.getFeedEvent();
 
-    assertEquals(alert.getTitle(), fs.get("Header"));
-    assertEquals(alert.getShortText(), fs.get("ShortText"));
-    assertEquals(alert.getPriorityClass(), fs.getShort("PriorityClass", (short) -1));
-    assertEquals(updated, fs.getLong("UpdatedTime", -1L));
+    assertEquals(alert.getTitle(), event.header());
+    assertEquals(alert.getShortText(), event.shortText());
+    assertEquals(text, event.text());
+    assertEquals(alert.getPriorityClass(), event.priorityClass());
+    assertEquals(updated, event.updatedTime());
 
     int textLen = text.getBytes(UTF_8).length;
-    assertEquals(textLen, fs.getInt("TextLength", -1));
-    assertEquals(textLen, fs.getInt("DataLength", -1));
+    assertEquals(textLen, event.text().getBytes(UTF_8).length);
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/alerts/DownloadFeedUserAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/DownloadFeedUserAlertTest.java
@@ -3,20 +3,16 @@ package network.crypta.runtime.alerts;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.URIFeedMessage;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.runtime.alerts.feed.UriUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
@@ -188,7 +184,7 @@ class DownloadFeedUserAlertTest {
   }
 
   @Test
-  void getFCPMessage_whenPopulated_expectURIFeedWithFields() throws MalformedURLException {
+  void getFeedEvent_whenPopulated_expectURIFeedWithFields() throws MalformedURLException {
     // Arrange
     DarknetPeerNode peer = mock(DarknetPeerNode.class);
     when(peer.getName()).thenReturn("Frank");
@@ -200,35 +196,26 @@ class DownloadFeedUserAlertTest {
 
     long updatedTime = alert.getUpdatedTime();
     String expectedTitle = alert.getTitle();
-    String expectedShort = alert.getShortText();
-    int expectedPriority = alert.getPriorityClass();
     int descriptionLen = description.getBytes(StandardCharsets.UTF_8).length;
 
     // Act
-    FCPMessage msg = alert.getFCPMessage();
-
-    // Assert basic type
-    URIFeedMessage uriMsg = assertInstanceOf(URIFeedMessage.class, msg);
-    assertEquals("URIFeed", uriMsg.getName());
+    UriUserAlertFeedEvent event = (UriUserAlertFeedEvent) alert.getFeedEvent();
 
     // Assert fields present and correct
-    SimpleFieldSet fs = uriMsg.getFieldSet();
-    assertEquals(expectedTitle, fs.get("Header"));
-    assertEquals(expectedShort, fs.get("ShortText"));
-    assertEquals(Integer.toString(expectedPriority), fs.get("PriorityClass"));
-    assertEquals(Long.toString(updatedTime), fs.get("UpdatedTime"));
-    assertEquals("Frank", fs.get("SourceNodeName"));
-    assertEquals(uri.toString(), fs.get("URI"));
-    assertEquals(Integer.toString(descriptionLen), fs.get("DescriptionLength"));
-    // composed was set, sent omitted (-1), received set
-    assertEquals(Long.toString(123L), fs.get("TimeComposed"));
-    assertNull(fs.get("TimeSent"));
-    assertEquals(Long.toString(789L), fs.get("TimeReceived"));
+    assertEquals(expectedTitle, event.header());
+    assertEquals(alert.getShortText(), event.shortText());
+    assertEquals(alert.getText(), event.text());
+    assertEquals(alert.getPriorityClass(), event.priorityClass());
+    assertEquals(updatedTime, event.updatedTime());
+    assertEquals("Frank", event.metadata().sourceNodeName());
+    assertEquals(123L, event.metadata().composed());
+    assertEquals(-1L, event.metadata().sent());
+    assertEquals(789L, event.metadata().received());
+    assertEquals(uri, event.uri());
+    assertEquals(description, event.description());
 
-    // DataLength is the sum of bucket sizes; at least check it's >= text length + description
-    // length
     int textLen = alert.getText().getBytes(StandardCharsets.UTF_8).length;
-    int dataLen = Integer.parseInt(fs.get("DataLength"));
-    assertEquals(textLen + descriptionLen, dataLen);
+    assertEquals(textLen, event.text().getBytes(StandardCharsets.UTF_8).length);
+    assertEquals(descriptionLen, event.description().getBytes(StandardCharsets.UTF_8).length);
   }
 }

--- a/src/test/java/network/crypta/runtime/alerts/DroppedOldPeersUserAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/DroppedOldPeersUserAlertTest.java
@@ -6,11 +6,10 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
-import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.PeerTooOldException;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -120,25 +119,24 @@ class DroppedOldPeersUserAlertTest {
   }
 
   @Test
-  void getFCPMessage_whenBuilt_expectFieldsMatchAlert(@TempDir java.nio.file.Path tmp) {
+  void getFeedEvent_whenBuilt_expectFieldsMatchAlert(@TempDir java.nio.file.Path tmp) {
     // Arrange
     DroppedOldPeersUserAlert alert =
         new DroppedOldPeersUserAlert(tmp.resolve("peers.bin").toFile());
     alert.add(new PeerTooOldException("r", 42, Instant.ofEpochMilli(1234)), "Zed");
 
     // Act
-    FCPMessage msg = alert.getFCPMessage();
-    SimpleFieldSet fs = msg.getFieldSet();
+    BasicUserAlertFeedEvent event = (BasicUserAlertFeedEvent) alert.getFeedEvent();
 
-    // Assert: name and key fields match, including data length matching full text bytes length
-    assertEquals("Feed", msg.getName());
-    assertEquals(alert.getTitle(), fs.get("Header"));
-    assertEquals(alert.getShortText(), fs.get("ShortText"));
-    assertEquals(String.valueOf(UserAlert.CRITICAL_ERROR), fs.get("PriorityClass"));
-    assertEquals(String.valueOf(alert.getUpdatedTime()), fs.get("UpdatedTime"));
+    // Assert: fields match the alert, including encoded plain-text length
+    assertEquals(alert.getTitle(), event.header());
+    assertEquals(alert.getShortText(), event.shortText());
+    assertEquals(alert.getText(), event.text());
+    assertEquals(UserAlert.CRITICAL_ERROR, event.priorityClass());
+    assertEquals(alert.getUpdatedTime(), event.updatedTime());
 
     int expectedLen = alert.getText().getBytes(UTF_8).length;
-    assertEquals(String.valueOf(expectedLen), fs.get("DataLength"));
+    assertEquals(expectedLen, event.text().getBytes(UTF_8).length);
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/alerts/N2NTMUserAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/N2NTMUserAlertTest.java
@@ -2,15 +2,13 @@ package network.crypta.runtime.alerts;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.TimeZone;
-import network.crypta.clients.fcp.FCPMessage;
-import network.crypta.clients.fcp.TextFeedMessage;
 import network.crypta.io.comm.Peer;
 import network.crypta.l10n.BaseL10n.LANGUAGE;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.DarknetPeerNode;
+import network.crypta.runtime.alerts.feed.TextUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -177,7 +176,7 @@ class N2NTMUserAlertTest {
   }
 
   @Test
-  void getFCPMessage_whenConstructed_expectFieldSetContainsSourceAndTimes() throws Exception {
+  void getFeedEvent_whenConstructed_expectFieldSetContainsSourceAndTimes() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
     when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
@@ -193,24 +192,24 @@ class N2NTMUserAlertTest {
         new N2NTMUserAlert(alertContext(7, composed, sent, received), messageText, 123L);
 
     // Act
-    FCPMessage fcp = alert.getFCPMessage();
+    TextUserAlertFeedEvent event = (TextUserAlertFeedEvent) alert.getFeedEvent();
 
     // Assert
-    assertNotNull(fcp, "FCP message must not be null");
-    assertEquals(TextFeedMessage.NAME, fcp.getName());
-    var fs = fcp.getFieldSet();
-    assertEquals("Alice", fs.get("SourceNodeName"));
-    assertEquals(Long.toString(composed), fs.get("TimeComposed"));
-    assertEquals(Long.toString(sent), fs.get("TimeSent"));
-    assertEquals(Long.toString(received), fs.get("TimeReceived"));
-    // Verify the additional bucket length for MessageText is present and equals payload size
-    assertEquals(
-        Integer.toString(messageText.getBytes(StandardCharsets.UTF_8).length),
-        fs.get("MessageTextLength"));
+    assertNotNull(event, "Feed event must not be null");
+    assertEquals("Alice", event.metadata().sourceNodeName());
+    assertEquals(composed, event.metadata().composed());
+    assertEquals(sent, event.metadata().sent());
+    assertEquals(received, event.metadata().received());
+    assertEquals(messageText, event.messageText());
+    assertEquals(alert.getTitle(), event.header());
+    assertEquals(alert.getShortText(), event.shortText());
+    assertEquals(alert.getText(), event.text());
+    assertEquals(alert.getPriorityClass(), event.priorityClass());
+    assertEquals(alert.getUpdatedTime(), event.updatedTime());
   }
 
   @Test
-  void getFCPMessage_whenMessageNull_expectZeroLengthMessageTextBucket() throws Exception {
+  void getFeedEvent_whenMessageNull_expectNullMessageText() throws Exception {
     // Arrange
     Peer peer = new Peer("example.com:1234", true);
     when(mockPeerNode.getWeakRef()).thenReturn(new WeakReference<>(mockPeerNode));
@@ -219,10 +218,10 @@ class N2NTMUserAlertTest {
     N2NTMUserAlert alert = new N2NTMUserAlert(alertContext(7, 0L, 1_000L, 2_000L), null, 123L);
 
     // Act
-    FCPMessage fcp = alert.getFCPMessage();
+    TextUserAlertFeedEvent event = (TextUserAlertFeedEvent) alert.getFeedEvent();
 
     // Assert
-    assertEquals("0", fcp.getFieldSet().get("MessageTextLength"));
+    assertNull(event.messageText());
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/alerts/SimpleUserAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/SimpleUserAlertTest.java
@@ -1,9 +1,8 @@
 package network.crypta.runtime.alerts;
 
-import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -95,7 +94,7 @@ class SimpleUserAlertTest {
   }
 
   @Test
-  void getFCPMessage_whenCalled_expectFeedFieldsReflectAlert() {
+  void getFeedEvent_whenCalled_expectFeedFieldsReflectAlert() {
     // Arrange
     String title = "Feed Title";
     String text = "Feed body text";
@@ -107,18 +106,17 @@ class SimpleUserAlertTest {
     assertTrue(updatedTime > 0L);
 
     // Act
-    FCPMessage msg = alert.getFCPMessage();
-    SimpleFieldSet fs = msg.getFieldSet();
+    BasicUserAlertFeedEvent event = (BasicUserAlertFeedEvent) alert.getFeedEvent();
 
     // Assert
-    assertEquals("Feed", msg.getName());
-    assertEquals(title, fs.get("Header"));
-    assertEquals(shortText, fs.get("ShortText"));
-    assertEquals(String.valueOf(priority), fs.get("PriorityClass"));
-    assertEquals(String.valueOf(updatedTime), fs.get("UpdatedTime"));
+    assertEquals(title, event.header());
+    assertEquals(shortText, event.shortText());
+    assertEquals(text, event.text());
+    assertEquals(priority, event.priorityClass());
+    assertEquals(updatedTime, event.updatedTime());
 
-    // Data length is encoded length of the plain text
+    // Basic feed events preserve the plain-text body exactly as exposed by the alert.
     int expectedLen = text.getBytes(UTF_8).length;
-    assertEquals(String.valueOf(expectedLen), fs.get("DataLength"));
+    assertEquals(expectedLen, event.text().getBytes(UTF_8).length);
   }
 }

--- a/src/test/java/network/crypta/runtime/alerts/TimeSkewDetectedUserAlertTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/TimeSkewDetectedUserAlertTest.java
@@ -1,9 +1,8 @@
 package network.crypta.runtime.alerts;
 
-import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,8 +83,8 @@ class TimeSkewDetectedUserAlertTest {
   }
 
   @Test
-  @DisplayName("getFCPMessage_whenCalled_containsExpectedFields")
-  void getFCPMessage_whenCalled_containsExpectedFields() {
+  @DisplayName("getFeedEvent_whenCalled_containsExpectedFields")
+  void getFeedEvent_whenCalled_containsExpectedFields() {
     // Arrange
     TimeSkewDetectedUserAlert alert = new TimeSkewDetectedUserAlert();
     long updated = alert.getUpdatedTime();
@@ -95,17 +94,16 @@ class TimeSkewDetectedUserAlertTest {
     String shortText = NodeL10n.getBase().getString("TimeSkewDetectedUserAlert.shortText");
 
     // Act
-    FCPMessage msg = alert.getFCPMessage();
-    SimpleFieldSet fs = msg.getFieldSet();
+    BasicUserAlertFeedEvent event = (BasicUserAlertFeedEvent) alert.getFeedEvent();
 
-    // Assert: message name and fields match the alert
-    assertEquals("Feed", msg.getName());
-    assertEquals(title, fs.get("Header"));
-    assertEquals(shortText, fs.get("ShortText"));
-    assertEquals(String.valueOf(UserAlert.CRITICAL_ERROR), fs.get("PriorityClass"));
-    assertEquals(String.valueOf(updated), fs.get("UpdatedTime"));
+    // Assert: event fields match the alert
+    assertEquals(title, event.header());
+    assertEquals(shortText, event.shortText());
+    assertEquals(text, event.text());
+    assertEquals(UserAlert.CRITICAL_ERROR, event.priorityClass());
+    assertEquals(updated, event.updatedTime());
 
     int expectedLen = text.getBytes(UTF_8).length;
-    assertEquals(String.valueOf(expectedLen), fs.get("DataLength"));
+    assertEquals(expectedLen, event.text().getBytes(UTF_8).length);
   }
 }

--- a/src/test/java/network/crypta/runtime/alerts/UserAlertManagerTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/UserAlertManagerTest.java
@@ -12,13 +12,13 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 import network.crypta.client.async.ClientContext;
-import network.crypta.clients.fcp.FCPConnectionHandler;
-import network.crypta.clients.fcp.FCPMessage;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.L10nTestUtils;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedSubscriber;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.PriorityAwareExecutor;
 import org.junit.jupiter.api.AfterEach;
@@ -704,20 +704,20 @@ class UserAlertManagerTest {
             "invalid");
     userAlertManager.register(validAlert);
     userAlertManager.register(invalidAlert);
-    FCPConnectionHandler subscriber = mock(FCPConnectionHandler.class);
+    UserAlertFeedSubscriber subscriber = mock(UserAlertFeedSubscriber.class);
 
     // Act
     userAlertManager.watch(subscriber);
 
     // Assert
-    verify(subscriber).send(validAlert.getFCPMessage());
-    verify(subscriber, never()).send(invalidAlert.getFCPMessage());
+    verify(subscriber).send(validAlert.getFeedEvent());
+    verify(subscriber, never()).send(invalidAlert.getFeedEvent());
   }
 
   @Test
   void watch_whenNewAlertRegistered_expectSubscriberNotified() {
     // Arrange
-    FCPConnectionHandler subscriber = mock(FCPConnectionHandler.class);
+    UserAlertFeedSubscriber subscriber = mock(UserAlertFeedSubscriber.class);
     userAlertManager.watch(subscriber);
     TestAlert alert =
         new TestAlert(
@@ -727,13 +727,13 @@ class UserAlertManagerTest {
     userAlertManager.register(alert);
 
     // Assert
-    verify(subscriber).send(alert.getFCPMessage());
+    verify(subscriber).send(alert.getFeedEvent());
   }
 
   @Test
   void unwatch_whenSubscriberRemoved_expectNoFurtherNotifications() {
     // Arrange
-    FCPConnectionHandler subscriber = mock(FCPConnectionHandler.class);
+    UserAlertFeedSubscriber subscriber = mock(UserAlertFeedSubscriber.class);
     userAlertManager.watch(subscriber);
     userAlertManager.unwatch(subscriber);
     TestAlert alert =
@@ -794,7 +794,7 @@ class UserAlertManagerTest {
     private final boolean eventNotification;
     private final long updatedTime;
     private final String anchor;
-    private final FCPMessage fcpMessage;
+    private final UserAlertFeedEvent feedEvent;
     private boolean dismissed;
 
     private TestAlert(
@@ -818,7 +818,7 @@ class UserAlertManagerTest {
       this.eventNotification = eventNotification;
       this.updatedTime = updatedTime;
       this.anchor = anchor;
-      this.fcpMessage = mock(FCPMessage.class);
+      this.feedEvent = mock(UserAlertFeedEvent.class);
     }
 
     @Override
@@ -837,8 +837,8 @@ class UserAlertManagerTest {
     }
 
     @Override
-    public FCPMessage getFCPMessage() {
-      return fcpMessage;
+    public UserAlertFeedEvent getFeedEvent() {
+      return feedEvent;
     }
 
     @Override

--- a/src/test/java/network/crypta/runtime/alerts/feed/UserAlertFeedEventRecordsTest.java
+++ b/src/test/java/network/crypta/runtime/alerts/feed/UserAlertFeedEventRecordsTest.java
@@ -1,0 +1,79 @@
+package network.crypta.runtime.alerts.feed;
+
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class UserAlertFeedEventRecordsTest {
+
+  @Test
+  void basicUserAlertFeedEvent_whenTextNull_expectNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new BasicUserAlertFeedEvent("header", "short", null, (short) 1, 123L));
+  }
+
+  @Test
+  void bookmarkUserAlertFeedEvent_whenMetadataNull_expectNullPointerException() throws Exception {
+    FreenetURI uri = new FreenetURI("KSK@bookmark.txt");
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new BookmarkUserAlertFeedEvent(
+                "header", "short", "text", (short) 1, 123L, null, "Bookmark", uri, null, true));
+  }
+
+  @Test
+  void bookmarkUserAlertFeedEvent_whenUriNull_expectNullPointerException() {
+    NodeToNodeFeedMetadata metadata = new NodeToNodeFeedMetadata("source", 1L, 2L, 3L);
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new BookmarkUserAlertFeedEvent(
+                "header",
+                "short",
+                "text",
+                (short) 1,
+                123L,
+                metadata,
+                "Bookmark",
+                null,
+                null,
+                true));
+  }
+
+  @Test
+  void uriUserAlertFeedEvent_whenUriNull_expectNullPointerException() {
+    NodeToNodeFeedMetadata metadata = new NodeToNodeFeedMetadata("source", 1L, 2L, 3L);
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new UriUserAlertFeedEvent(
+                "header", "short", "text", (short) 1, 123L, metadata, null, null));
+  }
+
+  @Test
+  void textUserAlertFeedEvent_whenMessageTextNull_expectNullAllowed() {
+    NodeToNodeFeedMetadata metadata = new NodeToNodeFeedMetadata("source", 1L, 2L, 3L);
+
+    TextUserAlertFeedEvent event =
+        new TextUserAlertFeedEvent("header", "short", "text", (short) 1, 123L, metadata, null);
+
+    assertEquals(metadata, event.metadata());
+    assertNull(event.messageText());
+  }
+
+  @Test
+  void textUserAlertFeedEvent_whenMetadataNull_expectNullPointerException() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new TextUserAlertFeedEvent("header", "short", "text", (short) 1, 123L, null, "x"));
+  }
+}

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/CoreFcpMessageRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/CoreFcpMessageRuntimeSupportTest.java
@@ -10,12 +10,14 @@ import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Type;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.feed.UserAlertFeedSubscriber;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,11 +31,29 @@ class CoreFcpMessageRuntimeSupportTest {
 
   @Mock private NodeClientCore core;
   @Mock private HighLevelSimpleClient client;
-  @Mock private UserAlertManager alerts;
   @Mock private Node node;
   @Mock private NodeNetworkSubsystem network;
   @Mock private PeerNode peerNode;
   @Mock private FCPConnectionHandler handler;
+
+  private static final class RecordingAlerts extends UserAlertManager {
+    private FcpUserAlertFeedSubscriber watched;
+    private FcpUserAlertFeedSubscriber unwatched;
+
+    private RecordingAlerts() {
+      super(org.mockito.Mockito.mock(NodeClientCore.class));
+    }
+
+    @Override
+    public void watch(UserAlertFeedSubscriber subscriber) {
+      watched = (FcpUserAlertFeedSubscriber) subscriber;
+    }
+
+    @Override
+    public void unwatch(UserAlertFeedSubscriber subscriber) {
+      unwatched = (FcpUserAlertFeedSubscriber) subscriber;
+    }
+  }
 
   @Test
   void constructor_whenCoreNull_throwsNullPointerException() {
@@ -54,23 +74,41 @@ class CoreFcpMessageRuntimeSupportTest {
   }
 
   @Test
-  void watchFeeds_whenEnabledTrue_watchesHandler() {
-    when(core.getAlerts()).thenReturn(alerts);
+  void watchFeeds_whenEnabledTrue_wrapsHandlerInFeedSubscriber() {
+    RecordingAlerts recordingAlerts = new RecordingAlerts();
+    when(core.getAlerts()).thenReturn(recordingAlerts);
     CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
 
     support.watchFeeds(handler, true);
 
-    verify(alerts).watch(handler);
+    assertNotNull(recordingAlerts.watched);
+    assertSame(handler, recordingAlerts.watched.handler());
   }
 
   @Test
-  void watchFeeds_whenEnabledFalse_unwatchesHandler() {
-    when(core.getAlerts()).thenReturn(alerts);
+  void watchFeeds_whenEnabledFalse_wrapsHandlerInFeedSubscriber() {
+    RecordingAlerts recordingAlerts = new RecordingAlerts();
+    when(core.getAlerts()).thenReturn(recordingAlerts);
     CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
 
     support.watchFeeds(handler, false);
 
-    verify(alerts).unwatch(handler);
+    assertNotNull(recordingAlerts.unwatched);
+    assertSame(handler, recordingAlerts.unwatched.handler());
+  }
+
+  @Test
+  void watchFeeds_whenSameHandlerToggled_expectStableSubscriberEquality() {
+    RecordingAlerts recordingAlerts = new RecordingAlerts();
+    when(core.getAlerts()).thenReturn(recordingAlerts);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    support.watchFeeds(handler, true);
+    support.watchFeeds(handler, false);
+
+    assertNotNull(recordingAlerts.watched);
+    assertNotNull(recordingAlerts.unwatched);
+    assertEquals(recordingAlerts.watched, recordingAlerts.unwatched);
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedMessageFactoryTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedMessageFactoryTest.java
@@ -1,0 +1,155 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.nio.charset.StandardCharsets;
+import network.crypta.clients.fcp.BookmarkFeed;
+import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.clients.fcp.FeedMessage;
+import network.crypta.clients.fcp.TextFeedMessage;
+import network.crypta.clients.fcp.URIFeedMessage;
+import network.crypta.keys.FreenetURI;
+import network.crypta.runtime.alerts.feed.BasicUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.BookmarkUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.NodeToNodeFeedMetadata;
+import network.crypta.runtime.alerts.feed.TextUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UriUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class FcpUserAlertFeedMessageFactoryTest {
+
+  @Test
+  void create_whenBasicEvent_expectFeedMessageWithTextPayloadMetadata() {
+    String text = "body\nline2";
+    BasicUserAlertFeedEvent event = new BasicUserAlertFeedEvent("h", "s", text, (short) 2, 123L);
+
+    FCPMessage message = FcpUserAlertFeedMessageFactory.create(event);
+
+    FeedMessage feed = assertInstanceOf(FeedMessage.class, message);
+    assertEquals(FeedMessage.NAME, feed.getName());
+    assertEquals("h", feed.getFieldSet().get("Header"));
+    assertEquals("s", feed.getFieldSet().get("ShortText"));
+    assertEquals("2", feed.getFieldSet().get("PriorityClass"));
+    assertEquals("123", feed.getFieldSet().get("UpdatedTime"));
+    assertEquals(String.valueOf(utf8Length(text)), feed.getFieldSet().get("TextLength"));
+    assertEquals(String.valueOf(utf8Length(text)), feed.getFieldSet().get("DataLength"));
+  }
+
+  @Test
+  void create_whenBookmarkEvent_expectBookmarkFeedWithNodeMetadataAndDescriptionPayload()
+      throws Exception {
+    FreenetURI uri = new FreenetURI("KSK@gpl.txt");
+    String text = "full text";
+    String description = "Description";
+    BookmarkUserAlertFeedEvent event =
+        new BookmarkUserAlertFeedEvent(
+            "h",
+            "s",
+            text,
+            (short) 1,
+            234L,
+            new NodeToNodeFeedMetadata("source", 11L, 22L, 33L),
+            "Bookmark Title",
+            uri,
+            description,
+            true);
+
+    FCPMessage message = FcpUserAlertFeedMessageFactory.create(event);
+
+    BookmarkFeed feed = assertInstanceOf(BookmarkFeed.class, message);
+    assertEquals(BookmarkFeed.NAME, feed.getName());
+    assertEquals("source", feed.getFieldSet().get("SourceNodeName"));
+    assertEquals("11", feed.getFieldSet().get("TimeComposed"));
+    assertEquals("22", feed.getFieldSet().get("TimeSent"));
+    assertEquals("33", feed.getFieldSet().get("TimeReceived"));
+    assertEquals("Bookmark Title", feed.getFieldSet().get("Name"));
+    assertEquals(uri.toString(), feed.getFieldSet().get("URI"));
+    assertEquals("true", feed.getFieldSet().get("HasAnActivelink"));
+    assertEquals(String.valueOf(utf8Length(text)), feed.getFieldSet().get("TextLength"));
+    assertEquals(
+        String.valueOf(utf8Length(description)), feed.getFieldSet().get("DescriptionLength"));
+    assertEquals(
+        String.valueOf(utf8Length(text) + utf8Length(description)),
+        feed.getFieldSet().get("DataLength"));
+  }
+
+  @Test
+  void create_whenUriEventDescriptionMissing_expectNullBucketLengthAndUnknownTimesOmitted()
+      throws Exception {
+    FreenetURI uri = new FreenetURI("KSK@uri.txt");
+    String text = "full text";
+    UriUserAlertFeedEvent event =
+        new UriUserAlertFeedEvent(
+            "h",
+            "s",
+            text,
+            (short) 3,
+            345L,
+            new NodeToNodeFeedMetadata("source", -1L, 55L, -1L),
+            uri,
+            null);
+
+    FCPMessage message = FcpUserAlertFeedMessageFactory.create(event);
+
+    URIFeedMessage feed = assertInstanceOf(URIFeedMessage.class, message);
+    assertEquals(URIFeedMessage.NAME, feed.getName());
+    assertEquals(uri.toString(), feed.getFieldSet().get("URI"));
+    assertEquals("source", feed.getFieldSet().get("SourceNodeName"));
+    assertNull(feed.getFieldSet().get("TimeComposed"));
+    assertEquals("55", feed.getFieldSet().get("TimeSent"));
+    assertNull(feed.getFieldSet().get("TimeReceived"));
+    assertEquals("0", feed.getFieldSet().get("DescriptionLength"));
+    assertEquals(String.valueOf(utf8Length(text)), feed.getFieldSet().get("TextLength"));
+    assertEquals(String.valueOf(utf8Length(text)), feed.getFieldSet().get("DataLength"));
+  }
+
+  @Test
+  void create_whenTextEventMessageMissing_expectTextFeedMessageWithNullBucketAndTimes() {
+    String text = "full text";
+    TextUserAlertFeedEvent event =
+        new TextUserAlertFeedEvent(
+            "h",
+            "s",
+            text,
+            (short) 4,
+            456L,
+            new NodeToNodeFeedMetadata("source", 77L, -1L, 99L),
+            null);
+
+    FCPMessage message = FcpUserAlertFeedMessageFactory.create(event);
+
+    TextFeedMessage feed = assertInstanceOf(TextFeedMessage.class, message);
+    assertEquals(TextFeedMessage.NAME, feed.getName());
+    assertEquals("source", feed.getFieldSet().get("SourceNodeName"));
+    assertEquals("77", feed.getFieldSet().get("TimeComposed"));
+    assertNull(feed.getFieldSet().get("TimeSent"));
+    assertEquals("99", feed.getFieldSet().get("TimeReceived"));
+    assertEquals("0", feed.getFieldSet().get("MessageTextLength"));
+    assertEquals(String.valueOf(utf8Length(text)), feed.getFieldSet().get("TextLength"));
+    assertEquals(String.valueOf(utf8Length(text)), feed.getFieldSet().get("DataLength"));
+  }
+
+  @Test
+  void create_whenEventNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> FcpUserAlertFeedMessageFactory.create(null));
+  }
+
+  @Test
+  void create_whenEventTypeUnsupported_expectIllegalArgumentException() {
+    UnsupportedUserAlertFeedEvent event = new UnsupportedUserAlertFeedEvent();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> FcpUserAlertFeedMessageFactory.create(event));
+  }
+
+  private static int utf8Length(String value) {
+    return value.getBytes(StandardCharsets.UTF_8).length;
+  }
+
+  private static final class UnsupportedUserAlertFeedEvent implements UserAlertFeedEvent {}
+}

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedSubscriberTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpUserAlertFeedSubscriberTest.java
@@ -1,0 +1,86 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.clients.fcp.BookmarkFeed;
+import network.crypta.clients.fcp.FCPConnectionHandler;
+import network.crypta.clients.fcp.FCPMessage;
+import network.crypta.keys.FreenetURI;
+import network.crypta.runtime.alerts.feed.BookmarkUserAlertFeedEvent;
+import network.crypta.runtime.alerts.feed.NodeToNodeFeedMetadata;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@SuppressWarnings("java:S100")
+class FcpUserAlertFeedSubscriberTest {
+
+  @Test
+  void constructor_whenHandlerNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new FcpUserAlertFeedSubscriber(null));
+  }
+
+  @Test
+  void equals_whenWrappedHandlerMatches_expectEqualSubscriber() {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+
+    FcpUserAlertFeedSubscriber first = new FcpUserAlertFeedSubscriber(handler);
+    FcpUserAlertFeedSubscriber second = new FcpUserAlertFeedSubscriber(handler);
+
+    assertEquals(first, second);
+    assertEquals(first.hashCode(), second.hashCode());
+  }
+
+  @Test
+  void equals_whenWrappedHandlerDiffers_expectNotEqualSubscriber() {
+    FcpUserAlertFeedSubscriber first =
+        new FcpUserAlertFeedSubscriber(mock(FCPConnectionHandler.class));
+    FcpUserAlertFeedSubscriber second =
+        new FcpUserAlertFeedSubscriber(mock(FCPConnectionHandler.class));
+
+    assertNotEquals(first, second);
+  }
+
+  @Test
+  void send_whenBookmarkEvent_expectEncodedBookmarkFeedSentToHandler() throws Exception {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    FcpUserAlertFeedSubscriber subscriber = new FcpUserAlertFeedSubscriber(handler);
+    FreenetURI uri = new FreenetURI("KSK@bookmark.txt");
+    BookmarkUserAlertFeedEvent event =
+        new BookmarkUserAlertFeedEvent(
+            "header",
+            "short",
+            "text",
+            (short) 1,
+            123L,
+            new NodeToNodeFeedMetadata("source", 11L, 22L, 33L),
+            "Bookmark",
+            uri,
+            "Description",
+            true);
+    ArgumentCaptor<FCPMessage> messageCaptor = ArgumentCaptor.forClass(FCPMessage.class);
+
+    subscriber.send(event);
+
+    verify(handler).send(messageCaptor.capture());
+    BookmarkFeed feed = assertInstanceOf(BookmarkFeed.class, messageCaptor.getValue());
+    assertEquals("Bookmark", feed.getFieldSet().get("Name"));
+    assertEquals(uri.toString(), feed.getFieldSet().get("URI"));
+    assertEquals("source", feed.getFieldSet().get("SourceNodeName"));
+  }
+
+  @Test
+  void send_whenEventNull_expectNullPointerExceptionWithoutHandlerInteraction() {
+    FCPConnectionHandler handler = mock(FCPConnectionHandler.class);
+    FcpUserAlertFeedSubscriber subscriber = new FcpUserAlertFeedSubscriber(handler);
+
+    assertThrows(NullPointerException.class, () -> subscriber.send(null));
+
+    verifyNoInteractions(handler);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce the runtime-owned `network.crypta.runtime.alerts.feed` seam for user-alert feed events and subscribers
- replace direct `runtime.alerts -> clients.fcp` message construction with runtime feed events and a thin FCP bridge in `network.crypta.runtime.endpoints.fcp`
- update `UserAlertManager`, runtime alert implementations, FCP runtime wiring, affected tests, and Javadocs while preserving existing alert/FCP behavior

## How to test
- `./gradlew test --tests "network.crypta.runtime.endpoints.fcp.FcpUserAlertFeedMessageFactoryTest"`
- `./gradlew test --tests "network.crypta.runtime.alerts.*" --tests "network.crypta.runtime.alerts.feed.*" --tests "network.crypta.runtime.endpoints.fcp.*" --tests "network.crypta.clients.http.UserAlertsToadletTest" --tests "network.crypta.node.IPDetectorManagerTest"`
- `./gradlew compileJava`

## Notes
- this is a behavior-preserving prep change for PR-95
- `src/main/java/network/crypta/runtime/alerts/**` no longer imports `network.crypta.clients.fcp.*` directly
- FCP subscribers still receive the same message kinds through the new adapter layer: `FeedMessage`, `BookmarkFeed`, `URIFeedMessage`, and `TextFeedMessage`