### PR TITLE
refactor(runtime): Prepare GeoIP seam for connections page

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -22,9 +22,10 @@ Use this skill when you need to:
   - `:foundation-support` → the current stable generic subset of `network.crypta.support`,
     `network.crypta.support.api`, `network.crypta.support.io`,
     `network.crypta.support.compress`, `network.crypta.support.math`,
-    `network.crypta.support.transport.ip`, plus `network.crypta.io.AddressIdentifier`,
-    `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FSParseException`,
-    `network.crypta.node.FastRunnable`, and `network.crypta.node.SemiOrderedShutdownHook`
+    `network.crypta.support.transport.ip`, and `network.crypta.support.http`, plus
+    `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
+    `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`,
+    `network.crypta.node.SemiOrderedShutdownHook`, and `network.crypta.support.IllegalValueException`
   - `:foundation-store-contracts` → neutral `network.crypta.store` contracts
     `BlockMetadata`, `GetPubkey`, `StorableBlock`, plus the `network.crypta.store.alerts` seam
     (`StoreAlertSink`, `StoreMaintenanceAlertKind`, `StoreMaintenanceAlertSource`)
@@ -37,11 +38,12 @@ Use this skill when you need to:
     selected `network.crypta.io.comm` types, `network.crypta.node.Version`,
     `network.crypta.node.probe.Error`, `network.crypta.node.probe.Type`, and
     `network.crypta.support.Serializer`
-  - `:foundation-config` → `network.crypta.config`, `network.crypta.l10n`, and the main l10n
-    resources; public config APIs re-export `:foundation-support` and `:foundation-fs` where they
-    expose shared types
+  - `:foundation-config` → `network.crypta.config`, `network.crypta.l10n`, the main l10n
+    resources, and shared setup helpers such as `DatastoreSizingSupport`; public config APIs
+    re-export `:foundation-support` and `:foundation-fs` where they expose shared types
   - `:foundation-fs` → `network.crypta.fs`
-  - `:foundation-compat` → `network.crypta.compat`
+  - `:foundation-compat` → `network.crypta.compat`, including
+    `network.crypta.compat.bandwidth`
   - `:runtime-spi` → `network.crypta.runtime.spi` (JDK-only runtime/config boundary)
   - `:thirdparty-onion` → `com.onionnetworks` plus `lib/fec.properties`
   - `:thirdparty-legacy` → `org.bitpedia`, `org.sevenzip`, `org.spaceroots`
@@ -56,12 +58,15 @@ Use this skill when you need to:
     `LegacyRequestQueuePort`, `LegacySecurityLevelsPort`, and `LegacyCoreUpdateActionPort`.
     Page-oriented adapters such as `LegacyConnectionsPagePort`,
     `LegacyConnectionsSupportPort`, `LegacyDarknetConnectionsPort`,
-    `LegacyDarknetMessagingPort`, `LegacyQueuePagePort`, `LegacyQueueDownloadPort`,
-    `LegacyQueueInsertPort`, `LegacyQueueMutationPort`, `LegacyQueueSupportPort`,
-    `LegacyQueueCompletionPort`, `LegacyPageChromePort`, `LegacyDiagnosticPort`,
+    `LegacyDarknetMessagingPort`, `LegacyQueuePagePort`, `LegacyQueueMutationPort`,
+    `LegacyQueueSupportPort`, `LegacyPageChromePort`, `LegacyDiagnosticPort`,
     `LegacyStatisticsPort`, `LegacyFirstTimeWizardPort`, `LegacyToadletSymlinkPort`,
     `LegacyWelcomePagePort`, and `LegacyWelcomeActionPort` now live in
-    `network.crypta.runtime.admin`.
+    `network.crypta.runtime.admin`, supported by queue helper seams under
+    `network.crypta.runtime.admin.queue` and `network.crypta.runtime.admin.queue.page`.
+    Queue completion/download/insert bridges now live under
+    `network.crypta.runtime.endpoints.fcp` as `LegacyQueueCompletionPort`,
+    `LegacyQueueDownloadPort`, and `LegacyQueueInsertPort`.
 - The large cyclic daemon core still lives in the root project:
   most of `network.crypta.node`, the daemon-coupled transport/socket/filter side of
   `network.crypta.io.comm`, `network.crypta.client`, `network.crypta.clients`, the
@@ -100,7 +105,7 @@ Use this skill when you need to:
   (`NodeStarter`, `NodeBootstrap`, `NodeCli`, `NodeConfigManager`, `LoggingConfigHandler`)
 - Runtime SPI nucleus and daemon-backed core adapters: `network.crypta.runtime.core`
 - Page-oriented admin/runtime adapters: `network.crypta.runtime.admin`
-- Operator-facing alerts: `network.crypta.runtime.alerts`
+- Operator-facing alerts and alert-feed seams: `network.crypta.runtime.alerts`
 - Endpoint bootstrap glue for FCP/HTTP/TMCI: `network.crypta.runtime.endpoints`
 - Service coordination: `network.crypta.runtime.services`
 - Core/plugin update subsystem: `network.crypta.runtime.updater`
@@ -141,6 +146,10 @@ Use this skill when you need to:
 
 ### Client APIs
 - High-level client: `network.crypta.client`
+  - The async client layer now also owns client-local seams under
+    `network.crypta.client.async.alerts` and `network.crypta.client.async.persistence` so
+    runtime/FCP bridges can post alerts and recover durable requests without owning those
+    contracts.
 - FCP: `network.crypta.clients.fcp`
   - Runtime-facing execution, randomness, lifecycle, transfer-policy, and config access now come
     through `RuntimePorts`.
@@ -152,6 +161,10 @@ Use this skill when you need to:
   - Package-local seams split the remaining daemon-backed work by concern:
     `FcpServerRuntimeSupport`, `FcpMessageRuntimeSupport`, `FcpFetchRuntimeSupport`, and
     `FcpInsertRuntimeSupport`.
+  - FCP-local runtime bridges now also own persistent-request recovery, queue backends, and alert
+    feed adapters such as `CoreFcpPersistentRequestCatalog`, `FcpPersistentRequestRecoveryCodec`,
+    `FcpQueueAdminBackend`, `FcpQueuePageBackend`, `FcpUserAlertFeedSubscriber`, and
+    `FcpUserAlertFeedMessageFactory`.
 - HTTP interface: `network.crypta.clients.http`
   - The migrated management and shell slices no longer depend directly on live daemon peers or
     node-info exports for their core data flow.
@@ -205,10 +218,14 @@ Use this skill when you need to:
 - Root adapters in `network.crypta.runtime.admin`: `LegacyConnectionsPagePort`,
   `LegacyConnectionsSupportPort`, `LegacyDarknetConnectionsPort`,
   `LegacyDarknetMessagingPort`, `LegacyDiagnosticPort`, `LegacyStatisticsPort`,
-  `LegacyPageChromePort`, `LegacyQueuePagePort`, `LegacyQueueDownloadPort`,
-  `LegacyQueueInsertPort`, `LegacyQueueMutationPort`, `LegacyQueueSupportPort`,
-  `LegacyQueueCompletionPort`, `LegacyFirstTimeWizardPort`, `LegacyToadletSymlinkPort`,
-  `LegacyWelcomePagePort`, and `LegacyWelcomeActionPort`
+  `LegacyPageChromePort`, `LegacyQueuePagePort`, `LegacyQueueMutationPort`,
+  `LegacyQueueSupportPort`, `LegacyFirstTimeWizardPort`, `LegacyToadletSymlinkPort`,
+  `LegacyWelcomePagePort`, and `LegacyWelcomeActionPort`, plus queue helper seams under
+  `network.crypta.runtime.admin.queue` and `network.crypta.runtime.admin.queue.page`
+- Root adapters in `network.crypta.runtime.endpoints.fcp`: `LegacyQueueCompletionPort`,
+  `LegacyQueueDownloadPort`, `LegacyQueueInsertPort`, `CoreFcpPersistentRequestCatalog`,
+  `FcpPersistentRequestRecoveryCodec`, `FcpQueueAdminBackend`, `FcpQueuePageBackend`,
+  `FcpUserAlertFeedSubscriber`, and `FcpUserAlertFeedMessageFactory`
 
 ### Plugin system (`network.crypta.pluginmanager`)
 - Management: `PluginManager`
@@ -220,6 +237,7 @@ Use this skill when you need to:
 - Type-safe configuration with persistence
 - Main localization sources and `crypta.l10n.en.properties` also live in `:foundation-config`
   under `network.crypta.l10n`.
+- Shared setup helpers such as `DatastoreSizingSupport` also live in `:foundation-config`.
 - Higher layers should prefer the narrow `RuntimePorts` sub-port that already covers the needed
   operation (`config()`, `peer()`, `nodeInfo()`, `connectionsPage()`, `connectionsSupport()`,
   `darknetConnections()`, `darknetMessaging()`, `queuePage()`, `queueDownload()`,
@@ -234,11 +252,12 @@ Use this skill when you need to:
 - Logging, data structures, threading, helpers
 - `:foundation-support` now owns the stable generic support subset across `network.crypta.support`,
   `network.crypta.support.api`, `network.crypta.support.io`,
-  `network.crypta.support.compress`, `network.crypta.support.math`, and
-  `network.crypta.support.transport.ip`.
+  `network.crypta.support.compress`, `network.crypta.support.math`,
+  `network.crypta.support.transport.ip`, and `network.crypta.support.http`.
 - `:foundation-support` also owns `network.crypta.io.AddressIdentifier`,
   `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FastRunnable`,
-  `network.crypta.node.SemiOrderedShutdownHook`, and `network.crypta.support.SerializationLimits`.
+  `network.crypta.node.SemiOrderedShutdownHook`, `network.crypta.support.IllegalValueException`,
+  and `network.crypta.support.SerializationLimits`.
 - The root project still owns daemon-coupled support code and higher-level wiring that is not yet
   stable enough to extract cleanly.
 
@@ -250,16 +269,18 @@ Use this skill when you need to:
 ### Foundation leaf modules
 - `:foundation-support`: stable generic `network.crypta.support*` subset plus
   `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
-  `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`, and
-  `network.crypta.node.SemiOrderedShutdownHook`
+  `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`,
+  `network.crypta.node.SemiOrderedShutdownHook`, `network.crypta.support.http`, and
+  `network.crypta.support.IllegalValueException`
 - `:foundation-store-contracts`: neutral `network.crypta.store` contracts plus
   `network.crypta.store.alerts`
 - `:foundation-crypto-keys`: `network.crypta.crypt`, `network.crypta.keys`
 - `:foundation-store`: reusable `network.crypta.store` implementations
 - `:interop-wire`: wire/message/schema/version/probe nucleus
-- `:foundation-config`: `network.crypta.config`, `network.crypta.l10n`
+- `:foundation-config`: `network.crypta.config`, `network.crypta.l10n`,
+  `DatastoreSizingSupport`
 - `:foundation-fs`: `network.crypta.fs`
-- `:foundation-compat`: `network.crypta.compat`
+- `:foundation-compat`: `network.crypta.compat`, `network.crypta.compat.bandwidth`
 - `:runtime-spi`: `network.crypta.runtime.spi`
 
 ### Vendored library leaf modules

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -26,9 +26,10 @@ Use this skill when you need to:
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
 - `:foundation-support` owns the current stable generic support subset under
   `network.crypta.support*`, `network.crypta.support.transport.ip`,
-  `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
-  `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`, and
-  `network.crypta.node.SemiOrderedShutdownHook`.
+  `network.crypta.support.http`, `network.crypta.io.AddressIdentifier`,
+  `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FSParseException`,
+  `network.crypta.node.FastRunnable`, `network.crypta.node.SemiOrderedShutdownHook`, and
+  `network.crypta.support.IllegalValueException`.
 - `:foundation-store-contracts` owns the neutral `network.crypta.store` contracts
   `BlockMetadata`, `GetPubkey`, and `StorableBlock`, plus the `network.crypta.store.alerts`
   seam.
@@ -39,8 +40,12 @@ Use this skill when you need to:
 - `:interop-wire` owns the narrow wire/message/schema/version/probe nucleus:
   leaf-safe `network.crypta.io.comm` message/schema classes, `network.crypta.node.Version`,
   `network.crypta.node.probe.Error` and `Type`, and `network.crypta.support.Serializer`.
-- `:foundation-config` owns the main `network.crypta.config` and `network.crypta.l10n` sources.
-  Its public APIs now re-export `:foundation-support` and `:foundation-fs` where needed.
+- `:foundation-config` owns the main `network.crypta.config` and `network.crypta.l10n` sources,
+  plus shared setup helpers such as `DatastoreSizingSupport`. Its public APIs now re-export
+  `:foundation-support` and `:foundation-fs` where needed.
+- `:foundation-compat` owns extracted compatibility helpers under `network.crypta.compat`,
+  including the wizard-neutral bandwidth support moved to
+  `network.crypta.compat.bandwidth`.
 - Every extracted internal leaf must keep leaf-owned aggregated-output metadata in sync at
   `<leaf>/gradle/owned-output-patterns.txt`, even for structurally separate package/resource
   moves. Non-clean builds and branch switches can leave stale non-owner aggregated outputs behind,
@@ -97,6 +102,9 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew :interop-wire:compileJava`
 - Compile the config/l10n leaf when you touched extracted config or l10n sources:
   - `./gradlew :foundation-config:classes`
+- Compile the compat leaf when you touched extracted compatibility helpers such as
+  `network.crypta.compat.bandwidth`:
+  - `./gradlew :foundation-compat:classes`
 - Compile only the runtime SPI leaf when you touched just that JDK-only API surface:
   - `./gradlew :runtime-spi:compileJava`
 - Compile the root project and its unchanged test tree against the leaf-module layout:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,10 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **$cryptad-hotfix-workflow** — Run emergency hotfix flow: cut `hotfix/<build-number>` from `main`, ship fix, tag `v<build>`, and no-squash `--no-ff` merges to `main` and `develop`.
 - **$cryptad-launcher-ui** — Work on the Swing launcher: start/stop logic, logging, keyboard shortcuts, FlatLaf/theme handling, and Windows specifics.
 - **$cryptad-packaging** — Build and troubleshoot distributions and installers (assembleCryptadDist, jpackage, Windows wrapper assets, Flatpak, Linux DEB/RPM behavior).
+- **$improve-unit-test-coverage-for-current-changes** — Improve unit test coverage for the current uncommitted Java changes with targeted Gradle runs and one final full-suite pass.
 - **$cryptad-runtime-debugging** — Debug live or reproducible Cryptad JVM failures on Windows, macOS, and Linux using `jcmd`, `jdb`, thread dumps, and the default JDWP listener on `127.0.0.1:5005`.
 - **$cryptad-write-release-notes** — Draft or review GitHub release notes and changelog artifacts for Cryptad builds, including `changelog-full.md`, `changelog-short.txt`, and `changelog-full.txt`.
+- **$write-javadoc-for-new-java-files** — Apply the repo’s `write-javadoc` workflow to every newly added non-test Java file in the current working tree or since a base ref.
 - **$cryptad-writing-guides** — Apply Cryptad prose conventions for README/docs content, release notes, migration notes, and other operator-facing writing.
 - **$cryptad-style-docs** — Apply Cryptad Java style, file layout rules, and long-lived documentation/commenting practices.
 - **$web-search** — Use both Exa and Tavily for external/current web research, then cross-check sources before answering.
@@ -56,7 +58,9 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **Release operations:** For `release/<build-number>` branch creation/stabilization, version bumping, tagging, and merge-back flow, load `$cryptad-release-workflow`.
 - **Release notes/changelog:** For GitHub Releases or changelog artifact work, load `$cryptad-write-release-notes` and `$cryptad-writing-guides`.
 - **Hotfix operations:** For urgent production fixes via `hotfix/<build-number>`, including tags and back-merges, load `$cryptad-hotfix-workflow`.
+- **Coverage work for local changes:** When improving unit coverage for the current uncommitted Java diff, load `$improve-unit-test-coverage-for-current-changes`.
 - **Prose/Javadoc writing:** For README/docs/release-note writing, and when using the generic `write-javadoc` skill in this repo, also load `$cryptad-writing-guides`.
+- **New Java file Javadoc:** When newly added non-test Java files need package/class/member docs, load `$write-javadoc-for-new-java-files` and `$cryptad-writing-guides`.
 - **Web research:** For the latest/current external information or multi-source fact checks, load `$web-search`.
 
 ## Quick commands (high-level)

--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ Cryptad now uses a partial multi-project Gradle build.
 - `:foundation-support` owns the current stable generic support subset under
   `network.crypta.support`, `network.crypta.support.api`, `network.crypta.support.io`,
   `network.crypta.support.compress`, `network.crypta.support.math`,
-  `network.crypta.support.transport.ip`, plus `network.crypta.io.AddressIdentifier`,
-  `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FSParseException`,
-  `network.crypta.node.FastRunnable`, and `network.crypta.node.SemiOrderedShutdownHook`.
+  `network.crypta.support.transport.ip`, and `network.crypta.support.http`, plus
+  `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
+  `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`,
+  `network.crypta.node.SemiOrderedShutdownHook`, and `network.crypta.support.IllegalValueException`.
 - `:foundation-store-contracts` owns the neutral `network.crypta.store` contracts
   `BlockMetadata`, `GetPubkey`, and `StorableBlock`, plus the store-maintenance alert seam under
   `network.crypta.store.alerts`.
@@ -185,11 +186,12 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.io.comm` message/schema classes, `network.crypta.node.Version`,
   `network.crypta.node.probe.Error` and `Type`, and `network.crypta.support.Serializer`.
 - `:foundation-config` owns `network.crypta.config`, `network.crypta.l10n`, and the main
-  `network/crypta/l10n/crypta.l10n.en.properties` resource. Its public APIs now export
-  `:foundation-support` and `:foundation-fs` where config types expose `SimpleFieldSet` or
-  filesystem-facing value types.
+  `network/crypta/l10n/crypta.l10n.en.properties` resource plus shared config helpers such as
+  `DatastoreSizingSupport`. Its public APIs now export `:foundation-support` and `:foundation-fs`
+  where config types expose `SimpleFieldSet` or filesystem-facing value types.
 - `:foundation-fs` owns `network.crypta.fs`.
-- `:foundation-compat` owns `network.crypta.compat`.
+- `:foundation-compat` owns `network.crypta.compat`, including compatibility helpers such as the
+  extracted bandwidth-detection support under `network.crypta.compat.bandwidth`.
 - `:runtime-spi` owns `network.crypta.runtime.spi` and the JDK-only runtime/config boundary used
   by higher layers, including detached FCP peer management plus the admin-HTTP config,
   connectivity, connections, queue, security-levels, shared page-chrome, core-update action,
@@ -207,7 +209,9 @@ Cryptad now uses a partial multi-project Gradle build.
   daemon-coupled support/UI wiring.
 - Higher-level infrastructure now crosses a narrower boundary through
   `network.crypta.runtime.spi.RuntimePorts`, the minimal wire-side `MessageSource` seam used by
-  leaf-owned messages, and package-local seams such as
+  leaf-owned messages, client-owned seams such as `network.crypta.client.async.alerts` and
+  `network.crypta.client.async.persistence`, runtime-owned seams such as
+  `network.crypta.runtime.alerts.feed`, and package-local bridges such as
   `network.crypta.runtime.core.LegacyRuntimePorts`,
   `network.crypta.clients.http.BookmarkEditorToadletRuntimePorts`,
   `network.crypta.clients.http.ConfigToadletRuntimePorts`,
@@ -219,7 +223,11 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.clients.http.WelcomeToadletRuntimePorts`,
   `network.crypta.clients.http.FProxyRuntimeSupport`,
   `network.crypta.clients.http.HttpShellRuntimeSupport`,
-  `network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport`, and
+  `network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport`,
+  `network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend`,
+  `network.crypta.runtime.endpoints.fcp.FcpQueuePageBackend`,
+  `network.crypta.runtime.endpoints.fcp.CoreFcpPersistentRequestCatalog`,
+  `network.crypta.runtime.endpoints.fcp.FcpPersistentRequestRecoveryCodec`, and
   `network.crypta.clients.http.bookmark.BookmarkRuntimeSupport`.
 
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
@@ -486,9 +494,10 @@ cd build/jpackage/Crypta.app/Contents
 
 Root build also includes:
 - `:foundation-support`: extracted stable support/api/io/compress/math/transport subset plus
-  `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
-  `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`, and
-  `network.crypta.node.SemiOrderedShutdownHook`.
+  `network.crypta.support.http`, `network.crypta.io.AddressIdentifier`,
+  `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FSParseException`,
+  `network.crypta.node.FastRunnable`, `network.crypta.node.SemiOrderedShutdownHook`, and
+  `network.crypta.support.IllegalValueException`.
 - `:foundation-store-contracts`: neutral store contracts plus the store-maintenance alert seam
   shared by store code and root runtime/UI adapters.
 - `:foundation-crypto-keys`: extracted `network.crypta.crypt`, `network.crypta.keys`, and the
@@ -497,15 +506,17 @@ Root build also includes:
   salted-hash storage code.
 - `:interop-wire`: extracted wire/message/schema/address/version/probe nucleus plus
   `network.crypta.support.Serializer`.
-- `:foundation-config`: extracted config/l10n code and main l10n resources. Its public APIs
-  re-export `:foundation-support` and `:foundation-fs` where required.
+- `:foundation-config`: extracted config/l10n code, main l10n resources, and shared sizing helpers
+  such as `DatastoreSizingSupport`. Its public APIs re-export `:foundation-support` and
+  `:foundation-fs` where required.
 - `:launcher-desktop`: Swing launcher code and desktop/theme detection dependencies.
 - `:thirdparty-onion`: Onion FEC and related vendored sources/resources.
 - `:thirdparty-legacy`: Bitpedia, SevenZip, and Spaceroots vendored code.
 - `:runtime-spi`: JDK-only runtime ports plus immutable config snapshot/value types used by FCP
   and other infrastructure code.
 - `:foundation-fs` and `:foundation-compat`: extracted filesystem/environment and compatibility
-  leaf modules used by the root daemon.
+  leaf modules used by the root daemon. `:foundation-compat` also carries the wizard-neutral
+  bandwidth-detection helpers now used by first-time setup flows.
 
 ### Spotless + Dependency Verification
 
@@ -572,13 +583,20 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   transport/socket/filter side of `network.crypta.io.comm`, and `Message` now depends on the
   minimal `MessageSource` seam rather than directly on `PeerContext`.
 - Clients: `network.crypta.client`, FCP (`network.crypta.clients.fcp`), HTTP
-  (`network.crypta.clients.http`). FCP now consumes execution, randomness, transfer policy,
+  (`network.crypta.clients.http`). The async client layer now also owns client-local seams under
+  `network.crypta.client.async.alerts` and `network.crypta.client.async.persistence` so runtime
+  bridges can publish alerts and recover durable requests without owning those contracts. FCP now
+  consumes execution, randomness, transfer policy,
   lifecycle, config access, and detached peer mutations through `RuntimePorts` and FCP-local
   adapters instead of reaching directly into daemon internals for those concerns. FCP bootstrap now
   flows through `FcpServerDependencies` and `CoreFcpServerDependenciesFactory`, with package-local
   seams such as `FcpServerRuntimeSupport`, `FcpMessageRuntimeSupport`,
   `FcpFetchRuntimeSupport`, and `FcpInsertRuntimeSupport` splitting server-owned, message-owned,
-  GET/fetch, and insert/USK concerns.
+  GET/fetch, and insert/USK concerns. FCP-local runtime bridges now also own persistent-request
+  catalog and recovery seams plus queue and alert-feed adapters such as
+  `CoreFcpPersistentRequestCatalog`, `FcpPersistentRequestRecoveryCodec`,
+  `FcpQueueAdminBackend`, `FcpQueuePageBackend`, `FcpUserAlertFeedSubscriber`, and
+  `FcpUserAlertFeedMessageFactory`.
   The migrated HTTP management and shell slices now cross the boundary in two layers:
   `RuntimePorts` for JDK-only detached runtime state and package-local helpers such as
   `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellRuntimeSupport`,
@@ -604,22 +622,27 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `LegacyRequestQueuePort`, `LegacySecurityLevelsPort`, and `LegacyCoreUpdateActionPort`;
   `runtime.admin` owns page-oriented adapters such as `LegacyConnectionsPagePort`,
   `LegacyQueuePagePort`, `LegacyPageChromePort`, `LegacyFirstTimeWizardPort`, and
-  `LegacyWelcomePagePort`; `runtime.alerts` owns operator-facing alerts and
-  `UserAlertManagerStoreAlertSink`; `runtime.endpoints` owns FCP/HTTP/TMCI bootstrap glue such as
-  `ClientEndpoints`, `NodeClientCoreInit`, `NodeClientPersistence`, and the HTTP-local runtime
-  adapters in `runtime.endpoints.http`; `runtime.services` owns `NodeServicesSubsystem`; and
-  `runtime.updater` owns `NodeUpdateManager`, `CoreUpdater`, and `CoreActionToadlet`.
+  `LegacyWelcomePagePort`, plus queue diagnostics/mutation/page seams under
+  `runtime.admin.queue` and `runtime.admin.queue.page`; `runtime.alerts` owns operator-facing
+  alerts, `UserAlertManagerStoreAlertSink`, and the runtime-owned alert-feed seam under
+  `runtime.alerts.feed`; `runtime.endpoints` owns FCP/HTTP/TMCI bootstrap glue such as
+  `ClientEndpoints`, `NodeClientCoreInit`, `NodeClientPersistence`, the HTTP-local runtime adapters
+  in `runtime.endpoints.http`, and FCP-local bridges for queue completion/download/insert,
+  persistent-request recovery, queue admin/page backends, and alert-feed subscriptions under
+  `runtime.endpoints.fcp`; `runtime.services` owns `NodeServicesSubsystem`; and `runtime.updater`
+  owns `NodeUpdateManager`, `CoreUpdater`, and `CoreActionToadlet`.
 - Config + localization leaf (`:foundation-config`): `network.crypta.config`,
   `network.crypta.l10n`, and the main l10n properties. Its public APIs re-export
   `:foundation-support` and `:foundation-fs` where config surfaces expose `SimpleFieldSet` or
-  filesystem-facing types. Higher layers should still prefer `RuntimePorts#config()` and the root
+  filesystem-facing types. Shared setup helpers such as `DatastoreSizingSupport` now also live in
+  this leaf. Higher layers should still prefer `RuntimePorts#config()` and the root
   `network.crypta.runtime.core.LegacyConfigPort` bridge instead of reaching through daemon
   internals.
 - Support foundation leaf (`:foundation-support`): stable generic support, support-api,
-  support-io, support-compress, support-math, and transport-IP classes plus
+  support-io, support-compress, support-math, transport-IP, and support-http classes plus
   `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
-  `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`, and
-  `network.crypta.node.SemiOrderedShutdownHook`.
+  `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`,
+  `network.crypta.node.SemiOrderedShutdownHook`, and `network.crypta.support.IllegalValueException`.
 - Support (`network.crypta.support`): logging, data structures, threading, and helpers are now
   split between `:foundation-support` and the root project. Keep generic reusable utilities in the
   foundation leaf; daemon-coupled support code still remains in root.
@@ -629,9 +652,11 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `:foundation-store-contracts` provides neutral store contracts and alert seams,
   `:foundation-crypto-keys` provides `network.crypta.crypt` and `network.crypta.keys`,
   `:foundation-store` provides reusable store implementations, `:interop-wire` provides the
-  wire/version/probe nucleus, `:foundation-config` provides config/l10n,
+  wire/version/probe nucleus, `:foundation-config` provides config/l10n plus datastore-sizing
+  helpers,
   `:foundation-fs` provides `network.crypta.fs`, and `:foundation-compat` provides
-  `network.crypta.compat`.
+  `network.crypta.compat` plus compatibility helpers such as the extracted bandwidth-detection
+  support.
 - Runtime boundary leaf: `:runtime-spi` provides `network.crypta.runtime.spi`.
 - Vendored libraries: `:thirdparty-onion` provides `com.onionnetworks`,
   `:thirdparty-legacy` provides `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.

--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -2,12 +2,14 @@ package network.crypta.runtime.admin;
 
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.NodeFile;
 import network.crypta.runtime.admin.queue.QueueAdminBackend;
 import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
 import network.crypta.runtime.endpoints.fcp.FcpQueuePageBackend;
 import network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPort;
 import network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPort;
 import network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPort;
+import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
 
 /**
  * Creates the legacy admin and page-oriented runtime SPI adapters as one package-owned bundle.
@@ -42,7 +44,8 @@ public final class AdminRuntimePortsFactory {
   public static AdminRuntimePortsBundle create(Node node, NodeClientCore core) {
     QueueAdminBackend queueBackend = new FcpQueueAdminBackend(core);
     return new AdminRuntimePortsBundle(
-        new LegacyConnectionsPagePort(node, core),
+        new LegacyConnectionsPagePort(
+            node, new HttpGeoIpCountryLookup(NodeFile.IPV4_TO_COUNTRY.getFile(node))),
         new LegacyConnectionsSupportPort(node),
         new LegacyDarknetConnectionsPort(node),
         new LegacyDarknetMessagingPort(node),

--- a/src/main/java/network/crypta/runtime/admin/LegacyConnectionsPagePort.java
+++ b/src/main/java/network/crypta/runtime/admin/LegacyConnectionsPagePort.java
@@ -8,8 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.clients.http.geoip.IPConverter.Country;
-import network.crypta.clients.http.geoip.IPConverter;
 import network.crypta.config.SubConfig;
 import network.crypta.io.xfer.BlockReceiver;
 import network.crypta.io.xfer.BlockTransmitter;
@@ -19,8 +17,6 @@ import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
 import network.crypta.node.DarknetPeerNodeStatus;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
-import network.crypta.node.NodeFile;
 import network.crypta.node.NodeStats;
 import network.crypta.node.OpennetManager;
 import network.crypta.node.OpennetPeerNodeStatus;
@@ -31,6 +27,8 @@ import network.crypta.node.PeerNodeStatus;
 import network.crypta.node.PeerStatusCounts;
 import network.crypta.node.RequestTracker;
 import network.crypta.node.Version;
+import network.crypta.runtime.admin.geoip.GeoIpCountryInfo;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
@@ -186,16 +184,19 @@ final class LegacyConnectionsPagePort implements ConnectionsPagePort {
   /** Shared peer manager facade used for status lookups and routing metadata. */
   private final PeerManager peers;
 
+  /** Runtime-owned GeoIP seam used to render optional country flags beside peer addresses. */
+  private final GeoIpCountryLookup geoIpCountryLookup;
+
   /**
    * Creates the daemon-side adapter for the legacy connections pages.
    *
    * @param node live node that supplies peer, routing, and bandwidth state for each render
-   * @param core live client core validated to preserve the legacy wiring contract for this adapter
+   * @param geoIpCountryLookup runtime-owned GeoIP lookup used for optional address flag rendering
    * @throws NullPointerException if either argument is {@code null}
    */
-  LegacyConnectionsPagePort(Node node, NodeClientCore core) {
+  LegacyConnectionsPagePort(Node node, GeoIpCountryLookup geoIpCountryLookup) {
     this.node = Objects.requireNonNull(node);
-    Objects.requireNonNull(core);
+    this.geoIpCountryLookup = Objects.requireNonNull(geoIpCountryLookup);
     this.stats = node.network().stats();
     this.peers = node.network().peers();
   }
@@ -841,10 +842,12 @@ final class LegacyConnectionsPagePort implements ConnectionsPagePort {
       }
 
       HTMLNode addressRow = peerRow.addChild("td", ATTR_CLASS, "peer-address");
-      IPConverter ipc = IPConverter.getInstance(NodeFile.IPV4_TO_COUNTRY.getFile(node));
-      Country country = ipc.locateIP(peerNodeStatus.getPeerAddressBytes());
-      if (country != null) {
-        country.renderFlagIcon(addressRow);
+      GeoIpCountryInfo country = geoIpCountryLookup.locate(peerNodeStatus.getPeerAddressBytes());
+      if (country != null && country.staticFlagUrl() != null) {
+        addressRow.addChild(
+            "img",
+            new String[] {"src", ATTR_CLASS, ATTR_TITLE},
+            new String[] {country.staticFlagUrl(), "flag", country.displayName()});
       }
 
       String address =

--- a/src/main/java/network/crypta/runtime/admin/geoip/GeoIpCountryInfo.java
+++ b/src/main/java/network/crypta/runtime/admin/geoip/GeoIpCountryInfo.java
@@ -1,0 +1,35 @@
+package network.crypta.runtime.admin.geoip;
+
+import java.util.Objects;
+
+/**
+ * Immutable country metadata used by the runtime-owned GeoIP seam.
+ *
+ * <p>This record carries the small amount of information that the legacy connections page needs
+ * after resolving a peer address against the GeoIP database. Runtime-admin code only needs a
+ * display label for tooltip text and an optional fully qualified static-resource URL for the flag
+ * icon. Keeping that data in a detached record avoids any direct dependency on the HTTP GeoIP
+ * implementation while preserving the exact HTML attributes that the legacy page already emits.
+ *
+ * <p>Instances are immutable and thread-safe. Callers may cache or pass them across runtime and
+ * endpoint boundaries without coordinating with the underlying GeoIP lookup implementation.
+ *
+ * @param displayName non-null UI label for the located country or region
+ * @param staticFlagUrl full static-resource URL for the flag icon, or {@code null} when absent
+ */
+public record GeoIpCountryInfo(String displayName, String staticFlagUrl) {
+  /**
+   * Creates one detached GeoIP country description for legacy page rendering.
+   *
+   * <p>The display name is required because the Connections page uses it directly for flag tooltip
+   * text. The flag URL may be absent when the lookup resolves a country or region that does not
+   * have a bundled static icon.
+   *
+   * @param displayName non-null country or region label suitable for direct UI display
+   * @param staticFlagUrl full static-resource URL for the country flag, or {@code null} if absent
+   * @throws NullPointerException if {@code displayName} is {@code null}
+   */
+  public GeoIpCountryInfo {
+    Objects.requireNonNull(displayName);
+  }
+}

--- a/src/main/java/network/crypta/runtime/admin/geoip/GeoIpCountryLookup.java
+++ b/src/main/java/network/crypta/runtime/admin/geoip/GeoIpCountryLookup.java
@@ -1,0 +1,29 @@
+package network.crypta.runtime.admin.geoip;
+
+/**
+ * Runtime-owned GeoIP lookup seam for legacy admin pages.
+ *
+ * <p>This interface gives {@code network.crypta.runtime.admin} a narrow, detached view of the GeoIP
+ * functionality still implemented on the HTTP side of the legacy stack. The Connections page only
+ * needs a best-effort country lookup keyed by raw peer-address bytes, so the seam exposes a single
+ * method and returns a small immutable DTO instead of leaking {@code IPConverter} types into
+ * runtime-admin code.
+ *
+ * <p>Implementations may perform file-backed lookups, cache results, or normalize IPv4 and IPv6
+ * address forms internally. Callers should treat the seam as the best effort and be prepared for a
+ * {@code null} result when the address cannot be resolved or when no country metadata is available.
+ */
+public interface GeoIpCountryLookup {
+  /**
+   * Resolves an IP address into detached country metadata for the legacy connections page.
+   *
+   * <p>The supplied bytes typically come from {@code PeerNodeStatus#getPeerAddressBytes()} and may
+   * represent IPv4 or an implementation-supported IPv6 form. Implementations return a detached
+   * value object when a lookup succeeds, or {@code null} when the address is unavailable,
+   * unsupported, or not present in the active GeoIP database.
+   *
+   * @param ipAddressBytes raw peer-address bytes supplied by the legacy peer-status view
+   * @return detached country metadata for UI rendering, or {@code null} when no mapping exists
+   */
+  GeoIpCountryInfo locate(byte[] ipAddressBytes);
+}

--- a/src/main/java/network/crypta/runtime/admin/geoip/package-info.java
+++ b/src/main/java/network/crypta/runtime/admin/geoip/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Tiny runtime-owned GeoIP seam used by legacy admin-page adapters.
+ *
+ * <p>The types in this package let {@code network.crypta.runtime.admin} render country names and
+ * optional flag URLs without importing HTTP GeoIP implementation classes from {@code
+ * network.crypta.clients.http}. The seam intentionally stays narrow so the legacy connections page
+ * can preserve its existing HTML while the broader runtime and HTTP decoupling work continues.
+ *
+ * <p>The package owns two small concepts:
+ *
+ * <ul>
+ *   <li>a detached country DTO carrying only UI-facing display data
+ *   <li>a best-effort lookup interface that runtime-admin can depend on without knowing how the
+ *       GeoIP database is loaded or queried
+ * </ul>
+ *
+ * <p>That ownership split keeps the legacy page behavior stable while making the remaining HTTP
+ * bridge explicit and easy to replace in later extraction work.
+ */
+package network.crypta.runtime.admin.geoip;

--- a/src/main/java/network/crypta/runtime/endpoints/http/geoip/HttpGeoIpCountryLookup.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/geoip/HttpGeoIpCountryLookup.java
@@ -1,0 +1,64 @@
+package network.crypta.runtime.endpoints.http.geoip;
+
+import java.io.File;
+import java.util.Objects;
+import network.crypta.clients.http.geoip.IPConverter.Country;
+import network.crypta.clients.http.geoip.IPConverter;
+import network.crypta.runtime.admin.geoip.GeoIpCountryInfo;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
+import network.crypta.support.http.StaticResourcePaths;
+
+/**
+ * HTTP-backed adapter from the runtime GeoIP seam to the legacy GeoIP database lookup.
+ *
+ * <p>This bridge keeps the {@code IPConverter} dependency out of {@code runtime.admin} while
+ * preserving the existing country-name and flag-path behavior used by the legacy connections page.
+ * It remains intentionally small: the runtime-owned seam only needs a detached country DTO, while
+ * this adapter handles the translation from the legacy singleton lookup and HTTP static-resource
+ * conventions.
+ *
+ * <p>Instances are inexpensive and immutable. They do not keep their own GeoIP cache; instead, they
+ * delegate to {@link IPConverter#getInstance(File)}, which preserves the historical singleton and
+ * file-switching behavior already used by the legacy HTTP code.
+ */
+public final class HttpGeoIpCountryLookup implements GeoIpCountryLookup {
+  private final File dbFile;
+
+  /**
+   * Creates an HTTP-backed GeoIP lookup bound to one GeoIP database file.
+   *
+   * <p>The file is passed through to the legacy {@link IPConverter} singleton on each lookup. That
+   * preserves the current behavior where swapping to a different database file transparently
+   * replaces the singleton instance without introducing an additional bridge-local state.
+   *
+   * @param dbFile GeoIP database file consumed by the legacy HTTP {@code IPConverter}
+   * @throws NullPointerException if {@code dbFile} is {@code null}
+   */
+  public HttpGeoIpCountryLookup(File dbFile) {
+    this.dbFile = Objects.requireNonNull(dbFile);
+  }
+
+  /**
+   * Resolves raw address bytes through the legacy HTTP GeoIP lookup and adapts the result.
+   *
+   * <p>When the underlying {@link IPConverter} finds a matching country or region, this method
+   * copies the display name into a detached runtime-owned DTO and expands any relative flag path
+   * into the full static-resource URL expected by the legacy connections-page HTML. If the lookup
+   * fails or the country has no bundled flag icon, the returned DTO either omits the flag URL or
+   * the method returns {@code null}, matching the existing best-effort behavior.
+   *
+   * @param ipAddressBytes raw IPv4 or supported IPv6 bytes passed from runtime-admin code
+   * @return detached country metadata, or {@code null} when the address cannot be resolved
+   */
+  @Override
+  public GeoIpCountryInfo locate(byte[] ipAddressBytes) {
+    Country country = IPConverter.getInstance(dbFile).locateIP(ipAddressBytes);
+    if (country == null) {
+      return null;
+    }
+
+    String flagPath = country.getFlagIconPath();
+    String staticFlagUrl = flagPath == null ? null : StaticResourcePaths.ROOT_URL + flagPath;
+    return new GeoIpCountryInfo(country.getName(), staticFlagUrl);
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/http/geoip/package-info.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/geoip/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * HTTP-owned GeoIP bridge implementations for runtime adapters.
+ *
+ * <p>This package contains small adapters that let runtime-owned code consume HTTP-layer GeoIP
+ * facilities without depending on {@code network.crypta.clients.http} directly. The bridge keeps
+ * the legacy GeoIP database lookup behavior unchanged while preserving the current runtime/HTTP
+ * ownership split.
+ *
+ * <p>The package deliberately stays narrow. It owns the adapter layer that translates HTTP-local
+ * GeoIP types, static-resource paths, and singleton lookup behavior into the detached DTOs and
+ * lookup interfaces defined under {@code network.crypta.runtime.admin.geoip}. That keeps the
+ * remaining coupling explicit while avoiding any {@code runtime-spi} expansion in this migration
+ * step.
+ */
+package network.crypta.runtime.endpoints.http.geoip;

--- a/src/test/java/network/crypta/runtime/admin/LegacyConnectionsPagePortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyConnectionsPagePortTest.java
@@ -1,19 +1,19 @@
 package network.crypta.runtime.admin;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Map;
 import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
 import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
 import network.crypta.node.DarknetPeerNodeStatus;
 import network.crypta.node.Node;
-import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeStats;
 import network.crypta.node.OpennetPeerNodeStatus;
 import network.crypta.node.PeerManager;
 import network.crypta.node.PeerNodeStatus;
 import network.crypta.node.PeerStatusBook;
 import network.crypta.node.RequestTracker;
+import network.crypta.runtime.admin.geoip.GeoIpCountryInfo;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPageRequest;
 import network.crypta.runtime.spi.ConnectionsPageSnapshot;
@@ -42,14 +42,12 @@ class LegacyConnectionsPagePortTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private Node node;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private NodeClientCore core;
-
   @Mock private NodeStats stats;
   @Mock private PeerManager peers;
   @Mock private PeerStatusBook statusBook;
   @Mock private RequestTracker tracker;
   @Mock private BandwidthStatsContainer bandwidthStats;
+  @Mock private GeoIpCountryLookup geoIpCountryLookup;
 
   private LegacyConnectionsPagePort port;
 
@@ -64,7 +62,6 @@ class LegacyConnectionsPagePortTest {
     when(node.getMyName()).thenReturn("LocalNode");
     when(node.isAdvancedModeEnabled()).thenReturn(false);
     when(node.isFProxyJavascriptEnabled()).thenReturn(false);
-    when(node.runDir().file("IpToCountry.dat")).thenReturn(new File("build/tmp/IpToCountry.dat"));
     when(node.services()
             .clientCore()
             .getClientLayerPersister()
@@ -86,7 +83,7 @@ class LegacyConnectionsPagePortTest {
     setRunningAverage("routingMissDistanceRT");
     setRunningAverage("backedOffPercent");
 
-    port = new LegacyConnectionsPagePort(node, core);
+    port = new LegacyConnectionsPagePort(node, geoIpCountryLookup);
   }
 
   @Test
@@ -158,6 +155,28 @@ class LegacyConnectionsPagePortTest {
     assertFalse(basic.peerTableHtml().contains("message-count"));
     assertTrue(detailed.peerTableHtml().contains("message-count"));
     assertTrue(detailed.peerTableHtml().contains("CHKData"));
+  }
+
+  @Test
+  void render_whenGeoIpCountryHasFlag_rendersFlagIconMarkupInPeerTable() {
+    byte[] peerAddressBytes = new byte[] {10, 0, 0, 1};
+    DarknetPeerNodeStatus peerStatus = mockDarknetStatus("Alpha", "10.0.0.1:1234", 0.25);
+    when(peerStatus.getPeerAddressBytes()).thenReturn(peerAddressBytes);
+    when(statusBook.getDarknetPeerNodeStatuses(true))
+        .thenReturn(new DarknetPeerNodeStatus[] {peerStatus});
+    when(statusBook.getDarknetPeerNodeStatuses(false))
+        .thenReturn(new DarknetPeerNodeStatus[] {peerStatus});
+    when(statusBook.getPeerNodeStatuses(true)).thenReturn(new PeerNodeStatus[] {peerStatus});
+    when(geoIpCountryLookup.locate(peerAddressBytes))
+        .thenReturn(new GeoIpCountryInfo("United States", "/static/icon/flags/us.png"));
+
+    ConnectionsPageSnapshot snapshot =
+        port.render(
+            new ConnectionsPageRequest(ConnectionsPageKind.DARKNET, false, false, null, false));
+
+    assertTrue(snapshot.peerTableHtml().contains("class=\"flag\""));
+    assertTrue(snapshot.peerTableHtml().contains("/static/icon/flags/us.png"));
+    assertTrue(snapshot.peerTableHtml().contains("title=\"United States\""));
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/admin/geoip/GeoIpCountryInfoTest.java
+++ b/src/test/java/network/crypta/runtime/admin/geoip/GeoIpCountryInfoTest.java
@@ -1,0 +1,27 @@
+package network.crypta.runtime.admin.geoip;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class GeoIpCountryInfoTest {
+
+  @Test
+  void constructor_whenDisplayNameNull_expectNullPointerException() {
+    // Arrange / Act / Assert
+    assertThrows(NullPointerException.class, () -> new GeoIpCountryInfo(null, "/static/flag.png"));
+  }
+
+  @Test
+  void constructor_whenStaticFlagUrlNull_expectRecordCreated() {
+    // Arrange / Act
+    GeoIpCountryInfo info = new GeoIpCountryInfo("United States", null);
+
+    // Assert
+    assertEquals("United States", info.displayName());
+    assertNull(info.staticFlagUrl());
+  }
+}

--- a/src/test/java/network/crypta/runtime/endpoints/http/geoip/HttpGeoIpCountryLookupTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/geoip/HttpGeoIpCountryLookupTest.java
@@ -1,0 +1,96 @@
+package network.crypta.runtime.endpoints.http.geoip;
+
+import java.io.File;
+import network.crypta.clients.http.geoip.IPConverter;
+import network.crypta.runtime.admin.geoip.GeoIpCountryInfo;
+import network.crypta.support.http.StaticResourcePaths;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class HttpGeoIpCountryLookupTest {
+
+  @Test
+  void constructor_whenDbFileNull_expectNullPointerException() {
+    // Arrange / Act / Assert
+    assertThrows(NullPointerException.class, () -> new HttpGeoIpCountryLookup(null));
+  }
+
+  @Test
+  void locate_whenCountryHasFlag_expectCountryInfoWithFullStaticFlagUrl() {
+    // Arrange
+    File dbFile = new File("build/tmp/geoip.dat");
+    byte[] ipAddressBytes = new byte[] {0, 0, 0, 1};
+    IPConverter converter = mock(IPConverter.class);
+    when(converter.locateIP(ipAddressBytes)).thenReturn(IPConverter.Country.US);
+
+    try (MockedStatic<IPConverter> ipConverter = mockStatic(IPConverter.class)) {
+      ipConverter.when(() -> IPConverter.getInstance(dbFile)).thenReturn(converter);
+      HttpGeoIpCountryLookup lookup = new HttpGeoIpCountryLookup(dbFile);
+
+      // Act
+      GeoIpCountryInfo info = lookup.locate(ipAddressBytes);
+
+      // Assert
+      assertNotNull(info);
+      assertEquals(IPConverter.Country.US.getName(), info.displayName());
+      assertEquals(
+          StaticResourcePaths.ROOT_URL + IPConverter.Country.US.getFlagIconPath(),
+          info.staticFlagUrl());
+      verify(converter).locateIP(ipAddressBytes);
+    }
+  }
+
+  @Test
+  void locate_whenCountryHasNoFlag_expectCountryInfoWithNullStaticFlagUrl() {
+    // Arrange
+    File dbFile = new File("build/tmp/geoip.dat");
+    byte[] ipAddressBytes = new byte[] {0, 0, 0, 2};
+    IPConverter converter = mock(IPConverter.class);
+    when(converter.locateIP(ipAddressBytes)).thenReturn(IPConverter.Country.ZZ);
+
+    try (MockedStatic<IPConverter> ipConverter = mockStatic(IPConverter.class)) {
+      ipConverter.when(() -> IPConverter.getInstance(dbFile)).thenReturn(converter);
+      HttpGeoIpCountryLookup lookup = new HttpGeoIpCountryLookup(dbFile);
+
+      // Act
+      GeoIpCountryInfo info = lookup.locate(ipAddressBytes);
+
+      // Assert
+      assertNotNull(info);
+      assertEquals(IPConverter.Country.ZZ.getName(), info.displayName());
+      assertNull(info.staticFlagUrl());
+      verify(converter).locateIP(ipAddressBytes);
+    }
+  }
+
+  @Test
+  void locate_whenCountryIsUnknown_expectNull() {
+    // Arrange
+    File dbFile = new File("build/tmp/geoip.dat");
+    byte[] ipAddressBytes = new byte[] {0, 0, 0, 3};
+    IPConverter converter = mock(IPConverter.class);
+    when(converter.locateIP(ipAddressBytes)).thenReturn(null);
+
+    try (MockedStatic<IPConverter> ipConverter = mockStatic(IPConverter.class)) {
+      ipConverter.when(() -> IPConverter.getInstance(dbFile)).thenReturn(converter);
+      HttpGeoIpCountryLookup lookup = new HttpGeoIpCountryLookup(dbFile);
+
+      // Act
+      GeoIpCountryInfo info = lookup.locate(ipAddressBytes);
+
+      // Assert
+      assertNull(info);
+      verify(converter).locateIP(ipAddressBytes);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a runtime-owned GeoIP seam for the legacy connections page and bridge the existing HTTP `IPConverter` through `HttpGeoIpCountryLookup`
- update `LegacyConnectionsPagePort` and `AdminRuntimePortsFactory` so `runtime.admin` no longer imports `network.crypta.clients.http.*` directly for the connections-page GeoIP path
- add focused seam and bridge tests, then refresh `README.md`, `AGENTS.md`, and the repo-local architecture/build skills to match the current extracted ownership and runtime queue/alert/persistence seams

## How to test
- `./gradlew compileJava`
- `./gradlew test --tests "network.crypta.runtime.admin.LegacyConnectionsPagePortTest"`
- `./gradlew test --tests "network.crypta.clients.http.DarknetConnectionsToadletTest"`
- `./gradlew test --tests "network.crypta.clients.http.OpennetConnectionsToadletTest"`
- `./gradlew test --tests "network.crypta.runtime.admin.LegacyConnectionsPagePortTest" --tests "network.crypta.runtime.admin.geoip.GeoIpCountryInfoTest" --tests "network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookupTest"`
- `./gradlew test`
- `rg -n "^import network\\.crypta\\.clients\\.http\\." src/main/java/network/crypta/runtime/admin -g'*.java'`
- `git diff --check -- README.md AGENTS.md .agents/skills/cryptad-architecture/SKILL.md .agents/skills/cryptad-build-test/SKILL.md`