### PR TITLE
refactor(runtime): Add HTTP shell creation seam

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -586,7 +586,7 @@ public final class Node implements TimeSkewDetectorCallback {
     this.nodeStarter = ns;
     this.messaging = new NodeMessagingSubsystem();
     this.bootstrap = new NodeBootstrap(this);
-    this.services = new NodeServicesSubsystem(this, HttpShellContainers.defaultFactory());
+    this.services = new NodeServicesSubsystem(this, HttpShellContainers::create);
     NodeConfigManager configManager = new NodeConfigManager(this);
     this.network = new NodeNetworkSubsystem(this);
     this.storage = new NodeStorageSubsystem(this);

--- a/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainerFactory.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainerFactory.java
@@ -20,6 +20,7 @@ import network.crypta.support.PriorityAwareExecutor;
  *
  * @see HttpShellContainer
  */
+@FunctionalInterface
 public interface HttpShellContainerFactory {
 
   /**

--- a/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainers.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainers.java
@@ -7,7 +7,7 @@ import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.io.ArrayBucketFactory;
 
 /**
- * Default factory provider for runtime-owned HTTP shell container wiring.
+ * Static factory helpers for runtime-owned HTTP shell container wiring.
  *
  * <p>This class centralizes creation of the runtime-facing HTTP shell seam, so bootstrap and
  * service code do not instantiate the legacy HTTP shell implementation directly. The class has no
@@ -21,23 +21,8 @@ import network.crypta.support.io.ArrayBucketFactory;
  * localized to this package rather than spreading new direct references back into bootstrap or
  * endpoint wiring code.
  */
-public final class HttpShellContainers implements HttpShellContainerFactory {
-  private static final HttpShellContainerFactory DEFAULT_FACTORY = new HttpShellContainers();
-
+public final class HttpShellContainers {
   private HttpShellContainers() {}
-
-  /**
-   * Returns the default runtime-owned HTTP shell container factory.
-   *
-   * <p>This preserves the legacy {@link SimpleToadletServer}-backed construction path behind a
-   * narrow seam so runtime bootstrap code can depend on factory injection instead of static helper
-   * calls.
-   *
-   * @return singleton factory preserving the current concrete HTTP shell construction behavior
-   */
-  public static HttpShellContainerFactory defaultFactory() {
-    return DEFAULT_FACTORY;
-  }
 
   /**
    * Creates the runtime-owned HTTP shell container backed by {@link SimpleToadletServer}.
@@ -56,8 +41,7 @@ public final class HttpShellContainers implements HttpShellContainerFactory {
    * @throws InvalidConfigValueException if the supplied FProxy configuration cannot produce a valid
    *     concrete shell server
    */
-  @Override
-  public HttpShellContainer create(SubConfig fproxyConfig, PriorityAwareExecutor executor)
+  public static HttpShellContainer create(SubConfig fproxyConfig, PriorityAwareExecutor executor)
       throws InvalidConfigValueException {
     return new SimpleToadletServerHttpShellContainer(
         new SimpleToadletServer(fproxyConfig, new ArrayBucketFactory(), executor));

--- a/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
+++ b/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
@@ -78,15 +78,15 @@ public final class NodeServicesSubsystem {
    * @param node owning node used for configuration, storage, and service wiring; must be non-null.
    */
   public NodeServicesSubsystem(Node node) {
-    this(node, HttpShellContainers.defaultFactory());
+    this(node, HttpShellContainers::create);
   }
 
   /**
    * Creates a services subsystem bound to a specific node instance and HTTP shell factory seam.
    *
    * <p>The supplied factory controls HTTP shell construction while preserving the existing startup
-   * order and lifecycle. Production code should pass the runtime package's default factory
-   * explicitly, while tests may inject a mock or stub implementation.
+   * order and lifecycle. Production code should pass the runtime package's static construction
+   * helper explicitly, while tests may inject a mock or stub implementation.
    *
    * @param node owning node used for configuration, storage, and service wiring; must be non-null.
    * @param httpShellContainerFactory factory used to create the runtime-owned HTTP shell container

--- a/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 class HttpShellContainersTest {
 
   @Test
-  void defaultFactory_whenCreateCalled_wrapsSimpleToadletServerAndDelegatesSeamMethods()
+  void createMethodReference_whenCreateCalled_wrapsSimpleToadletServerAndDelegatesSeamMethods()
       throws Exception {
     SubConfig fproxyConfig = mock(SubConfig.class);
     PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
@@ -59,7 +59,7 @@ class HttpShellContainersTest {
               when(server.isFProxyJavascriptEnabled()).thenReturn(false);
               when(server.isLinkExcepted(uri)).thenReturn(true);
             })) {
-      HttpShellContainerFactory factory = HttpShellContainers.defaultFactory();
+      HttpShellContainerFactory factory = HttpShellContainers::create;
       HttpShellContainer container = factory.create(fproxyConfig, executor);
 
       assertEquals(1, construction.constructed().size());


### PR DESCRIPTION
## Summary
- add a narrow `HttpShellContainerFactory` method-reference seam for runtime-owned HTTP shell creation
- wire `NodeServicesSubsystem` and `Node` through `HttpShellContainers::create` instead of the singleton-style default factory helper
- keep behavior unchanged while preserving the focused helper test around the seam shape

## How to test
- `./gradlew test --tests 'network.crypta.runtime.services.NodeServicesSubsystemTest'`
- `./gradlew test --tests 'network.crypta.runtime.endpoints.http.HttpShellContainersTest'`
- `./gradlew compileJava testClasses`
- `rg -n "HttpShellContainers\.create\(" src/main/java src/test/java`
- `rg -n "mockStatic\(HttpShellContainers" src/test/java`
