### PR TITLE
refactor(queue-page): Decouple legacy queue page seam

### DIFF
--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -4,6 +4,7 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.admin.queue.QueueAdminBackend;
 import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
+import network.crypta.runtime.endpoints.fcp.FcpQueuePageBackend;
 
 /**
  * Creates the legacy admin and page-oriented runtime SPI adapters as one package-owned bundle.
@@ -45,7 +46,7 @@ public final class AdminRuntimePortsFactory {
         new LegacyDiagnosticPort(node, core, queueBackend),
         new LegacyPageChromePort(node),
         new LegacyQueueCompletionPort(core),
-        new LegacyQueuePagePort(core),
+        new LegacyQueuePagePort(core, new FcpQueuePageBackend(core)),
         new LegacyQueueDownloadPort(core),
         new LegacyQueueInsertPort(core),
         new LegacyQueueMutationPort(queueBackend),

--- a/src/main/java/network/crypta/runtime/admin/LegacyQueuePagePort.java
+++ b/src/main/java/network/crypta/runtime/admin/LegacyQueuePagePort.java
@@ -13,25 +13,24 @@ import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.InsertContext;
-import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.FilterMIMEType;
 import network.crypta.client.filter.KnownUnsafeContentTypeException;
-import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
-import network.crypta.clients.fcp.DownloadRequestStatus;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.RequestStatus;
-import network.crypta.clients.fcp.UploadDirRequestStatus;
-import network.crypta.clients.fcp.UploadFileRequestStatus;
-import network.crypta.clients.fcp.UploadRequestStatus;
-import network.crypta.clients.http.ProgressCellContext;
-import network.crypta.clients.http.QueueToadlet;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.runtime.admin.queue.page.QueueCompressionState;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageDownloadView;
+import network.crypta.runtime.admin.queue.page.QueuePageRequestView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadDirView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadFileView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadView;
+import network.crypta.runtime.admin.queue.page.QueueProgressCellContext;
+import network.crypta.runtime.admin.queue.page.QueueProgressCellRenderer;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
@@ -53,9 +52,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Each render reads the current daemon state directly. The adapter does not cache queue data or
  * retain request-specific HTML trees between calls. That preserves the legacy queue page behavior
- * while moving live traversal logic behind the runtime SPI boundary introduced for the queue GET
- * path. When FCP access is required, the adapter resolves {@code FCPServer} lazily through {@code
- * NodeClientCore} so startup order remains unchanged.
+ * while moving live traversal logic behind the runtime-owned queue-page seam used by this adapter.
  *
  * <p>The class is intentionally internal to the root daemon module. It translates daemon-owned
  * request status objects into detached {@link QueuePageSnapshot} instances and plain-text key-list
@@ -127,18 +124,22 @@ final class LegacyQueuePagePort implements QueuePagePort {
   private static final char[] HEX_ARRAY = "0123456789abcdef".toCharArray();
 
   private final NodeClientCore core;
+  private final QueuePageBackend queueBackend;
 
   /**
    * Creates the legacy queue-page adapter for one daemon instance.
    *
-   * <p>The adapter keeps only a reference to {@link NodeClientCore}. It resolves queue readers,
-   * request starters, and lazy FCP access from that core when individual render methods execute.
+   * <p>The adapter keeps only the daemon core plus the runtime-owned queue-page backend. Queue
+   * reads flow through the backend seam, while scheduler counts, security-level checks, and local
+   * path selection still come from the client core.
    *
    * @param core daemon core that provides queue state, request schedulers, and lazy endpoint access
+   * @param queueBackend runtime-owned queue-page backend used to read the current global queue
    * @throws NullPointerException if {@code core} is {@code null}
    */
-  LegacyQueuePagePort(NodeClientCore core) {
-    this.core = Objects.requireNonNull(core);
+  LegacyQueuePagePort(NodeClientCore core, QueuePageBackend queueBackend) {
+    this.core = Objects.requireNonNull(core, "core");
+    this.queueBackend = Objects.requireNonNull(queueBackend, "queueBackend");
   }
 
   /**
@@ -153,14 +154,14 @@ final class LegacyQueuePagePort implements QueuePagePort {
   public QueuePageSnapshot renderPage(QueuePageRequest request)
       throws RequestQueueUnavailableException {
     Objects.requireNonNull(request, "request");
-    RequestStatus[] reqs = globalRequests();
+    QueuePageRequestView[] reqs = globalRequests();
     QueuePartitions partitions = partitionRequests(reqs, request.uploads());
     if (!partitions.hasAny()) {
       return new QueuePageSnapshot(
           emptyPageTitle(request.uploads()), buildEmptyQueueContent(request.uploads()));
     }
 
-    Comparator<RequestStatus> jobComparator =
+    Comparator<QueuePageRequestView> jobComparator =
         createJobComparator(request.sortBy(), request.reversed());
     sortPartitions(partitions, jobComparator);
     logTotals(partitions);
@@ -223,14 +224,14 @@ final class LegacyQueuePagePort implements QueuePagePort {
    */
   @Override
   public String renderKeyList(boolean uploads) throws RequestQueueUnavailableException {
-    RequestStatus[] reqs = globalRequests();
+    QueuePageRequestView[] reqs = globalRequests();
     StringBuilder sb = new StringBuilder();
-    for (RequestStatus req : reqs) {
-      if (!uploads && req instanceof DownloadRequestStatus get) {
-        FreenetURI uri = get.getURI();
+    for (QueuePageRequestView req : reqs) {
+      if (!uploads && req instanceof QueuePageDownloadView get) {
+        FreenetURI uri = get.getUri();
         sb.append(uri).append('\n');
-      } else if (uploads && req instanceof UploadRequestStatus put) {
-        FreenetURI uri = put.getURI();
+      } else if (uploads && req instanceof QueuePageUploadView put) {
+        FreenetURI uri = put.getFinalUri();
         if (uri != null) {
           sb.append(uri).append('\n');
         }
@@ -240,26 +241,17 @@ final class LegacyQueuePagePort implements QueuePagePort {
   }
 
   /**
-   * Resolves the live global request array through the lazily available FCP endpoint.
+   * Returns the live global request array through the runtime-owned queue-page seam.
    *
-   * <p>The queue runtime port must not force early {@code FCPServer} construction during daemon
-   * startup. This helper therefore resolves the endpoint on demand for each render. A missing FCP
-   * server is treated as an empty queue snapshot, while persistence-disabled failures are mapped to
-   * the runtime SPI exception used by the HTTP layer.
+   * <p>The backend owns protocol-specific lookup rules such as lazy endpoint resolution, absent
+   * backends yielding an empty queue, and translation of persistence failures into the runtime SPI
+   * exception used by the HTTP layer.
    *
-   * @return current global requests, or an empty array if the FCP endpoint is not yet available
+   * @return current global requests, or an empty array if the queue backend is unavailable
    * @throws RequestQueueUnavailableException if the persistent request queue cannot be read
    */
-  private RequestStatus[] globalRequests() throws RequestQueueUnavailableException {
-    FCPServer fcpServer = core.getEndpoints().getFCPServer();
-    if (fcpServer == null) {
-      return new RequestStatus[0];
-    }
-    try {
-      return fcpServer.getGlobalRequests();
-    } catch (PersistenceDisabledException e) {
-      throw new RequestQueueUnavailableException("Persistent request queue unavailable", e);
-    }
+  private QueuePageRequestView[] globalRequests() throws RequestQueueUnavailableException {
+    return queueBackend.getGlobalRequests();
   }
 
   private void addAlertSummaryPlaceholder(HTMLNode contentNode) {
@@ -295,24 +287,24 @@ final class LegacyQueuePagePort implements QueuePagePort {
     };
   }
 
-  private QueuePartitions partitionRequests(RequestStatus[] reqs, boolean uploads) {
+  private QueuePartitions partitionRequests(QueuePageRequestView[] reqs, boolean uploads) {
     QueuePartitions partitions = new QueuePartitions();
     if (LOG.isDebugEnabled()) {
       LOG.debug("Request count: {}", reqs.length);
     }
-    for (RequestStatus req : reqs) {
-      if (req instanceof DownloadRequestStatus download && !uploads) {
+    for (QueuePageRequestView req : reqs) {
+      if (req instanceof QueuePageDownloadView download && !uploads) {
         handleDownloadPartition(download, partitions);
-      } else if (req instanceof UploadFileRequestStatus upload && uploads) {
+      } else if (req instanceof QueuePageUploadFileView upload && uploads) {
         handleUploadFilePartition(upload, partitions);
-      } else if (req instanceof UploadDirRequestStatus upload && uploads) {
+      } else if (req instanceof QueuePageUploadDirView upload && uploads) {
         handleUploadDirPartition(upload, partitions);
       }
     }
     return partitions;
   }
 
-  private void handleUploadDirPartition(UploadDirRequestStatus upload, QueuePartitions partitions) {
+  private void handleUploadDirPartition(QueuePageUploadDirView upload, QueuePartitions partitions) {
     if (upload.hasSucceeded()) {
       partitions.completedDirUpload.add(upload);
     } else if (upload.hasFinished()) {
@@ -332,7 +324,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
   }
 
   private void handleUploadFilePartition(
-      UploadFileRequestStatus upload, QueuePartitions partitions) {
+      QueuePageUploadFileView upload, QueuePartitions partitions) {
     if (upload.hasSucceeded()) {
       partitions.completedUpload.add(upload);
     } else if (upload.hasFinished()) {
@@ -351,7 +343,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
     partitions.added = true;
   }
 
-  private void handleDownloadPartition(DownloadRequestStatus download, QueuePartitions partitions) {
+  private void handleDownloadPartition(QueuePageDownloadView download, QueuePartitions partitions) {
     if (download.hasSucceeded()) {
       if (download.toTempSpace()) {
         partitions.completedDownloadToTemp.add(download);
@@ -374,7 +366,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
     partitions.added = true;
   }
 
-  private void handleFinishedDownload(DownloadRequestStatus download, QueuePartitions partitions) {
+  private void handleFinishedDownload(QueuePageDownloadView download, QueuePartitions partitions) {
     FetchExceptionMode failureCode = download.getFailureCode();
     String mimeType = normalizeMimeType(download, failureCode);
     switch (failureCode) {
@@ -384,8 +376,8 @@ final class LegacyQueuePagePort implements QueuePagePort {
     }
   }
 
-  private String normalizeMimeType(DownloadRequestStatus download, FetchExceptionMode failureCode) {
-    String mimeType = download.getMIMEType();
+  private String normalizeMimeType(QueuePageDownloadView download, FetchExceptionMode failureCode) {
+    String mimeType = download.getMimeType();
     if (mimeType == null
         && (failureCode == FetchExceptionMode.CONTENT_VALIDATION_UNKNOWN_MIME
             || failureCode == FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME)) {
@@ -394,7 +386,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
             "MIME type is null but failure code is {} for {} : {}",
             FetchException.getMessage(failureCode),
             download.getIdentifier(),
-            download.getURI());
+            download.getUri());
       }
       return DefaultMIMETypes.DEFAULT_MIME_TYPE;
     }
@@ -402,7 +394,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
   }
 
   private void addUnknownMimeFailure(
-      DownloadRequestStatus download, QueuePartitions partitions, String mimeType) {
+      QueuePageDownloadView download, QueuePartitions partitions, String mimeType) {
     String normalizedMimeType = ContentFilter.stripMIMEType(mimeType);
     partitions
         .failedUnknownMIMEType
@@ -411,10 +403,10 @@ final class LegacyQueuePagePort implements QueuePagePort {
   }
 
   private void handleBadMimeFailure(
-      DownloadRequestStatus download, QueuePartitions partitions, String mimeType) {
+      QueuePageDownloadView download, QueuePartitions partitions, String mimeType) {
     String normalizedMimeType = ContentFilter.stripMIMEType(mimeType);
     FilterMIMEType type = ContentFilter.getMIMEType(normalizedMimeType);
-    Map<String, List<DownloadRequestStatus>> bucket =
+    Map<String, List<QueuePageDownloadView>> bucket =
         type == null ? partitions.failedUnknownMIMEType : partitions.failedBadMIMEType;
     if (type == null) {
       LOG.error(
@@ -424,8 +416,8 @@ final class LegacyQueuePagePort implements QueuePagePort {
     bucket.computeIfAbsent(normalizedMimeType, _ -> new ArrayList<>()).add(download);
   }
 
-  private Comparator<RequestStatus> createJobComparator(String sortBy, boolean reversed) {
-    Comparator<RequestStatus> baseComparator =
+  private Comparator<QueuePageRequestView> createJobComparator(String sortBy, boolean reversed) {
+    Comparator<QueuePageRequestView> baseComparator =
         switch (sortBy) {
           case "id" -> this::compareById;
           case "size" -> this::compareBySize;
@@ -446,7 +438,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
     };
   }
 
-  private int compareById(RequestStatus first, RequestStatus second) {
+  private int compareById(QueuePageRequestView first, QueuePageRequestView second) {
     int result = first.getIdentifier().compareToIgnoreCase(second.getIdentifier());
     if (result == 0) {
       result = first.getIdentifier().compareTo(second.getIdentifier());
@@ -454,11 +446,11 @@ final class LegacyQueuePagePort implements QueuePagePort {
     return result;
   }
 
-  private int compareBySize(RequestStatus first, RequestStatus second) {
+  private int compareBySize(QueuePageRequestView first, QueuePageRequestView second) {
     return Fields.compare(first.getTotalBlocks(), second.getTotalBlocks());
   }
 
-  private int compareByProgress(RequestStatus first, RequestStatus second) {
+  private int compareByProgress(QueuePageRequestView first, QueuePageRequestView second) {
     boolean firstFinalized = first.isTotalFinalized();
     boolean secondFinalized = second.isTotalFinalized();
     if (firstFinalized && !secondFinalized) {
@@ -472,15 +464,15 @@ final class LegacyQueuePagePort implements QueuePagePort {
     return Fields.compare(firstProgress, secondProgress);
   }
 
-  private int compareByLastActivity(RequestStatus first, RequestStatus second) {
+  private int compareByLastActivity(QueuePageRequestView first, QueuePageRequestView second) {
     return Fields.compare(first.getLastSuccess(), second.getLastSuccess());
   }
 
-  private int compareByLastFailure(RequestStatus first, RequestStatus second) {
+  private int compareByLastFailure(QueuePageRequestView first, QueuePageRequestView second) {
     return Fields.compare(first.getLastFailure(), second.getLastFailure());
   }
 
-  private int compareByPriorityThenId(RequestStatus first, RequestStatus second) {
+  private int compareByPriorityThenId(QueuePageRequestView first, QueuePageRequestView second) {
     int result = Fields.compare(first.getPriority(), second.getPriority());
     if (result == 0) {
       result = first.getIdentifier().compareTo(second.getIdentifier());
@@ -488,7 +480,8 @@ final class LegacyQueuePagePort implements QueuePagePort {
     return result;
   }
 
-  private void sortPartitions(QueuePartitions partitions, Comparator<RequestStatus> jobComparator) {
+  private void sortPartitions(
+      QueuePartitions partitions, Comparator<QueuePageRequestView> jobComparator) {
     partitions.completedDownloadToDisk.sort(jobComparator);
     partitions.completedDownloadToTemp.sort(jobComparator);
     partitions.completedUpload.sort(jobComparator);
@@ -801,7 +794,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
       RequestTableContext tableContext,
       HTMLNode contentNode,
       QueuePartitions partitions,
-      Comparator<RequestStatus> jobComparator) {
+      Comparator<QueuePageRequestView> jobComparator) {
     addBadMimeFailures(tableContext, contentNode, partitions, jobComparator);
     addUnknownMimeFailures(tableContext, contentNode, partitions, jobComparator);
   }
@@ -810,11 +803,11 @@ final class LegacyQueuePagePort implements QueuePagePort {
       RequestTableContext tableContext,
       HTMLNode contentNode,
       QueuePartitions partitions,
-      Comparator<RequestStatus> jobComparator) {
+      Comparator<QueuePageRequestView> jobComparator) {
     String[] types = partitions.failedBadMIMEType.keySet().toArray(new String[0]);
     Arrays.sort(types);
     for (String type : types) {
-      List<DownloadRequestStatus> getters = partitions.failedBadMIMEType.get(type);
+      List<QueuePageDownloadView> getters = partitions.failedBadMIMEType.get(type);
       String atype = type.replace("-", "--").replace('/', '-');
       contentNode.addChild("a", "id", "failedDownload-badtype-" + atype);
       FilterMIMEType typeHandler = ContentFilter.getMIMEType(type);
@@ -865,11 +858,11 @@ final class LegacyQueuePagePort implements QueuePagePort {
       RequestTableContext tableContext,
       HTMLNode contentNode,
       QueuePartitions partitions,
-      Comparator<RequestStatus> jobComparator) {
+      Comparator<QueuePageRequestView> jobComparator) {
     String[] types = partitions.failedUnknownMIMEType.keySet().toArray(new String[0]);
     Arrays.sort(types);
     for (String type : types) {
-      List<DownloadRequestStatus> getters = partitions.failedUnknownMIMEType.get(type);
+      List<QueuePageDownloadView> getters = partitions.failedUnknownMIMEType.get(type);
       String atype = type.replace("-", "--").replace('/', '-');
       contentNode.addChild("a", "id", "failedDownload-unknowntype-" + atype);
       HTMLNode failedContent =
@@ -1315,7 +1308,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
 
   private HTMLNode createRequestTable(
       RequestTableContext tableContext,
-      List<? extends RequestStatus> requests,
+      List<? extends QueuePageRequestView> requests,
       QueueColumn[] columns,
       String id,
       QueueType queueType,
@@ -1325,7 +1318,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
 
   private HTMLNode createRequestTable(
       RequestTableContext tableContext,
-      List<? extends RequestStatus> requests,
+      List<? extends QueuePageRequestView> requests,
       QueueColumn[] columns,
       String id,
       String mimeType,
@@ -1393,11 +1386,11 @@ final class LegacyQueuePagePort implements QueuePagePort {
 
   private void addRequestRows(
       HTMLNode table,
-      List<? extends RequestStatus> requests,
+      List<? extends QueuePageRequestView> requests,
       QueueColumn[] columns,
       RowRenderContext rowContext) {
     int index = 0;
-    for (RequestStatus clientRequest : requests) {
+    for (QueuePageRequestView clientRequest : requests) {
       HTMLNode requestRow =
           table.addChild("tr", ATTR_CLASS, PRIORITY + clientRequest.getPriority());
       requestRow.addChild(createCheckboxCell(clientRequest, index++));
@@ -1411,13 +1404,13 @@ final class LegacyQueuePagePort implements QueuePagePort {
   }
 
   private HTMLNode createColumnCell(
-      QueueColumn column, RequestStatus clientRequest, RowRenderContext rowContext) {
+      QueueColumn column, QueuePageRequestView clientRequest, RowRenderContext rowContext) {
     return switch (column) {
       case IDENTIFIER ->
           createIdentifierCell(
-              clientRequest.getURI(),
+              clientRequest.getUri(),
               clientRequest.getIdentifier(),
-              clientRequest instanceof UploadDirRequestStatus);
+              clientRequest instanceof QueuePageUploadDirView);
       case SIZE -> createSizeCellForRequest(clientRequest, rowContext.advancedModeEnabled);
       case MIME_TYPE -> createMimeTypeCell(clientRequest);
       case PERSISTENCE ->
@@ -1425,10 +1418,10 @@ final class LegacyQueuePagePort implements QueuePagePort {
       case KEY -> createKeyCellForRequest(clientRequest);
       case FILENAME -> createFilenameCellForRequest(clientRequest);
       case PRIORITY -> createPriorityCell(clientRequest.getPriority(), rowContext.priorityClasses);
-      case FILES -> createNumberCell(((UploadDirRequestStatus) clientRequest).getNumberOfFiles());
+      case FILES -> createNumberCell(((QueuePageUploadDirView) clientRequest).getNumberOfFiles());
       case TOTAL_SIZE ->
           createSizeCell(
-              ((UploadDirRequestStatus) clientRequest).getTotalDataSize(),
+              ((QueuePageUploadDirView) clientRequest).getTotalDataSize(),
               true,
               rowContext.advancedModeEnabled);
       case PROGRESS ->
@@ -1600,7 +1593,7 @@ final class LegacyQueuePagePort implements QueuePagePort {
     return queueType.isUpload && !queueType.isCompleted;
   }
 
-  private HTMLNode createCheckboxCell(RequestStatus clientRequest, int counter) {
+  private HTMLNode createCheckboxCell(QueuePageRequestView clientRequest, int counter) {
     HTMLNode cell = new HTMLNode("td", ATTR_CLASS, "checkbox-cell");
     cell.addChild(
         TAG_INPUT,
@@ -1610,11 +1603,11 @@ final class LegacyQueuePagePort implements QueuePagePort {
         });
     FreenetURI uri;
     long size = -1;
-    if (clientRequest instanceof DownloadRequestStatus) {
-      uri = clientRequest.getURI();
+    if (clientRequest instanceof QueuePageDownloadView) {
+      uri = clientRequest.getUri();
       size = clientRequest.getDataSize();
-    } else if (clientRequest instanceof UploadRequestStatus status) {
-      uri = status.getFinalURI();
+    } else if (clientRequest instanceof QueuePageUploadView status) {
+      uri = status.getFinalUri();
       size = clientRequest.getDataSize();
     } else {
       uri = null;
@@ -1731,52 +1724,52 @@ final class LegacyQueuePagePort implements QueuePagePort {
   }
 
   private HTMLNode createSizeCellForRequest(
-      RequestStatus clientRequest, boolean advancedModeEnabled) {
+      QueuePageRequestView clientRequest, boolean advancedModeEnabled) {
     boolean isFinal =
-        !(clientRequest instanceof DownloadRequestStatus) || clientRequest.isTotalFinalized();
+        !(clientRequest instanceof QueuePageDownloadView) || clientRequest.isTotalFinalized();
     return createSizeCell(clientRequest.getDataSize(), isFinal, advancedModeEnabled);
   }
 
-  private HTMLNode createMimeTypeCell(RequestStatus clientRequest) {
-    if (clientRequest instanceof DownloadRequestStatus downloadStatus) {
-      return createTypeCell(downloadStatus.getMIMEType());
+  private HTMLNode createMimeTypeCell(QueuePageRequestView clientRequest) {
+    if (clientRequest instanceof QueuePageDownloadView downloadStatus) {
+      return createTypeCell(downloadStatus.getMimeType());
     }
-    if (clientRequest instanceof UploadFileRequestStatus uploadStatus) {
-      return createTypeCell(uploadStatus.getMIMEType());
+    if (clientRequest instanceof QueuePageUploadFileView uploadStatus) {
+      return createTypeCell(uploadStatus.getMimeType());
     }
     return null;
   }
 
-  private HTMLNode createKeyCellForRequest(RequestStatus clientRequest) {
-    if (clientRequest instanceof DownloadRequestStatus) {
-      return createKeyCell(clientRequest.getURI(), false);
+  private HTMLNode createKeyCellForRequest(QueuePageRequestView clientRequest) {
+    if (clientRequest instanceof QueuePageDownloadView) {
+      return createKeyCell(clientRequest.getUri(), false);
     }
-    if (clientRequest instanceof UploadFileRequestStatus uploadStatus) {
-      return createKeyCell(uploadStatus.getFinalURI(), false);
+    if (clientRequest instanceof QueuePageUploadFileView uploadStatus) {
+      return createKeyCell(uploadStatus.getFinalUri(), false);
     }
-    return createKeyCell(((UploadDirRequestStatus) clientRequest).getFinalURI(), true);
+    return createKeyCell(((QueuePageUploadDirView) clientRequest).getFinalUri(), true);
   }
 
-  private HTMLNode createFilenameCellForRequest(RequestStatus clientRequest) {
-    if (clientRequest instanceof DownloadRequestStatus downloadStatus) {
+  private HTMLNode createFilenameCellForRequest(QueuePageRequestView clientRequest) {
+    if (clientRequest instanceof QueuePageDownloadView downloadStatus) {
       return createFilenameCell(downloadStatus.getDestFilename());
     }
-    if (clientRequest instanceof UploadFileRequestStatus uploadStatus) {
+    if (clientRequest instanceof QueuePageUploadFileView uploadStatus) {
       return createFilenameCell(uploadStatus.getOrigFilename());
     }
     return null;
   }
 
   private HTMLNode createProgressCellForRequest(
-      RequestStatus clientRequest, boolean advancedModeEnabled, boolean isUploadQueue) {
-    COMPRESS_STATE compressing =
-        clientRequest instanceof UploadFileRequestStatus uploadStatus
-            ? uploadStatus.isCompressing()
-            : COMPRESS_STATE.WORKING;
+      QueuePageRequestView clientRequest, boolean advancedModeEnabled, boolean isUploadQueue) {
+    QueueCompressionState compressing =
+        clientRequest instanceof QueuePageUploadFileView uploadStatus
+            ? uploadStatus.getCompressionState()
+            : QueueCompressionState.WORKING;
     boolean finalizedTotal =
-        clientRequest instanceof UploadFileRequestStatus || clientRequest.isTotalFinalized();
-    ProgressCellContext progressContext =
-        new ProgressCellContext(
+        clientRequest instanceof QueuePageUploadFileView || clientRequest.isTotalFinalized();
+    QueueProgressCellContext progressContext =
+        new QueueProgressCellContext(
             advancedModeEnabled, clientRequest.isStarted(), compressing, isUploadQueue);
     SplitfileProgressCounts progressCounts =
         new SplitfileProgressCounts(
@@ -1787,17 +1780,17 @@ final class LegacyQueuePagePort implements QueuePagePort {
             clientRequest.getMinBlocks(),
             clientRequest.getMinBlocks(),
             finalizedTotal);
-    return QueueToadlet.createProgressCell(progressContext, progressCounts);
+    return QueueProgressCellRenderer.createProgressCell(progressContext, progressCounts);
   }
 
-  private HTMLNode createCompatModeCellForRequest(RequestStatus clientRequest) {
-    if (clientRequest instanceof DownloadRequestStatus downloadStatus) {
+  private HTMLNode createCompatModeCellForRequest(QueuePageRequestView clientRequest) {
+    if (clientRequest instanceof QueuePageDownloadView downloadStatus) {
       return createCompatModeCell(downloadStatus);
     }
     return new HTMLNode("td");
   }
 
-  private HTMLNode createCompatModeCell(DownloadRequestStatus get) {
+  private HTMLNode createCompatModeCell(QueuePageDownloadView get) {
     HTMLNode compatCell = new HTMLNode("td", ATTR_CLASS, "request-compat-mode");
     InsertContext.CompatibilityMode[] compat = get.getCompatibilityMode();
     if (!(compat[0] == InsertContext.CompatibilityMode.COMPAT_UNKNOWN
@@ -1953,18 +1946,18 @@ final class LegacyQueuePagePort implements QueuePagePort {
   }
 
   private static final class QueuePartitions {
-    private final List<DownloadRequestStatus> completedDownloadToDisk = new ArrayList<>();
-    private final List<DownloadRequestStatus> completedDownloadToTemp = new ArrayList<>();
-    private final List<UploadFileRequestStatus> completedUpload = new ArrayList<>();
-    private final List<UploadDirRequestStatus> completedDirUpload = new ArrayList<>();
-    private final List<DownloadRequestStatus> failedDownload = new ArrayList<>();
-    private final List<UploadFileRequestStatus> failedUpload = new ArrayList<>();
-    private final List<UploadDirRequestStatus> failedDirUpload = new ArrayList<>();
-    private final List<DownloadRequestStatus> uncompletedDownload = new ArrayList<>();
-    private final List<UploadFileRequestStatus> uncompletedUpload = new ArrayList<>();
-    private final List<UploadDirRequestStatus> uncompletedDirUpload = new ArrayList<>();
-    private final Map<String, List<DownloadRequestStatus>> failedUnknownMIMEType = new HashMap<>();
-    private final Map<String, List<DownloadRequestStatus>> failedBadMIMEType = new HashMap<>();
+    private final List<QueuePageDownloadView> completedDownloadToDisk = new ArrayList<>();
+    private final List<QueuePageDownloadView> completedDownloadToTemp = new ArrayList<>();
+    private final List<QueuePageUploadFileView> completedUpload = new ArrayList<>();
+    private final List<QueuePageUploadDirView> completedDirUpload = new ArrayList<>();
+    private final List<QueuePageDownloadView> failedDownload = new ArrayList<>();
+    private final List<QueuePageUploadFileView> failedUpload = new ArrayList<>();
+    private final List<QueuePageUploadDirView> failedDirUpload = new ArrayList<>();
+    private final List<QueuePageDownloadView> uncompletedDownload = new ArrayList<>();
+    private final List<QueuePageUploadFileView> uncompletedUpload = new ArrayList<>();
+    private final List<QueuePageUploadDirView> uncompletedDirUpload = new ArrayList<>();
+    private final Map<String, List<QueuePageDownloadView>> failedUnknownMIMEType = new HashMap<>();
+    private final Map<String, List<QueuePageDownloadView>> failedBadMIMEType = new HashMap<>();
     private short lowestQueuedPrio = RequestStarter.PAUSED_PRIORITY_CLASS;
     private long totalQueuedDownloadSize;
     private long totalQueuedUploadSize;

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueueCompressionState.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueueCompressionState.java
@@ -1,0 +1,23 @@
+package network.crypta.runtime.admin.queue.page;
+
+/**
+ * Captures the user-visible compression lifecycle for queue-page progress rendering.
+ *
+ * <p>The legacy queue page does not expose the full FCP compression state machine. It only needs a
+ * small status value that explains why an upload progress cell is not yet showing normal block
+ * counts. This enum keeps that presentation-oriented state inside the runtime-owned seam so callers
+ * can render stable HTML without depending on {@code ClientPut.COMPRESS_STATE}.
+ *
+ * <p>The values describe what the operator should infer from the queue row at render time. They do
+ * not attempt to model every internal insert phase.
+ */
+public enum QueueCompressionState {
+  /** The upload is queued for compression work but has not started compressing yet. */
+  WAITING,
+
+  /** The upload is actively compressing data before regular progress counters can advance. */
+  COMPRESSING,
+
+  /** The upload is past the compression gate and should render ordinary progress information. */
+  WORKING
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageBackend.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageBackend.java
@@ -1,0 +1,30 @@
+package network.crypta.runtime.admin.queue.page;
+
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+
+/**
+ * Defines the runtime-owned backend seam for legacy queue-page reads.
+ *
+ * <p>Implementations expose the current global queue as narrow runtime-owned views. The seam keeps
+ * protocol-specific lookup rules, status adaptation, and availability checks out of {@code
+ * network.crypta.runtime.admin}. That lets the legacy queue-page renderer keep its existing sorting
+ * and HTML behavior while depending only on stable runtime-owned types.
+ *
+ * <p>Callers should treat each invocation as consulting live daemon state rather than a cached
+ * snapshot. Returning an empty array is the normal way to represent a queue backend that is absent,
+ * disabled, or currently has no visible requests.
+ */
+public interface QueuePageBackend {
+  /**
+   * Returns the current global queue snapshot as runtime-owned request views.
+   *
+   * <p>The returned array is a point-in-time view of whatever queue state the implementation can
+   * currently observe. Implementations may return an empty array when the backing queue is missing
+   * or has nothing visible to expose, but they should raise an exception when the queue exists and
+   * an operational failure prevents the read from completing.
+   *
+   * @return point-in-time queue request views, or an empty array when nothing can be shown
+   * @throws RequestQueueUnavailableException if a live queue exists but cannot be queried safely
+   */
+  QueuePageRequestView[] getGlobalRequests() throws RequestQueueUnavailableException;
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageDownloadView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageDownloadView.java
@@ -1,0 +1,64 @@
+package network.crypta.runtime.admin.queue.page;
+
+import java.io.File;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.InsertContext;
+
+/**
+ * Adds the download-specific fields still rendered by the legacy queue page.
+ *
+ * <p>The legacy queue page needs a little more than the generic request counters when it renders
+ * download rows. It still shows destination details, MIME metadata, compatibility information, and
+ * failure categorization. This subtype exposes only those read-only values, so the runtime-owned
+ * seam can support the existing page without importing the full FCP download status API.
+ */
+public interface QueuePageDownloadView extends QueuePageRequestView {
+  /**
+   * Indicates whether the completed or in-progress download targets temporary storage.
+   *
+   * @return {@code true} when the queue row represents a temp-space download destination
+   */
+  boolean toTempSpace();
+
+  /**
+   * Returns the structured failure code associated with the current download state.
+   *
+   * @return failure classification used for MIME and error grouping on the queue page
+   */
+  FetchExceptionMode getFailureCode();
+
+  /**
+   * Returns the MIME type currently associated with the download, if one is known.
+   *
+   * @return MIME type text used for the queue type column, or {@code null} when unavailable
+   */
+  String getMimeType();
+
+  /**
+   * Returns the destination file selected for this download when it writes to disk.
+   *
+   * @return destination file path for queue-page display, or {@code null} when not applicable
+   */
+  File getDestFilename();
+
+  /**
+   * Returns the compatibility-mode hints attached to the underlying fetch request.
+   *
+   * @return compatibility modes shown in advanced queue-page output, possibly empty or {@code null}
+   */
+  InsertContext.CompatibilityMode[] getCompatibilityMode();
+
+  /**
+   * Returns any override splitfile crypto key associated with the request.
+   *
+   * @return override key bytes for advanced diagnostics, or {@code null} when no override exists
+   */
+  byte[] getOverriddenSplitfileCryptoKey();
+
+  /**
+   * Indicates whether the download detected content that should avoid compression.
+   *
+   * @return {@code true} when the request observed a do-not-compress condition
+   */
+  boolean detectedDontCompress();
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageRequestView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageRequestView.java
@@ -1,0 +1,153 @@
+package network.crypta.runtime.admin.queue.page;
+
+import java.time.Instant;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Describes the minimal runtime-owned view of a queue entry needed by the legacy queue page.
+ *
+ * <p>The interface deliberately mirrors only the read-only fields currently consumed by {@code
+ * LegacyQueuePagePort}: identifiers, progress counters, persistence flags, timestamps, failure
+ * text, and the canonical URI used in the existing HTML. It is not intended to be a general queue
+ * domain model.
+ *
+ * <p>Implementations usually adapt the live request state from another subsystem. Callers should
+ * treat each accessor as presentation data for one queue snapshot, not as a mutable handle they can
+ * use to control the request. The methods remain narrow on purpose, so later refactors can move the
+ * queue page away from FCP details without widening the runtime-owned surface again.
+ */
+public interface QueuePageRequestView {
+  /**
+   * Returns the stable queue identifier associated with this request.
+   *
+   * @return queue identifier text used in forms, actions, and diagnostics
+   */
+  String getIdentifier();
+
+  /**
+   * Indicates whether the request has completed successfully.
+   *
+   * @return {@code true} when the request reached a successful terminal state
+   */
+  boolean hasSucceeded();
+
+  /**
+   * Indicates whether the request has reached any terminal state.
+   *
+   * @return {@code true} when the request is finished, regardless of success or failure
+   */
+  boolean hasFinished();
+
+  /**
+   * Returns the current scheduler priority for the request.
+   *
+   * @return priority value used for queue ordering and display
+   */
+  short getPriority();
+
+  /**
+   * Returns the currently known total block count for the request.
+   *
+   * @return total block count visible to the queue page in this snapshot
+   */
+  int getTotalBlocks();
+
+  /**
+   * Indicates whether the total block count is final rather than provisional.
+   *
+   * @return {@code true} when {@link #getTotalBlocks()} will no longer increase
+   */
+  boolean isTotalFinalized();
+
+  /**
+   * Returns the minimum block success threshold needed for completion.
+   *
+   * @return minimum successful block count required to satisfy the request
+   */
+  int getMinBlocks();
+
+  /**
+   * Returns the number of blocks fetched or inserted successfully so far.
+   *
+   * @return successful block count visible in the current queue snapshot
+   */
+  int getFetchedBlocks();
+
+  /**
+   * Returns the most recent successful activity timestamp for this request.
+   *
+   * @return last success instant, or {@code null} when no success has been recorded
+   */
+  Instant getLastSuccess();
+
+  /**
+   * Returns the most recent failure timestamp for this request.
+   *
+   * @return last failure instant, or {@code null} when no failure has been recorded
+   */
+  Instant getLastFailure();
+
+  /**
+   * Returns the canonical request URI used by the queue page for display and grouping.
+   *
+   * @return request URI associated with this queue entry, or {@code null} when unavailable
+   */
+  FreenetURI getUri();
+
+  /**
+   * Returns the current data-size estimate associated with this request.
+   *
+   * @return request data size in bytes, using the semantics of the adapted backend
+   */
+  long getDataSize();
+
+  /**
+   * Indicates whether the request is stored in the persistent queue.
+   *
+   * @return {@code true} when the request survives ordinary daemon restarts
+   */
+  boolean isPersistent();
+
+  /**
+   * Indicates whether the request is marked as persistent forever.
+   *
+   * @return {@code true} when the request uses the strongest persistent lifetime
+   */
+  boolean isPersistentForever();
+
+  /**
+   * Returns the number of permanently failed blocks recorded for the request.
+   *
+   * @return fatal block failure count used in advanced queue diagnostics
+   */
+  int getFatalyFailedBlocks();
+
+  /**
+   * Returns the number of retryable block failures recorded for the request.
+   *
+   * @return non-fatal block failure count visible to the queue page
+   */
+  int getFailedBlocks();
+
+  /**
+   * Indicates whether the request has started doing work yet.
+   *
+   * @return {@code true} once the request moved past its initial waiting state
+   */
+  boolean isStarted();
+
+  /**
+   * Returns the current failure description in either short or long form.
+   *
+   * @param longDescription {@code true} to request a more detailed explanation when supported
+   * @return failure description text, or {@code null} when no failure message is available
+   */
+  String getFailureReason(boolean longDescription);
+
+  /**
+   * Returns the sanitized preferred filename derived for display.
+   *
+   * @return safe filename text for queue-page columns, or {@code null} when none is known
+   */
+  String getPreferredFilenameSafe();
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageUploadDirView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageUploadDirView.java
@@ -1,0 +1,25 @@
+package network.crypta.runtime.admin.queue.page;
+
+/**
+ * Adds the directory-upload-specific fields still needed by the legacy queue page.
+ *
+ * <p>Directory inserts share the generic upload state exposed by {@link QueuePageUploadView}, but
+ * the queue page also renders aggregate size and file-count columns for them. This subtype exposes
+ * only those extra read-only values, so the seam stays aligned with the current HTML rather than
+ * turning into a broad directory-insert API.
+ */
+public interface QueuePageUploadDirView extends QueuePageUploadView {
+  /**
+   * Returns the aggregate size of the directory upload payload.
+   *
+   * @return total upload payload size in bytes across all files included in the directory insert
+   */
+  long getTotalDataSize();
+
+  /**
+   * Returns the number of files included in the directory upload.
+   *
+   * @return file count rendered in the queue page's directory-specific columns
+   */
+  int getNumberOfFiles();
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageUploadFileView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageUploadFileView.java
@@ -1,0 +1,34 @@
+package network.crypta.runtime.admin.queue.page;
+
+import java.io.File;
+
+/**
+ * Adds the file-upload-specific fields still needed by the legacy queue page.
+ *
+ * <p>Single-file inserts expose a few presentation details that directory inserts do not share: the
+ * detected MIME type, the original filename, and the user-visible compression phase used by the
+ * progress cell. This subtype keeps those values narrow and read-only so the queue page can
+ * preserve its existing output without depending directly on FCP upload status classes.
+ */
+public interface QueuePageUploadFileView extends QueuePageUploadView {
+  /**
+   * Returns the MIME type currently associated with the file upload.
+   *
+   * @return MIME type text for the queue page's type column, or {@code null} when unavailable
+   */
+  String getMimeType();
+
+  /**
+   * Returns the original file selected for the upload when that path is known.
+   *
+   * @return original upload file path for display, or {@code null} when unavailable
+   */
+  File getOrigFilename();
+
+  /**
+   * Returns the presentation-oriented compression state for the upload row.
+   *
+   * @return runtime-owned compression state used to choose progress-cell messaging
+   */
+  QueueCompressionState getCompressionState();
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageUploadView.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueuePageUploadView.java
@@ -1,0 +1,22 @@
+package network.crypta.runtime.admin.queue.page;
+
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Marks a queue-page view representing an upload request.
+ *
+ * <p>The queue page still treats the finalized URI specially for uploads. It uses that value when
+ * rendering hidden form fields and key columns.
+ *
+ * <p>This subtype exposes the finalized URI explicitly. Callers do not need to infer it from the
+ * generic request URI. That keeps upload-specific rendering concerns out of generic queue-page code
+ * while still avoiding a broad dependency on the upstream upload status model.
+ */
+public interface QueuePageUploadView extends QueuePageRequestView {
+  /**
+   * Returns the finalized insert URI associated with the upload request.
+   *
+   * @return finalized upload URI for queue-page key rendering, or {@code null} when not available
+   */
+  FreenetURI getFinalUri();
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueueProgressCellContext.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueueProgressCellContext.java
@@ -1,0 +1,32 @@
+package network.crypta.runtime.admin.queue.page;
+
+import java.util.Objects;
+
+/**
+ * Bundles the non-counter flags required to render a queue progress cell.
+ *
+ * <p>The queue page derives block counters separately from request status objects, but the progress
+ * renderer also needs a few boolean and enum flags to decide whether it should show a progress bar
+ * at all. This record groups those non-counter inputs into one immutable value so callers can pass
+ * a stable rendering context without keeping HTTP-layer helper types alive.
+ *
+ * <p>Instances are safe to reuse within one render pass because the record is immutable. The
+ * compact constructor enforces a non-null compression state, so rendering code can branch on the
+ * enum directly instead of carrying nullable checks through every call path.
+ *
+ * @param advancedMode {@code true} to render detailed progress fractions when available
+ * @param started {@code true} once the request has moved beyond its initial waiting state
+ * @param compressing current compression state used to select early progress messaging
+ * @param upload {@code true} when rendering an upload progress cell instead of a download cell
+ */
+public record QueueProgressCellContext(
+    boolean advancedMode, boolean started, QueueCompressionState compressing, boolean upload) {
+  /**
+   * Creates a progress-cell rendering context with a stable non-counter state.
+   *
+   * @throws NullPointerException if {@code compressing} is {@code null}
+   */
+  public QueueProgressCellContext {
+    Objects.requireNonNull(compressing, "compressing");
+  }
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/QueueProgressCellRenderer.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/QueueProgressCellRenderer.java
@@ -1,0 +1,179 @@
+package network.crypta.runtime.admin.queue.page;
+
+import java.util.Objects;
+import network.crypta.client.events.SplitfileProgressCounts;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.HTMLNode;
+
+/**
+ * Renders the legacy queue progress cell without depending on HTTP-layer helpers.
+ *
+ * <p>The implementation intentionally preserves the established queue-page HTML structure and
+ * localization keys, so the extracted queue-page seam remains a mechanical decoupling step. Callers
+ * hand the renderer a small immutable context plus the current splitfile counters, and the renderer
+ * returns the exact queue-cell subtree that can be embedded in the legacy table output.
+ *
+ * <p>The class is deliberately stateless. All operator-visible wording still comes from the
+ * existing {@code QueueToadlet.*} localization keys, and the progress-bar structure matches the
+ * legacy page so this seam extraction does not become an HTML redesign.
+ */
+public final class QueueProgressCellRenderer {
+  private static final String ATTR_CLASS = "class";
+  private static final String ATTR_STYLE = "style";
+  private static final String ATTR_TITLE = "title";
+  private static final String CSS_WIDTH_PREFIX = "width: ";
+  private static final String UNKNOWN = "unknown";
+  private static final String QUEUE_TOADLET_PREFIX = "QueueToadlet.";
+
+  private QueueProgressCellRenderer() {}
+
+  /**
+   * Creates the queue progress cell for the provided context and counters.
+   *
+   * <p>The renderer first handles the early states that should display plain text instead of a
+   * progress bar, such as requests that have not started or uploads waiting for compression. Once a
+   * row is eligible for numeric progress, the method computes the same percentages and titles that
+   * the legacy HTTP helper produced and returns a detached {@code <td>} subtree ready for insertion
+   * into the queue table.
+   *
+   * @param context rendering context that describes the request state outside the numeric counters
+   * @param counts splitfile progress counters captured for the request at this render instant
+   * @return HTML node representing the queue progress cell with legacy-compatible structure
+   */
+  public static HTMLNode createProgressCell(
+      QueueProgressCellContext context, SplitfileProgressCounts counts) {
+    Objects.requireNonNull(context, "context");
+    Objects.requireNonNull(counts, "counts");
+
+    HTMLNode progressCell = new HTMLNode("td", ATTR_CLASS, "request-progress");
+    if (handleEarlyProgressMessages(context, progressCell)) {
+      return progressCell;
+    }
+
+    int adjustedTotal =
+        adjustTotal(context.advancedMode(), counts.minSuccessfulBlocks(), counts.totalBlocks());
+
+    if (counts.succeedBlocks() < 0 || adjustedTotal <= 0) {
+      progressCell.addChild("span", ATTR_CLASS, "progress_fraction_unknown", l10n(UNKNOWN));
+    } else {
+      addProgressBar(
+          progressCell, counts, adjustedTotal, counts.finalizedTotal(), context.upload());
+    }
+    return progressCell;
+  }
+
+  private static boolean handleEarlyProgressMessages(
+      QueueProgressCellContext context, HTMLNode progressCell) {
+    if (!context.started()) {
+      progressCell.addChild("#", l10n("starting"));
+      return true;
+    }
+    if (context.compressing() == QueueCompressionState.WAITING && context.advancedMode()) {
+      progressCell.addChild("#", l10n("awaitingCompression"));
+      return true;
+    }
+    if (context.compressing() != QueueCompressionState.WORKING) {
+      progressCell.addChild("#", l10n("compressing"));
+      return true;
+    }
+    return false;
+  }
+
+  private static int adjustTotal(boolean advancedMode, int min, int total) {
+    return !advancedMode || total < min ? min : total;
+  }
+
+  private static void addProgressBar(
+      HTMLNode progressCell,
+      SplitfileProgressCounts progressCounts,
+      int adjustedTotal,
+      boolean finalized,
+      boolean upload) {
+    int fetchedPercent = (int) (progressCounts.succeedBlocks() / (double) adjustedTotal * 100);
+    int failedPercent = (int) (progressCounts.failedBlocks() / (double) adjustedTotal * 100);
+    int fatallyFailedPercent =
+        (int) (progressCounts.fatallyFailedBlocks() / (double) adjustedTotal * 100);
+    int minPercent = (int) (progressCounts.minSuccessfulBlocks() / (double) adjustedTotal * 100);
+    HTMLNode progressBar = progressCell.addChild("div", ATTR_CLASS, "progressbar");
+    progressBar.addChild(
+        "div",
+        new String[] {ATTR_CLASS, ATTR_STYLE},
+        new String[] {"progressbar-done", CSS_WIDTH_PREFIX + fetchedPercent + "%;"});
+
+    if (progressCounts.failedBlocks() > 0) {
+      progressBar.addChild(
+          "div",
+          new String[] {ATTR_CLASS, ATTR_STYLE},
+          new String[] {"progressbar-failed", CSS_WIDTH_PREFIX + failedPercent + "%;"});
+    }
+    if (progressCounts.fatallyFailedBlocks() > 0) {
+      progressBar.addChild(
+          "div",
+          new String[] {ATTR_CLASS, ATTR_STYLE},
+          new String[] {"progressbar-failed2", CSS_WIDTH_PREFIX + fatallyFailedPercent + "%;"});
+    }
+    if ((progressCounts.succeedBlocks()
+            + progressCounts.failedBlocks()
+            + progressCounts.fatallyFailedBlocks())
+        < progressCounts.minSuccessfulBlocks()) {
+      progressBar.addChild(
+          "div",
+          new String[] {ATTR_CLASS, ATTR_STYLE},
+          new String[] {
+            "progressbar-min", CSS_WIDTH_PREFIX + (minPercent - fetchedPercent) + "%;"
+          });
+    }
+
+    String prefix =
+        '('
+            + Integer.toString(progressCounts.succeedBlocks())
+            + "/ "
+            + progressCounts.minSuccessfulBlocks()
+            + "): ";
+    addProgressTitle(
+        progressBar,
+        progressCounts.succeedBlocks(),
+        progressCounts.minSuccessfulBlocks(),
+        finalized,
+        upload,
+        prefix);
+  }
+
+  private static void addProgressTitle(
+      HTMLNode progressBar,
+      int fetched,
+      int min,
+      boolean finalized,
+      boolean upload,
+      String prefix) {
+    double percent = min == 0 ? 0.0 : (fetched / (double) min) * 100.0;
+    double roundedPercent = Math.round(percent * 10.0) / 10.0;
+    String percentText = roundedPercent + "%";
+    if (finalized) {
+      progressBar.addChild(
+          "div",
+          new String[] {ATTR_CLASS, ATTR_TITLE},
+          new String[] {"progress_fraction_finalized", prefix + l10n("progressbarAccurate")},
+          percentText);
+      return;
+    }
+    String text = fetched + " (" + percentText + "??)";
+    progressBar.addChild(
+        "div",
+        new String[] {ATTR_CLASS, ATTR_TITLE},
+        new String[] {
+          "progress_fraction_not_finalized",
+          prefix
+              + NodeL10n.getBase()
+                  .getString(
+                      upload
+                          ? QUEUE_TOADLET_PREFIX + "uploadProgressbarNotAccurate"
+                          : QUEUE_TOADLET_PREFIX + "progressbarNotAccurate")
+        },
+        text);
+  }
+
+  private static String l10n(String key) {
+    return NodeL10n.getBase().getString(QUEUE_TOADLET_PREFIX + key);
+  }
+}

--- a/src/main/java/network/crypta/runtime/admin/queue/page/package-info.java
+++ b/src/main/java/network/crypta/runtime/admin/queue/page/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Provides the runtime-owned seam for the legacy queue page read path.
+ *
+ * <p>The types in this package let {@code network.crypta.runtime.admin} render the existing queue
+ * page without importing FCP request-status classes or HTTP-layer progress helpers. The seam stays
+ * intentionally narrow: it carries only the backend lookup needed for queue-page reads, the small
+ * request views consumed by {@code LegacyQueuePagePort}, and a runtime-owned progress-cell renderer
+ * that preserves the established HTML output.
+ *
+ * <p>This package is not a general queue domain model. It exists to keep one legacy admin page
+ * working while the runtime/admin boundary is narrowed in small, behavior-preserving steps.
+ */
+package network.crypta.runtime.admin.queue.page;

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackend.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackend.java
@@ -1,0 +1,323 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.io.File;
+import java.time.Instant;
+import java.util.Objects;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
+import network.crypta.clients.fcp.DownloadRequestStatus;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.RequestStatus;
+import network.crypta.clients.fcp.UploadDirRequestStatus;
+import network.crypta.clients.fcp.UploadFileRequestStatus;
+import network.crypta.clients.fcp.UploadRequestStatus;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.page.QueueCompressionState;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageDownloadView;
+import network.crypta.runtime.admin.queue.page.QueuePageRequestView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadDirView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadFileView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadView;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+
+/**
+ * Implements the runtime-owned queue-page seam on top of the live FCP server.
+ *
+ * <p>This bridge keeps the remaining FCP-specific queue-page knowledge inside {@code
+ * network.crypta.runtime.endpoints.fcp}. Runtime-admin callers interact only with runtime-owned
+ * queue-page views, while this type resolves the live {@link FCPServer} lazily, translates
+ * persistence failures into {@link RequestQueueUnavailableException}, and adapts protocol-specific
+ * request statuses into the minimal runtime-owned view used by {@code LegacyQueuePagePort}.
+ *
+ * <p>The bridge is intentionally mechanical. It does not try to redesign queue semantics, cache
+ * snapshots, or normalize more data than the legacy page currently consumes. Missing FCP access is
+ * treated as an empty queue-page snapshot, so the daemon startup order stays unchanged, while an
+ * actual persistent-queue failure still surfaces as a runtime SPI exception that the HTTP layer
+ * already knows how to report.
+ */
+public final class FcpQueuePageBackend implements QueuePageBackend {
+  private static final String QUEUE_UNAVAILABLE = "Persistent request queue unavailable";
+
+  private final NodeClientCore core;
+
+  /**
+   * Creates an FCP-backed queue-page bridge.
+   *
+   * @param core daemon client core used to resolve the current FCP endpoint bundle on demand
+   */
+  public FcpQueuePageBackend(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core, "core");
+  }
+
+  /**
+   * Returns the current global requests adapted into runtime-owned queue-page views.
+   *
+   * <p>The method resolves the FCP server lazily on each call, so constructing this backend does
+   * not force endpoint initialization during startup. When no FCP server is currently available,
+   * the bridge reports an empty queue snapshot. When the server exists but persistent queue access
+   * is disabled, the method translates that protocol-specific failure into the runtime SPI
+   * exception expected by callers above the seam.
+   *
+   * @return adapted global request views, or an empty array when the FCP queue cannot be reached
+   *     yet
+   * @throws RequestQueueUnavailableException if the persistent queue exists but cannot be queried
+   */
+  @Override
+  public QueuePageRequestView[] getGlobalRequests() throws RequestQueueUnavailableException {
+    FCPServer fcpServer = fcpServerOrNull();
+    if (fcpServer == null) {
+      return new QueuePageRequestView[0];
+    }
+    try {
+      return adapt(fcpServer.getGlobalRequests());
+    } catch (PersistenceDisabledException e) {
+      throw new RequestQueueUnavailableException(QUEUE_UNAVAILABLE, e);
+    }
+  }
+
+  private FCPServer fcpServerOrNull() {
+    var endpoints = core.getEndpoints();
+    return endpoints == null ? null : endpoints.getFCPServer();
+  }
+
+  private QueuePageRequestView[] adapt(RequestStatus[] statuses) {
+    QueuePageRequestView[] views = new QueuePageRequestView[statuses.length];
+    for (int i = 0; i < statuses.length; i++) {
+      views[i] = adapt(statuses[i]);
+    }
+    return views;
+  }
+
+  private QueuePageRequestView adapt(RequestStatus status) {
+    if (status instanceof DownloadRequestStatus downloadStatus) {
+      return new DownloadView(downloadStatus);
+    }
+    if (status instanceof UploadFileRequestStatus uploadFileStatus) {
+      return new UploadFileView(uploadFileStatus);
+    }
+    if (status instanceof UploadDirRequestStatus uploadDirStatus) {
+      return new UploadDirView(uploadDirStatus);
+    }
+    if (status instanceof UploadRequestStatus uploadStatus) {
+      return new UploadView(uploadStatus);
+    }
+    return new RequestViewAdapter(status);
+  }
+
+  private static class RequestViewAdapter implements QueuePageRequestView {
+    private final RequestStatus status;
+
+    private RequestViewAdapter(RequestStatus status) {
+      this.status = Objects.requireNonNull(status, "status");
+    }
+
+    @Override
+    public String getIdentifier() {
+      return status.getIdentifier();
+    }
+
+    @Override
+    public boolean hasSucceeded() {
+      return status.hasSucceeded();
+    }
+
+    @Override
+    public boolean hasFinished() {
+      return status.hasFinished();
+    }
+
+    @Override
+    public short getPriority() {
+      return status.getPriority();
+    }
+
+    @Override
+    public int getTotalBlocks() {
+      return status.getTotalBlocks();
+    }
+
+    @Override
+    public boolean isTotalFinalized() {
+      return status.isTotalFinalized();
+    }
+
+    @Override
+    public int getMinBlocks() {
+      return status.getMinBlocks();
+    }
+
+    @Override
+    public int getFetchedBlocks() {
+      return status.getFetchedBlocks();
+    }
+
+    @Override
+    public Instant getLastSuccess() {
+      return status.getLastSuccess();
+    }
+
+    @Override
+    public Instant getLastFailure() {
+      return status.getLastFailure();
+    }
+
+    @Override
+    public FreenetURI getUri() {
+      return status.getURI();
+    }
+
+    @Override
+    public long getDataSize() {
+      return status.getDataSize();
+    }
+
+    @Override
+    public boolean isPersistent() {
+      return status.isPersistent();
+    }
+
+    @Override
+    public boolean isPersistentForever() {
+      return status.isPersistentForever();
+    }
+
+    @Override
+    public int getFatalyFailedBlocks() {
+      return status.getFatalyFailedBlocks();
+    }
+
+    @Override
+    public int getFailedBlocks() {
+      return status.getFailedBlocks();
+    }
+
+    @Override
+    public boolean isStarted() {
+      return status.isStarted();
+    }
+
+    @Override
+    public String getFailureReason(boolean longDescription) {
+      return status.getFailureReason(longDescription);
+    }
+
+    @Override
+    public String getPreferredFilenameSafe() {
+      return status.getPreferredFilenameSafe();
+    }
+  }
+
+  private static final class DownloadView extends RequestViewAdapter
+      implements QueuePageDownloadView {
+    private final DownloadRequestStatus status;
+
+    private DownloadView(DownloadRequestStatus status) {
+      super(status);
+      this.status = status;
+    }
+
+    @Override
+    public boolean toTempSpace() {
+      return status.toTempSpace();
+    }
+
+    @Override
+    public FetchExceptionMode getFailureCode() {
+      return status.getFailureCode();
+    }
+
+    @Override
+    public String getMimeType() {
+      return status.getMIMEType();
+    }
+
+    @Override
+    public File getDestFilename() {
+      return status.getDestFilename();
+    }
+
+    @Override
+    public CompatibilityMode[] getCompatibilityMode() {
+      return status.getCompatibilityMode();
+    }
+
+    @Override
+    public byte[] getOverriddenSplitfileCryptoKey() {
+      return status.getOverriddenSplitfileCryptoKey();
+    }
+
+    @Override
+    public boolean detectedDontCompress() {
+      return status.detectedDontCompress();
+    }
+  }
+
+  private static class UploadView extends RequestViewAdapter implements QueuePageUploadView {
+    private final UploadRequestStatus status;
+
+    private UploadView(UploadRequestStatus status) {
+      super(status);
+      this.status = status;
+    }
+
+    @Override
+    public FreenetURI getFinalUri() {
+      return status.getFinalURI();
+    }
+  }
+
+  private static final class UploadFileView extends UploadView implements QueuePageUploadFileView {
+    private final UploadFileRequestStatus status;
+
+    private UploadFileView(UploadFileRequestStatus status) {
+      super(status);
+      this.status = status;
+    }
+
+    @Override
+    public String getMimeType() {
+      return status.getMIMEType();
+    }
+
+    @Override
+    public File getOrigFilename() {
+      return status.getOrigFilename();
+    }
+
+    @Override
+    public QueueCompressionState getCompressionState() {
+      return mapCompressionState(status.isCompressing());
+    }
+
+    private static QueueCompressionState mapCompressionState(COMPRESS_STATE state) {
+      return switch (state) {
+        case WAITING -> QueueCompressionState.WAITING;
+        case COMPRESSING -> QueueCompressionState.COMPRESSING;
+        case WORKING -> QueueCompressionState.WORKING;
+      };
+    }
+  }
+
+  private static final class UploadDirView extends UploadView implements QueuePageUploadDirView {
+    private final UploadDirRequestStatus status;
+
+    private UploadDirView(UploadDirRequestStatus status) {
+      super(status);
+      this.status = status;
+    }
+
+    @Override
+    public long getTotalDataSize() {
+      return status.getTotalDataSize();
+    }
+
+    @Override
+    public int getNumberOfFiles() {
+      return status.getNumberOfFiles();
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/admin/LegacyQueuePagePortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyQueuePagePortTest.java
@@ -4,18 +4,16 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import network.crypta.client.async.ClientRequestScheduler;
-import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.clients.fcp.DownloadRequestStatus;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.RequestStatus;
-import network.crypta.clients.fcp.UploadFileRequestStatus;
-import network.crypta.clients.fcp.UploadRequestStatus;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarterGroup;
-import network.crypta.runtime.endpoints.ClientEndpoints;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageDownloadView;
+import network.crypta.runtime.admin.queue.page.QueuePageRequestView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadFileView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadView;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
@@ -43,8 +41,7 @@ import static org.mockito.Mockito.when;
 class LegacyQueuePagePortTest {
 
   @Mock private NodeClientCore core;
-  @Mock private ClientEndpoints endpoints;
-  @Mock private FCPServer fcp;
+  @Mock private QueuePageBackend queueBackend;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private Node node;
@@ -59,28 +56,27 @@ class LegacyQueuePagePortTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    when(core.getEndpoints()).thenReturn(endpoints);
     when(core.getNode()).thenReturn(node);
     when(core.getRequestStarters()).thenReturn(requestStarters);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
     when(node.network().darknetConnections()).thenReturn(new DarknetPeerNode[0]);
     setRequestStarterField("chkFetchSchedulerBulk", chkFetchSchedulerBulk);
     setRequestStarterField("chkFetchSchedulerRT", chkFetchSchedulerRT);
-    port = new LegacyQueuePagePort(core);
+    port = new LegacyQueuePagePort(core, queueBackend);
   }
 
   @Test
   void renderPage_whenUploadQueueHasCompletedRequest_returnsDetachedHtmlSnapshot()
       throws Exception {
-    UploadFileRequestStatus upload = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
+    QueuePageUploadFileView upload = org.mockito.Mockito.mock(QueuePageUploadFileView.class);
     when(upload.hasSucceeded()).thenReturn(true);
     when(upload.getIdentifier()).thenReturn("upload-1");
     when(upload.getPriority()).thenReturn((short) 2);
     when(upload.getOrigFilename()).thenReturn(new File("hello.txt"));
     when(upload.getPreferredFilenameSafe()).thenReturn("hello.txt");
     when(upload.getDataSize()).thenReturn(123L);
-    when(upload.getFinalURI()).thenReturn(sampleUri());
-    when(fcp.getGlobalRequests()).thenReturn(new RequestStatus[] {upload});
+    when(upload.getFinalUri()).thenReturn(sampleUri());
+    when(upload.getUri()).thenReturn(sampleUri());
+    when(queueBackend.getGlobalRequests()).thenReturn(new QueuePageRequestView[] {upload});
 
     QueuePageSnapshot snapshot = port.renderPage(new QueuePageRequest(true, false, null, false));
 
@@ -109,8 +105,9 @@ class LegacyQueuePagePortTest {
   }
 
   @Test
-  void renderPage_whenFcpServerMissing_returnsEmptyDownloadsSnapshot() throws Exception {
-    when(endpoints.getFCPServer()).thenReturn(null);
+  void renderPage_whenQueueBackendReturnsNoRequests_returnsEmptyDownloadsSnapshot()
+      throws Exception {
+    when(queueBackend.getGlobalRequests()).thenReturn(new QueuePageRequestView[0]);
     when(core.getDownloadsDir()).thenReturn(new File("downloads"));
     when(core.allowDownloadTo(any(File.class))).thenReturn(true);
 
@@ -120,18 +117,18 @@ class LegacyQueuePagePortTest {
     assertTrue(snapshot.contentHtmlTemplate().contains("queue-empty"));
     assertTrue(snapshot.contentHtmlTemplate().contains("queueDownloadForm"));
     assertTrue(snapshot.contentHtmlTemplate().contains("<!--CRYPTA_ALERT_SUMMARY-->"));
-    verifyNoInteractions(fcp);
   }
 
   @Test
   void renderKeyList_whenDownloadsRequested_returnsOnlyDownloadUris() throws Exception {
-    DownloadRequestStatus download = org.mockito.Mockito.mock(DownloadRequestStatus.class);
-    UploadRequestStatus upload = org.mockito.Mockito.mock(UploadRequestStatus.class);
+    QueuePageDownloadView download = org.mockito.Mockito.mock(QueuePageDownloadView.class);
+    QueuePageUploadView upload = org.mockito.Mockito.mock(QueuePageUploadView.class);
     FreenetURI downloadUri = sampleUri();
     FreenetURI uploadUri = sampleUri();
-    when(download.getURI()).thenReturn(downloadUri);
-    when(upload.getURI()).thenReturn(uploadUri);
-    when(fcp.getGlobalRequests()).thenReturn(new RequestStatus[] {download, upload});
+    when(download.getUri()).thenReturn(downloadUri);
+    when(upload.getFinalUri()).thenReturn(uploadUri);
+    when(queueBackend.getGlobalRequests())
+        .thenReturn(new QueuePageRequestView[] {download, upload});
 
     String keyList = port.renderKeyList(false);
 
@@ -140,15 +137,15 @@ class LegacyQueuePagePortTest {
 
   @Test
   void renderKeyList_whenUploadsRequested_skipsNullUploadUris() throws Exception {
-    DownloadRequestStatus download = org.mockito.Mockito.mock(DownloadRequestStatus.class);
-    UploadRequestStatus uploadWithUri = org.mockito.Mockito.mock(UploadRequestStatus.class);
-    UploadRequestStatus uploadWithoutUri = org.mockito.Mockito.mock(UploadRequestStatus.class);
+    QueuePageDownloadView download = org.mockito.Mockito.mock(QueuePageDownloadView.class);
+    QueuePageUploadView uploadWithUri = org.mockito.Mockito.mock(QueuePageUploadView.class);
+    QueuePageUploadView uploadWithoutUri = org.mockito.Mockito.mock(QueuePageUploadView.class);
     FreenetURI uploadUri = sampleUri();
-    when(download.getURI()).thenReturn(sampleUri());
-    when(uploadWithUri.getURI()).thenReturn(uploadUri);
-    when(uploadWithoutUri.getURI()).thenReturn(null);
-    when(fcp.getGlobalRequests())
-        .thenReturn(new RequestStatus[] {download, uploadWithUri, uploadWithoutUri});
+    when(download.getUri()).thenReturn(sampleUri());
+    when(uploadWithUri.getFinalUri()).thenReturn(uploadUri);
+    when(uploadWithoutUri.getFinalUri()).thenReturn(null);
+    when(queueBackend.getGlobalRequests())
+        .thenReturn(new QueuePageRequestView[] {download, uploadWithUri, uploadWithoutUri});
 
     String keyList = port.renderKeyList(true);
 
@@ -156,20 +153,12 @@ class LegacyQueuePagePortTest {
   }
 
   @Test
-  void renderKeyList_whenFcpServerMissing_returnsEmptyString() throws Exception {
-    when(endpoints.getFCPServer()).thenReturn(null);
-
-    String keyList = port.renderKeyList(false);
-
-    assertEquals("", keyList);
-    verifyNoInteractions(fcp);
-  }
-
-  @Test
-  void renderPage_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
+  void renderPage_whenQueueBackendUnavailable_propagatesRequestQueueUnavailableException()
       throws Exception {
-    PersistenceDisabledException cause = new PersistenceDisabledException();
-    when(fcp.getGlobalRequests()).thenThrow(cause);
+    IllegalStateException cause = new IllegalStateException("queue disabled");
+    RequestQueueUnavailableException failure =
+        new RequestQueueUnavailableException("Persistent request queue unavailable", cause);
+    when(queueBackend.getGlobalRequests()).thenThrow(failure);
 
     RequestQueueUnavailableException thrown =
         assertThrows(
@@ -180,14 +169,13 @@ class LegacyQueuePagePortTest {
   }
 
   @Test
-  void lazyFcpLookup_whenPortConstructed_defersEndpointAccessUntilMethodCall() throws Exception {
-    verifyNoInteractions(endpoints, fcp);
-    when(fcp.getGlobalRequests()).thenReturn(new RequestStatus[0]);
+  void queueBackendLookup_whenPortConstructed_defersBackendReadUntilMethodCall() throws Exception {
+    verifyNoInteractions(queueBackend);
+    when(queueBackend.getGlobalRequests()).thenReturn(new QueuePageRequestView[0]);
 
     port.renderKeyList(false);
 
-    verify(endpoints).getFCPServer();
-    verify(fcp).getGlobalRequests();
+    verify(queueBackend).getGlobalRequests();
   }
 
   private FreenetURI sampleUri() {

--- a/src/test/java/network/crypta/runtime/admin/queue/page/QueueProgressCellRendererTest.java
+++ b/src/test/java/network/crypta/runtime/admin/queue/page/QueueProgressCellRendererTest.java
@@ -1,0 +1,204 @@
+package network.crypta.runtime.admin.queue.page;
+
+import java.util.List;
+import network.crypta.client.events.SplitfileProgressCounts;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class QueueProgressCellRendererTest {
+  private static final String ATTR_CLASS = "class";
+  private static final String ATTR_STYLE = "style";
+  private static final String ATTR_TITLE = "title";
+
+  @Test
+  void createProgressCell_whenRequestNotStarted_rendersStartingMessage() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(false, false, QueueCompressionState.WORKING, false);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(10, 0, 0, 0, 5, false));
+
+    // Assert
+    assertEquals("td", progressCell.getName());
+    assertEquals("request-progress", progressCell.getAttribute(ATTR_CLASS));
+    assertTextChild(progressCell, l10n("starting"));
+  }
+
+  @Test
+  void createProgressCell_whenAdvancedModeAwaitingCompression_rendersAwaitingCompressionMessage() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(true, true, QueueCompressionState.WAITING, false);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(10, 0, 0, 0, 5, false));
+
+    // Assert
+    assertTextChild(progressCell, l10n("awaitingCompression"));
+  }
+
+  @Test
+  void createProgressCell_whenCompressionInProgress_rendersCompressingMessage() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(false, true, QueueCompressionState.COMPRESSING, true);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(10, 0, 0, 0, 5, false));
+
+    // Assert
+    assertTextChild(progressCell, l10n("compressing"));
+  }
+
+  @Test
+  void createProgressCell_whenSucceedBlocksNegative_rendersUnknownProgress() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(true, true, QueueCompressionState.WORKING, false);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(10, -1, 0, 0, 5, false));
+
+    // Assert
+    assertUnknownProgress(progressCell);
+  }
+
+  @Test
+  void createProgressCell_whenAdjustedTotalNonPositive_rendersUnknownProgress() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(true, true, QueueCompressionState.WORKING, false);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(0, 0, 0, 0, 0, false));
+
+    // Assert
+    assertUnknownProgress(progressCell);
+  }
+
+  @Test
+  void createProgressCell_whenFinalizedWithFailures_rendersAccurateProgressBar() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(true, true, QueueCompressionState.WORKING, false);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(10, 5, 2, 1, 9, true));
+
+    // Assert
+    HTMLNode progressBar = getSingleChild(progressCell);
+    assertEquals("div", progressBar.getName());
+    assertEquals("progressbar", progressBar.getAttribute(ATTR_CLASS));
+    assertEquals(
+        "width: 50%;", getChildWithClass(progressBar, "progressbar-done").getAttribute(ATTR_STYLE));
+    getChildWithClass(progressBar, "progressbar-failed");
+    getChildWithClass(progressBar, "progressbar-failed2");
+    assertEquals(
+        "width: 40%;", getChildWithClass(progressBar, "progressbar-min").getAttribute(ATTR_STYLE));
+
+    HTMLNode fraction = getChildWithClass(progressBar, "progress_fraction_finalized");
+    assertEquals("(5/ 9): " + l10n("progressbarAccurate"), fraction.getAttribute(ATTR_TITLE));
+    assertTextChild(fraction, "55.6%");
+  }
+
+  @Test
+  void createProgressCell_whenDownloadNotFinalized_usesMinimumBlocksForPercentAndDownloadTitle() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(false, true, QueueCompressionState.WORKING, false);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(10, 3, 0, 0, 6, false));
+
+    // Assert
+    HTMLNode progressBar = getSingleChild(progressCell);
+    assertEquals(
+        "width: 50%;", getChildWithClass(progressBar, "progressbar-done").getAttribute(ATTR_STYLE));
+    getChildWithClass(progressBar, "progressbar-min");
+    HTMLNode fraction = getChildWithClass(progressBar, "progress_fraction_not_finalized");
+    assertEquals("(3/ 6): " + l10n("progressbarNotAccurate"), fraction.getAttribute(ATTR_TITLE));
+    assertTextChild(fraction, "3 (50.0%??)");
+  }
+
+  @Test
+  void createProgressCell_whenUploadNotFinalized_usesUploadSpecificInaccurateTitle() {
+    // Arrange
+    QueueProgressCellContext context =
+        new QueueProgressCellContext(true, true, QueueCompressionState.WORKING, true);
+
+    // Act
+    HTMLNode progressCell =
+        QueueProgressCellRenderer.createProgressCell(context, counts(4, 3, 0, 0, 6, false));
+
+    // Assert
+    HTMLNode progressBar = getSingleChild(progressCell);
+    assertEquals(
+        "width: 50%;", getChildWithClass(progressBar, "progressbar-done").getAttribute(ATTR_STYLE));
+    getChildWithClass(progressBar, "progressbar-min");
+    HTMLNode fraction = getChildWithClass(progressBar, "progress_fraction_not_finalized");
+    assertEquals(
+        "(3/ 6): " + l10n("uploadProgressbarNotAccurate"), fraction.getAttribute(ATTR_TITLE));
+    assertTextChild(fraction, "3 (50.0%??)");
+  }
+
+  @Test
+  void constructor_whenCompressionStateNull_throwsNullPointerException() {
+    // Act + Assert
+    assertThrows(
+        NullPointerException.class, () -> new QueueProgressCellContext(true, true, null, false));
+  }
+
+  private static SplitfileProgressCounts counts(
+      int total, int succeed, int failed, int fatal, int minSuccessful, boolean finalized) {
+    return new SplitfileProgressCounts(total, succeed, failed, fatal, minSuccessful, 0, finalized);
+  }
+
+  private static void assertUnknownProgress(HTMLNode progressCell) {
+    HTMLNode unknown = getSingleChild(progressCell);
+    assertEquals("span", unknown.getName());
+    assertEquals("progress_fraction_unknown", unknown.getAttribute(ATTR_CLASS));
+    assertTextChild(unknown, l10n("unknown"));
+  }
+
+  private static void assertTextChild(HTMLNode parent, String expectedContent) {
+    HTMLNode child = getSingleChild(parent);
+    assertEquals("#", child.getName());
+    assertEquals(expectedContent, child.getContent());
+  }
+
+  private static HTMLNode getSingleChild(HTMLNode parent) {
+    List<HTMLNode> children = parent.getChildren();
+    assertEquals(1, children.size(), "Expected exactly one child node");
+    return children.getFirst();
+  }
+
+  private static HTMLNode getChildWithClass(HTMLNode parent, String className) {
+    HTMLNode match = null;
+    for (HTMLNode child : parent.getChildren()) {
+      if (className.equals(child.getAttribute(ATTR_CLASS))) {
+        match = child;
+        break;
+      }
+    }
+    assertNotNull(match, "Expected child with class " + className);
+    return match;
+  }
+
+  private static String l10n(String key) {
+    return NodeL10n.getBase().getString("QueueToadlet." + key);
+  }
+}

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackendTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackendTest.java
@@ -1,0 +1,441 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.time.Instant;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
+import network.crypta.clients.fcp.DownloadRequestStatus;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.RequestStatus;
+import network.crypta.clients.fcp.UploadDirRequestStatus;
+import network.crypta.clients.fcp.UploadFileRequestStatus;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.page.QueueCompressionState;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageDownloadView;
+import network.crypta.runtime.admin.queue.page.QueuePageRequestView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadDirView;
+import network.crypta.runtime.admin.queue.page.QueuePageUploadFileView;
+import network.crypta.runtime.endpoints.ClientEndpoints;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("java:S100")
+class FcpQueuePageBackendTest {
+
+  @Mock private NodeClientCore core;
+  @Mock private ClientEndpoints endpoints;
+  @Mock private FCPServer fcpServer;
+
+  private QueuePageBackend backend;
+
+  @BeforeEach
+  void setUp() {
+    when(core.getEndpoints()).thenReturn(endpoints);
+    backend = new FcpQueuePageBackend(core);
+  }
+
+  @Test
+  void getGlobalRequests_whenConstructed_defersFcpLookupUntilMethodCall() throws Exception {
+    verifyNoInteractions(endpoints, fcpServer);
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.getGlobalRequests()).thenReturn(new RequestStatus[0]);
+
+    backend.getGlobalRequests();
+
+    verify(endpoints).getFCPServer();
+    verify(fcpServer).getGlobalRequests();
+  }
+
+  @Test
+  void getGlobalRequests_whenFcpServerMissing_returnsEmptyArray() throws Exception {
+    when(endpoints.getFCPServer()).thenReturn(null);
+
+    QueuePageRequestView[] views = backend.getGlobalRequests();
+
+    assertEquals(0, views.length);
+  }
+
+  @Test
+  void getGlobalRequests_whenEndpointsMissing_returnsEmptyArray() throws Exception {
+    when(core.getEndpoints()).thenReturn(null);
+
+    QueuePageRequestView[] views = backend.getGlobalRequests();
+
+    assertEquals(0, views.length);
+    verifyNoInteractions(fcpServer);
+  }
+
+  @Test
+  void getGlobalRequests_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
+      throws Exception {
+    PersistenceDisabledException cause = new PersistenceDisabledException();
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.getGlobalRequests()).thenThrow(cause);
+
+    RequestQueueUnavailableException thrown =
+        assertThrows(RequestQueueUnavailableException.class, backend::getGlobalRequests);
+
+    assertSame(cause, thrown.getCause());
+  }
+
+  @Test
+  void getGlobalRequests_whenStatusesPresent_adaptsDownloadAndUploadViews() throws Exception {
+    DownloadRequestStatus download = org.mockito.Mockito.mock(DownloadRequestStatus.class);
+    UploadFileRequestStatus uploadFile = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
+    UploadDirRequestStatus uploadDir = org.mockito.Mockito.mock(UploadDirRequestStatus.class);
+    Instant lastSuccess = Instant.parse("2026-03-28T12:34:56Z");
+    Instant lastFailure = Instant.parse("2026-03-28T12:35:56Z");
+    InsertContext.CompatibilityMode[] compatModes = {
+      InsertContext.CompatibilityMode.COMPAT_1468, InsertContext.CompatibilityMode.COMPAT_1468
+    };
+    byte[] overrideKey = new byte[] {0x01, 0x23};
+    FreenetURI downloadUri = sampleUri("index_d51.xml");
+    FreenetURI uploadUri = sampleUri("upload.txt");
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.getGlobalRequests())
+        .thenReturn(new RequestStatus[] {download, uploadFile, uploadDir});
+
+    when(download.getIdentifier()).thenReturn("download-1");
+    when(download.hasSucceeded()).thenReturn(false);
+    when(download.hasFinished()).thenReturn(true);
+    when(download.getPriority()).thenReturn((short) 3);
+    when(download.getTotalBlocks()).thenReturn(20);
+    when(download.isTotalFinalized()).thenReturn(true);
+    when(download.getMinBlocks()).thenReturn(10);
+    when(download.getFetchedBlocks()).thenReturn(7);
+    when(download.getLastSuccess()).thenReturn(lastSuccess);
+    when(download.getLastFailure()).thenReturn(lastFailure);
+    when(download.getURI()).thenReturn(downloadUri);
+    when(download.getDataSize()).thenReturn(4096L);
+    when(download.isPersistent()).thenReturn(true);
+    when(download.isPersistentForever()).thenReturn(false);
+    when(download.getFatalyFailedBlocks()).thenReturn(2);
+    when(download.getFailedBlocks()).thenReturn(1);
+    when(download.isStarted()).thenReturn(true);
+    when(download.getFailureReason(false)).thenReturn("Bad MIME");
+    when(download.getPreferredFilenameSafe()).thenReturn("index_d51.xml");
+    when(download.toTempSpace()).thenReturn(false);
+    when(download.getFailureCode()).thenReturn(FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME);
+    when(download.getMIMEType()).thenReturn("text/plain");
+    when(download.getDestFilename()).thenReturn(new File("downloads/index_d51.xml"));
+    when(download.getCompatibilityMode()).thenReturn(compatModes);
+    when(download.getOverriddenSplitfileCryptoKey()).thenReturn(overrideKey);
+    when(download.detectedDontCompress()).thenReturn(true);
+
+    when(uploadFile.getIdentifier()).thenReturn("upload-file-1");
+    when(uploadFile.hasSucceeded()).thenReturn(true);
+    when(uploadFile.hasFinished()).thenReturn(true);
+    when(uploadFile.getPriority()).thenReturn((short) 2);
+    when(uploadFile.getTotalBlocks()).thenReturn(12);
+    when(uploadFile.isTotalFinalized()).thenReturn(false);
+    when(uploadFile.getMinBlocks()).thenReturn(8);
+    when(uploadFile.getFetchedBlocks()).thenReturn(8);
+    when(uploadFile.getLastSuccess()).thenReturn(lastSuccess);
+    when(uploadFile.getLastFailure()).thenReturn(null);
+    when(uploadFile.getURI()).thenReturn(uploadUri);
+    when(uploadFile.getDataSize()).thenReturn(512L);
+    when(uploadFile.isPersistent()).thenReturn(true);
+    when(uploadFile.isPersistentForever()).thenReturn(true);
+    when(uploadFile.getFatalyFailedBlocks()).thenReturn(0);
+    when(uploadFile.getFailedBlocks()).thenReturn(0);
+    when(uploadFile.isStarted()).thenReturn(true);
+    when(uploadFile.getFailureReason(false)).thenReturn(null);
+    when(uploadFile.getPreferredFilenameSafe()).thenReturn("upload.txt");
+    when(uploadFile.getFinalURI()).thenReturn(uploadUri);
+    when(uploadFile.getMIMEType()).thenReturn("text/plain");
+    when(uploadFile.getOrigFilename()).thenReturn(new File("uploads/upload.txt"));
+    when(uploadFile.isCompressing()).thenReturn(COMPRESS_STATE.COMPRESSING);
+
+    when(uploadDir.getIdentifier()).thenReturn("upload-dir-1");
+    when(uploadDir.hasSucceeded()).thenReturn(false);
+    when(uploadDir.hasFinished()).thenReturn(false);
+    when(uploadDir.getPriority()).thenReturn((short) 4);
+    when(uploadDir.getTotalBlocks()).thenReturn(30);
+    when(uploadDir.isTotalFinalized()).thenReturn(true);
+    when(uploadDir.getMinBlocks()).thenReturn(20);
+    when(uploadDir.getFetchedBlocks()).thenReturn(15);
+    when(uploadDir.getLastSuccess()).thenReturn(lastSuccess);
+    when(uploadDir.getLastFailure()).thenReturn(lastFailure);
+    when(uploadDir.getURI()).thenReturn(uploadUri);
+    when(uploadDir.getDataSize()).thenReturn(2048L);
+    when(uploadDir.isPersistent()).thenReturn(false);
+    when(uploadDir.isPersistentForever()).thenReturn(false);
+    when(uploadDir.getFatalyFailedBlocks()).thenReturn(1);
+    when(uploadDir.getFailedBlocks()).thenReturn(2);
+    when(uploadDir.isStarted()).thenReturn(false);
+    when(uploadDir.getFailureReason(false)).thenReturn("Pending");
+    when(uploadDir.getPreferredFilenameSafe()).thenReturn("site");
+    when(uploadDir.getFinalURI()).thenReturn(uploadUri);
+    when(uploadDir.getTotalDataSize()).thenReturn(2048L);
+    when(uploadDir.getNumberOfFiles()).thenReturn(7);
+
+    QueuePageRequestView[] views = backend.getGlobalRequests();
+
+    assertEquals(3, views.length);
+    assertDownloadView(views[0], lastSuccess, lastFailure, downloadUri, compatModes, overrideKey);
+    assertUploadFileView(views[1], lastSuccess, uploadUri);
+    assertUploadDirView(views[2], lastSuccess, lastFailure, uploadUri);
+  }
+
+  @Test
+  void getGlobalRequests_whenGenericStatusPresent_adaptsBaseRequestView() throws Exception {
+    RequestStatus genericStatus = org.mockito.Mockito.mock(RequestStatus.class);
+    Instant lastSuccess = Instant.parse("2026-03-28T12:34:56Z");
+    Instant lastFailure = Instant.parse("2026-03-28T12:35:56Z");
+    FreenetURI uri = sampleUri("generic.txt");
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.getGlobalRequests()).thenReturn(new RequestStatus[] {genericStatus});
+    when(genericStatus.getIdentifier()).thenReturn("generic-1");
+    when(genericStatus.hasSucceeded()).thenReturn(true);
+    when(genericStatus.hasFinished()).thenReturn(false);
+    when(genericStatus.getPriority()).thenReturn((short) 5);
+    when(genericStatus.getTotalBlocks()).thenReturn(11);
+    when(genericStatus.isTotalFinalized()).thenReturn(true);
+    when(genericStatus.getMinBlocks()).thenReturn(7);
+    when(genericStatus.getFetchedBlocks()).thenReturn(4);
+    when(genericStatus.getLastSuccess()).thenReturn(lastSuccess);
+    when(genericStatus.getLastFailure()).thenReturn(lastFailure);
+    when(genericStatus.getURI()).thenReturn(uri);
+    when(genericStatus.getDataSize()).thenReturn(204L);
+    when(genericStatus.isPersistent()).thenReturn(true);
+    when(genericStatus.isPersistentForever()).thenReturn(false);
+    when(genericStatus.getFatalyFailedBlocks()).thenReturn(1);
+    when(genericStatus.getFailedBlocks()).thenReturn(2);
+    when(genericStatus.isStarted()).thenReturn(true);
+    when(genericStatus.getFailureReason(false)).thenReturn("generic failure");
+    when(genericStatus.getPreferredFilenameSafe()).thenReturn("generic.txt");
+
+    QueuePageRequestView[] views = backend.getGlobalRequests();
+
+    assertEquals(1, views.length);
+    assertCommonRequestView(
+        views[0],
+        "generic-1",
+        true,
+        false,
+        (short) 5,
+        11,
+        true,
+        7,
+        4,
+        lastSuccess,
+        lastFailure,
+        uri,
+        204L,
+        true,
+        false,
+        1,
+        2,
+        true,
+        "generic failure",
+        "generic.txt");
+    assertFalse(views[0] instanceof QueuePageDownloadView);
+    assertFalse(views[0] instanceof QueuePageUploadFileView);
+    assertFalse(views[0] instanceof QueuePageUploadDirView);
+  }
+
+  @Test
+  void getGlobalRequests_whenUploadCompressionStatesPresent_mapsAllCompressionStates()
+      throws Exception {
+    UploadFileRequestStatus waiting = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
+    UploadFileRequestStatus compressing = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
+    UploadFileRequestStatus working = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
+    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(fcpServer.getGlobalRequests())
+        .thenReturn(new RequestStatus[] {waiting, compressing, working});
+    when(waiting.isCompressing()).thenReturn(COMPRESS_STATE.WAITING);
+    when(compressing.isCompressing()).thenReturn(COMPRESS_STATE.COMPRESSING);
+    when(working.isCompressing()).thenReturn(COMPRESS_STATE.WORKING);
+
+    QueuePageRequestView[] views = backend.getGlobalRequests();
+
+    assertSame(
+        QueueCompressionState.WAITING,
+        assertInstanceOf(QueuePageUploadFileView.class, views[0]).getCompressionState());
+    assertSame(
+        QueueCompressionState.COMPRESSING,
+        assertInstanceOf(QueuePageUploadFileView.class, views[1]).getCompressionState());
+    assertSame(
+        QueueCompressionState.WORKING,
+        assertInstanceOf(QueuePageUploadFileView.class, views[2]).getCompressionState());
+  }
+
+  private FreenetURI sampleUri(String suffix) {
+    try {
+      return new FreenetURI(
+          "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/"
+              + suffix);
+    } catch (MalformedURLException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private void assertDownloadView(
+      QueuePageRequestView actual,
+      Instant lastSuccess,
+      Instant lastFailure,
+      FreenetURI downloadUri,
+      InsertContext.CompatibilityMode[] compatModes,
+      byte[] overrideKey) {
+    QueuePageDownloadView downloadView = assertInstanceOf(QueuePageDownloadView.class, actual);
+    assertCommonRequestView(
+        downloadView,
+        "download-1",
+        false,
+        true,
+        (short) 3,
+        20,
+        true,
+        10,
+        7,
+        lastSuccess,
+        lastFailure,
+        downloadUri,
+        4096L,
+        true,
+        false,
+        2,
+        1,
+        true,
+        "Bad MIME",
+        "index_d51.xml");
+    assertFalse(downloadView.toTempSpace());
+    assertSame(FetchExceptionMode.CONTENT_VALIDATION_BAD_MIME, downloadView.getFailureCode());
+    assertEquals("text/plain", downloadView.getMimeType());
+    assertEquals(new File("downloads/index_d51.xml"), downloadView.getDestFilename());
+    assertArrayEquals(compatModes, downloadView.getCompatibilityMode());
+    assertArrayEquals(overrideKey, downloadView.getOverriddenSplitfileCryptoKey());
+    assertTrue(downloadView.detectedDontCompress());
+  }
+
+  private void assertUploadFileView(
+      QueuePageRequestView actual, Instant lastSuccess, FreenetURI uploadUri) {
+    QueuePageUploadFileView uploadFileView =
+        assertInstanceOf(QueuePageUploadFileView.class, actual);
+    assertCommonRequestView(
+        uploadFileView,
+        "upload-file-1",
+        true,
+        true,
+        (short) 2,
+        12,
+        false,
+        8,
+        8,
+        lastSuccess,
+        null,
+        uploadUri,
+        512L,
+        true,
+        true,
+        0,
+        0,
+        true,
+        null,
+        "upload.txt");
+    assertSame(uploadUri, uploadFileView.getFinalUri());
+    assertEquals("text/plain", uploadFileView.getMimeType());
+    assertEquals(new File("uploads/upload.txt"), uploadFileView.getOrigFilename());
+    assertSame(QueueCompressionState.COMPRESSING, uploadFileView.getCompressionState());
+  }
+
+  private void assertUploadDirView(
+      QueuePageRequestView actual, Instant lastSuccess, Instant lastFailure, FreenetURI uploadUri) {
+    QueuePageUploadDirView uploadDirView = assertInstanceOf(QueuePageUploadDirView.class, actual);
+    assertCommonRequestView(
+        uploadDirView,
+        "upload-dir-1",
+        false,
+        false,
+        (short) 4,
+        30,
+        true,
+        20,
+        15,
+        lastSuccess,
+        lastFailure,
+        uploadUri,
+        2048L,
+        false,
+        false,
+        1,
+        2,
+        false,
+        "Pending",
+        "site");
+    assertSame(uploadUri, uploadDirView.getFinalUri());
+    assertEquals(2048L, uploadDirView.getTotalDataSize());
+    assertEquals(7, uploadDirView.getNumberOfFiles());
+  }
+
+  private void assertCommonRequestView(
+      QueuePageRequestView actual,
+      String identifier,
+      boolean succeeded,
+      boolean finished,
+      short priority,
+      int totalBlocks,
+      boolean totalFinalized,
+      int minBlocks,
+      int fetchedBlocks,
+      Instant lastSuccess,
+      Instant lastFailure,
+      FreenetURI uri,
+      long dataSize,
+      boolean persistent,
+      boolean persistentForever,
+      int fatalFailedBlocks,
+      int failedBlocks,
+      boolean started,
+      String failureReason,
+      String preferredFilename) {
+    assertEquals(identifier, actual.getIdentifier());
+    assertEquals(succeeded, actual.hasSucceeded());
+    assertEquals(finished, actual.hasFinished());
+    assertEquals(priority, actual.getPriority());
+    assertEquals(totalBlocks, actual.getTotalBlocks());
+    assertEquals(totalFinalized, actual.isTotalFinalized());
+    assertEquals(minBlocks, actual.getMinBlocks());
+    assertEquals(fetchedBlocks, actual.getFetchedBlocks());
+    assertSame(lastSuccess, actual.getLastSuccess());
+    assertSame(lastFailure, actual.getLastFailure());
+    assertSame(uri, actual.getUri());
+    assertEquals(dataSize, actual.getDataSize());
+    assertEquals(persistent, actual.isPersistent());
+    assertEquals(persistentForever, actual.isPersistentForever());
+    assertEquals(fatalFailedBlocks, actual.getFatalyFailedBlocks());
+    assertEquals(failedBlocks, actual.getFailedBlocks());
+    assertEquals(started, actual.isStarted());
+    if (failureReason == null) {
+      assertNull(actual.getFailureReason(false));
+    } else {
+      assertEquals(failureReason, actual.getFailureReason(false));
+    }
+    assertEquals(preferredFilename, actual.getPreferredFilenameSafe());
+  }
+}


### PR DESCRIPTION
## Summary
- add a runtime-owned `network.crypta.runtime.admin.queue.page` seam for legacy queue-page reads and progress-cell rendering
- introduce `FcpQueuePageBackend` to lazily adapt FCP request statuses into runtime-owned queue-page views
- refactor `LegacyQueuePagePort` and `AdminRuntimePortsFactory` to consume the new seam instead of direct `clients.fcp` and `clients.http` dependencies
- add focused tests for the FCP adapter and progress-cell renderer, and add Javadoc for the newly added public seam types

## How to test
- `./gradlew compileJava`
- `./gradlew test --tests "network.crypta.runtime.admin.LegacyQueuePagePortTest" --tests "network.crypta.runtime.endpoints.fcp.FcpQueuePageBackendTest"`
- `./gradlew test --tests "network.crypta.runtime.admin.queue.page.QueueProgressCellRendererTest"`
- `./gradlew test`
- `rg -n "^import network\\.crypta\\.clients\\.(fcp|http)" src/main/java/network/crypta/runtime/admin/LegacyQueuePagePort.java`

## Notes
- base branch: `develop`
- branch: `feature/runtime-queue-page-seam`
- the final post-validation edits after the full suite were Javadoc-only updates on the new public seam files
