### PR TITLE
refactor(runtime): Clean up HTTP bridge seams

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -42,9 +42,8 @@ import network.crypta.runtime.bootstrap.NodeBootstrap;
 import network.crypta.runtime.bootstrap.NodeConfigManager;
 import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
-import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
-import network.crypta.runtime.endpoints.http.HttpShellContainers;
+import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.Fields;
 import network.crypta.support.HexUtil;
@@ -586,7 +585,7 @@ public final class Node implements TimeSkewDetectorCallback {
     this.nodeStarter = ns;
     this.messaging = new NodeMessagingSubsystem();
     this.bootstrap = new NodeBootstrap(this);
-    this.services = new NodeServicesSubsystem(this, HttpShellContainers::create);
+    this.services = new NodeServicesSubsystem(this);
     NodeConfigManager configManager = new NodeConfigManager(this);
     this.network = new NodeNetworkSubsystem(this);
     this.storage = new NodeStorageSubsystem(this);
@@ -709,7 +708,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
             persistentSecret);
     services.setClientCore(clientCoreLocal);
     HttpShellContainer toadlets = services.toadlets();
-    toadlets.setRuntimeSupport(new CoreHttpShellRuntimeSupport(clientCoreLocal));
+    toadlets.setRuntimeSupport(HttpShellRuntimeSupportFactory.coreBacked().create(clientCoreLocal));
 
     services.registerJvmVersionAlertIfNeeded();
 

--- a/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainerFactory.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/HttpShellContainerFactory.java
@@ -24,6 +24,20 @@ import network.crypta.support.PriorityAwareExecutor;
 public interface HttpShellContainerFactory {
 
   /**
+   * Returns the default runtime-owned HTTP shell factory.
+   *
+   * <p>The default entry point preserves the existing legacy bridge construction path while keeping
+   * concrete shell-host knowledge inside {@code network.crypta.runtime.endpoints.http}. Callers
+   * outside this package can therefore depend on the seam without naming {@link
+   * HttpShellContainers} directly.
+   *
+   * @return factory that creates the current runtime-owned HTTP shell container bridge
+   */
+  static HttpShellContainerFactory defaultFactory() {
+    return HttpShellContainers::create;
+  }
+
+  /**
    * Creates a new HTTP shell container for the supplied FProxy configuration and executor.
    *
    * <p>Implementations should translate the provided runtime configuration into a concrete shell

--- a/src/main/java/network/crypta/runtime/endpoints/http/HttpShellRuntimeSupportFactory.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/HttpShellRuntimeSupportFactory.java
@@ -1,0 +1,55 @@
+package network.crypta.runtime.endpoints.http;
+
+import network.crypta.clients.http.HttpShellRuntimeSupport;
+import network.crypta.node.NodeClientCore;
+
+/**
+ * Creates runtime-owned {@link HttpShellRuntimeSupport} instances for HTTP shell wiring.
+ *
+ * <p>This interface is the narrow construction seam that higher-level runtime code uses when it
+ * needs HTTP shell support backed by a {@link NodeClientCore}. It lets packages outside {@code
+ * network.crypta.runtime.endpoints.http} request runtime support without naming a concrete bridge
+ * class directly. That keeps the endpoint package responsible for binding top-level wiring to the
+ * current implementation while preserving the existing startup behavior.
+ *
+ * <p>Typical callers choose a factory during daemon startup, then invoke {@link
+ * #create(NodeClientCore)} while assembling HTTP shell components. The interface does not define
+ * caching, singleton semantics, or ownership transfer. It only describes how to get a support
+ * object for a given core, and concrete implementations remain free to decide whether each call
+ * returns a new bridge instance.
+ */
+@FunctionalInterface
+public interface HttpShellRuntimeSupportFactory {
+
+  /**
+   * Creates a runtime support bridge for the supplied daemon core.
+   *
+   * <p>The supplied {@code core} becomes the backing runtime object for the returned support
+   * instance. Callers usually invoke this during HTTP shell startup after the node has created its
+   * client core and before endpoint code begins serving requests. This method does not impose
+   * caching requirements, so repeated calls may produce distinct support instances over the same
+   * core when an implementation chooses to do so.
+   *
+   * @param core daemon core that the returned runtime support delegates to for node-backed
+   *     operations
+   * @return a runtime support bridge compatible with the current HTTP shell implementation for the
+   *     supplied daemon core
+   */
+  HttpShellRuntimeSupport create(NodeClientCore core);
+
+  /**
+   * Returns the core-backed runtime support factory used by the current HTTP bridge.
+   *
+   * <p>This helper centralizes the production binding to {@link CoreHttpShellRuntimeSupport} inside
+   * the runtime HTTP endpoint package. Callers outside this package can therefore use the default
+   * runtime path without importing the concrete bridge class directly. The returned factory is
+   * suitable for repeated reuse anywhere the current node runtime should preserve the legacy
+   * core-backed behavior.
+   *
+   * @return factory that constructs {@link CoreHttpShellRuntimeSupport} instances from a supplied
+   *     daemon core
+   */
+  static HttpShellRuntimeSupportFactory coreBacked() {
+    return CoreHttpShellRuntimeSupport::new;
+  }
+}

--- a/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
+++ b/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
@@ -20,7 +20,6 @@ import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.diagnostics.DefaultNodeDiagnostics;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.endpoints.http.HttpShellContainerFactory;
-import network.crypta.runtime.endpoints.http.HttpShellContainers;
 import network.crypta.support.JVMVersion;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -78,15 +77,15 @@ public final class NodeServicesSubsystem {
    * @param node owning node used for configuration, storage, and service wiring; must be non-null.
    */
   public NodeServicesSubsystem(Node node) {
-    this(node, HttpShellContainers::create);
+    this(node, HttpShellContainerFactory.defaultFactory());
   }
 
   /**
    * Creates a services subsystem bound to a specific node instance and HTTP shell factory seam.
    *
    * <p>The supplied factory controls HTTP shell construction while preserving the existing startup
-   * order and lifecycle. Production code should pass the runtime package's static construction
-   * helper explicitly, while tests may inject a mock or stub implementation.
+   * order and lifecycle. Tests may inject a mock or stub implementation while production code can
+   * continue to use the default runtime-owned seam entry point.
    *
    * @param node owning node used for configuration, storage, and service wiring; must be non-null.
    * @param httpShellContainerFactory factory used to create the runtime-owned HTTP shell container

--- a/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
@@ -59,7 +59,7 @@ class HttpShellContainersTest {
               when(server.isFProxyJavascriptEnabled()).thenReturn(false);
               when(server.isLinkExcepted(uri)).thenReturn(true);
             })) {
-      HttpShellContainerFactory factory = HttpShellContainers::create;
+      HttpShellContainerFactory factory = HttpShellContainerFactory.defaultFactory();
       HttpShellContainer container = factory.create(fproxyConfig, executor);
 
       assertEquals(1, construction.constructed().size());

--- a/src/test/java/network/crypta/runtime/endpoints/http/HttpShellRuntimeSupportFactoryTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/HttpShellRuntimeSupportFactoryTest.java
@@ -1,0 +1,25 @@
+package network.crypta.runtime.endpoints.http;
+
+import network.crypta.clients.http.HttpShellRuntimeSupport;
+import network.crypta.node.NodeClientCore;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+@SuppressWarnings("java:S100")
+class HttpShellRuntimeSupportFactoryTest {
+
+  @Test
+  void coreBacked_whenCreateCalled_returnsCoreBackedRuntimeSupport() {
+    NodeClientCore core = mock(NodeClientCore.class);
+
+    HttpShellRuntimeSupport runtimeSupport =
+        HttpShellRuntimeSupportFactory.coreBacked().create(core);
+
+    CoreHttpShellRuntimeSupport coreRuntimeSupport =
+        assertInstanceOf(CoreHttpShellRuntimeSupport.class, runtimeSupport);
+    assertSame(core, coreRuntimeSupport.core());
+  }
+}

--- a/src/test/java/network/crypta/runtime/services/NodeServicesSubsystemTest.java
+++ b/src/test/java/network/crypta/runtime/services/NodeServicesSubsystemTest.java
@@ -85,6 +85,29 @@ class NodeServicesSubsystemTest {
   }
 
   @Test
+  void startWebInterface_whenConstructedWithDefaultFactory_usesDefaultFactorySeam()
+      throws Exception {
+    when(config.createSubConfig("fproxy")).thenReturn(subConfig);
+    HttpShellContainer toadlets = mock(HttpShellContainer.class);
+
+    try (MockedStatic<HttpShellContainerFactory> mocked =
+        mockStatic(HttpShellContainerFactory.class)) {
+      mocked.when(HttpShellContainerFactory::defaultFactory).thenReturn(httpShellContainerFactory);
+      when(httpShellContainerFactory.create(subConfig, executor)).thenReturn(toadlets);
+      NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
+
+      subsystem.startWebInterface(config, executor);
+
+      mocked.verify(HttpShellContainerFactory::defaultFactory);
+      assertSame(toadlets, subsystem.toadlets());
+      InOrder order = inOrder(httpShellContainerFactory, subConfig, toadlets);
+      order.verify(httpShellContainerFactory).create(subConfig, executor);
+      order.verify(subConfig).finishedInitialization();
+      order.verify(toadlets).start();
+    }
+  }
+
+  @Test
   void startWebInterface_whenConfigInvalid_throwsNodeInitException() throws Exception {
     NodeServicesSubsystem subsystem = newSubsystem();
     when(config.createSubConfig("fproxy")).thenReturn(subConfig);


### PR DESCRIPTION
## Summary
- add runtime-owned seam entry points for HTTP shell container and runtime support construction
- route `NodeServicesSubsystem` through `HttpShellContainerFactory.defaultFactory()` so runtime services no longer name `HttpShellContainers` directly
- route `Node` through the default services seam and `HttpShellRuntimeSupportFactory.coreBacked()` so top-level node wiring no longer imports concrete HTTP bridge classes
- keep the existing startup order and configuration path intact, and add focused tests for the new seams

## How to test
- `./gradlew compileJava`
- `./gradlew test --tests "network.crypta.runtime.services.NodeServicesSubsystemTest"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.http.HttpShellContainersTest"`
- `./gradlew test --tests "network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactoryTest"`