### PR TITLE
refactor(endpoints): Narrow FCP endpoint seam

### DIFF
--- a/src/main/java/network/crypta/runtime/endpoints/ClientEndpoints.java
+++ b/src/main/java/network/crypta/runtime/endpoints/ClientEndpoints.java
@@ -2,13 +2,13 @@ package network.crypta.runtime.endpoints;
 
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.async.ClientContext;
-import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeClientCoreSupport;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.io.TempBucketFactory;
@@ -17,10 +17,11 @@ import network.crypta.support.io.TempBucketFactory;
  * Bundles client-facing endpoints (FCP, TMCI, and HTTP shell container) and their lifecycle.
  *
  * <p>This type centralizes the node's externally visible interfaces so callers can wire them
- * consistently during startup and expose simple accessors during runtime. It holds the FCP server,
- * the optional text-mode interface, and the HTTP shell container, and it exposes a small set of
- * methods that delegate to those collaborators. Typical usage is to build an instance during node
- * initialization, register any startup alerts, and then start the endpoints once the core is ready.
+ * consistently during startup and expose simple accessors during runtime. It holds the FCP endpoint
+ * handle, the optional text-mode interface, and the HTTP shell container, and it exposes a small
+ * set of methods that delegate to those collaborators. Typical usage is to build an instance during
+ * node initialization, register any startup alerts, and then start the endpoints once the core is
+ * ready.
  *
  * <p>Thread-safety is limited to safe publication of a small set of references via atomic holders;
  * the underlying endpoint implementations define their own concurrency guarantees. Callers should
@@ -33,12 +34,11 @@ import network.crypta.support.io.TempBucketFactory;
  *   <li>Registers and unregisters a startup alert during initialization.
  * </ul>
  *
- * @see FCPServer
  * @see HttpShellContainer
  * @see TextModeClientInterfaceServer
  */
 public final class ClientEndpoints {
-  private final FCPServer fcpServer;
+  private final FcpEndpointHandle fcpEndpoint;
   private final TextModeClientInterfaceServer tmci;
   private final HttpShellContainer toadletContainer;
   private final AtomicReference<TextModeClientInterface> directTMCI = new AtomicReference<>();
@@ -68,31 +68,31 @@ public final class ClientEndpoints {
    * storing the references, and it does not perform any lifecycle work such as starting servers or
    * registering alerts.
    *
-   * @param fcpServer FCP server instance to expose and manage for the node.
+   * @param fcpEndpoint FCP endpoint handle to expose and manage for the node.
    * @param tmci text-mode client interface server, or {@code null} when disabled.
    * @param toadletContainer HTTP shell container used for browser-facing endpoints.
    */
   public ClientEndpoints(
-      FCPServer fcpServer,
+      FcpEndpointHandle fcpEndpoint,
       TextModeClientInterfaceServer tmci,
       HttpShellContainer toadletContainer) {
-    this.fcpServer = fcpServer;
+    this.fcpEndpoint = fcpEndpoint;
     this.tmci = tmci;
     this.toadletContainer = toadletContainer;
   }
 
   /**
-   * Returns the FCP server associated with this bundle.
+   * Returns the FCP endpoint handle associated with this bundle.
    *
-   * <p>The returned reference is the same instance supplied at construction time and is not wrapped
-   * or proxied. The call is inexpensive and side-effect-free, and it does not guarantee that the
-   * server has been started or loaded. Use it when wiring other components that already manage the
-   * server lifecycle.
+   * <p>The returned reference is the same instance supplied at construction time. The call is
+   * inexpensive and side-effect-free, and it does not guarantee that the endpoint has been started
+   * or loaded. Bridge code that still needs concrete FCP operations can unwrap the handle through
+   * {@code network.crypta.runtime.endpoints.fcp.FcpEndpointHandles}.
    *
-   * @return the FCP server instance owned by this bundle.
+   * @return the FCP endpoint handle owned by this bundle.
    */
-  public FCPServer getFCPServer() {
-    return fcpServer;
+  public FcpEndpointHandle getFcpEndpoint() {
+    return fcpEndpoint;
   }
 
   /**
@@ -179,27 +179,27 @@ public final class ClientEndpoints {
   }
 
   /**
-   * Loads persistent requests through the FCP server.
+   * Loads persistent requests through the FCP endpoint handle.
    *
-   * <p>This method delegates directly to {@link FCPServer#load()} without checking any additional
-   * conditions. It is up to the caller to decide whether loading is required for the current node
-   * state, such as skipping it when a database has been intentionally reset. The method itself does
-   * not cache or record whether loading has been performed.
+   * <p>This method delegates directly to the underlying FCP endpoint handle without checking any
+   * additional conditions. It is up to the caller to decide whether loading is required for the
+   * current node state, such as skipping it when a database has been intentionally reset. The
+   * method itself does not cache or record whether loading has been performed.
    */
   public void loadPersistentRequestsIfNeeded() {
-    fcpServer.load();
+    fcpEndpoint.load();
   }
 
   /**
    * Starts the client-facing endpoints when appropriate.
    *
-   * <p>The FCP server is asked to start via {@link FCPServer#maybeStart()}, and the text-mode
-   * interface server is started only if it is present. This method does not create new endpoints
-   * and performs no retries; it simply forwards to the underlying components. It is safe to call
-   * multiple times if the underlying components implement idempotent start logic.
+   * <p>The FCP endpoint handle is asked to start, and the text-mode interface server is started
+   * only if it is present. This method does not create new endpoints and performs no retries; it
+   * simply forwards to the underlying components. It is safe to call multiple times if the
+   * underlying components implement idempotent start logic.
    */
   public void maybeStart() {
-    fcpServer.maybeStart();
+    fcpEndpoint.maybeStart();
     if (tmci != null) {
       tmci.start();
     }
@@ -292,13 +292,13 @@ public final class ClientEndpoints {
   /**
    * Builds a fully wired {@link ClientEndpoints} instance from core node components.
    *
-   * <p>The method conditionally creates the text-mode interface server, creates an FCP server via
-   * the persistence layer, and registers that server as the download cache in the client context.
-   * If the node has not killed its database, it loads persistent requests immediately. This method
-   * starts no endpoints; callers typically invoke {@link #maybeStart()} once the node is ready.
-   * When direct TMCI is enabled, it is created but not started; callers must register it on the
-   * endpoint bundle and schedule it after {@link NodeClientCore#getEndpoints()} is assigned. The
-   * returned instance captures the created references and does not perform any additional
+   * <p>The method conditionally creates the text-mode interface server, creates an FCP endpoint
+   * handle via the persistence layer, and registers that handle as the download cache in the client
+   * context. If the node has not killed its database, it loads persistent requests immediately.
+   * This method starts no endpoints; callers typically invoke {@link #maybeStart()} once the node
+   * is ready. When direct TMCI is enabled, it is created but not started; callers must register it
+   * on the endpoint bundle and schedule it after {@link NodeClientCore#getEndpoints()} is assigned.
+   * The returned instance captures the created references and does not perform any additional
    * initialization beyond the steps described above.
    *
    * <pre>{@code
@@ -311,7 +311,7 @@ public final class ClientEndpoints {
    * @param core client core used by endpoint factories and alert registration.
    * @param runtimePorts runtime SPI bridge passed to the FCP infrastructure.
    * @param init initializer providing configuration and toadlet container access.
-   * @param persistence persistence layer responsible for creating the FCP server.
+   * @param persistence persistence layer responsible for creating the FCP endpoint handle.
    * @param clientContext client context updated with the FCP download cache.
    * @return an {@link InitResult} containing the endpoint bundle and optional direct TMCI instance.
    */
@@ -325,12 +325,12 @@ public final class ClientEndpoints {
     TextModeClientInterfaceServer.InitResult tmciInit =
         TextModeClientInterfaceServer.maybeCreate(node, core, init.config());
     TextModeClientInterfaceServer tmci = tmciInit.server();
-    FCPServer fcpServer = persistence.createFcpServer(node, core, runtimePorts);
-    clientContext.setDownloadCache(fcpServer);
+    FcpEndpointHandle fcpEndpoint = persistence.createFcpEndpointHandle(node, core, runtimePorts);
+    clientContext.setDownloadCache(fcpEndpoint);
     if (!core.killedDatabase()) {
-      fcpServer.load();
+      fcpEndpoint.load();
     }
     return new InitResult(
-        new ClientEndpoints(fcpServer, tmci, init.toadlets()), tmciInit.directTMCI());
+        new ClientEndpoints(fcpEndpoint, tmci, init.toadlets()), tmciInit.directTMCI());
   }
 }

--- a/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
@@ -9,11 +9,9 @@ import network.crypta.client.async.ClientContextRuntime;
 import network.crypta.client.async.ClientContextServices;
 import network.crypta.client.async.ClientContextStorageFactories;
 import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
-import network.crypta.clients.fcp.ClientRequest;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.MasterSecret;
@@ -24,9 +22,8 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeInitException;
 import network.crypta.node.Persistable;
-import network.crypta.runtime.endpoints.fcp.CoreFcpPersistentRequestCatalog;
-import network.crypta.runtime.endpoints.fcp.CoreFcpServerDependenciesFactory;
-import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestRecoveryCodec;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
+import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestServices;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.Ticker;
@@ -43,9 +40,10 @@ import network.crypta.support.io.TempBucketFactory;
  * <p>This helper isolates the construction of persistence infrastructure that would otherwise
  * sprawl across the client-core initialization flow. Callers typically construct an instance early
  * in node startup, configure disk-checking factories once storage directories are known, and then
- * use it to build the {@link ClientContext} and FCP server wiring. The instance owns a shared
- * {@link PersistentRequestRoot} so persistent request registration is consistent across the
- * client-layer components it creates.
+ * use it to build the {@link ClientContext} and FCP endpoint wiring. Concrete persistent-request
+ * infrastructure is hidden behind the bridge package, so registration remains consistent across the
+ * client-layer components it creates without exposing concrete FCP endpoint or owner types directly
+ * from this package.
  *
  * <p>State is initialized in stages: the disk checker and persistent RAF factory are {@code null}
  * until {@link #initDiskChecker(FilenameGenerator, File, long, TempBucketFactory, boolean)} is
@@ -57,21 +55,23 @@ import network.crypta.support.io.TempBucketFactory;
  * <ul>
  *   <li>Creating and starting a configurable persister for throttle state.
  *   <li>Building persistent random-access buffer factories with optional encryption.
- *   <li>Exposing persistent requests and wiring FCP server state.
- *   <li>Constructing {@link ClientContext} with shared persistent roots.
+ *   <li>Exposing persistent requests and wiring the FCP endpoint handle.
+ *   <li>Constructing {@link ClientContext} with shared persistent-request coordination.
  * </ul>
  *
  * @see NodeClientCore
  * @see ClientContext
- * @see PersistentRequestRoot
  */
 public final class NodeClientPersistence {
   private final ConfigurablePersister persister;
-  private final PersistentRequestRoot persistentRoot = new PersistentRequestRoot();
+  private final FcpPersistentRequestServices fcpPersistentRequestServices =
+      new FcpPersistentRequestServices();
+  private final PersistentRequestCoordinator persistentRequestCoordinator =
+      fcpPersistentRequestServices.coordinator();
   private final PersistentRequestCatalog persistentRequestCatalog =
-      new CoreFcpPersistentRequestCatalog(persistentRoot);
+      fcpPersistentRequestServices.catalog();
   private final PersistentRequestRecoveryCodec persistentRequestRecoveryCodec =
-      new FcpPersistentRequestRecoveryCodec();
+      fcpPersistentRequestServices.recoveryCodec();
   private DiskSpaceCheckingRandomAccessBufferFactory diskChecker;
   private MaybeEncryptedRandomAccessBufferFactory persistentRafFactory;
   private final int sortOrderAfter;
@@ -268,50 +268,49 @@ public final class NodeClientPersistence {
   }
 
   /**
-   * Creates the FCP server configured for this node and client core.
+   * Creates the FCP endpoint handle configured for this node and client core.
    *
-   * <p>The server is constructed via a local dependency bundle, so the remaining core-backed
-   * runtime adapters stay localized to the FCP bootstrap seam. It shares this instance's persistent
-   * request root so durable requests can be managed consistently across reconnections.
+   * <p>The endpoint is constructed via a local dependency bundle, so the remaining core-backed
+   * runtime adapters stay localized to the FCP bootstrap seam. The persistent request
+   * implementation is supplied by the bridge package and remains hidden behind the seam.
    *
    * @param node node instance supplying configuration and shared services.
-   * @param core client core used by the FCP server for callbacks.
+   * @param core client core used by the FCP endpoint for callbacks.
    * @param runtimePorts runtime SPI bridge passed to the FCP infrastructure.
-   * @return the configured FCP server instance from {@code maybeCreate}.
+   * @return the configured FCP endpoint handle from the bridge seam.
    */
-  public FCPServer createFcpServer(Node node, NodeClientCore core, RuntimePorts runtimePorts) {
-    return FCPServer.maybeCreate(
-        CoreFcpServerDependenciesFactory.create(core, runtimePorts, persistentRoot),
-        node.getConfig());
+  public FcpEndpointHandle createFcpEndpointHandle(
+      Node node, NodeClientCore core, RuntimePorts runtimePorts) {
+    return fcpPersistentRequestServices.createEndpointHandle(node, core, runtimePorts);
   }
 
   /**
    * Returns a snapshot of all currently registered persistent requests.
    *
-   * <p>The snapshot is provided by the shared {@link PersistentRequestRoot} and may include global
-   * and per-client persistent requests. The returned array is a point-in-time view; later request
-   * registrations or removals are not reflected in the array. The concrete request instances may
-   * still be {@link ClientRequest} objects, but callers should depend on the narrower persistent
-   * request handle seam.
+   * <p>The snapshot is provided by the bridge-owned persistent request services and may include
+   * global and per-client persistent requests. The returned array is a point-in-time view; later
+   * request registrations or removals are not reflected in the array. Callers should depend on the
+   * narrower persistent request handle seam rather than concrete request implementations.
    *
    * @return an array of persistent request handles; never {@code null}.
    */
   public PersistentRequestHandle[] getPersistentRequests() {
-    return persistentRoot.getPersistentRequests();
+    return fcpPersistentRequestServices.getPersistentRequests();
   }
 
   /**
    * Builds a fully wired {@link ClientContext} for client-layer operations.
    *
    * <p>This method assembles the context from the supplied schedulers, factories, and defaults,
-   * wiring in the persistent request root and disk checker owned by this instance. Callers should
-   * invoke {@link #initDiskChecker} first; otherwise a {@link NullPointerException} is thrown to
-   * signal the missing persistence wiring. The returned context is a new object and does not mutate
-   * any of the provided collaborators beyond normal constructor usage.
+   * wiring in the persistent-request coordinator and disk checker owned by this instance. Callers
+   * should invoke {@link #initDiskChecker} first; otherwise a {@link NullPointerException} is
+   * thrown to signal the missing persistence wiring. The returned context is a new object and does
+   * not mutate any of the provided collaborators beyond normal constructor usage.
    *
    * @param node node instance supplying boot id and configuration references.
    * @param params bundle of runtime, storage, service, and default context dependencies.
-   * @return newly constructed client context with wired factories and persistent root.
+   * @return newly constructed client context with wired factories and persistent-request
+   *     coordination.
    * @throws NullPointerException if the disk checker has not been initialized.
    */
   public ClientContext createClientContext(Node node, ClientContextInitParams params) {
@@ -346,7 +345,7 @@ public final class NodeClientPersistence {
             params.uskManager(),
             params.compressor(),
             params.storeChecker(),
-            persistentRoot,
+            persistentRequestCoordinator,
             init.toadlets());
     ClientContextDefaults defaults =
         new ClientContextDefaults(

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/CoreFcpEndpointHandle.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/CoreFcpEndpointHandle.java
@@ -1,0 +1,75 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.util.Objects;
+import network.crypta.client.async.CacheFetchResult;
+import network.crypta.client.async.ClientContext;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Bridge-owned wrapper around the concrete {@link FCPServer}.
+ *
+ * <p>This adapter is the narrow implementation behind {@link FcpEndpointHandle}. It keeps the
+ * concrete server type confined to the FCP bridge package while still exposing the same
+ * download-cache lookups and lifecycle hooks that the higher-level runtime code expects.
+ * Construction is intentionally simple: callers hand the wrapper a fully configured server, and
+ * every operation delegates straight through without caching, policy changes, or queue-specific
+ * interpretation. That preserves the current FCP startup and lookup behavior while giving the
+ * runtime package a stable seam for later decoupling work.
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+final class CoreFcpEndpointHandle implements FcpEndpointHandle {
+  /** Concrete FCP server that still owns queue state, startup, and cache lookups. */
+  private final FCPServer server;
+
+  /**
+   * Creates a wrapper around the supplied concrete FCP server.
+   *
+   * <p>The wrapped server is retained for the lifetime of this handle and must already be fully
+   * configured by the bridge package. The constructor performs only null-checking, so callers can
+   * safely create the handle during endpoint bootstrap without changing any startup sequencing or
+   * persistence behavior.
+   *
+   * @param server concrete FCP server instance to expose through the runtime-owned seam
+   * @throws NullPointerException if {@code server} is {@code null}
+   */
+  CoreFcpEndpointHandle(FCPServer server) {
+    this.server = Objects.requireNonNull(server, "server");
+  }
+
+  @Override
+  public void load() {
+    server.load();
+  }
+
+  @Override
+  public void maybeStart() {
+    server.maybeStart();
+  }
+
+  @Override
+  public CacheFetchResult lookupInstant(
+      FreenetURI key, boolean noFilter, boolean mustCopy, Bucket preferred) {
+    return server.lookupInstant(key, noFilter, mustCopy, preferred);
+  }
+
+  @Override
+  public CacheFetchResult lookup(
+      FreenetURI key, boolean noFilter, ClientContext context, boolean mustCopy, Bucket preferred) {
+    return server.lookup(key, noFilter, context, mustCopy, preferred);
+  }
+
+  /**
+   * Returns the concrete server wrapped by this handle.
+   *
+   * <p>Bridge helpers use this accessor when legacy queue and admin code still need operations that
+   * are intentionally not part of {@link FcpEndpointHandle}. Higher-level runtime code should keep
+   * depending on the seam instead of calling this method directly.
+   *
+   * @return wrapped concrete FCP server instance
+   */
+  FCPServer server() {
+    return server;
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandle.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandle.java
@@ -1,0 +1,43 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.client.async.DownloadCache;
+
+/**
+ * Runtime-owned handle for the active FCP endpoint and its download-cache behavior.
+ *
+ * <p>The runtime-endpoints package depends on this narrow handle rather than directly on the
+ * concrete {@code network.crypta.clients.fcp.FCPServer}. Bridge code in this package can still
+ * unwrap the legacy server when it needs protocol-specific operations. Higher-level runtime wiring
+ * uses the seam only for endpoint lifecycle and cache registration.
+ *
+ * <p>Typical usage is straightforward: endpoint bootstrap creates one handle, registers it as the
+ * {@link DownloadCache}, and later asks it to load persistent requests and maybe start listening.
+ * The interface intentionally stays small, so queue behavior, persistence ownership, and
+ * protocol-specific administration can remain in the FCP bridge package. Implementations should
+ * preserve the wrapped endpoint's existing lifecycle semantics rather than adding retries, caching
+ * layers, or alternative startup policy.
+ */
+public interface FcpEndpointHandle extends DownloadCache {
+
+  /**
+   * Loads persistent request state for the wrapped endpoint.
+   *
+   * <p>Callers typically invoke this during startup once persistence is known to be healthy, so
+   * durable FCP requests are available before serving queue and status queries. Implementations are
+   * expected to preserve the endpoint's existing loading rules, including how duplicates,
+   * checkpointed requests, and database-reset scenarios are handled. The method does not imply that
+   * the endpoint will also start listening for new client connections.
+   */
+  void load();
+
+  /**
+   * Starts the wrapped endpoint when configuration allows.
+   *
+   * <p>Implementations preserve the underlying endpoint's idempotent start behavior and do not
+   * promise that a listener will bind when the endpoint is disabled by configuration. Callers may
+   * invoke this after dependency wiring is complete and after any required request loading has
+   * already happened. The method should not broaden startup policy beyond what the concrete
+   * endpoint already does today.
+   */
+  void maybeStart();
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandles.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandles.java
@@ -1,0 +1,98 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.util.Objects;
+import network.crypta.clients.fcp.FCPServer;
+
+/**
+ * Helpers for wrapping and unwrapping runtime-owned FCP endpoint handles.
+ *
+ * <p>Top-level runtime packages should keep only {@link FcpEndpointHandle} references. Bridge code
+ * under {@code network.crypta.runtime.endpoints.fcp} can recover the underlying {@link FCPServer}
+ * through this utility when legacy queue and admin paths still need concrete FCP operations.
+ *
+ * <p>The utility is intentionally strict about provenance. Handles created through {@link
+ * #wrap(FCPServer)} can later be unwrapped safely by bridge code, but ad hoc implementations of
+ * {@link FcpEndpointHandle} are rejected so the seam does not silently mask incompatible state or
+ * alternate lifecycle rules. In practice this means runtime wiring can stay narrow and bridge code
+ * can still recover the legacy server only at the specific edges that continue to need
+ * protocol-specific behavior.
+ */
+public final class FcpEndpointHandles {
+  private FcpEndpointHandles() {}
+
+  /**
+   * Wraps a concrete FCP server in the runtime-owned endpoint-handle seam.
+   *
+   * <p>The returned handle exposes only the seam methods required by top-level runtime wiring and
+   * by the {@link network.crypta.client.async.DownloadCache} contract. Callers should use this when
+   * moving a concrete server instance from bridge bootstrap code into runtime code that must no
+   * longer retain a direct {@link FCPServer} dependency.
+   *
+   * @param server concrete FCP server to expose behind the seam
+   * @return runtime-owned handle that delegates directly to {@code server}
+   */
+  public static FcpEndpointHandle wrap(FCPServer server) {
+    return new CoreFcpEndpointHandle(server);
+  }
+
+  /**
+   * Returns the concrete FCP server behind the supplied handle.
+   *
+   * <p>This is the strict unwrapping path for bridge code that still needs full FCP access. It
+   * accepts only handles created by this package, which keeps the seam honest and avoids silently
+   * treating unrelated implementations as compatible with the current bridge assumptions.
+   *
+   * @param endpointHandle runtime-owned handle produced by this bridge package
+   * @return wrapped concrete FCP server
+   * @throws NullPointerException if {@code endpointHandle} is {@code null}
+   * @throws IllegalArgumentException if the handle was not created by this bridge package
+   */
+  public static FCPServer unwrap(FcpEndpointHandle endpointHandle) {
+    return requireCoreHandle(Objects.requireNonNull(endpointHandle, "endpointHandle")).server();
+  }
+
+  /**
+   * Returns the wrapped FCP server when present, otherwise {@code null}.
+   *
+   * <p>Call this when the surrounding code already treats the endpoint as optional. The method
+   * preserves that optionality while still validating that any non-null handle came from this
+   * bridge package rather than from an unsupported implementation.
+   *
+   * @param endpointHandle runtime-owned handle, or {@code null}
+   * @return wrapped FCP server, or {@code null} when no handle is available
+   * @throws IllegalArgumentException if the handle was not created by this bridge package
+   */
+  public static FCPServer serverOrNull(FcpEndpointHandle endpointHandle) {
+    return endpointHandle == null ? null : requireCoreHandle(endpointHandle).server();
+  }
+
+  /**
+   * Returns the wrapped FCP server or throws when no handle is available.
+   *
+   * <p>Use this when the caller cannot proceed without a live FCP endpoint and wants a clear
+   * failure instead of propagating a nullable server reference. The thrown exception preserves the
+   * existing bridge expectation that queue and admin paths should fail fast when the endpoint is
+   * unavailable.
+   *
+   * @param endpointHandle runtime-owned handle expected to wrap a live FCP server
+   * @return wrapped concrete FCP server
+   * @throws IllegalStateException if {@code endpointHandle} is {@code null}
+   * @throws IllegalArgumentException if the handle was not created by this bridge package
+   */
+  @SuppressWarnings("unused")
+  public static FCPServer requireServer(FcpEndpointHandle endpointHandle) {
+    FCPServer server = serverOrNull(endpointHandle);
+    if (server == null) {
+      throw new IllegalStateException("FCP server unavailable");
+    }
+    return server;
+  }
+
+  private static CoreFcpEndpointHandle requireCoreHandle(FcpEndpointHandle endpointHandle) {
+    if (endpointHandle instanceof CoreFcpEndpointHandle coreHandle) {
+      return coreHandle;
+    }
+    throw new IllegalArgumentException(
+        "Unsupported FcpEndpointHandle implementation: " + endpointHandle.getClass().getName());
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServices.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServices.java
@@ -1,0 +1,122 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import java.util.Objects;
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+
+/**
+ * Bridge-owned holder for concrete FCP persistent-request infrastructure.
+ *
+ * <p>This service keeps the legacy {@link PersistentRequestRoot}, request-catalog adapter, recovery
+ * codec, and FCP endpoint creation logic inside {@code runtime.endpoints.fcp}. Callers in the
+ * top-level runtime package interact only with the narrower client-owned persistence seams and the
+ * runtime-owned {@link FcpEndpointHandle}.
+ *
+ * <p>Each instance owns one shared persistent-request root and the adapters derived from it. That
+ * keeps request enumeration, recovery, owner lookup, and endpoint creation aligned around the same
+ * durable state without forcing top-level runtime packages to import legacy FCP types. Typical
+ * usage is to construct this service once during runtime bootstrap, pass its seam views into
+ * client-layer persistence wiring, and later ask it to create the endpoint handle that will expose
+ * the same persistent state to the running node.
+ */
+public final class FcpPersistentRequestServices {
+  private final PersistentRequestRoot persistentRoot;
+  private final PersistentRequestCatalog catalog;
+  private final PersistentRequestRecoveryCodec recoveryCodec;
+
+  /** Creates bridge-owned persistent-request services backed by a fresh FCP request root. */
+  public FcpPersistentRequestServices() {
+    persistentRoot = new PersistentRequestRoot();
+    catalog = new CoreFcpPersistentRequestCatalog(persistentRoot);
+    recoveryCodec = new FcpPersistentRequestRecoveryCodec();
+  }
+
+  /**
+   * Returns the coordinator used by client-context persistence flows.
+   *
+   * <p>The returned coordinator resolves or recreates the runtime-owned persistent client for a
+   * durable request during creation and recovery. It is backed by the same shared request root used
+   * by this service's catalog and endpoint creation logic, so client-layer persistence work stays
+   * consistent with the live FCP queue state.
+   *
+   * @return persistent-request coordinator backed by the bridge-owned request root
+   */
+  public PersistentRequestCoordinator coordinator() {
+    return persistentRoot;
+  }
+
+  /**
+   * Returns the client-owned catalog seam for listing and deduplicating persistent requests.
+   *
+   * <p>Callers use this catalog during checkpoint and startup replay to list the durable requests
+   * that currently exist and to avoid restoring duplicates. The adapter preserves the legacy FCP
+   * request-identity rules while still exposing only the client-owned catalog interface.
+   *
+   * @return persistent-request catalog backed by the bridge-owned request root
+   */
+  public PersistentRequestCatalog catalog() {
+    return catalog;
+  }
+
+  /**
+   * Returns the client-owned recovery codec seam for reconstructing persistent requests.
+   *
+   * <p>This codec reconstructs persistent FCP requests from compact recovery data while leaving the
+   * outer persistence framing to the client layer. Keeping the codec here lets the runtime package
+   * evolve its FCP-specific restart logic without widening the persistence SPI.
+   *
+   * @return recovery codec that restores FCP persistent requests through the seam
+   */
+  public PersistentRequestRecoveryCodec recoveryCodec() {
+    return recoveryCodec;
+  }
+
+  /**
+   * Returns a snapshot of the currently registered persistent requests.
+   *
+   * <p>The returned array is a point-in-time snapshot from the shared request root. Later queue
+   * changes are not reflected in the same array instance. Callers should treat the contents as
+   * durable request handles rather than depending on the concrete FCP request implementations that
+   * happen to back them today.
+   *
+   * @return snapshot of persistent request handles; never {@code null}
+   */
+  public PersistentRequestHandle[] getPersistentRequests() {
+    return persistentRoot.getPersistentRequests();
+  }
+
+  /**
+   * Creates the runtime-owned FCP endpoint handle for this node and core.
+   *
+   * <p>The concrete {@link FCPServer} remains owned by this bridge package. Callers receive only
+   * the narrower runtime-owned handle and can continue to treat it as the client-layer download
+   * cache. The created endpoint shares this service's persistent-request root, which preserves the
+   * existing relationship between queue ownership, request recovery, and FCP startup without
+   * leaking concrete bridge types back into the top-level runtime package.
+   *
+   * @param node node instance supplying configuration and shared services
+   * @param core client core used by the FCP server
+   * @param runtimePorts runtime SPI bridge passed to FCP infrastructure
+   * @return runtime-owned handle that wraps the configured FCP server
+   * @throws NullPointerException if any required dependency is {@code null}
+   */
+  public FcpEndpointHandle createEndpointHandle(
+      Node node, NodeClientCore core, RuntimePorts runtimePorts) {
+    Node nonNullNode = Objects.requireNonNull(node, "node");
+    FCPServer server =
+        FCPServer.maybeCreate(
+            CoreFcpServerDependenciesFactory.create(
+                Objects.requireNonNull(core, "core"),
+                Objects.requireNonNull(runtimePorts, "runtimePorts"),
+                persistentRoot),
+            nonNullNode.getConfig());
+    return FcpEndpointHandles.wrap(server);
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackend.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackend.java
@@ -152,7 +152,7 @@ public final class FcpQueueAdminBackend implements QueueAdminBackend {
 
   private FCPServer fcpServerOrNull() {
     var endpoints = core.getEndpoints();
-    return endpoints == null ? null : endpoints.getFCPServer();
+    return endpoints == null ? null : FcpEndpointHandles.serverOrNull(endpoints.getFcpEndpoint());
   }
 
   private QueueRequestStatusView[] adapt(RequestStatus[] statuses) {

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackend.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackend.java
@@ -81,7 +81,7 @@ public final class FcpQueuePageBackend implements QueuePageBackend {
 
   private FCPServer fcpServerOrNull() {
     var endpoints = core.getEndpoints();
-    return endpoints == null ? null : endpoints.getFCPServer();
+    return endpoints == null ? null : FcpEndpointHandles.serverOrNull(endpoints.getFcpEndpoint());
   }
 
   private QueuePageRequestView[] adapt(RequestStatus[] statuses) {

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPort.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPort.java
@@ -109,7 +109,7 @@ public final class LegacyQueueCompletionPort implements QueueCompletionPort {
   }
 
   private FCPServer fcpServer() {
-    FCPServer fcpServer = core.getEndpoints().getFCPServer();
+    FCPServer fcpServer = FcpEndpointHandles.serverOrNull(core.getEndpoints().getFcpEndpoint());
     if (fcpServer == null) {
       throw new IllegalStateException("FCP server unavailable");
     }

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPort.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPort.java
@@ -22,7 +22,7 @@ import network.crypta.runtime.spi.RequestQueueUnavailableException;
  * not force early endpoint initialization during startup.
  *
  * <p>The adapter preserves the current queue-download behavior exactly: each request is bridged to
- * the legacy blocking persistent-global-request call, disk-download disablement is delegated to the
+ * the legacy-blocking persistent-global-request call, disk-download disablement is delegated to the
  * client core, and policy rejections and persistence failures are mapped to the SPI-specific
  * checked exceptions expected by higher layers.
  *
@@ -83,7 +83,7 @@ public final class LegacyQueueDownloadPort implements QueueDownloadPort {
   }
 
   private FCPServer fcpServer() {
-    FCPServer fcpServer = core.getEndpoints().getFCPServer();
+    FCPServer fcpServer = FcpEndpointHandles.serverOrNull(core.getEndpoints().getFcpEndpoint());
     if (fcpServer == null) {
       throw new IllegalStateException("FCP server unavailable");
     }

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPort.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPort.java
@@ -394,7 +394,7 @@ public final class LegacyQueueInsertPort implements QueueInsertPort {
     if (clientEndpoints == null) {
       throw new RequestQueueUnavailableException("Persistent request queue unavailable");
     }
-    FCPServer fcpServer = clientEndpoints.getFCPServer();
+    FCPServer fcpServer = FcpEndpointHandles.serverOrNull(clientEndpoints.getFcpEndpoint());
     if (fcpServer == null) {
       throw new RequestQueueUnavailableException("Persistent request queue unavailable");
     }

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
@@ -2,9 +2,9 @@
  * Runtime-owned FCP endpoint bootstrap glue.
  *
  * <p>This package adapts daemon- and runtime-backed services to the narrow runtime-support seams
- * defined in {@code network.crypta.clients.fcp}. The types here exist to keep remaining {@code
- * NodeClientCore}-backed FCP bootstrap, persistence-bridge, and queue download/insert/completion
- * SPI wiring under runtime ownership while preserving the current protocol behavior and without
- * widening {@code runtime-spi}.
+ * defined in {@code network.crypta.clients.fcp}. The types here keep the concrete FCP server and
+ * persistent-request root owned by bridge-local wrappers such as {@code FcpEndpointHandle} and
+ * {@code FcpPersistentRequestServices}, preserving the current protocol behavior without widening
+ * {@code runtime-spi}.
  */
 package network.crypta.runtime.endpoints.fcp;

--- a/src/main/java/network/crypta/runtime/endpoints/package-info.java
+++ b/src/main/java/network/crypta/runtime/endpoints/package-info.java
@@ -1,13 +1,16 @@
 /**
  * Client endpoint wiring and TMCI bootstrap support for the runtime boundary.
  *
- * <p>This package groups the legacy endpoint bootstrap cluster that still wires the live FCP, HTTP,
- * and text-mode client interfaces from daemon-backed services. The classes remain in the root
- * project and keep their existing collaboration patterns, including package-private TMCI access,
- * but they now sit under a neutral runtime-oriented package instead of {@code network.crypta.node}.
+ * <p>This package groups the legacy endpoint bootstrap cluster that wires the live FCP, HTTP, and
+ * text-mode client interfaces from daemon-backed services. The classes remain in the root project
+ * and keep their existing collaboration patterns, including package-private TMCI access, but they
+ * now sit under a neutral runtime-oriented package instead of {@code network.crypta.node}.
  *
  * <p>The intent is ownership clarification only. These types still depend on daemon-local services
- * such as {@code Node}, {@code NodeClientCore}, queue persistence, and HTTP/FCP bootstrap helpers,
- * and they intentionally preserve the current runtime behavior and lifecycle semantics.
+ * such as {@code Node}, {@code NodeClientCore}, queue persistence, and HTTP bootstrap helpers, but
+ * the FCP-specific concrete types now live behind the bridge package in {@code
+ * network.crypta.runtime.endpoints.fcp}. The runtime-endpoint types intentionally preserve the
+ * current behavior and lifecycle semantics while depending only on the seam-owned FCP endpoint
+ * handle and persistent-request service abstractions.
  */
 package network.crypta.runtime.endpoints;

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -23,6 +23,7 @@ import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.core.LegacyRuntimePorts;
 import network.crypta.runtime.endpoints.ClientEndpoints;
 import network.crypta.runtime.endpoints.NodeClientPersistence;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointHandles;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -130,7 +131,8 @@ class NodeClientCoreTest {
     setField(core, "tempDir", coreTempDir);
     setField(core, "persistentTempDir", persistentTempDir);
 
-    ClientEndpoints endpoints = new ClientEndpoints(Mockito.mock(FCPServer.class), null, toadlets);
+    ClientEndpoints endpoints =
+        new ClientEndpoints(FcpEndpointHandles.wrap(Mockito.mock(FCPServer.class)), null, toadlets);
     setField(core, "endpoints", endpoints);
     setField(core, "requestStarters", requestStarters);
     transfers = Mockito.mock(NodeClientCoreTransfers.class);

--- a/src/test/java/network/crypta/runtime/endpoints/ClientEndpointsTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/ClientEndpointsTest.java
@@ -1,7 +1,6 @@
 package network.crypta.runtime.endpoints;
 
 import network.crypta.client.async.ClientContext;
-import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.config.Config;
 import network.crypta.node.Node;
@@ -9,6 +8,7 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeClientCoreSupport;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.io.TempBucketFactory;
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MockitoExtension.class)
 class ClientEndpointsTest {
 
-  @Mock private FCPServer fcpServer;
+  @Mock private FcpEndpointHandle fcpEndpoint;
   @Mock private TextModeClientInterfaceServer tmci;
   @Mock private HttpShellContainer toadletContainer;
   @Mock private FProxyToadlet fproxy;
@@ -45,9 +45,9 @@ class ClientEndpointsTest {
 
   @Test
   void constructor_whenProvidedDependencies_returnsSameInstances() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
-    assertSame(fcpServer, endpoints.getFCPServer());
+    assertSame(fcpEndpoint, endpoints.getFcpEndpoint());
     assertSame(tmci, endpoints.getTextModeClientInterface());
     assertSame(toadletContainer, endpoints.getToadletContainer());
     assertNull(endpoints.getFProxy());
@@ -56,7 +56,7 @@ class ClientEndpointsTest {
 
   @Test
   void setFProxy_whenAssigned_updatesGetter() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     endpoints.setFProxy(fproxy);
 
@@ -65,7 +65,7 @@ class ClientEndpointsTest {
 
   @Test
   void setDirectTMCI_whenAssigned_updatesGetter() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     endpoints.setDirectTMCI(directTmci);
 
@@ -74,36 +74,36 @@ class ClientEndpointsTest {
 
   @Test
   void loadPersistentRequestsIfNeeded_whenCalled_loadInvoked() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     endpoints.loadPersistentRequestsIfNeeded();
 
-    Mockito.verify(fcpServer).load();
+    Mockito.verify(fcpEndpoint).load();
   }
 
   @Test
   void maybeStart_whenTmciPresent_startsFcpAndTmci() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     endpoints.maybeStart();
 
-    Mockito.verify(fcpServer).maybeStart();
+    Mockito.verify(fcpEndpoint).maybeStart();
     Mockito.verify(tmci).start();
   }
 
   @Test
   void maybeStart_whenTmciNull_startsFcpOnly() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, null, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, null, toadletContainer);
 
     endpoints.maybeStart();
 
-    Mockito.verify(fcpServer).maybeStart();
+    Mockito.verify(fcpEndpoint).maybeStart();
   }
 
   @Test
   void configureBucketFactory_whenCalled_delegatesToToadletContainer() {
     TempBucketFactory tempBucketFactory = Mockito.mock(TempBucketFactory.class);
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     endpoints.configureBucketFactory(tempBucketFactory);
 
@@ -112,7 +112,7 @@ class ClientEndpointsTest {
 
   @Test
   void registerStartupAlerts_whenCalled_registersAlertAndStoresForUnregister() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
     UserAlert alert = Mockito.mock(UserAlert.class);
     String title = "Title";
     String longText = "Long";
@@ -138,7 +138,7 @@ class ClientEndpointsTest {
 
   @Test
   void unregisterStartupAlert_whenMissing_doesNothing() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     endpoints.unregisterStartupAlert(userAlertManager);
 
@@ -148,7 +148,7 @@ class ClientEndpointsTest {
   @Test
   void isAdvancedModeEnabled_whenQueried_delegatesToToadletContainer() {
     Mockito.when(toadletContainer.isAdvancedModeEnabled()).thenReturn(true);
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     boolean enabled = endpoints.isAdvancedModeEnabled();
 
@@ -158,7 +158,7 @@ class ClientEndpointsTest {
   @Test
   void isFProxyJavascriptEnabled_whenQueried_delegatesToToadletContainer() {
     Mockito.when(toadletContainer.isFProxyJavascriptEnabled()).thenReturn(false);
-    ClientEndpoints endpoints = new ClientEndpoints(fcpServer, tmci, toadletContainer);
+    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
 
     boolean enabled = endpoints.isFProxyJavascriptEnabled();
 
@@ -171,7 +171,8 @@ class ClientEndpointsTest {
     HttpShellContainer toadlets = Mockito.mock(HttpShellContainer.class);
     NodeClientCoreInit init = new NodeClientCoreInit(config, null, null, toadlets);
 
-    Mockito.when(persistence.createFcpServer(node, core, runtimePorts)).thenReturn(fcpServer);
+    Mockito.when(persistence.createFcpEndpointHandle(node, core, runtimePorts))
+        .thenReturn(fcpEndpoint);
     Mockito.when(core.killedDatabase()).thenReturn(false);
 
     try (MockedStatic<TextModeClientInterfaceServer> tmciMock =
@@ -184,15 +185,15 @@ class ClientEndpointsTest {
           ClientEndpoints.create(node, core, runtimePorts, init, persistence, clientContext);
       ClientEndpoints endpoints = initResult.endpoints();
 
-      assertSame(fcpServer, endpoints.getFCPServer());
+      assertSame(fcpEndpoint, endpoints.getFcpEndpoint());
       assertSame(tmci, endpoints.getTextModeClientInterface());
       assertSame(toadlets, endpoints.getToadletContainer());
       tmciMock.verify(() -> TextModeClientInterfaceServer.maybeCreate(node, core, config));
     }
 
-    Mockito.verify(persistence).createFcpServer(node, core, runtimePorts);
-    Mockito.verify(clientContext).setDownloadCache(fcpServer);
-    Mockito.verify(fcpServer).load();
+    Mockito.verify(persistence).createFcpEndpointHandle(node, core, runtimePorts);
+    Mockito.verify(clientContext).setDownloadCache(fcpEndpoint);
+    Mockito.verify(fcpEndpoint).load();
   }
 
   @Test
@@ -201,7 +202,8 @@ class ClientEndpointsTest {
     HttpShellContainer toadlets = Mockito.mock(HttpShellContainer.class);
     NodeClientCoreInit init = new NodeClientCoreInit(config, null, null, toadlets);
 
-    Mockito.when(persistence.createFcpServer(node, core, runtimePorts)).thenReturn(fcpServer);
+    Mockito.when(persistence.createFcpEndpointHandle(node, core, runtimePorts))
+        .thenReturn(fcpEndpoint);
     Mockito.when(core.killedDatabase()).thenReturn(true);
 
     try (MockedStatic<TextModeClientInterfaceServer> tmciMock =
@@ -214,12 +216,12 @@ class ClientEndpointsTest {
           ClientEndpoints.create(node, core, runtimePorts, init, persistence, clientContext);
       ClientEndpoints endpoints = initResult.endpoints();
 
-      assertSame(fcpServer, endpoints.getFCPServer());
+      assertSame(fcpEndpoint, endpoints.getFcpEndpoint());
       assertSame(tmci, endpoints.getTextModeClientInterface());
       assertSame(toadlets, endpoints.getToadletContainer());
     }
 
-    Mockito.verify(fcpServer, Mockito.never()).load();
-    Mockito.verify(clientContext).setDownloadCache(fcpServer);
+    Mockito.verify(fcpEndpoint, Mockito.never()).load();
+    Mockito.verify(clientContext).setDownloadCache(fcpEndpoint);
   }
 }

--- a/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
@@ -17,8 +17,6 @@ import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.FcpServerDependencies;
-import network.crypta.clients.fcp.PersistentRequestClient;
-import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
@@ -32,6 +30,8 @@ import network.crypta.node.NodeInitException;
 import network.crypta.node.Persistable;
 import network.crypta.runtime.endpoints.fcp.CoreFcpPersistentRequestCatalog;
 import network.crypta.runtime.endpoints.fcp.CoreFcpServerDependenciesFactory;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointHandles;
 import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestRecoveryCodec;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -460,12 +460,10 @@ class NodeClientPersistenceTest {
             mock(InsertContext.class));
     ClientContext context = persistence.createClientContext(node, params);
 
-    PersistentRequestRoot root = (PersistentRequestRoot) context.persistentRequestCoordinator;
-    PersistentRequestClient client = root.registerForeverClient("client", null);
     ClientRequest request = mock(ClientRequest.class);
     when(request.hasFinished()).thenReturn(false);
     when(request.isPersistentForever()).thenReturn(true);
-    client.resume(request);
+    context.persistentRequestCoordinator.resumePersistentRequest(request, true, "client");
 
     // Act
     PersistentRequestHandle[] requests = persistence.getPersistentRequests();
@@ -475,7 +473,7 @@ class NodeClientPersistenceTest {
   }
 
   @Test
-  void createFcpServer_whenCalled_expectDelegatesToMaybeCreate(@TempDir File tempDir)
+  void createFcpEndpointHandle_whenCalled_expectDelegatesToMaybeCreate(@TempDir File tempDir)
       throws NodeInitException {
     // Arrange
     Persistable persistable = mock(Persistable.class);
@@ -498,20 +496,24 @@ class NodeClientPersistenceTest {
           .when(
               () ->
                   CoreFcpServerDependenciesFactory.create(
-                      eq(core), eq(runtimePorts), any(PersistentRequestRoot.class)))
+                      eq(core),
+                      eq(runtimePorts),
+                      any(network.crypta.clients.fcp.PersistentRequestRoot.class)))
           .thenReturn(dependencies);
       fcpServerMock
           .when(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)))
           .thenReturn(expected);
 
-      FCPServer result = persistence.createFcpServer(node, core, runtimePorts);
+      FcpEndpointHandle result = persistence.createFcpEndpointHandle(node, core, runtimePorts);
 
       // Assert
-      assertSame(expected, result);
+      assertSame(expected, FcpEndpointHandles.unwrap(result));
       factoryMock.verify(
           () ->
               CoreFcpServerDependenciesFactory.create(
-                  eq(core), eq(runtimePorts), any(PersistentRequestRoot.class)));
+                  eq(core),
+                  eq(runtimePorts),
+                  any(network.crypta.clients.fcp.PersistentRequestRoot.class)));
       fcpServerMock.verify(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)));
     }
   }

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandlesTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandlesTest.java
@@ -1,0 +1,110 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.client.async.CacheFetchResult;
+import network.crypta.client.async.ClientContext;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class FcpEndpointHandlesTest {
+
+  @Test
+  void wrap_whenServerProvided_delegatesToWrappedServer() {
+    // Arrange
+    FCPServer server = mock(FCPServer.class);
+    FcpEndpointHandle handle = FcpEndpointHandles.wrap(server);
+    FreenetURI key = mock(FreenetURI.class);
+    ClientContext context = mock(ClientContext.class);
+    Bucket preferred = mock(Bucket.class);
+    CacheFetchResult instantResult = mock(CacheFetchResult.class);
+    CacheFetchResult lookupResult = mock(CacheFetchResult.class);
+    when(server.lookupInstant(key, true, false, preferred)).thenReturn(instantResult);
+    when(server.lookup(key, false, context, true, preferred)).thenReturn(lookupResult);
+
+    // Act
+    handle.load();
+    handle.maybeStart();
+    CacheFetchResult actualInstant = handle.lookupInstant(key, true, false, preferred);
+    CacheFetchResult actualLookup = handle.lookup(key, false, context, true, preferred);
+
+    // Assert
+    assertSame(server, FcpEndpointHandles.unwrap(handle));
+    assertSame(server, FcpEndpointHandles.serverOrNull(handle));
+    assertSame(server, FcpEndpointHandles.requireServer(handle));
+    assertSame(instantResult, actualInstant);
+    assertSame(lookupResult, actualLookup);
+    verify(server).load();
+    verify(server).maybeStart();
+    verify(server).lookupInstant(key, true, false, preferred);
+    verify(server).lookup(key, false, context, true, preferred);
+  }
+
+  @Test
+  void serverOrNull_whenHandleMissing_returnsNull() {
+    // Act + Assert
+    assertNull(FcpEndpointHandles.serverOrNull(null));
+  }
+
+  @Test
+  void requireServer_whenHandleMissing_throwsIllegalStateException() {
+    // Act
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> FcpEndpointHandles.requireServer(null));
+
+    // Assert
+    assertTrue(thrown.getMessage().contains("FCP server unavailable"));
+  }
+
+  @Test
+  void unwrap_whenHandleNotCreatedByBridge_throwsIllegalArgumentException() {
+    // Arrange
+    FcpEndpointHandle unsupportedHandle = new UnsupportedEndpointHandle();
+
+    // Act
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> FcpEndpointHandles.unwrap(unsupportedHandle));
+
+    // Assert
+    assertTrue(thrown.getMessage().contains(UnsupportedEndpointHandle.class.getName()));
+  }
+
+  private static final class UnsupportedEndpointHandle implements FcpEndpointHandle {
+
+    @Override
+    public void load() {
+      // No-op: test double exists only to hit the unsupported unwrapping path.
+    }
+
+    @Override
+    public void maybeStart() {
+      // No-op: test double exists only to hit the unsupported unwrapping path.
+    }
+
+    @Override
+    public CacheFetchResult lookupInstant(
+        FreenetURI key, boolean noFilter, boolean mustCopy, Bucket preferred) {
+      return null;
+    }
+
+    @Override
+    public CacheFetchResult lookup(
+        FreenetURI key,
+        boolean noFilter,
+        ClientContext context,
+        boolean mustCopy,
+        Bucket preferred) {
+      return null;
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServicesTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServicesTest.java
@@ -1,0 +1,91 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
+import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpServerDependencies;
+import network.crypta.clients.fcp.PersistentRequestRoot;
+import network.crypta.config.PersistentConfig;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.spi.RuntimePorts;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class FcpPersistentRequestServicesTest {
+
+  @Test
+  void accessors_whenFreshInstance_exposeSharedEmptyPersistentState() {
+    // Arrange
+    FcpPersistentRequestServices services = new FcpPersistentRequestServices();
+    PersistentRequestCoordinator coordinator = services.coordinator();
+    PersistentRequestCatalog catalog = services.catalog();
+    PersistentRequestRecoveryCodec recoveryCodec = services.recoveryCodec();
+    PersistentRequestIdentifier lookupIdentifier =
+        new PersistentRequestIdentifier(
+            false, "client-a", "request-1", PersistentRequestIdentifier.RequestType.PUT);
+
+    // Assert
+    assertSame(coordinator, services.coordinator());
+    assertSame(catalog, services.catalog());
+    assertSame(recoveryCodec, services.recoveryCodec());
+    assertInstanceOf(FcpPersistentRequestRecoveryCodec.class, recoveryCodec);
+    assertNotNull(coordinator.getOrCreateClientHandle(false, "client-a"));
+    assertArrayEquals(new PersistentRequestHandle[0], services.getPersistentRequests());
+    assertArrayEquals(new PersistentRequestHandle[0], catalog.getPersistentRequests());
+    assertFalse(catalog.hasRequest(lookupIdentifier));
+  }
+
+  @Test
+  void createEndpointHandle_whenCalled_wrapsCreatedServer() {
+    // Arrange
+    FcpPersistentRequestServices services = new FcpPersistentRequestServices();
+    Node node = mock(Node.class);
+    PersistentConfig config = mock(PersistentConfig.class);
+    NodeClientCore core = mock(NodeClientCore.class);
+    RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    FcpServerDependencies dependencies = mock(FcpServerDependencies.class);
+    FCPServer server = mock(FCPServer.class);
+    when(node.getConfig()).thenReturn(config);
+
+    // Act
+    try (MockedStatic<CoreFcpServerDependenciesFactory> factoryMock =
+            mockStatic(CoreFcpServerDependenciesFactory.class);
+        MockedStatic<FCPServer> fcpServerMock = mockStatic(FCPServer.class)) {
+      factoryMock
+          .when(
+              () ->
+                  CoreFcpServerDependenciesFactory.create(
+                      eq(core), eq(runtimePorts), any(PersistentRequestRoot.class)))
+          .thenReturn(dependencies);
+      fcpServerMock
+          .when(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)))
+          .thenReturn(server);
+
+      FcpEndpointHandle endpointHandle = services.createEndpointHandle(node, core, runtimePorts);
+
+      // Assert
+      assertSame(server, FcpEndpointHandles.unwrap(endpointHandle));
+      factoryMock.verify(
+          () ->
+              CoreFcpServerDependenciesFactory.create(
+                  eq(core), eq(runtimePorts), any(PersistentRequestRoot.class)));
+      fcpServerMock.verify(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)));
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackendTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueueAdminBackendTest.java
@@ -46,7 +46,7 @@ class FcpQueueAdminBackendTest {
 
   @Test
   void isEnabled_whenNoFcpServerPresent_returnsFalse() {
-    when(endpoints.getFCPServer()).thenReturn(null);
+    when(endpoints.getFcpEndpoint()).thenReturn(null);
 
     assertFalse(backend.isEnabled());
   }
@@ -60,7 +60,7 @@ class FcpQueueAdminBackendTest {
 
   @Test
   void isEnabled_whenServerPresent_delegatesToEnabledFlag() {
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.isEnabled()).thenReturn(true).thenReturn(false);
 
     assertTrue(backend.isEnabled());
@@ -73,7 +73,7 @@ class FcpQueueAdminBackendTest {
     UploadFileRequestStatus uploadFile = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
     UploadDirRequestStatus uploadDir = org.mockito.Mockito.mock(UploadDirRequestStatus.class);
     RequestStatus generic = org.mockito.Mockito.mock(RequestStatus.class);
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.getGlobalRequests())
         .thenReturn(new RequestStatus[] {download, uploadFile, uploadDir, generic});
 
@@ -111,7 +111,7 @@ class FcpQueueAdminBackendTest {
 
   @Test
   void getGlobalRequests_whenServerUnavailable_throwsIllegalStateException() {
-    when(endpoints.getFCPServer()).thenReturn(null);
+    when(endpoints.getFcpEndpoint()).thenReturn(null);
 
     IllegalStateException thrown =
         assertThrows(IllegalStateException.class, backend::getGlobalRequests);
@@ -123,7 +123,7 @@ class FcpQueueAdminBackendTest {
   void getGlobalRequests_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
       throws Exception {
     PersistenceDisabledException cause = new PersistenceDisabledException();
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.getGlobalRequests()).thenThrow(cause);
 
     RequestQueueUnavailableException thrown =
@@ -134,7 +134,7 @@ class FcpQueueAdminBackendTest {
 
   @Test
   void removeGlobalRequestBlocking_whenCalled_delegatesToServer() throws Exception {
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.removeGlobalRequestBlocking("request-1")).thenReturn(true);
 
     assertTrue(backend.removeGlobalRequestBlocking("request-1"));
@@ -146,7 +146,7 @@ class FcpQueueAdminBackendTest {
       removeGlobalRequestBlocking_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
           throws Exception {
     PersistenceDisabledException cause = new PersistenceDisabledException();
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.removeGlobalRequestBlocking("request-1")).thenThrow(cause);
 
     RequestQueueUnavailableException thrown =
@@ -159,7 +159,7 @@ class FcpQueueAdminBackendTest {
 
   @Test
   void restartBlocking_whenCalled_delegatesToServer() throws Exception {
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.restartBlocking("request-1", true)).thenReturn(true);
 
     assertTrue(backend.restartBlocking("request-1", true));
@@ -170,7 +170,7 @@ class FcpQueueAdminBackendTest {
   void restartBlocking_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
       throws Exception {
     PersistenceDisabledException cause = new PersistenceDisabledException();
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.restartBlocking("request-1", false)).thenThrow(cause);
 
     RequestQueueUnavailableException thrown =
@@ -183,7 +183,7 @@ class FcpQueueAdminBackendTest {
 
   @Test
   void modifyGlobalRequestBlocking_whenCalled_delegatesToServer() throws Exception {
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.modifyGlobalRequestBlocking("request-1", "new-token", (short) 3))
         .thenReturn(true);
 
@@ -196,7 +196,7 @@ class FcpQueueAdminBackendTest {
       modifyGlobalRequestBlocking_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
           throws Exception {
     PersistenceDisabledException cause = new PersistenceDisabledException();
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.modifyGlobalRequestBlocking("request-1", null, (short) 7)).thenThrow(cause);
 
     RequestQueueUnavailableException thrown =

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackendTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueuePageBackendTest.java
@@ -62,18 +62,18 @@ class FcpQueuePageBackendTest {
   @Test
   void getGlobalRequests_whenConstructed_defersFcpLookupUntilMethodCall() throws Exception {
     verifyNoInteractions(endpoints, fcpServer);
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.getGlobalRequests()).thenReturn(new RequestStatus[0]);
 
     backend.getGlobalRequests();
 
-    verify(endpoints).getFCPServer();
+    verify(endpoints).getFcpEndpoint();
     verify(fcpServer).getGlobalRequests();
   }
 
   @Test
   void getGlobalRequests_whenFcpServerMissing_returnsEmptyArray() throws Exception {
-    when(endpoints.getFCPServer()).thenReturn(null);
+    when(endpoints.getFcpEndpoint()).thenReturn(null);
 
     QueuePageRequestView[] views = backend.getGlobalRequests();
 
@@ -94,7 +94,7 @@ class FcpQueuePageBackendTest {
   void getGlobalRequests_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
       throws Exception {
     PersistenceDisabledException cause = new PersistenceDisabledException();
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.getGlobalRequests()).thenThrow(cause);
 
     RequestQueueUnavailableException thrown =
@@ -116,7 +116,7 @@ class FcpQueuePageBackendTest {
     byte[] overrideKey = new byte[] {0x01, 0x23};
     FreenetURI downloadUri = sampleUri("index_d51.xml");
     FreenetURI uploadUri = sampleUri("upload.txt");
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.getGlobalRequests())
         .thenReturn(new RequestStatus[] {download, uploadFile, uploadDir});
 
@@ -208,7 +208,7 @@ class FcpQueuePageBackendTest {
     Instant lastSuccess = Instant.parse("2026-03-28T12:34:56Z");
     Instant lastFailure = Instant.parse("2026-03-28T12:35:56Z");
     FreenetURI uri = sampleUri("generic.txt");
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.getGlobalRequests()).thenReturn(new RequestStatus[] {genericStatus});
     when(genericStatus.getIdentifier()).thenReturn("generic-1");
     when(genericStatus.hasSucceeded()).thenReturn(true);
@@ -265,7 +265,7 @@ class FcpQueuePageBackendTest {
     UploadFileRequestStatus waiting = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
     UploadFileRequestStatus compressing = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
     UploadFileRequestStatus working = org.mockito.Mockito.mock(UploadFileRequestStatus.class);
-    when(endpoints.getFCPServer()).thenReturn(fcpServer);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcpServer));
     when(fcpServer.getGlobalRequests())
         .thenReturn(new RequestStatus[] {waiting, compressing, working});
     when(waiting.isCompressing()).thenReturn(COMPRESS_STATE.WAITING);

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPortTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueCompletionPortTest.java
@@ -20,12 +20,12 @@ import network.crypta.client.async.HealingQueue;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.USKManager;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.ClientGet;
 import network.crypta.clients.fcp.ClientPut;
 import network.crypta.clients.fcp.ClientPutDir;
 import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.clients.fcp.RequestCompletionCallback;
 import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
@@ -112,7 +112,7 @@ class LegacyQueueCompletionPortTest {
     when(node.getUserDir()).thenReturn(userDir.dir());
     when(node.network()).thenReturn(network);
     when(network.executor()).thenReturn(executor);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcp));
 
     doAnswer(
             invocation -> {
@@ -189,7 +189,7 @@ class LegacyQueueCompletionPortTest {
 
   @Test
   void ensureTrackingStarted_whenFcpServerUnavailable_throwsIllegalStateException() {
-    when(endpoints.getFCPServer()).thenReturn(null);
+    when(endpoints.getFcpEndpoint()).thenReturn(null);
 
     IllegalStateException thrown =
         assertThrows(IllegalStateException.class, () -> port.ensureTrackingStarted(false));
@@ -411,7 +411,8 @@ class LegacyQueueCompletionPortTest {
         org.mockito.Mockito.mock(FileRandomAccessBufferFactory.class);
     RealCompressor rc = org.mockito.Mockito.mock(RealCompressor.class);
     DatastoreChecker checker = org.mockito.Mockito.mock(DatastoreChecker.class);
-    PersistentRequestRoot persistentRoot = org.mockito.Mockito.mock(PersistentRequestRoot.class);
+    PersistentRequestCoordinator persistentRoot =
+        org.mockito.Mockito.mock(PersistentRequestCoordinator.class);
     MasterSecret masterSecret = org.mockito.Mockito.mock(MasterSecret.class);
     LinkFilterExceptionProvider linkFilterExceptionProvider =
         org.mockito.Mockito.mock(LinkFilterExceptionProvider.class);

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPortTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueDownloadPortTest.java
@@ -68,7 +68,7 @@ class LegacyQueueDownloadPortTest {
   @Test
   void enqueueDownload_whenCalled_resolvesFcpLazilyAndForwardsExpectedValues() throws Exception {
     when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcp));
     QueueDownloadRequest request =
         new QueueDownloadRequest(
             "CHK@", true, "text/plain", "forever", "disk", new File("/tmp/downloads"));
@@ -79,7 +79,7 @@ class LegacyQueueDownloadPortTest {
 
     ArgumentCaptor<PersistentGlobalRequestParams> paramsCaptor =
         ArgumentCaptor.forClass(PersistentGlobalRequestParams.class);
-    verify(endpoints).getFCPServer();
+    verify(endpoints).getFcpEndpoint();
     verify(fcp).makePersistentGlobalRequestBlocking(paramsCaptor.capture());
     PersistentGlobalRequestParams params = paramsCaptor.getValue();
     assertEquals("CHK@", params.fetchURI().toString());
@@ -95,7 +95,7 @@ class LegacyQueueDownloadPortTest {
   void enqueueDownload_whenNotAllowed_translatesToQueueDownloadRejectedException()
       throws Exception {
     when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcp));
     NotAllowedException cause = new NotAllowedException();
     doThrow(cause)
         .when(fcp)
@@ -115,7 +115,7 @@ class LegacyQueueDownloadPortTest {
   void enqueueDownload_whenPersistenceDisabled_translatesToRequestQueueUnavailableException()
       throws Exception {
     when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcp));
     PersistenceDisabledException cause = new PersistenceDisabledException();
     doThrow(cause)
         .when(fcp)

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPortTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/LegacyQueueInsertPortTest.java
@@ -26,15 +26,14 @@ import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.client.async.USKManager;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.ClientPut;
-import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.IdentifierCollisionException;
 import network.crypta.clients.fcp.NotAllowedException;
 import network.crypta.clients.fcp.PersistentRequestClient;
-import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
@@ -101,7 +100,6 @@ class LegacyQueueInsertPortTest {
   @Mock private FCPServer fcp;
   @Mock private ClientLayerPersister jobRunner;
   @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
-  @Mock private PersistentRequestRoot persistentRoot;
   @Mock private RuntimePorts runtimePorts;
   @Mock private TransferAccessPort transferAccessPort;
   @Mock private PriorityAwareExecutor executor;
@@ -112,11 +110,9 @@ class LegacyQueueInsertPortTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    PersistentRequestClient persistentClient =
-        new PersistentRequestClient(
-            "global", null, true, null, Persistence.FOREVER, persistentRoot);
+    PersistentRequestClient persistentClient = mock(PersistentRequestClient.class);
     when(core.getEndpoints()).thenReturn(endpoints);
-    when(endpoints.getFCPServer()).thenReturn(fcp);
+    when(endpoints.getFcpEndpoint()).thenReturn(FcpEndpointHandles.wrap(fcp));
     when(core.getClientLayerPersister()).thenReturn(jobRunner);
     when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
     when(core.getRuntimePorts()).thenReturn(runtimePorts);
@@ -167,7 +163,7 @@ class LegacyQueueInsertPortTest {
     assertEquals(QueueInsertOutcome.STARTED, outcome);
     assertTrue(copiedBeforeQueue.get());
     assertTrue(checkpointRequested.get());
-    verify(endpoints).getFCPServer();
+    verify(endpoints).getFcpEndpoint();
     verify(fcp).startBlocking(any(ClientRequest.class));
   }
 
@@ -321,7 +317,7 @@ class LegacyQueueInsertPortTest {
     RandomAccessBucket copiedBucket = mock(RandomAccessBucket.class);
     when(copiedBucket.getOutputStream()).thenReturn(new ByteArrayOutputStream());
     when(persistentTempBucketFactory.makeBucket(anyLong())).thenReturn(copiedBucket);
-    when(endpoints.getFCPServer()).thenReturn(null);
+    when(endpoints.getFcpEndpoint()).thenReturn(null);
 
     RequestQueueUnavailableException thrown =
         assertThrows(
@@ -388,8 +384,8 @@ class LegacyQueueInsertPortTest {
         org.mockito.Mockito.mock(FileRandomAccessBufferFactory.class);
     RealCompressor rc = org.mockito.Mockito.mock(RealCompressor.class);
     DatastoreChecker checker = org.mockito.Mockito.mock(DatastoreChecker.class);
-    PersistentRequestRoot clientContextPersistentRoot =
-        org.mockito.Mockito.mock(PersistentRequestRoot.class);
+    PersistentRequestCoordinator clientContextPersistentRequestCoordinator =
+        org.mockito.Mockito.mock(PersistentRequestCoordinator.class);
     MasterSecret masterSecret = org.mockito.Mockito.mock(MasterSecret.class);
     LinkFilterExceptionProvider linkFilterExceptionProvider =
         org.mockito.Mockito.mock(LinkFilterExceptionProvider.class);
@@ -415,7 +411,7 @@ class LegacyQueueInsertPortTest {
             uskManager,
             rc,
             checker,
-            clientContextPersistentRoot,
+            clientContextPersistentRequestCoordinator,
             linkFilterExceptionProvider),
         new ClientContextDefaults(fetchContext, insertContext, config));
   }


### PR DESCRIPTION
## Summary
- add a runtime-owned `FcpEndpointHandle` seam and bridge-owned `FcpPersistentRequestServices`
- update `ClientEndpoints` and `NodeClientPersistence` to depend on seam-owned types instead of concrete `clients.fcp.*`
- keep concrete FCP server access inside `runtime.endpoints.fcp`, and update the queue/admin bridges, tests, and Javadocs to unwrap through `FcpEndpointHandles`

## Testing
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests 'network.crypta.runtime.endpoints.ClientEndpointsTest'`
- `./gradlew test --tests 'network.crypta.runtime.endpoints.NodeClientPersistenceTest'`
- `./gradlew test --tests 'network.crypta.runtime.admin.LegacyDiagnosticPortTest'`
- `./gradlew test --tests 'network.crypta.runtime.admin.LegacyQueueSupportPortTest'`
- `./gradlew test --tests 'network.crypta.runtime.endpoints.fcp.FcpEndpointHandlesTest'`
- `./gradlew test --tests 'network.crypta.runtime.endpoints.fcp.FcpPersistentRequestServicesTest'`
- `./gradlew test --tests 'network.crypta.node.NodeClientCoreTest' --tests 'network.crypta.runtime.endpoints.ClientEndpointsTest' --tests 'network.crypta.runtime.endpoints.NodeClientPersistenceTest' --tests 'network.crypta.runtime.endpoints.fcp.FcpEndpointHandlesTest' --tests 'network.crypta.runtime.endpoints.fcp.FcpPersistentRequestServicesTest' --tests 'network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackendTest' --tests 'network.crypta.runtime.endpoints.fcp.FcpQueuePageBackendTest' --tests 'network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPortTest' --tests 'network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPortTest' --tests 'network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPortTest'`
- `./gradlew test`