### PR TITLE
refactor(runtime): Re-home FCP queue SPI ports

### DIFF
--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -5,6 +5,9 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.admin.queue.QueueAdminBackend;
 import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
 import network.crypta.runtime.endpoints.fcp.FcpQueuePageBackend;
+import network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPort;
+import network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPort;
+import network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPort;
 
 /**
  * Creates the legacy admin and page-oriented runtime SPI adapters as one package-owned bundle.

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPort.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPort.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.admin;
+package network.crypta.runtime.endpoints.fcp;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPort.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPort.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.admin;
+package network.crypta.runtime.endpoints.fcp;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPort.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPort.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.admin;
+package network.crypta.runtime.endpoints.fcp;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
@@ -3,7 +3,8 @@
  *
  * <p>This package adapts daemon- and runtime-backed services to the narrow runtime-support seams
  * defined in {@code network.crypta.clients.fcp}. The types here exist to keep remaining {@code
- * NodeClientCore}-backed FCP bootstrap and persistence-bridge wiring under runtime ownership while
- * preserving the current protocol behavior and without widening {@code runtime-spi}.
+ * NodeClientCore}-backed FCP bootstrap, persistence-bridge, and queue download/insert/completion
+ * SPI wiring under runtime ownership while preserving the current protocol behavior and without
+ * widening {@code runtime-spi}.
  */
 package network.crypta.runtime.endpoints.fcp;

--- a/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
@@ -142,7 +142,7 @@ class LegacyRuntimePortsTest {
                 snapshot.queueSupportPort()),
         () ->
             assertInstanceOf(
-                loadClass("network.crypta.runtime.admin.LegacyQueueCompletionPort"),
+                loadClass("network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPort"),
                 snapshot.queueCompletionPort()),
         () ->
             assertInstanceOf(
@@ -150,11 +150,11 @@ class LegacyRuntimePortsTest {
                 snapshot.queuePagePort()),
         () ->
             assertInstanceOf(
-                loadClass("network.crypta.runtime.admin.LegacyQueueDownloadPort"),
+                loadClass("network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPort"),
                 snapshot.queueDownloadPort()),
         () ->
             assertInstanceOf(
-                loadClass("network.crypta.runtime.admin.LegacyQueueInsertPort"),
+                loadClass("network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPort"),
                 snapshot.queueInsertPort()),
         () ->
             assertInstanceOf(

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPortTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPortTest.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.admin;
+package network.crypta.runtime.endpoints.fcp;
 
 import java.io.File;
 import java.net.MalformedURLException;

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPortTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPortTest.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.admin;
+package network.crypta.runtime.endpoints.fcp;
 
 import java.io.File;
 import network.crypta.client.async.PersistenceDisabledException;

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPortTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPortTest.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.admin;
+package network.crypta.runtime.endpoints.fcp;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;


### PR DESCRIPTION
## Summary
- move `LegacyQueueDownloadPort`, `LegacyQueueInsertPort`, and `LegacyQueueCompletionPort` from `network.crypta.runtime.admin` to `network.crypta.runtime.endpoints.fcp`
- update `AdminRuntimePortsFactory` to wire the moved FCP-backed queue SPI implementations from their new package and refresh the FCP package docs
- move the package-local tests with the implementations and update `LegacyRuntimePortsTest` to assert the new reflective FQCN ownership

## Testing
- `./gradlew test --tests network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPortTest --tests network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPortTest --tests network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPortTest --tests network.crypta.runtime.core.LegacyRuntimePortsTest`
- `rg -n "^import network\.crypta\.clients\.fcp\." src/main/java/network/crypta/runtime/admin`
- `rg -n "runtime\.admin\.LegacyQueue(CompletionPort|DownloadPort|InsertPort)" src/main/java src/test/java build-logic`

## Notes
- `runtime.admin/package-info.java` is unchanged because its remaining wording still fits the adapters left in that package.
- The repository root did not contain `Archive.zip`, so the earlier review note about an accidental archive artifact was not applicable to the current tree.