### PR TITLE
refactor(runtime): Move admin bridge assembly into NodeClientCore

### DIFF
--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -22,6 +22,7 @@ import network.crypta.crypt.RandomSource;
 import network.crypta.keys.Key;
 import network.crypta.keys.NodeSSK;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
 import network.crypta.runtime.bootstrap.NodeStarter;
@@ -32,6 +33,8 @@ import network.crypta.runtime.endpoints.ClientEndpoints;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
 import network.crypta.runtime.endpoints.NodeClientPersistence;
 import network.crypta.runtime.endpoints.TextModeClientInterface;
+import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
+import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
 import network.crypta.runtime.persistence.Persistable;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Base64;
@@ -387,7 +390,7 @@ public final class NodeClientCore implements Persistable {
     sortOrder = transferPolicy.registerDownloadAllowedDirs(init, sortOrder);
 
     sortOrder = transferPolicy.registerUploadAllowedDirs(init, sortOrder);
-    runtimePorts = new LegacyRuntimePorts(node, this);
+    runtimePorts = new LegacyRuntimePorts(node, this, createAdminRuntimeBridgeInputs(node, this));
 
     LOG.info("Initializing USK Manager");
     uskManager.init(getClientContext());
@@ -591,6 +594,18 @@ public final class NodeClientCore implements Persistable {
       long uid = random.nextLong();
       if (uid != -1) return uid;
     }
+  }
+
+  private static AdminRuntimeBridgeInputs createAdminRuntimeBridgeInputs(
+      Node node, NodeClientCore core) {
+    FcpQueuePorts.Bundle queuePorts = FcpQueuePorts.create(core);
+    return new AdminRuntimeBridgeInputs(
+        queuePorts.adminBackend(),
+        queuePorts.pageBackend(),
+        queuePorts.completionPort(),
+        queuePorts.downloadPort(),
+        queuePorts.insertPort(),
+        HttpGeoIpCountryLookups.forNode(node));
   }
 
   private FilenameGenerator createTempFilenameGeneratorOrThrow() throws NodeInitException {

--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputs.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputs.java
@@ -10,12 +10,11 @@ import network.crypta.runtime.spi.QueueInsertPort;
 /**
  * Carries the runtime-owned bridge inputs needed to assemble the admin runtime-port bundle.
  *
- * <p>{@link network.crypta.runtime.core.LegacyRuntimePorts} creates this record at the runtime
- * composition root after it has already chosen the concrete bridge factories for queue handling and
- * GeoIP lookup. {@link AdminRuntimePortsFactory} then consumes the record and wires the legacy
- * admin adapters without importing endpoint-owned factory entry points. That keeps the wiring
- * explicit while preserving the existing daemon-backed behavior for queue pages, queue mutations,
- * diagnostics, and connections-page country rendering.
+ * <p>The runtime composition root creates this record after it has already chosen the concrete
+ * bridge factories for queue handling and GeoIP lookup. {@link AdminRuntimePortsFactory} then
+ * consumes the record and wires the legacy admin adapters without importing endpoint-owned factory
+ * entry points. That keeps the wiring explicit while preserving the existing daemon-backed behavior
+ * for queue pages, queue mutations, diagnostics, and connections-page country rendering.
  *
  * <p>The record is intentionally mechanical. It does not validate, normalize, cache, or lazily
  * resolve any of its members. Callers are expected to populate every component with the live seam

--- a/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
+++ b/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
@@ -1,14 +1,13 @@
 package network.crypta.runtime.core;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.Random;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
 import network.crypta.runtime.admin.AdminRuntimePortsBundle;
 import network.crypta.runtime.admin.AdminRuntimePortsFactory;
-import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
-import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
@@ -96,8 +95,9 @@ public final class LegacyRuntimePorts implements RuntimePorts {
    *
    * @param node live daemon node that provides execution, randomness, and lifecycle behavior
    * @param core live client core that provides transfer-policy checks and directory access
+   * @param bridgeInputs runtime-owned admin bridge seams assembled by the composition root
    */
-  public LegacyRuntimePorts(Node node, NodeClientCore core) {
+  public LegacyRuntimePorts(Node node, NodeClientCore core, AdminRuntimeBridgeInputs bridgeInputs) {
     this.node = node;
     this.core = core;
     this.executionPort =
@@ -176,17 +176,8 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.nodeInfoPort = new LegacyNodeInfoPort(node);
     this.peerPort = new LegacyPeerPort(node);
 
-    FcpQueuePorts.Bundle queuePorts = FcpQueuePorts.create(core);
-    AdminRuntimeBridgeInputs bridgeInputs =
-        new AdminRuntimeBridgeInputs(
-            queuePorts.adminBackend(),
-            queuePorts.pageBackend(),
-            queuePorts.completionPort(),
-            queuePorts.downloadPort(),
-            queuePorts.insertPort(),
-            HttpGeoIpCountryLookups.forNode(node));
     AdminRuntimePortsBundle adminRuntimePorts =
-        AdminRuntimePortsFactory.create(node, core, bridgeInputs);
+        AdminRuntimePortsFactory.create(node, core, Objects.requireNonNull(bridgeInputs));
     this.connectionsPagePort = adminRuntimePorts.connectionsPage();
     this.connectionsSupportPort = adminRuntimePorts.connectionsSupport();
     this.darknetConnectionsPort = adminRuntimePorts.darknetConnections();

--- a/src/test/java/network/crypta/node/NodeClientCoreTest.java
+++ b/src/test/java/network/crypta/node/NodeClientCoreTest.java
@@ -18,6 +18,10 @@ import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.NodeSSK;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.core.LegacyRuntimePorts;
 import network.crypta.runtime.endpoints.ClientEndpoints;
@@ -25,6 +29,9 @@ import network.crypta.runtime.endpoints.NodeClientPersistence;
 import network.crypta.runtime.endpoints.fcp.FcpEndpointHandles;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.services.NodeServicesSubsystem;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.SimpleFieldSet;
@@ -84,6 +91,12 @@ class NodeClientCoreTest {
   @Mock private PersistentConfig config;
   @Mock private PriorityAwareExecutor executor;
   @Mock private IPDetectorManager ipDetectorManager;
+  @Mock private QueueAdminBackend queueAdminBackend;
+  @Mock private QueuePageBackend queuePageBackend;
+  @Mock private QueueCompletionPort queueCompletionPort;
+  @Mock private QueueDownloadPort queueDownloadPort;
+  @Mock private QueueInsertPort queueInsertPort;
+  @Mock private GeoIpCountryLookup geoIpCountryLookup;
 
   @TempDir Path tempDir; // base dir for downloads and test files
 
@@ -138,7 +151,15 @@ class NodeClientCoreTest {
     uskManager = Mockito.mock(USKManager.class);
     setField(core, "transfers", transfers);
     setField(core, "uskManager", uskManager);
-    runtimePorts = new LegacyRuntimePorts(node, core);
+    AdminRuntimeBridgeInputs bridgeInputs =
+        new AdminRuntimeBridgeInputs(
+            queueAdminBackend,
+            queuePageBackend,
+            queueCompletionPort,
+            queueDownloadPort,
+            queueInsertPort,
+            geoIpCountryLookup);
+    runtimePorts = new LegacyRuntimePorts(node, core, bridgeInputs);
     setField(core, "runtimePorts", runtimePorts);
     NodeIPDetector nodeIpDetector = Mockito.mock(NodeIPDetector.class);
     setField(nodeIpDetector, NodeIPDetector.class, "ipDetectorManager", ipDetectorManager);

--- a/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
@@ -5,6 +5,13 @@ import java.util.Random;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
 import network.crypta.support.PriorityAwareExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +45,12 @@ class LegacyRuntimePortsTest {
 
   @Mock private PriorityAwareExecutor executor;
   @Mock private RandomSource secureRandom;
+  @Mock private QueueAdminBackend queueAdminBackend;
+  @Mock private QueuePageBackend queuePageBackend;
+  @Mock private QueueCompletionPort queueCompletionPort;
+  @Mock private QueueDownloadPort queueDownloadPort;
+  @Mock private QueueInsertPort queueInsertPort;
+  @Mock private GeoIpCountryLookup geoIpCountryLookup;
 
   private final Random weakRandom = new Random(1234L);
   private final File downloadsDir = new File("downloads");
@@ -57,7 +70,15 @@ class LegacyRuntimePortsTest {
     when(core.getAllowedUploadDirs()).thenReturn(allowedUploadDirs);
     when(core.getAllowedDownloadDirs()).thenReturn(allowedDownloadDirs);
 
-    ports = new LegacyRuntimePorts(node, core);
+    AdminRuntimeBridgeInputs bridgeInputs =
+        new AdminRuntimeBridgeInputs(
+            queueAdminBackend,
+            queuePageBackend,
+            queueCompletionPort,
+            queueDownloadPort,
+            queueInsertPort,
+            geoIpCountryLookup);
+    ports = new LegacyRuntimePorts(node, core, bridgeInputs);
   }
 
   @Test
@@ -105,7 +126,7 @@ class LegacyRuntimePortsTest {
   }
 
   @Test
-  void getters_whenRequested_expectLegacyAdapterTypes() {
+  void getters_whenRequested_expectInjectedBridgePortsAndLegacyAdapterTypes() {
     PortsSnapshot snapshot = capturePorts();
 
     assertAll(
@@ -140,22 +161,13 @@ class LegacyRuntimePortsTest {
             assertInstanceOf(
                 loadClass("network.crypta.runtime.admin.LegacyQueueSupportPort"),
                 snapshot.queueSupportPort()),
-        () ->
-            assertInstanceOf(
-                loadClass("network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPort"),
-                snapshot.queueCompletionPort()),
+        () -> assertSame(queueCompletionPort, snapshot.queueCompletionPort()),
         () ->
             assertInstanceOf(
                 loadClass("network.crypta.runtime.admin.LegacyQueuePagePort"),
                 snapshot.queuePagePort()),
-        () ->
-            assertInstanceOf(
-                loadClass("network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPort"),
-                snapshot.queueDownloadPort()),
-        () ->
-            assertInstanceOf(
-                loadClass("network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPort"),
-                snapshot.queueInsertPort()),
+        () -> assertSame(queueDownloadPort, snapshot.queueDownloadPort()),
+        () -> assertSame(queueInsertPort, snapshot.queueInsertPort()),
         () ->
             assertInstanceOf(
                 loadClass("network.crypta.runtime.admin.LegacyQueueMutationPort"),


### PR DESCRIPTION
## Summary
- inject `AdminRuntimeBridgeInputs` into `LegacyRuntimePorts` instead of assembling endpoint-owned bridge inputs inside the runtime-core adapter
- move the existing FCP queue and GeoIP bridge-input assembly into `NodeClientCore` so behavior stays unchanged while the seam ownership becomes explicit
- update the focused `LegacyRuntimePortsTest` and `NodeClientCoreTest` cases to use mocked bridge-input members rather than concrete endpoint bridge construction

## How to test
- `./gradlew compileJava compileTestJava`
- `./gradlew test --tests "network.crypta.runtime.core.LegacyRuntimePortsTest"`
- `./gradlew test --tests "network.crypta.node.NodeClientCoreTest"`
