### PR TITLE
refactor(runtime): Add HTTP shell factory seam

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -44,6 +44,7 @@ import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
 import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
+import network.crypta.runtime.endpoints.http.HttpShellContainers;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.Fields;
 import network.crypta.support.HexUtil;
@@ -585,7 +586,7 @@ public final class Node implements TimeSkewDetectorCallback {
     this.nodeStarter = ns;
     this.messaging = new NodeMessagingSubsystem();
     this.bootstrap = new NodeBootstrap(this);
-    this.services = new NodeServicesSubsystem(this);
+    this.services = new NodeServicesSubsystem(this, HttpShellContainers.defaultFactory());
     NodeConfigManager configManager = new NodeConfigManager(this);
     this.network = new NodeNetworkSubsystem(this);
     this.storage = new NodeStorageSubsystem(this);

--- a/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainerFactory.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainerFactory.java
@@ -1,0 +1,43 @@
+package network.crypta.runtime.endpoints.http;
+
+import network.crypta.config.InvalidConfigValueException;
+import network.crypta.config.SubConfig;
+import network.crypta.support.PriorityAwareExecutor;
+
+/**
+ * Creates runtime-owned {@link HttpShellContainer} instances for node-facing HTTP services.
+ *
+ * <p>This interface is the narrow seam between runtime bootstrap code and the concrete HTTP shell
+ * bridge implementation. Callers such as the node services subsystem depend on this factory instead
+ * of naming a specific shell host directly. That keeps concrete bridge construction localized to
+ * the runtime HTTP endpoint package and makes startup wiring easier to test.
+ *
+ * <p>The contract is intentionally small. A factory implementation receives the already-selected
+ * FProxy sub-configuration and executor, constructs a matching shell container, and returns the
+ * runtime-facing wrapper. The interface does not define caching, singleton behavior, or lifecycle
+ * ownership beyond creation; callers remain responsible for deciding when to start and manage the
+ * returned container.
+ *
+ * @see HttpShellContainer
+ */
+public interface HttpShellContainerFactory {
+
+  /**
+   * Creates a new HTTP shell container for the supplied FProxy configuration and executor.
+   *
+   * <p>Implementations should translate the provided runtime configuration into a concrete shell
+   * host without widening the dependency surface that runtime code must see. The method is expected
+   * to return a fresh container suitable for one startup path. It does not start the container,
+   * finalize configuration, or apply any separate lifecycle policy on behalf of the caller.
+   *
+   * @param fproxyConfig FProxy sub-configuration that supplies listener and shell initialization
+   *     values
+   * @param executor priority-aware executor that the created shell uses for request-adjacent work
+   * @return a newly constructed runtime-facing container that wraps the concrete HTTP shell
+   *     implementation
+   * @throws InvalidConfigValueException if the supplied FProxy configuration cannot produce a valid
+   *     shell container
+   */
+  HttpShellContainer create(SubConfig fproxyConfig, PriorityAwareExecutor executor)
+      throws InvalidConfigValueException;
+}

--- a/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainers.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainers.java
@@ -7,9 +7,9 @@ import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.io.ArrayBucketFactory;
 
 /**
- * Factory helpers for runtime-owned HTTP shell container wiring.
+ * Default factory provider for runtime-owned HTTP shell container wiring.
  *
- * <p>This utility centralizes creation of the runtime-facing HTTP shell seam, so bootstrap and
+ * <p>This class centralizes creation of the runtime-facing HTTP shell seam, so bootstrap and
  * service code do not instantiate the legacy HTTP shell implementation directly. The class has no
  * policy of its own: it preserves the existing concrete construction path, including the current
  * bucket-factory choice and executor handoff, and simply returns the narrow {@link
@@ -21,8 +21,23 @@ import network.crypta.support.io.ArrayBucketFactory;
  * localized to this package rather than spreading new direct references back into bootstrap or
  * endpoint wiring code.
  */
-public final class HttpShellContainers {
+public final class HttpShellContainers implements HttpShellContainerFactory {
+  private static final HttpShellContainerFactory DEFAULT_FACTORY = new HttpShellContainers();
+
   private HttpShellContainers() {}
+
+  /**
+   * Returns the default runtime-owned HTTP shell container factory.
+   *
+   * <p>This preserves the legacy {@link SimpleToadletServer}-backed construction path behind a
+   * narrow seam so runtime bootstrap code can depend on factory injection instead of static helper
+   * calls.
+   *
+   * @return singleton factory preserving the current concrete HTTP shell construction behavior
+   */
+  public static HttpShellContainerFactory defaultFactory() {
+    return DEFAULT_FACTORY;
+  }
 
   /**
    * Creates the runtime-owned HTTP shell container backed by {@link SimpleToadletServer}.
@@ -41,7 +56,8 @@ public final class HttpShellContainers {
    * @throws InvalidConfigValueException if the supplied FProxy configuration cannot produce a valid
    *     concrete shell server
    */
-  public static HttpShellContainer create(SubConfig fproxyConfig, PriorityAwareExecutor executor)
+  @Override
+  public HttpShellContainer create(SubConfig fproxyConfig, PriorityAwareExecutor executor)
       throws InvalidConfigValueException {
     return new SimpleToadletServerHttpShellContainer(
         new SimpleToadletServer(fproxyConfig, new ArrayBucketFactory(), executor));

--- a/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
+++ b/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
@@ -19,6 +19,7 @@ import network.crypta.runtime.alerts.TimeSkewDetectedUserAlert;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.diagnostics.DefaultNodeDiagnostics;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
+import network.crypta.runtime.endpoints.http.HttpShellContainerFactory;
 import network.crypta.runtime.endpoints.http.HttpShellContainers;
 import network.crypta.support.JVMVersion;
 import network.crypta.support.PriorityAwareExecutor;
@@ -54,6 +55,7 @@ import network.crypta.support.Ticker;
  */
 public final class NodeServicesSubsystem {
   private final Node node;
+  private final HttpShellContainerFactory httpShellContainerFactory;
   private HttpShellContainer toadlets;
   private network.crypta.node.NodeClientCore clientCore;
   private network.crypta.runtime.updater.NodeUpdateManager nodeUpdater;
@@ -76,7 +78,22 @@ public final class NodeServicesSubsystem {
    * @param node owning node used for configuration, storage, and service wiring; must be non-null.
    */
   public NodeServicesSubsystem(Node node) {
+    this(node, HttpShellContainers.defaultFactory());
+  }
+
+  /**
+   * Creates a services subsystem bound to a specific node instance and HTTP shell factory seam.
+   *
+   * <p>The supplied factory controls HTTP shell construction while preserving the existing startup
+   * order and lifecycle. Production code should pass the runtime package's default factory
+   * explicitly, while tests may inject a mock or stub implementation.
+   *
+   * @param node owning node used for configuration, storage, and service wiring; must be non-null.
+   * @param httpShellContainerFactory factory used to create the runtime-owned HTTP shell container
+   */
+  public NodeServicesSubsystem(Node node, HttpShellContainerFactory httpShellContainerFactory) {
     this.node = node;
+    this.httpShellContainerFactory = httpShellContainerFactory;
   }
 
   /**
@@ -96,7 +113,7 @@ public final class NodeServicesSubsystem {
       throws NodeInitException {
     SubConfig fproxyConfig = config.createSubConfig("fproxy");
     try {
-      toadlets = HttpShellContainers.create(fproxyConfig, executor);
+      toadlets = httpShellContainerFactory.create(fproxyConfig, executor);
       fproxyConfig.finishedInitialization();
       toadlets.start();
     } catch (InvalidConfigValueException e4) {

--- a/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
@@ -38,7 +38,8 @@ import static org.mockito.Mockito.when;
 class HttpShellContainersTest {
 
   @Test
-  void create_whenCalled_wrapsSimpleToadletServerAndDelegatesSeamMethods() throws Exception {
+  void defaultFactory_whenCreateCalled_wrapsSimpleToadletServerAndDelegatesSeamMethods()
+      throws Exception {
     SubConfig fproxyConfig = mock(SubConfig.class);
     PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
     StartupToadlet startupToadlet = mock(StartupToadlet.class);
@@ -58,7 +59,8 @@ class HttpShellContainersTest {
               when(server.isFProxyJavascriptEnabled()).thenReturn(false);
               when(server.isLinkExcepted(uri)).thenReturn(true);
             })) {
-      HttpShellContainer container = HttpShellContainers.create(fproxyConfig, executor);
+      HttpShellContainerFactory factory = HttpShellContainers.defaultFactory();
+      HttpShellContainer container = factory.create(fproxyConfig, executor);
 
       assertEquals(1, construction.constructed().size());
       SimpleToadletServer server = construction.constructed().getFirst();

--- a/src/test/java/network/crypta/runtime/services/NodeServicesSubsystemTest.java
+++ b/src/test/java/network/crypta/runtime/services/NodeServicesSubsystemTest.java
@@ -2,6 +2,7 @@ package network.crypta.runtime.services;
 
 import java.io.File;
 import network.crypta.config.BooleanCallback;
+import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.Option;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
@@ -21,7 +22,7 @@ import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.diagnostics.DefaultNodeDiagnostics;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
-import network.crypta.runtime.endpoints.http.HttpShellContainers;
+import network.crypta.runtime.endpoints.http.HttpShellContainerFactory;
 import network.crypta.runtime.updater.NodeUpdateManager;
 import network.crypta.support.JVMVersion;
 import network.crypta.support.PriorityAwareExecutor;
@@ -41,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.inOrder;
@@ -66,42 +66,30 @@ class NodeServicesSubsystemTest {
   @Mock private PersistentConfig config;
   @Mock private SubConfig subConfig;
   @Mock private PriorityAwareExecutor executor;
+  @Mock private HttpShellContainerFactory httpShellContainerFactory;
 
   @Test
   void startWebInterface_whenInitialized_startsAndExposesToadletServer() throws Exception {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     when(config.createSubConfig("fproxy")).thenReturn(subConfig);
     HttpShellContainer toadlets = mock(HttpShellContainer.class);
+    when(httpShellContainerFactory.create(subConfig, executor)).thenReturn(toadlets);
 
-    try (MockedStatic<HttpShellContainers> factoryMock = mockStatic(HttpShellContainers.class)) {
-      factoryMock.when(() -> HttpShellContainers.create(subConfig, executor)).thenReturn(toadlets);
+    subsystem.startWebInterface(config, executor);
 
-      subsystem.startWebInterface(config, executor);
-
-      assertSame(toadlets, subsystem.toadlets());
-      InOrder order = inOrder(subConfig, toadlets);
-      order.verify(subConfig).finishedInitialization();
-      order.verify(toadlets).start();
-      factoryMock.verify(() -> HttpShellContainers.create(subConfig, executor));
-    }
+    assertSame(toadlets, subsystem.toadlets());
+    InOrder order = inOrder(httpShellContainerFactory, subConfig, toadlets);
+    order.verify(httpShellContainerFactory).create(subConfig, executor);
+    order.verify(subConfig).finishedInitialization();
+    order.verify(toadlets).start();
   }
 
   @Test
-  void startWebInterface_whenConfigInvalid_throwsNodeInitException() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+  void startWebInterface_whenConfigInvalid_throwsNodeInitException() throws Exception {
+    NodeServicesSubsystem subsystem = newSubsystem();
     when(config.createSubConfig("fproxy")).thenReturn(subConfig);
-    when(subConfig.getString(anyString()))
-        .thenAnswer(
-            invocation -> {
-              String key = invocation.getArgument(0, String.class);
-              if ("css".equals(key)) {
-                return "bad:css";
-              }
-              if ("refilterPolicy".equals(key)) {
-                return "RE_FILTER";
-              }
-              return "";
-            });
+    when(httpShellContainerFactory.create(subConfig, executor))
+        .thenThrow(new InvalidConfigValueException("bad:css"));
 
     NodeInitException ex =
         assertThrows(NodeInitException.class, () -> subsystem.startWebInterface(config, executor));
@@ -112,7 +100,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void initUpdater_whenMaybeCreateReturns_setsUpdater() throws Exception {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     NodeUpdateManager updater = mock(NodeUpdateManager.class);
 
     try (MockedStatic<NodeUpdateManager> mocked = mockStatic(NodeUpdateManager.class)) {
@@ -126,7 +114,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void initDiagnostics_whenNetworkProvided_createsDiagnostics() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     when(network.stats()).thenReturn(mock(network.crypta.node.NodeStats.class));
     when(network.ticker()).thenReturn(ticker);
 
@@ -138,7 +126,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void initNodeNameUserAlert_whenCalled_createsAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
 
     subsystem.initNodeNameUserAlert();
 
@@ -148,7 +136,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void registerJvmVersionAlertIfNeeded_whenEol_registersAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
 
@@ -163,7 +151,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void registerNotEnoughNiceLevelsAlert_whenClientCorePresent_registersAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
 
@@ -174,7 +162,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void warnIfNotUsingWrapper_whenWarningRequired_registersAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
 
@@ -185,7 +173,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void warnIfNotUsingWrapper_whenUsingWrapper_skipsAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
 
     subsystem.warnIfNotUsingWrapper(true, false);
@@ -195,7 +183,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void registerCantDeletePasswordFileAlert_whenClientCorePresent_registersCriticalAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
     when(node.storage()).thenReturn(storage);
@@ -208,7 +196,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void configurePeersOffersFrefFiles_whenDismissed_unregistersExistingAlert() throws Exception {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
     PeersOffersUserAlert existingAlert = mock(PeersOffersUserAlert.class);
@@ -229,7 +217,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void configurePeersOffersFrefFiles_whenNotDismissed_createsAlert() throws Exception {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     when(subConfig.getBoolean(PEERS_OFFERS_DISMISSED)).thenReturn(false);
 
     ArgumentCaptor<BooleanCallback> captor = ArgumentCaptor.forClass(BooleanCallback.class);
@@ -249,7 +237,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void maybeCreatePeersOffersAlertIfNeeded_whenNotDismissedAndHasFiles_createsAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     when(subConfig.getBoolean(PEERS_OFFERS_DISMISSED)).thenReturn(false);
 
     subsystem.configurePeersOffersFrefFiles(subConfig, 1);
@@ -263,7 +251,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void setTimeSkewDetectedUserAlert_whenCalledTwice_registersOnce() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
 
@@ -275,7 +263,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void createVisibilityAlert_whenNotShown_registersAndQueuesStore() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
     when(node.network()).thenReturn(network);
@@ -296,7 +284,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void createVisibilityAlert_whenDismissed_clearsFlagPersistsAndUnregistersAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
     when(node.network()).thenReturn(network);
@@ -318,7 +306,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void createVisibilityAlert_whenRegistered_usesExistingLocalizedVisibilityStrings() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     when(clientCore.getAlerts()).thenReturn(alerts);
     when(node.network()).thenReturn(network);
@@ -346,7 +334,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void maybeRegisterVisibilityAlert_whenAlertsNotReady_queuesRetry() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setShowFriendsVisibilityAlert(true);
     when(node.network()).thenReturn(network);
     when(network.ticker()).thenReturn(ticker);
@@ -359,7 +347,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void clearVisibilityAlert_whenCalled_unregistersAlertAndResetsFlag() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
     subsystem.setShowFriendsVisibilityAlert(true);
     when(clientCore.getAlerts()).thenReturn(alerts);
@@ -372,7 +360,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void registerJvmVersionAlertIfNeeded_whenNoClientCore_skipsAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
 
     subsystem.registerJvmVersionAlertIfNeeded();
 
@@ -381,7 +369,7 @@ class NodeServicesSubsystemTest {
 
   @Test
   void registerNotEnoughNiceLevelsAlert_whenNoClientCore_skipsAlert() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
 
     subsystem.registerNotEnoughNiceLevelsAlert();
 
@@ -390,11 +378,15 @@ class NodeServicesSubsystemTest {
 
   @Test
   void warnIfNotUsingWrapper_whenSkipped_doesNotRegister() {
-    NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+    NodeServicesSubsystem subsystem = newSubsystem();
     subsystem.setClientCore(clientCore);
 
     subsystem.warnIfNotUsingWrapper(false, true);
 
     verify(alerts, never()).register(any(UserAlert.class));
+  }
+
+  private NodeServicesSubsystem newSubsystem() {
+    return new NodeServicesSubsystem(node, httpShellContainerFactory);
   }
 }


### PR DESCRIPTION
## Summary
- add a runtime-owned `HttpShellContainerFactory` seam in `runtime.endpoints.http`
- make `HttpShellContainers` expose the default legacy factory while preserving `SimpleToadletServer` construction behavior
- inject the factory into `NodeServicesSubsystem` and wire the default factory explicitly from `Node`
- update the subsystem and container tests to use seam injection instead of static helper mocking
- document the new interface contract with doclint-clean Javadoc

## How to test
- `./gradlew compileJava`
- `./gradlew test --tests 'network.crypta.runtime.services.NodeServicesSubsystemTest'`
- `./gradlew test --tests 'network.crypta.runtime.endpoints.http.HttpShellContainersTest'`
- `./gradlew test --tests 'network.crypta.node.NodeTest'`

## Notes
- behavior is intentionally unchanged in this prep PR
- the concrete `SimpleToadletServer` bridge remains localized in `runtime.endpoints.http` for now