### PR TITLE
refactor(runtime): Prepare kernel split baseline

### DIFF
--- a/runtime-node/gradle/owned-output-patterns.txt
+++ b/runtime-node/gradle/owned-output-patterns.txt
@@ -371,12 +371,14 @@ network/crypta/node/UptimeEstimator.class
 network/crypta/node/UptimeEstimator$*.class
 network/crypta/node/WaitingMultiMessageCallback.class
 network/crypta/node/WaitingMultiMessageCallback$*.class
+network/crypta/node/package-info*
 network/crypta/node/probe/Counter.class
 network/crypta/node/probe/Counter$*.class
 network/crypta/node/probe/Listener.class
 network/crypta/node/probe/Listener$*.class
 network/crypta/node/probe/Probe.class
 network/crypta/node/probe/Probe$*.class
+network/crypta/node/probe/package-info*
 network/crypta/io/AddressMatcher.class
 network/crypta/io/AddressMatcher$*.class
 network/crypta/io/AddressTracker.class

--- a/runtime-node/src/main/java/network/crypta/node/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/node/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Core daemon node runtime: peer coordination, request orchestration, transport handling, and
+ * node-owned persistence helpers.
+ *
+ * <p>This package contains the live daemon body centered on {@code Node} and {@code
+ * NodeClientCore}. It owns peer management, packet and handshake processing, request scheduling,
+ * insert and fetch execution, security-level handling, statistics export, and the node-local file
+ * and key material helpers that still depend directly on a running daemon instance. The package is
+ * therefore broader than the future kernel leaves, but it captures the current post-extraction
+ * ownership explicitly.
+ *
+ * <p>For the kernel split preparation baseline, these classes remain in {@code runtime-node}. They
+ * are not a stable public extension surface, and this package still mixes transport, routing, and
+ * content-adjacent responsibilities that later work will separate into more focused kernel modules.
+ * Documenting the boundary here freezes the current structure without moving production code or
+ * changing runtime behavior.
+ */
+package network.crypta.node;

--- a/runtime-node/src/main/java/network/crypta/node/probe/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/node/probe/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Probe request handling, listener dispatch, and probe-local aggregation helpers.
+ *
+ * <p>This package contains the runtime logic behind node probes: the classes that accept probe
+ * work, track counters, and notify listeners about probe-specific activity. The data types that
+ * define probe wire-level categories stay in the narrower interoperability layer, while this
+ * package keeps the daemon-backed execution and bookkeeping that depend on the live node state.
+ *
+ * <p>The package remains adjacent to the main node runtime because probes are part of node
+ * introspection and operational visibility, not a detached adapter API. It should stay focused on
+ * executing and reporting probe flows rather than rendering operator-facing output.
+ */
+package network.crypta.node.probe;

--- a/runtime-node/src/main/java/network/crypta/node/subsystem/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/node/subsystem/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Internal node startup subsystems that break daemon initialization into explicit runtime-owned
+ * slices.
+ *
+ * <p>This package groups the subsystem coordinators used while constructing and starting the node:
+ * storage, networking, routing, messaging, and the shared crypto or transport parameters that tie
+ * those pieces together. The classes exist to keep the large {@code Node} bootstrap sequence
+ * readable and testable while preserving the current daemon lifecycle and ordering semantics.
+ *
+ * <p>These subsystem types are runtime orchestration helpers, not a general plugin or extension
+ * surface. They stay inside {@code runtime-node} for now because they still compose daemon-local
+ * services directly and provide the current seam for a later kernel extraction.
+ */
+package network.crypta.node.subsystem;

--- a/runtime-node/src/main/java/network/crypta/runtime/diagnostics/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/diagnostics/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Runtime-owned diagnostics seams and façade types for operator visibility.
+ *
+ * <p>This package defines the runtime-level diagnostics entry points that expose information about
+ * a running node without committing higher layers to any specific UI or transport. It contains the
+ * façade and small service interfaces that connect daemon-backed sampling to the rest of the
+ * runtime. Concrete rendering remains outside this package, so diagnostics data can be reused by
+ * multiple operator-facing surfaces.
+ *
+ * <p>Keeping diagnostics here makes the boundary explicit for later extraction work: the runtime
+ * owns collection and publication of diagnostic states, while adapters remain responsible for
+ * formatting, transport, and presentation.
+ */
+package network.crypta.runtime.diagnostics;

--- a/runtime-node/src/main/java/network/crypta/runtime/diagnostics/threads/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/diagnostics/threads/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Thread inspection and snapshot helpers used by the runtime diagnostics layer.
+ *
+ * <p>This package contains the concrete thread sampler plus the immutable snapshot records that
+ * describe thread activity inside a running daemon. The code bridges JVM thread information and
+ * node-local execution metadata into a reusable runtime representation that higher layers can poll
+ * or export.
+ *
+ * <p>The package intentionally stops at the collection and modeling. It does not own HTTP
+ * rendering, alert presentation, or endpoint-specific formatting, which keeps the thread
+ * diagnostics boundary reusable for later kernel and adapter splits.
+ */
+package network.crypta.runtime.diagnostics.threads;

--- a/runtime-node/src/main/java/network/crypta/runtime/endpoints/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/endpoints/package-info.java
@@ -2,9 +2,9 @@
  * Client endpoint wiring and TMCI bootstrap support for the runtime boundary.
  *
  * <p>This package groups the legacy endpoint bootstrap cluster that wires the live FCP, HTTP, and
- * text-mode client interfaces from daemon-backed services. The classes remain in the root project
- * and keep their existing collaboration patterns, including package-private TMCI access, but they
- * now sit under a neutral runtime-oriented package instead of {@code network.crypta.node}.
+ * text-mode client interfaces from daemon-backed services. The classes remain part of the daemon
+ * runtime and keep their existing collaboration patterns, including package-private TMCI access,
+ * but they now sit under a neutral runtime-oriented package instead of {@code network.crypta.node}.
  *
  * <p>The package also owns {@link network.crypta.runtime.endpoints.ClientContextInitParams}, the
  * immutable bootstrap bundle used to assemble client context dependencies during node startup.

--- a/runtime-node/src/main/java/network/crypta/runtime/services/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/services/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Runtime-owned service coordination for daemon startup and long-lived node services.
+ *
+ * <p>This package groups the service-level orchestrators that wire the running node to operator
+ * services such as the web interface lifecycle, diagnostics, updater setup, and alert helpers. The
+ * coordinating logic lives here because it belongs to the daemon runtime and has to respect the
+ * node startup sequence, not because it defines an endpoint adapter contract.
+ *
+ * <p>Keeping these classes separate from the endpoint adapters clarifies the current boundary:
+ * adapters render or transport requests, while this package manages service creation, attachment,
+ * and lifecycle coordination within {@code runtime-node}.
+ */
+package network.crypta.runtime.services;

--- a/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
+++ b/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
@@ -1,0 +1,137 @@
+package network.crypta.runtime;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class RuntimeNodeKernelSplitPrepBoundaryTest {
+  private static final Path ROOT_MAIN_PACKAGE = Path.of("src", "main", "java", "network", "crypta");
+  private static final Path ROOT_BOOTSTRAP_PACKAGE =
+      Path.of("src", "main", "java", "network", "crypta", "runtime", "bootstrap");
+  private static final Path ROOT_TOOLS_PACKAGE =
+      Path.of("src", "main", "java", "network", "crypta", "tools");
+  private static final Path RUNTIME_NODE_MAIN_JAVA = Path.of("runtime-node", "src", "main", "java");
+  private static final Pattern ADAPTER_IMPORT_PATTERN =
+      Pattern.compile(
+          "^import(?:\\s+static)?\\s+(network\\.crypta\\.clients\\.(?:fcp|http)\\.[^;]+);$");
+
+  @Test
+  void rootMainJava_whenScanningPackages_expectOnlyBootstrapAndToolsOwnership() throws IOException {
+    Path repoRoot = repoRoot();
+    Path rootMainPackage = repoRoot.resolve(ROOT_MAIN_PACKAGE);
+    List<String> violations = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(rootMainPackage), "Root main package tree must exist");
+
+    for (Path sourceFile : findJavaSources(rootMainPackage)) {
+      Path relativePath = repoRoot.relativize(sourceFile);
+      if (!relativePath.startsWith(ROOT_BOOTSTRAP_PACKAGE)
+          && !relativePath.startsWith(ROOT_TOOLS_PACKAGE)) {
+        violations.add(relativePath.toString());
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Root src/main/java/network/crypta must stay limited to runtime/bootstrap and tools."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void runtimeNodeMain_whenScanningImports_expectNoAdapterImports() throws IOException {
+    Path repoRoot = repoRoot();
+    Path runtimeNodeMain = repoRoot.resolve(RUNTIME_NODE_MAIN_JAVA);
+    List<String> violations = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(runtimeNodeMain), "runtime-node main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(runtimeNodeMain)) {
+      Set<String> imports = readAdapterImports(sourceFile);
+      if (!imports.isEmpty()) {
+        violations.add(repoRoot.relativize(sourceFile) + " -> " + String.join(", ", imports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "runtime-node main sources must stay free of adapter imports."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void runtimeNodeMain_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path runtimeNodeMain = repoRoot.resolve(RUNTIME_NODE_MAIN_JAVA);
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(runtimeNodeMain), "runtime-node main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(runtimeNodeMain)) {
+      String fileName = sourceFile.getFileName().toString();
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(sourceFile.getParent());
+    }
+
+    for (Path packagePath : productionPackages) {
+      Path packageInfo = packagePath.resolve("package-info.java");
+      if (!Files.isRegularFile(packageInfo)) {
+        missingPackageInfos.add(runtimeNodeMain.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every runtime-node main package with production Java files must declare package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
+  }
+
+  private static List<Path> findJavaSources(Path root) throws IOException {
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(RuntimeNodeKernelSplitPrepBoundaryTest::isTrackedJavaSource)
+          .sorted(Comparator.comparing(Path::toString))
+          .toList();
+    }
+  }
+
+  private static boolean isTrackedJavaSource(Path path) {
+    String fileName = path.getFileName().toString();
+    return fileName.endsWith(".java") && !fileName.startsWith("._");
+  }
+
+  private static Set<String> readAdapterImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .map(ADAPTER_IMPORT_PATTERN::matcher)
+          .filter(Matcher::matches)
+          .map(matcher -> matcher.group(1))
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static Path repoRoot() throws IOException {
+    Path repoRoot = Path.of("").toAbsolutePath().normalize();
+    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
+    return repoRoot.toRealPath();
+  }
+}


### PR DESCRIPTION
## Summary
- add the remaining `runtime-node` `package-info.java` files for `network.crypta.node`, `network.crypta.node.probe`, `network.crypta.node.subsystem`, `network.crypta.runtime.diagnostics`, `network.crypta.runtime.diagnostics.threads`, and `network.crypta.runtime.services`
- add a focused root-level boundary test that freezes the current post-PR-133 baseline by checking root main ownership, adapter-free `runtime-node` imports, and `package-info.java` coverage for `runtime-node` production packages
- update `runtime-node` selective leaf ownership metadata for the new `package-info.class` outputs and fix one nearby stale package-doc statement in `network.crypta.runtime.endpoints`

## How to test
- `./gradlew verifySelectiveLeafOwnershipMetadata buildJar test --tests network.crypta.runtime.RuntimeNodeKernelSplitPrepBoundaryTest`

## Notes
- no production sources or resources move between modules in this PR
- no new `:kernel-*` subprojects are introduced in this PR