### PR TITLE
refactor(runtime-admin): Prepare queue admin decoupling

### DIFF
--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -2,6 +2,8 @@ package network.crypta.runtime.admin;
 
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
 
 /**
  * Creates the legacy admin and page-oriented runtime SPI adapters as one package-owned bundle.
@@ -34,19 +36,20 @@ public final class AdminRuntimePortsFactory {
    * @return immutable bundle containing the moved admin and page-oriented runtime adapters
    */
   public static AdminRuntimePortsBundle create(Node node, NodeClientCore core) {
+    QueueAdminBackend queueBackend = new FcpQueueAdminBackend(core);
     return new AdminRuntimePortsBundle(
         new LegacyConnectionsPagePort(node, core),
         new LegacyConnectionsSupportPort(node),
         new LegacyDarknetConnectionsPort(node),
         new LegacyDarknetMessagingPort(node),
-        new LegacyDiagnosticPort(node, core),
+        new LegacyDiagnosticPort(node, core, queueBackend),
         new LegacyPageChromePort(node),
         new LegacyQueueCompletionPort(core),
         new LegacyQueuePagePort(core),
         new LegacyQueueDownloadPort(core),
         new LegacyQueueInsertPort(core),
-        new LegacyQueueMutationPort(core),
-        new LegacyQueueSupportPort(core),
+        new LegacyQueueMutationPort(queueBackend),
+        new LegacyQueueSupportPort(core, queueBackend),
         new LegacyStatisticsPort(node, core),
         new LegacyFirstTimeWizardPort(node, core),
         new LegacyToadletSymlinkPort(node, core),

--- a/src/main/java/network/crypta/runtime/admin/LegacyDiagnosticPort.java
+++ b/src/main/java/network/crypta/runtime/admin/LegacyDiagnosticPort.java
@@ -10,13 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentStatsPutter;
-import network.crypta.clients.fcp.DownloadRequestStatus;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.RequestStatus;
-import network.crypta.clients.fcp.UploadDirRequestStatus;
-import network.crypta.clients.fcp.UploadFileRequestStatus;
 import network.crypta.config.SubConfig;
 import network.crypta.fs.AppEnv;
 import network.crypta.io.xfer.BlockReceiver;
@@ -34,6 +28,11 @@ import network.crypta.node.stats.DataStoreInstanceType;
 import network.crypta.node.stats.DataStoreStats;
 import network.crypta.node.stats.StatsNotAvailableException;
 import network.crypta.node.stats.StoreAccessStats;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.QueueDownloadStatusView;
+import network.crypta.runtime.admin.queue.QueueRequestStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadDirStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadFileStatusView;
 import network.crypta.runtime.diagnostics.NodeDiagnostics;
 import network.crypta.runtime.diagnostics.ThreadDiagnostics;
 import network.crypta.runtime.diagnostics.threads.NodeThreadInfo;
@@ -41,6 +40,7 @@ import network.crypta.runtime.diagnostics.threads.NodeThreadSnapshot;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.DiagnosticReportSnapshot;
 import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.support.BandwidthStatsContainer;
 import network.crypta.support.SizeUtil;
 
@@ -50,8 +50,8 @@ import network.crypta.support.SizeUtil;
  * <p>This adapter keeps the existing diagnostic traversal inside the daemon root module while
  * exposing only detached line-oriented report sections to higher layers. It preserves the legacy
  * `/diagnostic/` page's plain-text structure, queue aggregation, peer counting, bandwidth summary,
- * and thread-diagnostics formatting without leaking {@link Node}, {@link FCPServer}, request
- * status, or thread snapshot types across the runtime boundary.
+ * and thread-diagnostics formatting without leaking {@link Node}, queue-backend implementation
+ * details, or thread snapshot types across the runtime boundary.
  *
  * <p>The adapter is intentionally report-oriented for this slice. It does not define a reusable
  * metrics schema, and it does not perform HTTP access control. Callers request one snapshot per
@@ -109,8 +109,11 @@ final class LegacyDiagnosticPort implements DiagnosticPort {
   /** Live daemon node traversed while building one detached diagnostic snapshot. */
   private final Node node;
 
-  /** Live client core used for bandwidth persistence and FCP queue access. */
+  /** Live client core used for bandwidth persistence access. */
   private final NodeClientCore core;
+
+  /** Runtime-owned queue backend seam used for queue diagnostics. */
+  private final QueueAdminBackend queueBackend;
 
   /** Cached node statistics view used by several report sections. */
   private final NodeStats stats;
@@ -140,10 +143,12 @@ final class LegacyDiagnosticPort implements DiagnosticPort {
    *
    * @param node live daemon node whose runtime state will be traversed during snapshot creation
    * @param core live client core that exposes persistence and FCP endpoint access
+   * @param queueBackend runtime-owned queue backend seam for queue diagnostics
    */
-  LegacyDiagnosticPort(Node node, NodeClientCore core) {
+  LegacyDiagnosticPort(Node node, NodeClientCore core, QueueAdminBackend queueBackend) {
     this.node = Objects.requireNonNull(node);
     this.core = Objects.requireNonNull(core);
+    this.queueBackend = Objects.requireNonNull(queueBackend);
     this.stats = node.network().stats();
     this.peers = node.network().peers();
     this.baseL10n =
@@ -894,13 +899,13 @@ final class LegacyDiagnosticPort implements DiagnosticPort {
   private DiagnosticSectionSnapshot queueSection() {
     List<String> lines = new ArrayList<>();
     try {
-      RequestStatus[] requests = globalRequests();
+      QueueRequestStatusView[] requests = globalRequests();
       if (requests.length < 1) {
         lines.add(baseL10n.getString("QueueToadlet.globalQueueIsEmpty"));
       } else {
         appendQueueCounts(lines, requests);
       }
-    } catch (PersistenceDisabledException _) {
+    } catch (RequestQueueUnavailableException _) {
       lines.add(DATABASE_DISABLED);
     }
     lines.add("");
@@ -908,30 +913,33 @@ final class LegacyDiagnosticPort implements DiagnosticPort {
   }
 
   /**
-   * Reads the current global request list from the FCP server when present.
+   * Reads the current global request list from the queue backend.
    *
-   * @return current global request snapshots, or an empty array when no FCP server exists
-   * @throws PersistenceDisabledException if the persistence layer rejects queue access
+   * @return current global request snapshots, or an empty array when no queue server exists
+   * @throws RequestQueueUnavailableException if the persistence layer rejects queue access
    */
-  private RequestStatus[] globalRequests() throws PersistenceDisabledException {
-    FCPServer fcpServer = core.getEndpoints().getFCPServer();
-    return fcpServer == null ? new RequestStatus[0] : fcpServer.getGlobalRequests();
+  private QueueRequestStatusView[] globalRequests() throws RequestQueueUnavailableException {
+    try {
+      return queueBackend.getGlobalRequests();
+    } catch (IllegalStateException _) {
+      return new QueueRequestStatusView[0];
+    }
   }
 
   /**
    * Appends the legacy download and upload queue counts.
    *
    * @param lines destination list for rendered queue lines
-   * @param requests global request snapshots returned by the FCP server
+   * @param requests global request snapshots returned by the queue backend
    */
-  private void appendQueueCounts(List<String> lines, RequestStatus[] requests) {
+  private void appendQueueCounts(List<String> lines, QueueRequestStatusView[] requests) {
     long totalQueuedDownload = 0;
     long totalQueuedUpload = 0;
-    for (RequestStatus request : requests) {
-      if (request instanceof DownloadRequestStatus) {
+    for (QueueRequestStatusView request : requests) {
+      if (request instanceof QueueDownloadStatusView) {
         totalQueuedDownload++;
-      } else if (request instanceof UploadFileRequestStatus
-          || request instanceof UploadDirRequestStatus) {
+      } else if (request instanceof QueueUploadFileStatusView
+          || request instanceof QueueUploadDirStatusView) {
         totalQueuedUpload++;
       }
     }

--- a/src/main/java/network/crypta/runtime/admin/LegacyQueueMutationPort.java
+++ b/src/main/java/network/crypta/runtime/admin/LegacyQueueMutationPort.java
@@ -2,12 +2,10 @@ package network.crypta.runtime.admin;
 
 import java.util.List;
 import java.util.Objects;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.clients.fcp.DownloadRequestStatus;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.RequestStatus;
-import network.crypta.clients.fcp.UploadFileRequestStatus;
-import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.QueueDownloadStatusView;
+import network.crypta.runtime.admin.queue.QueueRequestStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadFileStatusView;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 
@@ -16,56 +14,38 @@ import network.crypta.runtime.spi.RequestQueueUnavailableException;
  *
  * <p>This adapter keeps the remaining existing-request queue mutations inside the daemon root
  * module while exposing only a narrow JDK-level interface to higher layers. It resolves the live
- * {@link FCPServer} lazily through {@link NodeClientCore#getEndpoints()} so construction does not
- * force early endpoint initialization during startup.
+ * queue backend lazily through a runtime-owned seam so construction does not force early endpoint
+ * initialization during startup.
  *
  * <p>The adapter preserves the current queue-mutation semantics exactly: selected identifiers are
- * forwarded directly to the legacy blocking FCP operations, and the finished-upload and
+ * forwarded directly to the blocking queue operations, and the finished-upload and
  * finished-download cleanup paths use the same status filters that the HTTP layer previously
- * applied inline. Persistence-disabled failures are translated to {@link
- * RequestQueueUnavailableException}.
- *
- * <p>Use this implementation when runtime wiring still depends on the legacy daemon internals but
- * higher layers should only see the narrow {@link QueueMutationPort} contract. The class is
- * state-light and holds only the owning {@link NodeClientCore}; each mutation resolves the live
- * {@link FCPServer} on demand so startup order remains unchanged and tests can substitute core
- * collaborators without constructing extra queue abstractions.
- *
- * <ul>
- *   <li>Selected-request mutations delegate directly to the blocking FCP operations.
- *   <li>Bulk cleanup methods preserve the legacy status filters exactly.
- *   <li>Persistence-disabled failures are mapped to the runtime-SPI exception type.
- * </ul>
+ * applied inline.
  *
  * @see QueueMutationPort
  */
 public final class LegacyQueueMutationPort implements QueueMutationPort {
-  private final NodeClientCore core;
+  private final QueueAdminBackend queueBackend;
 
   /**
-   * Creates a queue-mutation adapter backed by the supplied client core.
+   * Creates a queue-mutation adapter backed by the supplied queue backend.
    *
-   * <p>The adapter does not resolve the {@link FCPServer} during construction. Callers can
-   * therefore create it as part of early runtime-port wiring, before endpoint initialization is
-   * complete, and rely on the individual mutation methods to get the current server lazily.
+   * <p>The adapter does not force resolution of the backing queue implementation during
+   * construction. Callers can therefore create it as part of early runtime-port wiring and rely on
+   * the individual mutation methods to reach the current queue backend lazily.
    *
-   * @param core live daemon client core that provides lazy access to runtime endpoints
+   * @param queueBackend runtime-owned queue backend seam for existing-request mutations
    */
-  public LegacyQueueMutationPort(NodeClientCore core) {
-    this.core = Objects.requireNonNull(core);
+  public LegacyQueueMutationPort(QueueAdminBackend queueBackend) {
+    this.queueBackend = Objects.requireNonNull(queueBackend);
   }
 
   /** {@inheritDoc} */
   @Override
   public void removeRequests(List<String> identifiers) throws RequestQueueUnavailableException {
     Objects.requireNonNull(identifiers);
-    try {
-      FCPServer fcpServer = fcpServer();
-      for (String identifier : identifiers) {
-        fcpServer.removeGlobalRequestBlocking(identifier);
-      }
-    } catch (PersistenceDisabledException e) {
-      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
+    for (String identifier : identifiers) {
+      queueBackend.removeGlobalRequestBlocking(identifier);
     }
   }
 
@@ -74,13 +54,8 @@ public final class LegacyQueueMutationPort implements QueueMutationPort {
   public void restartRequests(List<String> identifiers, boolean disableFilterData)
       throws RequestQueueUnavailableException {
     Objects.requireNonNull(identifiers);
-    try {
-      FCPServer fcpServer = fcpServer();
-      for (String identifier : identifiers) {
-        fcpServer.restartBlocking(identifier, disableFilterData);
-      }
-    } catch (PersistenceDisabledException e) {
-      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
+    for (String identifier : identifiers) {
+      queueBackend.restartBlocking(identifier, disableFilterData);
     }
   }
 
@@ -89,23 +64,17 @@ public final class LegacyQueueMutationPort implements QueueMutationPort {
   public void changePriority(List<String> identifiers, short newPriorityClass)
       throws RequestQueueUnavailableException {
     Objects.requireNonNull(identifiers);
-    try {
-      FCPServer fcpServer = fcpServer();
-      for (String identifier : identifiers) {
-        fcpServer.modifyGlobalRequestBlocking(identifier, null, newPriorityClass);
-      }
-    } catch (PersistenceDisabledException e) {
-      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
+    for (String identifier : identifiers) {
+      queueBackend.modifyGlobalRequestBlocking(identifier, null, newPriorityClass);
     }
   }
 
   /** {@inheritDoc} */
   @Override
   public void removeFinishedUploads() throws RequestQueueUnavailableException {
-    FCPServer fcpServer = fcpServer();
-    for (RequestStatus requestStatus : globalRequests()) {
-      if (requestStatus instanceof UploadFileRequestStatus upload && upload.hasSucceeded()) {
-        removeRequest(fcpServer, upload.getIdentifier());
+    for (QueueRequestStatusView requestStatus : globalRequests()) {
+      if (requestStatus instanceof QueueUploadFileStatusView upload && upload.hasSucceeded()) {
+        queueBackend.removeGlobalRequestBlocking(upload.getIdentifier());
       }
     }
   }
@@ -113,40 +82,18 @@ public final class LegacyQueueMutationPort implements QueueMutationPort {
   /** {@inheritDoc} */
   @Override
   public void removeFinishedDownloads() throws RequestQueueUnavailableException {
-    FCPServer fcpServer = fcpServer();
-    for (RequestStatus requestStatus : globalRequests()) {
-      if (requestStatus instanceof DownloadRequestStatus download
+    for (QueueRequestStatusView requestStatus : globalRequests()) {
+      if (requestStatus instanceof QueueDownloadStatusView download
           && download.isPersistent()
           && download.hasSucceeded()
           && download.isTotalFinalized()
           && !download.toTempSpace()) {
-        removeRequest(fcpServer, download.getIdentifier());
+        queueBackend.removeGlobalRequestBlocking(download.getIdentifier());
       }
     }
   }
 
-  private void removeRequest(FCPServer fcpServer, String identifier)
-      throws RequestQueueUnavailableException {
-    try {
-      fcpServer.removeGlobalRequestBlocking(identifier);
-    } catch (PersistenceDisabledException e) {
-      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
-    }
-  }
-
-  private RequestStatus[] globalRequests() throws RequestQueueUnavailableException {
-    try {
-      return fcpServer().getGlobalRequests();
-    } catch (PersistenceDisabledException e) {
-      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
-    }
-  }
-
-  private FCPServer fcpServer() {
-    FCPServer fcpServer = core.getEndpoints().getFCPServer();
-    if (fcpServer == null) {
-      throw new IllegalStateException("FCP server unavailable");
-    }
-    return fcpServer;
+  private QueueRequestStatusView[] globalRequests() throws RequestQueueUnavailableException {
+    return queueBackend.getGlobalRequests();
   }
 }

--- a/src/main/java/network/crypta/runtime/admin/LegacyQueueSupportPort.java
+++ b/src/main/java/network/crypta/runtime/admin/LegacyQueueSupportPort.java
@@ -2,52 +2,55 @@ package network.crypta.runtime.admin;
 
 import java.io.IOException;
 import java.util.Objects;
-import network.crypta.clients.fcp.FCPServer;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
 import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
 import network.crypta.runtime.spi.QueueSupportPort;
 
 /**
  * Bridges the remaining legacy queue support helpers onto the runtime SPI.
  *
- * <p>This adapter is intentionally small. It keeps the queue backend availability check, the
- * persistence support-state inspection, and the panic start / finish sequence in the daemon root
- * module while presenting the HTTP layer with the detached contract defined by {@link
- * QueueSupportPort}. That split lets the queue toadlets preserve their current pages and flow
- * ordering without continuing to read live daemon objects directly for this support slice.
+ * <p>This adapter is intentionally small. It keeps the persistence support-state inspection and the
+ * panic start / finish sequence in the daemon root module while presenting the HTTP layer with the
+ * detached contract defined by {@link QueueSupportPort}. Queue availability itself is read through
+ * the runtime-owned queue backend seam.
  *
- * <p>The adapter does not attempt to normalize or reinterpret daemon state. It forwards the live
- * checks in the same order the legacy queue code previously used, including the short-circuit that
- * avoids resolving persistence-broken path details while the node is still awaiting a password or
- * already stopping.
+ * <p>The adapter does not attempt to normalize or reinterpret the daemon state. It forwards the
+ * live checks in the same order the legacy queue code previously used, including the short-circuit
+ * that avoids resolving persistence-broken path details while the node is still awaiting a password
+ * or already stopping.
  */
 final class LegacyQueueSupportPort implements QueueSupportPort {
   /** Shared daemon client core used to reach the live queue support state. */
   private final NodeClientCore core;
 
+  /** Runtime-owned queue backend seam used for queue availability checks. */
+  private final QueueAdminBackend queueBackend;
+
   /**
    * Creates a queue support adapter backed by the current daemon runtime.
    *
    * <p>The adapter keeps a direct reference to {@code core} because the remaining queue support
-   * helpers still span FCP availability, node persistence state, and the panic lifecycle.
+   * helpers still span node persistence state and the panic lifecycle. Queue availability is
+   * supplied separately through the runtime-owned backend seam.
    *
-   * @param core daemon client core that owns the live queue support collaborators
+   * @param core daemon client core that owns the live persistence and panic collaborators
+   * @param queueBackend queue backend seam that exposes the live queue availability state
    */
-  LegacyQueueSupportPort(NodeClientCore core) {
+  LegacyQueueSupportPort(NodeClientCore core, QueueAdminBackend queueBackend) {
     this.core = Objects.requireNonNull(core, "core");
+    this.queueBackend = Objects.requireNonNull(queueBackend, "queueBackend");
   }
 
   /**
    * {@inheritDoc}
    *
-   * <p>This implementation consults the live FCP server exported through the daemon endpoints and
-   * treats a missing server instance as disabled.
+   * <p>This implementation delegates to the runtime-owned queue backend seam.
    */
   @Override
   public boolean isQueueBackendEnabled() {
-    FCPServer fcpServer = core.getEndpoints().getFCPServer();
-    return fcpServer != null && fcpServer.isEnabled();
+    return queueBackend.isEnabled();
   }
 
   /**

--- a/src/main/java/network/crypta/runtime/admin/queue/QueueAdminBackend.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/QueueAdminBackend.java
@@ -1,0 +1,95 @@
+package network.crypta.runtime.admin.queue;
+
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+
+/**
+ * Defines the runtime-owned backend seam for the remaining legacy queue administration work.
+ *
+ * <p>This interface keeps runtime-admin detached from protocol-specific queue implementations while
+ * the broader queue extraction is still in progress. Callers use it to ask whether queue-backed
+ * administration is available, inspect the current global request list, and apply the small set of
+ * blocking mutations that the legacy HTTP adapters still expose.
+ *
+ * <p>The seam is intentionally narrow. It is not a full queue-management API, and it does not try
+ * to normalize every backend detail. Instead, it carries only the data and operations that the
+ * diagnostics, support, and mutation adapters currently need. Backends may resolve their live
+ * implementation lazily, but callers should treat each method as consulting the current queue state
+ * rather than a cached snapshot.
+ */
+public interface QueueAdminBackend {
+  /**
+   * Reports whether queue-backed administration is currently available.
+   *
+   * <p>This is a lightweight availability check used by runtime-admin before it renders queue pages
+   * or offers queue mutations. Returning {@code false} means callers should treat the queue backend
+   * as unavailable for administrative work at this moment, typically because the endpoint is
+   * disabled or absent.
+   *
+   * @return {@code true} when the live queue backend is currently enabled for admin operations
+   */
+  boolean isEnabled();
+
+  /**
+   * Returns the current global request statuses.
+   *
+   * <p>The returned array is a point-in-time view of the global queue as exposed by the backend.
+   * Callers should not assume the contents remain current after the method returns. Implementations
+   * may return an empty array when the queue is reachable but has no visible requests.
+   *
+   * @return runtime-owned status views describing the requests currently visible in the global
+   *     queue
+   * @throws RequestQueueUnavailableException if the persistent queue exists but cannot be queried
+   *     for status information
+   */
+  QueueRequestStatusView[] getGlobalRequests() throws RequestQueueUnavailableException;
+
+  /**
+   * Removes a single global request by identifier.
+   *
+   * <p>This operation is synchronous from the caller's perspective. Implementations perform the
+   * backend mutation before returning so runtime-admin can report deterministic results to the HTTP
+   * layer. An identifier that no longer exists is treated as a normal miss rather than a transport
+   * failure.
+   *
+   * @param identifier stable queue identifier for the request that should be removed
+   * @return {@code true} when the backend found a matching request and removed it
+   * @throws RequestQueueUnavailableException if the persistent queue cannot process the removal
+   *     request
+   */
+  boolean removeGlobalRequestBlocking(String identifier) throws RequestQueueUnavailableException;
+
+  /**
+   * Restarts a single global request by identifier.
+   *
+   * <p>The backend applies the restart immediately and returns only after the request has been
+   * handed back to the queue implementation. The {@code disableFilterData} flag is forwarded
+   * unchanged so protocol-specific backends can preserve their existing restart semantics.
+   *
+   * @param identifier stable queue identifier for the request that should be restarted
+   * @param disableFilterData whether the restarted request should disable filter-data handling
+   * @return {@code true} when the backend found a matching request and restarted it
+   * @throws RequestQueueUnavailableException if the persistent queue cannot process the restart
+   *     request
+   */
+  @SuppressWarnings("UnusedReturnValue")
+  boolean restartBlocking(String identifier, boolean disableFilterData)
+      throws RequestQueueUnavailableException;
+
+  /**
+   * Updates the token and priority of a single global request.
+   *
+   * <p>This method lets runtime-admin apply the small set of existing queue mutations without
+   * importing backend-specific request classes. Passing {@code null} for {@code newToken} keeps the
+   * current token, while {@code newPriority} is interpreted in the backend's native priority scale.
+   *
+   * @param identifier stable queue identifier for the request that should be modified
+   * @param newToken replacement token, or {@code null} when the current token should be preserved
+   * @param newPriority replacement priority value in the backend's native priority scale
+   * @return {@code true} when the backend found a matching request and applied the mutation
+   * @throws RequestQueueUnavailableException if the persistent queue cannot process the requested
+   *     mutation
+   */
+  @SuppressWarnings("UnusedReturnValue")
+  boolean modifyGlobalRequestBlocking(String identifier, String newToken, short newPriority)
+      throws RequestQueueUnavailableException;
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/QueueDownloadStatusView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/QueueDownloadStatusView.java
@@ -1,0 +1,22 @@
+package network.crypta.runtime.admin.queue;
+
+/**
+ * Describes the runtime-owned view of a queued download request.
+ *
+ * <p>This subtype lets runtime-admin distinguish downloads from other queue entries without
+ * importing backend-specific request classes. The extra download-specific flag is small but
+ * important: legacy cleanup behavior treats downloads targeting temporary space differently from
+ * normal persistent downloads.
+ */
+public interface QueueDownloadStatusView extends QueueRequestStatusView {
+  /**
+   * Returns whether the download currently targets temporary space.
+   *
+   * <p>Temporary-space downloads are intentionally excluded from the finished-download cleanup path
+   * even when they otherwise look successful and finalized. Callers therefore use this flag only as
+   * a policy input for queue administration, not as a general storage description.
+   *
+   * @return {@code true} when the download currently writes into temporary space
+   */
+  boolean toTempSpace();
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/QueueRequestStatusView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/QueueRequestStatusView.java
@@ -1,0 +1,59 @@
+package network.crypta.runtime.admin.queue;
+
+/**
+ * Describes the minimal runtime-owned view of a queued request status.
+ *
+ * <p>This interface exists so runtime-admin can reason about queue entries without importing
+ * protocol-specific status classes. Implementations expose only the fields that the current
+ * diagnostics and cleanup flows need: a stable identifier, coarse success state, persistence mode,
+ * and whether the request's total block count is finalized.
+ *
+ * <p>Callers should treat instances as read-only views for a specific queue traversal. The
+ * interface intentionally omits richer progress, failure, and protocol metadata because those
+ * details still belong to the backend-specific queue layer.
+ */
+public interface QueueRequestStatusView {
+  /**
+   * Returns the stable queue identifier.
+   *
+   * <p>The identifier is the value runtime-admin can pass back into mutation methods such as
+   * removal, restart, or reprioritization. It is expected to remain stable for the lifetime of the
+   * corresponding queued request.
+   *
+   * @return backend-specific identifier used to refer to this queued request later
+   */
+  String getIdentifier();
+
+  /**
+   * Returns whether the request completed successfully.
+   *
+   * <p>A value of {@code false} does not distinguish between an in-progress request and a completed
+   * request that failed. Callers use this only as a coarse success signal when building summary
+   * counts or deciding whether a cleanup action should proceed.
+   *
+   * @return {@code true} when the backend reports the request as successful
+   */
+  boolean hasSucceeded();
+
+  /**
+   * Returns whether the request is persistent.
+   *
+   * <p>This flag tells runtime-admin whether the request belongs to a persistent queue mode rather
+   * than an ephemeral one. Cleanup logic combines it with other status flags before removing
+   * finished downloads.
+   *
+   * @return {@code true} when the request uses a persistent queue mode
+   */
+  boolean isPersistent();
+
+  /**
+   * Returns whether the total block count is finalized.
+   *
+   * <p>This reports whether the backend considers the request's total block count settled enough
+   * for callers to rely on it. Runtime-admin uses the flag as part of its legacy cleanup criteria
+   * for finished downloads.
+   *
+   * @return {@code true} when the request's total block count is finalized
+   */
+  boolean isTotalFinalized();
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/QueueUploadDirStatusView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/QueueUploadDirStatusView.java
@@ -1,0 +1,11 @@
+package network.crypta.runtime.admin.queue;
+
+/**
+ * Marks a runtime-owned view of a queued directory-upload request.
+ *
+ * <p>This interface exists so runtime-admin can tell directory uploads apart from file uploads
+ * without importing backend-specific status classes. The distinction matters because the legacy
+ * cleanup path only removes succeeding file uploads automatically; directory uploads remain visible
+ * unless a caller removes them explicitly through another queue action.
+ */
+public interface QueueUploadDirStatusView extends QueueRequestStatusView {}

--- a/src/main/java/network/crypta/runtime/admin/queue/QueueUploadFileStatusView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/QueueUploadFileStatusView.java
@@ -1,0 +1,11 @@
+package network.crypta.runtime.admin.queue;
+
+/**
+ * Marks a runtime-owned view of a queued file-upload request.
+ *
+ * <p>This interface intentionally adds no extra methods. Runtime-admin only needs to distinguish
+ * file uploads from downloads and directory uploads when it applies the legacy finished-upload
+ * cleanup rule. Keeping the type as a marker avoids pulling backend-specific upload details across
+ * the queue seam while still preserving the existing category-specific behavior.
+ */
+public interface QueueUploadFileStatusView extends QueueRequestStatusView {}

--- a/src/main/java/network/crypta/runtime/admin/queue/package-info.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Provides the runtime-owned internal seam for the remaining legacy queue administration helpers.
+ *
+ * <p>The types in this package deliberately stay small and focused on the queue diagnostics,
+ * support, and mutation work still owned by {@code network.crypta.runtime.admin}. They let the
+ * admin adapters depend on a narrow queue backend view without importing protocol-specific FCP
+ * request-status classes and without widening {@code runtime-spi} while the broader extraction is
+ * still in flight.
+ *
+ * <p>The package has two responsibilities:
+ *
+ * <ul>
+ *   <li>define the backend seam used by runtime-admin to query and mutate the global queue
+ *   <li>define minimal status views that preserve the legacy admin behavior without leaking FCP
+ *       types across the runtime boundary
+ * </ul>
+ */
+package network.crypta.runtime.admin.queue;

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackend.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackend.java
@@ -1,0 +1,235 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.util.Objects;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.DownloadRequestStatus;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.RequestStatus;
+import network.crypta.clients.fcp.UploadDirRequestStatus;
+import network.crypta.clients.fcp.UploadFileRequestStatus;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.QueueDownloadStatusView;
+import network.crypta.runtime.admin.queue.QueueRequestStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadDirStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadFileStatusView;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+
+/**
+ * Implements the runtime-owned queue administration seam on top of the live FCP server.
+ *
+ * <p>This bridge keeps the remaining FCP-specific queue knowledge inside {@code
+ * network.crypta.runtime.endpoints.fcp}. Runtime-admin callers interact only with the runtime-owned
+ * queue seam, while this type resolves the live {@link FCPServer} lazily from {@link
+ * NodeClientCore}, translates persistence failures into {@link RequestQueueUnavailableException},
+ * and adapts protocol-specific {@link RequestStatus} objects into the narrow runtime-owned status
+ * views used by diagnostics and queue mutations.
+ *
+ * <p>The implementation is intentionally small and mechanical. It does not reinterpret the queue
+ * state, cache snapshots, or change the FCP wire behavior. Each call reaches the current FCP server
+ * state, preserving the existing distinction between an unavailable persistent request queue and
+ * the complete absence of an FCP server.
+ */
+public final class FcpQueueAdminBackend implements QueueAdminBackend {
+  private static final String QUEUE_UNAVAILABLE = "Persistent request queue unavailable";
+
+  private final NodeClientCore core;
+
+  /**
+   * Creates an FCP-backed queue admin bridge.
+   *
+   * <p>Callers normally create one instance during runtime-port wiring and reuse it for the admin
+   * adapters that still need queue diagnostics, queue support, or queue mutation behavior. The
+   * constructor itself is side-effect free: it stores the client core and defers endpoint
+   * resolution until a queue method is invoked.
+   *
+   * @param core daemon client core used to resolve the live FCP endpoint bundle on demand
+   */
+  public FcpQueueAdminBackend(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core, "core");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation treats a missing FCP endpoint bundle or a missing FCP server as disabled
+   * rather than exceptional. That lets runtime-admin probe queue availability during startup
+   * without forcing endpoint initialization or triggering persistence access.
+   */
+  @Override
+  public boolean isEnabled() {
+    FCPServer fcpServer = fcpServerOrNull();
+    return fcpServer != null && fcpServer.isEnabled();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The bridge resolves the live {@link FCPServer} lazily for each call and adapts the returned
+   * protocol-specific statuses into runtime-owned views before returning them. Persistence failures
+   * are translated into {@link RequestQueueUnavailableException} so runtime-admin does not need to
+   * know about the FCP-layer exception type.
+   *
+   * @throws IllegalStateException if no live FCP server is currently available from the endpoint
+   *     bundle
+   */
+  @Override
+  public QueueRequestStatusView[] getGlobalRequests() throws RequestQueueUnavailableException {
+    try {
+      return adapt(fcpServer().getGlobalRequests());
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException(QUEUE_UNAVAILABLE, e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This delegates directly to the live FCP server once it has been resolved. The method keeps
+   * the existing blocking behavior and only translates persistence-disabled failures into the
+   * runtime-owned exception type used by higher layers.
+   *
+   * @throws IllegalStateException if no live FCP server is currently available from the endpoint
+   *     bundle
+   */
+  @Override
+  public boolean removeGlobalRequestBlocking(String identifier)
+      throws RequestQueueUnavailableException {
+    try {
+      return fcpServer().removeGlobalRequestBlocking(identifier);
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException(QUEUE_UNAVAILABLE, e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This forwards the restart request to the live FCP server without changing the identifier or
+   * restart flags. Runtime-admin therefore preserves the legacy restart semantics while seeing only
+   * the runtime-owned queue seam.
+   *
+   * @throws IllegalStateException if no live FCP server is currently available from the endpoint
+   *     bundle
+   */
+  @Override
+  public boolean restartBlocking(String identifier, boolean disableFilterData)
+      throws RequestQueueUnavailableException {
+    try {
+      return fcpServer().restartBlocking(identifier, disableFilterData);
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException(QUEUE_UNAVAILABLE, e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This forwards the mutation request to the live FCP server without translating the token or
+   * priority arguments. The bridge keeps its role narrow by adapting only exception types and
+   * request-status views, not backend-specific queue semantics.
+   *
+   * @throws IllegalStateException if no live FCP server is currently available from the endpoint
+   *     bundle
+   */
+  @Override
+  public boolean modifyGlobalRequestBlocking(String identifier, String newToken, short newPriority)
+      throws RequestQueueUnavailableException {
+    try {
+      return fcpServer().modifyGlobalRequestBlocking(identifier, newToken, newPriority);
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException(QUEUE_UNAVAILABLE, e);
+    }
+  }
+
+  private FCPServer fcpServer() {
+    FCPServer fcpServer = fcpServerOrNull();
+    if (fcpServer == null) {
+      throw new IllegalStateException("FCP server unavailable");
+    }
+    return fcpServer;
+  }
+
+  private FCPServer fcpServerOrNull() {
+    var endpoints = core.getEndpoints();
+    return endpoints == null ? null : endpoints.getFCPServer();
+  }
+
+  private QueueRequestStatusView[] adapt(RequestStatus[] statuses) {
+    QueueRequestStatusView[] views = new QueueRequestStatusView[statuses.length];
+    for (int i = 0; i < statuses.length; i++) {
+      views[i] = adapt(statuses[i]);
+    }
+    return views;
+  }
+
+  private QueueRequestStatusView adapt(RequestStatus status) {
+    if (status instanceof DownloadRequestStatus downloadStatus) {
+      return new DownloadStatusView(downloadStatus);
+    }
+    if (status instanceof UploadFileRequestStatus uploadFileStatus) {
+      return new UploadFileStatusView(uploadFileStatus);
+    }
+    if (status instanceof UploadDirRequestStatus uploadDirStatus) {
+      return new UploadDirStatusView(uploadDirStatus);
+    }
+    return new RequestStatusViewAdapter(status);
+  }
+
+  private static class RequestStatusViewAdapter implements QueueRequestStatusView {
+    private final RequestStatus status;
+
+    private RequestStatusViewAdapter(RequestStatus status) {
+      this.status = Objects.requireNonNull(status, "status");
+    }
+
+    @Override
+    public String getIdentifier() {
+      return status.getIdentifier();
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return status.hasSucceeded();
+    }
+
+    @Override
+    public boolean isPersistent() {
+      return status.isPersistent();
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return status.isTotalFinalized();
+    }
+  }
+
+  private static final class DownloadStatusView extends RequestStatusViewAdapter
+      implements QueueDownloadStatusView {
+    private final DownloadRequestStatus status;
+
+    private DownloadStatusView(DownloadRequestStatus status) {
+      super(status);
+      this.status = status;
+    }
+
+    @Override
+    public boolean toTempSpace() {
+      return status.toTempSpace();
+    }
+  }
+
+  private static final class UploadFileStatusView extends RequestStatusViewAdapter
+      implements QueueUploadFileStatusView {
+    private UploadFileStatusView(UploadFileRequestStatus status) {
+      super(status);
+    }
+  }
+
+  private static final class UploadDirStatusView extends RequestStatusViewAdapter
+      implements QueueUploadDirStatusView {
+    private UploadDirStatusView(UploadDirRequestStatus status) {
+      super(status);
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/admin/LegacyDiagnosticPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyDiagnosticPortTest.java
@@ -3,11 +3,6 @@ package network.crypta.runtime.admin;
 import java.util.List;
 import java.util.Map;
 import network.crypta.client.async.PersistentStatsPutter;
-import network.crypta.clients.fcp.DownloadRequestStatus;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.RequestStatus;
-import network.crypta.clients.fcp.UploadDirRequestStatus;
-import network.crypta.clients.fcp.UploadFileRequestStatus;
 import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -19,10 +14,16 @@ import network.crypta.node.stats.DataStoreKeyType;
 import network.crypta.node.stats.DataStoreStats;
 import network.crypta.node.stats.DataStoreType;
 import network.crypta.node.stats.StoreAccessStats;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.QueueDownloadStatusView;
+import network.crypta.runtime.admin.queue.QueueRequestStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadDirStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadFileStatusView;
 import network.crypta.runtime.diagnostics.threads.NodeThreadInfo;
 import network.crypta.runtime.diagnostics.threads.NodeThreadSnapshot;
 import network.crypta.runtime.spi.DiagnosticReportSnapshot;
 import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.support.BandwidthStatsContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class LegacyDiagnosticPortTest {
   @Mock private RequestTracker tracker;
   @Mock private PersistentStatsPutter bandwidthStatsPutter;
   @Mock private BandwidthStatsContainer bandwidthStats;
-  @Mock private FCPServer fcpServer;
+  @Mock private QueueAdminBackend queueBackend;
   @Mock private SubConfig nodeConfig;
 
   private LegacyDiagnosticPort port;
@@ -68,7 +69,7 @@ class LegacyDiagnosticPortTest {
     when(node.network().stats()).thenReturn(stats);
     when(node.network().peers()).thenReturn(peers);
 
-    port = new LegacyDiagnosticPort(node, core);
+    port = new LegacyDiagnosticPort(node, core, queueBackend);
 
     when(node.storage().getDataStoreStats()).thenReturn(Map.of());
     when(node.routing().tracker()).thenReturn(tracker);
@@ -85,8 +86,7 @@ class LegacyDiagnosticPortTest {
     when(bandwidthStatsPutter.getLatestBWData()).thenReturn(bandwidthStats);
     lenient().when(bandwidthStats.getTotalBytesIn()).thenReturn(40_000L);
     lenient().when(bandwidthStats.getTotalBytesOut()).thenReturn(30_000L);
-    when(core.getEndpoints().getFCPServer()).thenReturn(fcpServer);
-    lenient().when(fcpServer.getGlobalRequests()).thenReturn(new RequestStatus[0]);
+    lenient().when(queueBackend.getGlobalRequests()).thenReturn(new QueueRequestStatusView[0]);
     when(stats.getActiveThreadCount()).thenReturn(3);
     when(stats.getThreadLimit()).thenReturn(64);
     lenient()
@@ -127,12 +127,12 @@ class LegacyDiagnosticPortTest {
   @Test
   void snapshot_whenQueueContainsDownloadsAndUploads_countsExpectedRequestCategories()
       throws Exception {
-    DownloadRequestStatus download = mock(DownloadRequestStatus.class);
-    UploadFileRequestStatus uploadFile = mock(UploadFileRequestStatus.class);
-    UploadDirRequestStatus uploadDir = mock(UploadDirRequestStatus.class);
-    RequestStatus ignored = mock(RequestStatus.class);
-    when(fcpServer.getGlobalRequests())
-        .thenReturn(new RequestStatus[] {download, uploadFile, uploadDir, ignored});
+    QueueDownloadStatusView download = mock(QueueDownloadStatusView.class);
+    QueueUploadFileStatusView uploadFile = mock(QueueUploadFileStatusView.class);
+    QueueUploadDirStatusView uploadDir = mock(QueueUploadDirStatusView.class);
+    QueueRequestStatusView ignored = mock(QueueRequestStatusView.class);
+    when(queueBackend.getGlobalRequests())
+        .thenReturn(new QueueRequestStatusView[] {download, uploadFile, uploadDir, ignored});
 
     DiagnosticSectionSnapshot queueSection = findSection(port.snapshot(), "Queue:");
 
@@ -181,7 +181,6 @@ class LegacyDiagnosticPortTest {
   void snapshot_whenOptionalDataAbsent_returnsBestEffortReport() {
     when(node.isNodeDiagnosticsEnabled()).thenReturn(false);
     when(bandwidthStatsPutter.getLatestBWData()).thenReturn(null);
-    when(core.getEndpoints().getFCPServer()).thenReturn(null);
 
     DiagnosticReportSnapshot snapshot = assertDoesNotThrow(port::snapshot);
 
@@ -196,6 +195,27 @@ class LegacyDiagnosticPortTest {
             "Queue:"),
         snapshot.sections().stream().map(DiagnosticSectionSnapshot::title).toList());
     assertEquals(List.of("bandwidth error", ""), findSection(snapshot, "Bandwidth:").lines());
+  }
+
+  @Test
+  void snapshot_whenQueueBackendUnavailable_rendersDatabaseDisabledSentinel() throws Exception {
+    when(queueBackend.getGlobalRequests())
+        .thenThrow(new RequestQueueUnavailableException("Persistent request queue unavailable"));
+
+    DiagnosticSectionSnapshot queueSection = findSection(port.snapshot(), "Queue:");
+
+    assertEquals(List.of("DatabaseDisabledException", ""), queueSection.lines());
+  }
+
+  @Test
+  void snapshot_whenQueueServerMissing_treatsQueueAsEmpty() throws Exception {
+    DiagnosticSectionSnapshot emptyQueueSection = findSection(port.snapshot(), "Queue:");
+    when(queueBackend.getGlobalRequests())
+        .thenThrow(new IllegalStateException("FCP server unavailable"));
+
+    DiagnosticSectionSnapshot fallbackQueueSection = findSection(port.snapshot(), "Queue:");
+
+    assertEquals(emptyQueueSection.lines(), fallbackQueueSection.lines());
   }
 
   private void stubThreadSnapshot(List<NodeThreadInfo> threads) {

--- a/src/test/java/network/crypta/runtime/admin/LegacyQueueMutationPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyQueueMutationPortTest.java
@@ -2,12 +2,11 @@ package network.crypta.runtime.admin;
 
 import java.util.List;
 import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.clients.fcp.DownloadRequestStatus;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.RequestStatus;
-import network.crypta.clients.fcp.UploadFileRequestStatus;
-import network.crypta.node.NodeClientCore;
-import network.crypta.runtime.endpoints.ClientEndpoints;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.QueueDownloadStatusView;
+import network.crypta.runtime.admin.queue.QueueRequestStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadDirStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadFileStatusView;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -25,69 +25,73 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 class LegacyQueueMutationPortTest {
 
-  @Mock private NodeClientCore core;
-  @Mock private ClientEndpoints endpoints;
-  @Mock private FCPServer fcp;
+  @Mock private QueueAdminBackend queueBackend;
 
   private LegacyQueueMutationPort port;
 
   @BeforeEach
   void setUp() {
-    when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
-    port = new LegacyQueueMutationPort(core);
+    port = new LegacyQueueMutationPort(queueBackend);
   }
 
   @Test
-  void removeRequests_whenCalled_delegatesToFcpForEachIdentifier() throws Exception {
+  void removeRequests_whenCalled_delegatesToBackendForEachIdentifier() throws Exception {
     port.removeRequests(List.of("download-1", "download-2"));
 
-    verify(fcp).removeGlobalRequestBlocking("download-1");
-    verify(fcp).removeGlobalRequestBlocking("download-2");
+    verify(queueBackend).removeGlobalRequestBlocking("download-1");
+    verify(queueBackend).removeGlobalRequestBlocking("download-2");
   }
 
   @Test
   void restartRequests_whenDisableFilterDataRequested_preservesFlag() throws Exception {
     port.restartRequests(List.of("download-1", "download-2"), true);
 
-    verify(fcp).restartBlocking("download-1", true);
-    verify(fcp).restartBlocking("download-2", true);
+    verify(queueBackend).restartBlocking("download-1", true);
+    verify(queueBackend).restartBlocking("download-2", true);
   }
 
   @Test
   void changePriority_whenCalled_delegatesToPriorityMutation() throws Exception {
     port.changePriority(List.of("download-1", "download-2"), (short) 4);
 
-    verify(fcp).modifyGlobalRequestBlocking("download-1", null, (short) 4);
-    verify(fcp).modifyGlobalRequestBlocking("download-2", null, (short) 4);
+    verify(queueBackend).modifyGlobalRequestBlocking("download-1", null, (short) 4);
+    verify(queueBackend).modifyGlobalRequestBlocking("download-2", null, (short) 4);
   }
 
   @Test
   void removeFinishedUploads_whenMixedStatusesPresent_removesOnlySucceededUploads()
       throws Exception {
-    UploadFileRequestStatus succeededUpload =
-        org.mockito.Mockito.mock(UploadFileRequestStatus.class);
-    UploadFileRequestStatus failedUpload = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
-    DownloadRequestStatus download = org.mockito.Mockito.mock(DownloadRequestStatus.class);
+    QueueUploadFileStatusView succeededUpload =
+        org.mockito.Mockito.mock(QueueUploadFileStatusView.class);
+    QueueUploadFileStatusView failedUpload =
+        org.mockito.Mockito.mock(QueueUploadFileStatusView.class);
+    QueueUploadDirStatusView succeededDirectoryUpload =
+        org.mockito.Mockito.mock(QueueUploadDirStatusView.class);
+    QueueDownloadStatusView download = org.mockito.Mockito.mock(QueueDownloadStatusView.class);
     when(succeededUpload.hasSucceeded()).thenReturn(true);
     when(succeededUpload.getIdentifier()).thenReturn("upload-1");
     when(failedUpload.hasSucceeded()).thenReturn(false);
-    when(fcp.getGlobalRequests())
-        .thenReturn(new RequestStatus[] {succeededUpload, failedUpload, download});
+    when(queueBackend.getGlobalRequests())
+        .thenReturn(
+            new QueueRequestStatusView[] {
+              succeededUpload, failedUpload, succeededDirectoryUpload, download
+            });
 
     port.removeFinishedUploads();
 
-    verify(fcp).removeGlobalRequestBlocking("upload-1");
+    verify(queueBackend).removeGlobalRequestBlocking("upload-1");
+    verify(queueBackend, never()).removeGlobalRequestBlocking("upload-dir-1");
   }
 
   @Test
   void removeFinishedDownloads_whenMixedStatusesPresent_removesOnlyPersistentFinalizedDownloads()
       throws Exception {
-    DownloadRequestStatus matchingDownload = org.mockito.Mockito.mock(DownloadRequestStatus.class);
-    DownloadRequestStatus tempDownload = org.mockito.Mockito.mock(DownloadRequestStatus.class);
-    DownloadRequestStatus unfinishedDownload =
-        org.mockito.Mockito.mock(DownloadRequestStatus.class);
-    UploadFileRequestStatus upload = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
+    QueueDownloadStatusView matchingDownload =
+        org.mockito.Mockito.mock(QueueDownloadStatusView.class);
+    QueueDownloadStatusView tempDownload = org.mockito.Mockito.mock(QueueDownloadStatusView.class);
+    QueueDownloadStatusView unfinishedDownload =
+        org.mockito.Mockito.mock(QueueDownloadStatusView.class);
+    QueueUploadFileStatusView upload = org.mockito.Mockito.mock(QueueUploadFileStatusView.class);
 
     when(matchingDownload.isPersistent()).thenReturn(true);
     when(matchingDownload.hasSucceeded()).thenReturn(true);
@@ -103,20 +107,24 @@ class LegacyQueueMutationPortTest {
     when(unfinishedDownload.isPersistent()).thenReturn(true);
     when(unfinishedDownload.hasSucceeded()).thenReturn(false);
 
-    when(fcp.getGlobalRequests())
+    when(queueBackend.getGlobalRequests())
         .thenReturn(
-            new RequestStatus[] {matchingDownload, tempDownload, unfinishedDownload, upload});
+            new QueueRequestStatusView[] {
+              matchingDownload, tempDownload, unfinishedDownload, upload
+            });
 
     port.removeFinishedDownloads();
 
-    verify(fcp).removeGlobalRequestBlocking("download-1");
+    verify(queueBackend).removeGlobalRequestBlocking("download-1");
   }
 
   @Test
   void removeRequests_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
       throws Exception {
     PersistenceDisabledException cause = new PersistenceDisabledException();
-    when(fcp.removeGlobalRequestBlocking("download-1")).thenThrow(cause);
+    RequestQueueUnavailableException queueUnavailable =
+        new RequestQueueUnavailableException("Persistent request queue unavailable", cause);
+    when(queueBackend.removeGlobalRequestBlocking("download-1")).thenThrow(queueUnavailable);
 
     RequestQueueUnavailableException thrown =
         assertThrows(
@@ -127,12 +135,11 @@ class LegacyQueueMutationPortTest {
   }
 
   @Test
-  void lazyFcpLookup_whenPortConstructed_defersEndpointAccessUntilMethodCall() throws Exception {
-    verifyNoInteractions(endpoints, fcp);
+  void lazyBackendUsage_whenPortConstructed_defersBackendAccessUntilMethodCall() throws Exception {
+    verifyNoInteractions(queueBackend);
 
     port.changePriority(List.of("download-1"), (short) 3);
 
-    verify(endpoints).getFCPServer();
-    verify(fcp).modifyGlobalRequestBlocking("download-1", null, (short) 3);
+    verify(queueBackend).modifyGlobalRequestBlocking("download-1", null, (short) 3);
   }
 }

--- a/src/test/java/network/crypta/runtime/admin/LegacyQueueSupportPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyQueueSupportPortTest.java
@@ -2,11 +2,10 @@ package network.crypta.runtime.admin;
 
 import java.io.File;
 import java.nio.file.Path;
-import network.crypta.clients.fcp.FCPServer;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
-import network.crypta.runtime.endpoints.ClientEndpoints;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
 import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,8 +29,7 @@ import static org.mockito.Mockito.when;
 class LegacyQueueSupportPortTest {
 
   @Mock private NodeClientCore core;
-  @Mock private ClientEndpoints endpoints;
-  @Mock private FCPServer fcp;
+  @Mock private QueueAdminBackend queueBackend;
   @Mock private Node node;
   @Mock private NodeStorageSubsystem storage;
 
@@ -41,14 +39,12 @@ class LegacyQueueSupportPortTest {
 
   @BeforeEach
   void setUp() {
-    port = new LegacyQueueSupportPort(core);
+    port = new LegacyQueueSupportPort(core, queueBackend);
   }
 
   @Test
-  void isQueueBackendEnabled_whenQueried_delegatesToFcpServerFlag() {
-    when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
-    when(fcp.isEnabled()).thenReturn(true).thenReturn(false);
+  void isQueueBackendEnabled_whenQueried_delegatesToBackendFlag() {
+    when(queueBackend.isEnabled()).thenReturn(true).thenReturn(false);
 
     assertTrue(port.isQueueBackendEnabled());
     assertFalse(port.isQueueBackendEnabled());

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackendTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackendTest.java
@@ -1,0 +1,209 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.DownloadRequestStatus;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.RequestStatus;
+import network.crypta.clients.fcp.UploadDirRequestStatus;
+import network.crypta.clients.fcp.UploadFileRequestStatus;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.QueueDownloadStatusView;
+import network.crypta.runtime.admin.queue.QueueRequestStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadDirStatusView;
+import network.crypta.runtime.admin.queue.QueueUploadFileStatusView;
+import network.crypta.runtime.endpoints.ClientEndpoints;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FcpQueueAdminBackendTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientEndpoints endpoints;
+  @Mock private FCPServer fcpServer;
+
+  private FcpQueueAdminBackend backend;
+
+  @BeforeEach
+  void setUp() {
+    when(core.getEndpoints()).thenReturn(endpoints);
+    backend = new FcpQueueAdminBackend(core);
+  }
+
+  @Test
+  void isEnabled_whenNoFcpServerPresent_returnsFalse() {
+    when(endpoints.getFCPServer()).thenReturn(null);
+
+    assertFalse(backend.isEnabled());
+  }
+
+  @Test
+  void isEnabled_whenEndpointsUnavailable_returnsFalse() {
+    when(core.getEndpoints()).thenReturn(null);
+
+    assertFalse(backend.isEnabled());
+  }
+
+  @Test
+  void isEnabled_whenServerPresent_delegatesToEnabledFlag() {
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.isEnabled()).thenReturn(true).thenReturn(false);
+
+    assertTrue(backend.isEnabled());
+    assertFalse(backend.isEnabled());
+  }
+
+  @Test
+  void getGlobalRequests_whenMixedStatusesPresent_adaptsExpectedViewSubtypes() throws Exception {
+    DownloadRequestStatus download = org.mockito.Mockito.mock(DownloadRequestStatus.class);
+    UploadFileRequestStatus uploadFile = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
+    UploadDirRequestStatus uploadDir = org.mockito.Mockito.mock(UploadDirRequestStatus.class);
+    RequestStatus generic = org.mockito.Mockito.mock(RequestStatus.class);
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.getGlobalRequests())
+        .thenReturn(new RequestStatus[] {download, uploadFile, uploadDir, generic});
+
+    when(download.hasSucceeded()).thenReturn(true);
+    when(download.isPersistent()).thenReturn(true);
+    when(download.isTotalFinalized()).thenReturn(true);
+    when(download.toTempSpace()).thenReturn(false);
+
+    when(generic.getIdentifier()).thenReturn("generic-1");
+    when(generic.hasSucceeded()).thenReturn(false);
+    when(generic.isPersistent()).thenReturn(true);
+    when(generic.isTotalFinalized()).thenReturn(false);
+
+    QueueRequestStatusView[] views = backend.getGlobalRequests();
+
+    QueueDownloadStatusView downloadView =
+        assertInstanceOf(QueueDownloadStatusView.class, views[0]);
+    assertTrue(downloadView.hasSucceeded());
+    assertTrue(downloadView.isPersistent());
+    assertTrue(downloadView.isTotalFinalized());
+    assertFalse(downloadView.toTempSpace());
+
+    assertInstanceOf(QueueUploadFileStatusView.class, views[1]);
+    assertInstanceOf(QueueUploadDirStatusView.class, views[2]);
+
+    QueueRequestStatusView genericView = views[3];
+    assertFalse(genericView instanceof QueueDownloadStatusView);
+    assertFalse(genericView instanceof QueueUploadFileStatusView);
+    assertFalse(genericView instanceof QueueUploadDirStatusView);
+    assertEquals("generic-1", genericView.getIdentifier());
+    assertFalse(genericView.hasSucceeded());
+    assertTrue(genericView.isPersistent());
+    assertFalse(genericView.isTotalFinalized());
+  }
+
+  @Test
+  void getGlobalRequests_whenServerUnavailable_throwsIllegalStateException() {
+    when(endpoints.getFCPServer()).thenReturn(null);
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, backend::getGlobalRequests);
+
+    assertTrue(thrown.getMessage().contains("FCP server unavailable"));
+  }
+
+  @Test
+  void getGlobalRequests_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
+      throws Exception {
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.getGlobalRequests()).thenThrow(cause);
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(RequestQueueUnavailableException.class, backend::getGlobalRequests);
+
+    assertSame(cause, thrown.getCause());
+  }
+
+  @Test
+  void removeGlobalRequestBlocking_whenCalled_delegatesToServer() throws Exception {
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.removeGlobalRequestBlocking("request-1")).thenReturn(true);
+
+    assertTrue(backend.removeGlobalRequestBlocking("request-1"));
+    verify(fcpServer).removeGlobalRequestBlocking("request-1");
+  }
+
+  @Test
+  void
+      removeGlobalRequestBlocking_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
+          throws Exception {
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.removeGlobalRequestBlocking("request-1")).thenThrow(cause);
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(
+            RequestQueueUnavailableException.class,
+            () -> backend.removeGlobalRequestBlocking("request-1"));
+
+    assertSame(cause, thrown.getCause());
+  }
+
+  @Test
+  void restartBlocking_whenCalled_delegatesToServer() throws Exception {
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.restartBlocking("request-1", true)).thenReturn(true);
+
+    assertTrue(backend.restartBlocking("request-1", true));
+    verify(fcpServer).restartBlocking("request-1", true);
+  }
+
+  @Test
+  void restartBlocking_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
+      throws Exception {
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.restartBlocking("request-1", false)).thenThrow(cause);
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(
+            RequestQueueUnavailableException.class,
+            () -> backend.restartBlocking("request-1", false));
+
+    assertSame(cause, thrown.getCause());
+  }
+
+  @Test
+  void modifyGlobalRequestBlocking_whenCalled_delegatesToServer() throws Exception {
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.modifyGlobalRequestBlocking("request-1", "new-token", (short) 3))
+        .thenReturn(true);
+
+    assertTrue(backend.modifyGlobalRequestBlocking("request-1", "new-token", (short) 3));
+    verify(fcpServer).modifyGlobalRequestBlocking("request-1", "new-token", (short) 3);
+  }
+
+  @Test
+  void
+      modifyGlobalRequestBlocking_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
+          throws Exception {
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.modifyGlobalRequestBlocking("request-1", null, (short) 7)).thenThrow(cause);
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(
+            RequestQueueUnavailableException.class,
+            () -> backend.modifyGlobalRequestBlocking("request-1", null, (short) 7));
+
+    assertSame(cause, thrown.getCause());
+  }
+}


### PR DESCRIPTION
## Summary
- add a runtime-owned queue admin seam under `network.crypta.runtime.admin.queue` for diagnostics, support, and mutation work
- add `FcpQueueAdminBackend` to keep the remaining FCP queue-specific adaptation and exception translation inside `network.crypta.runtime.endpoints.fcp`
- rewire `AdminRuntimePortsFactory`, `LegacyDiagnosticPort`, `LegacyQueueMutationPort`, and `LegacyQueueSupportPort` to use the new seam instead of importing `network.crypta.clients.fcp.*`
- update the focused admin tests, add bridge coverage for the FCP-backed adapter, and add Javadoc for the new production types

## Notes
- behavior is preserved for the touched runtime-admin adapters
- FCP wire behavior is unchanged
- the non-goal queue ports remain untouched in this PR

## How to test
- `./gradlew test`
- `./gradlew classes`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/admin/queue/QueueAdminBackend.java`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/admin/queue/QueueRequestStatusView.java`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/admin/queue/QueueDownloadStatusView.java`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/admin/queue/QueueUploadFileStatusView.java`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/admin/queue/QueueUploadDirStatusView.java`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackend.java`
- `javac -proc:none -Xdoclint:all -Werror -classpath 'build/classes/java/main:build/resources/main:runtime-spi/build/classes/java/main:runtime-spi/build/resources/main' -d /tmp/doclint-out src/main/java/network/crypta/runtime/admin/queue/package-info.java`