### PR TITLE
refactor(http): Decouple remaining FCP seams

### DIFF
--- a/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -5,27 +5,24 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.PeerAddFailureReason;
 import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
 import network.crypta.runtime.spi.PeerSnapshot;
 import network.crypta.runtime.spi.PeerTrust;
 import network.crypta.runtime.spi.PeerVisibility;
-import network.crypta.support.MediaType;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,18 +155,10 @@ public final class AddPeer extends FCPMessage {
   }
 
   /**
-   * Fetches a peer reference document from the given URL.
+   * Delegates to the neutral peer-reference text loader for regular URLs.
    *
-   * <p>This helper opens a {@link URLConnection}, selects an appropriate character set using {@link
-   * MediaType#getCharsetRobustOrUTF(String)} based on the {@code Content-Type} header, and reads
-   * the entire response as text. Lines are appended to a {@link StringBuilder} in order with single
-   * {@code '\n'} separators, producing a form that can later be parsed into a {@link
-   * SimpleFieldSet} representation of the peer reference.
-   *
-   * <p>The connection's input stream is closed automatically when the method returns, but the
-   * {@link URLConnection} itself is not further configured (for example, no timeouts are changed).
-   * Callers are expected to provide a URL that yields a small text document containing the desired
-   * reference.
+   * <p>The returned buffer and newline-joining behavior match the runtime-owned loader used by the
+   * HTTP and console adapters.
    *
    * @param url absolute URL pointing to a textual peer reference document; must not be {@code null}
    * @return mutable buffer containing the full textual contents of the response, including trailing
@@ -178,37 +167,16 @@ public final class AddPeer extends FCPMessage {
    *     reason, including network errors or unexpected end-of-stream conditions
    */
   public static StringBuilder getReferenceFromURL(URL url) throws IOException {
-    StringBuilder ref = new StringBuilder(1024);
-
-    URLConnection uc = url.openConnection();
-    try (InputStream is = uc.getInputStream();
-        BufferedReader in =
-            new BufferedReader(
-                new InputStreamReader(is, MediaType.getCharsetRobustOrUTF(uc.getContentType())))) {
-
-      String line;
-      while ((line = in.readLine()) != null) {
-        ref.append(line).append('\n');
-      }
-      return ref;
-    }
+    return PeerReferenceTextLoader.readFromUrl(url);
   }
 
   /**
-   * Fetches a peer reference document from a {@link FreenetURI}.
+   * Delegates to the neutral peer-reference text loader for Freenet URIs.
    *
-   * <p>The supplied {@link HighLevelSimpleClient} is used to request up to approximately
-   * 31&nbsp;000 bytes of data from the given URI. The response is exposed as a {@link Bucket}, from
-   * which this method opens an input stream and reads the contents as text using {@link
-   * MediaType#getCharsetRobustOrUTF(String)} with a {@code text/plain} content type hint. Each line
-   * of text is appended to a {@link StringBuilder} with a single {@code '\n'} separator, producing
-   * a buffer suitable for later parsing into a {@link SimpleFieldSet}.
+   * <p>The supplied client still performs the legacy 31,000-byte fetch, and the returned text keeps
+   * the same newline-joining behavior as the URL path.
    *
-   * <p>The client instance is not closed or modified by this method; callers remain responsible for
-   * its lifecycle and any broader request management. This helper focuses purely on efficiently
-   * retrieving small textual reference documents.
-   *
-   * @param url Freenet URI locating the remotely stored peer reference document; must not be {@code
+   * @param uri Freenet URI locating the remotely stored peer reference document; must not be {@code
    *     null}
    * @param client high-level client instance used to perform the fetch within the appropriate
    *     request priority class and security context; must be configured for the target node
@@ -220,22 +188,8 @@ public final class AddPeer extends FCPMessage {
    *     failures, timeouts, or protocol-level error responses
    */
   public static StringBuilder getReferenceFromFreenetURI(
-      FreenetURI url, HighLevelSimpleClient client) throws IOException, FetchException {
-    StringBuilder ref = new StringBuilder(1024); // the 1024 is the initial capacity
-
-    try (Bucket bucket = client.fetch(url, 31000).asBucket();
-        // limit to 31k, which should suffice even if we add many more ipv6 addresses
-        InputStream is = bucket.getInputStream();
-        BufferedReader in =
-            new BufferedReader(
-                new InputStreamReader(is, MediaType.getCharsetRobustOrUTF("text/plain")))) {
-
-      String line;
-      while ((line = in.readLine()) != null) {
-        ref.append(line).append('\n');
-      }
-      return ref;
-    }
+      FreenetURI uri, HighLevelSimpleClient client) throws IOException, FetchException {
+    return PeerReferenceTextLoader.readFromFreenetUri(uri, client);
   }
 
   /**
@@ -347,11 +301,11 @@ public final class AddPeer extends FCPMessage {
               .getServer()
               .messageRuntimeSupport()
               .makeClient(FcpPriorityClasses.IMMEDIATE_SPLITFILE, true, true);
-      return AddPeer.getReferenceFromFreenetURI(refUri, client);
+      return getReferenceFromFreenetURI(refUri, client);
     } catch (MalformedURLException | FetchException _) {
       LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urlString);
       URL url = createUrlFromString(urlString);
-      return AddPeer.getReferenceFromURL(url);
+      return getReferenceFromURL(url);
     }
   }
 

--- a/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.StringTokenizer;
 import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.clients.fcp.AddPeer;
 import network.crypta.config.ConfigException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
@@ -23,6 +22,7 @@ import network.crypta.node.PeerNodeStatus;
 import network.crypta.node.Version;
 import network.crypta.runtime.peers.html.PeerTrustInputForAddPeerBoxNode;
 import network.crypta.runtime.peers.html.PeerVisibilityInputForAddPeerBoxNode;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
@@ -305,7 +305,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   /**
-   * Renders the connections page and optional message-type breakdowns.
+   * Renders the Connections page and optional message-type breakdowns.
    *
    * <p>The handler validates access, resolves download endpoints for the current node reference,
    * builds sorted peer tables, and writes the resulting HTML response. When no peers exist, it
@@ -571,11 +571,11 @@ public abstract class ConnectionsToadlet extends Toadlet {
   private StringBuilder fetchReferenceViaUrl(String urltext) throws IOException {
     try {
       FreenetURI refUri = new FreenetURI(urltext);
-      return AddPeer.getReferenceFromFreenetURI(refUri, client);
+      return PeerReferenceTextLoader.readFromFreenetUri(refUri, client);
     } catch (MalformedURLException | FetchException _) {
       LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urltext);
       URL url = buildUrl(urltext);
-      return AddPeer.getReferenceFromURL(url);
+      return PeerReferenceTextLoader.readFromUrl(url);
     }
   }
 

--- a/src/main/java/network/crypta/clients/http/ProgressCellContext.java
+++ b/src/main/java/network/crypta/clients/http/ProgressCellContext.java
@@ -1,6 +1,6 @@
 package network.crypta.clients.http;
 
-import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
+import network.crypta.runtime.admin.queue.page.QueueCompressionState;
 
 /**
  * Bundles rendering flags needed for queue progress cells.
@@ -17,4 +17,4 @@ import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
  * @param upload {@code true} when rendering an upload progress cell
  */
 public record ProgressCellContext(
-    boolean advancedMode, boolean started, COMPRESS_STATE compressing, boolean upload) {}
+    boolean advancedMode, boolean started, QueueCompressionState compressing, boolean upload) {}

--- a/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -13,10 +13,10 @@ import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.events.SplitfileProgressCounts;
-import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
-import network.crypta.clients.fcp.NotAllowedException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.runtime.admin.queue.page.QueueProgressCellContext;
+import network.crypta.runtime.admin.queue.page.QueueProgressCellRenderer;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -75,7 +75,6 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @see FProxyRegistrar
- * @see network.crypta.clients.fcp.RequestStatus
  */
 public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private static final Logger LOG = LoggerFactory.getLogger(QueueToadlet.class);
@@ -149,8 +148,6 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private static final String ATTR_VALUE = "value";
   private static final String ATTR_CHECKED = "checked";
   private static final String ATTR_CLASS = "class";
-  private static final String ATTR_STYLE = "style";
-  private static final String ATTR_TITLE = "title";
   private static final String TAG_LABEL = "label";
   private static final String TAG_TABLE = "table";
   private static final String INPUT_TYPE_HIDDEN = "hidden";
@@ -158,8 +155,6 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private static final String INFOBOX_ERROR = "infobox-error";
   private static final String PRIORITY = "priority";
   private static final String SORT_BY = "sortBy";
-  private static final String UNKNOWN = "unknown";
-  private static final String CSS_WIDTH_PREFIX = "width: ";
   private static final String QUEUE_TOADLET_PREFIX = "QueueToadlet.";
 
   /**
@@ -570,7 +565,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
         downloadPath = request.getPartAsStringFailsafe("path", MAX_FILENAME_LENGTH);
         try {
           downloadsDir = getDownloadsDir(downloadPath);
-        } catch (NotAllowedException e) {
+        } catch (DownloadTargetNotAllowedException e) {
           downloadDisallowedPage(e, downloadPath, ctx);
           return true;
         }
@@ -640,7 +635,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       String downloadPath = request.getPartAsStringFailsafe("path", MAX_FILENAME_LENGTH);
       try {
         return new DownloadTarget(target, getDownloadsDir(downloadPath));
-      } catch (NotAllowedException e) {
+      } catch (DownloadTargetNotAllowedException e) {
         downloadDisallowedPage(e, downloadPath, ctx);
         return null;
       }
@@ -717,6 +712,11 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       alertContent.addChild(
           "a", "href", path(), NodeL10n.getBase().getString("Toadlet.returnToQueuepage"));
       writeHTMLReply(ctx, 200, "OK", page.generate());
+    }
+
+    /** Signals that the requested download target is not allowed for this queue operation. */
+    private static final class DownloadTargetNotAllowedException extends Exception {
+      private DownloadTargetNotAllowedException() {}
     }
 
     private record DownloadTarget(String target, File downloadsDir) {}
@@ -1583,7 +1583,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     }
 
     private void downloadDisallowedPage(
-        NotAllowedException e, String downloadPath, ToadletContext ctx)
+        DownloadTargetNotAllowedException e, String downloadPath, ToadletContext ctx)
         throws IOException, ToadletContextClosedException {
       PageNode page = ctx.getPageMaker().getPageNode(l10n(DOWNLOAD_FILES), ctx);
       HTMLNode contentNode = page.getContentNode();
@@ -1603,12 +1603,12 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
           || (ctx.getContainer().publicGatewayMode() && !ctx.isAllowedFullAccess());
     }
 
-    private File getDownloadsDir(String downloadPath) throws NotAllowedException {
+    private File getDownloadsDir(String downloadPath) throws DownloadTargetNotAllowedException {
       File downloadsDir = new File(downloadPath);
       // Invalid if it's disallowed, doesn't exist, isn't a directory, or can't be created.
       if (!transferAccessPort.allowDownloadTo(downloadsDir)
           || !((downloadsDir.exists() && downloadsDir.isDirectory()) || !downloadsDir.mkdirs())) {
-        throw new NotAllowedException();
+        throw new DownloadTargetNotAllowedException();
       }
       return downloadsDir;
     }
@@ -1846,134 +1846,13 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
    * @param counts progress counters for the request.
    * @return HTML node representing the progress cell, ready to attach.
    */
+  @SuppressWarnings("unused")
   public static HTMLNode createProgressCell(
       ProgressCellContext context, SplitfileProgressCounts counts) {
-    HTMLNode progressCell = new HTMLNode("td", ATTR_CLASS, "request-progress");
-    if (handleEarlyProgressMessages(context, progressCell)) {
-      return progressCell;
-    }
-
-    int adjustedTotal =
-        adjustTotal(context.advancedMode(), counts.minSuccessfulBlocks(), counts.totalBlocks());
-
-    if ((counts.succeedBlocks() < 0) || (adjustedTotal <= 0)) {
-      progressCell.addChild("span", ATTR_CLASS, "progress_fraction_unknown", l10n(UNKNOWN));
-    } else {
-      addProgressBar(
-          progressCell, counts, adjustedTotal, counts.finalizedTotal(), context.upload());
-    }
-    return progressCell;
-  }
-
-  private static boolean handleEarlyProgressMessages(
-      ProgressCellContext context, HTMLNode progressCell) {
-    if (!context.started()) {
-      progressCell.addChild("#", l10n("starting"));
-      return true;
-    }
-    if (context.compressing() == COMPRESS_STATE.WAITING && context.advancedMode()) {
-      progressCell.addChild("#", l10n("awaitingCompression"));
-      return true;
-    }
-    if (context.compressing() != COMPRESS_STATE.WORKING) {
-      progressCell.addChild("#", l10n("compressing"));
-      return true;
-    }
-    return false;
-  }
-
-  private static int adjustTotal(boolean advancedMode, int min, int total) {
-    return (!advancedMode || total < min) ? min : total;
-  }
-
-  private static void addProgressBar(
-      HTMLNode progressCell,
-      SplitfileProgressCounts progressCounts,
-      int adjustedTotal,
-      boolean finalized,
-      boolean upload) {
-    int fetchedPercent = (int) (progressCounts.succeedBlocks() / (double) adjustedTotal * 100);
-    int failedPercent = (int) (progressCounts.failedBlocks() / (double) adjustedTotal * 100);
-    int fatallyFailedPercent =
-        (int) (progressCounts.fatallyFailedBlocks() / (double) adjustedTotal * 100);
-    int minPercent = (int) (progressCounts.minSuccessfulBlocks() / (double) adjustedTotal * 100);
-    HTMLNode progressBar = progressCell.addChild("div", ATTR_CLASS, "progressbar");
-    progressBar.addChild(
-        "div",
-        new String[] {ATTR_CLASS, ATTR_STYLE},
-        new String[] {"progressbar-done", CSS_WIDTH_PREFIX + fetchedPercent + "%;"});
-
-    if (progressCounts.failedBlocks() > 0) {
-      progressBar.addChild(
-          "div",
-          new String[] {ATTR_CLASS, ATTR_STYLE},
-          new String[] {"progressbar-failed", CSS_WIDTH_PREFIX + failedPercent + "%;"});
-    }
-    if (progressCounts.fatallyFailedBlocks() > 0) {
-      progressBar.addChild(
-          "div",
-          new String[] {ATTR_CLASS, ATTR_STYLE},
-          new String[] {"progressbar-failed2", CSS_WIDTH_PREFIX + fatallyFailedPercent + "%;"});
-    }
-    if ((progressCounts.succeedBlocks()
-            + progressCounts.failedBlocks()
-            + progressCounts.fatallyFailedBlocks())
-        < progressCounts.minSuccessfulBlocks()) {
-      progressBar.addChild(
-          "div",
-          new String[] {ATTR_CLASS, ATTR_STYLE},
-          new String[] {
-            "progressbar-min", CSS_WIDTH_PREFIX + (minPercent - fetchedPercent) + "%;"
-          });
-    }
-
-    String prefix =
-        '('
-            + Integer.toString(progressCounts.succeedBlocks())
-            + "/ "
-            + progressCounts.minSuccessfulBlocks()
-            + "): ";
-    addProgressTitle(
-        progressBar,
-        progressCounts.succeedBlocks(),
-        progressCounts.minSuccessfulBlocks(),
-        finalized,
-        upload,
-        prefix);
-  }
-
-  private static void addProgressTitle(
-      HTMLNode progressBar,
-      int fetched,
-      int min,
-      boolean finalized,
-      boolean upload,
-      String prefix) {
-    double percent = min == 0 ? 0.0 : (fetched / (double) min) * 100.0;
-    double roundedPercent = Math.round(percent * 10.0) / 10.0;
-    String percentText = roundedPercent + "%";
-    if (finalized) {
-      progressBar.addChild(
-          "div",
-          new String[] {ATTR_CLASS, ATTR_TITLE},
-          new String[] {"progress_fraction_finalized", prefix + l10n("progressbarAccurate")},
-          percentText);
-      return;
-    }
-    String text = fetched + " (" + percentText + "??)";
-    progressBar.addChild(
-        "div",
-        new String[] {ATTR_CLASS, ATTR_TITLE},
-        new String[] {
-          "progress_fraction_not_finalized",
-          prefix
-              + NodeL10n.getBase()
-                  .getString(
-                      upload
-                          ? QUEUE_TOADLET_PREFIX + "uploadProgressbarNotAccurate"
-                          : QUEUE_TOADLET_PREFIX + "progressbarNotAccurate")
-        },
-        text);
+    QueueProgressCellContext progressContext =
+        new QueueProgressCellContext(
+            context.advancedMode(), context.started(), context.compressing(), context.upload());
+    return QueueProgressCellRenderer.createProgressCell(progressContext, counts);
   }
 
   private HTMLNode createPanicBox(PageMaker pageMaker, ToadletContext ctx) {

--- a/src/main/java/network/crypta/runtime/endpoints/TextModeClientInterface.java
+++ b/src/main/java/network/crypta/runtime/endpoints/TextModeClientInterface.java
@@ -49,7 +49,6 @@ import network.crypta.client.events.EventDumper;
 import network.crypta.client.filter.ContentFilter;
 import network.crypta.client.filter.ContentFilterCallbacks;
 import network.crypta.client.filter.ContentFilterRequest;
-import network.crypta.clients.fcp.AddPeer;
 import network.crypta.crypt.RandomSource;
 import network.crypta.fs.AppEnv;
 import network.crypta.io.comm.Peer;
@@ -69,6 +68,7 @@ import network.crypta.node.PeerTooOldException;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.Version;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.SizeUtil;
@@ -1166,7 +1166,7 @@ public class TextModeClientInterface implements Runnable {
       } else {
         outsb.append("Given string seems to be an URL, loading...\r\n");
         URL url = parseUrl(key);
-        content = AddPeer.getReferenceFromURL(url).toString();
+        content = PeerReferenceTextLoader.readFromUrl(url).toString();
       }
     } else {
       content = readLines(reader, true);

--- a/src/main/java/network/crypta/runtime/peers/reference/PeerReferenceTextLoader.java
+++ b/src/main/java/network/crypta/runtime/peers/reference/PeerReferenceTextLoader.java
@@ -1,0 +1,99 @@
+package network.crypta.runtime.peers.reference;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import network.crypta.client.FetchException;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.MediaType;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Loads peer-reference text from URL or Freenet URI sources.
+ *
+ * <p>This helper centralizes the small amount of I/O needed by peer-add workflows when the noderef
+ * itself is not embedded in the original request. HTTP toadlets, text-mode endpoints, and FCP
+ * compatibility layers can all call the same runtime-owned API instead of importing one another's
+ * transport-specific helpers.
+ *
+ * <p>The implementation is intentionally narrow. It preserves the legacy charset selection,
+ * line-by-line reading, and newline-joining behavior that existing noderef parsing code expects.
+ * The methods return a mutable {@link StringBuilder} so callers can keep their current parsing and
+ * compatibility code paths with minimal churn while this seam is being decoupled.
+ */
+public final class PeerReferenceTextLoader {
+  private PeerReferenceTextLoader() {}
+
+  /**
+   * Reads peer-reference text from a regular URL.
+   *
+   * <p>The method opens the supplied URL, inspects the response content type, and selects the same
+   * effective charset resolution path used by the historical loader. It then reads the response one
+   * line at a time and appends a single {@code '\n'} after each line. This preserves the text shape
+   * expected by downstream noderef parsers, including a trailing newline for non-empty final lines.
+   *
+   * @param url absolute URL pointing at a textual peer-reference document that is small enough to
+   *     read into memory in one pass
+   * @return mutable buffer containing the fetched peer-reference text with one newline appended
+   *     after each source line
+   * @throws IOException if opening the connection or reading the response body fails for any reason
+   *     exposed by the underlying stream or URL implementation
+   */
+  public static StringBuilder readFromUrl(URL url) throws IOException {
+    StringBuilder ref = new StringBuilder(1024);
+
+    URLConnection uc = url.openConnection();
+    try (InputStream is = uc.getInputStream();
+        BufferedReader in =
+            new BufferedReader(
+                new InputStreamReader(is, MediaType.getCharsetRobustOrUTF(uc.getContentType())))) {
+
+      String line;
+      while ((line = in.readLine()) != null) {
+        ref.append(line).append('\n');
+      }
+      return ref;
+    }
+  }
+
+  /**
+   * Reads peer-reference text from a Freenet URI.
+   *
+   * <p>The supplied client performs the historical {@code client.fetch(uri, 31000)} call so the
+   * loader remains behaviorally identical to the code it replaces. The fetched bucket is then read
+   * as plain text, again appending a single {@code '\n'} after each line so callers receive the
+   * same normalized noderef text shape as the URL-based variant.
+   *
+   * @param uri Freenet URI that identifies the stored peer-reference document to fetch from the
+   *     node network
+   * @param client high-level client used to execute the fetch within the caller's existing runtime
+   *     configuration and request policy
+   * @return mutable buffer containing the fetched peer-reference text with one newline appended
+   *     after each source line
+   * @throws IOException if the fetch succeeds but the returned bucket cannot be read completely as
+   *     text
+   * @throws FetchException if the client cannot fetch the URI successfully, including timeout,
+   *     routing, or protocol-level failures reported by the fetch path
+   */
+  public static StringBuilder readFromFreenetUri(FreenetURI uri, HighLevelSimpleClient client)
+      throws IOException, FetchException {
+    StringBuilder ref = new StringBuilder(1024);
+
+    try (Bucket bucket = client.fetch(uri, 31000).asBucket();
+        InputStream is = bucket.getInputStream();
+        BufferedReader in =
+            new BufferedReader(
+                new InputStreamReader(is, MediaType.getCharsetRobustOrUTF("text/plain")))) {
+
+      String line;
+      while ((line = in.readLine()) != null) {
+        ref.append(line).append('\n');
+      }
+      return ref;
+    }
+  }
+}

--- a/src/main/java/network/crypta/runtime/peers/reference/package-info.java
+++ b/src/main/java/network/crypta/runtime/peers/reference/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Peer-reference text loading helpers shared by runtime and client adapters.
+ *
+ * <p>This package hosts the small, transport-neutral seam that turns noderef text stored behind a
+ * regular URL or a Freenet URI into the newline-preserving {@link java.lang.StringBuilder} form
+ * expected by existing peer-add parsers. Keeping that logic in runtime code lets HTTP toadlets,
+ * text-mode endpoints, and FCP compatibility shims reuse one implementation without importing each
+ * other's transport-specific classes.
+ *
+ * <p>The classes here are intentionally narrow. They preserve established charset handling and
+ * fetch limits while helping the surrounding codebase continue its package-boundary cleanup with
+ * minimal behavior risk.
+ */
+package network.crypta.runtime.peers.reference;

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -1,18 +1,16 @@
 package network.crypta.clients.fcp;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import network.crypta.client.ClientMetadata;
-import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.RequestStarter;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.PeerAddFailureReason;
 import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
@@ -22,8 +20,6 @@ import network.crypta.runtime.spi.PeerTrust;
 import network.crypta.runtime.spi.PeerVisibility;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.api.Bucket;
-import network.crypta.support.io.ArrayBucket;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -36,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -138,34 +135,34 @@ class AddPeerTest {
   }
 
   @Test
-  void getReferenceFromURL_whenFileHasTwoLines_readsBothLinesWithTrailingNewlines(
-      @TempDir Path tempDir) throws IOException {
-    Path file = tempDir.resolve("peer-ref.txt");
-    Files.writeString(file, "line1\nline2\n", StandardCharsets.UTF_8);
+  void getReferenceFromURL_whenCalled_delegatesToPeerReferenceTextLoader() throws IOException {
+    URL url = mock(URL.class);
+    StringBuilder reference = new StringBuilder("line1\nline2\n");
 
-    URL url = file.toUri().toURL();
+    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
+        Mockito.mockStatic(PeerReferenceTextLoader.class)) {
+      mockedLoader.when(() -> PeerReferenceTextLoader.readFromUrl(url)).thenReturn(reference);
 
-    StringBuilder result = AddPeer.getReferenceFromURL(url);
-
-    assertEquals("line1\nline2\n", result.toString());
+      assertSame(reference, AddPeer.getReferenceFromURL(url));
+      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromUrl(url));
+    }
   }
 
   @Test
-  void getReferenceFromFreenetURI_whenClientReturnsBucket_readsBucketContent() throws Exception {
-    Bucket bucket = new ArrayBucket();
-    try (OutputStream out = bucket.getOutputStream()) {
-      out.write("ref-line-1\nref-line-2\n".getBytes(StandardCharsets.UTF_8));
-    }
-
-    FetchResult fetchResult = FetchResult.create(new ClientMetadata("text/plain"), bucket);
+  void getReferenceFromFreenetURI_whenCalled_delegatesToPeerReferenceTextLoader() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    when(client.fetch(any(FreenetURI.class), eq(31000L))).thenReturn(fetchResult);
-
     FreenetURI uri = mock(FreenetURI.class);
+    StringBuilder reference = new StringBuilder("ref-line-1\nref-line-2\n");
 
-    StringBuilder result = AddPeer.getReferenceFromFreenetURI(uri, client);
+    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
+        Mockito.mockStatic(PeerReferenceTextLoader.class)) {
+      mockedLoader
+          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client))
+          .thenReturn(reference);
 
-    assertEquals("ref-line-1\nref-line-2\n", result.toString());
+      assertSame(reference, AddPeer.getReferenceFromFreenetURI(uri, client));
+      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client));
+    }
   }
 
   @Test
@@ -184,12 +181,12 @@ class AddPeerTest {
 
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
 
-    try (MockedStatic<AddPeer> mockedAddPeer =
-        Mockito.mockStatic(AddPeer.class, Mockito.CALLS_REAL_METHODS)) {
+    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
+        Mockito.mockStatic(PeerReferenceTextLoader.class)) {
       StringBuilder reference = new StringBuilder();
       reference.append("identity=peer-url\n");
-      mockedAddPeer
-          .when(() -> AddPeer.getReferenceFromFreenetURI(any(FreenetURI.class), eq(client)))
+      mockedLoader
+          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(any(FreenetURI.class), eq(client)))
           .thenReturn(reference);
       when(messageRuntimeSupport.makeClient(
               RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true))

--- a/src/test/java/network/crypta/runtime/peers/reference/PeerReferenceTextLoaderTest.java
+++ b/src/test/java/network/crypta/runtime/peers/reference/PeerReferenceTextLoaderTest.java
@@ -1,0 +1,61 @@
+package network.crypta.runtime.peers.reference;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchResult;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PeerReferenceTextLoaderTest {
+
+  @Mock private HighLevelSimpleClient client;
+
+  @Test
+  void readFromUrl_whenFileHasTwoLines_readsBothLinesWithTrailingNewlines(@TempDir Path tempDir)
+      throws IOException {
+    Path file = tempDir.resolve("peer-ref.txt");
+    Files.writeString(file, "line1\nline2\n", StandardCharsets.UTF_8);
+
+    URL url = file.toUri().toURL();
+
+    StringBuilder result = PeerReferenceTextLoader.readFromUrl(url);
+
+    assertEquals("line1\nline2\n", result.toString());
+  }
+
+  @Test
+  void readFromFreenetUri_whenClientReturnsBucket_readsBucketContent() throws Exception {
+    Bucket bucket = new ArrayBucket();
+    try (OutputStream out = bucket.getOutputStream()) {
+      out.write("ref-line-1\nref-line-2\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    FetchResult fetchResult = FetchResult.create(new ClientMetadata("text/plain"), bucket);
+    when(client.fetch(any(FreenetURI.class), eq(31000L))).thenReturn(fetchResult);
+
+    FreenetURI uri = mock(FreenetURI.class);
+
+    StringBuilder result = PeerReferenceTextLoader.readFromFreenetUri(uri, client);
+
+    assertEquals("ref-line-1\nref-line-2\n", result.toString());
+  }
+}


### PR DESCRIPTION
## Summary
- add a runtime-owned `PeerReferenceTextLoader` and keep `AddPeer`'s static helpers as compatibility shims
- switch `ConnectionsToadlet` and `TextModeClientInterface` to the neutral loader so the remaining `clients.http -> clients.fcp` main-source imports drop to zero
- route queue progress rendering through the existing runtime queue renderer and replace `QueueToadlet`'s `NotAllowedException` control flow with a local checked exception
- add focused tests for the extracted loader and update `AddPeerTest` to verify delegation
- expand Javadocs for the new runtime helper package and class

## Verification
- `rg -n '^import network\.crypta\.clients\.fcp\.' src/main/java/network/crypta/clients/http`
- `rg -n '^import network\.crypta\.clients\.fcp\.AddPeer;' src/main/java/network/crypta/runtime/endpoints/TextModeClientInterface.java`
- `./gradlew spotlessApply`
- `./gradlew compileJava`
- `./gradlew testClasses`
- `./gradlew test --tests 'network.crypta.clients.fcp.AddPeerTest' --tests 'network.crypta.clients.http.QueueToadletTest' --tests 'network.crypta.clients.http.QueueToadletPostDownloadTest' --tests 'network.crypta.clients.http.DarknetConnectionsToadletTest' --tests 'network.crypta.runtime.endpoints.TextModeClientInterfaceTest' --tests 'network.crypta.runtime.peers.reference.PeerReferenceTextLoaderTest'`
- `javadoc -quiet -Xdoclint:all -classpath 'bin/main:build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/peers/reference/PeerReferenceTextLoader.java`
- `javac -proc:none -Xdoclint:all -Werror -classpath 'bin/main:build/resources/main' -d /tmp/doclint-out src/main/java/network/crypta/runtime/peers/reference/package-info.java`