### PR TITLE
refactor(runtime-http): Neutralize legacy HTTP seam

### DIFF
--- a/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
+++ b/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
@@ -1101,6 +1101,19 @@ public class SecurityLevelsToadlet extends Toadlet {
   static final String PATH = System.getProperty(PATH_PROPERTY, "/seclevels/");
 
   /**
+   * Returns the already-resolved routing path used by this toadlet class.
+   *
+   * <p>This accessor exposes the same cached value that backs {@link #path()}, allowing callers to
+   * build links and form targets that stay aligned with the registered handler even if the backing
+   * system property changes later in process lifetime.
+   *
+   * @return canonical cached toadlet path, resolved during class initialization.
+   */
+  public static String resolvedPath() {
+    return PATH;
+  }
+
+  /**
    * Returns the routing path for this toadlet. The value comes from the {@code
    * network.crypta.seclevels.path} system property when set, otherwise falls back to {@code
    * /seclevels/}. Callers should treat the path as a stable identifier for hyperlink generation and

--- a/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
@@ -503,6 +503,7 @@ public final class NodeStorageSubsystem {
           PasswordFormPageRenderer.generate(
               new PasswordPromptOptions(false, false, false, false, null, null),
               node.services().clientCore().getEndpoints().getToadletContainer(),
+              PasswordFormPageRenderer.resolvedSecurityLevelsPath(),
               content);
           return content;
         }

--- a/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
@@ -19,7 +19,10 @@ import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
  * network.crypta.runtime.bootstrap.NodeStarter}, and then let the node reuse those seams at the
  * same construction points where it previously hard-coded the legacy endpoint seams. The record is
  * immutable and carries no caching or policy beyond that wiring choice, so startup order and bridge
- * behavior stay aligned with the existing daemon bootstrap flow.
+ * behavior stay aligned with the existing daemon bootstrap flow. The contained factories are
+ * expected to be a compatible set rather than arbitrary independent choices. In particular, the
+ * current legacy-backed HTTP shell container still requires a runtime-support implementation that
+ * can also satisfy the legacy HTTP adapter contract.
  *
  * @param adminRuntimeBridgeInputsFactory factory for the admin/runtime bridge inputs used by the
  *     client core
@@ -38,8 +41,9 @@ public record NodeRuntimeBridgeFactories(
    *
    * <p>All factories are required because node construction expects explicit seams for the admin
    * runtime bridge inputs, the HTTP shell runtime support path, and the HTTP shell container
-   * creation path. The constructor only validates presence; it does not invoke the factories, cache
-   * runtime state, or trigger any endpoint startup work on its own.
+   * creation path. The constructor only validates presence; it does not invoke the factories, prove
+   * cross-factory compatibility, cache runtime state, or trigger any endpoint startup work on its
+   * own.
    *
    * @param adminRuntimeBridgeInputsFactory factory for admin bridge inputs passed into the client
    *     core during node construction

--- a/src/main/java/network/crypta/runtime/endpoints/http/CoreHttpShellRuntimeSupport.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/CoreHttpShellRuntimeSupport.java
@@ -32,7 +32,8 @@ import network.crypta.support.Ticker;
  *
  * @param core daemon core that backs delegated shell services and FProxy bootstrap wiring
  */
-public record CoreHttpShellRuntimeSupport(NodeClientCore core) implements HttpShellRuntimeSupport {
+public record CoreHttpShellRuntimeSupport(NodeClientCore core)
+    implements network.crypta.runtime.http.HttpShellRuntimeSupport, HttpShellRuntimeSupport {
   /**
    * Creates a core-backed HTTP runtime adapter.
    *

--- a/src/main/java/network/crypta/runtime/endpoints/http/HttpShellBridgeFactories.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/HttpShellBridgeFactories.java
@@ -45,7 +45,9 @@ public final class HttpShellBridgeFactories {
    * CoreHttpShellRuntimeSupport} instances for the supplied client core. Bootstrap code typically
    * chooses this binding once, stores it alongside the other runtime seams, and invokes it later
    * after the node has created a live {@code NodeClientCore}. The method itself does not retain the
-   * core or initialize any shell state.
+   * core or initialize any shell state. The created support objects are intentionally compatible
+   * with both the runtime-owned seam and the legacy HTTP shell adapter, so they match the default
+   * container factory returned by {@link #defaultContainerFactory()}.
    *
    * @return factory that creates the current endpoint-backed HTTP shell runtime support bridge for
    *     a supplied daemon core

--- a/src/main/java/network/crypta/runtime/endpoints/http/SimpleToadletServerHttpShellContainer.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/SimpleToadletServerHttpShellContainer.java
@@ -1,19 +1,10 @@
 package network.crypta.runtime.endpoints.http;
 
-import java.io.File;
-import java.net.InetAddress;
 import java.net.URI;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
-import network.crypta.clients.http.HttpShellRuntimeSupport;
-import network.crypta.clients.http.PageMaker.THEME;
-import network.crypta.clients.http.PageMaker;
-import network.crypta.clients.http.PermanentRedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
-import network.crypta.clients.http.Toadlet;
-import network.crypta.clients.http.ToadletRegistration;
 import network.crypta.runtime.http.HttpShellContainer;
+import network.crypta.runtime.http.HttpShellRuntimeSupport;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.TempBucketFactory;
 
 /**
@@ -55,7 +46,15 @@ final class SimpleToadletServerHttpShellContainer implements HttpShellContainer 
 
   @Override
   public void setRuntimeSupport(HttpShellRuntimeSupport runtimeSupport) {
-    delegate.setRuntimeSupport(runtimeSupport);
+    if (!(runtimeSupport
+        instanceof network.crypta.clients.http.HttpShellRuntimeSupport legacySupport)) {
+      throw new IllegalArgumentException(
+          "SimpleToadletServerHttpShellContainer requires runtimeSupport to also implement "
+              + "network.crypta.clients.http.HttpShellRuntimeSupport; pair custom "
+              + "HttpShellRuntimeSupportFactory bindings with a compatible "
+              + "HttpShellContainerFactory");
+    }
+    delegate.setRuntimeSupport(legacySupport);
   }
 
   @Override
@@ -104,142 +103,7 @@ final class SimpleToadletServerHttpShellContainer implements HttpShellContainer 
   }
 
   @Override
-  public void register(Toadlet t, ToadletRegistration registration) {
-    delegate.register(t, registration);
-  }
-
-  @Override
-  public void unregister(Toadlet t) {
-    delegate.unregister(t);
-  }
-
-  @Override
-  public Toadlet findToadlet(URI uri) throws PermanentRedirectException {
-    return delegate.findToadlet(uri);
-  }
-
-  @Override
-  public THEME getTheme() {
-    return delegate.getTheme();
-  }
-
-  @Override
-  public String getFormPassword() {
-    return delegate.getFormPassword();
-  }
-
-  @Override
-  public boolean isAllowedFullAccess(InetAddress remoteAddr) {
-    return delegate.isAllowedFullAccess(remoteAddr);
-  }
-
-  @Override
-  public boolean doRobots() {
-    return delegate.doRobots();
-  }
-
-  @Override
   public HTMLNode addFormChild(HTMLNode parentNode, String target, String name) {
     return delegate.addFormChild(parentNode, target, name);
-  }
-
-  @Override
-  public boolean enablePersistentConnections() {
-    return delegate.enablePersistentConnections();
-  }
-
-  @Override
-  public boolean enableInlinePrefetch() {
-    return delegate.enableInlinePrefetch();
-  }
-
-  @Override
-  public boolean enableExtendedMethodHandling() {
-    return delegate.enableExtendedMethodHandling();
-  }
-
-  @Override
-  public boolean enableCachingForChkAndSskKeys() {
-    return delegate.enableCachingForChkAndSskKeys();
-  }
-
-  @Override
-  public BucketFactory getBucketFactory() {
-    return delegate.getBucketFactory();
-  }
-
-  @Override
-  public boolean allowPosts() {
-    return delegate.allowPosts();
-  }
-
-  @Override
-  public boolean publicGatewayMode() {
-    return delegate.publicGatewayMode();
-  }
-
-  @Override
-  public boolean enableActivelinks() {
-    return delegate.enableActivelinks();
-  }
-
-  @Override
-  public boolean sendAllThemes() {
-    return delegate.sendAllThemes();
-  }
-
-  @Override
-  public boolean isFProxyWebPushingEnabled() {
-    return delegate.isFProxyWebPushingEnabled();
-  }
-
-  @Override
-  public boolean disableProgressPage() {
-    return delegate.disableProgressPage();
-  }
-
-  @Override
-  public PageMaker getPageMaker() {
-    return delegate.getPageMaker();
-  }
-
-  @Override
-  public void setAdvancedMode(boolean enabled) {
-    delegate.setAdvancedMode(enabled);
-  }
-
-  @Override
-  public boolean fproxyHasCompletedWizard() {
-    return delegate.fproxyHasCompletedWizard();
-  }
-
-  @Override
-  public REFILTER_POLICY getReFilterPolicy() {
-    return delegate.getReFilterPolicy();
-  }
-
-  @Override
-  public File getOverrideFile() {
-    return delegate.getOverrideFile();
-  }
-
-  @Override
-  public String getURL() {
-    return delegate.getURL();
-  }
-
-  @Override
-  public String getURL(String host) {
-    return delegate.getURL(host);
-  }
-
-  @Override
-  public boolean isSSL() {
-    return delegate.isSSL();
-  }
-
-  @Override
-  public long generateUniqueID() {
-    return delegate.generateUniqueID();
   }
 }

--- a/src/main/java/network/crypta/runtime/http/HttpShellContainer.java
+++ b/src/main/java/network/crypta/runtime/http/HttpShellContainer.java
@@ -1,18 +1,16 @@
 package network.crypta.runtime.http;
 
 import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.clients.http.HttpShellRuntimeSupport;
-import network.crypta.clients.http.ToadletContainer;
+import network.crypta.support.HTMLNode;
 import network.crypta.support.io.TempBucketFactory;
 
 /**
  * Runtime-owned seam for the HTTP shell host used during bootstrap and endpoint wiring.
  *
  * <p>This interface isolates runtime code from the concrete legacy HTTP shell implementation while
- * still exposing the small set of operations that bootstrap and endpoint wiring need. Callers keep
- * using the shared {@link ToadletContainer} and {@link LinkFilterExceptionProvider} contracts for
- * normal toadlet registration and filtering behavior, and they use this seam only for the remaining
- * shell lifecycle hooks that are still runtime-owned.
+ * still exposing only the small set of operations that non-adapter runtime code still needs.
+ * Callers use this seam for lifecycle, filtering, and a few shell-level rendering/configuration
+ * queries without depending on the broader legacy HTTP container contract.
  *
  * <p>The intent is structural rather than behavioral. Implementations preserve the existing shell
  * startup order, FProxy creation flow, and startup-page behavior, but runtime packages no longer
@@ -20,7 +18,7 @@ import network.crypta.support.io.TempBucketFactory;
  * ownership boundaries narrower while allowing future HTTP-shell changes to stay behind a
  * runtime-local abstraction.
  */
-public interface HttpShellContainer extends ToadletContainer, LinkFilterExceptionProvider {
+public interface HttpShellContainer extends LinkFilterExceptionProvider {
 
   /**
    * Starts the underlying HTTP shell listener when the shell is configured to run.
@@ -38,7 +36,11 @@ public interface HttpShellContainer extends ToadletContainer, LinkFilterExceptio
    * <p>This hook connects the shell to the daemon-backed services that require a live {@code
    * NodeClientCore}. Callers usually provide this after the core exists but before the shell
    * finishes its final startup sequence. Implementations are expected to retain the supplied
-   * adapter for later callbacks rather than copying or translating it.
+   * adapter for later callbacks rather than copying or translating it. Because {@link
+   * HttpShellRuntimeSupport} is only a marker seam in this PR, container implementations may still
+   * require additional implementation-specific interfaces on the same object. The default
+   * production pairing supplied by {@code NodeRuntimeBridgeFactories.coreBacked()} satisfies that
+   * requirement; custom bridge bindings must supply a compatible container/support pair.
    *
    * @param runtimeSupport daemon-backed adapter that serves later HTTP shell callbacks and runtime
    *     lookups
@@ -57,6 +59,20 @@ public interface HttpShellContainer extends ToadletContainer, LinkFilterExceptio
    *     temporary storage work
    */
   void setBucketFactory(TempBucketFactory tempBucketFactory);
+
+  /**
+   * Appends a form node configured with the shell's hidden form password.
+   *
+   * <p>Runtime-owned callers use this when they need the existing HTTP shell to create a form that
+   * behaves the same way as shell-generated forms, including the expected submission target and
+   * hidden password field handling.
+   *
+   * @param parentNode HTML node that receives the form as a child
+   * @param target submission target path for the form
+   * @param name optional form name or identifier
+   * @return created form node
+   */
+  HTMLNode addFormChild(HTMLNode parentNode, String target, String name);
 
   /**
    * Indicates whether the HTTP shell is configured to run.
@@ -89,6 +105,20 @@ public interface HttpShellContainer extends ToadletContainer, LinkFilterExceptio
    * current FProxy behavior and should not use this seam to reorder or broaden endpoint startup.
    */
   void createFproxy();
+
+  /**
+   * Reports whether advanced mode is enabled for HTTP shell consumers.
+   *
+   * @return {@code true} when advanced mode features should be shown
+   */
+  boolean isAdvancedModeEnabled();
+
+  /**
+   * Reports whether FProxy JavaScript helpers are enabled.
+   *
+   * @return {@code true} when FProxy JavaScript support is enabled
+   */
+  boolean isFProxyJavascriptEnabled();
 
   /**
    * Removes the temporary startup toadlet once shell startup is complete.

--- a/src/main/java/network/crypta/runtime/http/HttpShellRuntimeSupport.java
+++ b/src/main/java/network/crypta/runtime/http/HttpShellRuntimeSupport.java
@@ -1,0 +1,19 @@
+package network.crypta.runtime.http;
+
+/**
+ * Runtime-owned marker seam for HTTP shell runtime support.
+ *
+ * <p>This interface exists to keep runtime/bootstrap code compile-neutral with respect to the
+ * legacy HTTP adapter package. Production bridge implementations may also implement the legacy
+ * adapter-side runtime-support interface when they still need to back the existing HTTP shell. When
+ * the runtime support is paired with the current {@code SimpleToadletServer}-backed container
+ * bridge, the same object must also implement the legacy adapter-side interface because the legacy
+ * shell still invokes that older API internally. Custom bridge configurations must therefore pair a
+ * runtime-support factory with a container factory that expects the same backing contract.
+ *
+ * <p>The seam is intentionally empty for this PR. It marks the runtime-owned support object that
+ * higher-level code creates and passes into the matching {@code
+ * HttpShellContainer.setRuntimeSupport(...)} hook without redesigning the legacy HTTP
+ * runtime-support API yet.
+ */
+public interface HttpShellRuntimeSupport {}

--- a/src/main/java/network/crypta/runtime/http/HttpShellRuntimeSupportFactory.java
+++ b/src/main/java/network/crypta/runtime/http/HttpShellRuntimeSupportFactory.java
@@ -1,6 +1,5 @@
 package network.crypta.runtime.http;
 
-import network.crypta.clients.http.HttpShellRuntimeSupport;
 import network.crypta.node.NodeClientCore;
 
 /**
@@ -32,8 +31,7 @@ public interface HttpShellRuntimeSupportFactory {
    *
    * @param core daemon core that the returned runtime support delegates to for node-backed
    *     operations
-   * @return a runtime support bridge compatible with the current HTTP shell implementation for the
-   *     supplied daemon core
+   * @return a runtime-owned support bridge for the supplied daemon core
    */
   HttpShellRuntimeSupport create(NodeClientCore core);
 }

--- a/src/main/java/network/crypta/runtime/http/security/PasswordFormPageRenderer.java
+++ b/src/main/java/network/crypta/runtime/http/security/PasswordFormPageRenderer.java
@@ -1,9 +1,7 @@
 package network.crypta.runtime.http.security;
 
 import java.util.Objects;
-import network.crypta.clients.http.PasswordFormOptions;
-import network.crypta.clients.http.SecurityLevelsToadlet;
-import network.crypta.clients.http.ToadletContainer;
+import network.crypta.runtime.http.HttpShellContainer;
 import network.crypta.support.HTMLNode;
 
 /**
@@ -20,7 +18,22 @@ import network.crypta.support.HTMLNode;
  * implementation.
  */
 public final class PasswordFormPageRenderer {
+  private static final String MASTER_PASSWORD_FORM = "masterPasswordForm";
+
   private PasswordFormPageRenderer() {}
+
+  /**
+   * Returns the cached security-levels form target used by the legacy HTTP renderer.
+   *
+   * <p>This keeps runtime-owned callers aligned with the actual route mounted by {@code
+   * SecurityLevelsToadlet}. The underlying toadlet resolves and caches its path during class
+   * initialization, so using this helper avoids drift if the backing system property changes later.
+   *
+   * @return canonical cached security-levels route used by the legacy HTTP shell.
+   */
+  public static String resolvedSecurityLevelsPath() {
+    return network.crypta.clients.http.SecurityLevelsToadlet.resolvedPath();
+  }
 
   /**
    * Renders the shared password form through the existing HTTP implementation.
@@ -35,26 +48,38 @@ public final class PasswordFormPageRenderer {
    *     rendered for the user.
    * @param ctx container used to create the form element with the correct submission endpoint and
    *     surrounding HTTP context.
+   * @param securityLevelsPath configurable submission target for the standard security-levels page
+   *     flow. This value is ignored when the prompt is being rendered for the first-time wizard,
+   *     which always submits to the wizard-owned endpoint.
    * @param content HTML node that receives explanatory text and the generated form structure from
    *     the delegated renderer.
    * @throws NullPointerException if any argument is {@code null}, because the underlying renderer
    *     requires all inputs to be present.
    */
   public static void generate(
-      PasswordPromptOptions options, ToadletContainer ctx, HTMLNode content) {
+      PasswordPromptOptions options,
+      HttpShellContainer ctx,
+      String securityLevelsPath,
+      HTMLNode content) {
     Objects.requireNonNull(options, "options");
     Objects.requireNonNull(ctx, "ctx");
+    Objects.requireNonNull(securityLevelsPath, "securityLevelsPath");
     Objects.requireNonNull(content, "content");
 
-    SecurityLevelsToadlet.generatePasswordFormPage(
-        new PasswordFormOptions(
+    String postTo =
+        options.forFirstTimeWizard()
+            ? network.crypta.clients.http.FirstTimeWizardToadlet.TOADLET_URL
+            : securityLevelsPath;
+    HTMLNode form = ctx.addFormChild(content, postTo, MASTER_PASSWORD_FORM);
+    network.crypta.clients.http.SecurityLevelsToadlet.generatePasswordFormPage(
+        new network.crypta.clients.http.PasswordFormOptions(
             options.wasWrong(),
             options.forFirstTimeWizard(),
             options.forDowngrade(),
             options.forUpgrade(),
             options.physicalSecurityLevel(),
             options.redirect()),
-        ctx,
+        form,
         content);
   }
 }

--- a/src/test/java/network/crypta/node/subsystem/NodeStorageSubsystemTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeStorageSubsystemTest.java
@@ -242,14 +242,63 @@ class NodeStorageSubsystemTest {
     when(clientCore.getEndpoints()).thenReturn(new ClientEndpoints(null, null, container));
 
     HTMLNode expectedContent = new HTMLNode("div");
+    HTMLNode expectedForm = expectedContent.addChild("form");
+    expectedForm.addAttribute("target", SecurityLevelsToadlet.resolvedPath());
+    expectedForm.addAttribute("id", "masterPasswordForm");
     SecurityLevelsToadlet.generatePasswordFormPage(
         new PasswordFormOptions(false, false, false, false, null, null),
-        container,
+        expectedForm,
         expectedContent);
 
     HTMLNode renderedContent = getMasterPasswordUserAlert(subsystem).getHTMLText();
 
     assertEquals(expectedContent.generate(), renderedContent.generate());
+  }
+
+  @Test
+  void
+      masterPasswordUserAlert_getHTMLText_whenSecurityLevelsPropertyChangesAfterPathResolution_usesResolvedRoute()
+          throws Exception {
+    HttpShellContainer container = org.mockito.Mockito.mock(HttpShellContainer.class);
+    when(container.addFormChild(any(HTMLNode.class), anyString(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parent = invocation.getArgument(0);
+              String target = invocation.getArgument(1);
+              String id = invocation.getArgument(2);
+              HTMLNode form = parent.addChild("form");
+              form.addAttribute("target", target);
+              form.addAttribute("id", id);
+              return form;
+            });
+    when(node.services()).thenReturn(services);
+    when(services.clientCore()).thenReturn(clientCore);
+    when(clientCore.getEndpoints()).thenReturn(new ClientEndpoints(null, null, container));
+
+    String originalProperty = System.getProperty("network.crypta.seclevels.path");
+    String resolvedPath = SecurityLevelsToadlet.resolvedPath();
+    System.setProperty("network.crypta.seclevels.path", "/changed-after-init/");
+
+    try {
+      HTMLNode expectedContent = new HTMLNode("div");
+      HTMLNode expectedForm = expectedContent.addChild("form");
+      expectedForm.addAttribute("target", resolvedPath);
+      expectedForm.addAttribute("id", "masterPasswordForm");
+      SecurityLevelsToadlet.generatePasswordFormPage(
+          new PasswordFormOptions(false, false, false, false, null, null),
+          expectedForm,
+          expectedContent);
+
+      HTMLNode renderedContent = getMasterPasswordUserAlert(subsystem).getHTMLText();
+
+      assertEquals(expectedContent.generate(), renderedContent.generate());
+    } finally {
+      if (originalProperty == null) {
+        System.clearProperty("network.crypta.seclevels.path");
+      } else {
+        System.setProperty("network.crypta.seclevels.path", originalProperty);
+      }
+    }
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
@@ -1,7 +1,6 @@
 package network.crypta.runtime.bootstrap;
 
 import java.io.File;
-import network.crypta.clients.http.HttpShellRuntimeSupport;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.ProgramDirectory;
@@ -11,6 +10,7 @@ import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
 import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
 import network.crypta.runtime.http.HttpShellContainerFactory;
+import network.crypta.runtime.http.HttpShellRuntimeSupport;
 import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +87,7 @@ class NodeRuntimeBridgeFactoriesTest {
     assertInstanceOf(HttpGeoIpCountryLookup.class, bridgeInputs.geoIpCountryLookup());
     CoreHttpShellRuntimeSupport coreRuntimeSupport =
         assertInstanceOf(CoreHttpShellRuntimeSupport.class, runtimeSupport);
+    assertInstanceOf(network.crypta.clients.http.HttpShellRuntimeSupport.class, runtimeSupport);
     assertSame(fixture.core(), coreRuntimeSupport.core());
   }
 

--- a/src/test/java/network/crypta/runtime/endpoints/http/HttpShellBridgeFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/HttpShellBridgeFactoriesTest.java
@@ -1,10 +1,10 @@
 package network.crypta.runtime.endpoints.http;
 
-import network.crypta.clients.http.HttpShellRuntimeSupport;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.config.SubConfig;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.http.HttpShellContainer;
+import network.crypta.runtime.http.HttpShellRuntimeSupport;
 import network.crypta.support.PriorityAwareExecutor;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
@@ -46,6 +46,7 @@ class HttpShellBridgeFactoriesTest {
 
     CoreHttpShellRuntimeSupport coreRuntimeSupport =
         assertInstanceOf(CoreHttpShellRuntimeSupport.class, runtimeSupport);
+    assertInstanceOf(network.crypta.clients.http.HttpShellRuntimeSupport.class, runtimeSupport);
     assertSame(core, coreRuntimeSupport.core());
   }
 }

--- a/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/HttpShellContainersTest.java
@@ -1,24 +1,16 @@
 package network.crypta.runtime.endpoints.http;
 
-import java.io.File;
-import java.net.InetAddress;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
-import network.crypta.clients.http.HttpShellRuntimeSupport;
-import network.crypta.clients.http.PageMaker.THEME;
-import network.crypta.clients.http.PageMaker;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.StartupToadlet;
-import network.crypta.clients.http.Toadlet;
-import network.crypta.clients.http.ToadletRegistration;
 import network.crypta.config.SubConfig;
 import network.crypta.runtime.http.HttpShellContainer;
 import network.crypta.runtime.http.HttpShellContainerFactory;
+import network.crypta.runtime.http.HttpShellRuntimeSupport;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.PriorityAwareExecutor;
-import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,11 +21,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
@@ -45,9 +40,11 @@ class HttpShellContainersTest {
     SubConfig fproxyConfig = mock(SubConfig.class);
     PriorityAwareExecutor executor = mock(PriorityAwareExecutor.class);
     StartupToadlet startupToadlet = mock(StartupToadlet.class);
-    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
+    HttpShellRuntimeSupport runtimeSupport = legacyCompatibleRuntimeSupport();
     TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
     URI uri = URI.create("http://127.0.0.1/filter");
+    HTMLNode parentNode = mock(HTMLNode.class);
+    HTMLNode formNode = mock(HTMLNode.class);
     AtomicReference<List<?>> constructorArgs = new AtomicReference<>();
 
     try (MockedConstruction<SimpleToadletServer> construction =
@@ -60,6 +57,7 @@ class HttpShellContainersTest {
               when(server.isAdvancedModeEnabled()).thenReturn(true);
               when(server.isFProxyJavascriptEnabled()).thenReturn(false);
               when(server.isLinkExcepted(uri)).thenReturn(true);
+              when(server.addFormChild(parentNode, "/submit", "form")).thenReturn(formNode);
             })) {
       HttpShellContainerFactory factory = HttpShellBridgeFactories.defaultContainerFactory();
       HttpShellContainer container = factory.create(fproxyConfig, executor);
@@ -83,105 +81,65 @@ class HttpShellContainersTest {
       assertTrue(container.isAdvancedModeEnabled());
       assertTrue(container.isLinkExcepted(uri));
       assertFalse(container.isFProxyJavascriptEnabled());
+      assertSame(formNode, container.addFormChild(parentNode, "/submit", "form"));
 
-      verify(server).setRuntimeSupport(runtimeSupport);
+      verify(server)
+          .setRuntimeSupport((network.crypta.clients.http.HttpShellRuntimeSupport) runtimeSupport);
       verify(server).setBucketFactory(tempBucketFactory);
       verify(server).createFproxy();
       verify(server).finishStart();
       verify(server).removeStartupToadlet();
       verify(server).start();
+      verify(server).addFormChild(parentNode, "/submit", "form");
       verify(startupToadlet).setIsPRNGReady();
     }
   }
 
   @Test
   void
-      simpleToadletServerHttpShellContainer_whenReadOnlyDelegationsQueried_expectDelegateValuesReturned()
-          throws Exception {
-    // Arrange
+      simpleToadletServerHttpShellContainer_whenRuntimeMethodsQueried_expectDelegateValuesReturned() {
     SimpleToadletServer server = mock(SimpleToadletServer.class);
     HttpShellContainer container = new SimpleToadletServerHttpShellContainer(server);
     URI uri = URI.create("http://127.0.0.1:8888/test");
-    InetAddress remoteAddress = InetAddress.getLoopbackAddress();
-    Toadlet toadlet = mock(Toadlet.class);
     HTMLNode parentNode = mock(HTMLNode.class);
     HTMLNode formNode = mock(HTMLNode.class);
-    BucketFactory bucketFactory = mock(BucketFactory.class);
-    PageMaker pageMaker = mock(PageMaker.class);
-    THEME theme = THEME.CRYPTAFORGE;
-    REFILTER_POLICY reFilterPolicy = REFILTER_POLICY.ACCEPT_OLD;
-    File overrideFile = new File("override.css");
 
-    when(server.findToadlet(uri)).thenReturn(toadlet);
-    when(server.getTheme()).thenReturn(theme);
-    when(server.getFormPassword()).thenReturn("form-password");
-    when(server.isAllowedFullAccess(remoteAddress)).thenReturn(true);
-    when(server.doRobots()).thenReturn(false);
+    when(server.isEnabled()).thenReturn(true);
     when(server.addFormChild(parentNode, "/submit", "form")).thenReturn(formNode);
-    when(server.enablePersistentConnections()).thenReturn(true);
-    when(server.enableInlinePrefetch()).thenReturn(false);
-    when(server.enableExtendedMethodHandling()).thenReturn(true);
-    when(server.enableCachingForChkAndSskKeys()).thenReturn(false);
-    when(server.getBucketFactory()).thenReturn(bucketFactory);
-    when(server.allowPosts()).thenReturn(true);
-    when(server.publicGatewayMode()).thenReturn(false);
-    when(server.enableActivelinks()).thenReturn(true);
-    when(server.sendAllThemes()).thenReturn(false);
-    when(server.isFProxyWebPushingEnabled()).thenReturn(true);
-    when(server.disableProgressPage()).thenReturn(false);
-    when(server.getPageMaker()).thenReturn(pageMaker);
-    when(server.fproxyHasCompletedWizard()).thenReturn(true);
-    when(server.getReFilterPolicy()).thenReturn(reFilterPolicy);
-    when(server.getOverrideFile()).thenReturn(overrideFile);
-    when(server.getURL()).thenReturn("http://127.0.0.1:8888/");
-    when(server.getURL("example.test")).thenReturn("http://example.test:8888/");
-    when(server.isSSL()).thenReturn(true);
-    when(server.generateUniqueID()).thenReturn(1234L);
+    when(server.isAdvancedModeEnabled()).thenReturn(false);
+    when(server.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(server.isLinkExcepted(uri)).thenReturn(true);
 
-    // Act + Assert
-    assertSame(toadlet, container.findToadlet(uri));
-    assertSame(theme, container.getTheme());
-    assertEquals("form-password", container.getFormPassword());
-    assertTrue(container.isAllowedFullAccess(remoteAddress));
-    assertFalse(container.doRobots());
+    assertTrue(container.isEnabled());
     assertSame(formNode, container.addFormChild(parentNode, "/submit", "form"));
-    assertTrue(container.enablePersistentConnections());
-    assertFalse(container.enableInlinePrefetch());
-    assertTrue(container.enableExtendedMethodHandling());
-    assertFalse(container.enableCachingForChkAndSskKeys());
-    assertSame(bucketFactory, container.getBucketFactory());
-    assertTrue(container.allowPosts());
-    assertFalse(container.publicGatewayMode());
-    assertTrue(container.enableActivelinks());
-    assertFalse(container.sendAllThemes());
-    assertTrue(container.isFProxyWebPushingEnabled());
-    assertFalse(container.disableProgressPage());
-    assertSame(pageMaker, container.getPageMaker());
-    assertTrue(container.fproxyHasCompletedWizard());
-    assertSame(reFilterPolicy, container.getReFilterPolicy());
-    assertSame(overrideFile, container.getOverrideFile());
-    assertEquals("http://127.0.0.1:8888/", container.getURL());
-    assertEquals("http://example.test:8888/", container.getURL("example.test"));
-    assertTrue(container.isSSL());
-    assertEquals(1234L, container.generateUniqueID());
+    assertFalse(container.isAdvancedModeEnabled());
+    assertTrue(container.isFProxyJavascriptEnabled());
+    assertTrue(container.isLinkExcepted(uri));
   }
 
   @Test
-  void simpleToadletServerHttpShellContainer_whenMutationMethodsInvoked_expectDelegateCalled() {
-    // Arrange
+  void simpleToadletServerHttpShellContainer_whenRuntimeSupportLacksLegacyBridge_throws() {
     SimpleToadletServer server = mock(SimpleToadletServer.class);
     HttpShellContainer container = new SimpleToadletServerHttpShellContainer(server);
-    Toadlet toadlet = mock(Toadlet.class);
-    ToadletRegistration registration = mock(ToadletRegistration.class);
+    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
 
-    // Act
-    container.register(toadlet, registration);
-    container.unregister(toadlet);
-    container.setAdvancedMode(true);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> container.setRuntimeSupport(runtimeSupport));
 
-    // Assert
-    verify(server).register(toadlet, registration);
-    verify(server).unregister(toadlet);
-    verify(server).setAdvancedMode(true);
+    assertEquals(
+        "SimpleToadletServerHttpShellContainer requires runtimeSupport to also implement "
+            + "network.crypta.clients.http.HttpShellRuntimeSupport; pair custom "
+            + "HttpShellRuntimeSupportFactory bindings with a compatible "
+            + "HttpShellContainerFactory",
+        exception.getMessage());
+    verifyNoInteractions(server);
+  }
+
+  private static HttpShellRuntimeSupport legacyCompatibleRuntimeSupport() {
+    return (HttpShellRuntimeSupport)
+        mock(
+            network.crypta.clients.http.HttpShellRuntimeSupport.class,
+            withSettings().extraInterfaces(HttpShellRuntimeSupport.class));
   }
 }

--- a/src/test/java/network/crypta/runtime/http/security/PasswordFormPageRendererTest.java
+++ b/src/test/java/network/crypta/runtime/http/security/PasswordFormPageRendererTest.java
@@ -1,8 +1,9 @@
 package network.crypta.runtime.http.security;
 
+import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.clients.http.PasswordFormOptions;
 import network.crypta.clients.http.SecurityLevelsToadlet;
-import network.crypta.clients.http.ToadletContainer;
+import network.crypta.runtime.http.HttpShellContainer;
 import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -14,20 +15,29 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 class PasswordFormPageRendererTest {
+  private static final String SECURITY_LEVELS_PROPERTY = "network.crypta.seclevels.path";
+  private static final String HIGH_SECURITY_LEVEL = "HIGH";
+  private static final String NEXT_REDIRECT = "/next";
+  private static final String SECURITY_LEVELS_TARGET = "/seclevels/";
+  private static final String CHANGED_SECURITY_LEVELS_TARGET = "/changed-after-init/";
+  private static final String MASTER_PASSWORD_FORM_ID = "masterPasswordForm";
 
   @Test
   void generate_whenCalled_matchesLegacySecurityLevelsRendering() {
     PasswordPromptOptions options =
-        new PasswordPromptOptions(false, false, false, true, "HIGH", "/next");
+        new PasswordPromptOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT);
 
     HTMLNode bridgedContent = new HTMLNode("div");
     HTMLNode legacyContent = new HTMLNode("div");
-    ToadletContainer container = stubContainer();
+    HttpShellContainer container = stubContainer();
+    HTMLNode legacyForm = legacyContent.addChild("form");
+    legacyForm.addAttribute("target", SECURITY_LEVELS_TARGET);
+    legacyForm.addAttribute("id", MASTER_PASSWORD_FORM_ID);
 
-    PasswordFormPageRenderer.generate(options, container, bridgedContent);
+    PasswordFormPageRenderer.generate(options, container, SECURITY_LEVELS_TARGET, bridgedContent);
     SecurityLevelsToadlet.generatePasswordFormPage(
-        new PasswordFormOptions(false, false, false, true, "HIGH", "/next"),
-        container,
+        new PasswordFormOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT),
+        legacyForm,
         legacyContent);
 
     assertEquals(legacyContent.generate(), bridgedContent.generate());
@@ -40,49 +50,83 @@ class PasswordFormPageRendererTest {
 
     HTMLNode bridgedContent = new HTMLNode("div");
     HTMLNode legacyContent = new HTMLNode("div");
-    ToadletContainer container = stubContainer();
+    HttpShellContainer container = stubContainer();
+    HTMLNode legacyForm = legacyContent.addChild("form");
+    legacyForm.addAttribute("target", FirstTimeWizardToadlet.TOADLET_URL);
+    legacyForm.addAttribute("id", MASTER_PASSWORD_FORM_ID);
 
-    PasswordFormPageRenderer.generate(options, container, bridgedContent);
+    PasswordFormPageRenderer.generate(options, container, SECURITY_LEVELS_TARGET, bridgedContent);
     SecurityLevelsToadlet.generatePasswordFormPage(
-        new PasswordFormOptions(false, true, false, false, null, null), container, legacyContent);
+        new PasswordFormOptions(false, true, false, false, null, null), legacyForm, legacyContent);
 
     assertEquals(legacyContent.generate(), bridgedContent.generate());
   }
 
   @Test
   void generate_whenOptionsNull_throwsNullPointerException() {
-    ToadletContainer container = stubContainer();
+    HttpShellContainer container = stubContainer();
     HTMLNode content = new HTMLNode("div");
 
     assertThrows(
         NullPointerException.class,
-        () -> PasswordFormPageRenderer.generate(null, container, content));
+        () -> PasswordFormPageRenderer.generate(null, container, SECURITY_LEVELS_TARGET, content));
   }
 
   @Test
   void generate_whenContainerNull_throwsNullPointerException() {
     PasswordPromptOptions options =
-        new PasswordPromptOptions(false, false, false, true, "HIGH", "/next");
+        new PasswordPromptOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT);
     HTMLNode content = new HTMLNode("div");
 
     assertThrows(
         NullPointerException.class,
-        () -> PasswordFormPageRenderer.generate(options, null, content));
+        () -> PasswordFormPageRenderer.generate(options, null, SECURITY_LEVELS_TARGET, content));
+  }
+
+  @Test
+  void generate_whenSecurityLevelsPathNull_throwsNullPointerException() {
+    PasswordPromptOptions options =
+        new PasswordPromptOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT);
+    HttpShellContainer container = stubContainer();
+    HTMLNode content = new HTMLNode("div");
+
+    assertThrows(
+        NullPointerException.class,
+        () -> PasswordFormPageRenderer.generate(options, container, null, content));
   }
 
   @Test
   void generate_whenContentNull_throwsNullPointerException() {
     PasswordPromptOptions options =
-        new PasswordPromptOptions(false, false, false, true, "HIGH", "/next");
-    ToadletContainer container = stubContainer();
+        new PasswordPromptOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT);
+    HttpShellContainer container = stubContainer();
 
     assertThrows(
         NullPointerException.class,
-        () -> PasswordFormPageRenderer.generate(options, container, null));
+        () -> PasswordFormPageRenderer.generate(options, container, SECURITY_LEVELS_TARGET, null));
   }
 
-  private ToadletContainer stubContainer() {
-    ToadletContainer container = Mockito.mock(ToadletContainer.class);
+  @Test
+  void resolvedSecurityLevelsPath_whenPropertyChangesAfterResolution_returnsCachedRoute() {
+    String originalProperty = System.getProperty(SECURITY_LEVELS_PROPERTY);
+    String resolvedPath = PasswordFormPageRenderer.resolvedSecurityLevelsPath();
+
+    System.setProperty(SECURITY_LEVELS_PROPERTY, CHANGED_SECURITY_LEVELS_TARGET);
+
+    try {
+      assertEquals(resolvedPath, PasswordFormPageRenderer.resolvedSecurityLevelsPath());
+      assertEquals(resolvedPath, SecurityLevelsToadlet.resolvedPath());
+    } finally {
+      if (originalProperty == null) {
+        System.clearProperty(SECURITY_LEVELS_PROPERTY);
+      } else {
+        System.setProperty(SECURITY_LEVELS_PROPERTY, originalProperty);
+      }
+    }
+  }
+
+  private HttpShellContainer stubContainer() {
+    HttpShellContainer container = Mockito.mock(HttpShellContainer.class);
     when(container.addFormChild(any(HTMLNode.class), anyString(), anyString()))
         .thenAnswer(
             invocation -> {


### PR DESCRIPTION
## Summary
- introduce a runtime-owned `HttpShellRuntimeSupport` seam and narrow `HttpShellContainer` so runtime-owned packages no longer compile against the legacy HTTP adapter surface
- keep the default `SimpleToadletServer` bridge compatible through the adapter layer, including explicit compatibility checks for runtime support objects and updated bridge/factory tests
- route password-form rendering through the cached security-levels path, cover the route-drift regression, and make the new seam file doclint-clean

## Testing
- `./gradlew test --tests 'network.crypta.runtime.http.security.PasswordFormPageRendererTest' --tests 'network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactoriesTest' --tests 'network.crypta.node.subsystem.NodeStorageSubsystemTest'`
- `./gradlew test`
