### PR TITLE
refactor(runtime): Inject FCP persistence seam

### DIFF
--- a/src/main/java/network/crypta/node/Node.java
+++ b/src/main/java/network/crypta/node/Node.java
@@ -38,7 +38,6 @@ import network.crypta.node.subsystem.NodeMessagingSubsystem;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.subsystem.NodeRoutingSubsystem;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
-import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.bootstrap.NodeBootstrap;
 import network.crypta.runtime.bootstrap.NodeConfigManager;
 import network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactories;
@@ -591,8 +590,6 @@ public final class Node implements TimeSkewDetectorCallback {
       throws NodeInitException {
     NodeRuntimeBridgeFactories nodeRuntimeBridgeFactories =
         Objects.requireNonNull(runtimeBridgeFactories, "runtimeBridgeFactories");
-    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
-        nodeRuntimeBridgeFactories.adminRuntimeBridgeInputsFactory();
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         nodeRuntimeBridgeFactories.httpShellRuntimeSupportFactory();
     HttpShellContainerFactory httpShellContainerFactory =
@@ -719,7 +716,7 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
     NodeClientCore clientCoreLocal =
         new NodeClientCore(
             this,
-            adminRuntimeBridgeInputsFactory,
+            nodeRuntimeBridgeFactories,
             clientCoreInit,
             network.darknetPortNumber(),
             sortOrder,

--- a/src/main/java/network/crypta/node/NodeClientCore.java
+++ b/src/main/java/network/crypta/node/NodeClientCore.java
@@ -2,6 +2,7 @@ package network.crypta.node;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
@@ -25,6 +26,7 @@ import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.alerts.UserAlertManagerClientAlertSink;
+import network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactories;
 import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.core.LegacyRuntimePorts;
 import network.crypta.runtime.core.NodeClientCoreSupport;
@@ -33,6 +35,7 @@ import network.crypta.runtime.endpoints.ClientEndpoints;
 import network.crypta.runtime.endpoints.NodeClientCoreInit;
 import network.crypta.runtime.endpoints.NodeClientPersistence;
 import network.crypta.runtime.endpoints.TextModeClientInterface;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServicesFactory;
 import network.crypta.runtime.persistence.Persistable;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Base64;
@@ -190,13 +193,19 @@ public final class NodeClientCore implements Persistable {
 
   NodeClientCore(
       Node node,
-      AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory,
+      NodeRuntimeBridgeFactories runtimeBridgeFactories,
       NodeClientCoreInit init,
       int portNumber,
       int sortOrder,
       DatabaseKey databaseKey,
       MasterSecret persistentSecret)
       throws NodeInitException {
+    NodeRuntimeBridgeFactories nodeRuntimeBridgeFactories =
+        Objects.requireNonNull(runtimeBridgeFactories, "runtimeBridgeFactories");
+    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
+        nodeRuntimeBridgeFactories.adminRuntimeBridgeInputsFactory();
+    PersistentRequestEndpointServicesFactory persistentRequestEndpointServicesFactory =
+        nodeRuntimeBridgeFactories.persistentRequestEndpointServicesFactory();
     this.node = node;
     this.random = node.bootstrap().random();
 
@@ -210,7 +219,9 @@ public final class NodeClientCore implements Persistable {
     compressor = new RealCompressor();
     this.formPassword = Base64.encode(pwdBuf);
     alerts = new UserAlertManager(this);
-    persistence = new NodeClientPersistence(this, init.nodeConfig(), node, sortOrder);
+    persistence =
+        new NodeClientPersistence(
+            this, init.nodeConfig(), node, sortOrder, persistentRequestEndpointServicesFactory);
     sortOrder = persistence.getSortOrderAfter();
 
     SimpleFieldSet throttleFS = persistence.readThrottle();

--- a/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
+++ b/src/main/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactories.java
@@ -3,8 +3,10 @@ package network.crypta.runtime.bootstrap;
 import java.util.Objects;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
 import network.crypta.runtime.endpoints.admin.AdminRuntimeBridgeInputsFactories;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointBridgeFactories;
 import network.crypta.runtime.endpoints.http.HttpShellBridgeFactories;
 import network.crypta.runtime.endpoints.http.security.CorePasswordFormPageRenderer;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServicesFactory;
 import network.crypta.runtime.http.HttpShellContainerFactory;
 import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
 import network.crypta.runtime.http.security.PasswordFormPageRenderer;
@@ -15,7 +17,7 @@ import network.crypta.runtime.http.security.PasswordFormPageRenderer;
  * <p>This holder keeps the composition-root decision about which runtime bridge implementations to
  * use out of the node kernel. Bootstrap code selects the seam implementations once, then passes
  * them into {@code Node} so the node can stay focused on coordination and lifecycle rather than on
- * choosing endpoint-backed defaults.
+ * choosing endpoint-backed defaults for admin bridges, FCP persistence, or HTTP helpers.
  *
  * <p>Typical startup paths create one instance during bootstrap, thread it through {@link
  * network.crypta.runtime.bootstrap.NodeStarter}, and then let the node reuse those seams at the
@@ -28,6 +30,8 @@ import network.crypta.runtime.http.security.PasswordFormPageRenderer;
  *
  * @param adminRuntimeBridgeInputsFactory factory for the admin/runtime bridge inputs used by the
  *     client core
+ * @param persistentRequestEndpointServicesFactory factory for the FCP persistent-request bundle
+ *     used by client-core persistence wiring
  * @param httpShellRuntimeSupportFactory factory for HTTP shell runtime support used by the toadlet
  *     container
  * @param httpShellContainerFactory factory for HTTP shell container creation used by the service
@@ -37,6 +41,7 @@ import network.crypta.runtime.http.security.PasswordFormPageRenderer;
  */
 public record NodeRuntimeBridgeFactories(
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory,
+    PersistentRequestEndpointServicesFactory persistentRequestEndpointServicesFactory,
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory,
     HttpShellContainerFactory httpShellContainerFactory,
     PasswordFormPageRenderer passwordFormPageRenderer) {
@@ -45,13 +50,15 @@ public record NodeRuntimeBridgeFactories(
    * Creates a bootstrap bridge-factory bundle.
    *
    * <p>All supplied seams are required because node construction expects explicit bindings for the
-   * admin runtime bridge inputs, the HTTP shell runtime support path, the HTTP shell container
-   * creation path, and the shared password-form renderer. The constructor only validates presence;
-   * it does not invoke factories, prove cross-binding compatibility, cache runtime state, or
-   * trigger any endpoint startup work on its own.
+   * admin runtime bridge inputs, the FCP persistent-request bundle, the HTTP shell runtime support
+   * path, the HTTP shell container creation path, and the shared password-form renderer. The
+   * constructor only validates presence; it does not invoke factories, prove cross-binding
+   * compatibility, cache runtime state, or trigger any endpoint startup work on its own.
    *
    * @param adminRuntimeBridgeInputsFactory factory for admin bridge inputs passed into the client
    *     core during node construction
+   * @param persistentRequestEndpointServicesFactory factory for the FCP persistent-request bundle
+   *     consumed by {@code NodeClientPersistence}
    * @param httpShellRuntimeSupportFactory factory for HTTP shell runtime support created after the
    *     client core exists
    * @param httpShellContainerFactory factory for HTTP shell container creation used by {@code
@@ -62,6 +69,8 @@ public record NodeRuntimeBridgeFactories(
    */
   public NodeRuntimeBridgeFactories {
     Objects.requireNonNull(adminRuntimeBridgeInputsFactory, "adminRuntimeBridgeInputsFactory");
+    Objects.requireNonNull(
+        persistentRequestEndpointServicesFactory, "persistentRequestEndpointServicesFactory");
     Objects.requireNonNull(httpShellRuntimeSupportFactory, "httpShellRuntimeSupportFactory");
     Objects.requireNonNull(httpShellContainerFactory, "httpShellContainerFactory");
     Objects.requireNonNull(passwordFormPageRenderer, "passwordFormPageRenderer");
@@ -72,14 +81,17 @@ public record NodeRuntimeBridgeFactories(
    * implementations.
    *
    * <p>This helper centralizes the existing production default in the bootstrap package. Callers
-   * that need the historical daemon wiring can therefore get the same admin and HTTP shell bridge
-   * choices without making the node kernel depend on the endpoint-owned static entry points.
+   * that need the historical daemon wiring can therefore get the same admin, FCP persistence, and
+   * HTTP shell bridge choices without making the node kernel depend on the endpoint-owned static
+   * entry points.
    *
-   * @return bridge factories that preserve the current core-backed admin and HTTP shell wiring
+   * @return bridge factories that preserve the current core-backed admin, FCP, and HTTP shell
+   *     wiring
    */
   public static NodeRuntimeBridgeFactories coreBacked() {
     return new NodeRuntimeBridgeFactories(
         AdminRuntimeBridgeInputsFactories.coreBacked(),
+        FcpEndpointBridgeFactories.coreBackedPersistentRequestServicesFactory(),
         HttpShellBridgeFactories.coreBackedRuntimeSupportFactory(),
         HttpShellBridgeFactories.defaultContainerFactory(),
         new CorePasswordFormPageRenderer());

--- a/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
+++ b/src/main/java/network/crypta/runtime/endpoints/NodeClientPersistence.java
@@ -19,7 +19,8 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeInitException;
 import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
-import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestServices;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServices;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServicesFactory;
 import network.crypta.runtime.persistence.ConfigurablePersister;
 import network.crypta.runtime.persistence.ConfigurablePersisterParams;
 import network.crypta.runtime.persistence.Persistable;
@@ -40,9 +41,9 @@ import network.crypta.support.io.TempBucketFactory;
  * sprawl across the client-core initialization flow. Callers typically construct an instance early
  * in node startup, configure disk-checking factories once storage directories are known, and then
  * use it to build the {@link ClientContext} and FCP endpoint wiring. Concrete persistent-request
- * infrastructure is hidden behind the bridge package, so registration remains consistent across the
- * client-layer components it creates without exposing concrete FCP endpoint or owner types directly
- * from this package.
+ * infrastructure is supplied through a runtime-owned seam selected at bootstrap time, so
+ * registration remains consistent across the client-layer components it creates without exposing
+ * endpoint-owned bridge classes directly from this package.
  *
  * <p>State is initialized in stages: the disk checker and persistent RAF factory are {@code null}
  * until {@link #initDiskChecker(FilenameGenerator, File, long, TempBucketFactory, boolean)} is
@@ -63,14 +64,10 @@ import network.crypta.support.io.TempBucketFactory;
  */
 public final class NodeClientPersistence {
   private final ConfigurablePersister persister;
-  private final FcpPersistentRequestServices fcpPersistentRequestServices =
-      new FcpPersistentRequestServices();
-  private final PersistentRequestCoordinator persistentRequestCoordinator =
-      fcpPersistentRequestServices.coordinator();
-  private final PersistentRequestCatalog persistentRequestCatalog =
-      fcpPersistentRequestServices.catalog();
-  private final PersistentRequestRecoveryCodec persistentRequestRecoveryCodec =
-      fcpPersistentRequestServices.recoveryCodec();
+  private final PersistentRequestEndpointServices persistentRequestEndpointServices;
+  private final PersistentRequestCoordinator persistentRequestCoordinator;
+  private final PersistentRequestCatalog persistentRequestCatalog;
+  private final PersistentRequestRecoveryCodec persistentRequestRecoveryCodec;
   private DiskSpaceCheckingRandomAccessBufferFactory diskChecker;
   private MaybeEncryptedRandomAccessBufferFactory persistentRafFactory;
   private final int sortOrderAfter;
@@ -88,11 +85,33 @@ public final class NodeClientPersistence {
    * @param nodeConfig configuration section used to register the throttle file option.
    * @param node node instance providing ticker and run directory settings.
    * @param initialSortOrder starting sort order for configuration registration.
+   * @param persistentRequestEndpointServicesFactory factory that supplies the FCP persistent
+   *     request bundle used by client-layer persistence and endpoint bootstrap
    * @throws NodeInitException if the configured throttle file cannot be created or used.
    */
   public NodeClientPersistence(
-      Persistable persistable, SubConfig nodeConfig, Node node, int initialSortOrder)
+      Persistable persistable,
+      SubConfig nodeConfig,
+      Node node,
+      int initialSortOrder,
+      PersistentRequestEndpointServicesFactory persistentRequestEndpointServicesFactory)
       throws NodeInitException {
+    persistentRequestEndpointServices =
+        Objects.requireNonNull(
+            Objects.requireNonNull(
+                    persistentRequestEndpointServicesFactory,
+                    "persistentRequestEndpointServicesFactory")
+                .create(),
+            "persistentRequestEndpointServices");
+    persistentRequestCoordinator =
+        Objects.requireNonNull(
+            persistentRequestEndpointServices.coordinator(), "persistentRequestCoordinator");
+    persistentRequestCatalog =
+        Objects.requireNonNull(
+            persistentRequestEndpointServices.catalog(), "persistentRequestCatalog");
+    persistentRequestRecoveryCodec =
+        Objects.requireNonNull(
+            persistentRequestEndpointServices.recoveryCodec(), "persistentRequestRecoveryCodec");
     int sortOrder = initialSortOrder;
     persister =
         new ConfigurablePersister(
@@ -270,8 +289,9 @@ public final class NodeClientPersistence {
    * Creates the FCP endpoint handle configured for this node and client core.
    *
    * <p>The endpoint is constructed via a local dependency bundle, so the remaining core-backed
-   * runtime adapters stay localized to the FCP bootstrap seam. The persistent request
-   * implementation is supplied by the bridge package and remains hidden behind the seam.
+   * runtime adapters stay localized to the FCP bootstrap seam. The persistent-request
+   * implementation is supplied through the injected runtime seam and remains hidden behind that
+   * boundary.
    *
    * @param node node instance supplying configuration and shared services.
    * @param core client core used by the FCP endpoint for callbacks.
@@ -280,21 +300,21 @@ public final class NodeClientPersistence {
    */
   public FcpEndpointHandle createFcpEndpointHandle(
       Node node, NodeClientCore core, RuntimePorts runtimePorts) {
-    return fcpPersistentRequestServices.createEndpointHandle(node, core, runtimePorts);
+    return persistentRequestEndpointServices.createFcpEndpointHandle(node, core, runtimePorts);
   }
 
   /**
    * Returns a snapshot of all currently registered persistent requests.
    *
-   * <p>The snapshot is provided by the bridge-owned persistent request services and may include
-   * global and per-client persistent requests. The returned array is a point-in-time view; later
-   * request registrations or removals are not reflected in the array. Callers should depend on the
-   * narrower persistent request handle seam rather than concrete request implementations.
+   * <p>The snapshot is provided by the injected persistent-request services and may include global
+   * and per-client persistent requests. The returned array is a point-in-time view; later request
+   * registrations or removals are not reflected in the array. Callers should depend on the narrower
+   * persistent request handle seam rather than concrete request implementations.
    *
    * @return an array of persistent request handles; never {@code null}.
    */
   public PersistentRequestHandle[] getPersistentRequests() {
-    return fcpPersistentRequestServices.getPersistentRequests();
+    return persistentRequestEndpointServices.getPersistentRequests();
   }
 
   /**

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointBridgeFactories.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointBridgeFactories.java
@@ -1,0 +1,39 @@
+package network.crypta.runtime.endpoints.fcp;
+
+import network.crypta.runtime.fcp.PersistentRequestEndpointServicesFactory;
+
+/**
+ * Endpoint-owned default production bindings for runtime-owned FCP persistence seams.
+ *
+ * <p>This helper keeps the composition-root knowledge about the current FCP bridge implementation
+ * inside the endpoint-owned package. Bootstrap code can call these factories once, select the
+ * historical endpoint-backed binding, and then thread only the runtime-owned seam upstream through
+ * {@code NodeRuntimeBridgeFactories}, {@code Node}, and {@code NodeClientCore}. That preserves the
+ * existing bootstrap order and persistent-request behavior without forcing higher-level runtime
+ * packages to import {@link FcpPersistentRequestServices} directly.
+ *
+ * <p>The class intentionally exposes only narrow static binding methods. It does not cache bridge
+ * instances, own endpoint lifecycle, or start FCP services by itself. Those responsibilities stay
+ * with the runtime bootstrap and client-persistence layers that consume the returned seam factory.
+ */
+public final class FcpEndpointBridgeFactories {
+  private FcpEndpointBridgeFactories() {}
+
+  /**
+   * Returns the default production factory for the FCP persistent-request bundle.
+   *
+   * <p>The returned factory preserves the existing production wiring by creating {@link
+   * FcpPersistentRequestServices} instances on demand. Callers typically pass the factory into
+   * runtime bootstrap structures and invoke it later from {@code NodeClientPersistence} so the
+   * persistence adapters, persistent-request snapshot, and eventual FCP endpoint handle all share
+   * one bundle instance for that node startup path. The factory itself remains side-effect free
+   * until invoked.
+   *
+   * @return factory that creates the current endpoint-backed persistent-request bundle for one
+   *     client-persistence construction path
+   */
+  public static PersistentRequestEndpointServicesFactory
+      coreBackedPersistentRequestServicesFactory() {
+    return FcpPersistentRequestServices::new;
+  }
+}

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServices.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServices.java
@@ -9,6 +9,7 @@ import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServices;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
@@ -16,7 +17,8 @@ import network.crypta.runtime.spi.RuntimePorts;
  *
  * <p>This service keeps the legacy {@link PersistentRequestRoot}, request-catalog adapter, recovery
  * codec, and FCP endpoint creation logic inside {@code runtime.endpoints.fcp}. Callers in the
- * top-level runtime package interact only with the narrower client-owned persistence seams and the
+ * top-level runtime package interact only with the narrower runtime-owned {@link
+ * PersistentRequestEndpointServices} seam, the client-owned persistence seams it exposes, and the
  * runtime-owned {@link FcpEndpointHandle}.
  *
  * <p>Each instance owns one shared persistent-request root and the adapters derived from it. That
@@ -26,7 +28,7 @@ import network.crypta.runtime.spi.RuntimePorts;
  * client-layer persistence wiring, and later ask it to create the endpoint handle that will expose
  * the same persistent state to the running node.
  */
-public final class FcpPersistentRequestServices {
+public final class FcpPersistentRequestServices implements PersistentRequestEndpointServices {
   private final PersistentRequestRoot persistentRoot;
   private final PersistentRequestCatalog catalog;
   private final PersistentRequestRecoveryCodec recoveryCodec;
@@ -48,6 +50,7 @@ public final class FcpPersistentRequestServices {
    *
    * @return persistent-request coordinator backed by the bridge-owned request root
    */
+  @Override
   public PersistentRequestCoordinator coordinator() {
     return persistentRoot;
   }
@@ -61,6 +64,7 @@ public final class FcpPersistentRequestServices {
    *
    * @return persistent-request catalog backed by the bridge-owned request root
    */
+  @Override
   public PersistentRequestCatalog catalog() {
     return catalog;
   }
@@ -74,6 +78,7 @@ public final class FcpPersistentRequestServices {
    *
    * @return recovery codec that restores FCP persistent requests through the seam
    */
+  @Override
   public PersistentRequestRecoveryCodec recoveryCodec() {
     return recoveryCodec;
   }
@@ -88,6 +93,7 @@ public final class FcpPersistentRequestServices {
    *
    * @return snapshot of persistent request handles; never {@code null}
    */
+  @Override
   public PersistentRequestHandle[] getPersistentRequests() {
     return persistentRoot.getPersistentRequests();
   }
@@ -107,7 +113,8 @@ public final class FcpPersistentRequestServices {
    * @return runtime-owned handle that wraps the configured FCP server
    * @throws NullPointerException if any required dependency is {@code null}
    */
-  public FcpEndpointHandle createEndpointHandle(
+  @Override
+  public FcpEndpointHandle createFcpEndpointHandle(
       Node node, NodeClientCore core, RuntimePorts runtimePorts) {
     Node nonNullNode = Objects.requireNonNull(node, "node");
     FCPServer server =

--- a/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
+++ b/src/main/java/network/crypta/runtime/endpoints/fcp/package-info.java
@@ -1,10 +1,11 @@
 /**
- * Runtime-owned FCP endpoint bootstrap glue.
+ * Endpoint-owned FCP bridge implementations and default bindings.
  *
  * <p>This package adapts daemon- and runtime-backed services to the narrow runtime-support seams
- * defined in {@code network.crypta.clients.fcp}. The types here keep the concrete FCP server and
- * persistent-request root owned by bridge-local wrappers such as {@code FcpEndpointHandle} and
- * {@code FcpPersistentRequestServices}, preserving the current protocol behavior without widening
+ * defined in {@code network.crypta.clients.fcp} and {@code network.crypta.runtime.fcp}. The types
+ * here keep the concrete FCP server, persistent-request root, and default production bindings owned
+ * by bridge-local wrappers such as {@code FcpEndpointHandle}, {@code FcpPersistentRequestServices},
+ * and {@code FcpEndpointBridgeFactories}, preserving the current protocol behavior without widening
  * {@code runtime-spi}.
  */
 package network.crypta.runtime.endpoints.fcp;

--- a/src/main/java/network/crypta/runtime/fcp/PersistentRequestEndpointServices.java
+++ b/src/main/java/network/crypta/runtime/fcp/PersistentRequestEndpointServices.java
@@ -1,0 +1,99 @@
+package network.crypta.runtime.fcp;
+
+import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
+import network.crypta.runtime.spi.RuntimePorts;
+
+/**
+ * Runtime-owned seam for the FCP persistent-request bundle used during client-core startup.
+ *
+ * <p>This interface captures the exact persistent-request services that higher-level runtime code
+ * needs while bootstrapping the client layer and later exposing the FCP endpoint. The seam keeps
+ * the concrete FCP request root, catalog adapter, recovery codec, and endpoint bootstrap logic on
+ * the bridge side of the boundary, while {@code NodeClientPersistence} and other runtime-owned code
+ * depend only on this narrow bundle.
+ *
+ * <p>Each implementation is expected to represent one shared persistent-request state bundle. The
+ * coordinator, catalog, snapshot view, and endpoint handle creation should all remain aligned to
+ * the same underlying durable request root, so startup ordering and recovery behavior stay
+ * unchanged. Callers normally create one bundle during {@code NodeClientPersistence} construction,
+ * reuse it when wiring the client-layer persistence adapters, and then ask the same bundle to
+ * create the FCP endpoint handle later in startup. That usage pattern keeps the runtime seam narrow
+ * while preserving the historical relationship between request recovery, request cataloging, and
+ * FCP server bootstrap.
+ */
+public interface PersistentRequestEndpointServices {
+
+  /**
+   * Returns the coordinator used by client-context persistence flows.
+   *
+   * <p>The returned coordinator is the runtime entry point for registering, resuming, and
+   * deregistering durable requests as the client layer rebuilds its state. Implementations should
+   * return the coordinator backed by the same durable request root exposed through the rest of this
+   * bundle, rather than a detached adapter.
+   *
+   * @return persistent-request coordinator for durable request ownership, recovery, and lifecycle
+   *     callbacks
+   */
+  PersistentRequestCoordinator coordinator();
+
+  /**
+   * Returns the catalog used to list and deduplicate persistent requests.
+   *
+   * <p>The catalog is the read-mostly view used by persistence and endpoint layers when they need a
+   * stable lookup surface for already-known requests. It should observe the same underlying durable
+   * request state as {@link #coordinator()} and {@link #getPersistentRequests()} so request
+   * discovery and deduplication remain consistent during startup and recovery.
+   *
+   * @return catalog view over the persistent-request state managed by this bundle
+   */
+  PersistentRequestCatalog catalog();
+
+  /**
+   * Returns the recovery codec used to reconstruct persistent requests from the saved state.
+   *
+   * <p>The recovery codec translates persisted client-layer records back into live request objects.
+   * Implementations should return the codec paired with the same coordinator and request root used
+   * elsewhere in this bundle so deserialized requests register against the correct persistent
+   * state.
+   *
+   * @return recovery codec for durable request restart within this bundle's request state
+   */
+  PersistentRequestRecoveryCodec recoveryCodec();
+
+  /**
+   * Returns a snapshot of the currently registered persistent requests.
+   *
+   * <p>The returned array is a point-in-time snapshot. Later registrations, completions, or
+   * removals do not need to be reflected in the previously returned array instance. Callers can use
+   * this snapshot to seed runtime-owned endpoint handles without depending on bridge-owned request
+   * root types directly.
+   *
+   * @return snapshot array of persistent request handles; never {@code null} but possibly empty
+   */
+  PersistentRequestHandle[] getPersistentRequests();
+
+  /**
+   * Creates the runtime-owned FCP endpoint handle backed by this persistent-request bundle.
+   *
+   * <p>Implementations should use the durable request state represented by this bundle when
+   * building the endpoint handle, so the eventual FCP server sees the same coordinator, catalog
+   * contents, and recovered requests that the client layer already uses. The method selects the
+   * concrete endpoint-side bootstrap path, but the returned handle remains the runtime-owned
+   * wrapper exposed upstream.
+   *
+   * @param node live daemon node supplying configuration, services, and persisted startup state
+   * @param core client core whose schedulers and persistence services back the FCP endpoint
+   * @param runtimePorts runtime SPI bridge passed to the FCP infrastructure during endpoint
+   *     creation
+   * @return runtime-owned handle for the configured FCP endpoint backed by this bundle's request
+   *     state
+   */
+  FcpEndpointHandle createFcpEndpointHandle(
+      Node node, NodeClientCore core, RuntimePorts runtimePorts);
+}

--- a/src/main/java/network/crypta/runtime/fcp/PersistentRequestEndpointServicesFactory.java
+++ b/src/main/java/network/crypta/runtime/fcp/PersistentRequestEndpointServicesFactory.java
@@ -1,0 +1,31 @@
+package network.crypta.runtime.fcp;
+
+/**
+ * Creates runtime-owned FCP persistent-request service bundles.
+ *
+ * <p>Bootstrap code selects one factory at composition-root time and threads it into node/client
+ * core construction. Higher-level runtime code can then request the persistent-request bundle it
+ * needs without naming endpoint-owned concrete bridge classes directly. The factory itself is
+ * intentionally narrow: it chooses an implementation but does not define caching or lifecycle
+ * policy beyond creating the bundle instance. In the current startup flow, the factory is usually
+ * invoked once while building {@code NodeClientPersistence}. The returned bundle is then reused for
+ * client-layer persistence wiring and later FCP endpoint bootstrap so those stages share the same
+ * durable request state.
+ */
+@FunctionalInterface
+public interface PersistentRequestEndpointServicesFactory {
+
+  /**
+   * Creates one persistent-request service bundle.
+   *
+   * <p>Callers typically invoke this once during {@code NodeClientPersistence} construction so the
+   * client-layer persistence adapters and later FCP endpoint bootstrap share the same underlying
+   * durable request state. Implementations may return a fresh bundle per invocation or delegate to
+   * another provider, but they should not expose endpoint-owned concrete types through this method
+   * signature.
+   *
+   * @return runtime-owned persistent-request service bundle aligned to one client-persistence
+   *     construction path
+   */
+  PersistentRequestEndpointServices create();
+}

--- a/src/main/java/network/crypta/runtime/fcp/package-info.java
+++ b/src/main/java/network/crypta/runtime/fcp/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Runtime-owned FCP seam types used by higher-level bootstrap and persistence code.
+ *
+ * <p>This package contains the neutral interfaces that runtime and node code should depend on when
+ * they need the FCP persistent-request bundle during startup. The types here describe the small
+ * surface that runtime-owned code uses to configure client-layer persistence, inspect the current
+ * persistent-request snapshot, and ask the endpoint layer to create an FCP handle later in startup.
+ *
+ * <p>Concrete bridge implementations and the default production bindings remain in {@code
+ * network.crypta.runtime.endpoints.fcp}. Bootstrap code selects those bindings once, threads only
+ * these seam types through node construction, and keeps the endpoint-owned request root and server
+ * bootstrap details behind that boundary. That split preserves the current startup order while
+ * making the composition-root choice explicit.
+ */
+package network.crypta.runtime.fcp;

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeRuntimeBridgeFactoriesTest.java
@@ -6,10 +6,13 @@ import network.crypta.node.NodeClientCore;
 import network.crypta.node.ProgramDirectory;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputsFactory;
+import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestServices;
 import network.crypta.runtime.endpoints.fcp.FcpQueueAdminBackend;
 import network.crypta.runtime.endpoints.http.CoreHttpShellRuntimeSupport;
 import network.crypta.runtime.endpoints.http.geoip.HttpGeoIpCountryLookup;
 import network.crypta.runtime.endpoints.http.security.CorePasswordFormPageRenderer;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServices;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServicesFactory;
 import network.crypta.runtime.http.HttpShellContainerFactory;
 import network.crypta.runtime.http.HttpShellRuntimeSupport;
 import network.crypta.runtime.http.HttpShellRuntimeSupportFactory;
@@ -18,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -28,6 +32,8 @@ class NodeRuntimeBridgeFactoriesTest {
 
   @Test
   void constructor_whenAdminRuntimeBridgeInputsFactoryIsNull_throws() {
+    PersistentRequestEndpointServicesFactory persistentRequestEndpointServicesFactory =
+        () -> mock(PersistentRequestEndpointServices.class);
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         ignoredCore -> mock(HttpShellRuntimeSupport.class);
     HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
@@ -37,6 +43,28 @@ class NodeRuntimeBridgeFactoriesTest {
         NullPointerException.class,
         () ->
             new NodeRuntimeBridgeFactories(
+                null,
+                persistentRequestEndpointServicesFactory,
+                httpShellRuntimeSupportFactory,
+                httpShellContainerFactory,
+                passwordFormPageRenderer));
+  }
+
+  @Test
+  void constructor_whenPersistentRequestEndpointServicesFactoryIsNull_throws() {
+    NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
+    AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
+        fixture.adminRuntimeBridgeInputsFactory();
+    HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
+        ignoredCore -> mock(HttpShellRuntimeSupport.class);
+    HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
+    PasswordFormPageRenderer passwordFormPageRenderer = (_, _, _) -> {};
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new NodeRuntimeBridgeFactories(
+                adminRuntimeBridgeInputsFactory,
                 null,
                 httpShellRuntimeSupportFactory,
                 httpShellContainerFactory,
@@ -48,6 +76,8 @@ class NodeRuntimeBridgeFactoriesTest {
     NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
         fixture.adminRuntimeBridgeInputsFactory();
+    PersistentRequestEndpointServicesFactory persistentRequestEndpointServicesFactory =
+        () -> mock(PersistentRequestEndpointServices.class);
     HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
     PasswordFormPageRenderer passwordFormPageRenderer = (_, _, _) -> {};
 
@@ -56,6 +86,7 @@ class NodeRuntimeBridgeFactoriesTest {
         () ->
             new NodeRuntimeBridgeFactories(
                 adminRuntimeBridgeInputsFactory,
+                persistentRequestEndpointServicesFactory,
                 null,
                 httpShellContainerFactory,
                 passwordFormPageRenderer));
@@ -66,6 +97,8 @@ class NodeRuntimeBridgeFactoriesTest {
     NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
         fixture.adminRuntimeBridgeInputsFactory();
+    PersistentRequestEndpointServicesFactory persistentRequestEndpointServicesFactory =
+        () -> mock(PersistentRequestEndpointServices.class);
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         ignoredCore -> mock(HttpShellRuntimeSupport.class);
     PasswordFormPageRenderer passwordFormPageRenderer = (_, _, _) -> {};
@@ -75,6 +108,7 @@ class NodeRuntimeBridgeFactoriesTest {
         () ->
             new NodeRuntimeBridgeFactories(
                 adminRuntimeBridgeInputsFactory,
+                persistentRequestEndpointServicesFactory,
                 httpShellRuntimeSupportFactory,
                 null,
                 passwordFormPageRenderer));
@@ -85,6 +119,8 @@ class NodeRuntimeBridgeFactoriesTest {
     NodeRuntimeBridgeFactoriesFixture fixture = new NodeRuntimeBridgeFactoriesFixture();
     AdminRuntimeBridgeInputsFactory adminRuntimeBridgeInputsFactory =
         fixture.adminRuntimeBridgeInputsFactory();
+    PersistentRequestEndpointServicesFactory persistentRequestEndpointServicesFactory =
+        () -> mock(PersistentRequestEndpointServices.class);
     HttpShellRuntimeSupportFactory httpShellRuntimeSupportFactory =
         ignoredCore -> mock(HttpShellRuntimeSupport.class);
     HttpShellContainerFactory httpShellContainerFactory = mock(HttpShellContainerFactory.class);
@@ -94,6 +130,7 @@ class NodeRuntimeBridgeFactoriesTest {
         () ->
             new NodeRuntimeBridgeFactories(
                 adminRuntimeBridgeInputsFactory,
+                persistentRequestEndpointServicesFactory,
                 httpShellRuntimeSupportFactory,
                 httpShellContainerFactory,
                 null));
@@ -108,6 +145,10 @@ class NodeRuntimeBridgeFactoriesTest {
         runtimeBridgeFactories
             .adminRuntimeBridgeInputsFactory()
             .create(fixture.node(), fixture.core());
+    PersistentRequestEndpointServices persistentRequestEndpointServices =
+        runtimeBridgeFactories.persistentRequestEndpointServicesFactory().create();
+    PersistentRequestEndpointServices anotherPersistentRequestEndpointServices =
+        runtimeBridgeFactories.persistentRequestEndpointServicesFactory().create();
     HttpShellRuntimeSupport runtimeSupport =
         runtimeBridgeFactories.httpShellRuntimeSupportFactory().create(fixture.core());
     HttpShellContainerFactory httpShellContainerFactory =
@@ -116,11 +157,18 @@ class NodeRuntimeBridgeFactoriesTest {
         runtimeBridgeFactories.passwordFormPageRenderer();
 
     assertNotNull(runtimeBridgeFactories.adminRuntimeBridgeInputsFactory());
+    assertNotNull(runtimeBridgeFactories.persistentRequestEndpointServicesFactory());
     assertNotNull(runtimeBridgeFactories.httpShellRuntimeSupportFactory());
     assertNotNull(httpShellContainerFactory);
     assertNotNull(passwordFormPageRenderer);
     assertInstanceOf(FcpQueueAdminBackend.class, bridgeInputs.queueAdminBackend());
     assertInstanceOf(HttpGeoIpCountryLookup.class, bridgeInputs.geoIpCountryLookup());
+    assertInstanceOf(FcpPersistentRequestServices.class, persistentRequestEndpointServices);
+    assertInstanceOf(FcpPersistentRequestServices.class, anotherPersistentRequestEndpointServices);
+    assertNotSame(
+        persistentRequestEndpointServices,
+        anotherPersistentRequestEndpointServices,
+        "core-backed FCP persistent-request services should be created on demand");
     CoreHttpShellRuntimeSupport coreRuntimeSupport =
         assertInstanceOf(CoreHttpShellRuntimeSupport.class, runtimeSupport);
     assertInstanceOf(network.crypta.clients.http.HttpShellRuntimeSupport.class, runtimeSupport);

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeStarterTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeStarterTest.java
@@ -507,6 +507,7 @@ class NodeStarterTest {
       NodeRuntimeBridgeFactories runtimeBridgeFactories) {
     assertNotNull(runtimeBridgeFactories);
     assertNotNull(runtimeBridgeFactories.adminRuntimeBridgeInputsFactory());
+    assertNotNull(runtimeBridgeFactories.persistentRequestEndpointServicesFactory());
     assertNotNull(runtimeBridgeFactories.httpShellRuntimeSupportFactory());
   }
 }

--- a/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
@@ -13,11 +13,10 @@ import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.DatastoreChecker;
 import network.crypta.client.async.USKManager;
 import network.crypta.client.async.persistence.PersistentRequestCatalog;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.clients.fcp.ClientRequest;
-import network.crypta.clients.fcp.FCPServer;
-import network.crypta.clients.fcp.FcpServerDependencies;
 import network.crypta.config.Config;
 import network.crypta.config.PersistentConfig;
 import network.crypta.config.SubConfig;
@@ -27,10 +26,11 @@ import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.NodeInitException;
 import network.crypta.runtime.endpoints.fcp.CoreFcpPersistentRequestCatalog;
-import network.crypta.runtime.endpoints.fcp.CoreFcpServerDependenciesFactory;
 import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
-import network.crypta.runtime.endpoints.fcp.FcpEndpointHandles;
 import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestRecoveryCodec;
+import network.crypta.runtime.endpoints.fcp.FcpPersistentRequestServices;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServices;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServicesFactory;
 import network.crypta.runtime.http.HttpShellContainer;
 import network.crypta.runtime.persistence.Persistable;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -51,7 +51,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -65,7 +64,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,11 +81,113 @@ class NodeClientPersistenceTest {
     Node node = newNode(ticker, tempDir);
 
     // Act
-    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 7);
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(persistable, nodeConfig, node, 7, newServicesFactory());
 
     // Assert
     assertEquals(8, persistence.getSortOrderAfter());
     assertFalse(persistence.hasPersistentRafFactory());
+  }
+
+  @Test
+  void constructor_whenPersistentRequestEndpointServicesFactoryIsNull_expectNullPointerException() {
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () ->
+                new NodeClientPersistence(
+                    mock(Persistable.class), mock(SubConfig.class), mock(Node.class), 0, null));
+
+    // Assert
+    assertEquals("persistentRequestEndpointServicesFactory", ex.getMessage());
+  }
+
+  @Test
+  void constructor_whenFactoryReturnsNullServices_expectNullPointerException() {
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () ->
+                new NodeClientPersistence(
+                    mock(Persistable.class),
+                    mock(SubConfig.class),
+                    mock(Node.class),
+                    0,
+                    () -> null));
+
+    // Assert
+    assertEquals("persistentRequestEndpointServices", ex.getMessage());
+  }
+
+  @Test
+  void constructor_whenServicesCoordinatorIsNull_expectNullPointerException() {
+    // Arrange
+    PersistentRequestEndpointServices services = mock(PersistentRequestEndpointServices.class);
+    when(services.coordinator()).thenReturn(null);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () ->
+                new NodeClientPersistence(
+                    mock(Persistable.class),
+                    mock(SubConfig.class),
+                    mock(Node.class),
+                    0,
+                    () -> services));
+
+    // Assert
+    assertEquals("persistentRequestCoordinator", ex.getMessage());
+  }
+
+  @Test
+  void constructor_whenServicesCatalogIsNull_expectNullPointerException() {
+    // Arrange
+    PersistentRequestEndpointServices services = mock(PersistentRequestEndpointServices.class);
+    when(services.coordinator()).thenReturn(mock(PersistentRequestCoordinator.class));
+    when(services.catalog()).thenReturn(null);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () ->
+                new NodeClientPersistence(
+                    mock(Persistable.class),
+                    mock(SubConfig.class),
+                    mock(Node.class),
+                    0,
+                    () -> services));
+
+    // Assert
+    assertEquals("persistentRequestCatalog", ex.getMessage());
+  }
+
+  @Test
+  void constructor_whenServicesRecoveryCodecIsNull_expectNullPointerException() {
+    // Arrange
+    PersistentRequestEndpointServices services = mock(PersistentRequestEndpointServices.class);
+    when(services.coordinator()).thenReturn(mock(PersistentRequestCoordinator.class));
+    when(services.catalog()).thenReturn(mock(PersistentRequestCatalog.class));
+    when(services.recoveryCodec()).thenReturn(null);
+
+    // Act
+    NullPointerException ex =
+        assertThrows(
+            NullPointerException.class,
+            () ->
+                new NodeClientPersistence(
+                    mock(Persistable.class),
+                    mock(SubConfig.class),
+                    mock(Node.class),
+                    0,
+                    () -> services));
+
+    // Assert
+    assertEquals("persistentRequestRecoveryCodec", ex.getMessage());
   }
 
   @Test
@@ -101,7 +201,8 @@ class NodeClientPersistenceTest {
     Ticker ticker = mock(Ticker.class);
     SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
     Node node = newNode(ticker, tempDir);
-    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(persistable, nodeConfig, node, 0, newServicesFactory());
 
     // Act
     persistence.startThrottle();
@@ -121,7 +222,8 @@ class NodeClientPersistenceTest {
     Ticker ticker = mock(Ticker.class);
     SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
     Node node = newNode(ticker, tempDir);
-    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(persistable, nodeConfig, node, 0, newServicesFactory());
 
     // Act
     persistence.startThrottle();
@@ -140,7 +242,8 @@ class NodeClientPersistenceTest {
     Ticker ticker = mock(Ticker.class);
     SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
     Node node = newNode(ticker, tempDir);
-    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(persistable, nodeConfig, node, 0, newServicesFactory());
     FilenameGenerator filenameGenerator = mock(FilenameGenerator.class);
     TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
     when(tempBucketFactory.getMaxRamUsed()).thenReturn(128L);
@@ -321,7 +424,8 @@ class NodeClientPersistenceTest {
     when(node.getBootId()).thenReturn(123L);
     SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
     NodeClientPersistence persistence =
-        new NodeClientPersistence(mock(Persistable.class), nodeConfig, node, 0);
+        new NodeClientPersistence(
+            mock(Persistable.class), nodeConfig, node, 0, newServicesFactory());
     TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
     when(tempBucketFactory.getMaxRamUsed()).thenReturn(0L);
     File persistentTempDir = new File(tempDir, "persistent");
@@ -412,6 +516,77 @@ class NodeClientPersistenceTest {
   }
 
   @Test
+  void createClientContext_whenFactoryInjected_expectUsesInjectedPersistenceServices(
+      @TempDir File tempDir) throws NodeInitException {
+    // Arrange
+    Ticker ticker = mock(Ticker.class);
+    PersistentConfig config = mock(PersistentConfig.class);
+    Node node = newNode(ticker, tempDir);
+    when(node.getBootId()).thenReturn(321L);
+    SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
+    PersistentRequestEndpointServicesFactory servicesFactory =
+        mock(PersistentRequestEndpointServicesFactory.class);
+    PersistentRequestEndpointServices services = mock(PersistentRequestEndpointServices.class);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    PersistentRequestCatalog catalog = mock(PersistentRequestCatalog.class);
+    PersistentRequestRecoveryCodec recoveryCodec = mock(PersistentRequestRecoveryCodec.class);
+    PersistentRequestHandle[] persistentRequests = {mock(PersistentRequestHandle.class)};
+    when(servicesFactory.create()).thenReturn(services);
+    when(services.coordinator()).thenReturn(coordinator);
+    when(services.catalog()).thenReturn(catalog);
+    when(services.recoveryCodec()).thenReturn(recoveryCodec);
+    when(services.getPersistentRequests()).thenReturn(persistentRequests);
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(mock(Persistable.class), nodeConfig, node, 0, servicesFactory);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    when(tempBucketFactory.getMaxRamUsed()).thenReturn(0L);
+    File persistentTempDir = new File(tempDir, "persistent");
+    assertTrue(persistentTempDir.mkdirs() || persistentTempDir.isDirectory());
+    persistence.initDiskChecker(
+        mock(FilenameGenerator.class), persistentTempDir, 1L, tempBucketFactory, false);
+    ClientLayerPersister clientLayerPersister = mock(ClientLayerPersister.class);
+
+    ClientContextInitParams params =
+        new ClientContextInitParams(
+            clientLayerPersister,
+            mock(PriorityAwareExecutor.class),
+            new ClientContextResources(
+                mock(ArchiveManager.class), mock(network.crypta.client.async.HealingQueue.class)),
+            mock(PersistentTempBucketFactory.class),
+            tempBucketFactory,
+            mock(USKManager.class),
+            mock(RandomSource.class),
+            new Random(9876L),
+            ticker,
+            mock(MemoryLimitedJobRunner.class),
+            mock(FilenameGenerator.class),
+            mock(FilenameGenerator.class),
+            mock(LockableRandomAccessBufferFactory.class),
+            persistence.getPersistentRafFactory(),
+            mock(FileRandomAccessBufferFactory.class),
+            mock(RealCompressor.class),
+            mock(DatastoreChecker.class),
+            new MasterSecret(new byte[64]),
+            new NodeClientCoreInit(
+                config,
+                mock(SubConfig.class),
+                mock(SubConfig.class),
+                mock(HttpShellContainer.class)),
+            mock(FetchContext.class),
+            mock(InsertContext.class));
+
+    // Act
+    ClientContext context = persistence.createClientContext(node, params);
+
+    // Assert
+    assertAll(
+        () -> assertSame(coordinator, context.persistentRequestCoordinator),
+        () -> assertSame(persistentRequests, persistence.getPersistentRequests()));
+    verify(servicesFactory).create();
+    verify(clientLayerPersister).configurePersistenceAdapters(catalog, recoveryCodec);
+  }
+
+  @Test
   void getPersistentRequests_whenRequestResumed_expectIncludesRequest(@TempDir File tempDir)
       throws NodeInitException {
     // Arrange
@@ -421,7 +596,8 @@ class NodeClientPersistenceTest {
     when(node.getBootId()).thenReturn(200L);
     SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
     NodeClientPersistence persistence =
-        new NodeClientPersistence(mock(Persistable.class), nodeConfig, node, 0);
+        new NodeClientPersistence(
+            mock(Persistable.class), nodeConfig, node, 0, newServicesFactory());
     TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
     when(tempBucketFactory.getMaxRamUsed()).thenReturn(0L);
     File persistentTempDir = new File(tempDir, "persistent");
@@ -472,49 +648,33 @@ class NodeClientPersistenceTest {
   }
 
   @Test
-  void createFcpEndpointHandle_whenCalled_expectDelegatesToMaybeCreate(@TempDir File tempDir)
-      throws NodeInitException {
+  void createFcpEndpointHandle_whenFactoryInjected_expectDelegatesToInjectedServices(
+      @TempDir File tempDir) throws NodeInitException {
     // Arrange
     Persistable persistable = mock(Persistable.class);
     Ticker ticker = mock(Ticker.class);
     SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
     Node node = newNode(ticker, tempDir);
-    PersistentConfig config = mock(PersistentConfig.class);
-    when(node.getConfig()).thenReturn(config);
-    NodeClientPersistence persistence = new NodeClientPersistence(persistable, nodeConfig, node, 0);
+    PersistentRequestEndpointServicesFactory servicesFactory =
+        mock(PersistentRequestEndpointServicesFactory.class);
+    PersistentRequestEndpointServices services = mock(PersistentRequestEndpointServices.class);
+    FcpEndpointHandle expectedHandle = mock(FcpEndpointHandle.class);
+    when(servicesFactory.create()).thenReturn(services);
+    when(services.coordinator()).thenReturn(mock(PersistentRequestCoordinator.class));
+    when(services.catalog()).thenReturn(mock(PersistentRequestCatalog.class));
+    when(services.recoveryCodec()).thenReturn(mock(PersistentRequestRecoveryCodec.class));
+    NodeClientPersistence persistence =
+        new NodeClientPersistence(persistable, nodeConfig, node, 0, servicesFactory);
     NodeClientCore core = mock(NodeClientCore.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
-    FCPServer expected = mock(FCPServer.class);
-    FcpServerDependencies dependencies = mock(FcpServerDependencies.class);
+    when(services.createFcpEndpointHandle(node, core, runtimePorts)).thenReturn(expectedHandle);
 
     // Act
-    try (MockedStatic<CoreFcpServerDependenciesFactory> factoryMock =
-            mockStatic(CoreFcpServerDependenciesFactory.class);
-        MockedStatic<FCPServer> fcpServerMock = mockStatic(FCPServer.class)) {
-      factoryMock
-          .when(
-              () ->
-                  CoreFcpServerDependenciesFactory.create(
-                      eq(core),
-                      eq(runtimePorts),
-                      any(network.crypta.clients.fcp.PersistentRequestRoot.class)))
-          .thenReturn(dependencies);
-      fcpServerMock
-          .when(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)))
-          .thenReturn(expected);
+    FcpEndpointHandle result = persistence.createFcpEndpointHandle(node, core, runtimePorts);
 
-      FcpEndpointHandle result = persistence.createFcpEndpointHandle(node, core, runtimePorts);
-
-      // Assert
-      assertSame(expected, FcpEndpointHandles.unwrap(result));
-      factoryMock.verify(
-          () ->
-              CoreFcpServerDependenciesFactory.create(
-                  eq(core),
-                  eq(runtimePorts),
-                  any(network.crypta.clients.fcp.PersistentRequestRoot.class)));
-      fcpServerMock.verify(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)));
-    }
+    // Assert
+    assertSame(expectedHandle, result);
+    verify(services).createFcpEndpointHandle(node, core, runtimePorts);
   }
 
   private static SubConfig newNodeConfig(File throttleFile) {
@@ -553,11 +713,15 @@ class NodeClientPersistenceTest {
     return node;
   }
 
+  private static PersistentRequestEndpointServicesFactory newServicesFactory() {
+    return FcpPersistentRequestServices::new;
+  }
+
   private static NodeClientPersistence newPersistence(File tempDir) throws NodeInitException {
     Persistable persistable = mock(Persistable.class);
     Ticker ticker = mock(Ticker.class);
     SubConfig nodeConfig = newNodeConfig(new File(tempDir, "client-throttle.dat"));
     Node node = newNode(ticker, tempDir);
-    return new NodeClientPersistence(persistable, nodeConfig, node, 0);
+    return new NodeClientPersistence(persistable, nodeConfig, node, 0, newServicesFactory());
   }
 }

--- a/src/test/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServicesTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/fcp/FcpPersistentRequestServicesTest.java
@@ -11,6 +11,7 @@ import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.runtime.fcp.PersistentRequestEndpointServices;
 import network.crypta.runtime.spi.RuntimePorts;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -44,6 +45,7 @@ class FcpPersistentRequestServicesTest {
     assertSame(coordinator, services.coordinator());
     assertSame(catalog, services.catalog());
     assertSame(recoveryCodec, services.recoveryCodec());
+    assertInstanceOf(PersistentRequestEndpointServices.class, services);
     assertInstanceOf(FcpPersistentRequestRecoveryCodec.class, recoveryCodec);
     assertNotNull(coordinator.getOrCreateClientHandle(false, "client-a"));
     assertArrayEquals(new PersistentRequestHandle[0], services.getPersistentRequests());
@@ -52,7 +54,7 @@ class FcpPersistentRequestServicesTest {
   }
 
   @Test
-  void createEndpointHandle_whenCalled_wrapsCreatedServer() {
+  void createFcpEndpointHandle_whenCalled_wrapsCreatedServer() {
     // Arrange
     FcpPersistentRequestServices services = new FcpPersistentRequestServices();
     Node node = mock(Node.class);
@@ -77,7 +79,7 @@ class FcpPersistentRequestServicesTest {
           .when(() -> FCPServer.maybeCreate(eq(dependencies), eq(config)))
           .thenReturn(server);
 
-      FcpEndpointHandle endpointHandle = services.createEndpointHandle(node, core, runtimePorts);
+      FcpEndpointHandle endpointHandle = services.createFcpEndpointHandle(node, core, runtimePorts);
 
       // Assert
       assertSame(server, FcpEndpointHandles.unwrap(endpointHandle));


### PR DESCRIPTION
## Summary
- add a runtime-owned `PersistentRequestEndpointServices` seam plus `PersistentRequestEndpointServicesFactory` and bind the default endpoint-backed implementation at bootstrap time
- thread the FCP persistent-request factory through `NodeRuntimeBridgeFactories`, `Node`, `NodeClientCore`, and `NodeClientPersistence` so `NodeClientPersistence` no longer instantiates `FcpPersistentRequestServices` directly
- keep the concrete FCP implementation in `runtime.endpoints.fcp`, update tests for the injected seam and constructor guard paths, and document the new public seam types
- reuse `NodeRuntimeBridgeFactories` in `NodeClientCore` to keep the constructor at 7 parameters after the new seam wiring

## How to test
- `./gradlew test --tests network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactoriesTest --tests network.crypta.runtime.bootstrap.NodeStarterTest --tests network.crypta.runtime.endpoints.NodeClientPersistenceTest --tests network.crypta.runtime.endpoints.ClientEndpointsTest --tests network.crypta.runtime.endpoints.fcp.FcpPersistentRequestServicesTest --tests network.crypta.node.NodeClientCoreTest`
- `./gradlew test`
- `rg -n "new FcpPersistentRequestServices\\(" src/main/java/network/crypta/runtime src/main/java/network/crypta/node src/test/java/network/crypta/runtime src/test/java/network/crypta/node`
- `rg -n "^import network\\.crypta\\.runtime\\.endpoints\\.fcp\\.FcpPersistentRequestServices" src/main/java/network/crypta/runtime src/main/java/network/crypta/node`

## Notes
- this keeps the FCP concrete bridge in `runtime.endpoints.fcp` intentionally; the later re-home remains follow-up work
- persistent-request loading and FCP startup ordering are unchanged
