### PR TITLE
refactor(runtime): Narrow admin bridge wiring

### DIFF
--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -2,14 +2,11 @@ package network.crypta.runtime.admin;
 
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.NodeFile;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
 import network.crypta.runtime.admin.queue.QueueAdminBackend;
-import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
-import network.crypta.runtime.endpoints.fcp.FcpQueuePageBackend;
-import network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPort;
-import network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPort;
-import network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPort;
-import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
+import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
 
 /**
  * Creates the legacy admin and page-oriented runtime SPI adapters as one package-owned bundle.
@@ -42,19 +39,20 @@ public final class AdminRuntimePortsFactory {
    * @return immutable bundle containing the moved admin and page-oriented runtime adapters
    */
   public static AdminRuntimePortsBundle create(Node node, NodeClientCore core) {
-    QueueAdminBackend queueBackend = new FcpQueueAdminBackend(core);
+    QueueAdminBackend queueBackend = FcpQueuePorts.adminBackend(core);
+    QueuePageBackend queuePageBackend = FcpQueuePorts.pageBackend(core);
+    GeoIpCountryLookup geoIpCountryLookup = HttpGeoIpCountryLookups.forNode(node);
     return new AdminRuntimePortsBundle(
-        new LegacyConnectionsPagePort(
-            node, new HttpGeoIpCountryLookup(NodeFile.IPV4_TO_COUNTRY.getFile(node))),
+        new LegacyConnectionsPagePort(node, geoIpCountryLookup),
         new LegacyConnectionsSupportPort(node),
         new LegacyDarknetConnectionsPort(node),
         new LegacyDarknetMessagingPort(node),
         new LegacyDiagnosticPort(node, core, queueBackend),
         new LegacyPageChromePort(node),
-        new LegacyQueueCompletionPort(core),
-        new LegacyQueuePagePort(core, new FcpQueuePageBackend(core)),
-        new LegacyQueueDownloadPort(core),
-        new LegacyQueueInsertPort(core),
+        FcpQueuePorts.completionPort(core),
+        new LegacyQueuePagePort(core, queuePageBackend),
+        FcpQueuePorts.downloadPort(core),
+        FcpQueuePorts.insertPort(core),
         new LegacyQueueMutationPort(queueBackend),
         new LegacyQueueSupportPort(core, queueBackend),
         new LegacyStatisticsPort(node, core),

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePorts.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePorts.java
@@ -1,0 +1,103 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
+
+/**
+ * Bridge-owned factory methods for the FCP queue adapters.
+ *
+ * <p>This class keeps the constructor knowledge for the queue bridge local to the {@code
+ * network.crypta.runtime.endpoints.fcp} package while exposing only the narrow runtime seams
+ * upstream. Runtime-owned wiring code can call these methods without naming the concrete bridge
+ * implementations that still belong to the FCP endpoint package. That keeps the ownership split
+ * explicit while leaving queue behavior, lazy endpoint resolution, and exception mapping in the
+ * existing adapter classes.
+ *
+ * <p>Each method is intentionally mechanical. It allocates the same bridge implementation that the
+ * runtime admin factory previously constructed directly, passes through the same {@link
+ * NodeClientCore} instance, and adds no caching or policy of its own. Callers therefore get the
+ * same queue semantics and lifecycle expectations as before this refactor.
+ */
+public final class FcpQueuePorts {
+  private FcpQueuePorts() {}
+
+  /**
+   * Creates the FCP-backed queue-admin bridge used by runtime-admin diagnostics and mutations.
+   *
+   * <p>The returned backend delegates queue inspection and mutation calls to the existing FCP
+   * bridge layer. This method performs no validation, caching, or eager endpoint initialization. It
+   * simply preserves the historical constructor wiring while exposing only the runtime-owned {@link
+   * QueueAdminBackend} seam to callers outside the package.
+   *
+   * @param core live daemon client core that the bridge uses to resolve current FCP endpoints
+   * @return queue-admin backend backed by the existing FCP bridge implementation for {@code core}
+   */
+  public static QueueAdminBackend adminBackend(NodeClientCore core) {
+    return new FcpQueueAdminBackend(core);
+  }
+
+  /**
+   * Creates the FCP-backed queue-page bridge used to read queue state for HTML rendering.
+   *
+   * <p>The returned backend is the same page-oriented adapter that the runtime-admin wiring used
+   * previously. It remains responsible for translating live FCP queue state into runtime-owned page
+   * views, while this factory method keeps only the constructor knowledge inside the bridge-owned
+   * package.
+   *
+   * @param core live daemon client core that provides access to the current FCP endpoint bundle
+   * @return queue-page backend backed by the existing FCP bridge implementation for {@code core}
+   */
+  public static QueuePageBackend pageBackend(NodeClientCore core) {
+    return new FcpQueuePageBackend(core);
+  }
+
+  /**
+   * Creates the bridge that enqueues persistent downloads through the legacy FCP path.
+   *
+   * <p>This method preserves the existing download-port construction exactly. The returned adapter
+   * still owns request translation, policy rejection mapping, and lazy FCP server lookup. The
+   * factory itself remains a thin package-owned entry point, so runtime-admin code does not import
+   * the concrete bridge class directly.
+   *
+   * @param core live daemon client core used by the download bridge for queue access and policy
+   *     checks
+   * @return queue-download port backed by the existing FCP bridge implementation for {@code core}
+   */
+  public static QueueDownloadPort downloadPort(NodeClientCore core) {
+    return new LegacyQueueDownloadPort(core);
+  }
+
+  /**
+   * Creates the bridge that enqueues persistent inserts through the legacy FCP path.
+   *
+   * <p>The returned adapter is unchanged from the previous wiring. It still translates detached
+   * insert requests into the legacy FCP insert flow and defers all queue semantics to the existing
+   * implementation. This method exists only to keep the constructor dependency local to the bridge
+   * package.
+   *
+   * @param core live daemon client core used by the insert bridge to reach the current FCP server
+   * @return queue-insert port backed by the existing FCP bridge implementation for {@code core}
+   */
+  public static QueueInsertPort insertPort(NodeClientCore core) {
+    return new LegacyQueueInsertPort(core);
+  }
+
+  /**
+   * Creates the bridge that exposes completed-request queue operations through the runtime SPI.
+   *
+   * <p>The returned adapter continues to use the existing legacy completion-port implementation,
+   * including its current persistence access and identifier loading behavior. This method adds no
+   * new policy. It only narrows the dependency that external wiring code takes on the bridge
+   * package.
+   *
+   * @param core live daemon client core that supplies the completion bridge with endpoint access
+   * @return queue-completion port backed by the existing FCP bridge implementation for {@code core}
+   */
+  public static QueueCompletionPort completionPort(NodeClientCore core) {
+    return new LegacyQueueCompletionPort(core);
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/http/geoip/HttpGeoIpCountryLookups.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/geoip/HttpGeoIpCountryLookups.java
@@ -1,0 +1,43 @@
+package network.crypta.runtime.endpoints.http.geoip;
+
+import java.io.File;
+import network.crypta.node.Node;
+import network.crypta.node.NodeFile;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
+
+/**
+ * Factory methods for HTTP-backed GeoIP country lookups.
+ *
+ * <p>This utility keeps the file-selection logic for the HTTP GeoIP bridge inside the bridge
+ * package. Runtime-admin code can ask for a {@link GeoIpCountryLookup} without depending on the
+ * concrete {@link HttpGeoIpCountryLookup} constructor or on the daemon's GeoIP database path
+ * lookup. The returned lookup preserves the existing behavior of the HTTP bridge: it reads the
+ * current IPv4-to-country database for the supplied node and delegates country resolution to the
+ * legacy HTTP adapter.
+ *
+ * <p>The class intentionally owns only the last piece of wiring that still depends on {@link
+ * NodeFile}. It does not cache database handles, inspect the selected file, or reinterpret the
+ * lookup results. Callers therefore keep the same best-effort GeoIP behavior that the Connections
+ * page already used, while runtime-admin depends only on its own lookup seam plus this narrow
+ * bridge-owned entry point.
+ */
+public final class HttpGeoIpCountryLookups {
+  private HttpGeoIpCountryLookups() {}
+
+  /**
+   * Creates a GeoIP lookup backed by the HTTP bridge for the supplied node.
+   *
+   * <p>The method resolves the current IPv4-to-country database file from the node and uses it to
+   * construct the existing HTTP GeoIP adapter. It does not cache the resulting lookup, interpret
+   * the database contents, or change how country or flag resolution works. Repeated calls therefore
+   * continue to create fresh bridge instances in the same way the old runtime-admin wiring did,
+   * leaving database selection and singleton behavior to the underlying HTTP GeoIP implementation.
+   *
+   * @param node live daemon node used to locate the current IPv4-to-country database file
+   * @return GeoIP lookup that resolves countries through the existing HTTP bridge for {@code node}
+   */
+  public static GeoIpCountryLookup forNode(Node node) {
+    File dbFile = NodeFile.IPV4_TO_COUNTRY.getFile(node);
+    return new HttpGeoIpCountryLookup(dbFile);
+  }
+}


### PR DESCRIPTION
## Summary
- add bridge-owned `FcpQueuePorts` factory helpers for the FCP queue bridges
- add `HttpGeoIpCountryLookups.forNode(node)` to keep HTTP GeoIP construction inside the bridge package
- rewire `AdminRuntimePortsFactory` to depend on narrow bridge entry points instead of concrete bridge implementations while keeping behavior unchanged
- enrich Javadoc on the two new bridge utility classes and verify them with single-file doclint runs

## How to test
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests "network.crypta.runtime.admin.*"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.fcp.*"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.http.geoip.*"`
- `./gradlew test`

Implements PR-108.