### PR TITLE
refactor(runtime.admin): Prepare bridge factory seams

### DIFF
--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -3,8 +3,6 @@ package network.crypta.runtime.admin;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
-import network.crypta.runtime.admin.queue.QueueAdminBackend;
-import network.crypta.runtime.admin.queue.page.QueuePageBackend;
 import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
 import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
 
@@ -39,22 +37,21 @@ public final class AdminRuntimePortsFactory {
    * @return immutable bundle containing the moved admin and page-oriented runtime adapters
    */
   public static AdminRuntimePortsBundle create(Node node, NodeClientCore core) {
-    QueueAdminBackend queueBackend = FcpQueuePorts.adminBackend(core);
-    QueuePageBackend queuePageBackend = FcpQueuePorts.pageBackend(core);
+    FcpQueuePorts.Bundle queuePorts = FcpQueuePorts.create(core);
     GeoIpCountryLookup geoIpCountryLookup = HttpGeoIpCountryLookups.forNode(node);
     return new AdminRuntimePortsBundle(
         new LegacyConnectionsPagePort(node, geoIpCountryLookup),
         new LegacyConnectionsSupportPort(node),
         new LegacyDarknetConnectionsPort(node),
         new LegacyDarknetMessagingPort(node),
-        new LegacyDiagnosticPort(node, core, queueBackend),
+        new LegacyDiagnosticPort(node, core, queuePorts.adminBackend()),
         new LegacyPageChromePort(node),
-        FcpQueuePorts.completionPort(core),
-        new LegacyQueuePagePort(core, queuePageBackend),
-        FcpQueuePorts.downloadPort(core),
-        FcpQueuePorts.insertPort(core),
-        new LegacyQueueMutationPort(queueBackend),
-        new LegacyQueueSupportPort(core, queueBackend),
+        queuePorts.completionPort(),
+        new LegacyQueuePagePort(core, queuePorts.pageBackend()),
+        queuePorts.downloadPort(),
+        queuePorts.insertPort(),
+        new LegacyQueueMutationPort(queuePorts.adminBackend()),
+        new LegacyQueueSupportPort(core, queuePorts.adminBackend()),
         new LegacyStatisticsPort(node, core),
         new LegacyFirstTimeWizardPort(node, core),
         new LegacyToadletSymlinkPort(node, core),

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePorts.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpQueuePorts.java
@@ -8,96 +8,54 @@ import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
 
 /**
- * Bridge-owned factory methods for the FCP queue adapters.
+ * Bridge-owned factory entrypoints for the FCP queue adapters.
  *
  * <p>This class keeps the constructor knowledge for the queue bridge local to the {@code
  * network.crypta.runtime.endpoints.fcp} package while exposing only the narrow runtime seams
- * upstream. Runtime-owned wiring code can call these methods without naming the concrete bridge
- * implementations that still belong to the FCP endpoint package. That keeps the ownership split
- * explicit while leaving queue behavior, lazy endpoint resolution, and exception mapping in the
- * existing adapter classes.
+ * upstream. Runtime-owned wiring code can call the bundle factory without naming the concrete
+ * bridge implementations that still belong to the FCP endpoint package. That keeps the ownership
+ * split explicit while leaving queue behavior, lazy endpoint resolution, and exception mapping in
+ * the existing adapter classes.
  *
- * <p>Each method is intentionally mechanical. It allocates the same bridge implementation that the
- * runtime admin factory previously constructed directly, passes through the same {@link
- * NodeClientCore} instance, and adds no caching or policy of its own. Callers therefore get the
- * same queue semantics and lifecycle expectations as before this refactor.
+ * <p>The bundle returned by {@link #create(NodeClientCore)} is intentionally mechanical. It
+ * allocates the same bridge implementations that the runtime admin factory previously constructed
+ * directly, passes through the same {@link NodeClientCore} instance, and adds no caching or policy
+ * of its own. Callers therefore get the same queue semantics and lifecycle expectations as before
+ * this refactor.
  */
 public final class FcpQueuePorts {
   private FcpQueuePorts() {}
 
   /**
-   * Creates the FCP-backed queue-admin bridge used by runtime-admin diagnostics and mutations.
+   * Bundle of queue-related runtime-owned ports backed by the FCP bridge implementations.
    *
-   * <p>The returned backend delegates queue inspection and mutation calls to the existing FCP
-   * bridge layer. This method performs no validation, caching, or eager endpoint initialization. It
-   * simply preserves the historical constructor wiring while exposing only the runtime-owned {@link
-   * QueueAdminBackend} seam to callers outside the package.
-   *
-   * @param core live daemon client core that the bridge uses to resolve current FCP endpoints
-   * @return queue-admin backend backed by the existing FCP bridge implementation for {@code core}
+   * <p>The bundle is a pure value object. It carries the existing queue bridge instances behind the
+   * runtime-owned interfaces so the caller can wire them without depending on the concrete FCP
+   * adapter classes.
    */
-  public static QueueAdminBackend adminBackend(NodeClientCore core) {
-    return new FcpQueueAdminBackend(core);
-  }
+  public record Bundle(
+      QueueAdminBackend adminBackend,
+      QueuePageBackend pageBackend,
+      QueueCompletionPort completionPort,
+      QueueDownloadPort downloadPort,
+      QueueInsertPort insertPort) {}
 
   /**
-   * Creates the FCP-backed queue-page bridge used to read queue state for HTML rendering.
+   * Creates the FCP-backed queue bridge bundle used by runtime-admin wiring.
    *
-   * <p>The returned backend is the same page-oriented adapter that the runtime-admin wiring used
-   * previously. It remains responsible for translating live FCP queue state into runtime-owned page
-   * views, while this factory method keeps only the constructor knowledge inside the bridge-owned
-   * package.
+   * <p>The returned bundle contains the exact bridge implementations previously created directly by
+   * the admin runtime factory. Each member preserves the historical constructor wiring and behavior
+   * for queue inspection, rendering, completion tracking, download handling, and insert handling.
    *
-   * @param core live daemon client core that provides access to the current FCP endpoint bundle
-   * @return queue-page backend backed by the existing FCP bridge implementation for {@code core}
+   * @param core live daemon client core used by all queue bridge adapters in the bundle
+   * @return immutable bundle containing the runtime-owned queue bridge interfaces for {@code core}
    */
-  public static QueuePageBackend pageBackend(NodeClientCore core) {
-    return new FcpQueuePageBackend(core);
-  }
-
-  /**
-   * Creates the bridge that enqueues persistent downloads through the legacy FCP path.
-   *
-   * <p>This method preserves the existing download-port construction exactly. The returned adapter
-   * still owns request translation, policy rejection mapping, and lazy FCP server lookup. The
-   * factory itself remains a thin package-owned entry point, so runtime-admin code does not import
-   * the concrete bridge class directly.
-   *
-   * @param core live daemon client core used by the download bridge for queue access and policy
-   *     checks
-   * @return queue-download port backed by the existing FCP bridge implementation for {@code core}
-   */
-  public static QueueDownloadPort downloadPort(NodeClientCore core) {
-    return new LegacyQueueDownloadPort(core);
-  }
-
-  /**
-   * Creates the bridge that enqueues persistent inserts through the legacy FCP path.
-   *
-   * <p>The returned adapter is unchanged from the previous wiring. It still translates detached
-   * insert requests into the legacy FCP insert flow and defers all queue semantics to the existing
-   * implementation. This method exists only to keep the constructor dependency local to the bridge
-   * package.
-   *
-   * @param core live daemon client core used by the insert bridge to reach the current FCP server
-   * @return queue-insert port backed by the existing FCP bridge implementation for {@code core}
-   */
-  public static QueueInsertPort insertPort(NodeClientCore core) {
-    return new LegacyQueueInsertPort(core);
-  }
-
-  /**
-   * Creates the bridge that exposes completed-request queue operations through the runtime SPI.
-   *
-   * <p>The returned adapter continues to use the existing legacy completion-port implementation,
-   * including its current persistence access and identifier loading behavior. This method adds no
-   * new policy. It only narrows the dependency that external wiring code takes on the bridge
-   * package.
-   *
-   * @param core live daemon client core that supplies the completion bridge with endpoint access
-   * @return queue-completion port backed by the existing FCP bridge implementation for {@code core}
-   */
-  public static QueueCompletionPort completionPort(NodeClientCore core) {
-    return new LegacyQueueCompletionPort(core);
+  public static Bundle create(NodeClientCore core) {
+    QueueAdminBackend adminBackend = new FcpQueueAdminBackend(core);
+    QueuePageBackend pageBackend = new FcpQueuePageBackend(core);
+    QueueCompletionPort completionPort = new LegacyQueueCompletionPort(core);
+    QueueDownloadPort downloadPort = new LegacyQueueDownloadPort(core);
+    QueueInsertPort insertPort = new LegacyQueueInsertPort(core);
+    return new Bundle(adminBackend, pageBackend, completionPort, downloadPort, insertPort);
   }
 }

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueuePortsTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpQueuePortsTest.java
@@ -1,0 +1,52 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.node.NodeClientCore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class FcpQueuePortsTest {
+
+  @Mock private NodeClientCore core;
+
+  @Test
+  void create_whenCalled_expectLegacyBridgeTypes() {
+    FcpQueuePorts.Bundle bundle = FcpQueuePorts.create(core);
+
+    assertAll(
+        () -> assertInstanceOf(FcpQueueAdminBackend.class, bundle.adminBackend()),
+        () -> assertInstanceOf(FcpQueuePageBackend.class, bundle.pageBackend()),
+        () -> assertInstanceOf(LegacyQueueCompletionPort.class, bundle.completionPort()),
+        () -> assertInstanceOf(LegacyQueueDownloadPort.class, bundle.downloadPort()),
+        () -> assertInstanceOf(LegacyQueueInsertPort.class, bundle.insertPort()));
+  }
+
+  @Test
+  void create_whenCalled_expectNoEagerCoreInteractions() {
+    FcpQueuePorts.create(core);
+
+    verifyNoInteractions(core);
+  }
+
+  @Test
+  void create_whenCalledTwice_expectFreshBridgeInstances() {
+    FcpQueuePorts.Bundle first = FcpQueuePorts.create(core);
+    FcpQueuePorts.Bundle second = FcpQueuePorts.create(core);
+
+    assertAll(
+        () -> assertNotSame(first, second),
+        () -> assertNotSame(first.adminBackend(), second.adminBackend()),
+        () -> assertNotSame(first.pageBackend(), second.pageBackend()),
+        () -> assertNotSame(first.completionPort(), second.completionPort()),
+        () -> assertNotSame(first.downloadPort(), second.downloadPort()),
+        () -> assertNotSame(first.insertPort(), second.insertPort()));
+  }
+}


### PR DESCRIPTION
## Summary
- replace the remaining direct FCP queue bridge construction in `AdminRuntimePortsFactory` with a single `FcpQueuePorts.create(core)` bundle handoff
- keep `runtime.admin` dependent on runtime-owned interfaces while preserving the existing HTTP GeoIP bridge entrypoint and legacy bridge behavior
- add focused `FcpQueuePortsTest` coverage for bridge types, lazy construction, and fresh bundle instances

## Testing
- `./gradlew compileJava`
- `./gradlew test --tests "network.crypta.runtime.core.LegacyRuntimePortsTest"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackendTest"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.fcp.FcpQueuePageBackendTest"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookupTest"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.fcp.FcpQueuePortsTest"`
- `./gradlew test`