### PR TITLE
refactor(runtime): Move admin bridge wiring behind factory seam

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -42,6 +42,7 @@ import network.crypta.runtime.bootstrap.NodeBootstrap;
 import network.crypta.runtime.bootstrap.NodeConfigManager;
 import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
+import network.crypta.runtime.endpoints.admin.AdminRuntimeBridgeInputsFactories;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
 import network.crypta.runtime.services.NodeServicesSubsystem;
@@ -701,6 +702,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     NodeClientCore clientCoreLocal =
         new NodeClientCore(
             this,
+            AdminRuntimeBridgeInputsFactories.coreBacked(),
             clientCoreInit,
             network.darknetPortNumber(),
             sortOrder,

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -22,7 +22,7 @@ import network.crypta.crypt.RandomSource;
 import network.crypta.keys.Key;
 import network.crypta.keys.NodeSSK;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
-import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
 import network.crypta.runtime.bootstrap.NodeStarter;
@@ -33,8 +33,6 @@ import network.crypta.runtime.endpoints.ClientEndpoints;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
 import network.crypta.runtime.endpoints.NodeClientPersistence;
 import network.crypta.runtime.endpoints.TextModeClientInterface;
-import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
-import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
 import network.crypta.runtime.persistence.Persistable;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Base64;
@@ -192,6 +190,7 @@ public final class NodeClientCore implements Persistable {
 
   NodeClientCore(
       Node node,
+      AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory,
       NodeClientCoreInit init,
       int portNumber,
       int sortOrder,
@@ -390,7 +389,8 @@ public final class NodeClientCore implements Persistable {
     sortOrder = transferPolicy.registerDownloadAllowedDirs(init, sortOrder);
 
     sortOrder = transferPolicy.registerUploadAllowedDirs(init, sortOrder);
-    runtimePorts = new LegacyRuntimePorts(node, this, createAdminRuntimeBridgeInputs(node, this));
+    runtimePorts =
+        new LegacyRuntimePorts(node, this, adminRuntimeBridgeInputsFactory.create(node, this));
 
     LOG.info("Initializing USK Manager");
     uskManager.init(getClientContext());
@@ -594,18 +594,6 @@ public final class NodeClientCore implements Persistable {
       long uid = random.nextLong();
       if (uid != -1) return uid;
     }
-  }
-
-  private static AdminRuntimeBridgeInputs createAdminRuntimeBridgeInputs(
-      Node node, NodeClientCore core) {
-    FcpQueuePorts.Bundle queuePorts = FcpQueuePorts.create(core);
-    return new AdminRuntimeBridgeInputs(
-        queuePorts.adminBackend(),
-        queuePorts.pageBackend(),
-        queuePorts.completionPort(),
-        queuePorts.downloadPort(),
-        queuePorts.insertPort(),
-        HttpGeoIpCountryLookups.forNode(node));
   }
 
   private FilenameGenerator createTempFilenameGeneratorOrThrow() throws NodeInitException {

--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputs.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputs.java
@@ -25,7 +25,7 @@ import network.crypta.runtime.spi.QueueInsertPort;
  * <ul>
  *   <li>Queue read and mutation seams stay grouped in one handoff object.
  *   <li>GeoIP lookup wiring stays explicit without widening {@code runtime-spi}.
- *   <li>Construction ownership stays in runtime core, not in {@code runtime.admin}.
+ *   <li>Construction ownership stays in the composition root, not in {@code runtime.admin}.
  * </ul>
  *
  * @param queueAdminBackend queue backend seam used by diagnostics, support helpers, and generic

--- a/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputsFactory.java
+++ b/src/main/java/network/crypta/runtime/admin/AdminRuntimeBridgeInputsFactory.java
@@ -1,0 +1,36 @@
+package network.crypta.runtime.admin;
+
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+
+/**
+ * Creates the runtime-owned bridge inputs required to assemble the legacy admin runtime ports.
+ *
+ * <p>The factory keeps the concrete bridge assembly behind a narrow seam so composition roots can
+ * choose the implementation without making lower-level code aware of endpoint-specific bridge
+ * classes. Callers typically create one factory during node bootstrap and pass it into the client
+ * core constructor, which then asks the factory for the admin bridge inputs at the same point in
+ * startup where it previously assembled them directly. The seam is intentionally narrow: it exposes
+ * only the owning {@link Node} and live {@link NodeClientCore}, leaving queue, GeoIP, and any
+ * future endpoint-backed bridge construction behind the returned {@link AdminRuntimeBridgeInputs}
+ * value.
+ */
+@FunctionalInterface
+public interface AdminRuntimeBridgeInputsFactory {
+  /**
+   * Creates the bridge inputs used to assemble the legacy admin runtime ports.
+   *
+   * <p>Implementations should construct the same runtime-owned bridge inputs that the daemon would
+   * otherwise wire inline but keep the concrete endpoint knowledge on the factory side of the seam.
+   * The method is called during client-core construction, before HTTP and FCP endpoint startup
+   * completes, so implementations should preserve the existing startup ordering and avoid forcing
+   * eager endpoint initialization.
+   *
+   * @param node live daemon node that owns filesystem layout and other bootstrap-time states needed
+   *     by endpoint-backed bridge adapters
+   * @param core live daemon client core that owns queue, persistence, and endpoint registries used
+   *     by bridge adapters
+   * @return fully assembled runtime-owned bridge inputs for {@code LegacyRuntimePorts}
+   */
+  AdminRuntimeBridgeInputs create(Node node, NodeClientCore core);
+}

--- a/src/main/java/network/crypta/runtime/endpoints/admin/AdminRuntimeBridgeInputsFactories.java
+++ b/src/main/java/network/crypta/runtime/endpoints/admin/AdminRuntimeBridgeInputsFactories.java
@@ -1,0 +1,45 @@
+package network.crypta.runtime.endpoints.admin;
+
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
+import network.crypta.runtime.endpoints.fcp.FcpQueuePorts;
+import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookups;
+
+/**
+ * Endpoint-owned factory entry points for admin bridge inputs.
+ *
+ * <p>This package keeps the concrete bridge construction local to the endpoint layer while exposing
+ * only the runtime-owned factory seam upstream. The class acts as the endpoint-layer composition
+ * helper for the legacy admin runtime adapters that still depend on concrete queue and GeoIP bridge
+ * implementations. Callers above this package see only {@link
+ * network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory}, while this helper preserves the
+ * current bridge choices, constructor arguments, and startup ordering behind that seam.
+ */
+public final class AdminRuntimeBridgeInputsFactories {
+  private AdminRuntimeBridgeInputsFactories() {}
+
+  /**
+   * Returns the default admin bridge-input factory backed by the current endpoint bridge classes.
+   *
+   * <p>The returned factory recreates the same queue and GeoIP bridge assembly that the client core
+   * previously performed inline. It delegates queue adapter construction to {@link FcpQueuePorts}
+   * and resolves the HTTP GeoIP lookup from the supplied node at factory invocation time. The
+   * method adds no caching or policy of its own, so callers retain the existing behavior for queue
+   * access, GeoIP rendering, and startup sequencing.
+   *
+   * @return factory that assembles admin bridge inputs from the existing endpoint-backed bridge
+   *     implementations
+   */
+  public static AdminRuntimeBridgeInputsFactory coreBacked() {
+    return (node, core) -> {
+      FcpQueuePorts.Bundle queuePorts = FcpQueuePorts.create(core);
+      return new AdminRuntimeBridgeInputs(
+          queuePorts.adminBackend(),
+          queuePorts.pageBackend(),
+          queuePorts.completionPort(),
+          queuePorts.downloadPort(),
+          queuePorts.insertPort(),
+          HttpGeoIpCountryLookups.forNode(node));
+    };
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/admin/package-info.java
+++ b/src/main/java/network/crypta/runtime/endpoints/admin/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Endpoint-owned admin endpoint bootstrap glue.
+ *
+ * <p>This package contains the endpoint-layer composition helpers that translate runtime-owned
+ * admin seams into the concrete bridge implementations still provided by endpoint packages. Its
+ * role is intentionally narrow: it keeps constructor knowledge for queue and HTTP-backed admin
+ * bridges near those implementations, while allowing upstream composition roots such as the node
+ * bootstrap path to depend only on runtime-owned factory types. That ownership split keeps endpoint
+ * details out of lower-level runtime wiring without changing queue behavior, GeoIP rendering, or
+ * startup sequencing.
+ */
+package network.crypta.runtime.endpoints.admin;

--- a/src/test/java/network/crypta/runtime/endpoints/admin/AdminRuntimeBridgeInputsFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/admin/AdminRuntimeBridgeInputsFactoriesTest.java
@@ -1,0 +1,83 @@
+package network.crypta.runtime.endpoints.admin;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.ProgramDirectory;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
+import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
+import network.crypta.runtime.endpoints.fcp.FcpQueuePageBackend;
+import network.crypta.runtime.endpoints.fcp.LegacyQueueCompletionPort;
+import network.crypta.runtime.endpoints.fcp.LegacyQueueDownloadPort;
+import network.crypta.runtime.endpoints.fcp.LegacyQueueInsertPort;
+import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class AdminRuntimeBridgeInputsFactoriesTest {
+
+  @Test
+  void coreBacked_whenCreateCalled_returnsBridgeInputsBackedByEndpointFactories() {
+    BridgeFactoryFixture fixture = new BridgeFactoryFixture();
+
+    AdminRuntimeBridgeInputsFactory factory = AdminRuntimeBridgeInputsFactories.coreBacked();
+
+    AdminRuntimeBridgeInputs bridgeInputs = factory.create(fixture.node(), fixture.core());
+
+    assertAll(
+        () -> assertNotNull(factory),
+        () -> assertNotNull(bridgeInputs),
+        () -> assertInstanceOf(FcpQueueAdminBackend.class, bridgeInputs.queueAdminBackend()),
+        () -> assertInstanceOf(FcpQueuePageBackend.class, bridgeInputs.queuePageBackend()),
+        () -> assertInstanceOf(LegacyQueueCompletionPort.class, bridgeInputs.queueCompletionPort()),
+        () -> assertInstanceOf(LegacyQueueDownloadPort.class, bridgeInputs.queueDownloadPort()),
+        () -> assertInstanceOf(LegacyQueueInsertPort.class, bridgeInputs.queueInsertPort()),
+        () -> assertInstanceOf(HttpGeoIpCountryLookup.class, bridgeInputs.geoIpCountryLookup()));
+  }
+
+  @Test
+  void coreBacked_whenCreateCalled_wiresQueueAdaptersToCoreAndGeoIpLookupToNodeFile() {
+    BridgeFactoryFixture fixture = new BridgeFactoryFixture();
+
+    AdminRuntimeBridgeInputs bridgeInputs =
+        AdminRuntimeBridgeInputsFactories.coreBacked().create(fixture.node(), fixture.core());
+
+    assertAll(
+        () -> assertSame(fixture.core(), readField(bridgeInputs.queueAdminBackend(), "core")),
+        () -> assertSame(fixture.core(), readField(bridgeInputs.queuePageBackend(), "core")),
+        () -> assertSame(fixture.core(), readField(bridgeInputs.queueCompletionPort(), "core")),
+        () -> assertSame(fixture.core(), readField(bridgeInputs.queueDownloadPort(), "core")),
+        () -> assertSame(fixture.core(), readField(bridgeInputs.queueInsertPort(), "core")),
+        () ->
+            assertSame(fixture.geoIpDb(), readField(bridgeInputs.geoIpCountryLookup(), "dbFile")));
+  }
+
+  private static Object readField(Object target, String fieldName) {
+    try {
+      Field field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.get(target);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed reading field '" + fieldName + "'", e);
+    }
+  }
+
+  private record BridgeFactoryFixture(Node node, NodeClientCore core, File geoIpDb) {
+    private BridgeFactoryFixture() {
+      this(mock(Node.class), mock(NodeClientCore.class), new File("run/IpToCountry.dat"));
+
+      ProgramDirectory runDir = mock(ProgramDirectory.class);
+      when(node.runDir()).thenReturn(runDir);
+      when(runDir.file("IpToCountry.dat")).thenReturn(geoIpDb);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the runtime-owned `AdminRuntimeBridgeInputsFactory` seam and the endpoint-owned `AdminRuntimeBridgeInputsFactories.coreBacked()` default
- update `NodeClientCore` to consume the seam instead of importing `FcpQueuePorts` and `HttpGeoIpCountryLookups` directly, with `Node` selecting the default implementation as the composition root
- add focused seam coverage in `AdminRuntimeBridgeInputsFactoriesTest` and enrich Javadoc for the new non-test Java files

## How to test
- `./gradlew test --tests 'network.crypta.runtime.endpoints.admin.AdminRuntimeBridgeInputsFactoriesTest'`
- `./gradlew test --tests 'network.crypta.runtime.core.LegacyRuntimePortsTest'`
- `./gradlew test --tests 'network.crypta.node.NodeClientCoreTest'`
- `./gradlew test`

## Notes
- preserves existing queue bridge construction, GeoIP lookup wiring, and startup sequencing while moving the concrete bridge assembly out of `NodeClientCore`
- addresses PR-118
