### PR TITLE
refactor(bootstrap): Move bridge factory defaults to bootstrap

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -38,11 +38,12 @@ import network.crypta.node.subsystem.NodeMessagingSubsystem;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.subsystem.NodeRoutingSubsystem;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.bootstrap.NodeBootstrap;
 import network.crypta.runtime.bootstrap.NodeConfigManager;
+import network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactories;
 import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
-import network.crypta.runtime.endpoints.admin.AdminRuntimeBridgeInputsFactories;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
 import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
 import network.crypta.runtime.services.NodeServicesSubsystem;
@@ -549,6 +550,7 @@ public final class Node implements TimeSkewDetectorCallback {
    * @param weakRandom the fast random source, or {@code null} to derive one from the secure source
    * @param ns the associated starter, or {@code null} for test bootstrap
    * @param executor the executor used by the node runtime
+   * @param runtimeBridgeFactories bootstrap-selected runtime bridge factories
    * @return a newly constructed node instance
    * @throws NodeInitException if the node initialization fails
    */
@@ -557,9 +559,10 @@ public final class Node implements TimeSkewDetectorCallback {
       RandomSource r,
       RandomSource weakRandom,
       NodeStarter ns,
-      PriorityAwareExecutor executor)
+      PriorityAwareExecutor executor,
+      NodeRuntimeBridgeFactories runtimeBridgeFactories)
       throws NodeInitException {
-    return new Node(config, r, weakRandom, ns, executor);
+    return new Node(config, r, weakRandom, ns, executor, runtimeBridgeFactories);
   }
 
   /**
@@ -573,6 +576,7 @@ public final class Node implements TimeSkewDetectorCallback {
    *     will be used, seeded from the secure PRNG.
    * @param ns NodeStarter
    * @param executor Executor
+   * @param runtimeBridgeFactories Bootstrap-selected runtime bridge factories
    * @throws NodeInitException If the node initialization fails.
    */
   Node(
@@ -580,8 +584,15 @@ public final class Node implements TimeSkewDetectorCallback {
       RandomSource r,
       RandomSource weakRandom,
       NodeStarter ns,
-      PriorityAwareExecutor executor)
+      PriorityAwareExecutor executor,
+      NodeRuntimeBridgeFactories runtimeBridgeFactories)
       throws NodeInitException {
+    NodeRuntimeBridgeFactories nodeRuntimeBridgeFactories =
+        Objects.requireNonNull(runtimeBridgeFactories, "runtimeBridgeFactories");
+    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
+        nodeRuntimeBridgeFactories.adminRuntimeBridgeInputsFactory();
+    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
+        nodeRuntimeBridgeFactories.httpShellRuntimeSupportFactory();
     this.executor = executor;
     this.nodeStarter = ns;
     this.messaging = new NodeMessagingSubsystem();
@@ -702,7 +713,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     NodeClientCore clientCoreLocal =
         new NodeClientCore(
             this,
-            AdminRuntimeBridgeInputsFactories.coreBacked(),
+            adminRuntimeBridgeInputsFactory,
             clientCoreInit,
             network.darknetPortNumber(),
             sortOrder,
@@ -710,7 +721,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
             persistentSecret);
     services.setClientCore(clientCoreLocal);
     HttpShellContainer toadlets = services.toadlets();
-    toadlets.setRuntimeSupport(HttpShellRuntimeSupportFactory.coreBacked().create(clientCoreLocal));
+    toadlets.setRuntimeSupport(httpShellRuntimeSupportFactory.create(clientCoreLocal));
 
     services.registerJvmVersionAlertIfNeeded();
 

--- a/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
@@ -1,0 +1,64 @@
+package network.crypta.runtime.bootstrap;
+
+import java.util.Objects;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
+import network.crypta.runtime.endpoints.admin.AdminRuntimeBridgeInputsFactories;
+import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
+
+/**
+ * Bootstrap-owned selection of runtime bridge factories for {@link network.crypta.node.Node}.
+ *
+ * <p>This holder keeps the composition-root decision about which runtime bridge implementations to
+ * use out of the node kernel. Bootstrap code selects the seam implementations once, then passes
+ * them into {@code Node} so the node can stay focused on coordination and lifecycle rather than on
+ * choosing endpoint-backed defaults.
+ *
+ * <p>Typical startup paths create one instance during bootstrap, thread it through {@link
+ * network.crypta.runtime.bootstrap.NodeStarter}, and then let the node reuse those seams at the
+ * same construction points where it previously hard-coded the legacy endpoint pair. The record is
+ * immutable and carries no caching or policy beyond that wiring choice, so startup order and bridge
+ * behavior stay aligned with the existing daemon bootstrap flow.
+ *
+ * @param adminRuntimeBridgeInputsFactory factory for the admin/runtime bridge inputs used by the
+ *     client core
+ * @param httpShellRuntimeSupportFactory factory for HTTP shell runtime support used by the toadlet
+ *     container
+ */
+public record NodeRuntimeBridgeFactories(
+    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory,
+    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory) {
+
+  /**
+   * Creates a bootstrap bridge-factory bundle.
+   *
+   * <p>Both factories are required because node construction expects explicit seams for the admin
+   * runtime bridge inputs and the HTTP shell runtime support path. The constructor only validates
+   * presence; it does not invoke the factories, cache runtime state, or trigger any endpoint
+   * startup work on its own.
+   *
+   * @param adminRuntimeBridgeInputsFactory factory for admin bridge inputs passed into the client
+   *     core during node construction
+   * @param httpShellRuntimeSupportFactory factory for HTTP shell runtime support created after the
+   *     client core exists
+   * @throws NullPointerException if either factory reference is {@code null}
+   */
+  public NodeRuntimeBridgeFactories {
+    Objects.requireNonNull(adminRuntimeBridgeInputsFactory, "adminRuntimeBridgeInputsFactory");
+    Objects.requireNonNull(httpShellRuntimeSupportFactory, "httpShellRuntimeSupportFactory");
+  }
+
+  /**
+   * Returns the legacy default bridge-factory pair backed by the current endpoint implementations.
+   *
+   * <p>This helper centralizes the existing production default in the bootstrap package. Callers
+   * that need the historical daemon wiring can therefore get the same admin and HTTP shell bridge
+   * choices without making the node kernel depend on the endpoint-owned static entry points.
+   *
+   * @return bridge factories that preserve the current core-backed admin and HTTP shell wiring
+   */
+  public static NodeRuntimeBridgeFactories coreBacked() {
+    return new NodeRuntimeBridgeFactories(
+        AdminRuntimeBridgeInputsFactories.coreBacked(),
+        HttpShellRuntimeSupportFactory.coreBacked());
+  }
+}

--- a/src/main/java/network/crypta/runtime/bootstrap/NodeStarter.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/NodeStarter.java
@@ -306,7 +306,12 @@ public class NodeStarter implements WrapperListener {
 
     Node node =
         Node.createForBootstrap(
-            config, params.getRandom(), params.getRandom(), null, params.getExecutor());
+            config,
+            params.getRandom(),
+            params.getRandom(),
+            null,
+            params.getExecutor(),
+            NodeRuntimeBridgeFactories.coreBacked());
 
     // All testing environments connect the nodes as they want, even if the old setup is restored,
     // it is not desired.
@@ -554,7 +559,9 @@ public class NodeStarter implements WrapperListener {
     initSSL(cfg);
 
     try {
-      node = Node.createForBootstrap(cfg, null, null, this, executor);
+      node =
+          Node.createForBootstrap(
+              cfg, null, null, this, executor, NodeRuntimeBridgeFactories.coreBacked());
       installSeednodesIfMissing(node);
       node.start(false);
       LOG.info("Node initialization completed");

--- a/src/main/java/network/crypta/runtime/bootstrap/package-info.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/package-info.java
@@ -3,7 +3,8 @@
  *
  * <p>This package groups the neutral runtime helpers that handle CLI parsing, startup logging
  * configuration, the wrapper lifecycle bridge, program-directory setup, and early bootstrap/config
- * wiring during daemon startup. The classes remain part of the daemon runtime and preserve their
+ * wiring during daemon startup. It also owns the default selection of runtime bridge factories
+ * passed into the node kernel. The classes remain part of the daemon runtime and preserve their
  * existing behavior, but they are not part of the routing, storage, or message kernel.
  */
 package network.crypta.runtime.bootstrap;

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
@@ -1,0 +1,81 @@
+package network.crypta.runtime.bootstrap;
+
+import java.io.File;
+import network.crypta.clients.http.HttpShellRuntimeSupport;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.ProgramDirectory;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
+import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
+import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
+import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
+import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
+import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class NodeRuntimeBridgeFactoriesTest {
+
+  @Test
+  void constructor_whenAdminRuntimeBridgeInputsFactoryIsNull_throws() {
+    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
+        ignoredCore -> mock(HttpShellRuntimeSupport.class);
+
+    assertThrows(
+        NullPointerException.class,
+        () -> new NodeRuntimeBridgeFactories(null, httpShellRuntimeSupportFactory));
+  }
+
+  @Test
+  void constructor_whenHttpShellRuntimeSupportFactoryIsNull_throws() {
+    NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
+    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
+        fixture.adminRuntimeBridgeInputsFactory();
+
+    assertThrows(
+        NullPointerException.class,
+        () -> new NodeRuntimeBridgeFactories(adminRuntimeBridgeInputsFactory, null));
+  }
+
+  @Test
+  void coreBacked_whenCreated_exposesCurrentEndpointBackedFactories() {
+    NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
+
+    NodeRuntimeBridgeFactories runtimeBridgeFactories = NodeRuntimeBridgeFactories.coreBacked();
+    AdminRuntimeBridgeInputs bridgeInputs =
+        runtimeBridgeFactories
+            .adminRuntimeBridgeInputsFactory()
+            .create(fixture.node(), fixture.core());
+    HttpShellRuntimeSupport runtimeSupport =
+        runtimeBridgeFactories.httpShellRuntimeSupportFactory().create(fixture.core());
+
+    assertNotNull(runtimeBridgeFactories.adminRuntimeBridgeInputsFactory());
+    assertNotNull(runtimeBridgeFactories.httpShellRuntimeSupportFactory());
+    assertInstanceOf(FcpQueueAdminBackend.class, bridgeInputs.queueAdminBackend());
+    assertInstanceOf(HttpGeoIpCountryLookup.class, bridgeInputs.geoIpCountryLookup());
+    CoreHttpShellRuntimeSupport coreRuntimeSupport =
+        assertInstanceOf(CoreHttpShellRuntimeSupport.class, runtimeSupport);
+    assertSame(fixture.core(), coreRuntimeSupport.core());
+  }
+
+  private record NodeRuntimeBridgeFactoriesFixture(Node node, NodeClientCore core, File geoIpDb) {
+    private NodeRuntimeBridgeFactoriesFixture() {
+      this(mock(Node.class), mock(NodeClientCore.class), new File("run/IpToCountry.dat"));
+
+      ProgramDirectory runDir = mock(ProgramDirectory.class);
+      when(node.runDir()).thenReturn(runDir);
+      when(runDir.file("IpToCountry.dat")).thenReturn(geoIpDb);
+    }
+
+    private AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory() {
+      return (ignoredNode, ignoredCore) -> mock(AdminRuntimeBridgeInputs.class);
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeStarterTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeStarterTest.java
@@ -7,6 +7,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
 import network.crypta.crypt.CryptoRandoms;
@@ -94,8 +95,9 @@ class NodeStarterTest {
     params.setExecutor(mock(network.crypta.support.PriorityAwareExecutor.class));
 
     // Capture constructor arguments and provide a mock PeerManager for getPeers()
-    java.util.concurrent.atomic.AtomicReference<PersistentConfig> capturedCfg =
-        new java.util.concurrent.atomic.AtomicReference<>();
+    AtomicReference<PersistentConfig> capturedCfg = new AtomicReference<>();
+    AtomicReference<NodeRuntimeBridgeFactories> capturedRuntimeBridgeFactories =
+        new AtomicReference<>();
 
     try (MockedConstruction<Node> mocked =
         Mockito.mockConstruction(
@@ -105,6 +107,10 @@ class NodeStarterTest {
               Object arg0 = context.arguments().getFirst();
               if (arg0 instanceof PersistentConfig pc) {
                 capturedCfg.set(pc);
+              }
+              Object arg5 = context.arguments().get(5);
+              if (arg5 instanceof NodeRuntimeBridgeFactories runtimeBridgeFactories) {
+                capturedRuntimeBridgeFactories.set(runtimeBridgeFactories);
               }
               // getPeers() must not return null because createTestNode() calls removeAllPeers()
               PeerManager peerManager = mock(PeerManager.class);
@@ -131,6 +137,7 @@ class NodeStarterTest {
       // Per-port derived paths exist under base/port
       File portDir = new File(tmpDir, "12345");
       assertEquals(new File(portDir, "throttle.dat").toString(), sfs.get("node.throttleFile"));
+      assertValidRuntimeBridgeFactories(capturedRuntimeBridgeFactories.get());
 
       // And ensure the peer list is cleared on the returned node
       verify(node.network().peers(), times(1)).removeAllPeers();
@@ -144,6 +151,8 @@ class NodeStarterTest {
     NodeStarter ns = newNodeStarterViaReflection();
     int expectedExitCode = NodeInitException.EXIT_COULD_NOT_START_UPDATER;
     String[] args = startupArgs(tmpDir);
+    AtomicReference<NodeRuntimeBridgeFactories> capturedRuntimeBridgeFactories =
+        new AtomicReference<>();
 
     try (MockedStatic<WrapperManager> wm = Mockito.mockStatic(WrapperManager.class);
         MockedConstruction<NativeThread> nativeThreadCtor =
@@ -151,16 +160,22 @@ class NodeStarterTest {
         MockedConstruction<Node> nodeCtor =
             Mockito.mockConstruction(
                 Node.class,
-                (mock, _) ->
-                    Mockito.doThrow(new NodeInitException(expectedExitCode, "simulated startup"))
-                        .when(mock)
-                        .start(false))) {
+                (mock, context) -> {
+                  Object arg5 = context.arguments().get(5);
+                  if (arg5 instanceof NodeRuntimeBridgeFactories runtimeBridgeFactories) {
+                    capturedRuntimeBridgeFactories.set(runtimeBridgeFactories);
+                  }
+                  Mockito.doThrow(new NodeInitException(expectedExitCode, "simulated startup"))
+                      .when(mock)
+                      .start(false);
+                })) {
       wm.when(WrapperManager::isControlledByNativeWrapper).thenReturn(true);
       Integer result = ns.start(args);
 
       assertEquals(expectedExitCode, result);
       assertEquals(1, nodeCtor.constructed().size());
       assertEquals(1, nativeThreadCtor.constructed().size());
+      assertValidRuntimeBridgeFactories(capturedRuntimeBridgeFactories.get());
       wm.verify(() -> WrapperManager.signalStarting(500000), times(1));
       wm.verify(() -> WrapperManager.stop(expectedExitCode), times(0));
     }
@@ -486,5 +501,12 @@ class NodeStarterTest {
     File dir = Files.createTempDirectory(prefix).toFile();
     dir.deleteOnExit();
     return dir;
+  }
+
+  private static void assertValidRuntimeBridgeFactories(
+      NodeRuntimeBridgeFactories runtimeBridgeFactories) {
+    assertNotNull(runtimeBridgeFactories);
+    assertNotNull(runtimeBridgeFactories.adminRuntimeBridgeInputsFactory());
+    assertNotNull(runtimeBridgeFactories.httpShellRuntimeSupportFactory());
   }
 }


### PR DESCRIPTION
## Summary
- add `NodeRuntimeBridgeFactories` so bootstrap owns the legacy default admin and HTTP shell bridge-factory selection
- thread the bootstrap-owned holder through `NodeStarter` into `Node.createForBootstrap(...)` so `Node` depends only on the seam factory types
- add focused bootstrap tests for the new holder and injected construction path, and document the new bootstrap-owned record

## How to test
- `./gradlew test --tests 'network.crypta.runtime.bootstrap.NodeStarterTest' --tests 'network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactoriesTest'`
- `javadoc -quiet -Xdoclint:all -classpath 'build/classes/java/main:build/resources/main' -sourcepath . -d /tmp/doclint-out src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java`