### PR TITLE
refactor(runtime): Inject HTTP shell container factory

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -45,6 +45,7 @@ import network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactories;
 import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
 import network.crypta.runtime.endpoints.http.HttpShellContainer;
+import network.crypta.runtime.endpoints.http.HttpShellContainerFactory;
 import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.Fields;
@@ -593,11 +594,13 @@ public final class Node implements TimeSkewDetectorCallback {
         nodeRuntimeBridgeFactories.adminRuntimeBridgeInputsFactory();
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         nodeRuntimeBridgeFactories.httpShellRuntimeSupportFactory();
+    HttpShellContainerFactory httpShellContainerFactory =
+        nodeRuntimeBridgeFactories.httpShellContainerFactory();
     this.executor = executor;
     this.nodeStarter = ns;
     this.messaging = new NodeMessagingSubsystem();
     this.bootstrap = new NodeBootstrap(this);
-    this.services = new NodeServicesSubsystem(this);
+    this.services = new NodeServicesSubsystem(this, httpShellContainerFactory);
     NodeConfigManager configManager = new NodeConfigManager(this);
     this.network = new NodeNetworkSubsystem(this);
     this.storage = new NodeStorageSubsystem(this);

--- a/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
@@ -3,6 +3,7 @@ package network.crypta.runtime.bootstrap;
 import java.util.Objects;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.endpoints.admin.AdminRuntimeBridgeInputsFactories;
+import network.crypta.runtime.endpoints.http.HttpShellContainerFactory;
 import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
 
 /**
@@ -15,7 +16,7 @@ import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
  *
  * <p>Typical startup paths create one instance during bootstrap, thread it through {@link
  * network.crypta.runtime.bootstrap.NodeStarter}, and then let the node reuse those seams at the
- * same construction points where it previously hard-coded the legacy endpoint pair. The record is
+ * same construction points where it previously hard-coded the legacy endpoint seams. The record is
  * immutable and carries no caching or policy beyond that wiring choice, so startup order and bridge
  * behavior stay aligned with the existing daemon bootstrap flow.
  *
@@ -23,32 +24,39 @@ import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
  *     client core
  * @param httpShellRuntimeSupportFactory factory for HTTP shell runtime support used by the toadlet
  *     container
+ * @param httpShellContainerFactory factory for HTTP shell container creation used by the service
+ *     subsystem
  */
 public record NodeRuntimeBridgeFactories(
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory,
-    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory) {
+    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory,
+    HttpShellContainerFactory httpShellContainerFactory) {
 
   /**
    * Creates a bootstrap bridge-factory bundle.
    *
-   * <p>Both factories are required because node construction expects explicit seams for the admin
-   * runtime bridge inputs and the HTTP shell runtime support path. The constructor only validates
-   * presence; it does not invoke the factories, cache runtime state, or trigger any endpoint
-   * startup work on its own.
+   * <p>All factories are required because node construction expects explicit seams for the admin
+   * runtime bridge inputs, the HTTP shell runtime support path, and the HTTP shell container
+   * creation path. The constructor only validates presence; it does not invoke the factories, cache
+   * runtime state, or trigger any endpoint startup work on its own.
    *
    * @param adminRuntimeBridgeInputsFactory factory for admin bridge inputs passed into the client
    *     core during node construction
    * @param httpShellRuntimeSupportFactory factory for HTTP shell runtime support created after the
    *     client core exists
-   * @throws NullPointerException if either factory reference is {@code null}
+   * @param httpShellContainerFactory factory for HTTP shell container creation used by {@code
+   *     NodeServicesSubsystem}
+   * @throws NullPointerException if any factory reference is {@code null}
    */
   public NodeRuntimeBridgeFactories {
     Objects.requireNonNull(adminRuntimeBridgeInputsFactory, "adminRuntimeBridgeInputsFactory");
     Objects.requireNonNull(httpShellRuntimeSupportFactory, "httpShellRuntimeSupportFactory");
+    Objects.requireNonNull(httpShellContainerFactory, "httpShellContainerFactory");
   }
 
   /**
-   * Returns the legacy default bridge-factory pair backed by the current endpoint implementations.
+   * Returns the legacy default bridge-factory bundle backed by the current endpoint
+   * implementations.
    *
    * <p>This helper centralizes the existing production default in the bootstrap package. Callers
    * that need the historical daemon wiring can therefore get the same admin and HTTP shell bridge
@@ -59,6 +67,7 @@ public record NodeRuntimeBridgeFactories(
   public static NodeRuntimeBridgeFactories coreBacked() {
     return new NodeRuntimeBridgeFactories(
         AdminRuntimeBridgeInputsFactories.coreBacked(),
-        HttpShellRuntimeSupportFactory.coreBacked());
+        HttpShellRuntimeSupportFactory.coreBacked(),
+        HttpShellContainerFactory.defaultFactory());
   }
 }

--- a/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
+++ b/src/main/java/network/crypta/runtime/services/NodeServicesSubsystem.java
@@ -67,25 +67,11 @@ public final class NodeServicesSubsystem {
   private TimeSkewDetectedUserAlert timeSkewDetectedUserAlert;
 
   /**
-   * Creates a services subsystem bound to a specific node instance.
-   *
-   * <p>The new instance starts with all service references unset and should be populated by the
-   * node's startup sequence. The {@code node} reference is used to access configuration, network
-   * components, and storage when alert or service wiring occurs. This constructor performs no I/O
-   * and does not start any services.
-   *
-   * @param node owning node used for configuration, storage, and service wiring; must be non-null.
-   */
-  public NodeServicesSubsystem(Node node) {
-    this(node, HttpShellContainerFactory.defaultFactory());
-  }
-
-  /**
    * Creates a services subsystem bound to a specific node instance and HTTP shell factory seam.
    *
    * <p>The supplied factory controls HTTP shell construction while preserving the existing startup
-   * order and lifecycle. Tests may inject a mock or stub implementation while production code can
-   * continue to use the default runtime-owned seam entry point.
+   * order and lifecycle. Tests may inject a mock or stub implementation while production code uses
+   * the bootstrap-selected seam entry point.
    *
    * @param node owning node used for configuration, storage, and service wiring; must be non-null.
    * @param httpShellContainerFactory factory used to create the runtime-owned HTTP shell container

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
@@ -9,6 +9,7 @@ import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
 import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
+import network.crypta.runtime.endpoints.http.HttpShellContainerFactory;
 import network.crypta.runtime.endpoints.http.HttpShellRuntimeSupportFactory;
 import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
 import org.junit.jupiter.api.Test;
@@ -27,10 +28,13 @@ class NodeRuntimeBridgeFactoriesTest {
   void constructor_whenAdminRuntimeBridgeInputsFactoryIsNull_throws() {
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         ignoredCore -> mock(HttpShellRuntimeSupport.class);
+    HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
 
     assertThrows(
         NullPointerException.class,
-        () -> new NodeRuntimeBridgeFactories(null, httpShellRuntimeSupportFactory));
+        () ->
+            new NodeRuntimeBridgeFactories(
+                null, httpShellRuntimeSupportFactory, httpShellContainerFactory));
   }
 
   @Test
@@ -38,10 +42,28 @@ class NodeRuntimeBridgeFactoriesTest {
     NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
         fixture.adminRuntimeBridgeInputsFactory();
+    HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
 
     assertThrows(
         NullPointerException.class,
-        () -> new NodeRuntimeBridgeFactories(adminRuntimeBridgeInputsFactory, null));
+        () ->
+            new NodeRuntimeBridgeFactories(
+                adminRuntimeBridgeInputsFactory, null, httpShellContainerFactory));
+  }
+
+  @Test
+  void constructor_whenHttpShellContainerFactoryIsNull_throws() {
+    NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
+    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
+        fixture.adminRuntimeBridgeInputsFactory();
+    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
+        ignoredCore -> mock(HttpShellRuntimeSupport.class);
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new NodeRuntimeBridgeFactories(
+                adminRuntimeBridgeInputsFactory, httpShellRuntimeSupportFactory, null));
   }
 
   @Test
@@ -55,9 +77,12 @@ class NodeRuntimeBridgeFactoriesTest {
             .create(fixture.node(), fixture.core());
     HttpShellRuntimeSupport runtimeSupport =
         runtimeBridgeFactories.httpShellRuntimeSupportFactory().create(fixture.core());
+    HttpShellContainerFactory httpShellContainerFactory =
+        runtimeBridgeFactories.httpShellContainerFactory();
 
     assertNotNull(runtimeBridgeFactories.adminRuntimeBridgeInputsFactory());
     assertNotNull(runtimeBridgeFactories.httpShellRuntimeSupportFactory());
+    assertNotNull(httpShellContainerFactory);
     assertInstanceOf(FcpQueueAdminBackend.class, bridgeInputs.queueAdminBackend());
     assertInstanceOf(HttpGeoIpCountryLookup.class, bridgeInputs.geoIpCountryLookup());
     CoreHttpShellRuntimeSupport coreRuntimeSupport =

--- a/src/test/java/network/crypta/runtime/services/NodeServicesSubsystemTest.java
+++ b/src/test/java/network/crypta/runtime/services/NodeServicesSubsystemTest.java
@@ -85,29 +85,6 @@ class NodeServicesSubsystemTest {
   }
 
   @Test
-  void startWebInterface_whenConstructedWithDefaultFactory_usesDefaultFactorySeam()
-      throws Exception {
-    when(config.createSubConfig("fproxy")).thenReturn(subConfig);
-    HttpShellContainer toadlets = mock(HttpShellContainer.class);
-
-    try (MockedStatic<HttpShellContainerFactory> mocked =
-        mockStatic(HttpShellContainerFactory.class)) {
-      mocked.when(HttpShellContainerFactory::defaultFactory).thenReturn(httpShellContainerFactory);
-      when(httpShellContainerFactory.create(subConfig, executor)).thenReturn(toadlets);
-      NodeServicesSubsystem subsystem = new NodeServicesSubsystem(node);
-
-      subsystem.startWebInterface(config, executor);
-
-      mocked.verify(HttpShellContainerFactory::defaultFactory);
-      assertSame(toadlets, subsystem.toadlets());
-      InOrder order = inOrder(httpShellContainerFactory, subConfig, toadlets);
-      order.verify(httpShellContainerFactory).create(subConfig, executor);
-      order.verify(subConfig).finishedInitialization();
-      order.verify(toadlets).start();
-    }
-  }
-
-  @Test
   void startWebInterface_whenConfigInvalid_throwsNodeInitException() throws Exception {
     NodeServicesSubsystem subsystem = newSubsystem();
     when(config.createSubConfig("fproxy")).thenReturn(subConfig);


### PR DESCRIPTION
## Summary
- extend `NodeRuntimeBridgeFactories` to carry `HttpShellContainerFactory` and keep the legacy default selection in `coreBacked()`
- remove the `NodeServicesSubsystem(Node)` convenience constructor so the subsystem only consumes an injected factory
- thread the injected factory through `Node` and update the focused tests for the new seam shape

## How to test
- `./gradlew test --tests "network.crypta.runtime.services.NodeServicesSubsystemTest"`
- `./gradlew test --tests "network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactoriesTest"`
- `./gradlew compileJava compileTestJava`

## Notes
- Implements PR-120.
- Startup order and HTTP/FProxy behavior are unchanged; this only moves default factory selection into the bootstrap/composition-root path.