### PR TITLE
feat(startup): Add structured launcher readiness protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ Build the portable distribution and run the Swing launcher without installing sy
 build/cryptad-dist/bin/cryptad-launcher    # Windows: cryptad-launcher.bat
 ```
 
-The launcher starts the daemon, streams live logs, detects the FProxy port from lines like
-`Starting FProxy on ...:<port>`, and opens `http://localhost:<port>/` on the first successful start.
+The launcher starts the daemon, streams live logs, waits for a structured readiness file under the
+resolved runtime directory (currently `<runDir>/platform-ui.properties`), and opens
+`http://localhost:<port>/` on the first successful start. If the readiness file cannot be used,
+the launcher can still fall back to the legacy `Starting FProxy on ...:<port>` log line.
 
 Shortcuts (global):
 - ↑/↓ one row; PgUp/PgDn one page.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -483,6 +483,18 @@ public final class SimpleToadletServer
         this);
   }
 
+  /**
+   * Returns the configured HTTP listen port used by the current shell instance.
+   *
+   * <p>The launcher readiness protocol consumes this value only after the shell finishes its normal
+   * startup sequence.
+   *
+   * @return configured HTTP port
+   */
+  public int listenPort() {
+    return port;
+  }
+
   private static synchronized void initializeFProxyRandom(RandomnessPort randomnessPort) {
     FProxyToadlet.random = new byte[32];
     randomnessPort.fillSecureRandom(FProxyToadlet.random);
@@ -1268,7 +1280,8 @@ public final class SimpleToadletServer
       maybeGetNetworkInterface();
       thread.start();
       LOG.info("Starting FProxy on {}:{}", bindTo, port);
-      // Keep a plain stdout line for the launcher parser when INFO logs are filtered by default.
+      // Keep a plain stdout line as a compatibility fallback when structured launcher readiness is
+      // unavailable.
       System.out.println("Starting FProxy on " + bindTo + ":" + port);
     }
   }
@@ -1719,6 +1732,7 @@ public final class SimpleToadletServer
    *
    * @return array of {@link FreenetURI} entries; empty when no bookmarks exist.
    */
+  @SuppressWarnings("unused")
   public FreenetURI[] getBookmarkURIs() {
     if (bookmarkManager == null) return new FreenetURI[0];
     return bookmarkManager.getBookmarkURIs();

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/bridge/SimpleToadletServerHttpShellContainer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/bridge/SimpleToadletServerHttpShellContainer.java
@@ -78,6 +78,11 @@ final class SimpleToadletServerHttpShellContainer implements HttpShellContainer 
   }
 
   @Override
+  public int listenPort() {
+    return delegate.listenPort();
+  }
+
+  @Override
   public void removeStartupToadlet() {
     delegate.removeStartupToadlet();
   }

--- a/foundation-fs/src/main/java/network/crypta/fs/readiness/LauncherReadinessFiles.java
+++ b/foundation-fs/src/main/java/network/crypta/fs/readiness/LauncherReadinessFiles.java
@@ -1,0 +1,327 @@
+package network.crypta.fs.readiness;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import network.crypta.fs.AppDirs;
+import network.crypta.fs.AppEnv;
+import network.crypta.fs.ServiceDirs;
+
+/**
+ * Reads, writes, and clears the launcher readiness file in the runtime directory.
+ *
+ * <p>The format is intentionally tiny: a UTF-8 properties-style file with one versioned ready
+ * payload. Writers replace the file via a temporary sibling so the launcher does not observe a
+ * partially written readiness signal, and readers treat missing or invalid content as "not ready"
+ * instead of failing startup coordination.
+ */
+public final class LauncherReadinessFiles {
+  /** Canonical readiness filename placed directly under the resolved runtime directory. */
+  public static final String FILE_NAME = "platform-ui.properties";
+
+  /** Suffix used for the sibling temporary file during replace-in-place writes. */
+  private static final String TEMP_SUFFIX = ".tmp";
+
+  /** Property key that carries the readiness-file schema version. */
+  private static final String VERSION_KEY = "version";
+
+  /** Properties key that marks the readiness state published by the daemon. */
+  private static final String STATE_KEY = "state";
+
+  /** Property key that carries the launcher-facing UI listen port. */
+  private static final String UI_PORT_KEY = "ui.port";
+
+  /** Property key that carries the launcher-facing UI root path. */
+  private static final String UI_ROOT_KEY = "ui.root";
+
+  /** Utility holder; use the static helpers instead of instantiating this type. */
+  private LauncherReadinessFiles() {}
+
+  /**
+   * Stable snapshot of a parsed readiness file and the concrete file generation it came from.
+   *
+   * <p>The launcher uses this to ensure it validates readiness contents against the same file
+   * generation it actually read, even when the daemon replaces the file atomically during startup.
+   *
+   * @param info parsed readiness payload
+   * @param lastModifiedTime the file's last-modified timestamp in milliseconds for the read
+   *     generation
+   * @param fileKey filesystem file key for the read generation when available, otherwise {@code
+   *     null}
+   */
+  public record ReadinessSnapshot(
+      LauncherReadinessInfo info, long lastModifiedTime, Object fileKey) {
+    /**
+     * Creates a snapshot for one concrete readiness-file generation.
+     *
+     * @param info parsed readiness payload from the observed generation
+     * @param lastModifiedTime last-modified timestamp in milliseconds for that generation
+     * @param fileKey filesystem file key for that generation, or {@code null} when unavailable
+     */
+    public ReadinessSnapshot {
+      Objects.requireNonNull(info);
+    }
+  }
+
+  /**
+   * Resolves the readiness-file path beneath the supplied runtime directory.
+   *
+   * @param runDir resolved runtime directory
+   * @return readiness-file path under {@code runDir}
+   */
+  public static Path resolve(Path runDir) {
+    return Objects.requireNonNull(runDir).resolve(FILE_NAME);
+  }
+
+  /**
+   * Resolves the readiness-file path for the current process environment.
+   *
+   * <p>This uses the same {@link AppEnv}/{@link AppDirs}/{@link ServiceDirs} directory logic as
+   * runtime bootstrap, so the desktop launcher does not need to hard-code platform-specific run
+   * directory rules.
+   *
+   * @return readiness-file path for the current process' resolved runtime directory
+   */
+  @SuppressWarnings("unused")
+  public static Path resolveCurrentProcessReadinessFile() {
+    AppEnv env = new AppEnv();
+    Path runDir =
+        env.isServiceMode()
+            ? new ServiceDirs().resolve().runDir()
+            : new AppDirs().resolve().runDir();
+    return resolve(runDir);
+  }
+
+  /**
+   * Deletes a previously published readiness file if one exists.
+   *
+   * @param readinessFile concrete readiness-file path
+   * @throws IOException if deletion fails for reasons other than the file being absent
+   */
+  public static void clear(Path readinessFile) throws IOException {
+    Objects.requireNonNull(readinessFile);
+    Files.deleteIfExists(readinessFile);
+    Files.deleteIfExists(tempPath(readinessFile));
+  }
+
+  /**
+   * Writes a readiness payload using best-effort atomic replacement.
+   *
+   * @param readinessFile concrete readiness-file path
+   * @param info readiness payload to persist
+   * @throws IOException if the temporary file cannot be written or moved into place
+   */
+  public static void write(Path readinessFile, LauncherReadinessInfo info) throws IOException {
+    Objects.requireNonNull(readinessFile);
+    Objects.requireNonNull(info);
+
+    Path tempFile = tempPath(readinessFile);
+    List<String> lines =
+        List.of(
+            VERSION_KEY + "=" + info.version(),
+            STATE_KEY + "=" + info.state(),
+            UI_PORT_KEY + "=" + info.uiPort(),
+            UI_ROOT_KEY + "=" + info.uiRoot());
+    Files.write(
+        tempFile,
+        lines,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE);
+    moveIntoPlace(tempFile, readinessFile);
+  }
+
+  /**
+   * Reads a readiness payload if a valid ready file exists.
+   *
+   * @param readinessFile concrete readiness-file path
+   * @return parsed readiness payload, or empty when the file is missing or invalid
+   * @throws IOException if the file exists but cannot be read
+   */
+  public static Optional<LauncherReadinessInfo> read(Path readinessFile) throws IOException {
+    return readSnapshot(readinessFile).map(ReadinessSnapshot::info);
+  }
+
+  /**
+   * Reads a readiness payload and returns it with same-generation file metadata.
+   *
+   * <p>If the file is replaced while it is being read, this method retries a small number of times
+   * and otherwise reports "not ready" so callers do not combine stale contents with fresh metadata.
+   *
+   * @param readinessFile concrete readiness-file path
+   * @return parsed readiness snapshot, or empty when the file is missing, invalid, or changed
+   *     during the read attempt
+   * @throws IOException if the file exists but cannot be read
+   */
+  public static Optional<ReadinessSnapshot> readSnapshot(Path readinessFile) throws IOException {
+    Objects.requireNonNull(readinessFile);
+    for (int attempt = 0; attempt < 3; attempt++) {
+      if (!Files.isRegularFile(readinessFile)) {
+        return Optional.empty();
+      }
+
+      try {
+        var before =
+            Files.readAttributes(readinessFile, java.nio.file.attribute.BasicFileAttributes.class);
+        if (!before.isRegularFile()) {
+          return Optional.empty();
+        }
+
+        String content = Files.readString(readinessFile, StandardCharsets.UTF_8);
+        var after =
+            Files.readAttributes(readinessFile, java.nio.file.attribute.BasicFileAttributes.class);
+        if (!isSameObservedGeneration(before, after)) {
+          continue;
+        }
+
+        Optional<LauncherReadinessInfo> info = parse(content);
+        return info.map(
+            value ->
+                new ReadinessSnapshot(value, after.lastModifiedTime().toMillis(), after.fileKey()));
+      } catch (NoSuchFileException _) {
+        return Optional.empty();
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Replaces the destination readiness file with the prepared temporary sibling.
+   *
+   * <p>The method prefers an atomic move, so the launcher never observes a partially written file,
+   * but it falls back to a normal replacement when the target filesystem does not support atomic
+   * renames.
+   *
+   * @param tempFile populated temporary sibling file
+   * @param readinessFile final readiness-file destination
+   * @throws IOException if neither move strategy succeeds
+   */
+  private static void moveIntoPlace(Path tempFile, Path readinessFile) throws IOException {
+    try {
+      Files.move(
+          tempFile,
+          readinessFile,
+          StandardCopyOption.ATOMIC_MOVE,
+          StandardCopyOption.REPLACE_EXISTING);
+    } catch (AtomicMoveNotSupportedException _) {
+      Files.move(tempFile, readinessFile, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  /**
+   * Resolves the temporary sibling path used while writing a new readiness generation.
+   *
+   * @param readinessFile final readiness-file destination
+   * @return sibling temporary path next to {@code readinessFile}
+   */
+  private static Path tempPath(Path readinessFile) {
+    return readinessFile.resolveSibling(readinessFile.getFileName() + TEMP_SUFFIX);
+  }
+
+  /**
+   * Checks whether two attribute reads still refer to the same on-disk file generation.
+   *
+   * <p>When the filesystem exposes stable file keys, they are the primary identity signal. The
+   * timestamp, size, and creation-time fallback keeps the check useful on filesystems that do not
+   * expose file keys.
+   *
+   * @param before attributes captured before reading file contents
+   * @param after attributes captured after reading file contents
+   * @return {@code true} when both attribute sets describe the same observed generation
+   */
+  private static boolean isSameObservedGeneration(
+      java.nio.file.attribute.BasicFileAttributes before,
+      java.nio.file.attribute.BasicFileAttributes after) {
+    Object beforeFileKey = before.fileKey();
+    Object afterFileKey = after.fileKey();
+    if (beforeFileKey != null && afterFileKey != null) {
+      return beforeFileKey.equals(afterFileKey);
+    }
+    return before.lastModifiedTime().equals(after.lastModifiedTime())
+        && before.size() == after.size()
+        && before.creationTime().equals(after.creationTime());
+  }
+
+  /**
+   * Parses one readiness payload from the UTF-8 properties text content.
+   *
+   * <p>Unsupported versions, malformed numbers, unknown states, and invalid root paths are all
+   * treated as "not ready" so callers can fall back without surfacing parser-specific failures.
+   *
+   * @param content UTF-8 properties-style readiness content
+   * @return parsed readiness payload, or empty when the content is invalid for the current schema
+   * @throws IOException if the {@link Properties} reader reports an I/O failure
+   */
+  private static Optional<LauncherReadinessInfo> parse(String content) throws IOException {
+    Properties properties = new Properties();
+    try (var reader = new StringReader(content)) {
+      properties.load(reader);
+    }
+
+    Integer version = parsePositiveInt(properties.getProperty(VERSION_KEY));
+    Integer uiPort = parsePositiveInt(properties.getProperty(UI_PORT_KEY));
+    String state = trimToNull(properties.getProperty(STATE_KEY));
+    String uiRoot = trimToNull(properties.getProperty(UI_ROOT_KEY));
+    if (version == null
+        || version != LauncherReadinessInfo.VERSION_1
+        || uiPort == null
+        || !LauncherReadinessInfo.READY_STATE.equals(state)) {
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(
+          new LauncherReadinessInfo(
+              version,
+              state,
+              uiPort,
+              uiRoot != null ? uiRoot : LauncherReadinessInfo.DEFAULT_UI_ROOT));
+    } catch (IllegalArgumentException _) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Parses a strictly positive integer from a readiness property.
+   *
+   * @param value raw property value
+   * @return positive integer value, or {@code null} when the property is missing or invalid
+   */
+  private static Integer parsePositiveInt(String value) {
+    String normalized = trimToNull(value);
+    if (normalized == null) {
+      return null;
+    }
+    try {
+      int parsed = Integer.parseInt(normalized);
+      return parsed > 0 ? parsed : null;
+    } catch (NumberFormatException _) {
+      return null;
+    }
+  }
+
+  /**
+   * Trims a readiness property and normalizes blank values to {@code null}.
+   *
+   * @param value raw property value
+   * @return trimmed value, or {@code null} when the input is missing or blank
+   */
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/foundation-fs/src/main/java/network/crypta/fs/readiness/LauncherReadinessInfo.java
+++ b/foundation-fs/src/main/java/network/crypta/fs/readiness/LauncherReadinessInfo.java
@@ -1,0 +1,69 @@
+package network.crypta.fs.readiness;
+
+import java.util.Objects;
+
+/**
+ * Versioned launcher readiness payload persisted under the resolved runtime directory.
+ *
+ * <p>The launcher needs only a small amount of structured state to discover when the daemon's UI is
+ * actually ready for normal use. This record deliberately keeps the contract narrow and stable:
+ * protocol version, readiness state, and the UI endpoint details required to open the browser
+ * without parsing human-facing log output.
+ *
+ * @param version protocol version carried by the readiness file
+ * @param state readiness state token
+ * @param uiPort local HTTP port where the UI is reachable
+ * @param uiRoot root path for the launcher-opened UI URL
+ */
+public record LauncherReadinessInfo(int version, String state, int uiPort, String uiRoot) {
+  /** Current readiness-file protocol version. */
+  public static final int VERSION_1 = 1;
+
+  /** Ready state token written once the HTTP shell is fully usable. */
+  public static final String READY_STATE = "ready";
+
+  /** Default UI root path used by the current launcher/browser flow. */
+  public static final String DEFAULT_UI_ROOT = "/";
+
+  /**
+   * Creates a validated readiness payload.
+   *
+   * <p>The v1 contract currently supports only the {@value #READY_STATE} state because the launcher
+   * consumes the file purely as a ready signal rather than a broader lifecycle stream.
+   */
+  public LauncherReadinessInfo {
+    if (version <= 0) {
+      throw new IllegalArgumentException("version must be positive");
+    }
+    Objects.requireNonNull(state);
+    if (!READY_STATE.equals(state)) {
+      throw new IllegalArgumentException("unsupported readiness state: " + state);
+    }
+    if (uiPort < 1 || uiPort > 65_535) {
+      throw new IllegalArgumentException("uiPort must be between 1 and 65535");
+    }
+    Objects.requireNonNull(uiRoot);
+    if (uiRoot.isBlank() || uiRoot.charAt(0) != '/') {
+      throw new IllegalArgumentException("uiRoot must start with '/'");
+    }
+  }
+
+  /**
+   * Creates the current ready payload for the supplied UI port.
+   *
+   * @param uiPort HTTP port exposed by the daemon's UI shell
+   * @return v1 ready payload for the default UI root
+   */
+  public static LauncherReadinessInfo ready(int uiPort) {
+    return new LauncherReadinessInfo(VERSION_1, READY_STATE, uiPort, DEFAULT_UI_ROOT);
+  }
+
+  /**
+   * Indicates whether this payload represents a ready UI.
+   *
+   * @return {@code true} when the state equals {@value #READY_STATE}
+   */
+  public boolean isReady() {
+    return READY_STATE.equals(state);
+  }
+}

--- a/foundation-fs/src/main/java/network/crypta/fs/readiness/package-info.java
+++ b/foundation-fs/src/main/java/network/crypta/fs/readiness/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Structured readiness-file helpers shared by the daemon runtime and the desktop launcher.
+ *
+ * <p>This package owns the tiny filesystem contract used for launcher startup coordination. The
+ * daemon publishes a versioned readiness payload under the resolved runtime directory once the HTTP
+ * shell is ready for normal use, and the launcher consumes that file instead of scraping
+ * human-facing log lines as its primary signal.
+ */
+package network.crypta.fs.readiness;

--- a/launcher-desktop/build.gradle.kts
+++ b/launcher-desktop/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 version = rootProject.version
 
 dependencies {
+  implementation(project(":foundation-config"))
   implementation(project(":foundation-fs"))
   implementation(libs.jna)
   implementation(libs.jnaPlatform)

--- a/launcher-desktop/src/main/java/com/jthemedetecor/GnomeThemeDetector.java
+++ b/launcher-desktop/src/main/java/com/jthemedetecor/GnomeThemeDetector.java
@@ -223,6 +223,7 @@ class GnomeThemeDetector extends OsThemeDetector {
      *
      * @param detector detector owning the listener set and theme-parsing rules
      */
+    @SuppressWarnings("ThreadPriorityCheck")
     DetectorThread(@NotNull GnomeThemeDetector detector) {
       this.detector = detector;
       this.themeState = detector.readThemeState();

--- a/launcher-desktop/src/main/java/com/jthemedetecor/KdeThemeDetector.java
+++ b/launcher-desktop/src/main/java/com/jthemedetecor/KdeThemeDetector.java
@@ -159,6 +159,7 @@ public class KdeThemeDetector extends OsThemeDetector {
     private final KdeThemeDetector detector;
     private boolean lastValue;
 
+    @SuppressWarnings("ThreadPriorityCheck")
     DetectorThread(@NotNull KdeThemeDetector detector) {
       this.detector = detector;
       this.lastValue = detector.isDark();

--- a/launcher-desktop/src/main/java/com/jthemedetecor/WindowsThemeDetector.java
+++ b/launcher-desktop/src/main/java/com/jthemedetecor/WindowsThemeDetector.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Windows detector backed by registry reads and change notifications through JNA.
+ * Windows detector backed by registry reads and changes notifications through JNA.
  *
  * <p>This implementation reads the user's theme preference from the {@code AppsUseLightTheme}
  * registry value under the standard personalization key. A missing value or a non-zero value is
@@ -116,6 +116,7 @@ class WindowsThemeDetector extends OsThemeDetector {
      *
      * @param themeDetector detector owning the registry query and listener collection
      */
+    @SuppressWarnings("ThreadPriorityCheck")
     DetectorThread(WindowsThemeDetector themeDetector) {
       this.themeDetector = themeDetector;
       this.lastValue = themeDetector.isDark();

--- a/launcher-desktop/src/main/java/network/crypta/launcher/LauncherController.java
+++ b/launcher-desktop/src/main/java/network/crypta/launcher/LauncherController.java
@@ -22,10 +22,13 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import network.crypta.fs.AppEnv;
+import network.crypta.fs.readiness.LauncherReadinessFiles;
 
 import static network.crypta.launcher.LauncherLog.logDebug;
 
@@ -47,6 +50,17 @@ import static network.crypta.launcher.LauncherLog.logDebug;
  * </ul>
  */
 public class LauncherController {
+  private record TrackedReadinessFile(
+      Path path,
+      boolean existedWhenTracked,
+      long lastModifiedWhenTracked,
+      Object fileKeyWhenTracked,
+      boolean trackedAfterLaunch) {
+    private TrackedReadinessFile {
+      Objects.requireNonNull(path);
+    }
+  }
+
   private static final ThreadFactory IO_THREAD_FACTORY =
       runnable -> {
         Thread thread = new Thread(runnable, "launcher-io");
@@ -61,7 +75,12 @@ public class LauncherController {
   private final AtomicReference<Process> process = new AtomicReference<>();
   private final AtomicReference<AppState> state = new AtomicReference<>(new AppState());
   private final AtomicReference<Path> wrapperConfPath = new AtomicReference<>();
+  private final AtomicReference<TrackedReadinessFile> readinessTarget = new AtomicReference<>();
+  private final AtomicLong launchStartedAtMillis = new AtomicLong();
   private final AtomicBoolean autoOpenedBrowser = new AtomicBoolean();
+  private final AtomicReference<Integer> pendingLegacyPort = new AtomicReference<>();
+  private final AtomicBoolean startupCompletionObserved = new AtomicBoolean();
+  private final AtomicBoolean logFallbackEnabled = new AtomicBoolean();
   private final AtomicReference<Thread> tailThread = new AtomicReference<>();
   private static final String UNIX_KILL_EXECUTABLE = "/bin/kill";
   private static final String WINDOWS_TASKKILL_EXECUTABLE =
@@ -77,6 +96,11 @@ public class LauncherController {
   private static final long TAIL_MAX_DELAY_MS = 1500L;
   private static final long TAIL_CANCEL_POLL_MS = 50L;
   private static final int TAIL_READ_CHUNK = 64 * 1024;
+  private static final long READINESS_POLL_MS = 100L;
+  private static final String NODE_INITIALIZATION_COMPLETED_MARKER =
+      "Node initialization completed";
+  private final Supplier<Path> readinessFileResolver;
+  private final Supplier<Path> daemonLogFileResolver;
 
   /**
    * Creates a controller rooted at the current working directory.
@@ -94,7 +118,21 @@ public class LauncherController {
    * @param cwd working directory used to locate the {@code cryptad} executable and wrapper files
    */
   public LauncherController(Path cwd) {
+    this(
+        cwd,
+        LauncherUtils::resolveConfiguredLauncherReadinessFile,
+        LauncherUtils::resolveConfiguredLauncherDaemonLogFile);
+  }
+
+  LauncherController(Path cwd, Supplier<Path> readinessFileResolver) {
+    this(cwd, readinessFileResolver, LauncherUtils::resolveConfiguredLauncherDaemonLogFile);
+  }
+
+  LauncherController(
+      Path cwd, Supplier<Path> readinessFileResolver, Supplier<Path> daemonLogFileResolver) {
     this.cwd = Objects.requireNonNull(cwd);
+    this.readinessFileResolver = Objects.requireNonNull(readinessFileResolver);
+    this.daemonLogFileResolver = Objects.requireNonNull(daemonLogFileResolver);
   }
 
   /**
@@ -188,6 +226,18 @@ public class LauncherController {
     updateState(s -> s.withRunning(true).withKnownPort(null));
 
     tryEnableConsoleFlush(cryptadPath);
+    readinessTarget.set(null);
+    launchStartedAtMillis.set(0);
+    pendingLegacyPort.set(null);
+    startupCompletionObserved.set(false);
+    TrackedReadinessFile initialReadinessTarget = prepareStructuredReadinessFile();
+    readinessTarget.set(initialReadinessTarget);
+    logFallbackEnabled.set(true);
+    Path configuredDaemonLogFile = resolveConfiguredDaemonLogFile();
+    long configuredDaemonLogOffset = currentFileLength(configuredDaemonLogFile);
+    Path wrapperConf = LauncherUtils.guessWrapperConfPathForCryptadScript(cryptadPath);
+    Path wrapperLogFile = resolveWrapperLogFile(wrapperConf);
+    long wrapperLogOffset = currentFileLength(wrapperLogFile);
 
     List<String> command = LauncherUtils.buildCryptadCommand(cryptadPath);
     emitLog(
@@ -197,8 +247,10 @@ public class LauncherController {
     pb.redirectErrorStream(true);
 
     Process started;
+    long currentLaunchStartedAtMillis = System.currentTimeMillis();
     try {
       started = pb.start();
+      launchStartedAtMillis.set(currentLaunchStartedAtMillis);
     } catch (Exception e) {
       logDebug("Launcher process start failed", e);
       emitLog(ts() + " ERROR: " + e.getMessage());
@@ -207,8 +259,10 @@ public class LauncherController {
     }
 
     process.set(started);
-    wrapperConfPath.set(LauncherUtils.guessWrapperConfPathForCryptadScript(cryptadPath));
-    startTailingWrapperLogIfAvailable();
+    wrapperConfPath.set(wrapperConf);
+    startTailingWrapperLogIfAvailable(wrapperLogFile, wrapperLogOffset);
+    startWatchingConfiguredDaemonLog(started, configuredDaemonLogFile, configuredDaemonLogOffset);
+    io.execute(() -> waitForStructuredReadiness(started));
     io.execute(() -> readProcessOutput(started));
     io.execute(() -> watchProcess(started));
   }
@@ -220,9 +274,10 @@ public class LauncherController {
       String line;
       while ((line = reader.readLine()) != null) {
         emitLog(line);
+        processStartupDiscoveryLine(line);
         Integer detectedPort = LauncherUtils.parseFProxyPortFromLine(line);
         if (detectedPort != null) {
-          handleDetectedPort(detectedPort);
+          handleLegacyDetectedPort(detectedPort, logFallbackEnabled.get());
         }
       }
     } catch (Exception e) {
@@ -230,7 +285,70 @@ public class LauncherController {
     }
   }
 
-  private void handleDetectedPort(int port) {
+  private void waitForStructuredReadiness(Process started) {
+    while (true) {
+      TrackedReadinessFile currentReadinessTarget = readinessTarget.get();
+      Path currentReadinessFile =
+          currentReadinessTarget != null ? currentReadinessTarget.path() : null;
+      try {
+        if (currentReadinessFile != null) {
+          var readiness = LauncherReadinessFiles.readSnapshot(currentReadinessFile);
+          if (readiness.isPresent()
+              && canConsumeCurrentLaunchReadiness(currentReadinessTarget, readiness.get())) {
+            handleReadyPort(readiness.get().info().uiPort());
+            return;
+          }
+        }
+      } catch (IOException e) {
+        logDebug("Launcher readiness-file reader failed for " + currentReadinessFile, e);
+        fallbackToLegacyReadiness();
+        return;
+      }
+
+      if (!started.isAlive()) {
+        return;
+      }
+
+      try {
+        TimeUnit.MILLISECONDS.sleep(READINESS_POLL_MS);
+      } catch (InterruptedException _) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  private void handleLegacyDetectedPort(int port, boolean allowAutoLaunch) {
+    if (readinessTarget.get() != null) {
+      pendingLegacyPort.set(port);
+      if (startupCompletionObserved.get()) {
+        fallbackToLegacyReadiness();
+      }
+      return;
+    }
+    publishLegacyPort(port, allowAutoLaunch);
+  }
+
+  private void publishLegacyPort(int port, boolean allowAutoLaunch) {
+    Integer oldPort = state.get().knownPort();
+    if (!Objects.equals(oldPort, port)) {
+      updateState(s -> s.withKnownPort(port));
+    }
+    if (!allowAutoLaunch) {
+      return;
+    }
+    if (readinessTarget.get() == null) {
+      if (startupCompletionObserved.get()) {
+        launchBrowserOnce();
+      } else {
+        launchBrowserOnceIfProcessAlive();
+      }
+    }
+  }
+
+  private void handleReadyPort(int port) {
+    logFallbackEnabled.set(false);
+    pendingLegacyPort.set(null);
     Integer oldPort = state.get().knownPort();
     if (!Objects.equals(oldPort, port)) {
       updateState(s -> s.withKnownPort(port));
@@ -250,7 +368,12 @@ public class LauncherController {
     }
     emitLog(ts() + " cryptad exited with code " + exitCode);
     clearTrackedProcess(started);
-    interruptTailThread();
+    finishTailThreadAfterProcessExit();
+    readinessTarget.set(null);
+    launchStartedAtMillis.set(0);
+    pendingLegacyPort.set(null);
+    startupCompletionObserved.set(false);
+    logFallbackEnabled.set(false);
     updateState(s -> s.withRunning(false));
   }
 
@@ -455,6 +578,297 @@ public class LauncherController {
     }
   }
 
+  private Path resolveConfiguredDaemonLogFile() {
+    try {
+      return daemonLogFileResolver.get();
+    } catch (RuntimeException e) {
+      logDebug("Launcher daemon-log resolution failed", e);
+      return null;
+    }
+  }
+
+  private Path resolveWrapperLogFile(Path wrapperConf) {
+    if (wrapperConf == null) {
+      return null;
+    }
+    String logSpec = readWrapperProperty(wrapperConf, "wrapper.logfile");
+    return LauncherUtils.computeWrapperLogPath(wrapperConf, logSpec);
+  }
+
+  private long currentFileLength(Path path) {
+    if (path == null || !Files.isRegularFile(path)) {
+      return 0L;
+    }
+    try {
+      return Files.size(path);
+    } catch (IOException e) {
+      logDebug("Launcher daemon-log length lookup failed for " + path, e);
+      return 0L;
+    }
+  }
+
+  private void startWatchingConfiguredDaemonLog(Process started, Path logFile, long initialOffset) {
+    if (logFile == null) {
+      return;
+    }
+    io.execute(() -> watchConfiguredDaemonLogForRunDir(started, logFile, initialOffset));
+  }
+
+  private void watchConfiguredDaemonLogForRunDir(
+      Process started, Path logFile, long initialOffset) {
+    long position = initialOffset;
+    StringBuilder leftover = new StringBuilder();
+    while (started.isAlive()) {
+      try {
+        if (Files.isRegularFile(logFile)) {
+          position = readDaemonLogDelta(logFile, position, leftover);
+        }
+      } catch (IOException e) {
+        logDebug("Launcher daemon-log reader failed for " + logFile, e);
+        return;
+      }
+
+      if (!started.isAlive()) {
+        return;
+      }
+
+      try {
+        TimeUnit.MILLISECONDS.sleep(READINESS_POLL_MS);
+      } catch (InterruptedException _) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+    }
+  }
+
+  private long readDaemonLogDelta(Path logFile, long position, StringBuilder leftover)
+      throws IOException {
+    long length = Files.size(logFile);
+    if (length < position) {
+      position = 0L;
+      leftover.setLength(0);
+    }
+    if (length <= position) {
+      return position;
+    }
+
+    try (RandomAccessFile handle = new RandomAccessFile(logFile.toFile(), "r")) {
+      handle.seek(position);
+      int toRead = (int) Math.min(length - position, TAIL_READ_CHUNK);
+      byte[] buffer = new byte[toRead];
+      int read = handle.read(buffer);
+      if (read <= 0) {
+        return position;
+      }
+      emitDiscoveryText(leftover, new String(buffer, 0, read, StandardCharsets.UTF_8));
+      return position + read;
+    }
+  }
+
+  private void emitDiscoveryText(StringBuilder leftover, String text) {
+    String[] parts = text.split("\n", -1);
+    if (parts.length == 1) {
+      leftover.append(parts[0]);
+      return;
+    }
+
+    String first = leftover.append(parts[0]).toString();
+    if (!first.isEmpty()) {
+      processStartupDiscoveryLine(first);
+    }
+    leftover.setLength(0);
+
+    for (int i = 1; i < parts.length - 1; i++) {
+      processStartupDiscoveryLine(parts[i]);
+    }
+    String last = parts[parts.length - 1];
+    if (text.endsWith("\n")) {
+      if (!last.isEmpty()) {
+        processStartupDiscoveryLine(last);
+      }
+    } else {
+      leftover.append(last);
+    }
+  }
+
+  private void processStartupDiscoveryLine(String line) {
+    Path detectedRunDir = LauncherUtils.parseResolvedRunDirFromLine(line);
+    if (detectedRunDir != null) {
+      updateStructuredReadinessFile(detectedRunDir);
+    }
+    if (line.contains(NODE_INITIALIZATION_COMPLETED_MARKER)) {
+      handleStartupCompletionSignal();
+    }
+  }
+
+  private void handleStartupCompletionSignal() {
+    startupCompletionObserved.set(true);
+    TrackedReadinessFile currentReadinessTarget = readinessTarget.get();
+    Path currentReadinessFile =
+        currentReadinessTarget != null ? currentReadinessTarget.path() : null;
+    if (currentReadinessFile == null) {
+      return;
+    }
+    try {
+      var readiness = LauncherReadinessFiles.readSnapshot(currentReadinessFile);
+      if (readiness.isPresent()
+          && canConsumeCurrentLaunchReadiness(currentReadinessTarget, readiness.get())) {
+        handleReadyPort(readiness.get().info().uiPort());
+        return;
+      }
+    } catch (IOException e) {
+      logDebug("Launcher readiness-file reader failed for " + currentReadinessFile, e);
+    }
+    if (pendingLegacyPort.get() != null) {
+      fallbackToLegacyReadiness();
+    }
+  }
+
+  private TrackedReadinessFile prepareStructuredReadinessFile() {
+    Path readinessFile;
+    try {
+      readinessFile = readinessFileResolver.get();
+    } catch (RuntimeException e) {
+      logDebug("Launcher readiness-file resolution failed", e);
+      return null;
+    }
+    if (readinessFile == null) {
+      return null;
+    }
+    return captureReadinessTarget(readinessFile, false);
+  }
+
+  private void updateStructuredReadinessFile(Path runDir) {
+    Path nextReadinessFile = LauncherReadinessFiles.resolve(runDir);
+    TrackedReadinessFile currentReadinessTarget = readinessTarget.get();
+    Path currentReadinessFile =
+        currentReadinessTarget != null ? currentReadinessTarget.path() : null;
+    if (Objects.equals(currentReadinessFile, nextReadinessFile)) {
+      return;
+    }
+    readinessTarget.set(captureReadinessTarget(nextReadinessFile, true));
+  }
+
+  private TrackedReadinessFile captureReadinessTarget(Path readinessFile) {
+    return captureReadinessTarget(readinessFile, false);
+  }
+
+  private TrackedReadinessFile captureReadinessTarget(
+      Path readinessFile, boolean trackedAfterLaunch) {
+    boolean existedWhenTracked = Files.isRegularFile(readinessFile);
+    long lastModifiedWhenTracked = Long.MIN_VALUE;
+    Object fileKeyWhenTracked = null;
+    if (existedWhenTracked) {
+      try {
+        lastModifiedWhenTracked = Files.getLastModifiedTime(readinessFile).toMillis();
+      } catch (IOException e) {
+        logDebug("Launcher readiness-file baseline lookup failed for " + readinessFile, e);
+      }
+      fileKeyWhenTracked = readFileKey(readinessFile);
+    }
+    return new TrackedReadinessFile(
+        readinessFile,
+        existedWhenTracked,
+        lastModifiedWhenTracked,
+        fileKeyWhenTracked,
+        trackedAfterLaunch);
+  }
+
+  boolean isCurrentLaunchReadinessFile(Path readinessFile) throws IOException {
+    if (!Files.isRegularFile(readinessFile)) {
+      return false;
+    }
+    var readiness = LauncherReadinessFiles.readSnapshot(readinessFile);
+    if (readiness.isEmpty()) {
+      return false;
+    }
+    TrackedReadinessFile trackedReadinessFile = readinessTarget.get();
+    if (trackedReadinessFile == null
+        || !Objects.equals(trackedReadinessFile.path(), readinessFile)) {
+      trackedReadinessFile = captureReadinessTarget(readinessFile);
+    }
+    return isPotentialCurrentLaunchReadiness(trackedReadinessFile, readiness.get());
+  }
+
+  private boolean canConsumeCurrentLaunchReadiness(
+      TrackedReadinessFile trackedReadinessFile,
+      LauncherReadinessFiles.ReadinessSnapshot readiness) {
+    if (trackedReadinessFile == null
+        || !isPotentialCurrentLaunchReadiness(trackedReadinessFile, readiness)) {
+      return false;
+    }
+    return readiness.lastModifiedTime() > launchStartedAtMillis.get()
+        || hasReadinessFileChangedSinceTracking(
+            trackedReadinessFile, readiness.lastModifiedTime(), readiness.fileKey())
+        || startupCompletionObserved.get();
+  }
+
+  private boolean isPotentialCurrentLaunchReadiness(
+      TrackedReadinessFile trackedReadinessFile,
+      LauncherReadinessFiles.ReadinessSnapshot readiness) {
+    long currentLaunchStartedAtMillis = launchStartedAtMillis.get();
+    if (currentLaunchStartedAtMillis <= 0) {
+      return false;
+    }
+    long lastModifiedTime = readiness.lastModifiedTime();
+    if (lastModifiedTime > currentLaunchStartedAtMillis) {
+      return true;
+    }
+    boolean changedSinceTracking =
+        hasReadinessFileChangedSinceTracking(
+            trackedReadinessFile, lastModifiedTime, readiness.fileKey());
+    if (changedSinceTracking) {
+      return true;
+    }
+    Integer deferredLegacyPort = pendingLegacyPort.get();
+    boolean corroboratedByLegacyPort =
+        deferredLegacyPort != null && deferredLegacyPort == readiness.info().uiPort();
+    if (trackedReadinessFile.existedWhenTracked()) {
+      return trackedReadinessFile.trackedAfterLaunch()
+          && startupCompletionObserved.get()
+          && corroboratedByLegacyPort;
+    }
+    if (lastModifiedTime < currentLaunchStartedAtMillis) {
+      return startupCompletionObserved.get() && corroboratedByLegacyPort;
+    }
+    return corroboratedByLegacyPort;
+  }
+
+  private boolean hasReadinessFileChangedSinceTracking(
+      TrackedReadinessFile trackedReadinessFile, long lastModifiedTime, Object currentFileKey) {
+    if (!trackedReadinessFile.existedWhenTracked()) {
+      return true;
+    }
+    Object trackedFileKey = trackedReadinessFile.fileKeyWhenTracked();
+    if (trackedFileKey != null && currentFileKey != null) {
+      return !trackedFileKey.equals(currentFileKey);
+    }
+    long trackedLastModifiedTime = trackedReadinessFile.lastModifiedWhenTracked();
+    return trackedLastModifiedTime != Long.MIN_VALUE && lastModifiedTime != trackedLastModifiedTime;
+  }
+
+  private void fallbackToLegacyReadiness() {
+    readinessTarget.set(null);
+    Integer deferredLegacyPort = pendingLegacyPort.getAndSet(null);
+    if (deferredLegacyPort != null) {
+      publishLegacyPort(deferredLegacyPort, logFallbackEnabled.get());
+    }
+  }
+
+  private void launchBrowserOnceIfProcessAlive() {
+    Process current = process.get();
+    if (current == null || !current.isAlive()) {
+      return;
+    }
+    launchBrowserOnce();
+  }
+
+  private void launchBrowserOnce() {
+    if (autoOpenedBrowser.compareAndSet(false, true)) {
+      launchBrowser();
+    }
+  }
+
   private boolean tryWindowsGracefulStopViaAnchor(List<Long> pids) {
     Path anchorPath = resolveWindowsAnchorPath();
     if (anchorPath == null) {
@@ -520,21 +934,16 @@ public class LauncherController {
     }
   }
 
-  private void startTailingWrapperLogIfAvailable() {
+  private void startTailingWrapperLogIfAvailable(Path logPath, long initialOffset) {
     interruptTailThread();
-
-    Path conf = wrapperConfPath.get();
-    if (conf == null) {
+    if (logPath == null) {
       return;
     }
-
-    String logSpec = readWrapperProperty(conf, "wrapper.logfile");
-    Path logPath = LauncherUtils.computeWrapperLogPath(conf, logSpec);
     Thread tailer =
         Thread.ofPlatform()
             .name("launcher-log-tail")
             .daemon(true)
-            .unstarted(() -> tailFileWhileAlive(logPath, Thread.currentThread()));
+            .unstarted(() -> tailFileWhileAlive(logPath, initialOffset, Thread.currentThread()));
     tailThread.set(tailer);
     tailer.start();
   }
@@ -546,15 +955,38 @@ public class LauncherController {
     }
   }
 
-  private void tailFileWhileAlive(Path path, Thread tailingThread) {
-    TailState tailState = new TailState();
+  private void finishTailThreadAfterProcessExit() {
+    Thread tailer = tailThread.getAndSet(null);
+    if (tailer == null) {
+      return;
+    }
     try {
-      while (!tailingThread.isInterrupted() && isTrackedProcessAlive()) {
+      tailer.join(TAIL_MAX_DELAY_MS + TAIL_BASE_DELAY_MS);
+    } catch (InterruptedException _) {
+      Thread.currentThread().interrupt();
+    }
+    if (tailer.isAlive()) {
+      tailer.interrupt();
+    }
+  }
+
+  private void tailFileWhileAlive(Path path, long initialOffset, Thread tailingThread) {
+    TailState tailState = new TailState();
+    tailState.pos = initialOffset;
+    try {
+      while (!tailingThread.isInterrupted()) {
+        boolean processAlive = isTrackedProcessAlive();
         try {
           boolean madeProgress = tailOnce(path, tailState);
+          if (!processAlive && !madeProgress) {
+            return;
+          }
           tailState.idleCount = madeProgress ? 0 : tailState.idleCount + 1;
         } catch (Exception _) {
           resetTailOnError(tailState);
+        }
+        if (!processAlive) {
+          continue;
         }
         if (!sleepWhileThreadActive(tailingThread, calcTailDelayMs(tailState.idleCount))) {
           return;
@@ -662,7 +1094,7 @@ public class LauncherController {
       RandomAccessFile opened = new RandomAccessFile(path.toFile(), "r");
       state.raf = opened;
       state.currentKey = newKey;
-      state.pos = opened.length();
+      state.pos = Math.min(state.pos, opened.length());
     }
   }
 
@@ -675,15 +1107,18 @@ public class LauncherController {
 
     String first = state.leftover.append(parts[0]).toString();
     if (!first.isEmpty()) {
+      processStartupDiscoveryLine(first);
       emitLog(first);
     }
     state.leftover = new StringBuilder();
 
     for (int i = 1; i < parts.length - 1; i++) {
+      processStartupDiscoveryLine(parts[i]);
       emitLog(parts[i]);
     }
     String last = parts[parts.length - 1];
     if (text.endsWith("\n")) {
+      processStartupDiscoveryLine(last);
       emitLog(last);
     } else {
       state.leftover.append(last);

--- a/launcher-desktop/src/main/java/network/crypta/launcher/LauncherUtils.java
+++ b/launcher-desktop/src/main/java/network/crypta/launcher/LauncherUtils.java
@@ -15,7 +15,12 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
+import network.crypta.config.CryptadConfig;
+import network.crypta.fs.AppDirs;
 import network.crypta.fs.AppEnv;
+import network.crypta.fs.Resolved;
+import network.crypta.fs.ServiceDirs;
+import network.crypta.fs.readiness.LauncherReadinessFiles;
 
 import static network.crypta.launcher.LauncherLog.logDebug;
 
@@ -51,14 +56,21 @@ public final class LauncherUtils {
 
   private static final String CRYPTAD_SCRIPT = "cryptad";
   private static final String CRYPTAD_SCRIPT_WINDOWS = "cryptad.bat";
+  private static final String CONFIG_FILE_NAME = "cryptad.ini";
+  private static final String NODE_INSTALL_RUN_DIR_KEY = "node.install.runDir";
+  private static final String LOGGER_DIRNAME_KEY = "logger.dirname";
+  private static final String DAEMON_LOG_FILE_NAME = "crypta-latest.log";
+  private static final String RUN_DIR_MARKER = "Run dir:";
 
   private LauncherUtils() {}
 
   /**
-   * Parses a likely FProxy listening port from a launcher log line.
+   * Parses a likely FProxy listening port from a legacy launcher log line.
    *
    * <p>The parser uses conservative heuristics and returns {@code null} unless the line appears to
-   * describe FProxy startup and contains a plausible numeric tail after the last colon.
+   * describe FProxy startup and contains a plausible numeric tail after the last colon. The
+   * launcher keeps this only as a narrow compatibility fallback when structured readiness-file
+   * discovery is unavailable.
    *
    * @param line launcher output line to inspect
    * @return parsed port number when recognized, otherwise {@code null}
@@ -84,6 +96,108 @@ public final class LauncherUtils {
       return null;
     }
     return parsePort(tail.substring(0, digits));
+  }
+
+  /**
+   * Parses the daemon's resolved runtime directory from startup diagnostics.
+   *
+   * <p>The node logs a multi-line "Resolved directories" block during bootstrap. When a line
+   * containing the resolved run directory is observed, the launcher can retarget readiness-file
+   * polling to the daemon's actual runtime directory even if configuration or CLI overrides moved
+   * it away from the launcher's default AppDirs or ServiceDirs path.
+   *
+   * @param line launcher output line to inspect
+   * @return normalized run-directory path when present, otherwise {@code null}
+   */
+  public static Path parseResolvedRunDirFromLine(String line) {
+    int idx = line.indexOf(RUN_DIR_MARKER);
+    if (idx < 0) {
+      return null;
+    }
+    String tail = line.substring(idx + RUN_DIR_MARKER.length()).trim();
+    if (tail.isEmpty()) {
+      return null;
+    }
+    try {
+      return Path.of(tail).normalize();
+    } catch (RuntimeException e) {
+      logDebug("Failed parsing launcher runDir from line: " + line, e);
+      return null;
+    }
+  }
+
+  /**
+   * Resolves the readiness file path the daemon is expected to use for this launcher process.
+   *
+   * <p>The launcher first resolves the default base directories from the current environment. If
+   * the normal {@code cryptad.ini} exists under the resolved config directory, the launcher loads
+   * it with the same placeholder expansion used by daemon startup so {@code node.install.runDir}
+   * overrides are honored before startup begins. When the config file is missing or unreadable, the
+   * default resolved run directory remains the fallback.
+   *
+   * @return readiness-file path for the configured or default daemon runtime directory
+   */
+  public static Path resolveConfiguredLauncherReadinessFile() {
+    Resolved resolvedDirs = resolveCurrentProcessDirs();
+    Path configFile = resolvedDirs.configDir().resolve(CONFIG_FILE_NAME);
+    return resolveConfiguredLauncherReadinessFile(configFile, resolvedDirs);
+  }
+
+  static Path resolveConfiguredLauncherReadinessFile(Path configFile, Resolved resolvedDirs) {
+    Path defaultReadinessFile = LauncherReadinessFiles.resolve(resolvedDirs.runDir());
+    if (!Files.isRegularFile(configFile)) {
+      return defaultReadinessFile;
+    }
+    try {
+      String runDir =
+          CryptadConfig.loadExpandingPlaceholders(configFile, resolvedDirs)
+              .get(NODE_INSTALL_RUN_DIR_KEY);
+      if (runDir == null || runDir.isBlank()) {
+        return defaultReadinessFile;
+      }
+      return LauncherReadinessFiles.resolve(Path.of(runDir).normalize());
+    } catch (Exception e) {
+      logDebug(
+          "Failed resolving launcher readiness path from " + configFile + "; using default runDir",
+          e);
+      return defaultReadinessFile;
+    }
+  }
+
+  /**
+   * Resolves the daemon log file path the launcher can watch for startup diagnostics.
+   *
+   * <p>The launcher uses the same placeholder-expanded {@code cryptad.ini} view as daemon startup
+   * so configured {@code logger.dirname} values are honored before the process begins. When the
+   * config file is missing or unreadable, the default resolved logs directory remains the fallback.
+   *
+   * @return expected path to the daemon's rolling startup log
+   */
+  public static Path resolveConfiguredLauncherDaemonLogFile() {
+    Resolved resolvedDirs = resolveCurrentProcessDirs();
+    Path configFile = resolvedDirs.configDir().resolve(CONFIG_FILE_NAME);
+    return resolveConfiguredLauncherDaemonLogFile(configFile, resolvedDirs);
+  }
+
+  static Path resolveConfiguredLauncherDaemonLogFile(Path configFile, Resolved resolvedDirs) {
+    Path logsDir = resolvedDirs.logsDir();
+    if (Files.isRegularFile(configFile)) {
+      try {
+        String configuredLogDir =
+            CryptadConfig.loadExpandingPlaceholders(configFile, resolvedDirs)
+                .get(LOGGER_DIRNAME_KEY);
+        if (configuredLogDir != null && !configuredLogDir.isBlank()) {
+          logsDir = Path.of(configuredLogDir).normalize();
+        }
+      } catch (Exception e) {
+        logDebug(
+            "Failed resolving launcher daemon log path from "
+                + configFile
+                + "; using default logsDir",
+            e);
+      }
+    }
+    return logsDir.resolve(DAEMON_LOG_FILE_NAME);
   }
 
   private static Integer parsePort(String value) {
@@ -390,6 +504,11 @@ public final class LauncherUtils {
       return false;
     }
     return trimmed.substring(0, idx).trim().equals(key);
+  }
+
+  private static Resolved resolveCurrentProcessDirs() {
+    AppEnv env = new AppEnv();
+    return env.isServiceMode() ? new ServiceDirs().resolve() : new AppDirs().resolve();
   }
 
   private static Path resolveCryptadPathFromEnv(Path cwd, Map<String, String> env) {

--- a/runtime-node/src/main/java/network/crypta/node/Node.java
+++ b/runtime-node/src/main/java/network/crypta/node/Node.java
@@ -38,6 +38,7 @@ import network.crypta.node.subsystem.NodeMessagingSubsystem;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.node.subsystem.NodeRoutingSubsystem;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
+import network.crypta.runtime.bootstrap.LauncherReadinessPublisher;
 import network.crypta.runtime.bootstrap.NodeBootstrap;
 import network.crypta.runtime.bootstrap.NodeConfigManager;
 import network.crypta.runtime.bootstrap.NodeRuntimeBridgeFactories;
@@ -2017,6 +2018,15 @@ In particular: YOU ARE WIDE OPEN TO YOUR IMMEDIATE PEERS! They can eavesdrop on 
       toadlets.finishStart();
       toadlets.createFproxy();
       toadlets.removeStartupToadlet();
+      publishLauncherReadiness(toadlets);
+    }
+  }
+
+  private void publishLauncherReadiness(HttpShellContainer toadlets) {
+    try {
+      LauncherReadinessPublisher.publishReady(runDir.dir().toPath(), toadlets.listenPort());
+    } catch (IOException | IllegalArgumentException e) {
+      LOG.warn("Failed to publish launcher readiness file under {}", runDir.dir(), e);
     }
   }
 

--- a/runtime-node/src/main/java/network/crypta/runtime/bootstrap/LauncherReadinessPublisher.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/bootstrap/LauncherReadinessPublisher.java
@@ -1,0 +1,29 @@
+package network.crypta.runtime.bootstrap;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import network.crypta.fs.readiness.LauncherReadinessFiles;
+import network.crypta.fs.readiness.LauncherReadinessInfo;
+
+/**
+ * Publishes the daemon-to-launcher readiness file once the HTTP shell is fully usable.
+ *
+ * <p>This helper keeps the small readiness-file write protocol out of the node kernel while letting
+ * runtime startup publish the structured launcher signal at the existing post-start lifecycle hook.
+ */
+public final class LauncherReadinessPublisher {
+  /** Utility holder; use {@link #publishReady(Path, int)} instead of creating instances. */
+  private LauncherReadinessPublisher() {}
+
+  /**
+   * Writes the current ready payload beneath the supplied runtime directory.
+   *
+   * @param runDir resolved runtime directory used by the active daemon process
+   * @param listenPort HTTP port that the launcher should open once the shell is ready
+   * @throws IOException if the readiness file cannot be written
+   */
+  public static void publishReady(Path runDir, int listenPort) throws IOException {
+    LauncherReadinessFiles.write(
+        LauncherReadinessFiles.resolve(runDir), LauncherReadinessInfo.ready(listenPort));
+  }
+}

--- a/runtime-node/src/main/java/network/crypta/runtime/bootstrap/NodeStarter.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/bootstrap/NodeStarter.java
@@ -476,6 +476,24 @@ public class NodeStarter implements WrapperListener {
     }
   }
 
+  @SuppressWarnings("java:S106")
+  private static void emitLauncherRunDirCompatibilityLine(String runDir) {
+    try {
+      System.out.println("Run dir:      " + runDir);
+    } catch (Exception _) {
+      // Do not fail to start up due to launcher compatibility output.
+    }
+  }
+
+  @SuppressWarnings("java:S106")
+  private static void emitLauncherStartupCompletionCompatibilityLine() {
+    try {
+      System.out.println("Node initialization completed");
+    } catch (Exception _) {
+      // Do not fail to start up due to launcher compatibility output.
+    }
+  }
+
   /**
    * The start method is called when the WrapperManager is signaled by the native wrapper code that
    * it can start its application. This method call is expected to return, so a new thread should be
@@ -564,6 +582,7 @@ public class NodeStarter implements WrapperListener {
       installSeednodesIfMissing(node);
       node.start(false);
       LOG.info("Node initialization completed");
+      emitLauncherStartupCompletionCompatibilityLine();
     } catch (NodeInitException e) {
       LOG.error("Node load failed (exitCode={}): {}", e.exitCode, e.getMessage(), e);
       // Return the exit code so WrapperManager handles process termination without re-entering
@@ -656,8 +675,17 @@ public class NodeStarter implements WrapperListener {
     printResolvedDirectories(resolved, configFilename, serviceMode);
     SimpleFieldSet sfs =
         CryptadConfig.loadExpandingPlaceholders(cfgPath, resolved, System.getProperties());
+    emitLauncherConfiguredRunDirCompatibilityLine(sfs);
     File tmp = new File(configFilename.getPath() + ".tmp");
     return new FreenetFilePersistentConfig(sfs, configFilename, tmp);
+  }
+
+  private static void emitLauncherConfiguredRunDirCompatibilityLine(SimpleFieldSet sfs) {
+    String configuredRunDir = sfs.get("node.install.runDir");
+    if (configuredRunDir == null || configuredRunDir.isBlank()) {
+      return;
+    }
+    emitLauncherRunDirCompatibilityLine(configuredRunDir);
   }
 
   private static void setupLogging(FreenetFilePersistentConfig cfg)

--- a/runtime-node/src/main/java/network/crypta/runtime/http/HttpShellContainer.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/http/HttpShellContainer.java
@@ -39,9 +39,8 @@ public interface HttpShellContainer extends LinkFilterExceptionProvider {
    * adapter for later callbacks rather than copying or translating it. Because {@link
    * HttpShellRuntimeSupport} is only a marker seam in this PR, container implementations may still
    * require additional implementation-specific interfaces on the same object. The default
-   * production pairing supplied by {@link
-   * network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories#coreBacked()} satisfies that
-   * requirement; custom bridge bindings must supply a compatible container/support pair.
+   * production pairing supplied by the root composition layer satisfies that requirement; custom
+   * bridge bindings must supply a compatible container/support pair.
    *
    * @param runtimeSupport daemon-backed adapter that serves later HTTP shell callbacks and runtime
    *     lookups
@@ -106,6 +105,17 @@ public interface HttpShellContainer extends LinkFilterExceptionProvider {
    * current FProxy behavior and should not use this seam to reorder or broaden endpoint startup.
    */
   void createFproxy();
+
+  /**
+   * Returns the local HTTP listen port used for launcher/browser access.
+   *
+   * <p>This is the effective port exposed by the current shell configuration. Runtime code uses it
+   * only to publish the launcher readiness file after normal shell startup is complete; callers
+   * should not treat it as a broader endpoint-discovery API.
+   *
+   * @return local HTTP port for the current shell listener
+   */
+  int listenPort();
 
   /**
    * Reports whether advanced mode is enabled for HTTP shell consumers.

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -137,7 +137,7 @@ class AddPeerTest {
   @Test
   void getReferenceFromURL_whenCalled_delegatesToPeerReferenceTextLoader() throws IOException {
     URL url = mock(URL.class);
-    StringBuilder reference = new StringBuilder("line1\nline2\n");
+    StringBuilder reference = mock(StringBuilder.class);
 
     try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
         Mockito.mockStatic(PeerReferenceTextLoader.class)) {
@@ -152,7 +152,7 @@ class AddPeerTest {
   void getReferenceFromFreenetURI_whenCalled_delegatesToPeerReferenceTextLoader() throws Exception {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     FreenetURI uri = mock(FreenetURI.class);
-    StringBuilder reference = new StringBuilder("ref-line-1\nref-line-2\n");
+    StringBuilder reference = mock(StringBuilder.class);
 
     try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
         Mockito.mockStatic(PeerReferenceTextLoader.class)) {

--- a/src/test/java/network/crypta/clients/http/bridge/HttpShellContainersTest.java
+++ b/src/test/java/network/crypta/clients/http/bridge/HttpShellContainersTest.java
@@ -55,6 +55,7 @@ class HttpShellContainersTest {
               when(server.isEnabled()).thenReturn(true);
               when(server.isAdvancedModeEnabled()).thenReturn(true);
               when(server.isFProxyJavascriptEnabled()).thenReturn(false);
+              when(server.listenPort()).thenReturn(8888);
               when(server.isLinkExcepted(uri)).thenReturn(true);
               when(server.addFormChild(parentNode, "/submit", "form")).thenReturn(formNode);
             })) {
@@ -79,6 +80,7 @@ class HttpShellContainersTest {
       assertTrue(container.isAdvancedModeEnabled());
       assertTrue(container.isLinkExcepted(uri));
       assertFalse(container.isFProxyJavascriptEnabled());
+      assertEquals(8888, container.listenPort());
       assertSame(formNode, container.addFormChild(parentNode, "/submit", "form"));
 
       verify(server)
@@ -106,12 +108,14 @@ class HttpShellContainersTest {
     when(server.addFormChild(parentNode, "/submit", "form")).thenReturn(formNode);
     when(server.isAdvancedModeEnabled()).thenReturn(false);
     when(server.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(server.listenPort()).thenReturn(7777);
     when(server.isLinkExcepted(uri)).thenReturn(true);
 
     assertTrue(container.isEnabled());
     assertSame(formNode, container.addFormChild(parentNode, "/submit", "form"));
     assertFalse(container.isAdvancedModeEnabled());
     assertTrue(container.isFProxyJavascriptEnabled());
+    assertEquals(7777, container.listenPort());
     assertTrue(container.isLinkExcepted(uri));
   }
 

--- a/src/test/java/network/crypta/fs/readiness/LauncherReadinessFilesTest.java
+++ b/src/test/java/network/crypta/fs/readiness/LauncherReadinessFilesTest.java
@@ -1,0 +1,77 @@
+package network.crypta.fs.readiness;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LauncherReadinessFilesTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void writeAndRead_whenReadyPayload_expectRoundTrip() throws Exception {
+    Path readinessFile = LauncherReadinessFiles.resolve(tempDir);
+    LauncherReadinessInfo expected =
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, 8888, "/");
+
+    LauncherReadinessFiles.write(readinessFile, expected);
+
+    LauncherReadinessInfo actual = LauncherReadinessFiles.read(readinessFile).orElseThrow();
+    assertEquals(expected, actual);
+    assertTrue(actual.isReady());
+    var snapshot = LauncherReadinessFiles.readSnapshot(readinessFile).orElseThrow();
+    assertEquals(expected, snapshot.info());
+  }
+
+  @Test
+  void read_whenVersionUnsupported_returnsEmpty() throws Exception {
+    Path readinessFile = LauncherReadinessFiles.resolve(tempDir);
+    Files.writeString(
+        readinessFile,
+        """
+        version=2
+        state=ready
+        ui.port=8888
+        ui.root=/
+        """);
+
+    assertFalse(LauncherReadinessFiles.read(readinessFile).isPresent());
+  }
+
+  @Test
+  void read_whenUiRootMissing_expectDefaultRoot() throws Exception {
+    Path readinessFile = LauncherReadinessFiles.resolve(tempDir);
+    Files.writeString(
+        readinessFile,
+        """
+        version=1
+        state=ready
+        ui.port=8888
+        """);
+
+    LauncherReadinessInfo actual = LauncherReadinessFiles.read(readinessFile).orElseThrow();
+
+    assertEquals(LauncherReadinessInfo.DEFAULT_UI_ROOT, actual.uiRoot());
+    assertTrue(actual.isReady());
+  }
+
+  @Test
+  void clear_whenReadinessAndTempFileExist_expectBothDeleted() throws Exception {
+    Path readinessFile = LauncherReadinessFiles.resolve(tempDir);
+    Path tempFile = readinessFile.resolveSibling(readinessFile.getFileName() + ".tmp");
+    LauncherReadinessFiles.write(readinessFile, LauncherReadinessInfo.ready(8888));
+    Files.writeString(tempFile, "stale");
+
+    LauncherReadinessFiles.clear(readinessFile);
+
+    assertFalse(Files.exists(readinessFile));
+    assertFalse(Files.exists(tempFile));
+  }
+}

--- a/src/test/java/network/crypta/fs/readiness/LauncherReadinessInfoTest.java
+++ b/src/test/java/network/crypta/fs/readiness/LauncherReadinessInfoTest.java
@@ -1,0 +1,35 @@
+package network.crypta.fs.readiness;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LauncherReadinessInfoTest {
+
+  @Test
+  void ready_whenPortValid_expectDefaultReadyPayload() {
+    LauncherReadinessInfo actual = LauncherReadinessInfo.ready(8888);
+
+    assertEquals(LauncherReadinessInfo.VERSION_1, actual.version());
+    assertEquals(LauncherReadinessInfo.READY_STATE, actual.state());
+    assertEquals(8888, actual.uiPort());
+    assertEquals(LauncherReadinessInfo.DEFAULT_UI_ROOT, actual.uiRoot());
+    assertTrue(actual.isReady());
+  }
+
+  @Test
+  void constructor_whenStateUnsupported_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new LauncherReadinessInfo(1, "booting", 8888, "/"));
+  }
+
+  @Test
+  void constructor_whenUiRootRelative_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new LauncherReadinessInfo(1, LauncherReadinessInfo.READY_STATE, 8888, "ui"));
+  }
+}

--- a/src/test/java/network/crypta/launcher/LauncherControllerTest.java
+++ b/src/test/java/network/crypta/launcher/LauncherControllerTest.java
@@ -1,15 +1,19 @@
 package network.crypta.launcher;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import network.crypta.fs.AppEnv;
+import network.crypta.fs.readiness.LauncherReadinessFiles;
+import network.crypta.fs.readiness.LauncherReadinessInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -17,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({"java:S100"})
@@ -42,31 +47,78 @@ class LauncherControllerTest {
 
   @Test
   void start_whenScriptRuns_updatesStateAndReadsPort() throws Exception {
-    LauncherController controller = new LauncherController(tempDir);
+    Path initialReadinessFile = createReadinessFilePath(tempDir, "default-runtime");
+    Path actualReadinessFile = createReadinessFilePath(tempDir, "configured-runtime");
+    Path daemonLogFile = createDaemonLogFilePath(tempDir);
+    Path legacyDetectedMarker = tempDir.resolve("legacy-detected.marker");
+    LauncherController controller =
+        new LauncherController(tempDir, () -> initialReadinessFile, () -> daemonLogFile);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
     Path wrapperConf = writeWrapperConf(tempDir);
-    writeCryptadScript(tempDir);
+    writeStructuredReadinessCryptadScript(
+        tempDir, actualReadinessFile, daemonLogFile, legacyDetectedMarker);
 
     controller.start();
 
     awaitState(controller, AppState::isRunning);
+    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+    awaitCondition(
+        () -> Files.exists(legacyDetectedMarker),
+        "legacy FProxy marker before structured readiness");
+    assertFalse(isBrowserAutoOpened(controller));
+    assertNull(controller.getState().knownPort());
+    assertFalse(isBrowserAutoOpened(controller));
+    awaitCondition(() -> Files.exists(actualReadinessFile), "structured readiness file");
     AppState stateWithPort =
         awaitState(controller, s -> s.knownPort() != null && s.knownPort() == TEST_PORT);
     assertEquals(TEST_PORT, stateWithPort.knownPort());
+    awaitCondition(() -> isBrowserAutoOpened(controller), "browser auto-open after readiness");
+    assertTrue(isBrowserAutoOpened(controller));
 
     AppState stopped =
         awaitState(
             controller, s -> !s.isRunning() && s.knownPort() != null && s.knownPort() == TEST_PORT);
     assertFalse(stopped.isRunning());
 
-    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+    awaitLog(logs, l -> l.contains("READY"));
+    assertFalse(logs.stream().anyMatch(l -> l.contains("Run dir:")));
     assertTrue(logs.stream().anyMatch(l -> l.contains("Starting 'cryptad")));
     assertTrue(logs.stream().anyMatch(l -> l.contains("exec:")));
 
     var confLines = Files.readAllLines(wrapperConf, StandardCharsets.UTF_8);
     assertTrue(confLines.stream().anyMatch(l -> l.trim().equals("wrapper.console.flush=TRUE")));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void start_whenPreexistingReadinessExists_preservesItWhileIgnoringIt() throws Exception {
+    Path initialReadinessFile = createReadinessFilePath(tempDir, "default-runtime");
+    Path actualReadinessFile = createReadinessFilePath(tempDir, "configured-runtime");
+    Path daemonLogFile = createDaemonLogFilePath(tempDir);
+    LauncherReadinessInfo existingReadiness =
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, 4321, "/");
+    LauncherReadinessFiles.write(actualReadinessFile, existingReadiness);
+    LauncherController controller =
+        new LauncherController(tempDir, () -> initialReadinessFile, () -> daemonLogFile);
+
+    writeWrapperConf(tempDir);
+    writeNoReadinessCryptadScript(tempDir, actualReadinessFile.getParent(), daemonLogFile);
+
+    controller.start();
+
+    awaitState(controller, AppState::isRunning);
+    awaitCondition(() -> Files.exists(actualReadinessFile), "pre-existing readiness preservation");
+    assertEquals(existingReadiness, LauncherReadinessFiles.read(actualReadinessFile).orElseThrow());
+    assertNull(controller.getState().knownPort());
+
+    AppState stopped = awaitState(controller, s -> !s.isRunning());
+    assertFalse(stopped.isRunning());
+    assertNull(stopped.knownPort());
+    assertEquals(existingReadiness, LauncherReadinessFiles.read(actualReadinessFile).orElseThrow());
 
     controller.shutdownAndWait();
   }
@@ -110,7 +162,8 @@ class LauncherControllerTest {
 
   @Test
   void stop_whenScriptRunsLong_processStopsAndStateClears() throws Exception {
-    LauncherController controller = new LauncherController(tempDir);
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
 
     writeWrapperConf(tempDir);
     Path heartbeat = tempDir.resolve("heartbeat.log");
@@ -126,6 +179,315 @@ class LauncherControllerTest {
     assertFalse(stopped.isRunning());
     assertFalse(stopped.isStopping());
     awaitFileSizeStable(heartbeat, Duration.ofMillis(2500));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void start_whenStructuredReadinessUnavailable_fallsBackToLegacyLogPortDetection()
+      throws Exception {
+    LauncherController controller = new LauncherController(tempDir, () -> null, () -> null);
+    CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+    controller.addLogListener(logs::add);
+
+    writeWrapperConf(tempDir);
+    writeLegacyPortCryptadScript(tempDir);
+
+    controller.start();
+
+    awaitState(controller, AppState::isRunning);
+    AppState stateWithPort =
+        awaitState(controller, s -> s.knownPort() != null && s.knownPort() == TEST_PORT);
+    assertEquals(TEST_PORT, stateWithPort.knownPort());
+    awaitCondition(() -> isBrowserAutoOpened(controller), "legacy fallback browser auto-open");
+    assertTrue(isBrowserAutoOpened(controller));
+    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void start_whenStructuredReadinessNeverPublishedAfterStartupCompletion_fallsBackToLegacyPort()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    Path daemonLogFile = createDaemonLogFilePath(tempDir);
+    LauncherController controller =
+        new LauncherController(tempDir, () -> readinessFile, () -> daemonLogFile);
+    CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+    controller.addLogListener(logs::add);
+
+    writeWrapperConf(tempDir);
+    writeLegacyPortWithoutReadinessCryptadScript(tempDir, daemonLogFile);
+
+    controller.start();
+
+    awaitState(controller, AppState::isRunning);
+    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+    AppState stateWithPort =
+        awaitState(controller, s -> s.knownPort() != null && s.knownPort() == TEST_PORT);
+    assertEquals(TEST_PORT, stateWithPort.knownPort());
+    awaitCondition(
+        () -> isBrowserAutoOpened(controller),
+        "legacy fallback browser auto-open after startup completion");
+    assertTrue(isBrowserAutoOpened(controller));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void start_whenStructuredReadinessPublishedMalformedAfterStartupCompletion_fallsBackToLegacyPort()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    Path daemonLogFile = createDaemonLogFilePath(tempDir);
+    LauncherController controller =
+        new LauncherController(tempDir, () -> readinessFile, () -> daemonLogFile);
+    CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+    controller.addLogListener(logs::add);
+
+    writeWrapperConf(tempDir);
+    writeLegacyPortWithMalformedReadinessCryptadScript(tempDir, readinessFile, daemonLogFile);
+
+    controller.start();
+
+    awaitState(controller, AppState::isRunning);
+    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+    awaitCondition(() -> Files.exists(readinessFile), "malformed structured readiness file");
+    AppState stateWithPort =
+        awaitState(controller, s -> s.knownPort() != null && s.knownPort() == TEST_PORT);
+    assertEquals(TEST_PORT, stateWithPort.knownPort());
+    awaitCondition(
+        () -> isBrowserAutoOpened(controller),
+        "legacy fallback browser auto-open after malformed readiness");
+    assertTrue(isBrowserAutoOpened(controller));
+    assertFalse(LauncherReadinessFiles.read(readinessFile).isPresent());
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void start_whenCompletionInfoLogUnavailable_stdoutCompletionFallsBackToLegacyPort()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherController controller =
+        new LauncherController(tempDir, () -> readinessFile, () -> null);
+    CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+    controller.addLogListener(logs::add);
+
+    writeWrapperConf(tempDir);
+    writeLegacyPortWithStdoutCompletionCryptadScript(tempDir);
+
+    controller.start();
+
+    awaitState(controller, AppState::isRunning);
+    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+    AppState stateWithPort =
+        awaitState(controller, s -> s.knownPort() != null && s.knownPort() == TEST_PORT);
+    assertEquals(TEST_PORT, stateWithPort.knownPort());
+    awaitCondition(
+        () -> isBrowserAutoOpened(controller),
+        "legacy fallback browser auto-open after stdout completion");
+    assertTrue(isBrowserAutoOpened(controller));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void start_whenDaemonLogDiscoveryUnavailable_wrapperLogCompletionFallsBackToLegacyPort()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    Path wrongDaemonLogFile = tempDir.resolve("missing-logs").resolve("crypta-latest.log");
+    Path wrapperLogFile = tempDir.resolve("logs").resolve("wrapper.log");
+    LauncherController controller =
+        new LauncherController(tempDir, () -> readinessFile, () -> wrongDaemonLogFile);
+    CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+    controller.addLogListener(logs::add);
+
+    writeWrapperConf(tempDir);
+    writeLegacyPortWithWrapperLogCompletionCryptadScript(tempDir, wrapperLogFile);
+
+    controller.start();
+
+    awaitState(controller, AppState::isRunning);
+    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+    AppState stateWithPort =
+        awaitState(controller, s -> s.knownPort() != null && s.knownPort() == TEST_PORT);
+    assertEquals(TEST_PORT, stateWithPort.knownPort());
+    awaitCondition(
+        () -> isBrowserAutoOpened(controller),
+        "legacy fallback browser auto-open after wrapper-log completion");
+    assertTrue(isBrowserAutoOpened(controller));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void start_whenStructuredReadinessPending_doesNotExposeLegacyPortOrAutoOpen() throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    Path heartbeat = tempDir.resolve("heartbeat.log");
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
+    controller.addLogListener(logs::add);
+
+    writeWrapperConf(tempDir);
+    writeLongRunningCryptadScript(tempDir, heartbeat);
+
+    controller.start();
+
+    awaitState(controller, AppState::isRunning);
+    awaitLog(logs, l -> l.contains("Starting FProxy on"));
+    awaitHeartbeat(heartbeat);
+    sleepMillis(300L);
+    assertNull(controller.getState().knownPort());
+    assertFalse(isBrowserAutoOpened(controller));
+
+    controller.stop();
+
+    AppState stopped = awaitState(controller, s -> !s.isRunning() && !s.isStopping());
+    assertFalse(stopped.isRunning());
+    assertNull(stopped.knownPort());
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void isCurrentLaunchReadinessFile_whenMtimeEqualsLaunchStartAndNoLegacyPortEvidence_returnsFalse()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
+    long launchStartedAtMillis = 17_000L;
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(launchStartedAtMillis));
+
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    setLaunchStartedAtMillis(controller, launchStartedAtMillis);
+
+    assertFalse(controller.isCurrentLaunchReadinessFile(readinessFile));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void isCurrentLaunchReadinessFile_whenMtimeEqualsLaunchStartAndLegacyPortMatches_returnsTrue()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    setLaunchStartedAtMillis(controller, 17_000L);
+    setPendingLegacyPort(controller);
+    setTrackedReadinessTarget(controller, readinessFile);
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(17_000L));
+
+    assertTrue(controller.isCurrentLaunchReadinessFile(readinessFile));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void isCurrentLaunchReadinessFile_whenFileChangesAfterTrackingButMtimeRoundsDown_returnsTrue()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    setLaunchStartedAtMillis(controller, 17_000L);
+    setTrackedReadinessTarget(controller, readinessFile);
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(16_000L));
+
+    assertTrue(controller.isCurrentLaunchReadinessFile(readinessFile));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void canConsumeCurrentLaunchReadiness_whenFileIsReplacedAfterRead_usesReadGeneration()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, 4321, "/"));
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(16_000L));
+
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    setLaunchStartedAtMillis(controller, 17_000L);
+    setTrackedReadinessTarget(controller, readinessFile);
+    var staleSnapshot = LauncherReadinessFiles.readSnapshot(readinessFile).orElseThrow();
+
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(18_000L));
+
+    assertFalse(invokeCanConsumeCurrentLaunchReadiness(controller, staleSnapshot));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void isCurrentLaunchReadinessFile_whenTrackedAfterCurrentFileWriteAndMtimeRoundsDown_returnsTrue()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(16_000L));
+
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    setLaunchStartedAtMillis(controller, 17_000L);
+    setPendingLegacyPort(controller);
+    markStartupCompletionObserved(controller);
+    setTrackedReadinessTarget(controller, readinessFile, true);
+
+    assertTrue(controller.isCurrentLaunchReadinessFile(readinessFile));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void isCurrentLaunchReadinessFile_whenFileIsCreatedAfterTrackingButMtimeRoundsDown_returnsTrue()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    Files.deleteIfExists(readinessFile);
+
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    setLaunchStartedAtMillis(controller, 17_001L);
+    setTrackedReadinessTarget(controller, readinessFile);
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(17_000L));
+
+    assertTrue(controller.isCurrentLaunchReadinessFile(readinessFile));
+
+    controller.shutdownAndWait();
+  }
+
+  @Test
+  void isCurrentLaunchReadinessFile_whenTrackedFilePreexistsAndLegacyPortMatches_returnsFalse()
+      throws Exception {
+    Path readinessFile = createReadinessFilePath(tempDir, "runtime");
+    LauncherReadinessFiles.write(
+        readinessFile,
+        new LauncherReadinessInfo(
+            LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
+    Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(17_000L));
+
+    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    setLaunchStartedAtMillis(controller, 17_000L);
+    setPendingLegacyPort(controller);
+    setTrackedReadinessTarget(controller, readinessFile);
+
+    assertFalse(controller.isCurrentLaunchReadinessFile(readinessFile));
 
     controller.shutdownAndWait();
   }
@@ -180,11 +542,27 @@ class LauncherControllerTest {
   }
 
   private static void sleepShort() {
-    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+    sleepMillis(10L);
+  }
+
+  private static void sleepMillis(long millis) {
+    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(millis));
     if (Thread.currentThread().isInterrupted()) {
       Thread.currentThread().interrupt();
       throw new AssertionError("Interrupted while waiting");
     }
+  }
+
+  private static void awaitCondition(ThrowingBooleanSupplier condition, String description)
+      throws Exception {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      sleepShort();
+    }
+    throw new AssertionError("Timed out waiting for " + description);
   }
 
   private static void setPrivateStateField(Object target, Object value) throws Exception {
@@ -198,6 +576,77 @@ class LauncherControllerTest {
       return;
     }
     field.set(target, value);
+  }
+
+  private static boolean isBrowserAutoOpened(LauncherController controller) throws Exception {
+    Field field = controller.getClass().getDeclaredField("autoOpenedBrowser");
+    field.setAccessible(true);
+    return ((java.util.concurrent.atomic.AtomicBoolean) field.get(controller)).get();
+  }
+
+  private static void setLaunchStartedAtMillis(LauncherController controller, long value)
+      throws Exception {
+    Field field = LauncherController.class.getDeclaredField("launchStartedAtMillis");
+    field.setAccessible(true);
+    ((java.util.concurrent.atomic.AtomicLong) field.get(controller)).set(value);
+  }
+
+  private static void setPendingLegacyPort(LauncherController controller) throws Exception {
+    Field field = LauncherController.class.getDeclaredField("pendingLegacyPort");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    AtomicReference<Integer> ref = (AtomicReference<Integer>) field.get(controller);
+    ref.set(TEST_PORT);
+  }
+
+  private static void markStartupCompletionObserved(LauncherController controller)
+      throws Exception {
+    Field field = LauncherController.class.getDeclaredField("startupCompletionObserved");
+    field.setAccessible(true);
+    ((java.util.concurrent.atomic.AtomicBoolean) field.get(controller)).set(true);
+  }
+
+  private static void setTrackedReadinessTarget(LauncherController controller, Path readinessFile)
+      throws Exception {
+    setTrackedReadinessTarget(controller, readinessFile, false);
+  }
+
+  private static void setTrackedReadinessTarget(
+      LauncherController controller, Path readinessFile, boolean trackedAfterLaunch)
+      throws Exception {
+    var captureMethod =
+        LauncherController.class.getDeclaredMethod(
+            "captureReadinessTarget", Path.class, boolean.class);
+    captureMethod.setAccessible(true);
+    Object target = captureMethod.invoke(controller, readinessFile, trackedAfterLaunch);
+    Field field = LauncherController.class.getDeclaredField("readinessTarget");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    AtomicReference<Object> ref = (AtomicReference<Object>) field.get(controller);
+    ref.set(target);
+  }
+
+  private static boolean invokeCanConsumeCurrentLaunchReadiness(
+      LauncherController controller, LauncherReadinessFiles.ReadinessSnapshot readiness)
+      throws Exception {
+    Field field = LauncherController.class.getDeclaredField("readinessTarget");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    AtomicReference<Object> ref = (AtomicReference<Object>) field.get(controller);
+    Object trackedTarget = ref.get();
+    Method method = findCanConsumeCurrentLaunchReadinessMethod();
+    method.setAccessible(true);
+    return (boolean) method.invoke(controller, trackedTarget, readiness);
+  }
+
+  private static Method findCanConsumeCurrentLaunchReadinessMethod() {
+    for (Method method : LauncherController.class.getDeclaredMethods()) {
+      if (method.getName().equals("canConsumeCurrentLaunchReadiness")
+          && method.getParameterCount() == 2) {
+        return method;
+      }
+    }
+    throw new AssertionError("Missing canConsumeCurrentLaunchReadiness helper");
   }
 
   private static void awaitHeartbeat(Path heartbeat) throws Exception {
@@ -230,7 +679,77 @@ class LauncherControllerTest {
     throw new AssertionError("Heartbeat file kept changing; process still appears alive");
   }
 
-  private static void writeCryptadScript(Path baseDir) throws Exception {
+  private static Path createReadinessFilePath(Path baseDir, String runDirName) throws Exception {
+    Path runDir = baseDir.resolve(runDirName);
+    Files.createDirectories(runDir);
+    return LauncherReadinessFiles.resolve(runDir);
+  }
+
+  private static Path createDaemonLogFilePath(Path baseDir) throws Exception {
+    Path logsDir = baseDir.resolve("logs");
+    Files.createDirectories(logsDir);
+    Path daemonLogFile = logsDir.resolve("crypta-latest.log");
+    Files.writeString(daemonLogFile, "", StandardCharsets.UTF_8);
+    return daemonLogFile;
+  }
+
+  private static void writeStructuredReadinessCryptadScript(
+      Path baseDir, Path readinessFile, Path daemonLogFile, Path legacyDetectedMarker)
+      throws Exception {
+    Path binDir = baseDir.resolve("bin");
+    Files.createDirectories(binDir);
+    boolean isWindows = new AppEnv().isWindows();
+    Path script = isWindows ? binDir.resolve("cryptad.bat") : binDir.resolve("cryptad");
+    String runDir = readinessFile.getParent().toAbsolutePath().toString();
+    Files.createDirectories(readinessFile.getParent());
+    String readinessPath = readinessFile.toAbsolutePath().toString();
+    String daemonLogPath = daemonLogFile.toAbsolutePath().toString();
+    String markerPath = legacyDetectedMarker.toAbsolutePath().toString();
+
+    String content;
+    if (isWindows) {
+      content =
+          String.join(
+              "\n",
+              "@echo off",
+              "echo Starting FProxy on 127.0.0.1:" + TEST_PORT,
+              "echo legacy>\"" + markerPath + "\"",
+              "echo   Run dir:      " + runDir + ">>\"" + daemonLogPath + "\"",
+              "ping -n 2 127.0.0.1 > nul",
+              "(",
+              "echo version=" + LauncherReadinessInfo.VERSION_1,
+              "echo state=" + LauncherReadinessInfo.READY_STATE,
+              "echo ui.port=" + TEST_PORT,
+              "echo ui.root=/",
+              ") > \"" + readinessPath + "\"",
+              "echo READY",
+              "ping -n 2 127.0.0.1 > nul");
+    } else {
+      content =
+          String.join(
+              "\n",
+              "#!/usr/bin/env sh",
+              "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
+              "printf 'legacy\\n' > \"" + markerPath + "\"",
+              "printf '  Run dir:      " + runDir + "\\n' >> \"" + daemonLogPath + "\"",
+              "sleep 0.1",
+              "cat <<'EOF' > \"" + readinessPath + "\"",
+              "version=" + LauncherReadinessInfo.VERSION_1,
+              "state=" + LauncherReadinessInfo.READY_STATE,
+              "ui.port=" + TEST_PORT,
+              "ui.root=/",
+              "EOF",
+              "echo \"READY\"",
+              "sleep 0.2");
+    }
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+
+    if (!isWindows && !script.toFile().setExecutable(true)) {
+      throw new AssertionError("Failed to mark script executable: " + script);
+    }
+  }
+
+  private static void writeLegacyPortCryptadScript(Path baseDir) throws Exception {
     Path binDir = baseDir.resolve("bin");
     Files.createDirectories(binDir);
     boolean isWindows = new AppEnv().isWindows();
@@ -252,6 +771,184 @@ class LauncherControllerTest {
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "echo \"READY\"",
+              "sleep 0.2");
+    }
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+
+    if (!isWindows && !script.toFile().setExecutable(true)) {
+      throw new AssertionError("Failed to mark script executable: " + script);
+    }
+  }
+
+  private static void writeLegacyPortWithoutReadinessCryptadScript(Path baseDir, Path daemonLogFile)
+      throws Exception {
+    Path binDir = baseDir.resolve("bin");
+    Files.createDirectories(binDir);
+    boolean isWindows = new AppEnv().isWindows();
+    Path script = isWindows ? binDir.resolve("cryptad.bat") : binDir.resolve("cryptad");
+    String daemonLogPath = daemonLogFile.toAbsolutePath().toString();
+
+    String content;
+    if (isWindows) {
+      content =
+          String.join(
+              "\n",
+              "@echo off",
+              "echo Starting FProxy on 127.0.0.1:" + TEST_PORT,
+              "echo Node initialization completed>>\"" + daemonLogPath + "\"",
+              "ping -n 3 127.0.0.1 > nul");
+    } else {
+      content =
+          String.join(
+              "\n",
+              "#!/usr/bin/env sh",
+              "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
+              "printf 'Node initialization completed\\n' >> \"" + daemonLogPath + "\"",
+              "sleep 0.3");
+    }
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+
+    if (!isWindows && !script.toFile().setExecutable(true)) {
+      throw new AssertionError("Failed to mark script executable: " + script);
+    }
+  }
+
+  private static void writeLegacyPortWithMalformedReadinessCryptadScript(
+      Path baseDir, Path readinessFile, Path daemonLogFile) throws Exception {
+    Path binDir = baseDir.resolve("bin");
+    Files.createDirectories(binDir);
+    boolean isWindows = new AppEnv().isWindows();
+    Path script = isWindows ? binDir.resolve("cryptad.bat") : binDir.resolve("cryptad");
+    String readinessPath = readinessFile.toAbsolutePath().toString();
+    String daemonLogPath = daemonLogFile.toAbsolutePath().toString();
+
+    String content;
+    if (isWindows) {
+      content =
+          String.join(
+              "\n",
+              "@echo off",
+              "echo Starting FProxy on 127.0.0.1:" + TEST_PORT,
+              "(",
+              "echo version=2",
+              "echo state=ready",
+              "echo ui.port=9999",
+              ") > \"" + readinessPath + "\"",
+              "echo Node initialization completed>>\"" + daemonLogPath + "\"",
+              "ping -n 3 127.0.0.1 > nul");
+    } else {
+      content =
+          String.join(
+              "\n",
+              "#!/usr/bin/env sh",
+              "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
+              "cat <<'EOF' > \"" + readinessPath + "\"",
+              "version=2",
+              "state=ready",
+              "ui.port=9999",
+              "EOF",
+              "printf 'Node initialization completed\\n' >> \"" + daemonLogPath + "\"",
+              "sleep 0.3");
+    }
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+
+    if (!isWindows && !script.toFile().setExecutable(true)) {
+      throw new AssertionError("Failed to mark script executable: " + script);
+    }
+  }
+
+  private static void writeLegacyPortWithWrapperLogCompletionCryptadScript(
+      Path baseDir, Path wrapperLogFile) throws Exception {
+    Path binDir = baseDir.resolve("bin");
+    Files.createDirectories(binDir);
+    boolean isWindows = new AppEnv().isWindows();
+    Path script = isWindows ? binDir.resolve("cryptad.bat") : binDir.resolve("cryptad");
+    String wrapperLogPath = wrapperLogFile.toAbsolutePath().toString();
+
+    String content;
+    if (isWindows) {
+      content =
+          String.join(
+              "\n",
+              "@echo off",
+              "echo Starting FProxy on 127.0.0.1:" + TEST_PORT,
+              "ping -n 3 127.0.0.1 > nul",
+              "echo Node initialization completed>>\"" + wrapperLogPath + "\"",
+              "ping -n 2 127.0.0.1 > nul");
+    } else {
+      content =
+          String.join(
+              "\n",
+              "#!/usr/bin/env sh",
+              "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
+              "sleep 0.2",
+              "printf 'Node initialization completed\\n' >> \"" + wrapperLogPath + "\"",
+              "sleep 0.2");
+    }
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+
+    if (!isWindows && !script.toFile().setExecutable(true)) {
+      throw new AssertionError("Failed to mark script executable: " + script);
+    }
+  }
+
+  private static void writeLegacyPortWithStdoutCompletionCryptadScript(Path baseDir)
+      throws Exception {
+    Path binDir = baseDir.resolve("bin");
+    Files.createDirectories(binDir);
+    boolean isWindows = new AppEnv().isWindows();
+    Path script = isWindows ? binDir.resolve("cryptad.bat") : binDir.resolve("cryptad");
+
+    String content;
+    if (isWindows) {
+      content =
+          String.join(
+              "\n",
+              "@echo off",
+              "echo Starting FProxy on 127.0.0.1:" + TEST_PORT,
+              "echo Node initialization completed",
+              "ping -n 3 127.0.0.1 > nul");
+    } else {
+      content =
+          String.join(
+              "\n",
+              "#!/usr/bin/env sh",
+              "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
+              "echo \"Node initialization completed\"",
+              "sleep 0.3");
+    }
+    Files.writeString(script, content, StandardCharsets.UTF_8);
+
+    if (!isWindows && !script.toFile().setExecutable(true)) {
+      throw new AssertionError("Failed to mark script executable: " + script);
+    }
+  }
+
+  private static void writeNoReadinessCryptadScript(Path baseDir, Path runDir, Path daemonLogFile)
+      throws Exception {
+    Path binDir = baseDir.resolve("bin");
+    Files.createDirectories(binDir);
+    boolean isWindows = new AppEnv().isWindows();
+    Path script = isWindows ? binDir.resolve("cryptad.bat") : binDir.resolve("cryptad");
+    String resolvedRunDir = runDir.toAbsolutePath().toString();
+    String daemonLogPath = daemonLogFile.toAbsolutePath().toString();
+
+    String content;
+    if (isWindows) {
+      content =
+          String.join(
+              "\n",
+              "@echo off",
+              "echo   Run dir:      " + resolvedRunDir + ">>\"" + daemonLogPath + "\"",
+              "echo BOOTING",
+              "ping -n 2 127.0.0.1 > nul");
+    } else {
+      content =
+          String.join(
+              "\n",
+              "#!/usr/bin/env sh",
+              "printf '  Run dir:      " + resolvedRunDir + "\\n' >> \"" + daemonLogPath + "\"",
+              "echo \"BOOTING\"",
               "sleep 0.2");
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
@@ -312,5 +1009,10 @@ class LauncherControllerTest {
         StandardCharsets.UTF_8);
     Files.writeString(logsDir.resolve("wrapper.log"), "", StandardCharsets.UTF_8);
     return conf;
+  }
+
+  @FunctionalInterface
+  private interface ThrowingBooleanSupplier {
+    boolean getAsBoolean() throws Exception;
   }
 }

--- a/src/test/java/network/crypta/launcher/LauncherUtilsTest.java
+++ b/src/test/java/network/crypta/launcher/LauncherUtilsTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import network.crypta.fs.AppEnv;
+import network.crypta.fs.Resolved;
+import network.crypta.fs.readiness.LauncherReadinessFiles;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -25,7 +27,10 @@ import static network.crypta.launcher.LauncherUtils.findOnPath;
 import static network.crypta.launcher.LauncherUtils.guessWrapperConfPathForCryptadScript;
 import static network.crypta.launcher.LauncherUtils.loadAppIconImage;
 import static network.crypta.launcher.LauncherUtils.parseFProxyPortFromLine;
+import static network.crypta.launcher.LauncherUtils.parseResolvedRunDirFromLine;
 import static network.crypta.launcher.LauncherUtils.parseWrapperProperties;
+import static network.crypta.launcher.LauncherUtils.resolveConfiguredLauncherDaemonLogFile;
+import static network.crypta.launcher.LauncherUtils.resolveConfiguredLauncherReadinessFile;
 import static network.crypta.launcher.LauncherUtils.resolveCryptadPath;
 import static network.crypta.launcher.LauncherUtils.resolveCryptadPathWithEnv;
 import static network.crypta.launcher.LauncherUtils.scanWrapperConfPath;
@@ -70,6 +75,62 @@ class LauncherUtilsTest {
   void parseFProxyPortFromLine_whenNoMatch_expectNull(String line) {
     Integer actual = parseFProxyPortFromLine(line);
     assertNull(actual);
+  }
+
+  @Test
+  void parseResolvedRunDirFromLine_whenPresent_expectParsedPath() {
+    Path actual = parseResolvedRunDirFromLine("INFO Run dir:      /var/lib/cryptad/custom-run");
+    assertEquals(Path.of("/var/lib/cryptad/custom-run"), actual);
+  }
+
+  @Test
+  void parseResolvedRunDirFromLine_whenMissing_expectNull() {
+    assertNull(parseResolvedRunDirFromLine("INFO Data dir:     /var/lib/cryptad/data"));
+  }
+
+  @Test
+  void resolveConfiguredLauncherReadinessFile_whenConfigOverridesRunDir_expectConfiguredPath(
+      @TempDir Path tempDir) throws Exception {
+    Path configDir = Files.createDirectories(tempDir.resolve("config"));
+    Path dataDir = Files.createDirectories(tempDir.resolve("data"));
+    Path cacheDir = Files.createDirectories(tempDir.resolve("cache"));
+    Path defaultRunDir = Files.createDirectories(tempDir.resolve("run-default"));
+    Path logsDir = Files.createDirectories(tempDir.resolve("logs"));
+    Resolved resolvedDirs = new Resolved(configDir, dataDir, cacheDir, defaultRunDir, logsDir);
+    Path configFile = configDir.resolve("cryptad.ini");
+    Files.writeString(
+        configFile,
+        """
+        logger.priority=NORMAL
+        node.install.runDir=${dataDir}/custom-run
+        End
+        """);
+
+    Path actual = resolveConfiguredLauncherReadinessFile(configFile, resolvedDirs);
+
+    assertEquals(LauncherReadinessFiles.resolve(dataDir.resolve("custom-run")), actual);
+  }
+
+  @Test
+  void resolveConfiguredLauncherDaemonLogFile_whenConfigOverridesLogDir_expectConfiguredPath(
+      @TempDir Path tempDir) throws Exception {
+    Path configDir = Files.createDirectories(tempDir.resolve("config"));
+    Path dataDir = Files.createDirectories(tempDir.resolve("data"));
+    Path cacheDir = Files.createDirectories(tempDir.resolve("cache"));
+    Path defaultRunDir = Files.createDirectories(tempDir.resolve("run-default"));
+    Path logsDir = Files.createDirectories(tempDir.resolve("logs"));
+    Resolved resolvedDirs = new Resolved(configDir, dataDir, cacheDir, defaultRunDir, logsDir);
+    Path configFile = configDir.resolve("cryptad.ini");
+    Files.writeString(
+        configFile,
+        """
+        logger.dirname=${dataDir}/custom-logs
+        End
+        """);
+
+    Path actual = resolveConfiguredLauncherDaemonLogFile(configFile, resolvedDirs);
+
+    assertEquals(dataDir.resolve("custom-logs").resolve("crypta-latest.log"), actual);
   }
 
   @Test

--- a/src/test/java/network/crypta/node/NodeTest.java
+++ b/src/test/java/network/crypta/node/NodeTest.java
@@ -1,17 +1,26 @@
 package network.crypta.node;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import network.crypta.fs.readiness.LauncherReadinessFiles;
+import network.crypta.fs.readiness.LauncherReadinessInfo;
 import network.crypta.io.comm.TrafficClass;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.http.HttpShellContainer;
+import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.objenesis.ObjenesisStd;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +40,16 @@ class NodeTest {
       f.set(target, value);
     } catch (ReflectiveOperationException e) {
       throw new LinkageError("Failed setting field '" + fieldName + "'", e);
+    }
+  }
+
+  private static void invokeFinishToadletsIfEnabled(Node node) {
+    try {
+      Method method = node.getClass().getDeclaredMethod("finishToadletsIfEnabled");
+      method.setAccessible(true);
+      method.invoke(node);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed invoking method 'finishToadletsIfEnabled'", e);
     }
   }
 
@@ -126,5 +145,64 @@ class NodeTest {
     Node node = newNodeInstance();
     // nodeStarter is null by default; short-circuits WrapperManager static call
     assertFalse(node.isUsingWrapper());
+  }
+
+  @Test
+  @DisplayName(
+      "finishToadletsIfEnabled_whenShellEnabled_publishesLauncherReadinessAfterStartupHooks")
+  void finishToadletsIfEnabled_whenShellEnabled_publishesLauncherReadinessAfterStartupHooks(
+      @TempDir Path tempDir) throws Exception {
+    Node node = newNodeInstance();
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    HttpShellContainer toadlets = mock(HttpShellContainer.class);
+    ProgramDirectory runDir = new ProgramDirectory();
+    runDir.move(tempDir.toString());
+    when(services.toadlets()).thenReturn(toadlets);
+    when(toadlets.isEnabled()).thenReturn(true);
+    when(toadlets.listenPort()).thenReturn(8888);
+
+    setField(node, "services", services);
+    setField(node, "runDir", runDir);
+
+    invokeFinishToadletsIfEnabled(node);
+
+    var order = inOrder(toadlets);
+    order.verify(toadlets).isEnabled();
+    order.verify(toadlets).finishStart();
+    order.verify(toadlets).createFproxy();
+    order.verify(toadlets).removeStartupToadlet();
+    order.verify(toadlets).listenPort();
+
+    Path readinessFile = LauncherReadinessFiles.resolve(tempDir);
+    LauncherReadinessInfo actual = LauncherReadinessFiles.read(readinessFile).orElseThrow();
+    assertEquals(LauncherReadinessInfo.ready(8888), actual);
+    assertTrue(actual.isReady());
+  }
+
+  @Test
+  @DisplayName("finishToadletsIfEnabled_whenReadinessPortInvalid_keepsStartupNonFatal")
+  void finishToadletsIfEnabled_whenReadinessPortInvalid_keepsStartupNonFatal(@TempDir Path tempDir)
+      throws Exception {
+    Node node = newNodeInstance();
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    HttpShellContainer toadlets = mock(HttpShellContainer.class);
+    ProgramDirectory runDir = new ProgramDirectory();
+    runDir.move(tempDir.toString());
+    when(services.toadlets()).thenReturn(toadlets);
+    when(toadlets.isEnabled()).thenReturn(true);
+    when(toadlets.listenPort()).thenReturn(0);
+
+    setField(node, "services", services);
+    setField(node, "runDir", runDir);
+
+    invokeFinishToadletsIfEnabled(node);
+
+    var order = inOrder(toadlets);
+    order.verify(toadlets).isEnabled();
+    order.verify(toadlets).finishStart();
+    order.verify(toadlets).createFproxy();
+    order.verify(toadlets).removeStartupToadlet();
+    order.verify(toadlets).listenPort();
+    assertTrue(LauncherReadinessFiles.read(LauncherReadinessFiles.resolve(tempDir)).isEmpty());
   }
 }

--- a/src/test/java/network/crypta/runtime/bootstrap/NodeStarterTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/NodeStarterTest.java
@@ -1,11 +1,16 @@
 package network.crypta.runtime.bootstrap;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.config.PersistentConfig;
@@ -429,6 +434,70 @@ class NodeStarterTest {
       ns.controlEvent(WrapperManager.WRAPPER_CTRL_C_EVENT);
       wm.verify(() -> WrapperManager.stop(0), times(1));
     }
+  }
+
+  @Test
+  void loadConfig_whenConfigOverridesRunDir_emitsFinalLauncherRunDirCompatibilityLine(
+      @TempDir Path tempDir) throws Exception {
+    Path configDir = tempDir.resolve("config");
+    Path dataDir = tempDir.resolve("data");
+    Path cacheDir = tempDir.resolve("cache");
+    Path cliRunDir = tempDir.resolve("run-default");
+    Path logsDir = tempDir.resolve("logs");
+    Path configFile = configDir.resolve("cryptad.ini");
+    Path configuredRunDir = dataDir.resolve("runtime-from-config");
+    Files.createDirectories(configDir);
+    Files.writeString(
+        configFile,
+        "node.install.runDir=${dataDir}/runtime-from-config\nEnd\n",
+        StandardCharsets.UTF_8);
+    var method =
+        NodeStarter.class.getDeclaredMethod(
+            "loadConfig", File.class, Map.class, boolean.class, network.crypta.fs.AppEnv.class);
+    method.setAccessible(true);
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+
+    try (PrintStream capture = new PrintStream(stdout, true, StandardCharsets.UTF_8)) {
+      System.setOut(capture);
+      method.invoke(
+          null,
+          configFile.toFile(),
+          Map.of(
+              "configDir", configDir.toString(),
+              "dataDir", dataDir.toString(),
+              "cacheDir", cacheDir.toString(),
+              "runDir", cliRunDir.toString(),
+              "logsDir", logsDir.toString()),
+          false,
+          new network.crypta.fs.AppEnv(Map.of()));
+    } finally {
+      System.setOut(originalOut);
+    }
+
+    String output = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(output.contains("Run dir:      " + configuredRunDir));
+    assertFalse(output.contains("Run dir:      " + cliRunDir));
+  }
+
+  @Test
+  void emitLauncherStartupCompletionCompatibilityLine_whenCalled_printsCompletionMarker()
+      throws Exception {
+    var method =
+        NodeStarter.class.getDeclaredMethod("emitLauncherStartupCompletionCompatibilityLine");
+    method.setAccessible(true);
+    ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+
+    try (PrintStream capture = new PrintStream(stdout, true, StandardCharsets.UTF_8)) {
+      System.setOut(capture);
+      method.invoke(null);
+    } finally {
+      System.setOut(originalOut);
+    }
+
+    String output = stdout.toString(StandardCharsets.UTF_8);
+    assertTrue(output.contains("Node initialization completed"));
   }
 
   // --- helpers ---


### PR DESCRIPTION
## Summary
Add a structured, versioned launcher-readiness handshake under the resolved runtime directory.

- add shared readiness-file helpers in `:foundation-fs`
- publish readiness from runtime only after the legacy HTTP shell is ready for normal use
- make the desktop launcher prefer the readiness file, keep narrow legacy fallback behavior, and handle configured run-directory and daemon-log discovery
- update focused tests and README wording for the new readiness contract
- keep supporting warning-cleanup changes needed to leave the touched launcher/test code clean

## How to test
- `./gradlew compileTestJava`
- `./gradlew test --tests 'network.crypta.launcher.LauncherControllerTest'`
- `./gradlew test`

## Notes
- Base branch: `develop`
- Branch: `feature/launcher-readiness-protocol`