### PR TITLE
refactor(http): Freeze legacy admin boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.clients.fcp.bridge`.
 - `:adapter-http-legacy-admin` owns the current legacy `network.crypta.clients.http` tree plus
   the matching `network/crypta/clients/http/**` main resources such as `staticfiles/**` and
-  `templates/**`.
+  `templates/**`. The root project no longer owns that main source/resource tree, and the
+  remaining legacy browse/FProxy shell inside this leaf is boundary-frozen until a later PR
+  refines it further.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
@@ -227,7 +229,9 @@ Cryptad now uses a partial multi-project Gradle build.
   higher-level runtime code depends on runtime-owned seam types such as
   `network.crypta.runtime.endpoints.fcp.FcpEndpointHandle`,
   `network.crypta.runtime.http.HttpShellContainer`, and
-  `network.crypta.runtime.http.security.PasswordFormPageRenderer`.
+  `network.crypta.runtime.http.security.PasswordFormPageRenderer`. For HTTP, this bootstrap
+  factory remains the production binding site that imports the concrete bridge classes from the
+  extracted adapter leaf.
 
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
 `gradle/wrapper/gradle-wrapper.properties`). To also verify the download by checksum, add
@@ -519,7 +523,9 @@ Root build also includes:
 - `:adapter-fcp`: extracted `network.crypta.clients.fcp` adapter code, including
   `network.crypta.clients.fcp.bridge`.
 - `:adapter-http-legacy-admin`: extracted legacy `network.crypta.clients.http` adapter code plus
-  `network/crypta/clients/http/**` main resources.
+  `network/crypta/clients/http/**` main resources. The root project no longer owns that main
+  HTTP source/resource tree, and the remaining browse/FProxy shell in this adapter is
+  boundary-frozen for now.
 - `:foundation-fs` and `:foundation-compat`: extracted filesystem/environment and compatibility
   leaf modules used by the root daemon. `:foundation-compat` also carries the wizard-neutral
   bandwidth-detection helpers now used by first-time setup flows.
@@ -613,7 +619,10 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `FProxyRegistrarDependencies`. Concrete HTTP shell, bookmark, GeoIP, security-page, and
   updater-action adapters now live under `network.crypta.clients.http.bridge` and
   `network.crypta.clients.http.updater`, while root-local bridge selection stays in
-  `DefaultNodeRuntimeBridgeFactories`.
+  `DefaultNodeRuntimeBridgeFactories`. The remaining legacy browse/FProxy tree inside
+  `:adapter-http-legacy-admin` is intentionally boundary-frozen until a later PR refines it
+  further, and production code outside the adapter should keep depending on runtime seams rather
+  than taking new `network.crypta.clients.http.*` dependencies.
 - Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and detached DTOs such as
   `RuntimePorts`, `ConfigPort`, `NodeInfoPort`, `PeerPort`, `ConnectionsPagePort`,
   `ConnectionsSupportPort`, `DarknetConnectionsPort`, `DarknetMessagingPort`, `QueuePagePort`,

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ajaxpush/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ajaxpush/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Legacy Ajax-push helper endpoints for the extracted HTTP and FProxy shell.
+ *
+ * <p>This package belongs to {@code :adapter-http-legacy-admin}. It holds the small toadlets that
+ * support the current browser push and long-poll update flow used by the legacy browse shell, such
+ * as notification, keepalive, failover, and dismiss flows. The package remains part of the
+ * extracted but still legacy {@code network.crypta.clients.http} tree while that shell is
+ * boundary-frozen.
+ *
+ * <p>These types are adapter-owned implementation details, not a new platform API. Code outside
+ * {@code :adapter-http-legacy-admin} should not begin depending on them. They remain here only to
+ * support the current legacy browse and FProxy shell until later refinement or replacement work
+ * narrows this adapter further.
+ */
+package network.crypta.clients.http.ajaxpush;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/annotation/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/annotation/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Legacy HTTP-handler annotations for the extracted browse and FProxy adapter.
+ *
+ * <p>This tiny package belongs to {@code :adapter-http-legacy-admin}. It provides annotation
+ * metadata interpreted by the current legacy HTTP shell so handler methods can describe request
+ * expectations such as whether a payload is accepted. The package remains inside the extracted
+ * {@code network.crypta.clients.http} tree while that shell is boundary-frozen.
+ *
+ * <p>These annotations are adapter-local implementation details, not a new platform API. Code
+ * outside {@code :adapter-http-legacy-admin} should not grow dependencies on them. They exist only
+ * to support the current legacy browse and FProxy shell until later refinement work replaces or
+ * narrows this surface.
+ */
+package network.crypta.clients.http.annotation;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/complexhtmlnodes/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/complexhtmlnodes/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Legacy-reusable HTML node fragments for the extracted HTTP and FProxy shell.
+ *
+ * <p>This package belongs to {@code :adapter-http-legacy-admin}. It contains small HTML-node
+ * helpers that the current legacy browse shell uses to assemble richer page fragments without
+ * duplicating markup logic inline. The package remains inside the extracted {@code
+ * network.crypta.clients.http} tree while that shell is boundary-frozen.
+ *
+ * <p>These helpers are adapter-owned implementation details, not a new platform API. Code outside
+ * {@code :adapter-http-legacy-admin} should not begin depending on them. They remain here only to
+ * support the current legacy browse and FProxy shell until later refinement or replacement work
+ * narrows this adapter further.
+ */
+package network.crypta.clients.http.complexhtmlnodes;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/filter/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/filter/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Legacy HTTP filtering callbacks for the extracted browse and FProxy adapter.
+ *
+ * <p>This package belongs to {@code :adapter-http-legacy-admin}. It contains HTTP-specific filter
+ * helpers that adapt the sanitized content-filter pipeline to the current FProxy shell, including
+ * rewriting tags so legacy push-enabled pages can inject scripts or updateable placeholders. The
+ * package remains part of the extracted but still legacy {@code network.crypta.clients.http} tree
+ * while that shell is boundary-frozen.
+ *
+ * <p>These types are adapter-owned implementation details, not a new platform API. Code outside
+ * {@code :adapter-http-legacy-admin} should not begin depending on them. They exist only to support
+ * the current legacy browse and FProxy shell until later refinement or replacement work narrows
+ * this adapter further.
+ */
+package network.crypta.clients.http.filter;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/package-info.java
@@ -1,6 +1,11 @@
 /**
  * Browser-facing HTTP interface for Crypta nodes, often referred to as the FProxy console.
  *
+ * <p>This package is owned by the extracted {@code :adapter-http-legacy-admin} leaf together with
+ * the matching {@code network/crypta/clients/http/**} main resources. The root project no longer
+ * owns this main source/resource tree. The remaining browse and FProxy shell collected here is
+ * boundary-frozen until a later PR narrows or replaces it with smaller seams.
+ *
  * <p>The package provides the lightweight HTTP server surface that lets users browse freesites,
  * upload or insert files, inspect queue progress, and configure the node without embedding a
  * servlet container. Each endpoint is implemented as a {@link network.crypta.clients.http.Toadlet}
@@ -18,6 +23,13 @@
  * rather than HTTP plumbing. The package also contains specialized toadlets for first-time setup,
  * security settings, translation, and bookmark management to cover the full administrative
  * workflow.
+ *
+ * <p>Code outside the HTTP adapter boundary should treat this package as legacy adapter-owned
+ * implementation detail rather than as a new platform API. Runtime and bootstrap code should
+ * continue to depend on runtime-owned seams and the narrow bridge/binding sites instead of growing
+ * new direct dependencies on {@code network.crypta.clients.http.*}. In production, {@code
+ * network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories} remains the bootstrap-owned
+ * binding site for the concrete HTTP bridge implementations.
  *
  * <ul>
  *   <li>Implements the public web console and REST-like helper endpoints.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Legacy updateable page elements for the extracted HTTP and FProxy shell.
+ *
+ * <p>This package belongs to {@code :adapter-http-legacy-admin}. It contains the server-side page
+ * fragments, event bookkeeping, and push-update coordination used by the current legacy browse and
+ * FProxy shell to refresh parts of a rendered page without rebuilding the whole response. The
+ * package remains inside the extracted {@code network.crypta.clients.http} tree while that shell is
+ * boundary-frozen.
+ *
+ * <p>These types are adapter-owned implementation details, not a new platform API. Code outside
+ * {@code :adapter-http-legacy-admin} should not begin depending on them. They exist only to support
+ * the current legacy browse and FProxy shell until later refinement or replacement work narrows
+ * this adapter further.
+ */
+package network.crypta.clients.http.updateableelements;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/utils/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/utils/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Legacy HTTP-shell utilities for the extracted browse and FProxy adapter.
+ *
+ * <p>This package belongs to {@code :adapter-http-legacy-admin}. It contains small helper types for
+ * the current legacy HTTP shell, including template rendering, localization glue, and conservative
+ * proxy-header parsing. The package remains inside the extracted {@code
+ * network.crypta.clients.http} tree while that shell is boundary-frozen.
+ *
+ * <p>These utilities are adapter-owned implementation details, not a new platform API. Code outside
+ * {@code :adapter-http-legacy-admin} should not begin depending on them. They exist only to support
+ * the current legacy browse and FProxy shell until later refinement or replacement work narrows
+ * this adapter further.
+ */
+package network.crypta.clients.http.utils;

--- a/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -1,0 +1,155 @@
+package network.crypta.runtime.bootstrap;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class HttpLegacyAdminBoundaryTest {
+  private static final Path ROOT_HTTP_MAIN_JAVA =
+      Path.of("src", "main", "java", "network", "crypta", "clients", "http");
+  private static final Path ROOT_HTTP_MAIN_RESOURCES =
+      Path.of("src", "main", "resources", "network", "crypta", "clients", "http");
+  private static final Path ADAPTER_HTTP_MAIN_JAVA =
+      Path.of(
+          "adapter-http-legacy-admin",
+          "src",
+          "main",
+          "java",
+          "network",
+          "crypta",
+          "clients",
+          "http");
+  private static final Path ADAPTER_HTTP_MAIN_RESOURCES =
+      Path.of(
+          "adapter-http-legacy-admin",
+          "src",
+          "main",
+          "resources",
+          "network",
+          "crypta",
+          "clients",
+          "http");
+  private static final Path DEFAULT_BRIDGE_FACTORIES =
+      Path.of(
+          "src",
+          "main",
+          "java",
+          "network",
+          "crypta",
+          "runtime",
+          "bootstrap",
+          "DefaultNodeRuntimeBridgeFactories.java");
+  private static final Pattern LEGACY_HTTP_IMPORT_PATTERN =
+      Pattern.compile("^import(?:\\s+static)?\\s+(network\\.crypta\\.clients\\.http\\.[^;]+);$");
+  private static final Set<String> EXPECTED_DEFAULT_BRIDGE_FACTORIES_HTTP_IMPORTS =
+      Set.of(
+          "network.crypta.clients.http.bridge.CoreHttpShellRuntimeSupport",
+          "network.crypta.clients.http.bridge.HttpShellContainers",
+          "network.crypta.clients.http.bridge.geoip.HttpGeoIpCountryLookups",
+          "network.crypta.clients.http.bridge.security.CorePasswordFormPageRenderer");
+
+  @Test
+  void mainSourceLayout_whenCheckingLegacyHttpOwnership_expectOnlyAdapterOwnsHttpTree()
+      throws IOException {
+    Path repoRoot = repoRoot();
+
+    assertTrue(
+        Files.isDirectory(repoRoot.resolve(ADAPTER_HTTP_MAIN_JAVA)),
+        "adapter-http-legacy-admin must own network/crypta/clients/http main sources");
+    assertTrue(
+        Files.isDirectory(repoRoot.resolve(ADAPTER_HTTP_MAIN_RESOURCES)),
+        "adapter-http-legacy-admin must own network/crypta/clients/http main resources");
+    assertFalse(
+        Files.exists(repoRoot.resolve(ROOT_HTTP_MAIN_JAVA)),
+        "Root project must not re-own network/crypta/clients/http main sources");
+    assertFalse(
+        Files.exists(repoRoot.resolve(ROOT_HTTP_MAIN_RESOURCES)),
+        "Root project must not re-own network/crypta/clients/http main resources");
+  }
+
+  @Test
+  void mainSources_whenScanningLegacyHttpImports_expectOnlyBootstrapBindingSiteOutsideAdapter()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+    Set<String> bootstrapHttpImports =
+        readLegacyHttpImports(repoRoot.resolve(DEFAULT_BRIDGE_FACTORIES));
+
+    for (Path sourceFile : findMainJavaSources(repoRoot)) {
+      Path relativePath = repoRoot.relativize(sourceFile);
+      if (relativePath.equals(DEFAULT_BRIDGE_FACTORIES)) {
+        continue;
+      }
+
+      Set<String> imports = readLegacyHttpImports(sourceFile);
+      if (!imports.isEmpty() && !relativePath.startsWith(ADAPTER_HTTP_MAIN_JAVA)) {
+        violations.add(relativePath + " -> " + String.join(", ", imports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Only adapter-http-legacy-admin main sources may import network.crypta.clients.http.*, "
+            + "except the bootstrap binding site."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+    assertEquals(
+        EXPECTED_DEFAULT_BRIDGE_FACTORIES_HTTP_IMPORTS,
+        bootstrapHttpImports,
+        "DefaultNodeRuntimeBridgeFactories must remain the narrow bootstrap-owned HTTP binding "
+            + "site");
+  }
+
+  private static List<Path> findMainJavaSources(Path repoRoot) throws IOException {
+    try (Stream<Path> walk = Files.walk(repoRoot)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(path -> path.getFileName().toString().endsWith(".java"))
+          .filter(path -> !path.getFileName().toString().startsWith("._"))
+          .filter(path -> isMainJavaSource(repoRoot.relativize(path)))
+          .sorted(Comparator.comparing(path -> repoRoot.relativize(path).toString()))
+          .toList();
+    }
+  }
+
+  private static boolean isMainJavaSource(Path relativePath) {
+    String normalized = relativePath.toString().replace(File.separatorChar, '/');
+    return !normalized.startsWith("build/")
+        && !normalized.contains("/build/")
+        && !normalized.startsWith(".gradle/")
+        && !normalized.contains("/.gradle/")
+        && !normalized.startsWith(".git/")
+        && !normalized.contains("/.git/")
+        && (normalized.startsWith("src/main/java/") || normalized.contains("/src/main/java/"));
+  }
+
+  private static Set<String> readLegacyHttpImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .map(LEGACY_HTTP_IMPORT_PATTERN::matcher)
+          .filter(Matcher::matches)
+          .map(matcher -> matcher.group(1))
+          .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+  }
+
+  private static Path repoRoot() throws IOException {
+    Path repoRoot = Path.of("").toAbsolutePath().normalize();
+    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
+    return repoRoot.toRealPath();
+  }
+}


### PR DESCRIPTION
## Summary
- document that `:adapter-http-legacy-admin` owns `network.crypta.clients.http/**` and the matching HTTP resources, that the root project no longer owns those main trees, and that the remaining legacy browse/FProxy shell is boundary-frozen for now
- add `package-info.java` docs for the remaining legacy HTTP helper packages that still belong to the frozen adapter-owned browse/FProxy slice
- add `HttpLegacyAdminBoundaryTest` to keep `network.crypta.clients.http.*` main-source imports inside `:adapter-http-legacy-admin`, with `DefaultNodeRuntimeBridgeFactories` as the only explicit bootstrap binding-site exception

## How to test
- `./gradlew test --tests network.crypta.runtime.bootstrap.HttpLegacyAdminBoundaryTest --tests network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactoriesTest`
- `rg -n --glob '!adapter-http-legacy-admin/**' '^import network\\.crypta\\.clients\\.http\\.' src/main/java */src/main/java`

## Notes
- no runtime behavior or wiring changes are intended in this PR