### PR TITLE
refactor(node): Remove final adapter imports

### DIFF
--- a/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
+++ b/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import java.util.List;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.runtime.endpoints.http.ConnectivityPagePaths;
 import network.crypta.runtime.spi.ConnectivityGapSnapshot;
 import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
 import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
@@ -34,15 +35,13 @@ public class ConnectivityToadlet extends Toadlet {
   private static final String EMPTY_HEADER_LABEL = " ";
   private static final String CONNECTIVITY_PORT_CLASS = "connectivity-port";
   private static final String CONNECTIVITY_IP_CLASS = "connectivity-ip";
-  private static final String PATH_DELIMITER = "/";
   private static final int GAP_COLUMNS = 5;
 
   /**
    * Publicly visible path segment for registering the connectivity dashboard endpoint, including
    * leading and trailing slashes as expected by the toadlet router for consistent URL generation.
    */
-  public static final String CONNECTIVITY_PATH =
-      String.join(PATH_DELIMITER, "", "connectivity", "");
+  public static final String CONNECTIVITY_PATH = ConnectivityPagePaths.CONNECTIVITY_PATH;
 
   private record TrafficContext(String noreply, String local, String remote, long now) {}
 

--- a/src/main/java/network/crypta/node/IPDetectorManager.java
+++ b/src/main/java/network/crypta/node/IPDetectorManager.java
@@ -9,8 +9,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import network.crypta.clients.http.ConnectivityToadlet;
-import network.crypta.clients.http.ExternalLinkToadlet;
 import network.crypta.compat.DetectedIP;
 import network.crypta.compat.ExternalIpDetector;
 import network.crypta.compat.ForwardPort;
@@ -26,9 +24,11 @@ import network.crypta.runtime.alerts.AbstractUserAlert;
 import network.crypta.runtime.alerts.ProxyUserAlert;
 import network.crypta.runtime.alerts.SimpleUserAlert;
 import network.crypta.runtime.alerts.UserAlert;
+import network.crypta.runtime.endpoints.http.ConnectivityPagePaths;
 import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
+import network.crypta.support.http.ExternalLinkSupport;
 import network.crypta.support.transport.ip.IPUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +87,7 @@ public class IPDetectorManager implements ForwardPortCallback {
     @Override
     public HTMLNode getHTMLText() {
       HTMLNode div = new HTMLNode("div");
-      String url = ExternalLinkToadlet.escape(HTMLEncoder.encode(l10n("portForwardHelpURL")));
+      String url = ExternalLinkSupport.escape(HTMLEncoder.encode(l10n("portForwardHelpURL")));
       boolean maybeForwarded = true;
       for (int portNotForwarded : portsNotForwarded) {
         if (portNotForwarded < 0) {
@@ -113,7 +113,7 @@ public class IPDetectorManager implements ForwardPortCallback {
                   HTMLNode.text(Math.abs(portsNotForwarded[0])),
                   HTMLNode.text(Math.abs(portsNotForwarded[1])),
                   HTMLNode.link(url),
-                  HTMLNode.link(ConnectivityToadlet.CONNECTIVITY_PATH)
+                  HTMLNode.link(ConnectivityPagePaths.CONNECTIVITY_PATH)
                 });
       } else {
         LOG.error(
@@ -293,7 +293,7 @@ public class IPDetectorManager implements ForwardPortCallback {
                   new String[] {"link", "port"},
                   new HTMLNode[] {
                     HTMLNode.link(
-                        ExternalLinkToadlet.escape(
+                        ExternalLinkSupport.escape(
                             "http://wiki.freenetproject.org/FirewallAndRouterIssues")),
                     HTMLNode.text(portsNotForwarded[0])
                   });
@@ -305,7 +305,7 @@ public class IPDetectorManager implements ForwardPortCallback {
                   new String[] {"link", L10N_PORT1, L10N_PORT2},
                   new HTMLNode[] {
                     HTMLNode.link(
-                        ExternalLinkToadlet.escape(
+                        ExternalLinkSupport.escape(
                             "http://wiki.freenetproject.org/FirewallAndRouterIssues")),
                     HTMLNode.text(portsNotForwarded[0]),
                     HTMLNode.text(portsNotForwarded[1])
@@ -543,9 +543,10 @@ public class IPDetectorManager implements ForwardPortCallback {
   /* Heuristics for when to run IP detection (e.g., STUN-like probing).
    *
    * - After a failed attempt that yielded no usable IP, wait 5 minutes before retrying.
-   * - If a direct (public) IP was detected and either (a) no peers are older than
-   *   30 minutes or (b) we have connected to at least two distinct real-IP peers since
-   *   startup, skip detection (we might still be firewalled, so this is not a hard ban).
+   * - If a direct (public) IP was detected, we may skip detection.
+   *   Skip when either (a) no peers are older than 30 minutes or (b) we have
+   *   connected to at least two distinct real-IP peers since startup.
+   *   We might still be firewalled, so this is not a hard ban.
    * - With zero peers: run at most once every 6 hours (time not persisted across restarts).
    * - With peers present: skip if detection ran within the last hour.
    * - Guard against bogus peer reports:
@@ -1178,8 +1179,7 @@ public class IPDetectorManager implements ForwardPortCallback {
   public void addConnectionTypeBox(HTMLNode contentNode) {
     if (node.services().clientCore() == null) return;
     if (node.services().clientCore().getAlerts() == null) return;
-    if (proxyAlert == null) {
-      LOG.error("start() not called yet");
+    if (isProxyAlertMissing("addConnectionTypeBox")) {
       return;
     }
     if (proxyAlert.isValid())
@@ -1187,11 +1187,11 @@ public class IPDetectorManager implements ForwardPortCallback {
   }
 
   /**
-   * Returns the current connection-type notice as a detached snapshot, if one is active.
+   * Returns the current connection-type notice as a detached snapshot if one is active.
    *
    * <p>Precondition: {@link #start()} has been called. If not, a log entry is emitted and the
    * method returns {@code null}. The returned value includes both plain-text fields and a rendered
-   * HTML alert fragment so HTTP surfaces can preserve the legacy alert infobox, forwarding-help
+   * HTML alert fragment, so HTTP surfaces can preserve the legacy alert infobox, forwarding-help
    * links, and dismissal controls without depending on daemon-only alert types.
    *
    * @return detached notice snapshot, or {@code null} when no connection-type notice is active
@@ -1200,8 +1200,7 @@ public class IPDetectorManager implements ForwardPortCallback {
     if (node.services().clientCore() == null) return null;
     var alerts = node.services().clientCore().getAlerts();
     if (alerts == null) return null;
-    if (proxyAlert == null) {
-      LOG.error("start() not called yet");
+    if (isProxyAlertMissing("connectionTypeNotice")) {
       return null;
     }
     if (!proxyAlert.isValid()) {
@@ -1209,6 +1208,14 @@ public class IPDetectorManager implements ForwardPortCallback {
     }
     return new ConnectivityNoticeSnapshot(
         proxyAlert.getTitle(), proxyAlert.getText(), alerts.renderAlert(proxyAlert).generate());
+  }
+
+  private boolean isProxyAlertMissing(String caller) {
+    if (proxyAlert == null) {
+      LOG.error("start() not called before {}", caller);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -9,7 +9,7 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.USKManager;
-import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.config.BooleanCallback;
 import network.crypta.config.IntCallback;
 import network.crypta.config.InvalidConfigValueException;
@@ -1520,9 +1520,9 @@ public final class NodeClientCore implements Persistable {
    * array as read-only and avoid modifying its elements. The accessor performs no I/O and returns
    * the in-memory snapshot immediately.
    *
-   * @return snapshot array of persisted {@link ClientRequest} entries at call time.
+   * @return snapshot array of persisted {@link PersistentRequestHandle} entries at call time.
    */
-  public ClientRequest[] getPersistentRequests() {
+  public PersistentRequestHandle[] getPersistentRequests() {
     return persistence.getPersistentRequests();
   }
 

--- a/src/main/java/network/crypta/node/PeerNodeStatus.java
+++ b/src/main/java/network/crypta/node/PeerNodeStatus.java
@@ -3,7 +3,6 @@ package network.crypta.node;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Map;
-import network.crypta.clients.http.DarknetConnectionsToadlet;
 import network.crypta.io.comm.FreenetInetAddress;
 import network.crypta.io.comm.Peer;
 import network.crypta.io.xfer.PacketThrottle;
@@ -13,11 +12,11 @@ import network.crypta.node.PeerNodeLoadTracker.IncomingLoadSummaryStats;
  * Immutable snapshot of a {@link PeerNode}'s observable state.
  *
  * <p>Instances are constructed from a live {@link PeerNode} and copy the values required by
- * presentation and diagnostics (for example {@link DarknetConnectionsToadlet}). Copying avoids
- * reading mutable state from the node while rendering and therefore reduces race conditions.
+ * presentation and diagnostics. Copying avoids reading mutable state from the node while rendering
+ * and therefore reduces race conditions.
  *
- * <p>Threading: this object is read-only and thread-safe after construction. No synchronization is
- * required by callers.
+ * <p>Threading: this object is read-only and thread-safe after construction. Callers require no
+ * synchronization.
  *
  * <p>Nullability: some address fields may be {@code null} when the peer is not known yet or the
  * address cannot be resolved.
@@ -127,8 +126,6 @@ public class PeerNodeStatus {
 
   private final long messageQueueLengthTime;
 
-  // int's because that's what they are transferred as
-
   /**
    * Aggregate "real‑time" inbound load view for this peer.
    *
@@ -236,17 +233,17 @@ public class PeerNodeStatus {
   /**
    * Returns the approximate size of the outbound message queue for this peer.
    *
-   * @return number of bytes currently queued for send; monotonically decreases as data is sent and
-   *     increases as messages are enqueued
+   * @return the number of bytes currently queued for sending; monotonically decreases as data is
+   *     sent and increases as messages are enqueued
    */
   public long getMessageQueueLengthBytes() {
     return messageQueueLengthBytes;
   }
 
   /**
-   * Returns a rough estimate of how long it will take to drain the outbound queue.
+   * Returns an estimate of how long it will take to drain the outbound queue.
    *
-   * @return estimated time to empty the send queue in milliseconds
+   * @return estimated time to empty the sending queue in milliseconds
    */
   public long getMessageQueueLengthTime() {
     return messageQueueLengthTime;
@@ -258,7 +255,7 @@ public class PeerNodeStatus {
    * <p>Available only when the snapshot was built with {@code noHeavy=false}; otherwise returns
    * {@code null}.
    *
-   * @return a map of message type to count, or {@code null}
+   * @return a map of message types to count, or {@code null}
    */
   public Map<String, Long> getLocalMessagesReceived() {
     return localMessagesReceived;
@@ -270,7 +267,7 @@ public class PeerNodeStatus {
    * <p>Available only when the snapshot was built with {@code noHeavy=false}; otherwise returns
    * {@code null}.
    *
-   * @return a map of message type to count, or {@code null}
+   * @return a map of message types to count, or {@code null}
    */
   public Map<String, Long> getLocalMessagesSent() {
     return localMessagesSent;
@@ -341,7 +338,7 @@ public class PeerNodeStatus {
   }
 
   /**
-   * Indicates whether our version is considered invalid by the peer according to public exchange.
+   * Indicates whether the peer considers our version invalid, according to public exchange.
    *
    * @return {@code true} if the peer reported our version as invalid
    */
@@ -451,7 +448,8 @@ public class PeerNodeStatus {
    * @return address and port formatted for display
    */
   public String getPeerAddressAndPort() {
-    if (peerAddressBytes != null && peerAddressBytes.length == 16) { // IPv6 address have [] around
+    if (peerAddressBytes != null
+        && peerAddressBytes.length == 16) { // IPv6 addresses have [] around
       return '[' + peerAddress + "]:" + peerPort;
     } else {
       return peerAddress + ':' + peerPort;
@@ -624,7 +622,7 @@ public class PeerNodeStatus {
   /**
    * Returns the number of bytes received from this peer since the node started.
    *
-   * @return cumulative bytes since current process start
+   * @return cumulative bytes since the current process start
    */
   public long getTotalInputSinceStartup() {
     return totalBytesInSinceStartup;
@@ -633,7 +631,7 @@ public class PeerNodeStatus {
   /**
    * Returns the number of bytes sent to this peer since the node started.
    *
-   * @return cumulative bytes since current process start
+   * @return cumulative bytes since the current process start
    */
   public long getTotalOutputSinceStartup() {
     return totalBytesOutSinceStartup;

--- a/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.clients.http.PasswordFormOptions;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
 import network.crypta.crypt.DSAPublicKey;
@@ -48,6 +47,8 @@ import network.crypta.node.stats.NotAvailNodeStoreStats;
 import network.crypta.node.stats.StoreCallbackStats;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.alerts.UserAlertManagerStoreAlertSink;
+import network.crypta.runtime.endpoints.http.security.PasswordFormPageRenderer;
+import network.crypta.runtime.endpoints.http.security.PasswordPromptOptions;
 import network.crypta.store.BlockMetadata;
 import network.crypta.store.CHKStore;
 import network.crypta.store.FreenetStore;
@@ -499,8 +500,8 @@ public final class NodeStorageSubsystem {
         @Override
         public HTMLNode getHTMLText() {
           HTMLNode content = new HTMLNode("div");
-          network.crypta.clients.http.SecurityLevelsToadlet.generatePasswordFormPage(
-              new PasswordFormOptions(false, false, false, false, null, null),
+          PasswordFormPageRenderer.generate(
+              new PasswordPromptOptions(false, false, false, false, null, null),
               node.services().clientCore().getEndpoints().getToadletContainer(),
               content);
           return content;
@@ -755,7 +756,7 @@ public final class NodeStorageSubsystem {
   }
 
   /**
-   * Initializes datastore sizing fields during startup configuration load.
+   * Initializes datastore sizing fields during the startup configuration load.
    *
    * @param storeSize configured datastore size in bytes
    * @throws NodeInitException if the size is invalid for the current store type
@@ -830,7 +831,7 @@ public final class NodeStorageSubsystem {
   }
 
   /**
-   * Initializes client-cache sizing fields during startup configuration load.
+   * Initializes client-cache sizing fields during the startup configuration load.
    *
    * @param storeSize configured client-cache size in bytes
    * @throws NodeInitException if the configured size is below the minimum allowed size
@@ -1800,7 +1801,7 @@ public final class NodeStorageSubsystem {
    * Sets slashdot-cache entry lifetime for all slashdot stores.
    *
    * @param value new lifetime value in milliseconds
-   * @throws InvalidConfigValueException if lifetime value is negative
+   * @throws InvalidConfigValueException if the lifetime value is negative
    */
   public void setSlashdotCacheLifetime(long value) throws InvalidConfigValueException {
     if (value < 0) throw new InvalidConfigValueException("Must be positive!");
@@ -2560,7 +2561,7 @@ public final class NodeStorageSubsystem {
   }
 
   /**
-   * Switches client-cache backend type and reinitializes backing stores.
+   * Switches the client-cache backend type and reinitializes backing stores.
    *
    * @param value requested client-cache backend type
    * @throws InvalidConfigValueException if the type is invalid or initialization cannot complete

--- a/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
@@ -9,6 +9,7 @@ import network.crypta.client.async.ClientContextRuntime;
 import network.crypta.client.async.ClientContextServices;
 import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
@@ -289,11 +290,13 @@ public final class NodeClientPersistence {
    *
    * <p>The snapshot is provided by the shared {@link PersistentRequestRoot} and may include global
    * and per-client persistent requests. The returned array is a point-in-time view; later request
-   * registrations or removals are not reflected in the array.
+   * registrations or removals are not reflected in the array. The concrete request instances may
+   * still be {@link ClientRequest} objects, but callers should depend on the narrower persistent
+   * request handle seam.
    *
-   * @return an array of persistent client requests; never {@code null}.
+   * @return an array of persistent request handles; never {@code null}.
    */
-  public ClientRequest[] getPersistentRequests() {
+  public PersistentRequestHandle[] getPersistentRequests() {
     return persistentRoot.getPersistentRequests();
   }
 

--- a/src/main/java/network/crypta/runtime/endpoints/http/ConnectivityPagePaths.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/ConnectivityPagePaths.java
@@ -1,0 +1,55 @@
+package network.crypta.runtime.endpoints.http;
+
+/**
+ * Publishes runtime-owned HTTP path constants that other layers can reuse safely.
+ *
+ * <p>This type gives the runtime endpoint layer a stable place to describe routes that must remain
+ * visible to non-HTTP code. The main use case in this package is the connectivity dashboard, which
+ * node classes need to reference when they generate status text and operator guidance. Keeping the
+ * canonical route here avoids a direct dependency on legacy toadlet implementations while
+ * preserving the exact URL shape that older code and bookmarks already expect.
+ *
+ * <p>The class exposes normalized paths with a leading and trailing slash so callers can use the
+ * same value for link generation and endpoint registration without extra string handling. A system
+ * property override exists for controlled test scenarios and specialized runtime wiring.
+ */
+public final class ConnectivityPagePaths {
+  private static final String PATH_PROPERTY =
+      "network.crypta.runtime.endpoints.http.ConnectivityPagePaths.path";
+  private static final char URL_PATH_SEPARATOR = '/';
+  private static final String URL_PATH_SEPARATOR_STR = String.valueOf(URL_PATH_SEPARATOR);
+  private static final String DEFAULT_CONNECTIVITY_SEGMENT = "connectivity";
+
+  /**
+   * Canonical path for the connectivity dashboard, including both boundary separators.
+   *
+   * <p>The default remains the historical {@code /connectivity/} route so existing links,
+   * bookmarks, and handlers continue to work without migration. Tests or custom runtime assembly
+   * can override the value with the {@value #PATH_PROPERTY} system property. The resolved path is
+   * normalized to start and end with {@code /}, which lets callers reuse it directly for both route
+   * registration and rendered links.
+   */
+  public static final String CONNECTIVITY_PATH = resolvePath(System.getProperty(PATH_PROPERTY));
+
+  private ConnectivityPagePaths() {}
+
+  static String resolvePath(String configuredPath) {
+    String path =
+        (configuredPath == null || configuredPath.isBlank())
+            ? defaultPath()
+            : configuredPath.trim();
+
+    if (!path.startsWith(URL_PATH_SEPARATOR_STR)) {
+      path = URL_PATH_SEPARATOR_STR + path;
+    }
+    if (!path.endsWith(URL_PATH_SEPARATOR_STR)) {
+      path = path + URL_PATH_SEPARATOR_STR;
+    }
+
+    return path;
+  }
+
+  private static String defaultPath() {
+    return URL_PATH_SEPARATOR_STR + DEFAULT_CONNECTIVITY_SEGMENT + URL_PATH_SEPARATOR_STR;
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/http/security/PasswordFormPageRenderer.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/security/PasswordFormPageRenderer.java
@@ -1,0 +1,60 @@
+package network.crypta.runtime.endpoints.http.security;
+
+import java.util.Objects;
+import network.crypta.clients.http.PasswordFormOptions;
+import network.crypta.clients.http.SecurityLevelsToadlet;
+import network.crypta.clients.http.ToadletContainer;
+import network.crypta.support.HTMLNode;
+
+/**
+ * Runtime-owned bridge for rendering the shared master-password form.
+ *
+ * <p>The node layer uses this helper when it needs the existing password prompt HTML but should not
+ * depend on HTTP adapter classes directly. The bridge accepts a runtime-owned snapshot of the
+ * prompt state, converts that snapshot into the legacy adapter record, and then hands control to
+ * the same renderer that already powers the administrative web UI. That keeps the architectural
+ * boundary clean while preserving the established form structure, wording, and submission behavior.
+ *
+ * <p>This class does not interpret security policy or build markup itself. Its job is intentionally
+ * narrow: validate the inputs, map fields one-for-one, and delegate rendering to the current HTTP
+ * implementation.
+ */
+public final class PasswordFormPageRenderer {
+  private PasswordFormPageRenderer() {}
+
+  /**
+   * Renders the shared password form through the existing HTTP implementation.
+   *
+   * <p>The supplied options are treated as a detached description of the prompt state. This method
+   * preserves those values exactly during conversion, so the downstream renderer sees the same
+   * flags, redirect target, and security-level context it would have received from legacy call
+   * sites. The provided container and content node are passed through unchanged, which keeps form
+   * creation and HTML assembly behavior identical to the established toadlet path.
+   *
+   * @param options detached prompt state that controls which password guidance and form options are
+   *     rendered for the user.
+   * @param ctx container used to create the form element with the correct submission endpoint and
+   *     surrounding HTTP context.
+   * @param content HTML node that receives explanatory text and the generated form structure from
+   *     the delegated renderer.
+   * @throws NullPointerException if any argument is {@code null}, because the underlying renderer
+   *     requires all inputs to be present.
+   */
+  public static void generate(
+      PasswordPromptOptions options, ToadletContainer ctx, HTMLNode content) {
+    Objects.requireNonNull(options, "options");
+    Objects.requireNonNull(ctx, "ctx");
+    Objects.requireNonNull(content, "content");
+
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        new PasswordFormOptions(
+            options.wasWrong(),
+            options.forFirstTimeWizard(),
+            options.forDowngrade(),
+            options.forUpgrade(),
+            options.physicalSecurityLevel(),
+            options.redirect()),
+        ctx,
+        content);
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/http/security/PasswordPromptOptions.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/security/PasswordPromptOptions.java
@@ -1,0 +1,33 @@
+package network.crypta.runtime.endpoints.http.security;
+
+/**
+ * Captures the detached state needed to render the shared master-password form.
+ *
+ * <p>This record mirrors the legacy HTTP-layer password form options while keeping ownership in the
+ * runtime endpoint package. Node and runtime services can assemble one immutable snapshot, pass it
+ * across the architectural boundary, and let the renderer bridge translate it into adapter-owned
+ * types only at the final rendering step. That keeps the seam explicit and avoids leaking UI helper
+ * classes back into core code.
+ *
+ * <p>Each component maps directly to one rendering decision or post-submit behavior. The record
+ * does not validate combinations or interpret policy. It simply preserves the prompt state so
+ * downstream rendering remains identical to the historical implementation.
+ *
+ * @param wasWrong whether the previous password attempt failed validation, and the next page should
+ *     display the corresponding error state.
+ * @param forFirstTimeWizard whether the generated form should submit to the first-time setup wizard
+ *     flow instead of the standard security page.
+ * @param forDowngrade whether the prompt is being shown to decrypt data during a downgrade path.
+ * @param forUpgrade whether the prompt is being shown to confirm or continue an upgrade path.
+ * @param physicalSecurityLevel physical threat-level name that should be persisted when the form
+ *     succeeds, or {@code null} when no level change is requested.
+ * @param redirect optional redirect target to use after a successful submission, or {@code null}
+ *     when the default destination should be kept.
+ */
+public record PasswordPromptOptions(
+    boolean wasWrong,
+    boolean forFirstTimeWizard,
+    boolean forDowngrade,
+    boolean forUpgrade,
+    String physicalSecurityLevel,
+    String redirect) {}

--- a/src/test/java/network/crypta/node/IPDetectorManagerTest.java
+++ b/src/test/java/network/crypta/node/IPDetectorManagerTest.java
@@ -14,8 +14,12 @@ import network.crypta.compat.PortForwardProvider;
 import network.crypta.io.AddressTracker.Status;
 import network.crypta.io.comm.Peer;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.alerts.ProxyUserAlert;
+import network.crypta.runtime.alerts.UserAlert;
+import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.alerts.feed.UserAlertFeedEvent;
 import network.crypta.runtime.services.NodeServicesSubsystem;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -31,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -278,105 +284,70 @@ class IPDetectorManagerTest {
   }
 
   @Test
+  void addConnectionTypeBox_whenProxyAlertMissing_doesNothing() {
+    IPDetectorManager mgr = newManager();
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    when(core.getAlerts()).thenReturn(alerts);
+    when(node.services().clientCore()).thenReturn(core);
+
+    HTMLNode root = new HTMLNode("div");
+
+    mgr.addConnectionTypeBox(root);
+
+    assertTrue(root.getChildren().isEmpty());
+  }
+
+  @Test
   void addConnectionTypeBox_whenProxyAlertValid_renders() throws Exception {
     IPDetectorManager mgr = newManager();
 
     // Provide a client core + alerts that can render
     NodeClientCore core = mock(NodeClientCore.class);
-    network.crypta.runtime.alerts.UserAlertManager alerts =
-        mock(network.crypta.runtime.alerts.UserAlertManager.class);
+    UserAlertManager alerts = mock(UserAlertManager.class);
     when(core.getAlerts()).thenReturn(alerts);
     when(node.services().clientCore()).thenReturn(core);
     when(alerts.renderAlert(any())).thenReturn(new HTMLNode("div"));
-
-    // Install a ProxyUserAlert with an underlying always-valid alert via reflection
-    network.crypta.runtime.alerts.ProxyUserAlert proxy =
-        new network.crypta.runtime.alerts.ProxyUserAlert(alerts, false);
-    proxy.setAlert(
-        new network.crypta.runtime.alerts.UserAlert() {
-          @Override
-          public boolean userCanDismiss() {
-            return true;
-          }
-
-          @Override
-          public String getTitle() {
-            return "t";
-          }
-
-          @Override
-          public String getText() {
-            return "x";
-          }
-
-          @Override
-          public HTMLNode getHTMLText() {
-            return new HTMLNode("div");
-          }
-
-          @Override
-          public short getPriorityClass() {
-            return 0;
-          }
-
-          @Override
-          public boolean isValid() {
-            return true;
-          }
-
-          @Override
-          public void isValid(boolean validity) {
-            // Intentionally empty: this test stub does not track the alert lifecycle state.
-          }
-
-          @Override
-          public String dismissButtonText() {
-            return "d";
-          }
-
-          @Override
-          public boolean shouldUnregisterOnDismiss() {
-            return false;
-          }
-
-          @Override
-          public void onDismiss() {
-            // Intentionally empty: no side effects are needed for dismissal in this test.
-          }
-
-          @Override
-          public String anchor() {
-            return "a";
-          }
-
-          @Override
-          public String getShortText() {
-            return "s";
-          }
-
-          @Override
-          public boolean isEventNotification() {
-            return false;
-          }
-
-          @Override
-          public UserAlertFeedEvent getFeedEvent() {
-            return null;
-          }
-
-          @Override
-          public long getUpdatedTime() {
-            return System.currentTimeMillis();
-          }
-        });
-
-    Field f = IPDetectorManager.class.getDeclaredField("proxyAlert");
-    f.setAccessible(true);
-    f.set(mgr, proxy);
+    setProxyAlert(mgr, newValidProxyAlert(alerts));
 
     HTMLNode root = new HTMLNode("div");
     mgr.addConnectionTypeBox(root);
     assertFalse(root.getChildren().isEmpty());
+  }
+
+  @Test
+  void connectionTypeNotice_whenProxyAlertMissing_returnsNull() {
+    IPDetectorManager mgr = newManager();
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    when(core.getAlerts()).thenReturn(alerts);
+    when(node.services().clientCore()).thenReturn(core);
+
+    ConnectivityNoticeSnapshot notice = mgr.connectionTypeNotice();
+
+    assertNull(notice);
+  }
+
+  @Test
+  void connectionTypeNotice_whenProxyAlertValid_returnsDetachedSnapshot() throws Exception {
+    IPDetectorManager mgr = newManager();
+
+    NodeClientCore core = mock(NodeClientCore.class);
+    UserAlertManager alerts = mock(UserAlertManager.class);
+    HTMLNode renderedAlert = new HTMLNode("div", "id", "alert");
+    when(core.getAlerts()).thenReturn(alerts);
+    when(node.services().clientCore()).thenReturn(core);
+    when(alerts.renderAlert(any())).thenReturn(renderedAlert);
+    setProxyAlert(mgr, newValidProxyAlert(alerts));
+
+    ConnectivityNoticeSnapshot notice = mgr.connectionTypeNotice();
+
+    assertNotNull(notice);
+    assertEquals("t", notice.title());
+    assertEquals("x", notice.text());
+    assertEquals(renderedAlert.generate(), notice.renderedAlertHtml());
   }
 
   @Test
@@ -472,5 +443,94 @@ class IPDetectorManagerTest {
 
     // Expect a detection run to be scheduled despite the hourly throttle.
     verify(executor, times(1)).execute(any(Runnable.class), any(String.class));
+  }
+
+  private static ProxyUserAlert newValidProxyAlert(UserAlertManager alerts) {
+    ProxyUserAlert proxy = new ProxyUserAlert(alerts, false);
+    proxy.setAlert(
+        new UserAlert() {
+          @Override
+          public boolean userCanDismiss() {
+            return true;
+          }
+
+          @Override
+          public String getTitle() {
+            return "t";
+          }
+
+          @Override
+          public String getText() {
+            return "x";
+          }
+
+          @Override
+          public HTMLNode getHTMLText() {
+            return new HTMLNode("div");
+          }
+
+          @Override
+          public short getPriorityClass() {
+            return 0;
+          }
+
+          @Override
+          public boolean isValid() {
+            return true;
+          }
+
+          @Override
+          public void isValid(boolean validity) {
+            // Intentionally empty: this test stub does not track the alert lifecycle state.
+          }
+
+          @Override
+          public String dismissButtonText() {
+            return "d";
+          }
+
+          @Override
+          public boolean shouldUnregisterOnDismiss() {
+            return false;
+          }
+
+          @Override
+          public void onDismiss() {
+            // Intentionally empty: no side effects are needed for dismissal in this test.
+          }
+
+          @Override
+          public String anchor() {
+            return "a";
+          }
+
+          @Override
+          public String getShortText() {
+            return "s";
+          }
+
+          @Override
+          public boolean isEventNotification() {
+            return false;
+          }
+
+          @Override
+          public UserAlertFeedEvent getFeedEvent() {
+            return null;
+          }
+
+          @Override
+          public long getUpdatedTime() {
+            return System.currentTimeMillis();
+          }
+        });
+    return proxy;
+  }
+
+  private static void setProxyAlert(IPDetectorManager target, ProxyUserAlert proxy)
+      throws ReflectiveOperationException {
+    Field field = IPDetectorManager.class.getDeclaredField("proxyAlert");
+    field.setAccessible(true);
+    field.set(target, proxy);
   }
 }

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -10,6 +10,7 @@ import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.ClientRequestScheduler;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.USKManager;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.http.FProxyToadlet;
@@ -471,7 +472,7 @@ class NodeClientCoreTest {
     ClientRequest[] requests = new ClientRequest[] {Mockito.mock(ClientRequest.class)};
     when(persistence.getPersistentRequests()).thenReturn(requests);
 
-    ClientRequest[] persisted = core.getPersistentRequests();
+    PersistentRequestHandle[] persisted = core.getPersistentRequests();
 
     assertSame(requests, persisted);
   }

--- a/src/test/java/network/crypta/node/subsystem/NodeStorageSubsystemTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeStorageSubsystemTest.java
@@ -3,6 +3,8 @@ package network.crypta.node.subsystem;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.security.SecureRandom;
+import network.crypta.clients.http.PasswordFormOptions;
+import network.crypta.clients.http.SecurityLevelsToadlet;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
 import network.crypta.keys.CHKBlock;
@@ -16,10 +18,13 @@ import network.crypta.node.SecurityLevels;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.bootstrap.NodeBootstrap;
+import network.crypta.runtime.endpoints.ClientEndpoints;
+import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.store.CHKStore;
 import network.crypta.store.FreenetStore;
 import network.crypta.store.saltedhash.SaltedHashFreenetStore;
+import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -216,6 +223,36 @@ class NodeStorageSubsystemTest {
   }
 
   @Test
+  void masterPasswordUserAlert_getHTMLText_whenRendered_matchesLegacyPasswordForm()
+      throws Exception {
+    HttpShellContainer container = org.mockito.Mockito.mock(HttpShellContainer.class);
+    when(container.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              String target = invocation.getArgument(1);
+              String id = invocation.getArgument(2);
+              HTMLNode form = parent.addChild("form");
+              form.addAttribute("target", target);
+              form.addAttribute("id", id);
+              return form;
+            });
+    when(node.services()).thenReturn(services);
+    when(services.clientCore()).thenReturn(clientCore);
+    when(clientCore.getEndpoints()).thenReturn(new ClientEndpoints(null, null, container));
+
+    HTMLNode expectedContent = new HTMLNode("div");
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        new PasswordFormOptions(false, false, false, false, null, null),
+        container,
+        expectedContent);
+
+    HTMLNode renderedContent = getMasterPasswordUserAlert(subsystem).getHTMLText();
+
+    assertEquals(expectedContent.generate(), renderedContent.generate());
+  }
+
+  @Test
   void setStorePreallocate_whenSaltHashBeforeStoresInitialized_doesNotThrow() {
     subsystem.setStoreType(Node.TYPE_SALT_HASH);
 
@@ -287,5 +324,12 @@ class NodeStorageSubsystemTest {
     Field field = target.getClass().getDeclaredField("chkDatastore");
     field.setAccessible(true);
     field.set(target, value);
+  }
+
+  private static UserAlert getMasterPasswordUserAlert(NodeStorageSubsystem target)
+      throws ReflectiveOperationException {
+    Field field = target.getClass().getDeclaredField("masterPasswordUserAlert");
+    field.setAccessible(true);
+    return (UserAlert) field.get(target);
   }
 }

--- a/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
@@ -12,6 +12,7 @@ import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.USKManager;
 import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
@@ -467,7 +468,7 @@ class NodeClientPersistenceTest {
     client.resume(request);
 
     // Act
-    ClientRequest[] requests = persistence.getPersistentRequests();
+    PersistentRequestHandle[] requests = persistence.getPersistentRequests();
 
     // Assert
     assertTrue(Arrays.asList(requests).contains(request));

--- a/src/test/java/network/crypta/runtime/endpoints/http/ConnectivityPagePathsTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/ConnectivityPagePathsTest.java
@@ -1,0 +1,29 @@
+package network.crypta.runtime.endpoints.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("java:S100")
+class ConnectivityPagePathsTest {
+
+  @Test
+  void resolvePath_whenConfiguredPathMissing_returnsLegacyConnectivityPath() {
+    assertEquals("/connectivity/", ConnectivityPagePaths.resolvePath(null));
+  }
+
+  @Test
+  void resolvePath_whenConfiguredPathBlank_returnsLegacyConnectivityPath() {
+    assertEquals("/connectivity/", ConnectivityPagePaths.resolvePath("   "));
+  }
+
+  @Test
+  void resolvePath_whenConfiguredPathNeedsNormalization_addsBoundarySlashes() {
+    assertEquals("/custom-connectivity/", ConnectivityPagePaths.resolvePath("custom-connectivity"));
+  }
+
+  @Test
+  void resolvePath_whenConfiguredPathHasWhitespace_trimsBeforeNormalizing() {
+    assertEquals("/custom/nested/", ConnectivityPagePaths.resolvePath(" custom/nested "));
+  }
+}

--- a/src/test/java/network/crypta/runtime/endpoints/http/security/PasswordFormPageRendererTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/security/PasswordFormPageRendererTest.java
@@ -1,0 +1,83 @@
+package network.crypta.runtime.endpoints.http.security;
+
+import network.crypta.clients.http.PasswordFormOptions;
+import network.crypta.clients.http.SecurityLevelsToadlet;
+import network.crypta.clients.http.ToadletContainer;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class PasswordFormPageRendererTest {
+
+  @Test
+  void generate_whenCalled_matchesLegacySecurityLevelsRendering() {
+    PasswordPromptOptions options =
+        new PasswordPromptOptions(false, false, false, true, "HIGH", "/next");
+
+    HTMLNode bridgedContent = new HTMLNode("div");
+    HTMLNode legacyContent = new HTMLNode("div");
+    ToadletContainer container = stubContainer();
+
+    PasswordFormPageRenderer.generate(options, container, bridgedContent);
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        new PasswordFormOptions(false, false, false, true, "HIGH", "/next"),
+        container,
+        legacyContent);
+
+    assertEquals(legacyContent.generate(), bridgedContent.generate());
+  }
+
+  @Test
+  void generate_whenOptionsNull_throwsNullPointerException() {
+    ToadletContainer container = stubContainer();
+    HTMLNode content = new HTMLNode("div");
+
+    assertThrows(
+        NullPointerException.class,
+        () -> PasswordFormPageRenderer.generate(null, container, content));
+  }
+
+  @Test
+  void generate_whenContainerNull_throwsNullPointerException() {
+    PasswordPromptOptions options =
+        new PasswordPromptOptions(false, false, false, true, "HIGH", "/next");
+    HTMLNode content = new HTMLNode("div");
+
+    assertThrows(
+        NullPointerException.class,
+        () -> PasswordFormPageRenderer.generate(options, null, content));
+  }
+
+  @Test
+  void generate_whenContentNull_throwsNullPointerException() {
+    PasswordPromptOptions options =
+        new PasswordPromptOptions(false, false, false, true, "HIGH", "/next");
+    ToadletContainer container = stubContainer();
+
+    assertThrows(
+        NullPointerException.class,
+        () -> PasswordFormPageRenderer.generate(options, container, null));
+  }
+
+  private ToadletContainer stubContainer() {
+    ToadletContainer container = Mockito.mock(ToadletContainer.class);
+    when(container.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              String target = invocation.getArgument(1);
+              String id = invocation.getArgument(2);
+              HTMLNode form = parent.addChild("form");
+              form.addAttribute("target", target);
+              form.addAttribute("id", id);
+              return form;
+            });
+    return container;
+  }
+}


### PR DESCRIPTION
## Summary
- move the remaining HTTP and FCP seams behind runtime-owned bridge types so `node/**` no longer imports adapter classes directly
- narrow persistent request accessors to `PersistentRequestHandle[]` while preserving the existing persistence snapshot behavior
- add focused regression coverage for connectivity path normalization, password form rendering, and detached proxy-alert snapshots

## Validation
- `./gradlew spotlessApply`
- `./gradlew compileJava`
- `./gradlew test --tests network.crypta.node.NodeClientCoreTest`
- `./gradlew test --tests network.crypta.clients.http.ConnectivityToadletTest`
- `./gradlew test --tests network.crypta.clients.http.SecurityLevelsToadletTest`
- `./gradlew test --tests network.crypta.runtime.endpoints.http.ConnectivityPagePathsTest --tests network.crypta.clients.http.ConnectivityToadletTest`
- `./gradlew test --tests network.crypta.node.IPDetectorManagerTest --tests network.crypta.node.subsystem.NodeStorageSubsystemTest --tests network.crypta.runtime.endpoints.http.security.PasswordFormPageRendererTest`
- `./gradlew test`
- `rg -n "import network\\.crypta\\.clients\\.(http|fcp)" src/main/java/network/crypta/node src/main/java/network/crypta/node/subsystem`

The final adapter-import grep returned no matches.