### PR TITLE
refactor(updater): Re-home core updater HTTP toadlet

### DIFF
--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -558,7 +558,7 @@
 
   <Match>
     <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
-    <Class name="network.crypta.runtime.updater.CoreActionToadlet"/>
+    <Class name="network.crypta.clients.http.updater.CoreActionToadlet"/>
     <Method name="isOstree"/>
   </Match>
 
@@ -1418,7 +1418,7 @@
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
-    <Class name="network.crypta.runtime.updater.CoreActionToadlet"/>
+    <Class name="network.crypta.clients.http.updater.CoreActionToadlet"/>
   </Match>
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -10,11 +10,11 @@ import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
 import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
 import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
 import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
+import network.crypta.clients.http.updater.CoreActionToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
-import network.crypta.runtime.updater.CoreActionToadlet;
 
 import static network.crypta.runtime.updater.UpdaterPaths.CORE_UPDATE_PATH;
 

--- a/src/main/java/network/crypta/clients/http/updater/CoreActionToadlet.java
+++ b/src/main/java/network/crypta/clients/http/updater/CoreActionToadlet.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.updater;
+package network.crypta.clients.http.updater;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -24,6 +24,7 @@ import network.crypta.fs.AppEnv;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
+import network.crypta.runtime.updater.UpdaterPaths;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;

--- a/src/main/java/network/crypta/clients/http/updater/package-info.java
+++ b/src/main/java/network/crypta/clients/http/updater/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * HTTP-facing adapter surface for core updater actions.
+ *
+ * <p>This package contains the web-layer types that expose the core updater to browser clients
+ * under {@code /core-update/}. Code here translates form submissions and request parameters into
+ * calls on the runtime updater ports, then renders redirects or HTML result pages that fit the
+ * existing FProxy user interface. It is the place for HTTP-specific concerns such as request
+ * parsing, form-password checks, redirect targets, and browser-oriented success or failure
+ * messaging.
+ *
+ * <p>The package does not own updater state, installer selection, download coordination, or package
+ * validation rules. Those responsibilities remain in {@code network.crypta.runtime.updater} and the
+ * runtime SPI it exposes. Keeping this package narrow preserves the intended architectural
+ * boundary: runtime code stays independent of {@code clients.http}, while the HTTP shell remains
+ * free to present the updater flow without embedding business logic.
+ *
+ * <p>In practice, types in this package should:
+ *
+ * <ul>
+ *   <li>bridge UI actions to runtime ports with minimal translation logic
+ *   <li>keep path handling and response rendering consistent with the rest of FProxy, and
+ *   <li>avoid reimplementing updater policy that already belongs to the runtime layer.
+ * </ul>
+ */
+package network.crypta.clients.http.updater;

--- a/src/main/java/network/crypta/runtime/updater/CoreUpdater.java
+++ b/src/main/java/network/crypta/runtime/updater/CoreUpdater.java
@@ -22,7 +22,6 @@ import network.crypta.client.async.ClientGetter;
 import network.crypta.client.events.ClientEvent;
 import network.crypta.client.events.ClientEventListener;
 import network.crypta.client.events.SplitfileProgressEvent;
-import network.crypta.clients.http.ExternalLinkToadlet;
 import network.crypta.fs.AppEnv;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
@@ -31,6 +30,7 @@ import network.crypta.node.Version;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SizeUtil;
 import network.crypta.support.api.Bucket;
+import network.crypta.support.http.ExternalLinkSupport;
 import network.crypta.support.io.FileBucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -556,7 +556,7 @@ public class CoreUpdater extends NodeUpdater {
       links.addChild(buildOpenStoreForm(kind, id, storeUrl));
       links.addChild("#", "  ");
     } else if (hasText(storeUrl)) {
-      links.addChild("a", "href", ExternalLinkToadlet.escape(storeUrl), "Open in Store");
+      links.addChild("a", "href", ExternalLinkSupport.escape(storeUrl), "Open in Store");
       links.addChild("#", "  ");
     }
     return links;
@@ -564,7 +564,7 @@ public class CoreUpdater extends NodeUpdater {
 
   private static void addReleaseNotesLink(HTMLNode links, String releasePageUrl) {
     if (hasText(releasePageUrl)) {
-      links.addChild("a", "href", ExternalLinkToadlet.escape(releasePageUrl), "Release Notes");
+      links.addChild("a", "href", ExternalLinkSupport.escape(releasePageUrl), "Release Notes");
       links.addChild("#", "  ");
     }
   }

--- a/src/main/java/network/crypta/runtime/updater/package-info.java
+++ b/src/main/java/network/crypta/runtime/updater/package-info.java
@@ -9,12 +9,17 @@
  * and offer a guided installation.
  *
  * <p>At a high level the updater strives to be robust, explicit, and user-driven. Network and file
- * operations surface progress and errors clearly so callers can present actionable status to users
+ * operations surface progress and errors clearly, so callers can present actionable status to users
  * and retry when appropriate. Artifacts are written to a staging area {@code
  * nodeDir/updates/core/<version>/} and integrity is verified before any installation step is
  * attempted. For core upgrades, the system disables JAR Update-over-Mandatory (UOM) and avoids
  * directly replacing a running {@code cryptad.jar}; instead, it prefers OS-native package tools or
  * interactive installers depending on platform capabilities.
+ *
+ * <p>The code in this package owns updater state, discovery, download coordination, and
+ * installation policy. HTTP exposure of updater actions now lives in the adapter layer under {@code
+ * network.crypta.clients.http.updater}, which keeps request handling out of runtime coordination
+ * code.
  *
  * <p>Notable behaviors and responsibilities:
  *
@@ -23,23 +28,22 @@
  *       selecting an installer.
  *   <li>Downloads installers to a predictable, versioned location and reports progress when
  *       available.
- *   <li>Validates content by cryptographic checks; only verified artifacts proceed to the install
- *       or deploy phase.
- *   <li>Handles core updates via external installers (for example DEB/RPM/DMG/EXE).
- *   <li>Exposes HTTP actions such as {@code /core-update/?action=download|install|openStore} so
- *       user interfaces can drive the flow without embedding update logic.
+ *   <li>Validates content by cryptographic checks; only verified artifacts proceed to the
+ *       installation or deploy phase.
+ *   <li>Handles core updates via external installers (for example, DEB/RPM/DMG/EXE).
+ *   <li>Coordinates the updater state machine that the HTTP adapter layer renders and drives.
  * </ul>
  *
  * <p>Concurrency and state: update actions perform blocking I/O and file-system work and should be
  * executed off the UI thread. The package is designed so repeated attempts are safe: partial
  * downloads and failed installations can be retried without corrupting existing installations.
- * Callers should ensure only one core install attempt runs at a time for a given target version to
- * avoid conflicting file operations.
+ * Callers should ensure only one core installation attempt runs at a time for a given target
+ * version to avoid conflicting file operations.
  *
  * <p>Platform specifics: on Linux, when a desktop is detected, the updater prefers handing off to a
  * graphical tool (for example {@code gio} or {@code xdg-open}). In sandboxed environments such as
  * Flatpak, helper bridges may be used to reach host tools. On macOS and Windows, installation is
  * typically guided by native installers; user messaging highlights common security prompts (for
- * example Gatekeeper or SmartScreen) and offers checksum verification tips when appropriate.
+ * example, Gatekeeper or SmartScreen) and offers checksum verification tips when appropriate.
  */
 package network.crypta.runtime.updater;

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -166,7 +166,7 @@ class FProxyRegistrarTest {
             .filter(
                 registered ->
                     registered.toadlet()
-                        instanceof network.crypta.runtime.updater.CoreActionToadlet)
+                        instanceof network.crypta.clients.http.updater.CoreActionToadlet)
             .findFirst()
             .orElseThrow();
     assertSame(

--- a/src/test/java/network/crypta/clients/http/updater/CoreActionToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/updater/CoreActionToadletTest.java
@@ -1,4 +1,4 @@
-package network.crypta.runtime.updater;
+package network.crypta.clients.http.updater;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -11,6 +11,7 @@ import network.crypta.clients.http.PageNode;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.fs.AppEnv;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
+import network.crypta.runtime.updater.UpdaterPaths;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;

--- a/src/test/java/network/crypta/clients/http/updater/CoreActionToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/updater/CoreActionToadletTest.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http.updater;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
 import network.crypta.client.HighLevelSimpleClient;
@@ -97,6 +98,31 @@ class CoreActionToadletTest {
 
     toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
 
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        (ArgumentCaptor<MultiValueTable<String, String>>)
+            (ArgumentCaptor<?>) ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), isNull(), eq(0L));
+    assertEquals("/alerts/", headersCaptor.getValue().getFirst("Location"));
+  }
+
+  @Test
+  void handleMethodPOST_whenActionUnknownAndCoreUpdaterAvailable_expectRedirect() throws Exception {
+    // Arrange
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
+    ToadletContext ctx = mock(ToadletContext.class);
+    HTTPRequest request = mock(HTTPRequest.class);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
+    when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("unknown");
+    doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
+
+    // Act
+    toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
+
+    // Assert
     ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
         (ArgumentCaptor<MultiValueTable<String, String>>)
             (ArgumentCaptor<?>) ArgumentCaptor.forClass(MultiValueTable.class);
@@ -212,22 +238,119 @@ class CoreActionToadletTest {
     verify(ctx).writeData(any(), anyInt(), anyInt());
   }
 
+  @Test
+  void handleMethodPOST_whenInstallSnapInsideSnapSandbox_expectGuidancePage() throws Exception {
+    // Arrange
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
+    ToadletContext ctx = mock(ToadletContext.class);
+    HTTPRequest request = mock(HTTPRequest.class);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+
+    File baseDir = tempDir.resolve("node").toFile();
+    File updatesDir = new File(baseDir, "updates/core");
+    File installer = new File(updatesDir, "cryptad.snap");
+    assertTrue(updatesDir.mkdirs() || updatesDir.isDirectory());
+    assertTrue(installer.createNewFile());
+
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
+    when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("install");
+    when(request.getPartAsStringFailsafe(eq("path"), anyInt()))
+        .thenReturn(installer.getAbsolutePath());
+    when(coreUpdateActionPort.resolveDownloadedInstaller(installer.getAbsolutePath()))
+        .thenReturn(Optional.of(installer.toPath()));
+
+    AppEnv appEnv = mock(AppEnv.class);
+    when(appEnv.osKind()).thenReturn(AppEnv.OsKind.LINUX);
+    when(appEnv.isServiceMode()).thenReturn(false);
+    when(appEnv.isSnap()).thenReturn(true);
+    replaceAppEnv(toadlet, appEnv);
+
+    stubHtmlContext(ctx);
+
+    // Act
+    toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
+
+    // Assert
+    verify(ctx)
+        .sendReplyHeaders(eq(200), eq("OK"), isNull(), eq("text/html; charset=utf-8"), anyLong());
+    String html = captureWrittenHtml(ctx);
+    assertTrue(
+        html.contains("This app is running inside a Snap sandbox and cannot elevate privileges."));
+    assertTrue(html.contains("Run this command in terminal:"));
+    assertTrue(html.contains("sudo snap install --dangerous"));
+    assertTrue(html.contains(installer.getAbsolutePath()));
+  }
+
+  @Test
+  void handleMethodPOST_whenOpenStoreSnapInsideSnapSandbox_expectManualCommandPage()
+      throws Exception {
+    // Arrange
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
+    ToadletContext ctx = mock(ToadletContext.class);
+    HTTPRequest request = mock(HTTPRequest.class);
+    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
+    when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("openStore");
+    when(request.getPartAsStringFailsafe(eq("kind"), anyInt())).thenReturn("snap");
+    when(request.getPartAsStringFailsafe(eq("id"), anyInt())).thenReturn("network.crypta");
+    when(request.getPartAsStringFailsafe(eq("url"), anyInt())).thenReturn("");
+
+    AppEnv appEnv = mock(AppEnv.class);
+    when(appEnv.osKind()).thenReturn(AppEnv.OsKind.LINUX);
+    when(appEnv.isFlatpak()).thenReturn(false);
+    when(appEnv.isSnap()).thenReturn(true);
+    replaceAppEnv(toadlet, appEnv);
+
+    stubHtmlContext(ctx);
+
+    // Act
+    toadlet.handleMethodPOST(URI.create("http://localhost/core-update/"), request, ctx);
+
+    // Assert
+    verify(ctx)
+        .sendReplyHeaders(eq(200), eq("OK"), isNull(), eq("text/html; charset=utf-8"), anyLong());
+    String html = captureWrittenHtml(ctx);
+    assertTrue(html.contains("cannot perform snap installs"));
+    assertTrue(html.contains("sudo snap install network.crypta"));
+  }
+
   private static void stubHtmlContext(ToadletContext ctx) throws Exception {
     PageMaker pageMaker = mock(PageMaker.class);
     PageNode pageNode = mock(PageNode.class);
-    HTMLNode contentNode = new HTMLNode("div");
-    HTMLNode infoboxNode = new HTMLNode("div");
+    HTMLNode pageRoot = new HTMLNode("html");
+    HTMLNode bodyNode = pageRoot.addChild("body");
+    HTMLNode contentNode = bodyNode.addChild("div");
 
     when(ctx.getPageMaker()).thenReturn(pageMaker);
     when(pageMaker.getPageNode(anyString(), eq(ctx), any(PageMaker.RenderParameters.class)))
         .thenReturn(pageNode);
     when(pageNode.getContentNode()).thenReturn(contentNode);
-    when(pageNode.generate()).thenReturn("<html></html>");
+    when(pageNode.generate()).thenAnswer(_ -> pageRoot.generate());
     when(pageMaker.getInfobox(anyString(), anyString(), eq(contentNode), anyString(), eq(true)))
-        .thenReturn(infoboxNode);
+        .thenAnswer(
+            invocation ->
+                contentNode.addChild(
+                    "div", "class", "infobox " + invocation.getArgument(0, String.class)));
 
     doNothing().when(ctx).sendReplyHeaders(anyInt(), anyString(), any(), any(), anyLong());
     doNothing().when(ctx).writeData(any(), anyInt(), anyInt());
+  }
+
+  private static String captureWrittenHtml(ToadletContext ctx) throws Exception {
+    ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> offsetCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> lengthCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(ctx).writeData(dataCaptor.capture(), offsetCaptor.capture(), lengthCaptor.capture());
+    return new String(
+        dataCaptor.getValue(),
+        offsetCaptor.getValue(),
+        lengthCaptor.getValue(),
+        StandardCharsets.UTF_8);
   }
 
   private static void replaceAppEnv(CoreActionToadlet toadlet, AppEnv appEnv) throws Exception {

--- a/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
+++ b/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
@@ -1,11 +1,31 @@
 package network.crypta.runtime.updater;
 
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Map;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.support.HTMLNode;
+import network.crypta.support.Ticker;
+import network.crypta.support.http.ExternalLinkSupport;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@SuppressWarnings("java:S100")
 class CoreUpdaterTest {
   @Test
   void parseJson_minimal() {
@@ -59,5 +79,79 @@ class CoreUpdaterTest {
     assertNull(CoreUpdater.parseStrictIntegerVersion("1.2.3+build123"));
     assertNull(CoreUpdater.parseStrictIntegerVersion("1501beta"));
     assertNull(CoreUpdater.parseStrictIntegerVersion("999999999999999999999"));
+  }
+
+  @Test
+  void buildLinksNode_whenReleaseAndStoreUrlsPresent_expectEscapedExternalLinks() throws Exception {
+    // Arrange
+    CoreUpdater updater = createCoreUpdater();
+    String releasePageUrl = "https://example.com/releases/core?q=a%20b";
+    String storeUrl = "https://store.example.com/apps/core?id=cryptad%20pkg";
+    CoreInfo info = new CoreInfo("1501", releasePageUrl, Map.of(), null, null);
+    PackageSpec spec = new PackageSpec(null, null, storeUrl);
+
+    // Act
+    HTMLNode links = invokeBuildLinksNode(updater, info, spec, "amd64.deb");
+    List<HTMLNode> anchors =
+        links.getChildren().stream().filter(node -> "a".equals(node.getName())).toList();
+
+    // Assert
+    assertEquals(2, anchors.size());
+    assertEquals(
+        ExternalLinkSupport.escape(releasePageUrl), anchors.get(0).getAttributes().get("href"));
+    assertEquals("Release Notes", anchors.get(0).generateChildren());
+    assertEquals(ExternalLinkSupport.escape(storeUrl), anchors.get(1).getAttributes().get("href"));
+    assertEquals("Open in Store", anchors.get(1).generateChildren());
+  }
+
+  private static CoreUpdater createCoreUpdater() throws Exception {
+    NodeUpdateManager manager = mock(NodeUpdateManager.class);
+    Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
+    NodeClientCore core = mock(NodeClientCore.class);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    Ticker ticker = mock(Ticker.class);
+
+    when(manager.getNode()).thenReturn(node);
+    when(node.services().clientCore()).thenReturn(core);
+    when(node.network().ticker()).thenReturn(ticker);
+    when(core.makeClient(anyShort(), anyBoolean(), anyBoolean())).thenReturn(client);
+    when(client.getFetchContext()).thenReturn(createFetchContext());
+
+    return new CoreUpdater(defaultParams(manager));
+  }
+
+  private static NodeUpdaterParams defaultParams(NodeUpdateManager manager)
+      throws MalformedURLException {
+    return new NodeUpdaterParams(
+        manager,
+        new FreenetURI("USK@" + NodeUpdateManager.UPDATE_URI + "/info/1200"),
+        1200,
+        -1,
+        Integer.MAX_VALUE,
+        "core-info-",
+        1325);
+  }
+
+  private static FetchContext createFetchContext() {
+    SimpleEventProducer eventProducer = new SimpleEventProducer();
+    return new FetchContext(
+        FetchContextOptions.builder()
+            .limits(Long.MAX_VALUE, Long.MAX_VALUE, 1024 * 1024)
+            .archiveLimits(1, 1, 1, false)
+            .retryLimits(0, 0, 0)
+            .splitfileLimits(true, 1, 1)
+            .behavior(true, false, false)
+            .clientOptions(eventProducer, false, true)
+            .filterOverrides(null, null, null)
+            .build());
+  }
+
+  private static HTMLNode invokeBuildLinksNode(
+      CoreUpdater updater, CoreInfo info, PackageSpec spec, String chosenKey) throws Exception {
+    Method buildLinksNode =
+        CoreUpdater.class.getDeclaredMethod(
+            "buildLinksNode", CoreInfo.class, PackageSpec.class, String.class);
+    buildLinksNode.setAccessible(true);
+    return (HTMLNode) buildLinksNode.invoke(updater, info, spec, chosenKey);
   }
 }


### PR DESCRIPTION
## Summary
- move `CoreActionToadlet` from `network.crypta.runtime.updater` to `network.crypta.clients.http.updater`
- move the package-local `CoreActionToadletTest`, update `FProxyRegistrar` and `FProxyRegistrarTest`, and retarget SpotBugs excludes to the new class name
- replace `CoreUpdater` uses of `ExternalLinkToadlet.escape(...)` with `ExternalLinkSupport.escape(...)` and clarify the runtime-vs-HTTP package boundary docs

## How to test
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests "network.crypta.clients.http.updater.CoreActionToadletTest"`
- `./gradlew test --tests "network.crypta.clients.http.FProxyRegistrarTest"`
- `./gradlew test --tests "network.crypta.runtime.updater.CoreUpdaterTest"`
- `./gradlew spotbugsMain`

## Notes
- `rg -n "import network\.crypta\.clients\.http\." src/main/java/network/crypta/runtime/updater` now returns no matches.
- `CoreUpdater` now references only `ExternalLinkSupport.escape(...)` for these updater links.