### PR TITLE
feat(platform-api): Add read-only Platform API v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Choose one of the following options.
     ```
 
 Linux servers (no desktop environment)
-- On systems without a desktop environment, the installer (deb/rpm) creates a systemd unit `cryptad.service` and enables it, but does not start it automatically. You must start it manually after install:
+- On systems without a desktop environment, the installer (deb/rpm) creates a systemd unit `cryptad.service` and enables it, but does not start it automatically. You must start it manually after installation:
   ```bash
   sudo systemctl start cryptad
   ```
@@ -133,7 +133,7 @@ The launcher starts the daemon, streams live logs, detects the FProxy port from 
 Shortcuts (global):
 - ↑/↓ one row; PgUp/PgDn one page.
 - ←/→ move focus among the three buttons (wrap‑around).
-- Enter/Space click focused button; s start/stop; q quit.
+- Enter/Space click the focused button; s start/stop; q quit.
 
 Notes
 - Live output combines the wrapper’s console with tailing of the wrapper log file when configured, so JVM logs appear while the wrapper is running.
@@ -198,7 +198,7 @@ Cryptad now uses a partial multi-project Gradle build.
   classes that stay free of `:runtime-node`, adapter, and root-composition dependencies.
 - `:kernel-transport` owns the compile-neutral phase-1 transport slice across selected
   `network.crypta.io`, `network.crypta.io.comm`, and `network.crypta.io.xfer` helpers such as
-  address matching, allow-list parsing, listener abstraction, I/O statistics collection, transfer
+  address matching, allowlist parsing, listener abstraction, I/O statistics collection, transfer
   throttling, and partially received block assembly that stay free of `:runtime-node`, adapters,
   and root-composition dependencies.
 - `:kernel-routing` owns the compile-neutral phase-1 routing/helper slice across selected
@@ -210,6 +210,12 @@ Cryptad now uses a partial multi-project Gradle build.
   by higher layers, including detached FCP peer management plus the admin-HTTP config,
   connectivity, connections, queue, security-levels, shared page-chrome, core-update action,
   first-time-wizard, symlinker, and welcome-page slices.
+- `:platform-api` owns the transport-neutral read-only Platform API v1 under
+  `network.crypta.platform.api`. It sits above `:runtime-spi`, exposes detached runtime snapshots
+  as JSON-oriented responses, and is currently mounted at `/api/v1/` through a thin legacy HTTP
+  bridge in `:adapter-http-legacy-admin`. The initial read-only surface covers node info, peers,
+  config export, connectivity, and security-level snapshots; `GET /api/v1/config` defaults to the
+  effective `CURRENT` section when `sections=` is omitted.
 - `:runtime-node` owns the remaining daemon runtime body across the still-cyclic
   `network.crypta.client` async/request engine and high-level client APIs, large slices of
   `network.crypta.node` after the phase-1 routing/helper move, the retained node-coupled
@@ -224,7 +230,8 @@ Cryptad now uses a partial multi-project Gradle build.
   the matching `network/crypta/clients/http/**` main resources such as `staticfiles/**` and
   `templates/**`. The root project no longer owns that main source/resource tree, and the
   remaining legacy browse/FProxy shell inside this leaf is boundary-frozen until a later PR
-  refines it further.
+  refines it further. That shell now also hosts the temporary `/api/v1/` mount for
+  `:platform-api`; future Web Shell and AppHost work remain separate.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
@@ -300,7 +307,7 @@ packages in `:kernel-content` and `:runtime-node` keep a `package-info.java`.
 ./gradlew compileJava
 ```
 
-- Formatting via Spotless is configured; see the Spotless + Dependency Verification section if verification blocks resolution.
+- Formatting via Spotless is configured; see the Spotless and Dependency Verification section if verification blocks resolution.
 - Gradle daemon is enabled by default; avoid passing `--no-daemon`.
 
 ## Running Your Build
@@ -433,7 +440,7 @@ macOS notes
 Linux behavior and service
 
 - Install location: the app image installs under `/opt/cryptad/Crypta` and the launcher/scripts expect `/opt/cryptad`.
-- Server vs desktop detection:
+- Server vs. desktop detection:
   - Considered a “desktop” only when a display manager (`display-manager.service`) exists and is enabled or active.
   - As a fallback, presence of session files (`/usr/share/xsessions/*.desktop` or `/usr/share/wayland-sessions/*.desktop`) also counts as desktop.
   - This avoids mislabeling headless servers that happen to default to `graphical.target`.
@@ -502,7 +509,7 @@ cd build/jpackage/Crypta.app/Contents
 - The Windows batch launcher (`bin/cryptad.bat`) passes a per‑user anchor location to the wrapper: `"wrapper.anchorfile=%LOCALAPPDATA%\Cryptad.anchor"`.
 - The Swing launcher requests a graceful stop by deleting that file; the Java Service Wrapper notices and shuts down the JVM cleanly (running shutdown hooks, flushing logs, etc.).
 - If the process tree is still alive after ~25 seconds, the launcher escalates to `taskkill` (first without `/F`, then with `/F`).
-- Advanced: To change the anchor path, customize the batch file or pass a different property on the command line; a value in `wrapper.conf` is overridden by the batch property.
+- Advanced: To change the anchor path, customize the batch file, or pass a different property on the command line; a value in `wrapper.conf` is overridden by the batch property.
 
 ### Launcher script resolution
 
@@ -555,7 +562,7 @@ Root build also includes:
   `network.crypta.client.async.alerts`, and `network.crypta.support.MediaType`.
 - `:kernel-transport`: compile-neutral phase-1 transport leaf spanning selected
   `network.crypta.io`, `network.crypta.io.comm`, and `network.crypta.io.xfer` helpers such as
-  allow-list parsing, listener abstraction, statistics collection, throttling, and partially
+  allowlist parsing, listener abstraction, statistics collection, throttling, and partially
   received block assembly.
 - `:kernel-routing`: compile-neutral phase-1 routing/helper leaf spanning selected
   `network.crypta.node` value, exception, callback, and request-item helper types such as
@@ -563,6 +570,8 @@ Root build also includes:
   `PeerStatusCounts`, and `SendableRequestItem*`.
 - `:runtime-spi`: JDK-only runtime ports plus immutable config snapshot/value types used by FCP
   and other infrastructure code.
+- `:platform-api`: transport-neutral read-only Platform API v1 built on top of `:runtime-spi`,
+  currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
 - `:runtime-node`: extracted daemon runtime body across the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine and transport-heavy
   `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled
@@ -625,7 +634,7 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   - Leaf subprojects are `:foundation-support`, `:foundation-store`,
     `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
     `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
-    `:kernel-transport`, `:kernel-routing`, `:runtime-spi`,
+    `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
     `:runtime-node`, `:adapter-fcp`, `:adapter-http-legacy-admin`, `:thirdparty-onion`,
     `:thirdparty-legacy`, and `:launcher-desktop`.
 - Core network (`network.crypta.node`): `Node`, `PeerNode`, `PeerManager`, `PacketSender`, `RequestStarter`, `RequestScheduler`, `NodeUpdateManager`.
@@ -676,6 +685,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.clients.http` now lives in `:adapter-http-legacy-admin` together with its
   `staticfiles/**` and `templates/**` resources. The migrated HTTP management and shell slices
   cross the boundary in three layers: `RuntimePorts` for JDK-only detached runtime state,
+  `:platform-api` for the read-only Platform API v1 router and JSON surface currently mounted at
+  `/api/v1/`,
   runtime-owned shell and password-prompt seams under `network.crypta.runtime.http` and
   `network.crypta.runtime.http.security`, and client-local helpers such as
   `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellFProxyBootstrap`, and
@@ -720,7 +731,7 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.node.SemiOrderedShutdownHook`, and `network.crypta.support.IllegalValueException`.
 - Support (`network.crypta.support`): logging, data structures, threading, and helpers are now
   split between `:foundation-support` and the root project. Keep generic reusable utilities in the
-  foundation leaf; daemon-coupled support code still remains in root.
+  foundation leaf; daemon-coupled support code still remains in the root.
 - Launcher/Desktop: `:launcher-desktop` provides `network.crypta.launcher`,
   `com.jthemedetecor`, launcher resources, and desktop-theme integration.
 - Extracted foundations: `:foundation-support` provides the stable generic support subset,
@@ -737,7 +748,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `:kernel-transport` provides the compile-neutral phase-1 transport slice across selected
   `network.crypta.io*` helpers; `:kernel-routing` provides the compile-neutral phase-1
   `network.crypta.node` helper slice across selected request/routing value, exception, callback,
-  and request-item types; `:runtime-spi` provides `network.crypta.runtime.spi`; `:runtime-node`
+  and request-item types; `:runtime-spi` provides `network.crypta.runtime.spi`;
+  `:platform-api` provides the transport-neutral read-only Platform API v1; `:runtime-node`
   provides the extracted daemon runtime body across the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine
   `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled

--- a/adapter-http-legacy-admin/build.gradle.kts
+++ b/adapter-http-legacy-admin/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation(project(":kernel-transport"))
   implementation(project(":kernel-routing"))
   implementation(project(":runtime-spi"))
+  implementation(project(":platform-api"))
   implementation(project(":runtime-node"))
   implementation(project(":thirdparty-onion"))
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -356,6 +356,11 @@ final class FProxyRegistrar {
     server.register(
         bookmarkEditorToadlet, ToadletRegistration.basic(null, "/bookmarkEditor/", true, false));
 
+    PlatformApiToadlet platformApiToadlet = new PlatformApiToadlet(client, runtimePorts);
+    server.register(
+        platformApiToadlet,
+        ToadletRegistration.basic(null, PlatformApiToadlet.MOUNT_PATH, true, true));
+
     BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(client);
     server.register(browserTestToadlet, ToadletRegistration.basic(null, "/test/", true, false));
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -1,0 +1,373 @@
+package network.crypta.clients.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.platform.api.PlatformApiPaths;
+import network.crypta.platform.api.PlatformApiRequest;
+import network.crypta.platform.api.PlatformApiResponse;
+import network.crypta.platform.api.PlatformApiRouter;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.URLDecoder;
+import network.crypta.support.URLEncodedFormatException;
+import network.crypta.support.api.HTTPRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thin legacy-HTTP bridge for the read-only Platform API v1.
+ *
+ * <p>This toadlet keeps all transport-neutral routing and JSON construction inside {@code
+ * :platform-api}. Its responsibility is limited to enforcing the existing full-access expectation
+ * for admin-facing routes, translating legacy HTTP request state into a {@link PlatformApiRequest},
+ * and writing the resulting JSON back through the legacy HTTP shell.
+ */
+@SuppressWarnings("unused")
+public final class PlatformApiToadlet extends Toadlet {
+  /** Versioned mount path for the legacy HTTP bridge. */
+  public static final String MOUNT_PATH = PlatformApiPaths.API_V1_PREFIX;
+
+  /**
+   * Logger for unexpected bridge failures that occur before the router can serialize a response.
+   */
+  private static final Logger LOG = LoggerFactory.getLogger(PlatformApiToadlet.class);
+
+  /** JSON media type advertised for every Platform API response emitted through the bridge. */
+  private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
+
+  /**
+   * Transport-neutral router that owns endpoint selection, validation, and JSON payload creation.
+   */
+  private final PlatformApiRouter router;
+
+  /**
+   * Creates a platform API toadlet backed by the supplied runtime ports.
+   *
+   * @param client high-level client helper retained by the toadlet base type
+   * @param runtimePorts detached runtime ports exposed to the platform API leaf
+   */
+  public PlatformApiToadlet(HighLevelSimpleClient client, RuntimePorts runtimePorts) {
+    this(client, new PlatformApiRouter(runtimePorts));
+  }
+
+  /**
+   * Creates a platform API toadlet backed by an already constructed router.
+   *
+   * <p>This constructor exists for tests and narrow composition sites that need to inject a router
+   * with controlled behavior. Production wiring normally uses {@link
+   * #PlatformApiToadlet(HighLevelSimpleClient, RuntimePorts)} so the bridge owns router creation.
+   *
+   * @param client high-level client helper retained by the toadlet base type
+   * @param router transport-neutral router that handles request validation and response generation
+   */
+  PlatformApiToadlet(HighLevelSimpleClient client, PlatformApiRouter router) {
+    super(client);
+    this.router = Objects.requireNonNull(router, "router");
+  }
+
+  @Override
+  public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException, RedirectException {
+    writePlatformApiResponse("GET", uri, request, ctx);
+  }
+
+  /**
+   * Returns a JSON {@code 405} error for unsupported POST requests.
+   *
+   * <p>The Platform API v1 surface is read-only. POST still routes through the shared Platform API
+   * error handling path, so callers receive the same JSON error shape and {@code Allow: GET} header
+   * that they would see for other unsupported verbs.
+   *
+   * @param uri request target as seen by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context, including full-access enforcement state
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse("POST", uri, request, ctx);
+  }
+
+  /**
+   * Returns a JSON {@code 405} error for unsupported HEAD requests in extended-method mode.
+   *
+   * <p>When the legacy HTTP shell is configured to dispatch HEAD explicitly, this bridge still
+   * routes the request through the Platform API router so method handling stays consistent with GET
+   * and POST. The bridge then suppresses the response body while preserving the JSON content type
+   * and reported content length.
+   *
+   * @param uri request target as seen by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context, including full-access enforcement state
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response headers
+   */
+  public void handleMethodHEAD(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse("HEAD", uri, request, ctx, false);
+  }
+
+  /**
+   * Returns a JSON {@code 405} error for unsupported OPTIONS requests.
+   *
+   * <p>The bridge forwards OPTIONS through the router when the legacy shell dispatches it. That
+   * keeps the Platform API method advertisement consistent with the read-only v1 contract.
+   *
+   * @param uri request target as seen by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context, including full-access enforcement state
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  public void handleMethodOPTIONS(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse("OPTIONS", uri, request, ctx);
+  }
+
+  /**
+   * Returns a JSON {@code 405} error for unsupported PUT requests.
+   *
+   * @param uri request target as seen by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context, including full-access enforcement state
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  public void handleMethodPUT(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse("PUT", uri, request, ctx);
+  }
+
+  /**
+   * Returns a JSON {@code 405} error for unsupported DELETE requests.
+   *
+   * @param uri request target as seen by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context, including full-access enforcement state
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  public void handleMethodDELETE(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse("DELETE", uri, request, ctx);
+  }
+
+  /**
+   * Returns a JSON {@code 405} error for unsupported PATCH requests.
+   *
+   * @param uri request target as seen by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context, including full-access enforcement state
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  public void handleMethodPATCH(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse("PATCH", uri, request, ctx);
+  }
+
+  /**
+   * Returns a JSON {@code 405} error for unsupported TRACE requests.
+   *
+   * @param uri request target as seen by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context, including full-access enforcement state
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  public void handleMethodTRACE(URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse("TRACE", uri, request, ctx);
+  }
+
+  @Override
+  public String path() {
+    return MOUNT_PATH;
+  }
+
+  @Override
+  public boolean allowPOSTWithoutPassword() {
+    return true;
+  }
+
+  /**
+   * Routes a request through the Platform API and writes the resulting JSON response.
+   *
+   * <p>This overload emits the response body normally. HEAD requests use the lower-level overload
+   * to suppress the body while still reporting the encoded content length.
+   *
+   * @param method HTTP method name forwarded into the Platform API router
+   * @param uri request target supplied by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context used for access checks and reply writes
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  private void writePlatformApiResponse(
+      String method, URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    writePlatformApiResponse(method, uri, request, ctx, true);
+  }
+
+  /**
+   * Routes a request through the Platform API and writes either a full or header-only reply.
+   *
+   * <p>Legacy HTTP integration keeps full-access enforcement at the bridge boundary. Requests that
+   * pass the access check are converted into a transport-neutral {@link PlatformApiRequest} and
+   * delegated to the router. Unexpected runtime failures are converted into a structured {@code
+   * 500} response so callers keep the Platform API JSON contract even when the bridge logs the
+   * underlying error.
+   *
+   * @param method HTTP method name forwarded into the Platform API router
+   * @param uri request target supplied by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context used for access checks and reply writes
+   * @param includeBody {@code true} to send the encoded JSON body, {@code false} for header-only
+   *     replies such as HEAD
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  private void writePlatformApiResponse(
+      String method, URI uri, HTTPRequest request, ToadletContext ctx, boolean includeBody)
+      throws ToadletContextClosedException, IOException {
+    PlatformApiResponse response;
+    if (!ctx.isAllowedFullAccess()) {
+      response = PlatformApiResponse.error(403, "forbidden", "Full access is required.");
+      writeJsonReply(ctx, response, includeBody);
+      return;
+    }
+
+    try {
+      response = router.route(toPlatformApiRequest(method, uri, request));
+    } catch (URLEncodedFormatException _) {
+      response =
+          PlatformApiResponse.error(
+              400, "invalid_path", "Request path contains malformed percent-encoding.");
+    } catch (RuntimeException e) {
+      LOG.error("Platform API request failed for path {}", requestPath(uri), e);
+      response =
+          PlatformApiResponse.error(500, "internal_error", "Unexpected platform API failure.");
+    }
+    writeJsonReply(ctx, response, includeBody);
+  }
+
+  /**
+   * Converts legacy HTTP request state into the transport-neutral Platform API request model.
+   *
+   * <p>Query parameters preserve encounter order and repeated values so the router can apply its
+   * own validation without depending on the legacy HTTP request type.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param uri request target supplied by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @return immutable Platform API request built from the method, relative path, and query values
+   * @throws URLEncodedFormatException if the request path contains malformed percent-encoding
+   */
+  private PlatformApiRequest toPlatformApiRequest(String method, URI uri, HTTPRequest request)
+      throws URLEncodedFormatException {
+    LinkedHashMap<String, List<String>> queryParameters =
+        LinkedHashMap.newLinkedHashMap(request.getParameterNames().size());
+    for (String parameterName : request.getParameterNames()) {
+      queryParameters.put(parameterName, List.of(request.getMultipleParam(parameterName)));
+    }
+    return new PlatformApiRequest(method, relativeApiPath(requestPath(uri)), queryParameters);
+  }
+
+  /**
+   * Splits the mounted request path into decoded Platform API path segments.
+   *
+   * <p>The bridge trims the API mount prefix, preserves encoded slashes until segment boundaries
+   * are determined, and then decodes each segment independently. That allows peer identifiers and
+   * similar values to contain {@code /} when they were percent-encoded in the incoming request.
+   *
+   * @param requestPath raw request path as received from the URI before query parsing
+   * @return immutable list of decoded path segments relative to {@link #MOUNT_PATH}
+   * @throws URLEncodedFormatException if any segment contains malformed percent-encoding
+   */
+  private static List<String> relativeApiPath(String requestPath) throws URLEncodedFormatException {
+    String relativePath = requestPath;
+    if (requestPath.startsWith(MOUNT_PATH)) {
+      relativePath = requestPath.substring(MOUNT_PATH.length());
+    } else {
+      String withoutTrailingSlash = MOUNT_PATH.substring(0, MOUNT_PATH.length() - 1);
+      if (requestPath.equals(withoutTrailingSlash)) {
+        relativePath = "";
+      }
+    }
+    if (relativePath.isEmpty()) {
+      return List.of();
+    }
+    List<String> pathSegments = new ArrayList<>();
+    int segmentStart = 0;
+    while (segmentStart < relativePath.length()) {
+      int nextSeparator = relativePath.indexOf('/', segmentStart);
+      String segment =
+          nextSeparator >= 0
+              ? relativePath.substring(segmentStart, nextSeparator)
+              : relativePath.substring(segmentStart);
+      if (!segment.isEmpty()) {
+        pathSegments.add(URLDecoder.decode(segment, false));
+      }
+      if (nextSeparator < 0) {
+        break;
+      }
+      segmentStart = nextSeparator + 1;
+    }
+    return List.copyOf(pathSegments);
+  }
+
+  /**
+   * Returns the raw request path when available so encoded path separators remain intact.
+   *
+   * @param uri request target supplied by the legacy HTTP shell
+   * @return raw path if present, otherwise the decoded URI path as a fallback
+   */
+  private static String requestPath(URI uri) {
+    String rawPath = uri.getRawPath();
+    return rawPath != null ? rawPath : uri.getPath();
+  }
+
+  /**
+   * Writes the Platform API response back through the legacy HTTP shell.
+   *
+   * <p>The bridge preserves router-supplied headers such as {@code Allow} and always advertises the
+   * Platform API JSON media type. HEAD responses suppress the body while still reporting the
+   * encoded byte length so clients can probe the endpoint without downloading the payload.
+   *
+   * @param ctx the current toadlet context used to send headers and body bytes
+   * @param response transport-neutral Platform API response returned by the router
+   * @param includeBody {@code true} to send the encoded JSON body, {@code false} for header-only
+   *     replies
+   * @throws ToadletContextClosedException if the client disconnects while the reply is being sent
+   * @throws IOException if the legacy HTTP shell fails while writing the response
+   */
+  private void writeJsonReply(ToadletContext ctx, PlatformApiResponse response, boolean includeBody)
+      throws ToadletContextClosedException, IOException {
+    MultiValueTable<String, String> headers = null;
+    if (!response.headers().isEmpty()) {
+      headers = new MultiValueTable<>();
+      response.headers().forEach(headers::put);
+    }
+    ReplyHeaders replyHeaders =
+        ReplyHeaders.of(response.statusCode(), response.reasonPhrase(), JSON_CONTENT_TYPE, headers);
+    if (includeBody) {
+      writeReply(ctx, replyHeaders, response.body());
+      return;
+    }
+
+    byte[] body = response.body().getBytes(StandardCharsets.UTF_8);
+    ctx.sendReplyHeaders(
+        replyHeaders.code(),
+        replyHeaders.description(),
+        replyHeaders.headers(),
+        replyHeaders.mimeType(),
+        body.length);
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
   application
 }
 
-// Update version manually before a new release development starts
+// Update version manually before new release development starts
 version = "3"
 
 val internalLeafProjects =
@@ -28,6 +28,7 @@ val internalLeafProjects =
     project(":kernel-transport"),
     project(":kernel-routing"),
     project(":runtime-spi"),
+    project(":platform-api"),
     project(":runtime-node"),
     project(":adapter-fcp"),
     project(":adapter-http-legacy-admin"),
@@ -56,6 +57,7 @@ dependencies {
   implementation(project(":kernel-transport"))
   implementation(project(":kernel-routing"))
   implementation(project(":runtime-spi"))
+  implementation(project(":platform-api"))
   implementation(project(":runtime-node"))
   implementation(project(":adapter-fcp"))
   implementation(project(":adapter-http-legacy-admin"))
@@ -323,7 +325,7 @@ val legacyRuntimeAlertsTestPackageDir =
   layout.buildDirectory.dir("classes/java/test/network/crypta/node/useralerts")
 
 // Selective leaf ownership metadata only covers root <-> leaf and leaf <-> leaf moves.
-// Root-local package re-homes still need explicit stale-output pruning so non-clean builds and
+// Root-local package re-homes still need explicit stale-output pruning, so non-clean builds and
 // branch switches do not keep packaging deleted classes from the old package path.
 val pruneLegacyRuntimeAlertsOutputs by
   tasks.registering(Delete::class) {

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  id("cryptad.java-kotlin-conventions")
+  id("cryptad.spotless")
+  `java-library`
+}
+
+version = rootProject.version
+
+dependencies {
+  api(project(":runtime-spi"))
+
+  compileOnly(libs.jetbrainsAnnotations)
+}

--- a/platform-api/gradle/owned-output-patterns.txt
+++ b/platform-api/gradle/owned-output-patterns.txt
@@ -1,0 +1,4 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :platform-api owns
+# them now.
+
+network/crypta/platform/api/**

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiException.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiException.java
@@ -1,0 +1,59 @@
+package network.crypta.platform.api;
+
+import java.util.Objects;
+
+/**
+ * Internal exception used to map validation and lookup failures onto API error responses.
+ *
+ * <p>The router catches this exception and serializes it through the standard Platform API error
+ * shape, keeping request-parsing helpers and endpoint handlers concise without exposing the
+ * exception type as part of the public API surface.
+ */
+public final class PlatformApiException extends RuntimeException {
+  /** HTTP-style status code that the router should expose for this failure. */
+  private final int statusCode;
+
+  /** Stable machine-readable error identifier included in the serialized error payload. */
+  private final String errorCode;
+
+  /**
+   * Creates a structured platform API exception.
+   *
+   * @param statusCode transport-level status code to emit
+   * @param errorCode machine-readable error code
+   * @param message human-readable error message
+   */
+  public PlatformApiException(int statusCode, String errorCode, String message) {
+    super(Objects.requireNonNull(message, "message"));
+    this.statusCode = statusCode;
+    this.errorCode = Objects.requireNonNull(errorCode, "errorCode");
+  }
+
+  /**
+   * Returns the transport-level status code associated with the failure.
+   *
+   * @return HTTP-style status code that the router should copy into the response
+   */
+  public int statusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Returns the machine-readable error code associated with the failure.
+   *
+   * @return stable error identifier included in the serialized JSON error body
+   */
+  public String errorCode() {
+    return errorCode;
+  }
+
+  /**
+   * Returns the standard reason phrase corresponding to {@link #statusCode()}.
+   *
+   * @return short reason phrase used when the router serializes this failure into a response
+   */
+  @SuppressWarnings("unused")
+  public String reasonPhrase() {
+    return PlatformApiResponse.reasonPhrase(statusCode);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiParameters.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiParameters.java
@@ -1,0 +1,166 @@
+package network.crypta.platform.api;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Shared query-parameter parsing helpers for Platform API endpoints.
+ *
+ * <p>The helpers in this package convert the small set of supported boolean and enum query
+ * parameters into strongly typed values while preserving a consistent {@code 400} mapping when a
+ * request is malformed.
+ */
+public final class PlatformApiParameters {
+  private static final String QUERY_PARAMETER_PREFIX = "Query parameter '";
+
+  /** Prevents instantiation of this static helper type. */
+  private PlatformApiParameters() {}
+
+  /**
+   * Reads one boolean query parameter, defaulting when the parameter is absent.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @param defaultValue value to return when the parameter is absent
+   * @return parsed boolean value
+   */
+  public static boolean readBoolean(
+      Map<String, List<String>> queryParameters, String name, boolean defaultValue) {
+    String raw = readSingle(queryParameters, name);
+    if (raw == null) {
+      return defaultValue;
+    }
+    if ("true".equalsIgnoreCase(raw)) {
+      return true;
+    }
+    if ("false".equalsIgnoreCase(raw)) {
+      return false;
+    }
+    throw invalidQuery(queryParameter(name) + " must be either 'true' or 'false'.");
+  }
+
+  /**
+   * Reads one required enum query parameter using the enum's exact {@link Enum#name()} values.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @param enumType target enum type
+   * @return parsed enum value
+   * @param <E> enum type
+   */
+  public static <E extends Enum<E>> E requireEnum(
+      Map<String, List<String>> queryParameters, String name, Class<E> enumType) {
+    String raw = readSingle(queryParameters, name);
+    if (raw == null || raw.isBlank()) {
+      throw invalidQuery("Missing required query parameter '" + name + "'.");
+    }
+    return parseEnum(name, raw, enumType);
+  }
+
+  /**
+   * Reads a comma-separated enum query parameter using exact enum names.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @param enumType target enum type
+   * @param defaultValue value to return when the parameter is absent
+   * @return parsed enum set
+   * @param <E> enum type
+   */
+  public static <E extends Enum<E>> Set<E> readCommaSeparatedEnums(
+      Map<String, List<String>> queryParameters,
+      String name,
+      Class<E> enumType,
+      Set<E> defaultValue) {
+    String raw = readSingle(queryParameters, name);
+    if (raw == null) {
+      return copyEnumSet(enumType, defaultValue);
+    }
+    if (raw.isBlank()) {
+      throw invalidQuery(queryParameter(name) + " must not be empty.");
+    }
+
+    EnumSet<E> values = EnumSet.noneOf(enumType);
+    for (String part : raw.split(",", -1)) {
+      String trimmed = part.trim();
+      if (trimmed.isEmpty()) {
+        throw invalidQuery(queryParameter(name) + " must not contain empty enum values.");
+      }
+      values.add(parseEnum(name, trimmed, enumType));
+    }
+    return values;
+  }
+
+  /**
+   * Reads exactly one query parameter value when it is present.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @return single supplied value, or {@code null} when the parameter is absent
+   * @throws PlatformApiException if the parameter was repeated
+   */
+  private static String readSingle(Map<String, List<String>> queryParameters, String name) {
+    List<String> values = queryParameters.get(name);
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    if (values.size() > 1) {
+      throw invalidQuery(queryParameter(name) + " must not be repeated.");
+    }
+    return values.getFirst();
+  }
+
+  /**
+   * Parses one enum value using the enum constant names exposed by the Platform API.
+   *
+   * @param name parameter name being validated
+   * @param raw raw query value supplied by the caller
+   * @param enumType target enum type
+   * @return parsed enum constant matching {@code raw}
+   * @param <E> enum type
+   * @throws PlatformApiException if {@code raw} does not match one of the allowed enum names
+   */
+  private static <E extends Enum<E>> E parseEnum(String name, String raw, Class<E> enumType) {
+    try {
+      return Enum.valueOf(enumType, raw);
+    } catch (IllegalArgumentException _) {
+      throw invalidQuery(
+          queryParameter(name)
+              + "' must be one of "
+              + Arrays.toString(enumType.getEnumConstants())
+              + ".");
+    }
+  }
+
+  /**
+   * Copies an enum set into a new mutable set while preserving the empty-set element type.
+   *
+   * @param enumType enum type represented by the set
+   * @param source source set to copy
+   * @return copied enum set suitable for further mutation by the caller
+   * @param <E> enum type
+   */
+  private static <E extends Enum<E>> EnumSet<E> copyEnumSet(Class<E> enumType, Set<E> source) {
+    if (source.isEmpty()) {
+      return EnumSet.noneOf(enumType);
+    }
+    return EnumSet.copyOf(source);
+  }
+
+  private static String queryParameter(String name) {
+    return QUERY_PARAMETER_PREFIX + name + "'";
+  }
+
+  /**
+   * Creates the standard {@code 400 invalid_query_parameter} exception.
+   *
+   * @param message human-readable validation failure
+   * @return platform API exception carrying the standard invalid-query error mapping
+   */
+  private static PlatformApiException invalidQuery(String message) {
+    return new PlatformApiException(400, "invalid_query_parameter", message);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiPaths.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiPaths.java
@@ -1,0 +1,15 @@
+package network.crypta.platform.api;
+
+/**
+ * Canonical path constants for the Platform API.
+ *
+ * <p>The initial read-only API is mounted under one versioned prefix, so transport-specific bridges
+ * can expose it consistently without duplicating the route string throughout the codebase.
+ */
+public final class PlatformApiPaths {
+  /** The current versioned mount prefix for the read-only Platform API v1. */
+  public static final String API_V1_PREFIX = "/api/v1/";
+
+  /** Prevents instantiation of this constants-only type. */
+  private PlatformApiPaths() {}
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRequest.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRequest.java
@@ -1,0 +1,81 @@
+package network.crypta.platform.api;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Transport-neutral request metadata passed into the Platform API router.
+ *
+ * <p>The record intentionally captures only the small amount of information that the current API
+ * needs: the HTTP-style method, the relative path split into path segments beneath {@link
+ * PlatformApiPaths#API_V1_PREFIX}, and the decoded query parameters with all supplied values.
+ * Bridges remain responsible for any transport-specific parsing, authentication, or header handling
+ * before constructing this request.
+ *
+ * @param method request method name such as {@code GET}
+ * @param pathSegments relative path segments beneath the API v1 mount point
+ * @param queryParameters decoded query parameters in encounter order
+ */
+public record PlatformApiRequest(
+    String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
+  /**
+   * Creates an immutable platform API request descriptor.
+   *
+   * <p>The constructor normalizes the method name to the upper case using the root locale and
+   * copies path segments and query parameters into encounter-order-preserving immutable
+   * collections.
+   *
+   * @throws NullPointerException if any component, path segment, query key, or query value is
+   *     {@code null}
+   */
+  public PlatformApiRequest {
+    method = Objects.requireNonNull(method, "method").toUpperCase(Locale.ROOT);
+    pathSegments =
+        List.copyOf(
+            Objects.requireNonNull(pathSegments, "pathSegments").stream()
+                .map(segment -> Objects.requireNonNull(segment, "pathSegments value"))
+                .toList());
+    queryParameters = immutableQueryParameters(queryParameters);
+  }
+
+  /**
+   * Returns all values supplied for one decoded query parameter.
+   *
+   * @param name parameter name to look up
+   * @return decoded parameter values, or an empty list when the parameter is absent
+   */
+  @SuppressWarnings("unused")
+  public List<String> queryValues(String name) {
+    Objects.requireNonNull(name, "name");
+    return queryParameters.getOrDefault(name, List.of());
+  }
+
+  /**
+   * Copies query parameters into an immutable encounter-order-preserving map.
+   *
+   * @param source decoded query parameter map supplied by the transport bridge
+   * @return immutable copy of {@code source} with immutable value lists
+   * @throws NullPointerException if the map, a key, a value list, or a value element is {@code
+   *     null}
+   */
+  private static Map<String, List<String>> immutableQueryParameters(
+      Map<String, List<String>> source) {
+    Objects.requireNonNull(source, "queryParameters");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, List<String>> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, List<String>> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "queryParameters key"),
+          List.copyOf(
+              Objects.requireNonNull(entry.getValue(), "queryParameters value").stream()
+                  .map(value -> Objects.requireNonNull(value, "queryParameters item"))
+                  .toList()));
+    }
+    return java.util.Collections.unmodifiableMap(copy);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
@@ -1,0 +1,133 @@
+package network.crypta.platform.api;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.json.PlatformApiJsonWriter;
+
+/**
+ * JSON response value returned by the transport-neutral Platform API router.
+ *
+ * <p>The current Platform API surface always emits JSON, so this response carries only the status
+ * code, reason phrase, optional headers, and serialized body. A transport-specific bridge remains
+ * responsible only for writing these values through its native protocol APIs.
+ *
+ * @param statusCode transport-level status code, using HTTP-style values such as {@code 200} or
+ *     {@code 404}
+ * @param reasonPhrase short reason phrase associated with {@code statusCode}
+ * @param headers response headers keyed by name
+ * @param body serialized JSON response body
+ */
+public record PlatformApiResponse(
+    int statusCode, String reasonPhrase, Map<String, String> headers, String body) {
+  /**
+   * Creates an immutable platform API response.
+   *
+   * @throws IllegalArgumentException if {@code statusCode} is outside the HTTP status-code range
+   * @throws NullPointerException if {@code reasonPhrase}, {@code headers}, or {@code body} is
+   *     {@code null}
+   */
+  public PlatformApiResponse {
+    if (statusCode < 100 || statusCode > 599) {
+      throw new IllegalArgumentException("statusCode must be a valid HTTP status code");
+    }
+    Objects.requireNonNull(reasonPhrase, "reasonPhrase");
+    headers = immutableHeaders(headers);
+    Objects.requireNonNull(body, "body");
+  }
+
+  /**
+   * Builds a successful JSON response for the supplied body value.
+   *
+   * @param value JSON-compatible body value to serialize
+   * @return {@code 200 OK} response carrying the serialized body
+   */
+  public static PlatformApiResponse ok(Object value) {
+    return json(200, Map.of(), value);
+  }
+
+  /**
+   * Builds a JSON error response using the standard Platform API error shape.
+   *
+   * @param statusCode transport-level status code to return
+   * @param errorCode stable machine-readable error code
+   * @param message human-readable error message
+   * @return JSON error response using the standard {@code {"error": ...}} shape
+   */
+  public static PlatformApiResponse error(int statusCode, String errorCode, String message) {
+    return error(statusCode, Map.of(), errorCode, message);
+  }
+
+  /**
+   * Builds a JSON error response using the standard Platform API error shape with explicit headers.
+   *
+   * @param statusCode transport-level status code to return
+   * @param headers response headers to include
+   * @param errorCode stable machine-readable error code
+   * @param message human-readable error message
+   * @return JSON error response using the standard {@code {"error": ...}} shape
+   */
+  public static PlatformApiResponse error(
+      int statusCode, Map<String, String> headers, String errorCode, String message) {
+    LinkedHashMap<String, Object> errorBody = LinkedHashMap.newLinkedHashMap(1);
+    LinkedHashMap<String, Object> error = LinkedHashMap.newLinkedHashMap(2);
+    error.put("code", Objects.requireNonNull(errorCode, "errorCode"));
+    error.put("message", Objects.requireNonNull(message, "message"));
+    errorBody.put("error", error);
+    return json(statusCode, headers, errorBody);
+  }
+
+  /**
+   * Returns the standard reason phrase for one HTTP-style status code.
+   *
+   * @param statusCode transport-level status code
+   * @return standard reason phrase used in serialized Platform API responses
+   */
+  static String reasonPhrase(int statusCode) {
+    return switch (statusCode) {
+      case 200 -> "OK";
+      case 400 -> "Bad Request";
+      case 403 -> "Forbidden";
+      case 404 -> "Not Found";
+      case 405 -> "Method Not Allowed";
+      case 500 -> "Internal Server Error";
+      default -> "Platform API";
+    };
+  }
+
+  /**
+   * Serializes one JSON-compatible value into a complete Platform API response.
+   *
+   * @param statusCode transport-level status code to emit
+   * @param headers response headers to include
+   * @param value JSON-compatible value to serialize as the body
+   * @return immutable Platform API response with a serialized JSON body
+   */
+  private static PlatformApiResponse json(
+      int statusCode, Map<String, String> headers, Object value) {
+    return new PlatformApiResponse(
+        statusCode, reasonPhrase(statusCode), headers, PlatformApiJsonWriter.write(value));
+  }
+
+  /**
+   * Copies response headers into an immutable encounter-order-preserving map.
+   *
+   * @param source source header map supplied by a caller
+   * @return immutable copy of {@code source}
+   * @throws NullPointerException if the map, a key, or a value is {@code null}
+   */
+  private static Map<String, String> immutableHeaders(Map<String, String> source) {
+    Objects.requireNonNull(source, "headers");
+    if (source.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, String> copy = LinkedHashMap.newLinkedHashMap(source.size());
+    for (Map.Entry<String, String> entry : source.entrySet()) {
+      copy.put(
+          Objects.requireNonNull(entry.getKey(), "headers key"),
+          Objects.requireNonNull(entry.getValue(), "headers value"));
+    }
+    return Collections.unmodifiableMap(copy);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -1,0 +1,152 @@
+package network.crypta.platform.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.config.ConfigApiHandler;
+import network.crypta.platform.api.connectivity.ConnectivityApiHandler;
+import network.crypta.platform.api.node.NodeApiHandler;
+import network.crypta.platform.api.peers.PeersApiHandler;
+import network.crypta.platform.api.security.SecurityLevelsApiHandler;
+import network.crypta.runtime.spi.RuntimePorts;
+
+/**
+ * Routes transport-neutral Platform API requests onto detached runtime ports.
+ *
+ * <p>The router keeps the initial Platform API v1 surface small and predictable. It accepts one
+ * request descriptor, validates the method and relative path beneath {@link
+ * PlatformApiPaths#API_V1_PREFIX}, delegates to the relevant endpoint family, and emits a JSON
+ * response with stable status codes for malformed requests and missing resources.
+ */
+public final class PlatformApiRouter {
+  /** Logger used for unexpected failures that escape endpoint-specific validation. */
+  private static final System.Logger LOG = System.getLogger(PlatformApiRouter.class.getName());
+
+  /** Handler for the {@code /node/...} endpoint family. */
+  private final NodeApiHandler nodeApiHandler;
+
+  /** Handler for the {@code /peers/...} endpoint family. */
+  private final PeersApiHandler peersApiHandler;
+
+  /** Handler for the {@code /config} endpoint. */
+  private final ConfigApiHandler configApiHandler;
+
+  /** Handler for the {@code /connectivity} endpoint. */
+  private final ConnectivityApiHandler connectivityApiHandler;
+
+  /** Handler for the {@code /security-levels} endpoint. */
+  private final SecurityLevelsApiHandler securityLevelsApiHandler;
+
+  /**
+   * Creates a router backed by the supplied runtime ports.
+   *
+   * @param runtimePorts detached runtime-port aggregate used to resolve API requests
+   * @throws NullPointerException if {@code runtimePorts} is {@code null}
+   */
+  public PlatformApiRouter(RuntimePorts runtimePorts) {
+    Objects.requireNonNull(runtimePorts, "runtimePorts");
+    nodeApiHandler = new NodeApiHandler(runtimePorts.nodeInfo());
+    peersApiHandler = new PeersApiHandler(runtimePorts.peer());
+    configApiHandler = new ConfigApiHandler(runtimePorts.config());
+    connectivityApiHandler = new ConnectivityApiHandler(runtimePorts.connectivity());
+    securityLevelsApiHandler = new SecurityLevelsApiHandler(runtimePorts.securityLevels());
+  }
+
+  /**
+   * Routes one request and returns the corresponding JSON response.
+   *
+   * <p>Known request validation failures are converted into structured error responses. Unexpected
+   * runtime failures are allowed to propagate so the transport-specific bridge can log them and map
+   * them onto a generic {@code 500} response.
+   *
+   * @param request transport-neutral request metadata to route
+   * @return JSON response for the routed endpoint
+   */
+  public PlatformApiResponse route(PlatformApiRequest request) {
+    try {
+      return routeInternal(Objects.requireNonNull(request, "request"));
+    } catch (PlatformApiException e) {
+      return PlatformApiResponse.error(e.statusCode(), e.errorCode(), e.getMessage());
+    } catch (RuntimeException e) {
+      LOG.log(System.Logger.Level.ERROR, "Unexpected Platform API failure", e);
+      return PlatformApiResponse.error(500, "internal_error", "Unexpected platform API failure.");
+    }
+  }
+
+  /**
+   * Performs method and path validation after null checking has already completed.
+   *
+   * @param request non-null transport-neutral request metadata
+   * @return JSON response for the routed endpoint or a structured error response
+   */
+  private PlatformApiResponse routeInternal(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return PlatformApiResponse.error(
+          405,
+          Map.of("Allow", "GET"),
+          "method_not_allowed",
+          "Platform API v1 supports GET requests only.");
+    }
+
+    List<String> segments = request.pathSegments();
+    if (segments.isEmpty()) {
+      throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    }
+
+    String firstSegment = segments.getFirst();
+    if ("node".equals(firstSegment)) {
+      return routeNodeRequest(segments, request);
+    }
+    if ("peers".equals(firstSegment)) {
+      return routePeersRequest(segments, request);
+    }
+    if ("config".equals(firstSegment) && segments.size() == 1) {
+      return PlatformApiResponse.ok(configApiHandler.exportConfig(request.queryParameters()));
+    }
+    if ("connectivity".equals(firstSegment) && segments.size() == 1) {
+      return PlatformApiResponse.ok(connectivityApiHandler.snapshot(request.queryParameters()));
+    }
+    if ("security-levels".equals(firstSegment) && segments.size() == 1) {
+      return PlatformApiResponse.ok(securityLevelsApiHandler.snapshot());
+    }
+
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /node} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected node endpoint
+   * @throws PlatformApiException if the path does not identify a supported node endpoint
+   */
+  private PlatformApiResponse routeNodeRequest(List<String> segments, PlatformApiRequest request) {
+    if (segments.size() == 2 && "greeting".equals(segments.get(1))) {
+      return PlatformApiResponse.ok(nodeApiHandler.greeting());
+    }
+    if (segments.size() == 2 && "reference".equals(segments.get(1))) {
+      return PlatformApiResponse.ok(nodeApiHandler.reference(request.queryParameters()));
+    }
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /peers} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for either the peer list or one peer detail endpoint
+   * @throws PlatformApiException if the path does not identify a supported peers endpoint
+   */
+  private PlatformApiResponse routePeersRequest(List<String> segments, PlatformApiRequest request) {
+    if (segments.size() == 1) {
+      return PlatformApiResponse.ok(peersApiHandler.list(request.queryParameters()));
+    }
+    if (segments.size() == 2) {
+      return PlatformApiResponse.ok(
+          peersApiHandler.get(segments.get(1), request.queryParameters()));
+    }
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/config/ConfigApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/config/ConfigApiHandler.java
@@ -1,0 +1,60 @@
+package network.crypta.platform.api.config;
+
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.api.json.PlatformApiFieldSetJson;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+
+/**
+ * Read-only configuration endpoint family for Platform API v1.
+ *
+ * <p>The initial API keeps configuration export conservative: when callers omit the {@code
+ * sections} query parameter, the handler exports only {@link ConfigSection#CURRENT}, which exposes
+ * effective values without broadening the surface to descriptions, metadata, or write-oriented
+ * flows.
+ */
+public final class ConfigApiHandler {
+  /** Conservative default export scope used when callers omit the {@code sections} query. */
+  private static final EnumSet<ConfigSection> DEFAULT_SECTIONS = EnumSet.of(ConfigSection.CURRENT);
+
+  /** Detached runtime port that exports configuration snapshots for the API layer. */
+  private final ConfigPort configPort;
+
+  /**
+   * Creates a configuration API handler backed by the supplied runtime port.
+   *
+   * @param configPort detached runtime config port
+   */
+  public ConfigApiHandler(ConfigPort configPort) {
+    this.configPort = Objects.requireNonNull(configPort, "configPort");
+  }
+
+  /**
+   * Exports the requested configuration sections.
+   *
+   * @param queryParameters decoded query parameters for the current request
+   * @return JSON-compatible configuration snapshot keyed by section name
+   */
+  public Map<String, Object> exportConfig(Map<String, List<String>> queryParameters) {
+    Set<ConfigSection> requestedSections =
+        PlatformApiParameters.readCommaSeparatedEnums(
+            queryParameters, "sections", ConfigSection.class, DEFAULT_SECTIONS);
+    ConfigSnapshot snapshot = configPort.export(requestedSections);
+
+    LinkedHashMap<String, Object> sections =
+        LinkedHashMap.newLinkedHashMap(snapshot.sections().size());
+    snapshot
+        .sections()
+        .forEach(
+            (section, fieldSet) ->
+                sections.put(section.name(), PlatformApiFieldSetJson.toJson(fieldSet)));
+    return sections;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/config/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/config/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Configuration-oriented Platform API handlers.
+ *
+ * <p>This package owns the read-only configuration export endpoint for Platform API v1. It keeps
+ * the default-section policy and section-name validation close to the runtime config port it
+ * serves.
+ */
+package network.crypta.platform.api.config;

--- a/platform-api/src/main/java/network/crypta/platform/api/connectivity/ConnectivityApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/connectivity/ConnectivityApiHandler.java
@@ -1,0 +1,142 @@
+package network.crypta.platform.api.connectivity;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.runtime.spi.ConnectivityGapSnapshot;
+import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
+import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.ConnectivitySnapshot;
+import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
+
+/**
+ * Read-only connectivity endpoint family for Platform API v1.
+ *
+ * <p>The handler reuses the cost boundary already present in {@link ConnectivityPort}: callers must
+ * explicitly request advanced details, otherwise the API returns only the summary snapshot.
+ */
+public final class ConnectivityApiHandler {
+  /** Detached runtime port that supplies connectivity snapshots for the API layer. */
+  private final ConnectivityPort connectivityPort;
+
+  /**
+   * Creates a connectivity API handler backed by the supplied runtime port.
+   *
+   * @param connectivityPort detached runtime connectivity port
+   */
+  public ConnectivityApiHandler(ConnectivityPort connectivityPort) {
+    this.connectivityPort = Objects.requireNonNull(connectivityPort, "connectivityPort");
+  }
+
+  /**
+   * Exports one connectivity snapshot.
+   *
+   * @param queryParameters decoded query parameters for the current request
+   * @return JSON-compatible connectivity snapshot
+   */
+  public Map<String, Object> snapshot(Map<String, List<String>> queryParameters) {
+    boolean includeAdvanced = PlatformApiParameters.readBoolean(queryParameters, "advanced", false);
+    ConnectivitySnapshot snapshot = connectivityPort.snapshot(includeAdvanced);
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    json.put("darknetFnpPort", snapshot.darknetFnpPort());
+    json.put("opennetFnpPort", snapshot.opennetFnpPort());
+    json.put("fproxyListener", toJson(snapshot.fproxyListener()));
+    json.put("fcpListener", toJson(snapshot.fcpListener()));
+    json.put("consoleListener", toJson(snapshot.consoleListener()));
+    json.put("connectionTypeNotice", toJson(snapshot.connectionTypeNotice()));
+    json.put("sockets", snapshot.sockets().stream().map(ConnectivityApiHandler::toJson).toList());
+    return json;
+  }
+
+  /**
+   * Converts one listener-port snapshot into a JSON-compatible object.
+   *
+   * @param snapshot detached runtime listener snapshot
+   * @return JSON-compatible listener representation
+   */
+  private static Map<String, Object> toJson(ConnectivityListenerPortSnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("enabled", snapshot.enabled());
+    json.put("port", snapshot.port());
+    return json;
+  }
+
+  /**
+   * Converts one optional connectivity notice into a JSON-compatible object.
+   *
+   * @param snapshot detached runtime notice snapshot, or {@code null} when no notice is present
+   * @return JSON-compatible notice representation, or an empty object when the notice is absent
+   */
+  private static Map<String, Object> toJson(ConnectivityNoticeSnapshot snapshot) {
+    if (snapshot == null) {
+      return Map.of();
+    }
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put("title", snapshot.title());
+    json.put("text", snapshot.text());
+    json.put("renderedAlertHtml", snapshot.renderedAlertHtml());
+    return json;
+  }
+
+  /**
+   * Converts one socket snapshot into a JSON-compatible object.
+   *
+   * @param snapshot detached runtime socket snapshot
+   * @return JSON-compatible socket representation
+   */
+  private static Map<String, Object> toJson(ConnectivitySocketSnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(5);
+    json.put("title", snapshot.title());
+    json.put("portForwardStatus", snapshot.portForwardStatus().name());
+    json.put("longestSendReceiveGapMillis", snapshot.longestSendReceiveGapMillis());
+    json.put("peerEntries", toJson(snapshot.peerEntries()));
+    json.put("ipEntries", toJson(snapshot.ipEntries()));
+    return json;
+  }
+
+  /**
+   * Converts a connectivity traffic-entry list into JSON-compatible objects.
+   *
+   * @param entries detached runtime traffic-entry snapshots in encounter order
+   * @return JSON-compatible traffic-entry objects in encounter order
+   */
+  private static List<Map<String, Object>> toJson(List<ConnectivityTrafficEntrySnapshot> entries) {
+    return entries.stream().map(ConnectivityApiHandler::toJson).toList();
+  }
+
+  /**
+   * Converts one traffic entry into a JSON-compatible object.
+   *
+   * @param snapshot detached runtime traffic-entry snapshot
+   * @return JSON-compatible traffic-entry representation
+   */
+  private static Map<String, Object> toJson(ConnectivityTrafficEntrySnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    json.put("address", snapshot.address());
+    json.put("packetsSent", snapshot.packetsSent());
+    json.put("packetsReceived", snapshot.packetsReceived());
+    json.put("initiator", snapshot.initiator().name());
+    json.put("firstSendLeadTimeMillis", snapshot.firstSendLeadTimeMillis());
+    json.put("firstReceiveLeadTimeMillis", snapshot.firstReceiveLeadTimeMillis());
+    json.put("gaps", snapshot.gaps().stream().map(ConnectivityApiHandler::toJson).toList());
+    return json;
+  }
+
+  /**
+   * Converts one receive-gap snapshot into a JSON-compatible object.
+   *
+   * @param snapshot detached runtime gap snapshot
+   * @return JSON-compatible gap representation
+   */
+  private static Map<String, Object> toJson(ConnectivityGapSnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("gapLengthMillis", snapshot.gapLengthMillis());
+    json.put("receivedPacketAtMillis", snapshot.receivedPacketAtMillis());
+    return json;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/connectivity/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/connectivity/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Connectivity-oriented Platform API handlers.
+ *
+ * <p>This package owns the read-only connectivity snapshot endpoint for Platform API v1. The
+ * exported JSON mirrors the detached runtime snapshot shape without depending on the legacy HTTP
+ * connectivity toadlet.
+ */
+package network.crypta.platform.api.connectivity;

--- a/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiFieldSetJson.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiFieldSetJson.java
@@ -1,0 +1,65 @@
+package network.crypta.platform.api.json;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.PeerFieldSet;
+
+/**
+ * Converts detached runtime field-set trees into nested JSON objects.
+ *
+ * <p>The Platform API exposes the existing runtime field-set trees as ordinary JSON objects. Direct
+ * scalar values appear first in encounter order, followed by child subsets rendered recursively as
+ * nested objects. This mirrors the logical shape already reconstructed for FCP field sets without
+ * introducing wrapper noise at each tree level.
+ */
+public final class PlatformApiFieldSetJson {
+  /** Prevents instantiation of this static helper type. */
+  private PlatformApiFieldSetJson() {}
+
+  /**
+   * Converts one node-reference field-set tree into a nested JSON object.
+   *
+   * @param fieldSet detached runtime node-reference tree
+   * @return encounter-order-preserving JSON object representation
+   */
+  public static Map<String, Object> toJson(NodeFieldSet fieldSet) {
+    LinkedHashMap<String, Object> json =
+        LinkedHashMap.newLinkedHashMap(
+            fieldSet.directValues().size() + fieldSet.directSubsets().size());
+    json.putAll(fieldSet.directValues());
+    fieldSet.directSubsets().forEach((name, subset) -> json.put(name, toJson(subset)));
+    return json;
+  }
+
+  /**
+   * Converts one peer field-set tree into a nested JSON object.
+   *
+   * @param fieldSet detached runtime peer tree
+   * @return encounter-order-preserving JSON object representation
+   */
+  public static Map<String, Object> toJson(PeerFieldSet fieldSet) {
+    LinkedHashMap<String, Object> json =
+        LinkedHashMap.newLinkedHashMap(
+            fieldSet.directValues().size() + fieldSet.directSubsets().size());
+    json.putAll(fieldSet.directValues());
+    fieldSet.directSubsets().forEach((name, subset) -> json.put(name, toJson(subset)));
+    return json;
+  }
+
+  /**
+   * Converts one configuration field-set tree into a nested JSON object.
+   *
+   * @param fieldSet detached runtime configuration tree
+   * @return encounter-order-preserving JSON object representation
+   */
+  public static Map<String, Object> toJson(ConfigFieldSet fieldSet) {
+    LinkedHashMap<String, Object> json =
+        LinkedHashMap.newLinkedHashMap(
+            fieldSet.directValues().size() + fieldSet.directSubsets().size());
+    json.putAll(fieldSet.directValues());
+    fieldSet.directSubsets().forEach((name, subset) -> json.put(name, toJson(subset)));
+    return json;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiJsonEncoder.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiJsonEncoder.java
@@ -1,0 +1,324 @@
+package network.crypta.platform.api.json;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.runtime.spi.ConnectivityGapSnapshot;
+import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
+import network.crypta.runtime.spi.ConnectivitySnapshot;
+import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+
+/**
+ * DTO-to-JSON encoders for the Platform API response surface.
+ *
+ * <p>These helpers map detached runtime SPI DTOs into compact JSON objects and arrays using only
+ * JDK types plus the minimal {@link PlatformApiJsonWriter}. Nested field-set trees are rendered as
+ * plain JSON objects that preserve the encounter order of direct values and direct child subsets.
+ */
+public final class PlatformApiJsonEncoder {
+  /** Shared null-check label used for snapshot-based encoders. */
+  private static final String SNAPSHOT = "snapshot";
+
+  /** Prevents instantiation of this static helper type. */
+  private PlatformApiJsonEncoder() {}
+
+  /**
+   * Encodes one node-greeting snapshot as JSON.
+   *
+   * @param snapshot detached runtime snapshot to encode
+   * @return compact JSON representation
+   */
+  @SuppressWarnings("unused")
+  public static String encodeNodeGreeting(NodeGreetingSnapshot snapshot) {
+    Objects.requireNonNull(snapshot, SNAPSHOT);
+
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(7);
+    object.put("nodeName", snapshot.nodeName());
+    object.put("versionString", snapshot.versionString());
+    object.put("buildNumber", snapshot.buildNumber());
+    object.put("revision", snapshot.revision());
+    object.put("testnetEnabled", snapshot.testnetEnabled());
+    object.put("compressionCodecs", snapshot.compressionCodecs());
+    object.put("nodeLanguage", snapshot.nodeLanguage());
+    return PlatformApiJsonWriter.write(object);
+  }
+
+  /**
+   * Encodes one node-reference snapshot as JSON.
+   *
+   * @param snapshot detached runtime snapshot to encode
+   * @return compact JSON representation
+   */
+  public static String encodeNodeReference(NodeReferenceSnapshot snapshot) {
+    Objects.requireNonNull(snapshot, SNAPSHOT);
+    return PlatformApiJsonWriter.write(encodeNodeFieldSet(snapshot.root()));
+  }
+
+  /**
+   * Encodes one peer snapshot as JSON.
+   *
+   * @param snapshot detached runtime snapshot to encode
+   * @return compact JSON representation
+   */
+  @SuppressWarnings("unused")
+  public static String encodePeer(PeerSnapshot snapshot) {
+    Objects.requireNonNull(snapshot, SNAPSHOT);
+    return PlatformApiJsonWriter.write(encodePeerFieldSet(snapshot.root()));
+  }
+
+  /**
+   * Encodes a peer snapshot list as JSON.
+   *
+   * @param snapshots detached runtime snapshots in encounter order
+   * @return compact JSON array representation
+   */
+  @SuppressWarnings("unused")
+  public static String encodePeers(List<PeerSnapshot> snapshots) {
+    Objects.requireNonNull(snapshots, "snapshots");
+    return PlatformApiJsonWriter.write(
+        snapshots.stream()
+            .map(PeerSnapshot::root)
+            .map(PlatformApiJsonEncoder::encodePeerFieldSet)
+            .toList());
+  }
+
+  /**
+   * Encodes one configuration snapshot as JSON.
+   *
+   * @param snapshot detached runtime snapshot to encode
+   * @return compact JSON representation
+   */
+  public static String encodeConfig(ConfigSnapshot snapshot) {
+    Objects.requireNonNull(snapshot, SNAPSHOT);
+
+    LinkedHashMap<String, Object> object =
+        LinkedHashMap.newLinkedHashMap(snapshot.sections().size());
+    for (Map.Entry<ConfigSection, ConfigFieldSet> entry : snapshot.sections().entrySet()) {
+      object.put(entry.getKey().name(), encodeConfigFieldSet(entry.getValue()));
+    }
+    return PlatformApiJsonWriter.write(object);
+  }
+
+  /**
+   * Encodes one connectivity snapshot as JSON.
+   *
+   * @param snapshot detached runtime snapshot to encode
+   * @return compact JSON representation
+   */
+  @SuppressWarnings("unused")
+  public static String encodeConnectivity(ConnectivitySnapshot snapshot) {
+    Objects.requireNonNull(snapshot, SNAPSHOT);
+
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(7);
+    object.put("darknetFnpPort", snapshot.darknetFnpPort());
+    object.put("opennetFnpPort", snapshot.opennetFnpPort());
+    object.put("fproxyListener", encodeConnectivityListener(snapshot.fproxyListener()));
+    object.put("fcpListener", encodeConnectivityListener(snapshot.fcpListener()));
+    object.put("consoleListener", encodeConnectivityListener(snapshot.consoleListener()));
+    object.put(
+        "connectionTypeNotice",
+        snapshot.connectionTypeNotice() == null
+            ? null
+            : encodeConnectivityNotice(snapshot.connectionTypeNotice()));
+    object.put(
+        "sockets",
+        snapshot.sockets().stream().map(PlatformApiJsonEncoder::encodeConnectivitySocket).toList());
+    return PlatformApiJsonWriter.write(object);
+  }
+
+  /**
+   * Encodes one security-levels snapshot as JSON.
+   *
+   * @param snapshot detached runtime snapshot to encode
+   * @return compact JSON representation
+   */
+  @SuppressWarnings("unused")
+  public static String encodeSecurityLevels(SecurityLevelsSnapshot snapshot) {
+    Objects.requireNonNull(snapshot, SNAPSHOT);
+
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(5);
+    object.put("networkThreatLevel", snapshot.networkThreatLevel().name());
+    object.put("physicalThreatLevel", snapshot.physicalThreatLevel().name());
+    object.put("hasDatabase", snapshot.hasDatabase());
+    object.put("masterPasswordFileExists", snapshot.masterPasswordFileExists());
+    object.put("masterPasswordFilePath", snapshot.masterPasswordFilePath());
+    return PlatformApiJsonWriter.write(object);
+  }
+
+  /**
+   * Encodes a standard Platform API error body as JSON.
+   *
+   * @param code stable machine-readable error code
+   * @param message human-readable error message
+   * @return compact JSON representation
+   */
+  public static String encodeError(String code, String message) {
+    Objects.requireNonNull(code, "code");
+    Objects.requireNonNull(message, "message");
+
+    LinkedHashMap<String, Object> error = LinkedHashMap.newLinkedHashMap(2);
+    error.put("code", code);
+    error.put("message", message);
+
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(1);
+    object.put("error", error);
+    return PlatformApiJsonWriter.write(object);
+  }
+
+  /**
+   * Encodes a node field-set tree as a nested JSON object.
+   *
+   * @param fieldSet detached runtime node field-set tree
+   * @return encounter-order-preserving nested JSON object representation
+   */
+  private static Map<String, Object> encodeNodeFieldSet(NodeFieldSet fieldSet) {
+    return encodeFieldSet(
+        fieldSet.directValues(),
+        fieldSet.directSubsets(),
+        PlatformApiJsonEncoder::encodeNodeFieldSet);
+  }
+
+  /**
+   * Encodes a peer field-set tree as a nested JSON object.
+   *
+   * @param fieldSet detached runtime peer field-set tree
+   * @return encounter-order-preserving nested JSON object representation
+   */
+  private static Map<String, Object> encodePeerFieldSet(PeerFieldSet fieldSet) {
+    return encodeFieldSet(
+        fieldSet.directValues(),
+        fieldSet.directSubsets(),
+        PlatformApiJsonEncoder::encodePeerFieldSet);
+  }
+
+  /**
+   * Encodes a configuration field-set tree as a nested JSON object.
+   *
+   * @param fieldSet detached runtime configuration field-set tree
+   * @return encounter-order-preserving nested JSON object representation
+   */
+  private static Map<String, Object> encodeConfigFieldSet(ConfigFieldSet fieldSet) {
+    return encodeFieldSet(
+        fieldSet.directValues(),
+        fieldSet.directSubsets(),
+        PlatformApiJsonEncoder::encodeConfigFieldSet);
+  }
+
+  /**
+   * Encodes one generic field-set tree as a nested JSON object.
+   *
+   * @param directValues direct scalar values at the current tree level
+   * @param directSubsets child subsets keyed by field-set name
+   * @param subsetEncoder encoder used for recursive child-subset mapping
+   * @return encounter-order-preserving nested JSON object representation
+   * @param <T> child subset type
+   */
+  private static <T> Map<String, Object> encodeFieldSet(
+      Map<String, String> directValues,
+      Map<String, T> directSubsets,
+      java.util.function.Function<T, Map<String, Object>> subsetEncoder) {
+    LinkedHashMap<String, Object> object =
+        LinkedHashMap.newLinkedHashMap(directValues.size() + directSubsets.size());
+    object.putAll(directValues);
+    directSubsets.forEach((name, subset) -> object.put(name, subsetEncoder.apply(subset)));
+    return object;
+  }
+
+  /**
+   * Encodes one connectivity listener snapshot as a JSON object.
+   *
+   * @param snapshot detached runtime listener snapshot
+   * @return JSON-compatible listener representation
+   */
+  private static Map<String, Object> encodeConnectivityListener(
+      ConnectivityListenerPortSnapshot snapshot) {
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(2);
+    object.put("enabled", snapshot.enabled());
+    object.put("port", snapshot.port());
+    return object;
+  }
+
+  /**
+   * Encodes one connectivity notice snapshot as a JSON object.
+   *
+   * @param snapshot detached runtime notice snapshot
+   * @return JSON-compatible notice representation
+   */
+  private static Map<String, Object> encodeConnectivityNotice(ConnectivityNoticeSnapshot snapshot) {
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(3);
+    object.put("title", snapshot.title());
+    object.put("text", snapshot.text());
+    object.put("renderedAlertHtml", snapshot.renderedAlertHtml());
+    return object;
+  }
+
+  /**
+   * Encodes one connectivity socket snapshot as a JSON object.
+   *
+   * @param snapshot detached runtime socket snapshot
+   * @return JSON-compatible socket representation
+   */
+  private static Map<String, Object> encodeConnectivitySocket(ConnectivitySocketSnapshot snapshot) {
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(5);
+    object.put("title", snapshot.title());
+    object.put("portForwardStatus", snapshot.portForwardStatus().name());
+    object.put("longestSendReceiveGapMillis", snapshot.longestSendReceiveGapMillis());
+    object.put(
+        "peerEntries",
+        snapshot.peerEntries().stream()
+            .map(PlatformApiJsonEncoder::encodeConnectivityTrafficEntry)
+            .toList());
+    object.put(
+        "ipEntries",
+        snapshot.ipEntries().stream()
+            .map(PlatformApiJsonEncoder::encodeConnectivityTrafficEntry)
+            .toList());
+    return object;
+  }
+
+  /**
+   * Encodes one connectivity traffic entry as a JSON object.
+   *
+   * @param snapshot detached runtime traffic-entry snapshot
+   * @return JSON-compatible traffic-entry representation
+   */
+  private static Map<String, Object> encodeConnectivityTrafficEntry(
+      ConnectivityTrafficEntrySnapshot snapshot) {
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(7);
+    object.put("address", snapshot.address());
+    object.put("packetsSent", snapshot.packetsSent());
+    object.put("packetsReceived", snapshot.packetsReceived());
+    object.put("initiator", snapshot.initiator().name());
+    object.put("firstSendLeadTimeMillis", snapshot.firstSendLeadTimeMillis());
+    object.put("firstReceiveLeadTimeMillis", snapshot.firstReceiveLeadTimeMillis());
+    object.put(
+        "gaps",
+        snapshot.gaps().stream().map(PlatformApiJsonEncoder::encodeConnectivityGap).toList());
+    return object;
+  }
+
+  /**
+   * Encodes one connectivity gap snapshot as a JSON object.
+   *
+   * @param snapshot detached runtime gap snapshot
+   * @return JSON-compatible gap representation
+   */
+  private static Map<String, Object> encodeConnectivityGap(ConnectivityGapSnapshot snapshot) {
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(2);
+    object.put("gapLengthMillis", snapshot.gapLengthMillis());
+    object.put("receivedPacketAtMillis", snapshot.receivedPacketAtMillis());
+    return object;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiJsonWriter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiJsonWriter.java
@@ -1,0 +1,170 @@
+package network.crypta.platform.api.json;
+
+import java.util.Map;
+
+/**
+ * Minimal JSON writer used by the initial Platform API surface.
+ *
+ * <p>The writer supports the limited set of JSON value types required by the read-only Platform API
+ * v1: strings, booleans, integers/longs, {@code null}, arrays, and nested objects. Callers are
+ * expected to supply already-structured JDK values such as {@link Map}, {@link Iterable}, and
+ * scalar types.
+ */
+public final class PlatformApiJsonWriter {
+  /** Prevents instantiation of this static helper type. */
+  private PlatformApiJsonWriter() {}
+
+  /**
+   * Serializes the supplied JSON-compatible value into a UTF-16 Java string.
+   *
+   * @param value JSON-compatible root value
+   * @return serialized JSON text
+   * @throws IllegalArgumentException if the value graph contains an unsupported type
+   */
+  public static String write(Object value) {
+    StringBuilder json = new StringBuilder();
+    appendValue(value, json);
+    return json.toString();
+  }
+
+  /**
+   * Appends one JSON-compatible value to the output buffer.
+   *
+   * @param value JSON-compatible value to serialize
+   * @param json destination buffer receiving serialized output
+   * @throws IllegalArgumentException if {@code value} has an unsupported type
+   */
+  private static void appendValue(Object value, StringBuilder json) {
+    if (value == null) {
+      json.append("null");
+      return;
+    }
+    if (value instanceof String stringValue) {
+      appendString(stringValue, json);
+      return;
+    }
+    if (value instanceof Boolean booleanValue) {
+      json.append(booleanValue);
+      return;
+    }
+    if (value instanceof Integer
+        || value instanceof Long
+        || value instanceof Short
+        || value instanceof Byte) {
+      json.append(value);
+      return;
+    }
+    if (value instanceof Float floatValue) {
+      appendFloatingPoint(floatValue, json);
+      return;
+    }
+    if (value instanceof Double doubleValue) {
+      appendFloatingPoint(doubleValue, json);
+      return;
+    }
+    if (value instanceof Enum<?> enumValue) {
+      appendString(enumValue.name(), json);
+      return;
+    }
+    if (value instanceof Map<?, ?> mapValue) {
+      appendObject(mapValue, json);
+      return;
+    }
+    if (value instanceof Iterable<?> iterableValue) {
+      appendArray(iterableValue, json);
+      return;
+    }
+
+    throw new IllegalArgumentException(
+        "Unsupported Platform API JSON value type: " + value.getClass().getName());
+  }
+
+  /**
+   * Appends one finite floating-point number to the output buffer.
+   *
+   * @param value floating-point value to serialize
+   * @param json destination buffer receiving serialized output
+   * @throws IllegalArgumentException if {@code value} is not finite
+   */
+  private static void appendFloatingPoint(double value, StringBuilder json) {
+    if (!Double.isFinite(value)) {
+      throw new IllegalArgumentException("Floating-point JSON values must be finite");
+    }
+    json.append(value);
+  }
+
+  /**
+   * Appends one JSON object to the output buffer.
+   *
+   * @param value object values keyed by JSON field name
+   * @param json destination buffer receiving serialized output
+   * @throws IllegalArgumentException if any key is not a string
+   */
+  private static void appendObject(Map<?, ?> value, StringBuilder json) {
+    json.append('{');
+    boolean first = true;
+    for (Map.Entry<?, ?> entry : value.entrySet()) {
+      Object rawKey = entry.getKey();
+      if (!(rawKey instanceof String key)) {
+        throw new IllegalArgumentException("JSON object keys must be strings");
+      }
+      if (!first) {
+        json.append(',');
+      }
+      appendString(key, json);
+      json.append(':');
+      appendValue(entry.getValue(), json);
+      first = false;
+    }
+    json.append('}');
+  }
+
+  /**
+   * Appends one JSON array to the output buffer.
+   *
+   * @param value iterable values to serialize in encounter order
+   * @param json destination buffer receiving serialized output
+   */
+  private static void appendArray(Iterable<?> value, StringBuilder json) {
+    json.append('[');
+    boolean first = true;
+    for (Object item : value) {
+      if (!first) {
+        json.append(',');
+      }
+      appendValue(item, json);
+      first = false;
+    }
+    json.append(']');
+  }
+
+  /**
+   * Appends one escaped JSON string literal to the output buffer.
+   *
+   * @param value string value to escape and quote
+   * @param json destination buffer receiving serialized output
+   */
+  private static void appendString(String value, StringBuilder json) {
+    json.append('"');
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      switch (ch) {
+        case '"' -> json.append("\\\"");
+        case '\\' -> json.append("\\\\");
+        case '\b' -> json.append("\\b");
+        case '\f' -> json.append("\\f");
+        case '\n' -> json.append("\\n");
+        case '\r' -> json.append("\\r");
+        case '\t' -> json.append("\\t");
+        default -> {
+          if (ch < 0x20) {
+            json.append(String.format("\\u%04x", (int) ch));
+          } else {
+            json.append(ch);
+          }
+        }
+      }
+    }
+    json.append('"');
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/json/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/json/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Small JSON encoding helpers for the Platform API.
+ *
+ * <p>This package owns the lightweight JSON writer and snapshot-to-JSON mappers used by {@code
+ * :platform-api}. It intentionally supports only the data shapes required by the initial read-only
+ * API surface, avoiding any new heavyweight serialization dependency.
+ */
+package network.crypta.platform.api.json;

--- a/platform-api/src/main/java/network/crypta/platform/api/node/NodeApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/node/NodeApiHandler.java
@@ -1,0 +1,65 @@
+package network.crypta.platform.api.node;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.api.json.PlatformApiFieldSetJson;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceView;
+
+/**
+ * Read-only node-info endpoint family for Platform API v1.
+ *
+ * <p>This handler exposes the detached node greeting and node-reference exports already provided by
+ * {@link NodeInfoPort}. Query parsing and JSON mapping stay local so the router can remain focused
+ * on path dispatch.
+ */
+public final class NodeApiHandler {
+  /** Detached runtime port that supplies node greeting and node-reference exports. */
+  private final NodeInfoPort nodeInfoPort;
+
+  /**
+   * Creates a node-info API handler backed by the supplied runtime port.
+   *
+   * @param nodeInfoPort detached runtime node-info port
+   */
+  public NodeApiHandler(NodeInfoPort nodeInfoPort) {
+    this.nodeInfoPort = Objects.requireNonNull(nodeInfoPort, "nodeInfoPort");
+  }
+
+  /**
+   * Returns the detached greeting snapshot as a JSON-compatible object.
+   *
+   * @return JSON-compatible greeting object
+   */
+  public Map<String, Object> greeting() {
+    NodeGreetingSnapshot snapshot = nodeInfoPort.greeting();
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    json.put("nodeName", snapshot.nodeName());
+    json.put("versionString", snapshot.versionString());
+    json.put("buildNumber", snapshot.buildNumber());
+    json.put("revision", snapshot.revision());
+    json.put("testnetEnabled", snapshot.testnetEnabled());
+    json.put("compressionCodecs", snapshot.compressionCodecs());
+    json.put("nodeLanguage", snapshot.nodeLanguage());
+    return json;
+  }
+
+  /**
+   * Returns one node-reference export as a nested JSON object.
+   *
+   * @param queryParameters decoded query parameters for the current request
+   * @return JSON-compatible node-reference export
+   */
+  public Map<String, Object> reference(Map<String, List<String>> queryParameters) {
+    NodeReferenceView view =
+        PlatformApiParameters.requireEnum(queryParameters, "view", NodeReferenceView.class);
+    boolean includeVolatile =
+        PlatformApiParameters.readBoolean(queryParameters, "includeVolatile", false);
+    return PlatformApiFieldSetJson.toJson(
+        nodeInfoPort.exportReference(view, includeVolatile).root());
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/node/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/node/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Node-oriented Platform API handlers.
+ *
+ * <p>This package owns the read-only node-info portion of Platform API v1, including the greeting
+ * snapshot and node-reference export endpoints that sit directly on top of {@code runtime-spi}.
+ */
+package network.crypta.platform.api.node;

--- a/platform-api/src/main/java/network/crypta/platform/api/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Transport-neutral core for the first Platform API surface.
+ *
+ * <p>This leaf owns the read-only Platform API v1 that sits on top of {@code runtime-spi} and below
+ * any future web-shell or application-host work. Code in this package family accepts simple request
+ * metadata, routes it to detached runtime ports, and produces JSON payloads without taking
+ * dependencies on legacy HTTP toadlets, FCP message types, or daemon-only runtime classes.
+ *
+ * <p>The API is intentionally narrow for the first platform-layer PR. It exposes small, immediately
+ * useful read-only resources such as node info, peers, configuration exports, connectivity
+ * snapshots, and security levels while preserving the extracted runtime boundary.
+ */
+package network.crypta.platform.api;

--- a/platform-api/src/main/java/network/crypta/platform/api/peers/PeersApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/peers/PeersApiHandler.java
@@ -1,0 +1,72 @@
+package network.crypta.platform.api.peers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.api.json.PlatformApiFieldSetJson;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.UnknownPeerException;
+
+/**
+ * Read-only peer endpoint family for Platform API v1.
+ *
+ * <p>The handler maps detached peer snapshots onto nested JSON objects and preserves the runtime
+ * distinction between malformed requests and a peer lookup that simply does not resolve.
+ */
+public final class PeersApiHandler {
+  /** Detached runtime port that supplies peer lists and individual peer snapshots. */
+  private final PeerPort peerPort;
+
+  /**
+   * Creates a peer API handler backed by the supplied runtime port.
+   *
+   * @param peerPort detached runtime peer port
+   */
+  public PeersApiHandler(PeerPort peerPort) {
+    this.peerPort = Objects.requireNonNull(peerPort, "peerPort");
+  }
+
+  /**
+   * Lists peers as JSON-compatible nested objects.
+   *
+   * <p>When the query parameters are omitted, both optional export flags default to {@code false}
+   * to keep the initial platform surface conservative and read-only.
+   *
+   * @param queryParameters decoded query parameters for the current request
+   * @return peer list in encounter order
+   */
+  public List<Map<String, Object>> list(Map<String, List<String>> queryParameters) {
+    boolean includeMetadata =
+        PlatformApiParameters.readBoolean(queryParameters, "includeMetadata", false);
+    boolean includeVolatile =
+        PlatformApiParameters.readBoolean(queryParameters, "includeVolatile", false);
+    return peerPort.list(includeMetadata, includeVolatile).stream()
+        .map(snapshot -> PlatformApiFieldSetJson.toJson(snapshot.root()))
+        .toList();
+  }
+
+  /**
+   * Resolves one peer and returns it as a JSON-compatible nested object.
+   *
+   * <p>When the query parameters are omitted, both optional export flags default to {@code false}
+   * to keep the initial platform surface conservative and read-only.
+   *
+   * @param nodeIdentifier detached peer identifier extracted from the request path
+   * @param queryParameters decoded query parameters for the current request
+   * @return JSON-compatible peer object
+   */
+  public Map<String, Object> get(String nodeIdentifier, Map<String, List<String>> queryParameters) {
+    boolean includeMetadata =
+        PlatformApiParameters.readBoolean(queryParameters, "includeMetadata", false);
+    boolean includeVolatile =
+        PlatformApiParameters.readBoolean(queryParameters, "includeVolatile", false);
+    try {
+      return PlatformApiFieldSetJson.toJson(
+          peerPort.get(nodeIdentifier, includeMetadata, includeVolatile).root());
+    } catch (UnknownPeerException _) {
+      throw new PlatformApiException(404, "unknown_peer", "Peer not found.");
+    }
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/peers/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/peers/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Peer-oriented Platform API handlers.
+ *
+ * <p>This package owns the read-only peer list and peer detail endpoints for Platform API v1. The
+ * handlers depend only on detached {@code runtime-spi} peer ports and immutable peer snapshots.
+ */
+package network.crypta.platform.api.peers;

--- a/platform-api/src/main/java/network/crypta/platform/api/security/SecurityLevelsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/security/SecurityLevelsApiHandler.java
@@ -1,0 +1,43 @@
+package network.crypta.platform.api.security;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+
+/**
+ * Read-only security-level endpoint family for Platform API v1.
+ *
+ * <p>The handler exposes the detached security-level page snapshot as JSON without bringing the
+ * legacy mutation or confirmation-warning flows into the first platform API surface.
+ */
+public final class SecurityLevelsApiHandler {
+  /** Detached runtime port that supplies security-level snapshots for the API layer. */
+  private final SecurityLevelsPort securityLevelsPort;
+
+  /**
+   * Creates a security-level API handler backed by the supplied runtime port.
+   *
+   * @param securityLevelsPort detached runtime security-level port
+   */
+  public SecurityLevelsApiHandler(SecurityLevelsPort securityLevelsPort) {
+    this.securityLevelsPort = Objects.requireNonNull(securityLevelsPort, "securityLevelsPort");
+  }
+
+  /**
+   * Returns the current detached security-level snapshot as a JSON-compatible object.
+   *
+   * @return JSON-compatible security-level snapshot
+   */
+  public Map<String, Object> snapshot() {
+    SecurityLevelsSnapshot snapshot = securityLevelsPort.snapshot();
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(5);
+    json.put("networkThreatLevel", snapshot.networkThreatLevel().name());
+    json.put("physicalThreatLevel", snapshot.physicalThreatLevel().name());
+    json.put("hasDatabase", snapshot.hasDatabase());
+    json.put("masterPasswordFileExists", snapshot.masterPasswordFileExists());
+    json.put("masterPasswordFilePath", snapshot.masterPasswordFilePath());
+    return json;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/security/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/security/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Security-level-oriented Platform API handlers.
+ *
+ * <p>This package owns the read-only security-level snapshot endpoint for Platform API v1. The
+ * exported JSON is built from detached runtime snapshots and deliberately omits mutation flows.
+ */
+package network.crypta.platform.api.security;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(
   ":kernel-transport",
   ":kernel-routing",
   ":runtime-spi",
+  ":platform-api",
   ":runtime-node",
   ":adapter-fcp",
   ":adapter-http-legacy-admin",

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -1,0 +1,168 @@
+package network.crypta.clients.http;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.platform.api.PlatformApiRequest;
+import network.crypta.platform.api.PlatformApiResponse;
+import network.crypta.platform.api.PlatformApiRouter;
+import network.crypta.support.MultiValueTable;
+import network.crypta.support.api.HTTPRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformApiToadletTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private PlatformApiRouter router;
+  @Mock private ToadletContext ctx;
+  @Mock private HTTPRequest request;
+
+  private PlatformApiToadlet toadlet;
+
+  @BeforeEach
+  void setUp() {
+    toadlet = new PlatformApiToadlet(client, router);
+  }
+
+  @Test
+  void handleMethodGET_whenPeerIdentifierContainsEncodedSlash_routesDecodedIdentifier()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(router.route(any(PlatformApiRequest.class)))
+        .thenReturn(PlatformApiResponse.ok(Map.of("peer", "alice/bob")));
+
+    toadlet.handleMethodGET(URI.create("http://localhost/api/v1/peers/alice%2Fbob"), request, ctx);
+
+    ArgumentCaptor<PlatformApiRequest> captor = ArgumentCaptor.forClass(PlatformApiRequest.class);
+    verify(router).route(captor.capture());
+    assertEquals("GET", captor.getValue().method());
+    assertEquals(List.of("peers", "alice/bob"), captor.getValue().pathSegments());
+    assertEquals(Map.of(), captor.getValue().queryParameters());
+  }
+
+  @Test
+  void findSupportedMethods_whenPlatformApiToadlet_expectAllBridgeHandledMethods() {
+    Set<String> methods = Set.copyOf(Arrays.asList(toadlet.findSupportedMethods().split(", ")));
+
+    assertEquals(
+        Set.of("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"), methods);
+  }
+
+  @Test
+  void handleMethodOPTIONS_whenUnsupportedVerb_expectRouterBackedJson405() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    PlatformApiResponse response =
+        PlatformApiResponse.error(
+            405,
+            Map.of("Allow", "GET"),
+            "method_not_allowed",
+            "Platform API v1 supports GET requests only.");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(response);
+
+    toadlet.handleMethodOPTIONS(URI.create("http://localhost/api/v1/node/greeting"), request, ctx);
+
+    verify(router).route(new PlatformApiRequest("OPTIONS", List.of("node", "greeting"), Map.of()));
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(405, replyHeaders.statusCode());
+    assertEquals("Method Not Allowed", replyHeaders.reasonPhrase());
+    assertEquals("GET", replyHeaders.headers().getFirst("Allow"));
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    assertEquals(response.body().getBytes(StandardCharsets.UTF_8).length, replyHeaders.length());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(0, bodyWrite.offset());
+    assertEquals(response.body().getBytes(StandardCharsets.UTF_8).length, bodyWrite.length());
+    assertEquals(response.body(), bodyWrite.bodyText());
+  }
+
+  @Test
+  void handleMethodHEAD_whenUnsupportedVerb_expectHeaderOnly405() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    PlatformApiResponse response =
+        PlatformApiResponse.error(
+            405,
+            Map.of("Allow", "GET"),
+            "method_not_allowed",
+            "Platform API v1 supports GET requests only.");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(response);
+
+    toadlet.handleMethodHEAD(URI.create("http://localhost/api/v1/node/greeting"), request, ctx);
+
+    verify(router).route(new PlatformApiRequest("HEAD", List.of("node", "greeting"), Map.of()));
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(405, replyHeaders.statusCode());
+    assertEquals("Method Not Allowed", replyHeaders.reasonPhrase());
+    assertEquals("GET", replyHeaders.headers().getFirst("Allow"));
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    assertEquals(response.body().getBytes(StandardCharsets.UTF_8).length, replyHeaders.length());
+    verify(ctx, never()).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  private ReplyHeadersCapture captureReplyHeaders() throws Exception {
+    ArgumentCaptor<Integer> statusCode = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<String> reasonPhrase = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<MultiValueTable<String, String>> headers = multiValueTableCaptor();
+    ArgumentCaptor<String> mimeType = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> length = ArgumentCaptor.forClass(Long.class);
+
+    verify(ctx)
+        .sendReplyHeaders(
+            statusCode.capture(),
+            reasonPhrase.capture(),
+            headers.capture(),
+            mimeType.capture(),
+            length.capture());
+
+    return new ReplyHeadersCapture(
+        statusCode.getValue(),
+        reasonPhrase.getValue(),
+        headers.getValue(),
+        mimeType.getValue(),
+        length.getValue());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ArgumentCaptor<MultiValueTable<String, String>> multiValueTableCaptor() {
+    return (ArgumentCaptor<MultiValueTable<String, String>>)
+        (ArgumentCaptor<?>) ArgumentCaptor.forClass(MultiValueTable.class);
+  }
+
+  private BodyWriteCapture captureBodyWrite() throws Exception {
+    ArgumentCaptor<byte[]> body = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> offset = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> length = ArgumentCaptor.forClass(Integer.class);
+
+    verify(ctx).writeData(body.capture(), offset.capture(), length.capture());
+
+    return new BodyWriteCapture(
+        new String(body.getValue(), StandardCharsets.UTF_8), offset.getValue(), length.getValue());
+  }
+
+  private record ReplyHeadersCapture(
+      int statusCode,
+      String reasonPhrase,
+      MultiValueTable<String, String> headers,
+      String mimeType,
+      long length) {}
+
+  private record BodyWriteCapture(String bodyText, int offset, int length) {}
+}

--- a/src/test/java/network/crypta/platform/api/PlatformApiBoundaryTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiBoundaryTest.java
@@ -1,0 +1,139 @@
+package network.crypta.platform.api;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class PlatformApiBoundaryTest {
+  private static final Path ROOT_PLATFORM_API_PACKAGE =
+      Path.of("src", "main", "java", "network", "crypta", "platform", "api");
+  private static final Path PLATFORM_API_MAIN_JAVA = Path.of("platform-api", "src", "main", "java");
+  private static final Path PLATFORM_API_PACKAGE =
+      Path.of("platform-api", "src", "main", "java", "network", "crypta", "platform", "api");
+  private static final Path PLATFORM_API_ROUTER =
+      PLATFORM_API_PACKAGE.resolve("PlatformApiRouter.java");
+  private static final Path PLATFORM_API_JSON_ENCODER =
+      PLATFORM_API_PACKAGE.resolve("json").resolve("PlatformApiJsonEncoder.java");
+  private static final Pattern FORBIDDEN_IMPORT_PATTERN =
+      Pattern.compile(
+          "^import(?:\\s+static)?\\s+(network\\.crypta\\.(?:clients\\.(?:http|fcp)|node|client|runtime\\.(?:bootstrap|core|admin|endpoints))\\.[^;]+);$");
+
+  @Test
+  void mainSourceLayout_whenCheckingPlatformApiOwnership_expectLeafOwnsPackageTree()
+      throws IOException {
+    Path repoRoot = repoRoot();
+
+    assertTrue(
+        Files.isDirectory(repoRoot.resolve(PLATFORM_API_PACKAGE)),
+        ":platform-api must own network/crypta/platform/api main sources");
+    assertFalse(
+        Files.exists(repoRoot.resolve(ROOT_PLATFORM_API_PACKAGE)),
+        "Root project must not own network/crypta/platform/api main sources");
+    assertTrue(
+        Files.isRegularFile(repoRoot.resolve(PLATFORM_API_ROUTER)),
+        ":platform-api must provide the Platform API router");
+    assertTrue(
+        Files.isRegularFile(repoRoot.resolve(PLATFORM_API_JSON_ENCODER)),
+        ":platform-api must provide the Platform API JSON encoder");
+  }
+
+  @Test
+  void platformApiMain_whenScanningImports_expectNoAdapterOrRuntimeImplementationImports()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path platformApiMain = repoRoot.resolve(PLATFORM_API_MAIN_JAVA);
+    List<String> violations = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(platformApiMain), ":platform-api main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(platformApiMain)) {
+      Set<String> imports = readForbiddenImports(sourceFile);
+      if (!imports.isEmpty()) {
+        violations.add(repoRoot.relativize(sourceFile) + " -> " + String.join(", ", imports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        ":platform-api main sources must stay above runtime-spi and free of adapter/daemon "
+            + "implementation imports."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void platformApiMain_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path platformApiMain = repoRoot.resolve(PLATFORM_API_MAIN_JAVA);
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(platformApiMain), ":platform-api main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(platformApiMain)) {
+      String fileName = sourceFile.getFileName().toString();
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(sourceFile.getParent());
+    }
+
+    for (Path packagePath : productionPackages) {
+      if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
+        missingPackageInfos.add(platformApiMain.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every :platform-api main package with production Java files must declare"
+            + " package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
+  }
+
+  private static List<Path> findJavaSources(Path root) throws IOException {
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(PlatformApiBoundaryTest::isTrackedJavaSource)
+          .sorted(Comparator.comparing(Path::toString))
+          .toList();
+    }
+  }
+
+  private static boolean isTrackedJavaSource(Path path) {
+    String fileName = path.getFileName().toString();
+    return fileName.endsWith(".java") && !fileName.startsWith("._");
+  }
+
+  private static Set<String> readForbiddenImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .map(FORBIDDEN_IMPORT_PATTERN::matcher)
+          .filter(Matcher::matches)
+          .map(matcher -> matcher.group(1))
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static Path repoRoot() throws IOException {
+    Path repoRoot = Path.of("").toAbsolutePath().normalize();
+    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
+    return repoRoot.toRealPath();
+  }
+}

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -1,0 +1,335 @@
+package network.crypta.platform.api;
+
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.runtime.spi.ConnectivityGapSnapshot;
+import network.crypta.runtime.spi.ConnectivityListenerPortSnapshot;
+import network.crypta.runtime.spi.ConnectivityNoticeSnapshot;
+import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.ConnectivityPortForwardStatus;
+import network.crypta.runtime.spi.ConnectivitySnapshot;
+import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
+import network.crypta.runtime.spi.ConnectivityTrafficInitiator;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeGreetingSnapshot;
+import network.crypta.runtime.spi.NodeInfoPort;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.PeerFieldSet;
+import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+import network.crypta.runtime.spi.UnknownPeerException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class PlatformApiRouterTest {
+
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private NodeInfoPort nodeInfoPort;
+  @Mock private PeerPort peerPort;
+  @Mock private ConfigPort configPort;
+  @Mock private ConnectivityPort connectivityPort;
+  @Mock private SecurityLevelsPort securityLevelsPort;
+
+  private PlatformApiRouter router;
+
+  @BeforeEach
+  void setUp() {
+    when(runtimePorts.nodeInfo()).thenReturn(nodeInfoPort);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(runtimePorts.config()).thenReturn(configPort);
+    when(runtimePorts.connectivity()).thenReturn(connectivityPort);
+    when(runtimePorts.securityLevels()).thenReturn(securityLevelsPort);
+    router = new PlatformApiRouter(runtimePorts);
+  }
+
+  @Test
+  void route_whenMethodNotGet_expectJson405AndAllowGetHeader() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("node", "greeting"), Map.of()));
+
+    assertEquals(405, response.statusCode());
+    assertEquals("Method Not Allowed", response.reasonPhrase());
+    assertEquals(Map.of("Allow", "GET"), response.headers());
+    assertEquals(
+        "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Platform API v1 supports GET"
+            + " requests only.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenNodeGreetingRequest_expectGreetingJson() {
+    when(nodeInfoPort.greeting())
+        .thenReturn(new NodeGreetingSnapshot("Crypta", "1.0", 7, "abc123", true, "gzip", "en"));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("node", "greeting"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"nodeName\":\"Crypta\",\"versionString\":\"1.0\",\"buildNumber\":7,\"revision\":\"abc123\",\"testnetEnabled\":true,\"compressionCodecs\":\"gzip\",\"nodeLanguage\":\"en\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenNodeReferenceRequested_expectReferenceJsonAndRequestedExport() {
+    LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(2);
+    directValues.put("identity", "alpha");
+    directValues.put("version", "42");
+    LinkedHashMap<String, NodeFieldSet> directSubsets = LinkedHashMap.newLinkedHashMap(1);
+    directSubsets.put("physical", new NodeFieldSet(Map.of("host", "127.0.0.1"), Map.of()));
+    when(nodeInfoPort.exportReference(NodeReferenceView.DARKNET_PUBLIC, true))
+        .thenReturn(new NodeReferenceSnapshot(new NodeFieldSet(directValues, directSubsets)));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "GET",
+                List.of("node", "reference"),
+                Map.of("view", List.of("DARKNET_PUBLIC"), "includeVolatile", List.of("true"))));
+
+    verify(nodeInfoPort).exportReference(NodeReferenceView.DARKNET_PUBLIC, true);
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"identity\":\"alpha\",\"version\":\"42\",\"physical\":{\"host\":\"127.0.0.1\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenNodeReferenceViewInvalid_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "GET",
+                List.of("node", "reference"),
+                Map.of("view", List.of("INVALID"), "includeVolatile", List.of("true"))));
+
+    assertEquals(400, response.statusCode());
+    assertTrue(response.body().contains("\"code\":\"invalid_query_parameter\""));
+    assertTrue(response.body().contains("Query parameter 'view'"));
+    verifyNoInteractions(nodeInfoPort);
+  }
+
+  @Test
+  void route_whenConfigSectionsInvalid_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(
+            request("GET", List.of("config"), Map.of("sections", List.of("CURRENT,BOGUS"))));
+
+    assertEquals(400, response.statusCode());
+    assertTrue(response.body().contains("\"code\":\"invalid_query_parameter\""));
+    assertTrue(response.body().contains("Query parameter 'sections'"));
+    verifyNoInteractions(configPort);
+  }
+
+  @Test
+  void route_whenPeersListFlagsOmitted_expectPeerJsonArrayAndConservativeDefaults() {
+    LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(2);
+    directValues.put("nodeIdentifier", "peer-1");
+    directValues.put("status", "connected");
+    LinkedHashMap<String, PeerFieldSet> directSubsets = LinkedHashMap.newLinkedHashMap(1);
+    directSubsets.put("metadata", new PeerFieldSet(Map.of("location", "0.5"), Map.of()));
+    when(peerPort.list(false, false))
+        .thenReturn(List.of(new PeerSnapshot(new PeerFieldSet(directValues, directSubsets))));
+
+    PlatformApiResponse response = router.route(request("GET", List.of("peers"), Map.of()));
+
+    verify(peerPort).list(false, false);
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "[{\"nodeIdentifier\":\"peer-1\",\"status\":\"connected\",\"metadata\":{\"location\":\"0.5\"}}]",
+        response.body());
+  }
+
+  @Test
+  void route_whenPeerRequested_expectPeerJsonAndRequestedFlags() throws UnknownPeerException {
+    LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(2);
+    directValues.put("nodeIdentifier", "peer-2");
+    directValues.put("status", "backed-off");
+    LinkedHashMap<String, PeerFieldSet> directSubsets = LinkedHashMap.newLinkedHashMap(1);
+    directSubsets.put("physical", new PeerFieldSet(Map.of("address", "127.0.0.1"), Map.of()));
+    when(peerPort.get("peer-2", true, true))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(directValues, directSubsets)));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "GET",
+                List.of("peers", "peer-2"),
+                Map.of("includeMetadata", List.of("true"), "includeVolatile", List.of("true"))));
+
+    verify(peerPort).get("peer-2", true, true);
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"nodeIdentifier\":\"peer-2\",\"status\":\"backed-off\",\"physical\":{\"address\":\"127.0.0.1\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenConnectivityAdvancedInvalid_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(
+            request("GET", List.of("connectivity"), Map.of("advanced", List.of("sometimes"))));
+
+    assertEquals(400, response.statusCode());
+    assertTrue(response.body().contains("\"code\":\"invalid_query_parameter\""));
+    assertTrue(response.body().contains("advanced"));
+    verifyNoInteractions(connectivityPort);
+  }
+
+  @Test
+  void route_whenConnectivityAdvancedRequested_expectDetailedSnapshotJson() {
+    when(connectivityPort.snapshot(true))
+        .thenReturn(
+            new ConnectivitySnapshot(
+                1234,
+                5678,
+                new ConnectivityListenerPortSnapshot(true, 8888),
+                new ConnectivityListenerPortSnapshot(false, 0),
+                new ConnectivityListenerPortSnapshot(true, 9999),
+                new ConnectivityNoticeSnapshot(
+                    "NAT detected", "Forward UDP to improve reachability.", "<div>notice</div>"),
+                List.of(
+                    new ConnectivitySocketSnapshot(
+                        "udp-main",
+                        ConnectivityPortForwardStatus.MAYBE_PORT_FORWARDED,
+                        42,
+                        List.of(
+                            new ConnectivityTrafficEntrySnapshot(
+                                "peer-1",
+                                10,
+                                7,
+                                ConnectivityTrafficInitiator.LOCAL,
+                                3,
+                                5,
+                                List.of(new ConnectivityGapSnapshot(8, 13)))),
+                        List.of(
+                            new ConnectivityTrafficEntrySnapshot(
+                                "203.0.113.5",
+                                4,
+                                6,
+                                ConnectivityTrafficInitiator.REMOTE,
+                                2,
+                                1,
+                                List.of()))))));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("connectivity"), Map.of("advanced", List.of("true"))));
+
+    verify(connectivityPort).snapshot(true);
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"darknetFnpPort\":1234,\"opennetFnpPort\":5678,\"fproxyListener\":{\"enabled\":true,\"port\":8888},\"fcpListener\":{\"enabled\":false,\"port\":0},\"consoleListener\":{\"enabled\":true,\"port\":9999},\"connectionTypeNotice\":{\"title\":\"NAT"
+            + " detected\",\"text\":\"Forward UDP to improve"
+            + " reachability.\",\"renderedAlertHtml\":\"<div>notice</div>\"},\"sockets\":[{\"title\":\"udp-main\",\"portForwardStatus\":\"MAYBE_PORT_FORWARDED\",\"longestSendReceiveGapMillis\":42,\"peerEntries\":[{\"address\":\"peer-1\",\"packetsSent\":10,\"packetsReceived\":7,\"initiator\":\"LOCAL\",\"firstSendLeadTimeMillis\":3,\"firstReceiveLeadTimeMillis\":5,\"gaps\":[{\"gapLengthMillis\":8,\"receivedPacketAtMillis\":13}]}],\"ipEntries\":[{\"address\":\"203.0.113.5\",\"packetsSent\":4,\"packetsReceived\":6,\"initiator\":\"REMOTE\",\"firstSendLeadTimeMillis\":2,\"firstReceiveLeadTimeMillis\":1,\"gaps\":[]}]}]}",
+        response.body());
+  }
+
+  @Test
+  void route_whenConnectivityNoticeMissing_expectEmptyJsonObject() {
+    when(connectivityPort.snapshot(false))
+        .thenReturn(
+            new ConnectivitySnapshot(
+                1234,
+                5678,
+                new ConnectivityListenerPortSnapshot(true, 8888),
+                new ConnectivityListenerPortSnapshot(false, 0),
+                new ConnectivityListenerPortSnapshot(true, 9999),
+                null,
+                List.of(
+                    new ConnectivitySocketSnapshot(
+                        "udp-main",
+                        ConnectivityPortForwardStatus.DONT_KNOW,
+                        -1,
+                        List.of(),
+                        List.of()))));
+
+    PlatformApiResponse response = router.route(request("GET", List.of("connectivity"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"darknetFnpPort\":1234,\"opennetFnpPort\":5678,\"fproxyListener\":{\"enabled\":true,\"port\":8888},\"fcpListener\":{\"enabled\":false,\"port\":0},\"consoleListener\":{\"enabled\":true,\"port\":9999},\"connectionTypeNotice\":{},\"sockets\":[{\"title\":\"udp-main\",\"portForwardStatus\":\"DONT_KNOW\",\"longestSendReceiveGapMillis\":-1,\"peerEntries\":[],\"ipEntries\":[]}]}",
+        response.body());
+  }
+
+  @Test
+  void route_whenSecurityLevelsRequested_expectSecurityLevelsJson() {
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.HIGH,
+                SecurityPhysicalThreatLevel.NORMAL,
+                true,
+                false,
+                "/var/lib/cryptad/master.keys"));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("security-levels"), Map.of()));
+
+    verify(securityLevelsPort).snapshot();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"networkThreatLevel\":\"HIGH\",\"physicalThreatLevel\":\"NORMAL\",\"hasDatabase\":true,\"masterPasswordFileExists\":false,\"masterPasswordFilePath\":\"/var/lib/cryptad/master.keys\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenPeerMissing_expectJson404() throws UnknownPeerException {
+    when(peerPort.get("peer-1", true, false)).thenThrow(new UnknownPeerException("peer-1"));
+
+    PlatformApiResponse response =
+        router.route(
+            request("GET", List.of("peers", "peer-1"), Map.of("includeMetadata", List.of("true"))));
+
+    assertEquals(404, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"unknown_peer\",\"message\":\"Peer not found.\"}}", response.body());
+  }
+
+  @Test
+  void route_whenConfigSectionsOmitted_expectCurrentSectionOnly() {
+    ConfigSnapshot snapshot =
+        new ConfigSnapshot(
+            Map.of(
+                ConfigSection.CURRENT,
+                new ConfigFieldSet(
+                    Map.of("enabled", "true"),
+                    Map.of("node", new ConfigFieldSet(Map.of("name", "alpha"), Map.of())))));
+    when(configPort.export(EnumSet.of(ConfigSection.CURRENT))).thenReturn(snapshot);
+
+    PlatformApiResponse response = router.route(request("GET", List.of("config"), Map.of()));
+
+    verify(configPort).export(EnumSet.of(ConfigSection.CURRENT));
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"CURRENT\":{\"enabled\":\"true\",\"node\":{\"name\":\"alpha\"}}}", response.body());
+  }
+
+  private static PlatformApiRequest request(
+      String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
+    return new PlatformApiRequest(method, pathSegments, queryParameters);
+  }
+}

--- a/src/test/java/network/crypta/platform/api/json/PlatformApiJsonEncoderTest.java
+++ b/src/test/java/network/crypta/platform/api/json/PlatformApiJsonEncoderTest.java
@@ -1,0 +1,106 @@
+package network.crypta.platform.api.json;
+
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.runtime.spi.NodeFieldSet;
+import network.crypta.runtime.spi.NodeReferenceSnapshot;
+import network.crypta.runtime.spi.NodeReferenceView;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class PlatformApiJsonEncoderTest {
+
+  @Test
+  void encodeNodeReference_whenNestedFieldSetPresent_expectMergedObjectPreservingEncounterOrder() {
+    LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(2);
+    directValues.put("identity", "alpha");
+    directValues.put("version", "42");
+
+    LinkedHashMap<String, NodeFieldSet> nestedSubsets = LinkedHashMap.newLinkedHashMap(1);
+    nestedSubsets.put(
+        "child",
+        new NodeFieldSet(
+            Map.of("name", "value"),
+            Map.of("volatile", new NodeFieldSet(Map.of("enabled", "true"), Map.of()))));
+
+    LinkedHashMap<String, NodeFieldSet> directSubsets = LinkedHashMap.newLinkedHashMap(1);
+    directSubsets.put("physical", new NodeFieldSet(Map.of("host", "127.0.0.1"), nestedSubsets));
+
+    NodeReferenceSnapshot snapshot =
+        new NodeReferenceSnapshot(new NodeFieldSet(directValues, directSubsets));
+
+    assertEquals(
+        "{\"identity\":\"alpha\",\"version\":\"42\",\"physical\":{\"host\":\"127.0.0.1\",\"child\":{\"name\":\"value\",\"volatile\":{\"enabled\":\"true\"}}}}",
+        PlatformApiJsonEncoder.encodeNodeReference(snapshot));
+  }
+
+  @Test
+  void encodeConfig_whenSectionsPresent_expectSectionKeysAndNestedObjects() {
+    EnumMap<ConfigSection, ConfigFieldSet> sections = new EnumMap<>(ConfigSection.class);
+    sections.put(
+        ConfigSection.CURRENT,
+        new ConfigFieldSet(
+            Map.of("enabled", "true"),
+            Map.of("node", new ConfigFieldSet(Map.of("name", "alpha"), Map.of()))));
+    sections.put(
+        ConfigSection.DATA_TYPES, new ConfigFieldSet(Map.of("enabled", "boolean"), Map.of()));
+
+    ConfigSnapshot snapshot = new ConfigSnapshot(sections);
+
+    assertEquals(
+        "{\"CURRENT\":{\"enabled\":\"true\",\"node\":{\"name\":\"alpha\"}},\"DATA_TYPES\":{\"enabled\":\"boolean\"}}",
+        PlatformApiJsonEncoder.encodeConfig(snapshot));
+  }
+
+  @Test
+  void encodeError_whenCalled_expectStandardErrorShape() {
+    assertEquals(
+        "{\"error\":{\"code\":\"unknown_peer\",\"message\":\"Peer not found.\"}}",
+        PlatformApiJsonEncoder.encodeError("unknown_peer", "Peer not found."));
+  }
+
+  @Test
+  void write_whenStringContainsEscapes_expectEscapedJson() {
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(2);
+    object.put("quoted", "\"slash\\line\n\t");
+    object.put("control", "\u0001");
+
+    assertEquals(
+        "{\"quoted\":\"\\\"slash\\\\line\\n\\t\",\"control\":\"\\u0001\"}",
+        PlatformApiJsonWriter.write(object));
+  }
+
+  @Test
+  void write_whenSupportedValueTypesPresent_expectSerializeScalarsEnumsAndArrays() {
+    LinkedHashMap<String, Object> object = LinkedHashMap.newLinkedHashMap(6);
+    object.put("flag", true);
+    object.put("count", 3L);
+    object.put("ratio", 1.5d);
+    object.put("view", NodeReferenceView.OPENNET_PRIVATE);
+    object.put("items", java.util.Arrays.asList("alpha", 2, null));
+    object.put("missing", null);
+
+    assertEquals(
+        "{\"flag\":true,\"count\":3,\"ratio\":1.5,\"view\":\"OPENNET_PRIVATE\",\"items\":[\"alpha\",2,null],\"missing\":null}",
+        PlatformApiJsonWriter.write(object));
+  }
+
+  @Test
+  void write_whenFloatingPointNotFinite_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> PlatformApiJsonWriter.write(Double.NaN));
+  }
+
+  @Test
+  void write_whenObjectKeyNotString_expectIllegalArgumentException() {
+    Map<Integer, String> invalidObject = Map.of(1, "value");
+
+    assertThrows(IllegalArgumentException.class, () -> PlatformApiJsonWriter.write(invalidObject));
+  }
+}


### PR DESCRIPTION
## Summary
- add the new `:platform-api` leaf with a transport-neutral router, request/response model, and minimal JSON encoding on top of `:runtime-spi`
- mount the read-only `/api/v1/...` surface through the legacy HTTP admin adapter with a thin `PlatformApiToadlet` bridge
- cover the new surface with focused router/toadlet/encoder/boundary tests and update module ownership metadata plus the README module map

## Testing
- `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`
- `./gradlew test --tests '*PlatformApi*'`
- `./gradlew test --tests '*HttpLegacyAdminBoundaryTest'`
- `./gradlew :platform-api:compileJava`