### PR TITLE
refactor(endpoints): Remove obsolete FProxy publication

### DIFF
--- a/src/main/java/network/crypta/client/filter/M3UFilter.java
+++ b/src/main/java/network/crypta/client/filter/M3UFilter.java
@@ -48,9 +48,9 @@ public class M3UFilter implements ContentDataFilter {
   static final int MAX_URI_LENGTH = 16384;
   static final String BAD_URI_REPLACEMENT = "#bad-uri-removed";
 
-  // pass-through for most files accessed via a playlist, likely through an external
-  // player. See FProxyToadlet.maxLengthNoProgress for the default. This value must
-  // be synchronized with the test data!
+  // Pass through most files accessed via a playlist, likely through an external
+  // player. Keep this limit aligned with the HTTP no-progress default and the
+  // corresponding test data.
 
   // Future: Add parsing of ext-comments to allow for gapless playback.
 

--- a/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
+++ b/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
@@ -22,7 +22,7 @@ import network.crypta.runtime.spi.RuntimePorts;
  * @param client shared interactive client used by registered HTTP toadlets
  * @param runtimePorts detached runtime ports exposed to the HTTP shell
  * @param config node configuration used to list sub-config toadlets
- * @param fproxy prebuilt root FProxy toadlet already published to client endpoints
+ * @param fproxy prebuilt root FProxy toadlet handed to the registrar for root-path registration
  */
 record FProxyRegistrarDependencies(
     HighLevelSimpleClient client, RuntimePorts runtimePorts, Config config, FProxyToadlet fproxy) {

--- a/src/main/java/network/crypta/clients/http/HttpShellFProxyBootstrap.java
+++ b/src/main/java/network/crypta/clients/http/HttpShellFProxyBootstrap.java
@@ -11,15 +11,14 @@ import network.crypta.clients.http.bookmark.BookmarkManager;
  * resulting collaborators when it registers child toadlets and bookmark-dependent views. This
  * record keeps that handoff explicit and minimal: the bookmark manager carries the daemon-backed
  * bookmark runtime, the interactive client is shared by HTTP toadlets, and the root {@link
- * FProxyToadlet} has already been published to client endpoints by the time the shell receives this
- * bundle.
+ * FProxyToadlet} is returned directly to the shell bootstrap path for registration.
  *
- * <p>This record is public only so runtime-owned HTTP bootstrap adapters can construct and return
+ * <p>This record is public only, so runtime-owned HTTP bootstrap adapters can construct and return
  * the bundle from outside {@code network.crypta.clients.http}. It is not a new platform API.
  *
  * @param bookmarkManager bookmark manager wired against the daemon-backed bookmark runtime support
  * @param client interactive client shared by HTTP toadlets created during shell startup
- * @param fproxy root FProxy toadlet that has already been connected to daemon client endpoints
+ * @param fproxy root FProxy toadlet constructed during bootstrap and handed to the registrar flow
  */
 public record HttpShellFProxyBootstrap(
     BookmarkManager bookmarkManager, HighLevelSimpleClient client, FProxyToadlet fproxy) {

--- a/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
+++ b/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
@@ -123,9 +123,9 @@ public interface HttpShellRuntimeSupport {
   /**
    * Creates the root FProxy collaborators required before the shell registers child toadlets.
    *
-   * <p>Implementations may perform daemon-side publication as part of this operation because the
-   * root FProxy wiring still belongs to the daemon-backed bootstrap path. Callers should treat the
-   * result as a one-time bootstrap bundle for the current shell instance.
+   * <p>Implementations assemble the daemon-backed collaborators required for root FProxy startup,
+   * and callers then pass the resulting bundle through the HTTP registration path. Callers should
+   * treat the result as a one-time bootstrap bundle for the current shell instance.
    *
    * @param publicGatewayMode whether the shell should bootstrap public-gateway bookmark behavior
    * @return bootstrap bundle containing the bookmark manager, interactive client, and root FProxy

--- a/src/main/java/network/crypta/runtime/endpoints/ClientEndpoints.java
+++ b/src/main/java/network/crypta/runtime/endpoints/ClientEndpoints.java
@@ -2,7 +2,6 @@ package network.crypta.runtime.endpoints;
 
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.async.ClientContext;
-import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeClientCoreSupport;
@@ -23,10 +22,10 @@ import network.crypta.support.io.TempBucketFactory;
  * node initialization, register any startup alerts, and then start the endpoints once the core is
  * ready.
  *
- * <p>Thread-safety is limited to safe publication of a small set of references via atomic holders;
- * the underlying endpoint implementations define their own concurrency guarantees. Callers should
- * avoid mutating the endpoint state concurrently unless the respective component documents that it
- * is safe to do so.
+ * <p>Thread-safety is limited to safe publication of the optional direct TMCI reference via an
+ * atomic holder; the underlying endpoint implementations define their own concurrency guarantees.
+ * Callers should avoid mutating the endpoint state concurrently unless the respective component
+ * documents that it is safe to do so.
  *
  * <ul>
  *   <li>Holds the endpoint instances and exposes read-only accessors.
@@ -42,7 +41,6 @@ public final class ClientEndpoints {
   private final TextModeClientInterfaceServer tmci;
   private final HttpShellContainer toadletContainer;
   private final AtomicReference<TextModeClientInterface> directTMCI = new AtomicReference<>();
-  private final AtomicReference<FProxyToadlet> fproxy = new AtomicReference<>();
   private UserAlert startingUpAlert;
 
   /**
@@ -93,34 +91,6 @@ public final class ClientEndpoints {
    */
   public FcpEndpointHandle getFcpEndpoint() {
     return fcpEndpoint;
-  }
-
-  /**
-   * Returns the currently configured FProxy toadlet, if any.
-   *
-   * <p>This value may be {@code null} when no FProxy has been installed or before configuration
-   * occurs. The reference is stored in an atomic holder for safe publication across threads, but it
-   * does not imply that the toadlet implementation itself is thread-safe. The returned reference is
-   * the direct instance currently published by this bundle.
-   *
-   * @return the current FProxy toadlet, or {@code null} when not set.
-   */
-  public FProxyToadlet getFProxy() {
-    return fproxy.get();
-  }
-
-  /**
-   * Sets the FProxy toadlet reference to expose via {@link #getFProxy()}.
-   *
-   * <p>The provided reference is stored as-is and can be {@code null} to clear a previous value.
-   * This method performs no additional registration or lifecycle actions, so callers must ensure
-   * the toadlet is registered with the container elsewhere if required. The update becomes visible
-   * to other threads via the atomic reference.
-   *
-   * @param fproxy FProxy toadlet instance to publish, or {@code null} to clear.
-   */
-  public void setFProxy(FProxyToadlet fproxy) {
-    this.fproxy.set(fproxy);
   }
 
   /**

--- a/src/main/java/network/crypta/runtime/endpoints/http/CoreHttpShellRuntimeSupport.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/CoreHttpShellRuntimeSupport.java
@@ -5,7 +5,6 @@ import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyRuntimeSupport;
-import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.HttpShellFProxyBootstrap;
 import network.crypta.clients.http.HttpShellRuntimeSupport;
 import network.crypta.clients.http.SimpleToadletServer;
@@ -124,12 +123,8 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core) implements HttpSh
             client.getFetchContext(),
             new RequestClientBuilder().realTime().build());
     FProxyRuntimeSupport fproxyRuntimeSupport = new CoreFProxyRuntimeSupport(core);
-    HttpShellFProxyBootstrap bootstrap =
-        HttpShellFProxyBootstrap.create(
-            bookmarkManager, client, fproxyRuntimeSupport, fetchTracker);
-    FProxyToadlet fproxy = bootstrap.fproxy();
-    core.getEndpoints().setFProxy(fproxy);
-    return bootstrap;
+    return HttpShellFProxyBootstrap.create(
+        bookmarkManager, client, fproxyRuntimeSupport, fetchTracker);
   }
 
   /**

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -17,7 +17,6 @@ import network.crypta.io.SSLNetworkInterface;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
 import network.crypta.runtime.alerts.UserAlertManager;
-import network.crypta.runtime.endpoints.ClientEndpoints;
 import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.endpoints.http.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.runtime.spi.RandomnessPort;
@@ -108,7 +107,6 @@ class SimpleToadletServerTest {
     PersistentConfig nodeConfig = new PersistentConfig(new SimpleFieldSet(true));
     Ticker ticker = mock(Ticker.class);
     ClientContext clientContext = mock(ClientContext.class);
-    ClientEndpoints endpoints = mock(ClientEndpoints.class);
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     FetchContext fetchContext = mock(FetchContext.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
@@ -118,7 +116,6 @@ class SimpleToadletServerTest {
     when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
     when(core.getClientContext()).thenReturn(clientContext);
     when(core.getRuntimePorts()).thenReturn(runtimePorts);
-    when(core.getEndpoints()).thenReturn(endpoints);
     when(core.getAlerts()).thenReturn(alerts);
     when(core.getNode().getConfig()).thenReturn(nodeConfig);
     when(core.getNode().network().ticker()).thenReturn(ticker);
@@ -156,7 +153,6 @@ class SimpleToadletServerTest {
     }
 
     ArgumentCaptor<byte[]> randomCaptor = ArgumentCaptor.forClass(byte[].class);
-    ArgumentCaptor<FProxyToadlet> fproxyCaptor = ArgumentCaptor.forClass(FProxyToadlet.class);
     verify(runtimePorts, times(1)).randomness();
     verify(randomnessPort, times(1)).fillSecureRandom(randomCaptor.capture());
     assertSame(FProxyToadlet.random, randomCaptor.getValue());
@@ -164,12 +160,11 @@ class SimpleToadletServerTest {
     verify(core, times(1)).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
     verify(core, times(1)).getAlerts();
     verify(core, never()).getRandom();
-    verify(endpoints, times(1)).setFProxy(fproxyCaptor.capture());
     assertEquals(1, registrarCalls.get());
     assertSame(client, dependenciesRef.get().client());
     assertSame(runtimePorts, dependenciesRef.get().runtimePorts());
     assertSame(nodeConfig, dependenciesRef.get().config());
-    assertSame(fproxyCaptor.getValue(), dependenciesRef.get().fproxy());
+    assertInstanceOf(FProxyToadlet.class, dependenciesRef.get().fproxy());
   }
 
   @Test

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -13,7 +13,6 @@ import network.crypta.client.async.USKManager;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.clients.fcp.ClientRequest;
 import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.config.PersistentConfig;
 import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
@@ -282,11 +281,7 @@ class NodeClientCoreTest {
   }
 
   @Test
-  void fproxySetterGetter_and_myName_delegations_work() {
-    FProxyToadlet fproxy = Mockito.mock(FProxyToadlet.class);
-    core.getEndpoints().setFProxy(fproxy);
-    assertSame(fproxy, core.getEndpoints().getFProxy());
-
+  void myName_and_endpointDelegations_work() {
     when(node.getMyName()).thenReturn("MyNode");
     assertEquals("MyNode", core.getMyName());
   }

--- a/src/test/java/network/crypta/runtime/endpoints/ClientEndpointsTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/ClientEndpointsTest.java
@@ -1,7 +1,6 @@
 package network.crypta.runtime.endpoints;
 
 import network.crypta.client.async.ClientContext;
-import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.config.Config;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
@@ -31,7 +30,6 @@ class ClientEndpointsTest {
   @Mock private FcpEndpointHandle fcpEndpoint;
   @Mock private TextModeClientInterfaceServer tmci;
   @Mock private HttpShellContainer toadletContainer;
-  @Mock private FProxyToadlet fproxy;
   @Mock private TextModeClientInterface directTmci;
   @Mock private UserAlertManager userAlertManager;
 
@@ -50,17 +48,7 @@ class ClientEndpointsTest {
     assertSame(fcpEndpoint, endpoints.getFcpEndpoint());
     assertSame(tmci, endpoints.getTextModeClientInterface());
     assertSame(toadletContainer, endpoints.getToadletContainer());
-    assertNull(endpoints.getFProxy());
     assertNull(endpoints.getDirectTMCI());
-  }
-
-  @Test
-  void setFProxy_whenAssigned_updatesGetter() {
-    ClientEndpoints endpoints = new ClientEndpoints(fcpEndpoint, tmci, toadletContainer);
-
-    endpoints.setFProxy(fproxy);
-
-    assertSame(fproxy, endpoints.getFProxy());
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/endpoints/http/CoreHttpShellRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/CoreHttpShellRuntimeSupportTest.java
@@ -22,7 +22,6 @@ import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.alerts.UserAlertManager;
-import network.crypta.runtime.endpoints.ClientEndpoints;
 import network.crypta.runtime.endpoints.http.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -46,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -233,13 +233,12 @@ class CoreHttpShellRuntimeSupportTest {
   }
 
   @Test
-  void createFProxyBootstrap_whenInvoked_constructsDependenciesAndPublishesFProxy() {
+  void createFProxyBootstrap_whenInvoked_constructsDependenciesAndReturnsBootstrap() {
     NodeClientCore core = mock(NodeClientCore.class);
     UserAlertManager alerts = mock(UserAlertManager.class);
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     ClientContext clientContext = mock(ClientContext.class);
     FetchContext fetchContext = mock(FetchContext.class);
-    ClientEndpoints endpoints = mock(ClientEndpoints.class);
     AtomicReference<List<Object>> bookmarkManagerArguments = new AtomicReference<>();
     AtomicReference<List<Object>> fetchTrackerArguments = new AtomicReference<>();
     AtomicReference<List<Object>> fproxyArguments = new AtomicReference<>();
@@ -247,7 +246,6 @@ class CoreHttpShellRuntimeSupportTest {
     when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
     when(core.getClientContext()).thenReturn(clientContext);
     when(client.getFetchContext()).thenReturn(fetchContext);
-    when(core.getEndpoints()).thenReturn(endpoints);
     CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
 
     try (MockedConstruction<BookmarkManager> bookmarkManagers =
@@ -280,7 +278,7 @@ class CoreHttpShellRuntimeSupportTest {
       assertSame(bookmarkManagers.constructed().getFirst(), bootstrap.bookmarkManager());
       assertSame(client, bootstrap.client());
       assertSame(fproxies.constructed().getFirst(), bootstrap.fproxy());
-      verify(endpoints).setFProxy(fproxies.constructed().getFirst());
+      verify(core, never()).getEndpoints();
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the obsolete `FProxyToadlet` storage and `getFProxy()` / `setFProxy(...)` accessors from `ClientEndpoints`
- stop `CoreHttpShellRuntimeSupport` from publishing the constructed FProxy into `core.getEndpoints()` while keeping bootstrap construction and registrar flow unchanged
- update nearby HTTP bootstrap docs/comments and focused tests to reflect that FProxy stays on the bootstrap/registrar path rather than being stored on client endpoints

## How to test
- `./gradlew compileJava testClasses --no-configuration-cache`
- `./gradlew test --tests "network.crypta.runtime.endpoints.ClientEndpointsTest" --tests "network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupportTest" --tests "network.crypta.clients.http.SimpleToadletServerTest" --tests "network.crypta.node.NodeClientCoreTest" --no-configuration-cache`
- `./gradlew test --tests "network.crypta.runtime.endpoints.ClientEndpointsTest" --tests "network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupportTest" --tests "network.crypta.clients.http.SimpleToadletServerTest" --tests "network.crypta.node.NodeClientCoreTest" --no-configuration-cache --rerun-tasks`
- `./gradlew test`
- `rg -n "FProxyToadlet|getFProxy\(|setFProxy\(" src/main/java src/test/java`

## Notes
- behavior of FProxy creation and registration is unchanged; the deleted publication path was the last top-level runtime dependency on the concrete adapter type