### PR TITLE
refactor(runtime-http): Detach password prompt renderer seam

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -47,6 +47,7 @@ import network.crypta.runtime.endpoints.NodeClientCoreInit;
 import network.crypta.runtime.http.HttpShellContainer;
 import network.crypta.runtime.http.HttpShellContainerFactory;
 import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
+import network.crypta.runtime.http.security.PasswordFormPageRenderer;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.Fields;
 import network.crypta.support.HexUtil;
@@ -596,6 +597,8 @@ public final class Node implements TimeSkewDetectorCallback {
         nodeRuntimeBridgeFactories.httpShellRuntimeSupportFactory();
     HttpShellContainerFactory httpShellContainerFactory =
         nodeRuntimeBridgeFactories.httpShellContainerFactory();
+    PasswordFormPageRenderer passwordFormPageRenderer =
+        nodeRuntimeBridgeFactories.passwordFormPageRenderer();
     this.executor = executor;
     this.nodeStarter = ns;
     this.messaging = new NodeMessagingSubsystem();
@@ -603,7 +606,7 @@ public final class Node implements TimeSkewDetectorCallback {
     this.services = new NodeServicesSubsystem(this, httpShellContainerFactory);
     NodeConfigManager configManager = new NodeConfigManager(this);
     this.network = new NodeNetworkSubsystem(this);
-    this.storage = new NodeStorageSubsystem(this);
+    this.storage = new NodeStorageSubsystem(this, passwordFormPageRenderer);
     this.routing = new NodeRoutingSubsystem(this);
     network.initCollector();
     bootstrap.logStartupInfo();

--- a/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
+++ b/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.SecureRandom;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
@@ -279,6 +280,7 @@ public final class NodeStorageSubsystem {
   private CachingFreenetStoreTracker cachingFreenetStoreTracker;
 
   private volatile boolean storePreallocate;
+  private final PasswordFormPageRenderer passwordFormPageRenderer;
 
   /**
    * Creates the storage subsystem facade for a running node instance.
@@ -287,9 +289,12 @@ public final class NodeStorageSubsystem {
    * SSK store operations. Heavy store initialization is deferred to explicit init methods.
    *
    * @param node owning node used for services, statistics, and lifecycle coordination
+   * @param passwordFormPageRenderer renderer used for the shared master-password prompt
    */
-  public NodeStorageSubsystem(Node node) {
-    this.node = node;
+  public NodeStorageSubsystem(Node node, PasswordFormPageRenderer passwordFormPageRenderer) {
+    this.node = Objects.requireNonNull(node, "node");
+    this.passwordFormPageRenderer =
+        Objects.requireNonNull(passwordFormPageRenderer, "passwordFormPageRenderer");
     this.getPubKey = new NodeGetPubkey(node);
   }
 
@@ -500,10 +505,9 @@ public final class NodeStorageSubsystem {
         @Override
         public HTMLNode getHTMLText() {
           HTMLNode content = new HTMLNode("div");
-          PasswordFormPageRenderer.generate(
+          passwordFormPageRenderer.generate(
               new PasswordPromptOptions(false, false, false, false, null, null),
               node.services().clientCore().getEndpoints().getToadletContainer(),
-              PasswordFormPageRenderer.resolvedSecurityLevelsPath(),
               content);
           return content;
         }

--- a/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
@@ -4,8 +4,10 @@ import java.util.Objects;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.endpoints.admin.AdminRuntimeBridgeInputsFactories;
 import network.crypta.runtime.endpoints.http.HttpShellBridgeFactories;
+import network.crypta.runtime.endpoints.http.security.CorePasswordFormPageRenderer;
 import network.crypta.runtime.http.HttpShellContainerFactory;
 import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
+import network.crypta.runtime.http.security.PasswordFormPageRenderer;
 
 /**
  * Bootstrap-owned selection of runtime bridge factories for {@link network.crypta.node.Node}.
@@ -30,20 +32,23 @@ import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
  *     container
  * @param httpShellContainerFactory factory for HTTP shell container creation used by the service
  *     subsystem
+ * @param passwordFormPageRenderer runtime-owned seam used to render the shared master-password
+ *     prompt
  */
 public record NodeRuntimeBridgeFactories(
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory,
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory,
-    HttpShellContainerFactory httpShellContainerFactory) {
+    HttpShellContainerFactory httpShellContainerFactory,
+    PasswordFormPageRenderer passwordFormPageRenderer) {
 
   /**
    * Creates a bootstrap bridge-factory bundle.
    *
-   * <p>All factories are required because node construction expects explicit seams for the admin
-   * runtime bridge inputs, the HTTP shell runtime support path, and the HTTP shell container
-   * creation path. The constructor only validates presence; it does not invoke the factories, prove
-   * cross-factory compatibility, cache runtime state, or trigger any endpoint startup work on its
-   * own.
+   * <p>All supplied seams are required because node construction expects explicit bindings for the
+   * admin runtime bridge inputs, the HTTP shell runtime support path, the HTTP shell container
+   * creation path, and the shared password-form renderer. The constructor only validates presence;
+   * it does not invoke factories, prove cross-binding compatibility, cache runtime state, or
+   * trigger any endpoint startup work on its own.
    *
    * @param adminRuntimeBridgeInputsFactory factory for admin bridge inputs passed into the client
    *     core during node construction
@@ -51,12 +56,15 @@ public record NodeRuntimeBridgeFactories(
    *     client core exists
    * @param httpShellContainerFactory factory for HTTP shell container creation used by {@code
    *     NodeServicesSubsystem}
-   * @throws NullPointerException if any factory reference is {@code null}
+   * @param passwordFormPageRenderer renderer used by node-owned password alerts without exposing
+   *     endpoint-owned HTTP helpers to runtime packages
+   * @throws NullPointerException if any supplied seam reference is {@code null}
    */
   public NodeRuntimeBridgeFactories {
     Objects.requireNonNull(adminRuntimeBridgeInputsFactory, "adminRuntimeBridgeInputsFactory");
     Objects.requireNonNull(httpShellRuntimeSupportFactory, "httpShellRuntimeSupportFactory");
     Objects.requireNonNull(httpShellContainerFactory, "httpShellContainerFactory");
+    Objects.requireNonNull(passwordFormPageRenderer, "passwordFormPageRenderer");
   }
 
   /**
@@ -73,6 +81,7 @@ public record NodeRuntimeBridgeFactories(
     return new NodeRuntimeBridgeFactories(
         AdminRuntimeBridgeInputsFactories.coreBacked(),
         HttpShellBridgeFactories.coreBackedRuntimeSupportFactory(),
-        HttpShellBridgeFactories.defaultContainerFactory());
+        HttpShellBridgeFactories.defaultContainerFactory(),
+        new CorePasswordFormPageRenderer());
   }
 }

--- a/src/main/java/network/crypta/runtime/endpoints/http/security/CorePasswordFormPageRenderer.java
+++ b/src/main/java/network/crypta/runtime/endpoints/http/security/CorePasswordFormPageRenderer.java
@@ -1,0 +1,79 @@
+package network.crypta.runtime.endpoints.http.security;
+
+import java.util.Objects;
+import network.crypta.clients.http.FirstTimeWizardToadlet;
+import network.crypta.clients.http.PasswordFormOptions;
+import network.crypta.clients.http.SecurityLevelsToadlet;
+import network.crypta.runtime.http.HttpShellContainer;
+import network.crypta.runtime.http.security.PasswordFormPageRenderer;
+import network.crypta.runtime.http.security.PasswordPromptOptions;
+import network.crypta.support.HTMLNode;
+
+/**
+ * Endpoint-owned default implementation of the shared password prompt renderer seam.
+ *
+ * <p>This renderer keeps the runtime-owned password prompt seam detached from legacy HTTP adapter
+ * classes while still producing the exact markup expected by the existing administrative web UI. It
+ * translates the neutral {@link PasswordPromptOptions} snapshot into the legacy {@link
+ * PasswordFormOptions} record, creates the form through the active {@link HttpShellContainer}, and
+ * then delegates the actual page body rendering to {@link SecurityLevelsToadlet}.
+ *
+ * <p>The implementation is intentionally narrow and stateless. It preserves the historical
+ * submitting routing rules, keeps the established {@code masterPasswordForm} identifier, and avoids
+ * embedding policy decisions in the endpoint layer. Callers are expected to supply the prompt state
+ * and the surrounding HTTP shell context; this class only maps and forwards that state to the
+ * legacy renderer.
+ *
+ * <ul>
+ *   <li>First-time wizard prompts submit to {@link FirstTimeWizardToadlet#TOADLET_URL}.
+ *   <li>Standard prompts submitting to the cached {@link SecurityLevelsToadlet#resolvedPath()}.
+ *   <li>The generated form keeps the historical {@code masterPasswordForm} name and id.
+ * </ul>
+ */
+public final class CorePasswordFormPageRenderer implements PasswordFormPageRenderer {
+  static final String MASTER_PASSWORD_FORM = "masterPasswordForm";
+
+  /**
+   * Creates the default endpoint-backed password prompt renderer.
+   *
+   * <p>The renderer holds no mutable state and performs no work until {@link
+   * #generate(PasswordPromptOptions, HttpShellContainer, HTMLNode)} is invoked. Reusing one
+   * instance therefore preserves the current behavior without introducing request-scoped caches or
+   * side effects at construction time.
+   */
+  public CorePasswordFormPageRenderer() {
+    // Intentionally empty: this renderer is stateless and defers all work to generate(...).
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation selects the historical submitting target, creates the password form
+   * through the active shell container, and passes the translated legacy options to {@link
+   * SecurityLevelsToadlet}. The supplied {@code content} node remains the parent for the generated
+   * explanatory text and form structure, so callers receive the same HTML tree that the legacy
+   * security page path would have produced.
+   */
+  @Override
+  public void generate(PasswordPromptOptions options, HttpShellContainer ctx, HTMLNode content) {
+    Objects.requireNonNull(options, "options");
+    Objects.requireNonNull(ctx, "ctx");
+    Objects.requireNonNull(content, "content");
+
+    String postTo =
+        options.forFirstTimeWizard()
+            ? FirstTimeWizardToadlet.TOADLET_URL
+            : SecurityLevelsToadlet.resolvedPath();
+    HTMLNode form = ctx.addFormChild(content, postTo, MASTER_PASSWORD_FORM);
+    SecurityLevelsToadlet.generatePasswordFormPage(
+        new PasswordFormOptions(
+            options.wasWrong(),
+            options.forFirstTimeWizard(),
+            options.forDowngrade(),
+            options.forUpgrade(),
+            options.physicalSecurityLevel(),
+            options.redirect()),
+        form,
+        content);
+  }
+}

--- a/src/main/java/network/crypta/runtime/http/security/PasswordFormPageRenderer.java
+++ b/src/main/java/network/crypta/runtime/http/security/PasswordFormPageRenderer.java
@@ -1,85 +1,26 @@
 package network.crypta.runtime.http.security;
 
-import java.util.Objects;
 import network.crypta.runtime.http.HttpShellContainer;
 import network.crypta.support.HTMLNode;
 
 /**
- * Runtime-owned bridge for rendering the shared master-password form.
+ * Runtime-owned seam for rendering the shared master-password form.
  *
- * <p>The node layer uses this helper when it needs the existing password prompt HTML but should not
- * depend on HTTP adapter classes directly. The bridge accepts a runtime-owned snapshot of the
- * prompt state, converts that snapshot into the legacy adapter record, and then hands control to
- * the same renderer that already powers the administrative web UI. That keeps the architectural
- * boundary clean while preserving the established form structure, wording, and submission behavior.
- *
- * <p>This class does not interpret security policy or build markup itself. Its job is intentionally
- * narrow: validate the inputs, map fields one-for-one, and delegate rendering to the current HTTP
- * implementation.
+ * <p>Runtime and node code depend on this abstraction when they need the existing password prompt
+ * HTML without importing concrete HTTP adapter helpers. Implementations remain responsible for
+ * preserving the established form structure, wording, and submit-target behavior.
  */
-public final class PasswordFormPageRenderer {
-  private static final String MASTER_PASSWORD_FORM = "masterPasswordForm";
-
-  private PasswordFormPageRenderer() {}
+@FunctionalInterface
+public interface PasswordFormPageRenderer {
 
   /**
-   * Returns the cached security-levels form target used by the legacy HTTP renderer.
-   *
-   * <p>This keeps runtime-owned callers aligned with the actual route mounted by {@code
-   * SecurityLevelsToadlet}. The underlying toadlet resolves and caches its path during class
-   * initialization, so using this helper avoids drift if the backing system property changes later.
-   *
-   * @return canonical cached security-levels route used by the legacy HTTP shell.
-   */
-  public static String resolvedSecurityLevelsPath() {
-    return network.crypta.clients.http.SecurityLevelsToadlet.resolvedPath();
-  }
-
-  /**
-   * Renders the shared password form through the existing HTTP implementation.
-   *
-   * <p>The supplied options are treated as a detached description of the prompt state. This method
-   * preserves those values exactly during conversion, so the downstream renderer sees the same
-   * flags, redirect target, and security-level context it would have received from legacy call
-   * sites. The provided container and content node are passed through unchanged, which keeps form
-   * creation and HTML assembly behavior identical to the established toadlet path.
+   * Renders the shared password form into the supplied content node.
    *
    * @param options detached prompt state that controls which password guidance and form options are
-   *     rendered for the user.
+   *     rendered for the user
    * @param ctx container used to create the form element with the correct submission endpoint and
-   *     surrounding HTTP context.
-   * @param securityLevelsPath configurable submission target for the standard security-levels page
-   *     flow. This value is ignored when the prompt is being rendered for the first-time wizard,
-   *     which always submits to the wizard-owned endpoint.
-   * @param content HTML node that receives explanatory text and the generated form structure from
-   *     the delegated renderer.
-   * @throws NullPointerException if any argument is {@code null}, because the underlying renderer
-   *     requires all inputs to be present.
+   *     surrounding HTTP context
+   * @param content HTML node that receives explanatory text and the generated form structure
    */
-  public static void generate(
-      PasswordPromptOptions options,
-      HttpShellContainer ctx,
-      String securityLevelsPath,
-      HTMLNode content) {
-    Objects.requireNonNull(options, "options");
-    Objects.requireNonNull(ctx, "ctx");
-    Objects.requireNonNull(securityLevelsPath, "securityLevelsPath");
-    Objects.requireNonNull(content, "content");
-
-    String postTo =
-        options.forFirstTimeWizard()
-            ? network.crypta.clients.http.FirstTimeWizardToadlet.TOADLET_URL
-            : securityLevelsPath;
-    HTMLNode form = ctx.addFormChild(content, postTo, MASTER_PASSWORD_FORM);
-    network.crypta.clients.http.SecurityLevelsToadlet.generatePasswordFormPage(
-        new network.crypta.clients.http.PasswordFormOptions(
-            options.wasWrong(),
-            options.forFirstTimeWizard(),
-            options.forDowngrade(),
-            options.forUpgrade(),
-            options.physicalSecurityLevel(),
-            options.redirect()),
-        form,
-        content);
-  }
+  void generate(PasswordPromptOptions options, HttpShellContainer ctx, HTMLNode content);
 }

--- a/src/main/java/network/crypta/runtime/http/security/PasswordPromptOptions.java
+++ b/src/main/java/network/crypta/runtime/http/security/PasswordPromptOptions.java
@@ -5,9 +5,9 @@ package network.crypta.runtime.http.security;
  *
  * <p>This record mirrors the legacy HTTP-layer password form options while keeping ownership in a
  * neutral runtime package. Node and runtime services can assemble one immutable snapshot, pass it
- * across the architectural boundary, and let the renderer bridge translate it into adapter-owned
- * types only at the final rendering step. That keeps the seam explicit and avoids leaking UI helper
- * classes back into core code.
+ * across the architectural boundary, and let the selected renderer implementation translate it into
+ * adapter-owned types only at the final rendering step. That keeps the seam explicit and avoids
+ * leaking UI helper classes back into core code.
  *
  * <p>Each component maps directly to one rendering decision or post-submit behavior. The record
  * does not validate combinations or interpret policy. It simply preserves the prompt state so

--- a/src/main/java/network/crypta/runtime/http/security/package-info.java
+++ b/src/main/java/network/crypta/runtime/http/security/package-info.java
@@ -1,17 +1,16 @@
 /**
  * Runtime-owned HTTP security-page rendering seams.
  *
- * <p>This package keeps the remaining password-prompt page seams under runtime ownership. Runtime
- * code can assemble immutable prompt state with {@code PasswordPromptOptions} and call {@code
+ * <p>This package keeps the remaining password-prompt page seam under runtime ownership. Runtime
+ * code can assemble immutable prompt state with {@code PasswordPromptOptions} and depend on {@code
  * PasswordFormPageRenderer} when it needs the shared master-password form without importing
  * adapter-owned HTTP helper types directly. That keeps node and subsystem code on the runtime side
- * of the boundary even when the final HTML still comes from older web-admin renderers.
+ * of the boundary even when the final HTML still comes from endpoint-owned renderers.
  *
  * <p>The package remains intentionally small. It does not define security policy, build a new form
  * markup, or replace the established administrative pages. Instead, it carries a detached prompt
- * state, validates the rendering call surface, and delegates to legacy HTTP adapter renderers when
- * those implementations remain the source of truth for markup, submission targets, and
- * operator-facing wording.
+ * state and the neutral rendering contract while endpoint-owned implementations remain the source
+ * of truth for markup, submission targets, and operator-facing wording.
  *
  * <p>When legacy HTTP rendering remains the source of truth, these seams act as the ownership
  * boundary. Higher-level runtime code should depend on the types in this package, while

--- a/src/test/java/network/crypta/node/subsystem/NodeStorageSubsystemTest.java
+++ b/src/test/java/network/crypta/node/subsystem/NodeStorageSubsystemTest.java
@@ -3,8 +3,6 @@ package network.crypta.node.subsystem;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.security.SecureRandom;
-import network.crypta.clients.http.PasswordFormOptions;
-import network.crypta.clients.http.SecurityLevelsToadlet;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
 import network.crypta.keys.CHKBlock;
@@ -20,6 +18,8 @@ import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.bootstrap.NodeBootstrap;
 import network.crypta.runtime.endpoints.ClientEndpoints;
 import network.crypta.runtime.http.HttpShellContainer;
+import network.crypta.runtime.http.security.PasswordFormPageRenderer;
+import network.crypta.runtime.http.security.PasswordPromptOptions;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.store.CHKStore;
 import network.crypta.store.FreenetStore;
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,12 +54,24 @@ class NodeStorageSubsystemTest {
   @Mock private NodeServicesSubsystem services;
   @Mock private NodeClientCore clientCore;
   @Mock private UserAlertManager alerts;
+  @Mock private PasswordFormPageRenderer passwordFormPageRenderer;
 
   private NodeStorageSubsystem subsystem;
 
   @BeforeEach
   void setUp() {
-    subsystem = new NodeStorageSubsystem(node);
+    subsystem = new NodeStorageSubsystem(node, passwordFormPageRenderer);
+  }
+
+  @Test
+  void constructor_whenNodeIsNull_throwsNullPointerException() {
+    assertThrows(
+        NullPointerException.class, () -> new NodeStorageSubsystem(null, passwordFormPageRenderer));
+  }
+
+  @Test
+  void constructor_whenPasswordFormPageRendererIsNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new NodeStorageSubsystem(node, null));
   }
 
   @Test
@@ -223,82 +235,28 @@ class NodeStorageSubsystemTest {
   }
 
   @Test
-  void masterPasswordUserAlert_getHTMLText_whenRendered_matchesLegacyPasswordForm()
+  void masterPasswordUserAlert_getHTMLText_whenRendered_delegatesToPasswordFormPageRenderer()
       throws Exception {
     HttpShellContainer container = org.mockito.Mockito.mock(HttpShellContainer.class);
-    when(container.addFormChild(any(HTMLNode.class), anyString(), anyString()))
-        .thenAnswer(
-            invocation -> {
-              HTMLNode parent = invocation.getArgument(0);
-              String target = invocation.getArgument(1);
-              String id = invocation.getArgument(2);
-              HTMLNode form = parent.addChild("form");
-              form.addAttribute("target", target);
-              form.addAttribute("id", id);
-              return form;
-            });
     when(node.services()).thenReturn(services);
     when(services.clientCore()).thenReturn(clientCore);
     when(clientCore.getEndpoints()).thenReturn(new ClientEndpoints(null, null, container));
-
-    HTMLNode expectedContent = new HTMLNode("div");
-    HTMLNode expectedForm = expectedContent.addChild("form");
-    expectedForm.addAttribute("target", SecurityLevelsToadlet.resolvedPath());
-    expectedForm.addAttribute("id", "masterPasswordForm");
-    SecurityLevelsToadlet.generatePasswordFormPage(
-        new PasswordFormOptions(false, false, false, false, null, null),
-        expectedForm,
-        expectedContent);
+    PasswordPromptOptions expectedOptions =
+        new PasswordPromptOptions(false, false, false, false, null, null);
+    doAnswer(
+            invocation -> {
+              HTMLNode content = invocation.getArgument(2);
+              content.addChild("p", "rendered");
+              return null;
+            })
+        .when(passwordFormPageRenderer)
+        .generate(
+            any(PasswordPromptOptions.class), any(HttpShellContainer.class), any(HTMLNode.class));
 
     HTMLNode renderedContent = getMasterPasswordUserAlert(subsystem).getHTMLText();
 
-    assertEquals(expectedContent.generate(), renderedContent.generate());
-  }
-
-  @Test
-  void
-      masterPasswordUserAlert_getHTMLText_whenSecurityLevelsPropertyChangesAfterPathResolution_usesResolvedRoute()
-          throws Exception {
-    HttpShellContainer container = org.mockito.Mockito.mock(HttpShellContainer.class);
-    when(container.addFormChild(any(HTMLNode.class), anyString(), anyString()))
-        .thenAnswer(
-            invocation -> {
-              HTMLNode parent = invocation.getArgument(0);
-              String target = invocation.getArgument(1);
-              String id = invocation.getArgument(2);
-              HTMLNode form = parent.addChild("form");
-              form.addAttribute("target", target);
-              form.addAttribute("id", id);
-              return form;
-            });
-    when(node.services()).thenReturn(services);
-    when(services.clientCore()).thenReturn(clientCore);
-    when(clientCore.getEndpoints()).thenReturn(new ClientEndpoints(null, null, container));
-
-    String originalProperty = System.getProperty("network.crypta.seclevels.path");
-    String resolvedPath = SecurityLevelsToadlet.resolvedPath();
-    System.setProperty("network.crypta.seclevels.path", "/changed-after-init/");
-
-    try {
-      HTMLNode expectedContent = new HTMLNode("div");
-      HTMLNode expectedForm = expectedContent.addChild("form");
-      expectedForm.addAttribute("target", resolvedPath);
-      expectedForm.addAttribute("id", "masterPasswordForm");
-      SecurityLevelsToadlet.generatePasswordFormPage(
-          new PasswordFormOptions(false, false, false, false, null, null),
-          expectedForm,
-          expectedContent);
-
-      HTMLNode renderedContent = getMasterPasswordUserAlert(subsystem).getHTMLText();
-
-      assertEquals(expectedContent.generate(), renderedContent.generate());
-    } finally {
-      if (originalProperty == null) {
-        System.clearProperty("network.crypta.seclevels.path");
-      } else {
-        System.setProperty("network.crypta.seclevels.path", originalProperty);
-      }
-    }
+    assertTrue(renderedContent.generate().contains("<p>rendered</p>"));
+    verify(passwordFormPageRenderer).generate(expectedOptions, container, renderedContent);
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
@@ -9,9 +9,11 @@ import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
 import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
+import network.crypta.runtime.endpoints.http.security.CorePasswordFormPageRenderer;
 import network.crypta.runtime.http.HttpShellContainerFactory;
 import network.crypta.runtime.http.HttpShellRuntimeSupport;
 import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
+import network.crypta.runtime.http.security.PasswordFormPageRenderer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -29,12 +31,16 @@ class NodeRuntimeBridgeFactoriesTest {
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         ignoredCore -> mock(HttpShellRuntimeSupport.class);
     HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
+    PasswordFormPageRenderer passwordFormPageRenderer = (_, _, _) -> {};
 
     assertThrows(
         NullPointerException.class,
         () ->
             new NodeRuntimeBridgeFactories(
-                null, httpShellRuntimeSupportFactory, httpShellContainerFactory));
+                null,
+                httpShellRuntimeSupportFactory,
+                httpShellContainerFactory,
+                passwordFormPageRenderer));
   }
 
   @Test
@@ -43,12 +49,16 @@ class NodeRuntimeBridgeFactoriesTest {
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
         fixture.adminRuntimeBridgeInputsFactory();
     HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
+    PasswordFormPageRenderer passwordFormPageRenderer = (_, _, _) -> {};
 
     assertThrows(
         NullPointerException.class,
         () ->
             new NodeRuntimeBridgeFactories(
-                adminRuntimeBridgeInputsFactory, null, httpShellContainerFactory));
+                adminRuntimeBridgeInputsFactory,
+                null,
+                httpShellContainerFactory,
+                passwordFormPageRenderer));
   }
 
   @Test
@@ -58,12 +68,35 @@ class NodeRuntimeBridgeFactoriesTest {
         fixture.adminRuntimeBridgeInputsFactory();
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         ignoredCore -> mock(HttpShellRuntimeSupport.class);
+    PasswordFormPageRenderer passwordFormPageRenderer = (_, _, _) -> {};
 
     assertThrows(
         NullPointerException.class,
         () ->
             new NodeRuntimeBridgeFactories(
-                adminRuntimeBridgeInputsFactory, httpShellRuntimeSupportFactory, null));
+                adminRuntimeBridgeInputsFactory,
+                httpShellRuntimeSupportFactory,
+                null,
+                passwordFormPageRenderer));
+  }
+
+  @Test
+  void constructor_whenPasswordFormPageRendererIsNull_throws() {
+    NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
+    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
+        fixture.adminRuntimeBridgeInputsFactory();
+    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
+        ignoredCore -> mock(HttpShellRuntimeSupport.class);
+    HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new NodeRuntimeBridgeFactories(
+                adminRuntimeBridgeInputsFactory,
+                httpShellRuntimeSupportFactory,
+                httpShellContainerFactory,
+                null));
   }
 
   @Test
@@ -79,15 +112,19 @@ class NodeRuntimeBridgeFactoriesTest {
         runtimeBridgeFactories.httpShellRuntimeSupportFactory().create(fixture.core());
     HttpShellContainerFactory httpShellContainerFactory =
         runtimeBridgeFactories.httpShellContainerFactory();
+    PasswordFormPageRenderer passwordFormPageRenderer =
+        runtimeBridgeFactories.passwordFormPageRenderer();
 
     assertNotNull(runtimeBridgeFactories.adminRuntimeBridgeInputsFactory());
     assertNotNull(runtimeBridgeFactories.httpShellRuntimeSupportFactory());
     assertNotNull(httpShellContainerFactory);
+    assertNotNull(passwordFormPageRenderer);
     assertInstanceOf(FcpQueueAdminBackend.class, bridgeInputs.queueAdminBackend());
     assertInstanceOf(HttpGeoIpCountryLookup.class, bridgeInputs.geoIpCountryLookup());
     CoreHttpShellRuntimeSupport coreRuntimeSupport =
         assertInstanceOf(CoreHttpShellRuntimeSupport.class, runtimeSupport);
     assertInstanceOf(network.crypta.clients.http.HttpShellRuntimeSupport.class, runtimeSupport);
+    assertInstanceOf(CorePasswordFormPageRenderer.class, passwordFormPageRenderer);
     assertSame(fixture.core(), coreRuntimeSupport.core());
   }
 

--- a/src/test/java/network/crypta/runtime/endpoints/http/security/CorePasswordFormPageRendererTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/http/security/CorePasswordFormPageRendererTest.java
@@ -1,9 +1,10 @@
-package network.crypta.runtime.http.security;
+package network.crypta.runtime.endpoints.http.security;
 
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.clients.http.PasswordFormOptions;
 import network.crypta.clients.http.SecurityLevelsToadlet;
 import network.crypta.runtime.http.HttpShellContainer;
+import network.crypta.runtime.http.security.PasswordPromptOptions;
 import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -14,13 +15,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-class PasswordFormPageRendererTest {
-  private static final String SECURITY_LEVELS_PROPERTY = "network.crypta.seclevels.path";
+class CorePasswordFormPageRendererTest {
   private static final String HIGH_SECURITY_LEVEL = "HIGH";
   private static final String NEXT_REDIRECT = "/next";
-  private static final String SECURITY_LEVELS_TARGET = "/seclevels/";
   private static final String CHANGED_SECURITY_LEVELS_TARGET = "/changed-after-init/";
-  private static final String MASTER_PASSWORD_FORM_ID = "masterPasswordForm";
+
+  private final CorePasswordFormPageRenderer renderer = new CorePasswordFormPageRenderer();
 
   @Test
   void generate_whenCalled_matchesLegacySecurityLevelsRendering() {
@@ -31,10 +31,10 @@ class PasswordFormPageRendererTest {
     HTMLNode legacyContent = new HTMLNode("div");
     HttpShellContainer container = stubContainer();
     HTMLNode legacyForm = legacyContent.addChild("form");
-    legacyForm.addAttribute("target", SECURITY_LEVELS_TARGET);
-    legacyForm.addAttribute("id", MASTER_PASSWORD_FORM_ID);
+    legacyForm.addAttribute("target", SecurityLevelsToadlet.resolvedPath());
+    legacyForm.addAttribute("id", CorePasswordFormPageRenderer.MASTER_PASSWORD_FORM);
 
-    PasswordFormPageRenderer.generate(options, container, SECURITY_LEVELS_TARGET, bridgedContent);
+    renderer.generate(options, container, bridgedContent);
     SecurityLevelsToadlet.generatePasswordFormPage(
         new PasswordFormOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT),
         legacyForm,
@@ -53,9 +53,9 @@ class PasswordFormPageRendererTest {
     HttpShellContainer container = stubContainer();
     HTMLNode legacyForm = legacyContent.addChild("form");
     legacyForm.addAttribute("target", FirstTimeWizardToadlet.TOADLET_URL);
-    legacyForm.addAttribute("id", MASTER_PASSWORD_FORM_ID);
+    legacyForm.addAttribute("id", CorePasswordFormPageRenderer.MASTER_PASSWORD_FORM);
 
-    PasswordFormPageRenderer.generate(options, container, SECURITY_LEVELS_TARGET, bridgedContent);
+    renderer.generate(options, container, bridgedContent);
     SecurityLevelsToadlet.generatePasswordFormPage(
         new PasswordFormOptions(false, true, false, false, null, null), legacyForm, legacyContent);
 
@@ -67,9 +67,7 @@ class PasswordFormPageRendererTest {
     HttpShellContainer container = stubContainer();
     HTMLNode content = new HTMLNode("div");
 
-    assertThrows(
-        NullPointerException.class,
-        () -> PasswordFormPageRenderer.generate(null, container, SECURITY_LEVELS_TARGET, content));
+    assertThrows(NullPointerException.class, () -> renderer.generate(null, container, content));
   }
 
   @Test
@@ -78,21 +76,7 @@ class PasswordFormPageRendererTest {
         new PasswordPromptOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT);
     HTMLNode content = new HTMLNode("div");
 
-    assertThrows(
-        NullPointerException.class,
-        () -> PasswordFormPageRenderer.generate(options, null, SECURITY_LEVELS_TARGET, content));
-  }
-
-  @Test
-  void generate_whenSecurityLevelsPathNull_throwsNullPointerException() {
-    PasswordPromptOptions options =
-        new PasswordPromptOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT);
-    HttpShellContainer container = stubContainer();
-    HTMLNode content = new HTMLNode("div");
-
-    assertThrows(
-        NullPointerException.class,
-        () -> PasswordFormPageRenderer.generate(options, container, null, content));
+    assertThrows(NullPointerException.class, () -> renderer.generate(options, null, content));
   }
 
   @Test
@@ -101,26 +85,38 @@ class PasswordFormPageRendererTest {
         new PasswordPromptOptions(false, false, false, true, HIGH_SECURITY_LEVEL, NEXT_REDIRECT);
     HttpShellContainer container = stubContainer();
 
-    assertThrows(
-        NullPointerException.class,
-        () -> PasswordFormPageRenderer.generate(options, container, SECURITY_LEVELS_TARGET, null));
+    assertThrows(NullPointerException.class, () -> renderer.generate(options, container, null));
   }
 
   @Test
-  void resolvedSecurityLevelsPath_whenPropertyChangesAfterResolution_returnsCachedRoute() {
-    String originalProperty = System.getProperty(SECURITY_LEVELS_PROPERTY);
-    String resolvedPath = PasswordFormPageRenderer.resolvedSecurityLevelsPath();
-
-    System.setProperty(SECURITY_LEVELS_PROPERTY, CHANGED_SECURITY_LEVELS_TARGET);
+  void generate_whenSecurityLevelsPropertyChangesAfterPathResolution_usesResolvedRoute() {
+    HttpShellContainer container = stubContainer();
+    String originalProperty = System.getProperty("network.crypta.seclevels.path");
+    String resolvedPath = SecurityLevelsToadlet.resolvedPath();
+    System.setProperty("network.crypta.seclevels.path", CHANGED_SECURITY_LEVELS_TARGET);
 
     try {
-      assertEquals(resolvedPath, PasswordFormPageRenderer.resolvedSecurityLevelsPath());
-      assertEquals(resolvedPath, SecurityLevelsToadlet.resolvedPath());
+      HTMLNode bridgedContent = new HTMLNode("div");
+      HTMLNode legacyContent = new HTMLNode("div");
+      HTMLNode legacyForm = legacyContent.addChild("form");
+      legacyForm.addAttribute("target", resolvedPath);
+      legacyForm.addAttribute("id", CorePasswordFormPageRenderer.MASTER_PASSWORD_FORM);
+
+      renderer.generate(
+          new PasswordPromptOptions(false, false, false, false, null, null),
+          container,
+          bridgedContent);
+      SecurityLevelsToadlet.generatePasswordFormPage(
+          new PasswordFormOptions(false, false, false, false, null, null),
+          legacyForm,
+          legacyContent);
+
+      assertEquals(legacyContent.generate(), bridgedContent.generate());
     } finally {
       if (originalProperty == null) {
-        System.clearProperty(SECURITY_LEVELS_PROPERTY);
+        System.clearProperty("network.crypta.seclevels.path");
       } else {
-        System.setProperty(SECURITY_LEVELS_PROPERTY, originalProperty);
+        System.setProperty("network.crypta.seclevels.path", originalProperty);
       }
     }
   }


### PR DESCRIPTION
## Summary
- convert `runtime.http.security.PasswordFormPageRenderer` from a static legacy-backed helper into a runtime-owned rendering seam
- add endpoint-owned `CorePasswordFormPageRenderer` and wire the default implementation through `NodeRuntimeBridgeFactories`, `Node`, and `NodeStorageSubsystem`
- move and update the focused tests to cover bootstrap wiring, subsystem seam delegation, and legacy password-form markup parity

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --tests 'network.crypta.node.subsystem.NodeStorageSubsystemTest'`
- `./gradlew test --tests 'network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactoriesTest' --tests 'network.crypta.node.subsystem.NodeStorageSubsystemTest' --tests 'network.crypta.runtime.endpoints.http.security.CorePasswordFormPageRendererTest'`
- `./gradlew test`

## Verification
- `rg -n "clients\\.http\\.|SecurityLevelsToadlet|PasswordFormOptions|FirstTimeWizardToadlet" src/main/java/network/crypta/runtime/http/security src/test/java/network/crypta/runtime/http/security`
