### PR TITLE
refactor(runtime-admin): Clean up AdminRuntimePortsFactory seam

### DIFF
--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputs.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputs.java
@@ -1,0 +1,52 @@
+package network.crypta.runtime.admin;
+
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
+
+/**
+ * Carries the runtime-owned bridge inputs needed to assemble the admin runtime-port bundle.
+ *
+ * <p>{@link network.crypta.runtime.core.LegacyRuntimePorts} creates this record at the runtime
+ * composition root after it has already chosen the concrete bridge factories for queue handling and
+ * GeoIP lookup. {@link AdminRuntimePortsFactory} then consumes the record and wires the legacy
+ * admin adapters without importing endpoint-owned factory entry points. That keeps the wiring
+ * explicit while preserving the existing daemon-backed behavior for queue pages, queue mutations,
+ * diagnostics, and connections-page country rendering.
+ *
+ * <p>The record is intentionally mechanical. It does not validate, normalize, cache, or lazily
+ * resolve any of its members. Callers are expected to populate every component with the live seam
+ * or port instance that should back one {@link AdminRuntimePortsBundle}. The record itself is
+ * immutable and thread-safe, but the contained adapters remain live views over the mutable daemon
+ * state.
+ *
+ * <ul>
+ *   <li>Queue read and mutation seams stay grouped in one handoff object.
+ *   <li>GeoIP lookup wiring stays explicit without widening {@code runtime-spi}.
+ *   <li>Construction ownership stays in runtime core, not in {@code runtime.admin}.
+ * </ul>
+ *
+ * @param queueAdminBackend queue backend seam used by diagnostics, support helpers, and generic
+ *     queue mutations
+ * @param queuePageBackend queue page seam used to render detached queue-page snapshots and exports
+ * @param queueCompletionPort queue completion port that exposes the existing completion-oriented
+ *     bridge behavior
+ * @param queueDownloadPort queue download mutation port that preserves the current bridge behavior
+ *     for downloads
+ * @param queueInsertPort queue insert mutation port that preserves the current bridge behavior for
+ *     inserts
+ * @param geoIpCountryLookup GeoIP lookup seam used when rendering country information on the
+ *     Connections page
+ * @see AdminRuntimePortsFactory
+ * @see network.crypta.runtime.core.LegacyRuntimePorts
+ */
+public record AdminRuntimeBridgeInputs(
+    QueueAdminBackend queueAdminBackend,
+    QueuePageBackend queuePageBackend,
+    QueueCompletionPort queueCompletionPort,
+    QueueDownloadPort queueDownloadPort,
+    QueueInsertPort queueInsertPort,
+    GeoIpCountryLookup geoIpCountryLookup) {}

--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -2,9 +2,6 @@ package network.crypta.runtime.admin;
 
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
-import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
-import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
-import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
 
 /**
  * Creates the legacy admin and page-oriented runtime SPI adapters as one package-owned bundle.
@@ -29,29 +26,30 @@ public final class AdminRuntimePortsFactory {
    * <p>Callers normally invoke this once while assembling {@link
    * network.crypta.runtime.core.LegacyRuntimePorts}. The returned bundle contains the exact legacy
    * adapter set that was moved out of {@code network.crypta.runtime.core}, with queue-oriented
-   * adapters bound to {@code core} and page or node-state adapters bound to {@code node}. The
-   * method performs no validation beyond the constructors it delegates to.
+   * adapters bound to {@code core}, page or node-state adapters bound to {@code node}, and
+   * bridge-owned construction supplied by the runtime composition root. The method performs no
+   * validation beyond the constructors it delegates to.
    *
    * @param node live daemon node used by node-backed admin adapters and page state lookups
    * @param core live client core used by queue, wizard, and persistence-oriented adapters
+   * @param bridgeInputs runtime-owned bridge seams and ports constructed by the composition root
    * @return immutable bundle containing the moved admin and page-oriented runtime adapters
    */
-  public static AdminRuntimePortsBundle create(Node node, NodeClientCore core) {
-    FcpQueuePorts.Bundle queuePorts = FcpQueuePorts.create(core);
-    GeoIpCountryLookup geoIpCountryLookup = HttpGeoIpCountryLookups.forNode(node);
+  public static AdminRuntimePortsBundle create(
+      Node node, NodeClientCore core, AdminRuntimeBridgeInputs bridgeInputs) {
     return new AdminRuntimePortsBundle(
-        new LegacyConnectionsPagePort(node, geoIpCountryLookup),
+        new LegacyConnectionsPagePort(node, bridgeInputs.geoIpCountryLookup()),
         new LegacyConnectionsSupportPort(node),
         new LegacyDarknetConnectionsPort(node),
         new LegacyDarknetMessagingPort(node),
-        new LegacyDiagnosticPort(node, core, queuePorts.adminBackend()),
+        new LegacyDiagnosticPort(node, core, bridgeInputs.queueAdminBackend()),
         new LegacyPageChromePort(node),
-        queuePorts.completionPort(),
-        new LegacyQueuePagePort(core, queuePorts.pageBackend()),
-        queuePorts.downloadPort(),
-        queuePorts.insertPort(),
-        new LegacyQueueMutationPort(queuePorts.adminBackend()),
-        new LegacyQueueSupportPort(core, queuePorts.adminBackend()),
+        bridgeInputs.queueCompletionPort(),
+        new LegacyQueuePagePort(core, bridgeInputs.queuePageBackend()),
+        bridgeInputs.queueDownloadPort(),
+        bridgeInputs.queueInsertPort(),
+        new LegacyQueueMutationPort(bridgeInputs.queueAdminBackend()),
+        new LegacyQueueSupportPort(core, bridgeInputs.queueAdminBackend()),
         new LegacyStatisticsPort(node, core),
         new LegacyFirstTimeWizardPort(node, core),
         new LegacyToadletSymlinkPort(node, core),

--- a/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
@@ -4,8 +4,11 @@ import java.io.File;
 import java.util.Random;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
 import network.crypta.runtime.admin.AdminRuntimePortsBundle;
 import network.crypta.runtime.admin.AdminRuntimePortsFactory;
+import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
+import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
@@ -173,7 +176,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
 
-    AdminRuntimePortsBundle adminRuntimePorts = AdminRuntimePortsFactory.create(node, core);
+    FcpQueuePorts.Bundle queuePorts = FcpQueuePorts.create(core);
+    AdminRuntimeBridgeInputs bridgeInputs =
+        new AdminRuntimeBridgeInputs(
+            queuePorts.adminBackend(),
+            queuePorts.pageBackend(),
+            queuePorts.completionPort(),
+            queuePorts.downloadPort(),
+            queuePorts.insertPort(),
+            HttpGeoIpCountryLookups.forNode(node));
+    AdminRuntimePortsBundle adminRuntimePorts =
+        AdminRuntimePortsFactory.create(node, core, bridgeInputs);
     this.connectionsPagePort = adminRuntimePorts.connectionsPage();
     this.connectionsSupportPort = adminRuntimePorts.connectionsSupport();
     this.darknetConnectionsPort = adminRuntimePorts.darknetConnections();


### PR DESCRIPTION
## Summary
- add `AdminRuntimeBridgeInputs` as the runtime-owned handoff for queue and GeoIP bridge inputs
- refactor `AdminRuntimePortsFactory` to depend only on runtime-owned seams and ports
- move `FcpQueuePorts` and `HttpGeoIpCountryLookups` construction into `LegacyRuntimePorts`
- keep the change mechanical and preserve existing wiring behavior

## How to test
- `./gradlew compileJava`
- `./gradlew test --tests network.crypta.runtime.core.LegacyRuntimePortsTest`
- `./gradlew test --tests network.crypta.runtime.endpoints.fcp.FcpQueuePortsTest`
- `./gradlew test --tests network.crypta.runtime.admin.LegacyConnectionsPagePortTest`
- `./gradlew test --tests network.crypta.runtime.admin.LegacyDiagnosticPortTest`