### PR TITLE
feat(platform-apphost): Add local AppHost core

### DIFF
--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -85,8 +85,9 @@ Use this skill when you need to:
   matching `network/crypta/clients/http/**` main resources. On the root test/runtime classpath,
   those resources often resolve from the leaf JAR, so tests must treat them as classpath resources
   rather than assume a plain filesystem `Path`.
-- All tests remain in the root project for now and compile against the leaf subprojects through
-  the root build.
+- Most tests still live in the root project and compile against the leaf subprojects through the
+  root build, but `:platform-apphost` now keeps its focused AppHost tests under
+  `platform-apphost/src/test/java` and they run via `:platform-apphost:test`.
 - File-system-based l10n tests still run from the root project and use
   `foundation-config/src/main/resources/network/crypta/l10n/` as the main resource path.
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ Cryptad now uses a partial multi-project Gradle build.
   bridge in `:adapter-http-legacy-admin`. The initial read-only surface covers node info, peers,
   config export, connectivity, and security-level snapshots; `GET /api/v1/config` defaults to the
   effective `CURRENT` section when `sections=` is omitted.
+- `:platform-apphost` owns the transport-neutral out-of-process AppHost v1 core under
+  `network.crypta.platform.apphost`. It defines the local manifest, installed-app layout, process
+  lifecycle, and per-start launch-token plumbing for local apps while staying separate from future
+  Web Shell, application-UI, and app update-channel work.
 - `:runtime-node` owns the remaining daemon runtime body across the still-cyclic
   `network.crypta.client` async/request engine and high-level client APIs, large slices of
   `network.crypta.node` after the phase-1 routing/helper move, the retained node-coupled
@@ -574,6 +578,8 @@ Root build also includes:
   and other infrastructure code.
 - `:platform-api`: transport-neutral read-only Platform API v1 built on top of `:runtime-spi`,
   currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
+- `:platform-apphost`: transport-neutral out-of-process AppHost v1 core for installed local apps.
+  Future Web Shell, app UI, and update-channel work remain separate and later.
 - `:runtime-node`: extracted daemon runtime body across the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine and transport-heavy
   `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled
@@ -637,7 +643,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
     `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
     `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
     `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
-    `:runtime-node`, `:adapter-fcp`, `:adapter-http-legacy-admin`, `:thirdparty-onion`,
+    `:platform-apphost`, `:runtime-node`, `:adapter-fcp`, `:adapter-http-legacy-admin`,
+    `:thirdparty-onion`,
     `:thirdparty-legacy`, and `:launcher-desktop`.
 - Core network (`network.crypta.node`): `Node`, `PeerNode`, `PeerManager`, `PacketSender`, `RequestStarter`, `RequestScheduler`, `NodeUpdateManager`.
 - Storage (`network.crypta.store`): `FreenetStore`, `CHKStore`, `SSKStore`, `SlashdotStore`.
@@ -751,7 +758,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.io*` helpers; `:kernel-routing` provides the compile-neutral phase-1
   `network.crypta.node` helper slice across selected request/routing value, exception, callback,
   and request-item types; `:runtime-spi` provides `network.crypta.runtime.spi`;
-  `:platform-api` provides the transport-neutral read-only Platform API v1; `:runtime-node`
+  `:platform-api` provides the transport-neutral read-only Platform API v1; `:platform-apphost`
+  provides the transport-neutral out-of-process AppHost v1 core for installed local apps; `:runtime-node`
   provides the extracted daemon runtime body across the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine
   `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -91,6 +91,18 @@ val kotlinTestReportDir: Provider<Directory> =
 val testExecutionReportFile: Provider<RegularFile> =
   layout.buildDirectory.file("sonar-test-results/test-execution.xml")
 val testResultsDir: Provider<Directory> = layout.buildDirectory.dir("test-results/test")
+val additionalSonarTestSourceDirs: Provider<List<File>> =
+  providers.provider {
+    (project.findProperty("cryptad.additionalSonarTestSourceDirs") as? Iterable<*>)?.mapNotNull {
+      it as? File
+    } ?: emptyList()
+  }
+val additionalSonarTestResultDirs: Provider<List<File>> =
+  providers.provider {
+    (project.findProperty("cryptad.additionalSonarTestResultDirs") as? Iterable<*>)?.mapNotNull {
+      it as? File
+    } ?: emptyList()
+  }
 
 tasks.register("prepareKotlinTestReports") {
   group = "verification"
@@ -147,9 +159,11 @@ tasks.register("prepareTestExecutionReport") {
   description = "Convert JUnit XML reports into Sonar's generic test execution format."
   dependsOn(tasks.withType<Test>())
   inputs.dir(testResultsDir)
+  inputs.files(additionalSonarTestSourceDirs)
+  inputs.files(additionalSonarTestResultDirs)
   outputs.file(testExecutionReportFile)
 
-  val projectPath = project.projectDir.toPath()
+  val projectPath = rootProject.projectDir.toPath()
 
   doLast {
     data class TestCase(
@@ -159,108 +173,110 @@ tasks.register("prepareTestExecutionReport") {
       val message: String?,
     )
 
-    val reportDir = testResultsDir.get().asFile
+    val reportDirs = listOf(testResultsDir.get().asFile) + additionalSonarTestResultDirs.get()
     val outputFile = testExecutionReportFile.get().asFile
     outputFile.parentFile.mkdirs()
 
     val testSourceSet = sourceSets.named("test").get()
-    val testSourceDirs = testSourceSet.allSource.srcDirs
+    val testSourceDirs = testSourceSet.allSource.srcDirs + additionalSonarTestSourceDirs.get()
 
     val byFile = linkedMapOf<String, MutableList<TestCase>>()
     val xmlInputFactory = XMLInputFactory.newInstance()
 
-    reportDir
-      .listFiles { _, name ->
-        (name.startsWith("TEST-") || name.startsWith("TESTS-")) && name.endsWith(".xml")
-      }
-      ?.forEach { reportFile ->
-        val reader = xmlInputFactory.createXMLStreamReader(reportFile.inputStream())
-        try {
-          var suiteName: String? = null
-          while (reader.hasNext()) {
-            when (reader.next()) {
-              XMLStreamConstants.START_ELEMENT -> {
-                when (reader.localName) {
-                  "testsuite" -> {
-                    suiteName = reader.getAttributeValue(null, "name")
-                  }
+    reportDirs.forEach { reportDir ->
+      reportDir
+        .listFiles { _, name ->
+          (name.startsWith("TEST-") || name.startsWith("TESTS-")) && name.endsWith(".xml")
+        }
+        ?.forEach { reportFile ->
+          val reader = xmlInputFactory.createXMLStreamReader(reportFile.inputStream())
+          try {
+            var suiteName: String? = null
+            while (reader.hasNext()) {
+              when (reader.next()) {
+                XMLStreamConstants.START_ELEMENT -> {
+                  when (reader.localName) {
+                    "testsuite" -> {
+                      suiteName = reader.getAttributeValue(null, "name")
+                    }
 
-                  "testcase" -> {
-                    val name = reader.getAttributeValue(null, "name") ?: continue
-                    val className =
-                      reader.getAttributeValue(null, "classname") ?: suiteName ?: continue
-                    val durationMs =
-                      reader.getAttributeValue(null, "time")?.toDoubleOrNull()?.let {
-                        (it * 1000).toLong()
-                      } ?: 0L
-                    var status: String? = null
-                    var messageText: String? = null
+                    "testcase" -> {
+                      val name = reader.getAttributeValue(null, "name") ?: continue
+                      val className =
+                        reader.getAttributeValue(null, "classname") ?: suiteName ?: continue
+                      val durationMs =
+                        reader.getAttributeValue(null, "time")?.toDoubleOrNull()?.let {
+                          (it * 1000).toLong()
+                        } ?: 0L
+                      var status: String? = null
+                      var messageText: String? = null
 
-                    while (reader.hasNext()) {
-                      when (reader.next()) {
-                        XMLStreamConstants.START_ELEMENT -> {
-                          when (reader.localName) {
-                            "failure",
-                            "error" -> {
-                              status = reader.localName
-                              val message =
-                                reader.getAttributeValue(null, "message")?.takeIf {
-                                  it.isNotBlank()
-                                }
-                              val type =
-                                reader.getAttributeValue(null, "type")?.takeIf { it.isNotBlank() }
-                              val text = reader.elementText.trim().takeIf { it.isNotBlank() }
-                              messageText =
-                                listOfNotNull(message, type, text).joinToString("\n").ifBlank {
-                                  null
-                                }
-                            }
+                      while (reader.hasNext()) {
+                        when (reader.next()) {
+                          XMLStreamConstants.START_ELEMENT -> {
+                            when (reader.localName) {
+                              "failure",
+                              "error" -> {
+                                status = reader.localName
+                                val message =
+                                  reader.getAttributeValue(null, "message")?.takeIf {
+                                    it.isNotBlank()
+                                  }
+                                val type =
+                                  reader.getAttributeValue(null, "type")?.takeIf { it.isNotBlank() }
+                                val text = reader.elementText.trim().takeIf { it.isNotBlank() }
+                                messageText =
+                                  listOfNotNull(message, type, text).joinToString("\n").ifBlank {
+                                    null
+                                  }
+                              }
 
-                            "skipped" -> {
-                              status = "skipped"
+                              "skipped" -> {
+                                status = "skipped"
+                              }
                             }
                           }
-                        }
 
-                        XMLStreamConstants.END_ELEMENT -> {
-                          if (reader.localName == "testcase") break
+                          XMLStreamConstants.END_ELEMENT -> {
+                            if (reader.localName == "testcase") break
+                          }
                         }
                       }
-                    }
 
-                    val normalizedClassName = className.substringBefore('$')
-                    val relativeBase = normalizedClassName.replace('.', '/')
-                    val relativePaths = mutableListOf("$relativeBase.java", "$relativeBase.kt")
-                    if (normalizedClassName.endsWith("Kt")) {
-                      relativePaths.add(
-                        normalizedClassName.removeSuffix("Kt").replace('.', '/') + ".kt"
-                      )
-                    }
-                    val sourceFile =
-                      relativePaths.firstNotNullOfOrNull { relativePath ->
-                        testSourceDirs
-                          .firstOrNull { srcDir -> File(srcDir, relativePath).isFile }
-                          ?.let { srcDir -> File(srcDir, relativePath) }
-                      } ?: continue
-                    val sourcePath = sourceFile.toPath()
-                    val sonarPath =
-                      if (sourcePath.startsWith(projectPath)) {
-                        projectPath.relativize(sourcePath).toString()
-                      } else {
-                        sourceFile.absolutePath
+                      val normalizedClassName = className.substringBefore('$')
+                      val relativeBase = normalizedClassName.replace('.', '/')
+                      val relativePaths = mutableListOf("$relativeBase.java", "$relativeBase.kt")
+                      if (normalizedClassName.endsWith("Kt")) {
+                        relativePaths.add(
+                          normalizedClassName.removeSuffix("Kt").replace('.', '/') + ".kt"
+                        )
                       }
-                    byFile
-                      .getOrPut(sonarPath) { mutableListOf() }
-                      .add(TestCase(name, durationMs, status, messageText))
+                      val sourceFile =
+                        relativePaths.firstNotNullOfOrNull { relativePath ->
+                          testSourceDirs
+                            .firstOrNull { srcDir -> File(srcDir, relativePath).isFile }
+                            ?.let { srcDir -> File(srcDir, relativePath) }
+                        } ?: continue
+                      val sourcePath = sourceFile.toPath()
+                      val sonarPath =
+                        if (sourcePath.startsWith(projectPath)) {
+                          projectPath.relativize(sourcePath).toString()
+                        } else {
+                          sourceFile.absolutePath
+                        }
+                      byFile
+                        .getOrPut(sonarPath) { mutableListOf() }
+                        .add(TestCase(name, durationMs, status, messageText))
+                    }
                   }
                 }
               }
             }
+          } finally {
+            reader.close()
           }
-        } finally {
-          reader.close()
         }
-      }
+    }
 
     val xmlOutputFactory = XMLOutputFactory.newInstance()
     outputFile.outputStream().use { stream ->

--- a/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.sonar.gradle.kts
@@ -93,15 +93,13 @@ val testExecutionReportFile: Provider<RegularFile> =
 val testResultsDir: Provider<Directory> = layout.buildDirectory.dir("test-results/test")
 val additionalSonarTestSourceDirs: Provider<List<File>> =
   providers.provider {
-    (project.findProperty("cryptad.additionalSonarTestSourceDirs") as? Iterable<*>)?.mapNotNull {
-      it as? File
-    } ?: emptyList()
+    (project.findProperty("cryptad.additionalSonarTestSourceDirs") as? Iterable<*>)
+      ?.filterIsInstance<File>() ?: emptyList()
   }
 val additionalSonarTestResultDirs: Provider<List<File>> =
   providers.provider {
-    (project.findProperty("cryptad.additionalSonarTestResultDirs") as? Iterable<*>)?.mapNotNull {
-      it as? File
-    } ?: emptyList()
+    (project.findProperty("cryptad.additionalSonarTestResultDirs") as? Iterable<*>)
+      ?.filterIsInstance<File>() ?: emptyList()
   }
 
 tasks.register("prepareKotlinTestReports") {

--- a/build-logic/src/main/kotlin/cryptad.spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.spotless.gradle.kts
@@ -2,6 +2,24 @@ import cryptad.SonarS8445ImportOrderFormatter
 
 plugins { id("com.diffplug.spotless") }
 
+val kotlinGradleTargets =
+  if (project == rootProject) {
+    fileTree(projectDir) {
+      include("build.gradle.kts")
+      include("settings.gradle.kts")
+      include("*/build.gradle.kts")
+      include("build-logic/build.gradle.kts")
+      include("build-logic/settings.gradle.kts")
+      include("build-logic/src/**/*.gradle.kts")
+    }
+  } else {
+    fileTree(projectDir) {
+      include("build.gradle.kts")
+      include("settings.gradle.kts")
+      include("src/**/*.gradle.kts")
+    }
+  }
+
 spotless {
   java {
     googleJavaFormat("1.28.0").reflowLongStrings()
@@ -21,12 +39,10 @@ spotless {
     endWithNewline()
   }
   kotlinGradle {
-    target("**/*.gradle.kts")
-    // Avoid scanning generated build output (including Spotless' own working directories) and IDE
-    // metadata which may contain non-UTF8 content or filenames.
-    targetExclude("**/build/**")
-    targetExclude("**/.gradle/**")
-    targetExclude("**/.idea/**")
+    // Keep the root task on checked-in Gradle scripts only. The broad repo-wide glob was pulling
+    // generated build-logic outputs into the root target set, which is both wasted work and can
+    // destabilize Spotless path validation on non-clean worktrees.
+    target(kotlinGradleTargets)
     ktfmt("0.58").googleStyle()
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ val internalLeafProjects =
     project(":kernel-routing"),
     project(":runtime-spi"),
     project(":platform-api"),
+    project(":platform-apphost"),
     project(":runtime-node"),
     project(":adapter-fcp"),
     project(":adapter-http-legacy-admin"),
@@ -42,6 +43,33 @@ val internalLeafMainJavaSourceDirs =
 
 val internalLeafMainClassDirs =
   internalLeafProjects.map { leaf -> leaf.layout.buildDirectory.dir("classes/java/main") }
+
+val internalLeafProjectsWithLocalTests =
+  internalLeafProjects.filter { leaf ->
+    leaf.layout.projectDirectory.dir("src/test/java").asFile.isDirectory ||
+      leaf.layout.projectDirectory.dir("src/test/kotlin").asFile.isDirectory
+  }
+
+val internalLeafTestSourceDirs =
+  internalLeafProjectsWithLocalTests
+    .flatMap { leaf ->
+      listOf(
+        leaf.layout.projectDirectory.dir("src/test/java"),
+        leaf.layout.projectDirectory.dir("src/test/kotlin"),
+      )
+    }
+    .map { it.asFile }
+    .filter { it.isDirectory }
+
+val internalLeafTestResultDirs =
+  internalLeafProjectsWithLocalTests.map { leaf ->
+    leaf.layout.buildDirectory.dir("test-results/test").get().asFile
+  }
+
+val internalLeafJacocoExecFiles =
+  internalLeafProjectsWithLocalTests.map { leaf ->
+    leaf.layout.buildDirectory.file("jacoco/test.exec")
+  }
 
 dependencies {
   // implementation
@@ -58,6 +86,7 @@ dependencies {
   implementation(project(":kernel-routing"))
   implementation(project(":runtime-spi"))
   implementation(project(":platform-api"))
+  implementation(project(":platform-apphost"))
   implementation(project(":runtime-node"))
   implementation(project(":adapter-fcp"))
   implementation(project(":adapter-http-legacy-admin"))
@@ -126,6 +155,20 @@ val aggregatedSonarBinaryPaths =
       internalLeafMainClassDirs.map { it.get().asFile })
     .distinct()
     .joinToString(",") { it.absolutePath }
+
+val aggregatedSonarTestPaths =
+  (sourceSets.test.get().allSource.srcDirs + internalLeafTestSourceDirs).distinct().joinToString(
+    ","
+  ) {
+    relativePath(it)
+  }
+
+val aggregatedSonarTestInclusions =
+  (sourceSets.test.get().allSource.srcDirs + internalLeafTestSourceDirs).distinct().joinToString(
+    ","
+  ) {
+    "${relativePath(it)}/**"
+  }
 
 val aggregatedSonarLibraryFiles = sourceSets.main.get().compileClasspath.filter { it.isFile }
 
@@ -324,6 +367,9 @@ val legacyRuntimeAlertsMainPackageDir =
 val legacyRuntimeAlertsTestPackageDir =
   layout.buildDirectory.dir("classes/java/test/network/crypta/node/useralerts")
 
+val legacyPlatformApphostRootTestPackageDir =
+  layout.buildDirectory.dir("classes/java/test/network/crypta/platform/apphost")
+
 // Selective leaf ownership metadata only covers root <-> leaf and leaf <-> leaf moves.
 // Root-local package re-homes still need explicit stale-output pruning, so non-clean builds and
 // branch switches do not keep packaging deleted classes from the old package path.
@@ -347,6 +393,16 @@ val pruneLegacyRuntimeAlertsOutputs by
     delete(staleOutputTrees)
   }
 
+val pruneLegacyPlatformApphostRootTestOutputs by
+  tasks.registering(Delete::class) {
+    val staleOutputTrees = listOf(legacyPlatformApphostRootTestPackageDir)
+    group = "build"
+    description =
+      "Removes stale root AppHost test outputs after the focused suite moved into :platform-apphost"
+    outputs.upToDateWhen { false }
+    delete(staleOutputTrees)
+  }
+
 internalLeafProjects.forEach { leaf ->
   leaf.wireSelectiveLeafOutputPruning(pruneSelectiveLeafOutputs, sharedSelectiveLeafPruneTaskNames)
   leaf.extensions.configure<org.sonarqube.gradle.SonarExtension>("sonar") { isSkipProject = true }
@@ -358,6 +414,15 @@ project.wireSelectiveLeafOutputPruning(
   pruneLegacyRuntimeAlertsOutputs,
   rootSelectiveLeafPruneTaskNames,
 )
+
+project.wireSelectiveLeafOutputPruning(
+  pruneLegacyPlatformApphostRootTestOutputs,
+  rootSelectiveLeafPruneTaskNames,
+)
+
+extensions.extraProperties["cryptad.additionalSonarTestSourceDirs"] = internalLeafTestSourceDirs
+
+extensions.extraProperties["cryptad.additionalSonarTestResultDirs"] = internalLeafTestResultDirs
 
 tasks.named<org.gradle.jvm.tasks.Jar>("buildJar") {
   dependsOn(pruneSelectiveLeafOutputs)
@@ -374,6 +439,10 @@ tasks.named<Copy>("prepareWrapperLibs") {
 
 tasks.named<JacocoReport>("jacocoTestReport") {
   dependsOn(internalLeafProjects.map { "${it.path}:classes" })
+  dependsOn(internalLeafProjectsWithLocalTests.map { "${it.path}:test" })
+  executionData.setFrom(
+    files(layout.buildDirectory.file("jacoco/test.exec"), internalLeafJacocoExecFiles)
+  )
   classDirectories.setFrom(
     files(sourceSets.main.get().output.classesDirs, internalLeafMainClassDirs)
   )
@@ -384,6 +453,10 @@ tasks.named<JacocoReport>("jacocoTestReport") {
 
 tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
   dependsOn(internalLeafProjects.map { "${it.path}:classes" })
+  dependsOn(internalLeafProjectsWithLocalTests.map { "${it.path}:test" })
+  executionData.setFrom(
+    files(layout.buildDirectory.file("jacoco/test.exec"), internalLeafJacocoExecFiles)
+  )
   classDirectories.setFrom(
     files(sourceSets.main.get().output.classesDirs, internalLeafMainClassDirs)
   )
@@ -392,11 +465,17 @@ tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
   )
 }
 
+tasks.named("prepareTestExecutionReport") {
+  dependsOn(internalLeafProjectsWithLocalTests.map { "${it.path}:test" })
+}
+
 sonar {
   properties {
     property("sonar.sources", aggregatedSonarSourcePaths)
     property("sonar.java.binaries", aggregatedSonarBinaryPaths)
     property("sonar.java.libraries", aggregatedSonarLibraryFiles)
+    property("sonar.tests", aggregatedSonarTestPaths)
+    property("sonar.test.inclusions", aggregatedSonarTestInclusions)
   }
 }
 

--- a/platform-apphost/build.gradle.kts
+++ b/platform-apphost/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+  id("cryptad.java-kotlin-conventions")
+  id("cryptad.spotless")
+  `java-library`
+}
+
+version = rootProject.version
+
+val mainSourceSet = sourceSets.named("main")
+
+dependencies {
+  // AppEnv is the repo's single source of truth for OS detection and keeps Windows launch
+  // handling out of raw os.name checks.
+  implementation(project(":foundation-fs"))
+
+  compileOnly(libs.jetbrainsAnnotations)
+
+  // Keep leaf-local tests runnable through :platform-apphost:test without depending on the root
+  // project's aggregated classpath.
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
+}

--- a/platform-apphost/gradle/owned-output-patterns.txt
+++ b/platform-apphost/gradle/owned-output-patterns.txt
@@ -1,0 +1,4 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :platform-apphost owns
+# them now.
+
+network/crypta/platform/apphost/**

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
@@ -1,0 +1,81 @@
+package network.crypta.platform.apphost;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Transport-neutral host API for locally installed out-of-process applications.
+ *
+ * <p>The interface stays intentionally small for AppHost v1: install from a local staging
+ * directory, list and describe installed apps, and manage one running child process per app.
+ */
+public interface AppHost {
+  /**
+   * Installs one app from a local staging directory.
+   *
+   * @param stagedAppDirectory staging directory containing {@code cryptad-app.properties}
+   * @return installed application snapshot
+   * @throws IOException if validation, copying, or directory provisioning fails
+   */
+  InstalledAppSnapshot installFromDirectory(Path stagedAppDirectory) throws IOException;
+
+  /**
+   * Removes one installed app and its host-owned directories.
+   *
+   * @param appId stable application identifier
+   * @throws IOException if the app is running, missing, or cannot be removed
+   */
+  void uninstall(String appId) throws IOException;
+
+  /**
+   * Lists all installed apps.
+   *
+   * @return installed application snapshots sorted by app id
+   * @throws IOException if the installed-app tree cannot be scanned
+   */
+  List<InstalledAppSnapshot> listInstalled() throws IOException;
+
+  /**
+   * Describes one installed app.
+   *
+   * @param appId stable application identifier
+   * @return installed snapshot when present
+   * @throws IOException if the installed-app tree cannot be read
+   */
+  Optional<InstalledAppSnapshot> describe(String appId) throws IOException;
+
+  /**
+   * Starts one installed app as a child process.
+   *
+   * @param appId stable application identifier
+   * @return running snapshot including the fresh launch token
+   * @throws IOException if the child process cannot be launched
+   */
+  RunningAppSnapshot start(String appId) throws IOException;
+
+  /**
+   * Stops one running app if it is active.
+   *
+   * @param appId stable application identifier
+   * @return {@code true} when a running process was stopped; {@code false} otherwise
+   * @throws IOException if the child process cannot be stopped cleanly
+   */
+  boolean stop(String appId) throws IOException;
+
+  /**
+   * Returns the current live process snapshot, if any.
+   *
+   * @param appId stable application identifier
+   * @return running snapshot when the child is alive
+   */
+  Optional<RunningAppSnapshot> status(String appId);
+
+  /**
+   * Lists all live child processes.
+   *
+   * @return immutable list of running snapshots sorted by app id
+   */
+  List<RunningAppSnapshot> listRunning();
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
@@ -8,32 +8,59 @@ import java.util.Optional;
 /**
  * Transport-neutral host API for locally installed out-of-process applications.
  *
- * <p>The interface stays intentionally small for AppHost v1: install from a local staging
- * directory, list and describe installed apps, and manage one running child process per app.
+ * <p>{@code AppHost} defines the narrow lifecycle surface that higher-level shells, transports, and
+ * future management APIs use to interact with locally installed app bundles. The interface is
+ * intentionally conservative for AppHost v1: it installs validated bundles from a caller-supplied
+ * staging directory, exposes immutable installation metadata, and manages at most one live child
+ * process per installed application identifier.
+ *
+ * <p>Implementations are responsible for keeping host-owned filesystem layout and runtime state
+ * consistent with the returned snapshots. Callers can treat {@link InstalledAppSnapshot} and {@link
+ * RunningAppSnapshot} as point-in-time views rather than persistent handles. A later call to {@link
+ * #describe(String)}, {@link #status(String)}, or {@link #listRunning()} may therefore reflect
+ * newer filesystem or process state than an earlier snapshot.
  */
 public interface AppHost {
   /**
    * Installs one app from a local staging directory.
    *
-   * @param stagedAppDirectory staging directory containing {@code cryptad-app.properties}
-   * @return installed application snapshot
-   * @throws IOException if validation, copying, or directory provisioning fails
+   * <p>The staging directory is treated as caller-owned input. Implementations validate the
+   * manifest, copy the bundle into host-managed storage, provision any required mutable
+   * directories, and return a snapshot that reflects the installed copy rather than the original
+   * staging path.
+   *
+   * @param stagedAppDirectory staging directory containing {@code cryptad-app.properties} and the
+   *     files referenced by the manifest
+   * @return installed application snapshot describing the copied bundle and derived host paths
+   * @throws IOException if validation fails, filesystem boundaries are unsafe, the bundle cannot be
+   *     copied, or host-owned directories cannot be provisioned
    */
   InstalledAppSnapshot installFromDirectory(Path stagedAppDirectory) throws IOException;
 
   /**
    * Removes one installed app and its host-owned directories.
    *
+   * <p>This operation removes both the immutable installed bundle and the mutable per-app data,
+   * cache, and run directories that belong to the host layout. Implementations are expected to
+   * reject removal while the app is still running, so callers do not delete files out from under a
+   * live child process.
+   *
    * @param appId stable application identifier
-   * @throws IOException if the app is running, missing, or cannot be removed
+   * @throws IOException if the app is still running, is not installed, or any owned files cannot be
+   *     removed cleanly
    */
   void uninstall(String appId) throws IOException;
 
   /**
    * Lists all installed apps.
    *
+   * <p>The returned list is a fresh filesystem-backed snapshot. Callers should not assume the list
+   * remains current after the method returns, especially if another actor is installing or
+   * uninstalling applications concurrently.
+   *
    * @return installed application snapshots sorted by app id
-   * @throws IOException if the installed-app tree cannot be scanned
+   * @throws IOException if the installed-app tree cannot be scanned, or one of the installed
+   *     manifests cannot be read safely
    */
   List<InstalledAppSnapshot> listInstalled() throws IOException;
 
@@ -41,26 +68,42 @@ public interface AppHost {
    * Describes one installed app.
    *
    * @param appId stable application identifier
-   * @return installed snapshot when present
-   * @throws IOException if the installed-app tree cannot be read
+   * @return installed snapshot when the application is present, or {@link Optional#empty()} when it
+   *     is not installed
+   * @throws IOException if the installed-app tree cannot be read safely or the installed manifest
+   *     is invalid
    */
   Optional<InstalledAppSnapshot> describe(String appId) throws IOException;
 
   /**
    * Starts one installed app as a child process.
    *
+   * <p>Implementations are expected to validate the installed bundle again at launch time, create
+   * or refresh runtime directories, start the child process, and return a snapshot that includes a
+   * fresh launch token and representative process identifier. A successful return means the host
+   * considers the app running and manageable through {@link #status(String)} and {@link
+   * #stop(String)}.
+   *
    * @param appId stable application identifier
-   * @return running snapshot including the fresh launch token
-   * @throws IOException if the child process cannot be launched
+   * @return running snapshot including the fresh launch token and launch timestamp
+   * @throws IOException if the app is not installed, is already running, or the child process
+   *     cannot be launched and tracked successfully
    */
   RunningAppSnapshot start(String appId) throws IOException;
 
   /**
    * Stops one running app if it is active.
    *
+   * <p>A return value of {@code false} means the host had no live process to stop at the time of
+   * the call. A return value of {@code true} means the host successfully transitioned a running app
+   * to the stopped state. Implementations may use graceful termination followed by escalation, but
+   * they should not report success while a recovered child process is still running.
+   *
    * @param appId stable application identifier
-   * @return {@code true} when a running process was stopped; {@code false} otherwise
-   * @throws IOException if the child process cannot be stopped cleanly
+   * @return {@code true} when a running process was found and stopped; {@code false} when no live
+   *     process was present
+   * @throws IOException if a running app cannot be stopped cleanly within the implementation's
+   *     shutdown policy
    */
   boolean stop(String appId) throws IOException;
 
@@ -68,12 +111,16 @@ public interface AppHost {
    * Returns the current live process snapshot, if any.
    *
    * @param appId stable application identifier
-   * @return running snapshot when the child is alive
+   * @return running snapshot when the app is still tracked as live, or {@link Optional#empty()}
+   *     when it is not currently running
    */
   Optional<RunningAppSnapshot> status(String appId);
 
   /**
    * Lists all live child processes.
+   *
+   * <p>The returned list is a point-in-time runtime view. It is sorted by app id to give callers a
+   * stable ordering for display, polling, and test assertions.
    *
    * @return immutable list of running snapshots sorted by app id
    */

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostException.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostException.java
@@ -1,0 +1,25 @@
+package network.crypta.platform.apphost;
+
+import java.io.IOException;
+
+/** Signals application-host validation or lifecycle failures. */
+public class AppHostException extends IOException {
+  /**
+   * Creates an exception with a message.
+   *
+   * @param message failure detail
+   */
+  public AppHostException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception with a message and cause.
+   *
+   * @param message failure detail
+   * @param cause underlying cause
+   */
+  public AppHostException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostException.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostException.java
@@ -2,12 +2,24 @@ package network.crypta.platform.apphost;
 
 import java.io.IOException;
 
-/** Signals application-host validation or lifecycle failures. */
+/**
+ * Signals AppHost validation or lifecycle failures.
+ *
+ * <p>{@code AppHostException} is the checked failure type used for host-specific problems such as
+ * invalid manifests, unsafe filesystem layouts, startup failures, and shutdown timeouts.
+ * Implementations throw this exception when the failure is part of the AppHost contract rather than
+ * an unexpected unchecked programming error.
+ *
+ * <p>The type extends {@link IOException} so callers that already treat filesystem and process
+ * lifecycle work as checked I/O can handle AppHost failures in the same control flow while still
+ * distinguishing them by concrete type when needed.
+ */
 public class AppHostException extends IOException {
   /**
    * Creates an exception with a message.
    *
-   * @param message failure detail
+   * @param message human-readable failure detail that explains the rejected operation or invalid
+   *     state
    */
   public AppHostException(String message) {
     super(message);
@@ -16,8 +28,9 @@ public class AppHostException extends IOException {
   /**
    * Creates an exception with a message and cause.
    *
-   * @param message failure detail
-   * @param cause underlying cause
+   * @param message human-readable failure detail that explains the rejected operation or invalid
+   *     state
+   * @param cause underlying cause that triggered this host-level failure classification
    */
   public AppHostException(String message, Throwable cause) {
     super(message, cause);

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostLayout.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostLayout.java
@@ -1,0 +1,87 @@
+package network.crypta.platform.apphost;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Stable filesystem layout for host-owned app state.
+ *
+ * <p>The layout uses caller-supplied base directories and derives all host-managed paths from them.
+ * The host keeps the installed bundle, persistent app data, cache, and per-session run data in
+ * separate trees so future shell and API layers can reuse the same placement rules.
+ *
+ * @param dataDir base directory for installed bundles and persistent app data
+ * @param cacheDir base directory for app cache data
+ * @param runDir base directory for session-scoped app run data
+ */
+public record AppHostLayout(Path dataDir, Path cacheDir, Path runDir) {
+  /**
+   * Creates a validated host layout.
+   *
+   * @param dataDir base directory for installed bundles and persistent app data
+   * @param cacheDir base directory for app cache data
+   * @param runDir base directory for session-scoped app run data
+   */
+  public AppHostLayout {
+    dataDir = normalizeBaseDir(dataDir, "dataDir");
+    cacheDir = normalizeBaseDir(cacheDir, "cacheDir");
+    runDir = normalizeBaseDir(runDir, "runDir");
+  }
+
+  /**
+   * Returns the root directory that holds installed bundles.
+   *
+   * @return install root under {@code dataDir}
+   */
+  public Path installedAppsDir() {
+    return dataDir.resolve("apps").resolve("installed");
+  }
+
+  /**
+   * Returns the root directory that holds persistent app data.
+   *
+   * @return data root under {@code dataDir}
+   */
+  public Path appDataRoot() {
+    return dataDir.resolve("apps").resolve("data");
+  }
+
+  /**
+   * Returns the root directory that holds app cache data.
+   *
+   * @return cache root under {@code cacheDir}
+   */
+  public Path appCacheRoot() {
+    return cacheDir.resolve("apps");
+  }
+
+  /**
+   * Returns the root directory that holds per-session app run data.
+   *
+   * @return run root under {@code runDir}
+   */
+  public Path appRunRoot() {
+    return runDir.resolve("apps");
+  }
+
+  /**
+   * Returns the derived filesystem paths for one app id.
+   *
+   * @param appId stable application identifier
+   * @return path bundle for the supplied app
+   */
+  public InstalledAppPaths pathsFor(String appId) {
+    String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
+    return new InstalledAppPaths(
+        normalizedAppId,
+        installedAppsDir().resolve(normalizedAppId),
+        appDataRoot().resolve(normalizedAppId),
+        appCacheRoot().resolve(normalizedAppId),
+        appRunRoot().resolve(normalizedAppId));
+  }
+
+  private static Path normalizeBaseDir(Path path, String label) {
+    Objects.requireNonNull(path, label);
+    return path.toAbsolutePath().normalize();
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostLayout.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostLayout.java
@@ -6,9 +6,16 @@ import java.util.Objects;
 /**
  * Stable filesystem layout for host-owned app state.
  *
- * <p>The layout uses caller-supplied base directories and derives all host-managed paths from them.
- * The host keeps the installed bundle, persistent app data, cache, and per-session run data in
- * separate trees so future shell and API layers can reuse the same placement rules.
+ * <p>{@code AppHostLayout} is the single source of truth for where an AppHost implementation keeps
+ * immutable bundles and mutable per-app state on disk. Callers provide the three top-level base
+ * directories, and the layout derives the installation, data, cache, and runtime trees from those
+ * roots deterministically. This keeps shell layers, tests, and future API adapters aligned on the
+ * same placement rules.
+ *
+ * <p>The design deliberately separates long-lived bundle contents from mutable data and
+ * session-scoped run files. That split makes it easier to validate installed bundles, clean up the
+ * runtime state, and apply tighter ownership checks to the directories that the host controls on
+ * behalf of each application.
  *
  * @param dataDir base directory for installed bundles and persistent app data
  * @param cacheDir base directory for app cache data
@@ -31,6 +38,10 @@ public record AppHostLayout(Path dataDir, Path cacheDir, Path runDir) {
   /**
    * Returns the root directory that holds installed bundles.
    *
+   * <p>This tree holds the immutable copied bundle for each installed application. Callers should
+   * treat entries beneath it as host-managed installation state rather than writable application
+   * data.
+   *
    * @return install root under {@code dataDir}
    */
   public Path installedAppsDir() {
@@ -39,6 +50,9 @@ public record AppHostLayout(Path dataDir, Path cacheDir, Path runDir) {
 
   /**
    * Returns the root directory that holds persistent app data.
+   *
+   * <p>This tree is the long-lived writable area that survives restarts and reinstalls unless the
+   * app is explicitly uninstalled.
    *
    * @return data root under {@code dataDir}
    */
@@ -49,6 +63,9 @@ public record AppHostLayout(Path dataDir, Path cacheDir, Path runDir) {
   /**
    * Returns the root directory that holds app cache data.
    *
+   * <p>Cache contents are mutable and host-managed, but unlike the data tree, they are intended for
+   * disposable or rebuildable state.
+   *
    * @return cache root under {@code cacheDir}
    */
   public Path appCacheRoot() {
@@ -58,6 +75,9 @@ public record AppHostLayout(Path dataDir, Path cacheDir, Path runDir) {
   /**
    * Returns the root directory that holds per-session app run data.
    *
+   * <p>This tree is intended for transient launch artifacts such as process logs, sockets, or
+   * pid-adjacent runtime files that should not survive indefinitely.
+   *
    * @return run root under {@code runDir}
    */
   public Path appRunRoot() {
@@ -66,6 +86,10 @@ public record AppHostLayout(Path dataDir, Path cacheDir, Path runDir) {
 
   /**
    * Returns the derived filesystem paths for one app id.
+   *
+   * <p>The returned value normalizes the identifier and derives the immutable and mutable paths
+   * that the host uses for one application. Callers can use the result as the canonical mapping
+   * between manifest identity and on-disk placement.
    *
    * @param appId stable application identifier
    * @return path bundle for the supplied app

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
@@ -105,6 +105,7 @@ public record InstalledAppPaths(
    *
    * @throws IOException if the installation parent cannot be created
    */
+  @SuppressWarnings("unused")
   public void ensureInstallParentDirectory() throws IOException {
     Files.createDirectories(installedRoot.getParent());
   }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
@@ -15,6 +15,18 @@ import network.crypta.platform.apphost.manifest.AppManifestParser;
 /**
  * Derived filesystem paths for one installed application.
  *
+ * <p>{@code InstalledAppPaths} is the confinement helper for one installed app. It ties the stable
+ * application identifier to the immutable copied bundle root and to the mutable data, cache, and
+ * run directories that the host manages outside the bundle. Runtime code uses this record whenever
+ * it needs to resolve manifest paths, create owned directories, or expose filesystem placement in
+ * snapshots.
+ *
+ * <p>The record normalizes all supplied paths eagerly, so later comparisons operate on canonical
+ * absolute paths instead of caller-provided relative forms. Public helpers also enforce the host's
+ * bundle-root assumptions by rejecting path traversal attempts and by creating mutable directories
+ * only after validating that the target entries are real directories rather than symlinks, aliases,
+ * or regular files.
+ *
  * @param appId stable application identifier
  * @param installedRoot immutable bundle copy root
  * @param dataDir persistent mutable data directory
@@ -47,7 +59,7 @@ public record InstalledAppPaths(
   /**
    * Returns the installed manifest file path.
    *
-   * @return installed manifest path
+   * @return the installed manifest path at the bundle root
    */
   public Path manifestFile() {
     return installedRoot.resolve(AppManifestParser.MANIFEST_FILE_NAME);
@@ -55,6 +67,9 @@ public record InstalledAppPaths(
 
   /**
    * Returns the combined child-process log path.
+   *
+   * <p>This file lives in the mutable run directory and is the conventional sink for combined
+   * stdout and stderr from the launched child process.
    *
    * @return runtime log file path
    */
@@ -65,8 +80,13 @@ public record InstalledAppPaths(
   /**
    * Resolves a relative bundle path beneath the installed root.
    *
+   * <p>The resolved path is normalized and then checked to ensure it still stays within the
+   * installed bundle root. Callers can use this helper when they already trust the logical meaning
+   * of a relative path but still need a guard against path traversal.
+   *
    * @param relativePath relative path inside the installed bundle
    * @return absolute installed-bundle path
+   * @throws IllegalArgumentException if the normalized path escapes the installed bundle root
    */
   public Path resolveInstalledPath(Path relativePath) {
     Objects.requireNonNull(relativePath, "relativePath");
@@ -92,7 +112,11 @@ public record InstalledAppPaths(
   /**
    * Creates the persistent and runtime directories managed by the host.
    *
-   * @throws IOException if any directory cannot be created
+   * <p>Each directory is validated before and after creation, so the host does not silently follow
+   * a symlink, junction, alias, or conflicting regular file when preparing a mutable app state.
+   *
+   * @throws IOException if any directory cannot be created or fails, the host's directory ownership
+   *     checks
    */
   public void ensureMutableDirectories() throws IOException {
     ensureMutableDirectory(dataDir, "dataDir");
@@ -102,6 +126,9 @@ public record InstalledAppPaths(
 
   /**
    * Creates the installation parent directory.
+   *
+   * <p>This helper exists for installation flows that need the parent directory before moving a
+   * copied bundle into place.
    *
    * @throws IOException if the installation parent cannot be created
    */
@@ -113,8 +140,13 @@ public record InstalledAppPaths(
   /**
    * Validates and normalizes an application identifier.
    *
+   * <p>The identifier is trimmed, lower-cased, and validated against the path-safe AppHost naming
+   * pattern before it is used to derive on-disk paths.
+   *
    * @param appId application identifier
    * @return normalized application identifier
+   * @throws IllegalArgumentException if the identifier is blank or does not match the supported
+   *     AppHost id pattern
    */
   public static String normalizeAppId(String appId) {
     Objects.requireNonNull(appId, "appId");

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
@@ -1,0 +1,178 @@
+package network.crypta.platform.apphost;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
+
+/**
+ * Derived filesystem paths for one installed application.
+ *
+ * @param appId stable application identifier
+ * @param installedRoot immutable bundle copy root
+ * @param dataDir persistent mutable data directory
+ * @param cacheDir mutable cache directory
+ * @param runDir current-session runtime directory
+ */
+public record InstalledAppPaths(
+    String appId, Path installedRoot, Path dataDir, Path cacheDir, Path runDir) {
+  private static final Pattern APP_ID_PATTERN =
+      Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
+  private static final String PROCESS_LOG_FILE = "process.log";
+
+  /**
+   * Creates a normalized path bundle.
+   *
+   * @param appId stable application identifier
+   * @param installedRoot immutable bundle copy root
+   * @param dataDir persistent mutable data directory
+   * @param cacheDir mutable cache directory
+   * @param runDir current-session runtime directory
+   */
+  public InstalledAppPaths {
+    appId = normalizeAppId(appId);
+    installedRoot = normalizePath(installedRoot, "installedRoot");
+    dataDir = normalizePath(dataDir, "dataDir");
+    cacheDir = normalizePath(cacheDir, "cacheDir");
+    runDir = normalizePath(runDir, "runDir");
+  }
+
+  /**
+   * Returns the installed manifest file path.
+   *
+   * @return installed manifest path
+   */
+  public Path manifestFile() {
+    return installedRoot.resolve(AppManifestParser.MANIFEST_FILE_NAME);
+  }
+
+  /**
+   * Returns the combined child-process log path.
+   *
+   * @return runtime log file path
+   */
+  public Path processLogFile() {
+    return runDir.resolve(PROCESS_LOG_FILE);
+  }
+
+  /**
+   * Resolves a relative bundle path beneath the installed root.
+   *
+   * @param relativePath relative path inside the installed bundle
+   * @return absolute installed-bundle path
+   */
+  public Path resolveInstalledPath(Path relativePath) {
+    Objects.requireNonNull(relativePath, "relativePath");
+    Path resolved = installedRoot.resolve(relativePath).normalize();
+    if (!resolved.startsWith(installedRoot)) {
+      throw new IllegalArgumentException(
+          "resolved path must stay under installedRoot: " + relativePath);
+    }
+    return resolved;
+  }
+
+  /**
+   * Resolves the manifest-declared executable beneath the installed root.
+   *
+   * @param manifest application manifest
+   * @return absolute executable path inside the installed bundle
+   */
+  public Path executablePath(AppManifest manifest) {
+    Objects.requireNonNull(manifest, "manifest");
+    return resolveInstalledPath(manifest.execPath());
+  }
+
+  /**
+   * Creates the persistent and runtime directories managed by the host.
+   *
+   * @throws IOException if any directory cannot be created
+   */
+  public void ensureMutableDirectories() throws IOException {
+    ensureMutableDirectory(dataDir, "dataDir");
+    ensureMutableDirectory(cacheDir, "cacheDir");
+    ensureMutableDirectory(runDir, "runDir");
+  }
+
+  /**
+   * Creates the installation parent directory.
+   *
+   * @throws IOException if the installation parent cannot be created
+   */
+  public void ensureInstallParentDirectory() throws IOException {
+    Files.createDirectories(installedRoot.getParent());
+  }
+
+  /**
+   * Validates and normalizes an application identifier.
+   *
+   * @param appId application identifier
+   * @return normalized application identifier
+   */
+  public static String normalizeAppId(String appId) {
+    Objects.requireNonNull(appId, "appId");
+    String normalized = appId.trim().toLowerCase(Locale.ROOT);
+    if (!APP_ID_PATTERN.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("invalid app id: " + appId);
+    }
+    return normalized;
+  }
+
+  private static Path normalizePath(Path path, String label) {
+    Objects.requireNonNull(path, label);
+    return path.toAbsolutePath().normalize();
+  }
+
+  private static void ensureMutableDirectory(Path directory, String label) throws IOException {
+    Path normalized = normalizePath(directory, label);
+    Deque<Path> missingSegments = new ArrayDeque<>();
+    Path current = normalized;
+    while (current != null && !Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+      Path fileName = current.getFileName();
+      if (fileName != null) {
+        missingSegments.push(fileName);
+      }
+      current = current.getParent();
+    }
+    if (current != null) {
+      validateDirectoryEntry(current, label);
+      while (!missingSegments.isEmpty()) {
+        current = current.resolve(missingSegments.pop());
+        Files.createDirectory(current);
+      }
+    } else {
+      Files.createDirectories(normalized);
+    }
+    validateDirectoryEntry(normalized, label);
+    if (!Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppHostException(label + " must be a directory: " + normalized);
+    }
+  }
+
+  private static void validateDirectoryEntry(Path entry, String label) throws IOException {
+    if (Files.exists(entry, LinkOption.NOFOLLOW_LINKS)
+        && (Files.isSymbolicLink(entry) || isAliasedPathEntry(entry))) {
+      throw new AppHostException(
+          label + " must not be a symlink, reparse point, or alias: " + entry);
+    }
+  }
+
+  private static boolean isAliasedPathEntry(Path entry) throws IOException {
+    if (Files.isSymbolicLink(entry)) {
+      return true;
+    }
+    Path parent = entry.getParent();
+    if (parent == null) {
+      return false;
+    }
+    Path expectedRealPath = parent.toRealPath().resolve(entry.getFileName()).normalize();
+    Path actualRealPath = entry.toRealPath();
+    return !actualRealPath.equals(expectedRealPath);
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppSnapshot.java
@@ -6,6 +6,16 @@ import network.crypta.platform.apphost.manifest.AppManifest;
 /**
  * Immutable snapshot of one installed application.
  *
+ * <p>This record joins the parsed manifest with the derived on-disk paths that the host uses for
+ * the same application identifier. It is the stable read model returned by install and discovery
+ * operations, so callers can inspect identity, version metadata, permissions, and the resolved host
+ * layout without re-reading the manifest themselves.
+ *
+ * <p>The snapshot is immutable, but it is still time-bound. Later host operations may uninstall or
+ * replace the application after the snapshot is created. Callers should therefore treat it as a
+ * report of what the host observed at one point in time, not as a durable lease on the underlying
+ * files.
+ *
  * @param manifest parsed application manifest
  * @param paths derived filesystem paths for the installed app
  */
@@ -23,6 +33,9 @@ public record InstalledAppSnapshot(AppManifest manifest, InstalledAppPaths paths
 
   /**
    * Returns the stable application identifier.
+   *
+   * <p>This convenience method exposes the canonical identifier that ties together the manifest and
+   * the derived path bundle.
    *
    * @return manifest application identifier
    */

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppSnapshot.java
@@ -1,0 +1,32 @@
+package network.crypta.platform.apphost;
+
+import java.util.Objects;
+import network.crypta.platform.apphost.manifest.AppManifest;
+
+/**
+ * Immutable snapshot of one installed application.
+ *
+ * @param manifest parsed application manifest
+ * @param paths derived filesystem paths for the installed app
+ */
+public record InstalledAppSnapshot(AppManifest manifest, InstalledAppPaths paths) {
+  /**
+   * Creates a validated installed-app snapshot.
+   *
+   * @param manifest parsed application manifest
+   * @param paths derived filesystem paths for the installed app
+   */
+  public InstalledAppSnapshot {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(paths, "paths");
+  }
+
+  /**
+   * Returns the stable application identifier.
+   *
+   * @return manifest application identifier
+   */
+  public String appId() {
+    return manifest.appId();
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
@@ -7,6 +7,15 @@ import network.crypta.platform.apphost.manifest.AppManifest;
 /**
  * Immutable snapshot of one running child process.
  *
+ * <p>This record extends the installed-app view with the launch token, representative process id,
+ * and start timestamp that the host uses for runtime tracking. It is the public read model for
+ * callers that need to display or poll AppHost runtime state without reaching into implementation
+ * internals.
+ *
+ * <p>The stored pid is the host's best current representative for the running app. For direct
+ * launches it is usually the root child process, while for wrapper or handoff launches it may be a
+ * recovered descendant that better represents the long-lived application process.
+ *
  * @param manifest parsed application manifest
  * @param paths derived filesystem paths for the installed app
  * @param token opaque per-start launch token
@@ -39,6 +48,9 @@ public record RunningAppSnapshot(
 
   /**
    * Returns the stable application identifier.
+   *
+   * <p>This mirrors the manifest identifier, so callers can correlate running state with installed
+   * state and sort snapshots without repeatedly dereferencing the manifest.
    *
    * @return manifest application identifier
    */

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
@@ -1,0 +1,48 @@
+package network.crypta.platform.apphost;
+
+import java.time.Instant;
+import java.util.Objects;
+import network.crypta.platform.apphost.manifest.AppManifest;
+
+/**
+ * Immutable snapshot of one running child process.
+ *
+ * @param manifest parsed application manifest
+ * @param paths derived filesystem paths for the installed app
+ * @param token opaque per-start launch token
+ * @param pid child-process id
+ * @param startedAt launch timestamp
+ */
+public record RunningAppSnapshot(
+    AppManifest manifest, InstalledAppPaths paths, String token, long pid, Instant startedAt) {
+  /**
+   * Creates a validated running-app snapshot.
+   *
+   * @param manifest parsed application manifest
+   * @param paths derived filesystem paths for the installed app
+   * @param token opaque per-start launch token
+   * @param pid child-process id
+   * @param startedAt launch timestamp
+   */
+  public RunningAppSnapshot {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(paths, "paths");
+    Objects.requireNonNull(token, "token");
+    Objects.requireNonNull(startedAt, "startedAt");
+    if (token.isBlank()) {
+      throw new IllegalArgumentException("token must not be blank");
+    }
+    if (pid <= 0) {
+      throw new IllegalArgumentException("pid must be positive");
+    }
+  }
+
+  /**
+   * Returns the stable application identifier.
+   *
+   * @return manifest application identifier
+   */
+  public String appId() {
+    return manifest.appId();
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
@@ -9,6 +9,16 @@ import network.crypta.platform.apphost.InstalledAppPaths;
 /**
  * Parsed v1 manifest for an installed application.
  *
+ * <p>{@code AppManifest} is the immutable normalized form of {@code cryptad-app.properties}. It
+ * carries the small set of metadata that AppHost v1 needs to identify a bundle, resolve its
+ * executable, expose a human-readable name and version, and publish optional permission and quota
+ * hints to higher layers.
+ *
+ * <p>The record stores string fields in their validated canonical form rather than preserving the
+ * source file verbatim. In particular, the app id is lower-cased, required text fields are trimmed,
+ * permissions are copied into a deterministic immutable list, and optional quota fields are checked
+ * for non-negative values before the manifest is exposed to runtime code.
+ *
  * @param manifestVersion manifest schema version
  * @param appId stable path-safe app identifier
  * @param appName human-readable application name
@@ -59,6 +69,10 @@ public record AppManifest(
   /**
    * Returns the executable path as a relative bundle path.
    *
+   * <p>The returned path is normalized but intentionally remains relative. Callers are expected to
+   * resolve it beneath an installed bundle root through {@code InstalledAppPaths} rather than treat
+   * it as an absolute filesystem location on its own.
+   *
    * @return relative executable path inside the installed bundle
    */
   public Path execPath() {
@@ -68,7 +82,10 @@ public record AppManifest(
   /**
    * Returns permissions as a deterministic comma-separated environment value.
    *
-   * @return comma-separated permissions, or an empty string
+   * <p>This is primarily useful for launch-time environment injection and diagnostics where the
+   * host needs a stable textual representation of the manifest permission list.
+   *
+   * @return comma-separated permissions, or an empty string when the manifest declares none
    */
   public String permissionsCsv() {
     return String.join(",", permissions);
@@ -77,8 +94,14 @@ public record AppManifest(
   /**
    * Normalizes and validates an app id.
    *
+   * <p>The method trims the input, lower-cases it using {@link Locale#ROOT}, and validates it
+   * against the same path-safe rules used by {@link InstalledAppPaths}. The result is suitable for
+   * directory naming and for stable identity comparisons across APIs.
+   *
    * @param appId raw application identifier
    * @return normalized lower-case app id
+   * @throws IllegalArgumentException if the identifier is blank or does not match the supported
+   *     AppHost naming pattern
    */
   public static String normalizeAppId(String appId) {
     String normalized = requireNonBlank(appId, "app.id").toLowerCase(Locale.ROOT);

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
@@ -1,0 +1,115 @@
+package network.crypta.platform.apphost.manifest;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import network.crypta.platform.apphost.InstalledAppPaths;
+
+/**
+ * Parsed v1 manifest for an installed application.
+ *
+ * @param manifestVersion manifest schema version
+ * @param appId stable path-safe app identifier
+ * @param appName human-readable application name
+ * @param appVersion display version string
+ * @param execPathText executable path relative to the installed app root
+ * @param uiEntry optional UI entry path, or {@code null}
+ * @param permissions normalized permission strings
+ * @param dataQuotaBytes optional data quota metadata, or {@code null}
+ * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+ */
+public record AppManifest(
+    int manifestVersion,
+    String appId,
+    String appName,
+    String appVersion,
+    String execPathText,
+    String uiEntry,
+    List<String> permissions,
+    Long dataQuotaBytes,
+    Long cacheQuotaBytes) {
+  /**
+   * Creates a validated manifest snapshot.
+   *
+   * @param manifestVersion manifest schema version
+   * @param appId stable path-safe app identifier
+   * @param appName human-readable application name
+   * @param appVersion display version string
+   * @param execPathText executable path relative to the installed app root
+   * @param uiEntry optional UI entry path, or {@code null}
+   * @param permissions normalized permission strings
+   * @param dataQuotaBytes optional data quota metadata, or {@code null}
+   * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+   */
+  public AppManifest {
+    if (manifestVersion != 1) {
+      throw new IllegalArgumentException("unsupported manifest.version: " + manifestVersion);
+    }
+    appId = normalizeAppId(appId);
+    appName = requireNonBlank(appName, "app.name");
+    appVersion = requireNonBlank(appVersion, "app.version");
+    execPathText = requireNonBlank(execPathText, "app.exec");
+    uiEntry = normalizeOptional(uiEntry);
+    permissions = List.copyOf(Objects.requireNonNull(permissions, "permissions"));
+    dataQuotaBytes = normalizeQuota(dataQuotaBytes, "quota.data.bytes");
+    cacheQuotaBytes = normalizeQuota(cacheQuotaBytes, "quota.cache.bytes");
+  }
+
+  /**
+   * Returns the executable path as a relative bundle path.
+   *
+   * @return relative executable path inside the installed bundle
+   */
+  public Path execPath() {
+    return Path.of(execPathText).normalize();
+  }
+
+  /**
+   * Returns permissions as a deterministic comma-separated environment value.
+   *
+   * @return comma-separated permissions, or an empty string
+   */
+  public String permissionsCsv() {
+    return String.join(",", permissions);
+  }
+
+  /**
+   * Normalizes and validates an app id.
+   *
+   * @param appId raw application identifier
+   * @return normalized lower-case app id
+   */
+  public static String normalizeAppId(String appId) {
+    String normalized = requireNonBlank(appId, "app.id").toLowerCase(Locale.ROOT);
+    InstalledAppPaths.normalizeAppId(normalized);
+    return normalized;
+  }
+
+  private static String normalizeOptional(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private static Long normalizeQuota(Long quota, String fieldName) {
+    if (quota == null) {
+      return null;
+    }
+    if (quota < 0L) {
+      throw new IllegalArgumentException(fieldName + " must be >= 0");
+    }
+    return quota;
+  }
+
+  private static String requireNonBlank(String value, String fieldName) {
+    Objects.requireNonNull(value, fieldName);
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return trimmed;
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestException.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestException.java
@@ -2,12 +2,22 @@ package network.crypta.platform.apphost.manifest;
 
 import network.crypta.platform.apphost.AppHostException;
 
-/** Signals manifest parsing or validation failures. */
+/**
+ * Signals manifest parsing or validation failures.
+ *
+ * <p>This checked exception specializes {@link network.crypta.platform.apphost.AppHostException}
+ * for problems in {@code cryptad-app.properties}. Typical causes include missing required keys,
+ * malformed numeric values, unsupported manifest versions, invalid path syntax, or permission and
+ * quota metadata that fails normalization.
+ *
+ * <p>Using a dedicated subtype lets callers distinguish bundle-shape problems from later runtime
+ * failures such as launch errors or shutdown timeouts.
+ */
 public class AppManifestException extends AppHostException {
   /**
    * Creates an exception with a message.
    *
-   * @param message failure detail
+   * @param message human-readable detail about the invalid manifest content or missing property
    */
   public AppManifestException(String message) {
     super(message);
@@ -16,8 +26,8 @@ public class AppManifestException extends AppHostException {
   /**
    * Creates an exception with a message and cause.
    *
-   * @param message failure detail
-   * @param cause underlying cause
+   * @param message human-readable detail about the invalid manifest content or missing property
+   * @param cause underlying parsing or validation cause
    */
   public AppManifestException(String message, Throwable cause) {
     super(message, cause);

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestException.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestException.java
@@ -1,0 +1,25 @@
+package network.crypta.platform.apphost.manifest;
+
+import network.crypta.platform.apphost.AppHostException;
+
+/** Signals manifest parsing or validation failures. */
+public class AppManifestException extends AppHostException {
+  /**
+   * Creates an exception with a message.
+   *
+   * @param message failure detail
+   */
+  public AppManifestException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception with a message and cause.
+   *
+   * @param message failure detail
+   * @param cause underlying cause
+   */
+  public AppManifestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
@@ -14,7 +14,21 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-/** Parser and validator for the v1 app-host manifest format. */
+/**
+ * Parser and validator for the v1 app-host manifest format.
+ *
+ * <p>{@code AppManifestParser} converts the narrow properties-style {@code cryptad-app.properties}
+ * format into an immutable {@link AppManifest}. The parser does not delegate blindly to the full
+ * Java properties reader because AppHost needs tighter control over escaping, UTF-8 handling,
+ * backslash preservation for Windows-style paths, and the small subset of keys that are valid for
+ * the v1 manifest schema.
+ *
+ * <p>Parsing is intentionally strict. The parser rejects missing required properties, unsupported
+ * schema versions, malformed numeric values, invalid permission identifiers, unsafe executable
+ * paths, and ambiguous or blank values before runtime code is allowed to inspect the manifest. That
+ * keeps bundle validation failures close to the source file and gives callers a deterministic
+ * checked exception model.
+ */
 public final class AppManifestParser {
   /** Canonical manifest filename stored at the installed app root. */
   public static final String MANIFEST_FILE_NAME = "cryptad-app.properties";
@@ -35,7 +49,8 @@ public final class AppManifestParser {
    *
    * @param content manifest content in properties-style syntax
    * @return the validated manifest snapshot
-   * @throws IOException if the manifest content is invalid
+   * @throws IOException if the manifest content is invalid, incomplete, or cannot be normalized
+   *     into the AppHost v1 manifest model
    */
   public static AppManifest parseContent(String content) throws IOException {
     return parse(parseProperties(stripLeadingBom(content)));
@@ -44,9 +59,13 @@ public final class AppManifestParser {
   /**
    * Parses a manifest from an on-disk properties file.
    *
+   * <p>The path must refer to a regular file and must not be a symbolic link. Callers that validate
+   * a staged or installed bundle can therefore use this entry point without accidentally following
+   * a manifest that escapes the intended bundle tree.
+   *
    * @param manifestFile path to {@code cryptad-app.properties}
    * @return the validated manifest snapshot
-   * @throws IOException if the file cannot be read or is invalid
+   * @throws IOException if the file cannot be read safely or the manifest content is invalid
    */
   public static AppManifest parse(Path manifestFile) throws IOException {
     if (Files.isSymbolicLink(manifestFile)) {

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
@@ -1,0 +1,390 @@
+package network.crypta.platform.apphost.manifest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Parser and validator for the v1 app-host manifest format. */
+public final class AppManifestParser {
+  /** Canonical manifest filename stored at the installed app root. */
+  public static final String MANIFEST_FILE_NAME = "cryptad-app.properties";
+
+  private static final char UTF_8_BOM = '\uFEFF';
+  private static final Pattern PERMISSION_PATTERN =
+      Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
+  private static final Pattern WINDOWS_DRIVE_PREFIX_PATTERN = Pattern.compile("^[a-zA-Z]:.*");
+
+  private AppManifestParser() {}
+
+  /**
+   * Parses a manifest from UTF-8 text content.
+   *
+   * <p>The manifest intentionally uses a narrow key/value syntax instead of Java's full {@link
+   * Properties#load(java.io.Reader)} behavior so UTF-8 characters and literal backslashes survive
+   * round-tripping before field validation normalizes them.
+   *
+   * @param content manifest content in properties-style syntax
+   * @return the validated manifest snapshot
+   * @throws IOException if the manifest content is invalid
+   */
+  public static AppManifest parseContent(String content) throws IOException {
+    return parse(parseProperties(stripLeadingBom(content)));
+  }
+
+  /**
+   * Parses a manifest from an on-disk properties file.
+   *
+   * @param manifestFile path to {@code cryptad-app.properties}
+   * @return the validated manifest snapshot
+   * @throws IOException if the file cannot be read or is invalid
+   */
+  public static AppManifest parse(Path manifestFile) throws IOException {
+    if (Files.isSymbolicLink(manifestFile)) {
+      throw new AppManifestException("manifest file must not be a symlink: " + manifestFile);
+    }
+    if (!Files.isRegularFile(manifestFile, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppManifestException("missing manifest file: " + manifestFile);
+    }
+    return parseContent(Files.readString(manifestFile));
+  }
+
+  private static Properties parseProperties(String content) throws IOException {
+    Properties properties = new Properties();
+    try (BufferedReader reader = new BufferedReader(new StringReader(content))) {
+      String line;
+      int lineNumber = 0;
+      while ((line = reader.readLine()) != null) {
+        lineNumber++;
+        parsePropertyLine(properties, line, lineNumber);
+      }
+      return properties;
+    }
+  }
+
+  private static String stripLeadingBom(String content) {
+    if (!content.isEmpty() && content.charAt(0) == UTF_8_BOM) {
+      return content.substring(1);
+    }
+    return content;
+  }
+
+  private static void parsePropertyLine(Properties properties, String line, int lineNumber)
+      throws AppManifestException {
+    String trimmedLine = line.trim();
+    if (trimmedLine.isEmpty() || trimmedLine.startsWith("#") || trimmedLine.startsWith("!")) {
+      return;
+    }
+    int separatorIndex = findSeparatorIndex(line);
+    if (separatorIndex < 0) {
+      throw new AppManifestException("invalid manifest line " + lineNumber + ": " + line);
+    }
+    String key =
+        decodePropertiesComponent(line.substring(0, separatorIndex).trim(), lineNumber, true, true);
+    if (key.isEmpty()) {
+      throw new AppManifestException("invalid manifest line " + lineNumber + ": " + line);
+    }
+    String rawValue = line.substring(separatorIndex + 1).trim();
+    String value =
+        decodePropertiesComponent(
+            rawValue, lineNumber, false, shouldDecodeUnicodeEscapesInValue(key, rawValue));
+    properties.setProperty(key, value);
+  }
+
+  private static boolean shouldDecodeUnicodeEscapesInValue(String key, String rawValue) {
+    if (!key.equals("app.exec")) {
+      return true;
+    }
+    return rawValue.contains("/")
+        || rawValue.contains("\\\\")
+        || rawValue.startsWith("\\u")
+        || rawValue.startsWith("\\U")
+        || (containsUnicodeEscape(rawValue) && !containsPlainBackslash(rawValue));
+  }
+
+  private static boolean containsUnicodeEscape(String rawValue) {
+    for (int index = 0; index + 5 < rawValue.length(); index++) {
+      if (rawValue.charAt(index) == '\\'
+          && (rawValue.charAt(index + 1) == 'u' || rawValue.charAt(index + 1) == 'U')
+          && isHexSequence(rawValue, index + 2)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsPlainBackslash(String rawValue) {
+    for (int index = 0; index < rawValue.length() - 1; index++) {
+      if (rawValue.charAt(index) == '\\'
+          && rawValue.charAt(index + 1) != 'u'
+          && rawValue.charAt(index + 1) != 'U') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isHexSequence(String rawValue, int startIndex) {
+    if (startIndex + 4 > rawValue.length()) {
+      return false;
+    }
+    for (int offset = 0; offset < 4; offset++) {
+      if (Character.digit(rawValue.charAt(startIndex + offset), 16) < 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int findSeparatorIndex(String line) {
+    int equalsIndex = line.indexOf('=');
+    int colonIndex = line.indexOf(':');
+    if (equalsIndex < 0) {
+      return colonIndex;
+    }
+    if (colonIndex < 0) {
+      return equalsIndex;
+    }
+    return Math.min(equalsIndex, colonIndex);
+  }
+
+  private static String decodePropertiesComponent(
+      String text, int lineNumber, boolean decodeControlEscapes, boolean decodeUnicodeEscapes)
+      throws AppManifestException {
+    StringBuilder decoded = new StringBuilder(text.length());
+    int index = 0;
+    while (index < text.length()) {
+      char character = text.charAt(index);
+      if (character != '\\' || index + 1 >= text.length()) {
+        decoded.append(character);
+        index++;
+      } else {
+        index =
+            appendEscapedCharacter(
+                decoded, text, index, lineNumber, decodeControlEscapes, decodeUnicodeEscapes);
+      }
+    }
+    return decoded.toString();
+  }
+
+  private static int appendEscapedCharacter(
+      StringBuilder decoded,
+      String text,
+      int escapeIndex,
+      int lineNumber,
+      boolean decodeControlEscapes,
+      boolean decodeUnicodeEscapes)
+      throws AppManifestException {
+    int nextIndex = escapeIndex + 1;
+    char escaped = text.charAt(nextIndex);
+    switch (escaped) {
+      case 't' -> appendControlEscape(decoded, escaped, '\t', decodeControlEscapes);
+      case 'n' -> appendControlEscape(decoded, escaped, '\n', decodeControlEscapes);
+      case 'r' -> appendControlEscape(decoded, escaped, '\r', decodeControlEscapes);
+      case 'f' -> appendControlEscape(decoded, escaped, '\f', decodeControlEscapes);
+      case '\\' -> decoded.append('\\');
+      case ' ' -> decoded.append(' ');
+      case ':', '=', '#', '!' -> decoded.append(escaped);
+      case 'u' -> {
+        if (decodeUnicodeEscapes) {
+          decoded.append(decodeUnicodeEscape(text, nextIndex, lineNumber));
+          nextIndex += 4;
+        } else {
+          decoded.append('\\');
+          decoded.append(escaped);
+        }
+      }
+      default -> {
+        decoded.append('\\');
+        decoded.append(escaped);
+      }
+    }
+    return nextIndex + 1;
+  }
+
+  private static void appendControlEscape(
+      StringBuilder decoded, char escaped, char decodedCharacter, boolean decodeControlEscapes) {
+    if (decodeControlEscapes) {
+      decoded.append(decodedCharacter);
+    } else {
+      decoded.append('\\');
+      decoded.append(escaped);
+    }
+  }
+
+  private static char decodeUnicodeEscape(String text, int escapeStartIndex, int lineNumber)
+      throws AppManifestException {
+    if (escapeStartIndex + 4 >= text.length()) {
+      throw new AppManifestException("invalid unicode escape in manifest line " + lineNumber);
+    }
+    int codePoint = 0;
+    for (int offset = 1; offset <= 4; offset++) {
+      int digit = Character.digit(text.charAt(escapeStartIndex + offset), 16);
+      if (digit < 0) {
+        throw new AppManifestException("invalid unicode escape in manifest line " + lineNumber);
+      }
+      codePoint = (codePoint << 4) + digit;
+    }
+    return (char) codePoint;
+  }
+
+  private static AppManifest parse(Properties properties) throws AppManifestException {
+    int manifestVersion = parseRequiredVersion(properties);
+    String appId = required(properties, "app.id");
+    String appName = required(properties, "app.name");
+    String appVersion = required(properties, "app.version");
+    String execPathText = normalizeExecPath(required(properties, "app.exec"));
+    String uiEntry = optional(properties, "app.ui.entry");
+    List<String> permissions = parsePermissions(optional(properties, "app.permissions"));
+    Long dataQuotaBytes = parseOptionalLong(properties, "quota.data.bytes");
+    Long cacheQuotaBytes = parseOptionalLong(properties, "quota.cache.bytes");
+    try {
+      return new AppManifest(
+          manifestVersion,
+          appId,
+          appName,
+          appVersion,
+          execPathText,
+          uiEntry,
+          permissions,
+          dataQuotaBytes,
+          cacheQuotaBytes);
+    } catch (IllegalArgumentException e) {
+      throw new AppManifestException(e.getMessage(), e);
+    }
+  }
+
+  private static int parseRequiredVersion(Properties properties) throws AppManifestException {
+    String value = required(properties, "manifest.version");
+    try {
+      int version = Integer.parseInt(value);
+      if (version != 1) {
+        throw new AppManifestException("unsupported manifest.version: " + value);
+      }
+      return version;
+    } catch (NumberFormatException e) {
+      throw new AppManifestException("invalid manifest.version: " + value, e);
+    }
+  }
+
+  private static String normalizeExecPath(String rawValue) throws AppManifestException {
+    String normalized = rawValue.trim().replace('\\', '/');
+    if (normalized.isEmpty()) {
+      throw new AppManifestException("app.exec must not be blank");
+    }
+    if (normalized.startsWith("/")
+        || normalized.startsWith("\\")
+        || WINDOWS_DRIVE_PREFIX_PATTERN.matcher(normalized).matches()) {
+      throw new AppManifestException("app.exec must be relative: " + rawValue);
+    }
+    ArrayList<String> normalizedSegments = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    for (int index = 0; index < normalized.length(); index++) {
+      char character = normalized.charAt(index);
+      if (character == '/') {
+        addExecSegment(normalizedSegments, current, rawValue);
+      } else {
+        current.append(character);
+      }
+    }
+    addExecSegment(normalizedSegments, current, rawValue);
+    for (String segment : normalizedSegments) {
+      if (segment.isBlank()) {
+        throw new AppManifestException("app.exec must be normalized: " + rawValue);
+      }
+      if (segment.equals(".") || segment.equals("..")) {
+        throw new AppManifestException("app.exec must stay under the app root: " + rawValue);
+      }
+    }
+    return String.join("/", normalizedSegments);
+  }
+
+  private static List<String> parsePermissions(String rawPermissions) throws AppManifestException {
+    if (rawPermissions == null) {
+      return List.of();
+    }
+    LinkedHashSet<String> normalized = new LinkedHashSet<>();
+    StringBuilder current = new StringBuilder();
+    for (int index = 0; index < rawPermissions.length(); index++) {
+      char character = rawPermissions.charAt(index);
+      if (character == ',') {
+        addPermission(normalized, current, rawPermissions);
+      } else {
+        current.append(character);
+      }
+    }
+    addPermission(normalized, current, rawPermissions);
+    return List.copyOf(normalized);
+  }
+
+  private static void addExecSegment(
+      List<String> normalizedSegments, StringBuilder current, String rawValue)
+      throws AppManifestException {
+    String segment = current.toString();
+    current.setLength(0);
+    if (segment.isBlank()) {
+      throw new AppManifestException("app.exec must be normalized: " + rawValue);
+    }
+    normalizedSegments.add(segment);
+  }
+
+  private static void addPermission(
+      Set<String> normalized, StringBuilder current, String rawPermissions)
+      throws AppManifestException {
+    String permission = current.toString().trim().toLowerCase(Locale.ROOT);
+    current.setLength(0);
+    if (permission.isEmpty()) {
+      throw new AppManifestException("app.permissions must not contain blank entries");
+    }
+    if (!PERMISSION_PATTERN.matcher(permission).matches()) {
+      throw new AppManifestException("invalid app.permissions entry: " + rawPermissions);
+    }
+    normalized.add(permission);
+  }
+
+  private static Long parseOptionalLong(Properties properties, String key)
+      throws AppManifestException {
+    String value = optional(properties, key);
+    if (value == null) {
+      return null;
+    }
+    try {
+      long parsed = Long.parseLong(value);
+      if (parsed < 0L) {
+        throw new AppManifestException(key + " must be >= 0");
+      }
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new AppManifestException("invalid " + key + ": " + value, e);
+    }
+  }
+
+  private static String required(Properties properties, String key) throws AppManifestException {
+    String value = optional(properties, key);
+    if (value == null) {
+      throw new AppManifestException("missing required property: " + key);
+    }
+    return value;
+  }
+
+  private static String optional(Properties properties, String key) throws AppManifestException {
+    String value = properties.getProperty(key);
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      throw new AppManifestException(key + " must not be blank");
+    }
+    return trimmed;
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/package-info.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/package-info.java
@@ -1,8 +1,13 @@
 /**
  * Strict v1 manifest parsing and validation for {@code cryptad-app.properties}.
  *
- * <p>The parser accepts only the small properties-style format used by the AppHost core. It
- * normalizes the manifest into immutable values and rejects unsupported schema versions, malformed
- * identifiers, unsafe executable paths, and invalid quota metadata.
+ * <p>This package owns the immutable manifest model and the parser that converts raw {@code
+ * cryptad-app.properties} files into validated AppHost metadata. The implementation accepts only
+ * the small properties-style surface used by the AppHost core rather than the broader Java
+ * properties feature set.
+ *
+ * <p>The package is responsible for schema version checks, app identity normalization, executable
+ * path confinement, permission parsing, and optional quota metadata. By rejecting malformed input
+ * here, the rest of the AppHost runtime can work with a smaller and safer manifest surface.
  */
 package network.crypta.platform.apphost.manifest;

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/package-info.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Strict v1 manifest parsing and validation for {@code cryptad-app.properties}.
+ *
+ * <p>The parser accepts only the small properties-style format used by the AppHost core. It
+ * normalizes the manifest into immutable values and rejects unsupported schema versions, malformed
+ * identifiers, unsafe executable paths, and invalid quota metadata.
+ */
+package network.crypta.platform.apphost.manifest;

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/package-info.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/package-info.java
@@ -1,9 +1,13 @@
 /**
  * Transport-neutral out-of-process AppHost core for locally installed applications.
  *
- * <p>This leaf owns the v1 app manifest, installed-app filesystem layout, and local process
- * lifecycle used to run applications outside the daemon process. It stays below future Web Shell
- * and transport/API layers, so code here avoids dependencies on adapters, runtime-node
- * implementation packages, and launcher code.
+ * <p>This package defines the public model and lifecycle contracts for AppHost v1. It owns the
+ * transport-neutral interface, immutable installed and running snapshots, the stable filesystem
+ * layout model, and the checked exception surface that callers use to reason about installation,
+ * discovery, launch, and shutdown behavior.
+ *
+ * <p>The package sits below transport adapters, launcher UI code, and higher-level management
+ * shells. That separation lets future API layers reuse the same manifest, path, and snapshot model
+ * whether the caller is a local administrative shell, a UI layer, or a transport endpoint.
  */
 package network.crypta.platform.apphost;

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/package-info.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Transport-neutral out-of-process AppHost core for locally installed applications.
+ *
+ * <p>This leaf owns the v1 app manifest, installed-app filesystem layout, and local process
+ * lifecycle used to run applications outside the daemon process. It stays below future Web Shell
+ * and transport/API layers, so code here avoids dependencies on adapters, runtime-node
+ * implementation packages, and launcher code.
+ */
+package network.crypta.platform.apphost;

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -54,6 +54,12 @@ import org.jetbrains.annotations.NotNull;
 public final class LocalProcessAppHost implements AppHost {
   private static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofSeconds(5);
   private static final String TEMP_INSTALL_PREFIX = "app-install-";
+  private static final String LOCAL_DIRECTORY_NAME = "local";
+  private static final String INSTALLED_APPS_DIR_LABEL = "installedAppsDir";
+  private static final String WINDOWS_SYSTEM32_DIRECTORY = "System32";
+  private static final String PROC_ROOT = "/proc";
+  private static final List<String> WINDOWS_ROOT_ENVIRONMENT_NAMES =
+      List.of("SystemRoot", "SYSTEMROOT", "WINDIR");
   private static final int MAX_SHEBANG_PROBE_BYTES = 4096;
   private static final int DOS_HEADER_SIZE = 64;
   private static final int PE_POINTER_OFFSET = 0x3C;
@@ -77,14 +83,14 @@ public final class LocalProcessAppHost implements AppHost {
           Path.of("/bin").toString(),
           Path.of("/usr", "sbin").toString(),
           Path.of("/sbin").toString(),
-          Path.of("/usr", "local", "bin").toString(),
-          Path.of("/usr", "local", "sbin").toString());
+          Path.of("/usr", LOCAL_DIRECTORY_NAME, "bin").toString(),
+          Path.of("/usr", LOCAL_DIRECTORY_NAME, "sbin").toString());
   private static final List<String> MAC_UNIX_PATH_ENTRIES =
       List.of(
           Path.of("/opt", "homebrew", "bin").toString(),
           Path.of("/opt", "homebrew", "sbin").toString(),
-          Path.of("/opt", "local", "bin").toString(),
-          Path.of("/opt", "local", "sbin").toString());
+          Path.of("/opt", LOCAL_DIRECTORY_NAME, "bin").toString(),
+          Path.of("/opt", LOCAL_DIRECTORY_NAME, "sbin").toString());
   private static final List<String> LINUX_UNIX_PATH_ENTRIES =
       List.of(
           Path.of("/home", "linuxbrew", ".linuxbrew", "bin").toString(),
@@ -102,6 +108,7 @@ public final class LocalProcessAppHost implements AppHost {
    *
    * @param layout filesystem layout managed by the host
    */
+  @SuppressWarnings("unused")
   public LocalProcessAppHost(AppHostLayout layout) {
     this(layout, DEFAULT_STOP_TIMEOUT, new SecureRandom(), new AppEnv());
   }
@@ -135,7 +142,7 @@ public final class LocalProcessAppHost implements AppHost {
     Path stagingRoot = normalizeExistingDirectory(stagedAppDirectory);
     rejectOverlappingInstallTree(stagingRoot, layout.installedAppsDir());
     Path installedAppsDir = layout.installedAppsDir();
-    ensureManagedDirectory(layout.dataDir(), installedAppsDir, "installedAppsDir");
+    ensureManagedDirectory(layout.dataDir(), installedAppsDir);
     Path temporaryInstallRoot = Files.createTempDirectory(installedAppsDir, TEMP_INSTALL_PREFIX);
     try {
       copyDirectoryTree(stagingRoot, temporaryInstallRoot);
@@ -287,58 +294,11 @@ public final class LocalProcessAppHost implements AppHost {
     if (trackedRunningProcess == null) {
       return true;
     }
-    List<ProcessHandle> processTree = trackedRunningProcess.processTree();
-    try {
-      Duration reapGracePeriod =
-          stopTimeout.compareTo(Duration.ofMillis(100)) > 0 ? Duration.ofMillis(100) : stopTimeout;
-
-      destroyProcessHandles(descendantHandles(trackedRunningProcess));
-      if (!waitForProcessTreeExit(processTree, reapGracePeriod)) {
-        trackedRunningProcess =
-            refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess);
-        if (trackedRunningProcess == null) {
-          return true;
-        }
-        processTree = trackedRunningProcess.processTree();
-        destroyRootProcess(trackedRunningProcess);
-        if (!waitForProcessTreeExit(processTree, stopTimeout)) {
-          trackedRunningProcess =
-              refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess);
-          if (trackedRunningProcess == null) {
-            return true;
-          }
-          processTree = trackedRunningProcess.processTree();
-          destroyProcessHandlesForcibly(descendantHandles(trackedRunningProcess));
-          if (!waitForProcessTreeExit(processTree, stopTimeout)) {
-            trackedRunningProcess =
-                refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess);
-            if (trackedRunningProcess == null) {
-              return true;
-            }
-            processTree = trackedRunningProcess.processTree();
-            destroyRootProcessForcibly(trackedRunningProcess);
-            waitForProcessExit(trackedRunningProcess.process(), stopTimeout);
-            if (!waitForProcessTreeExit(processTree, stopTimeout)) {
-              if (!preserveRunningState(normalizedAppId, trackedRunningProcess)) {
-                return true;
-              }
-              throw new AppHostException("timed out stopping app: " + appId);
-            }
-          }
-        }
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      if (!preserveRunningState(normalizedAppId, trackedRunningProcess)) {
-        return true;
-      }
-      throw new AppHostException("interrupted while stopping app: " + appId, e);
+    trackedRunningProcess = stopWithEscalation(normalizedAppId, appId, trackedRunningProcess);
+    if (trackedRunningProcess == null) {
+      return true;
     }
-    if (refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess) != null) {
-      throw new AppHostException("timed out stopping app: " + appId);
-    }
-    trackedRunningProcess.exitCleanup().join();
-    runningApps.remove(normalizedAppId, trackedRunningProcess);
+    completeStop(normalizedAppId, appId, trackedRunningProcess);
     return true;
   }
 
@@ -470,10 +430,10 @@ public final class LocalProcessAppHost implements AppHost {
         || secondComparablePath.startsWith(firstComparablePath);
   }
 
-  private static void ensureManagedDirectory(Path baseDirectory, Path directory, String label)
+  private static void ensureManagedDirectory(Path baseDirectory, Path directory)
       throws IOException {
     Path normalized = directory.toAbsolutePath().normalize();
-    validateManagedPathPrefixes(baseDirectory, normalized, label);
+    validateManagedPathPrefixes(baseDirectory, normalized, INSTALLED_APPS_DIR_LABEL);
     Deque<Path> missingSegments = new ArrayDeque<>();
     Path current = normalized;
     while (current != null && !Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
@@ -484,28 +444,30 @@ public final class LocalProcessAppHost implements AppHost {
       current = current.getParent();
     }
     if (current == null) {
-      throw new AppHostException(label + " must resolve beneath an existing filesystem root");
+      throw new AppHostException(
+          INSTALLED_APPS_DIR_LABEL + " must resolve beneath an existing filesystem root");
     }
-    validateManagedDirectoryEntry(current, label);
+    validateManagedDirectoryEntry(current, INSTALLED_APPS_DIR_LABEL);
     while (!missingSegments.isEmpty()) {
       current = current.resolve(missingSegments.pop());
       Files.createDirectory(current);
     }
-    validateManagedDirectoryEntry(normalized, label);
+    validateManagedDirectoryEntry(normalized, INSTALLED_APPS_DIR_LABEL);
     if (!Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
-      throw new AppHostException(label + " must be a directory: " + normalized);
+      throw new AppHostException(INSTALLED_APPS_DIR_LABEL + " must be a directory: " + normalized);
     }
   }
 
   private Path validateInstalledAppsDirectory() throws IOException {
     Path installedAppsDir = layout.installedAppsDir().toAbsolutePath().normalize();
-    validateManagedPathPrefixes(layout.dataDir(), installedAppsDir, "installedAppsDir");
+    validateManagedPathPrefixes(layout.dataDir(), installedAppsDir, INSTALLED_APPS_DIR_LABEL);
     if (!Files.exists(installedAppsDir, LinkOption.NOFOLLOW_LINKS)) {
       return installedAppsDir;
     }
-    validateManagedDirectoryEntry(installedAppsDir, "installedAppsDir");
+    validateManagedDirectoryEntry(installedAppsDir, INSTALLED_APPS_DIR_LABEL);
     if (!Files.isDirectory(installedAppsDir, LinkOption.NOFOLLOW_LINKS)) {
-      throw new AppHostException("installedAppsDir must be a directory: " + installedAppsDir);
+      throw new AppHostException(
+          INSTALLED_APPS_DIR_LABEL + " must be a directory: " + installedAppsDir);
     }
     return installedAppsDir;
   }
@@ -544,7 +506,7 @@ public final class LocalProcessAppHost implements AppHost {
     }
   }
 
-  private static boolean shouldSkipInstalledEntry(Path appRoot) throws IOException {
+  private static boolean shouldSkipInstalledEntry(Path appRoot) {
     if (!Files.isDirectory(appRoot, LinkOption.NOFOLLOW_LINKS)) {
       return true;
     }
@@ -616,45 +578,49 @@ public final class LocalProcessAppHost implements AppHost {
     long handoffDeadline = captureDeadline + STARTUP_POST_CAPTURE_HANDOFF_GRACE_PERIOD.toNanos();
     while (System.nanoTime() < deadline) {
       observedHandles.addAll(snapshotProcessTree(startupSeedHandles(rootHandle, observedHandles)));
-      if (!rootHandle.isAlive()) {
-        break;
-      }
       long now = System.nanoTime();
-      if (now >= handoffDeadline) {
+      if (shouldStopStartupObservation(rootHandle, now, handoffDeadline)) {
         break;
       }
-      long remainingNanos = deadline - now;
-      if (remainingNanos <= 0L) {
-        break;
-      }
-      long pollIntervalNanos =
-          now >= captureDeadline
-              ? STARTUP_HANDOFF_POLL_INTERVAL_NANOS
-              : STARTUP_PROCESS_POLL_INTERVAL_NANOS;
-      long pollNanos = Math.min(remainingNanos, pollIntervalNanos);
-      boolean exited = waitForProcess(process, pollNanos, appId);
-      if (!exited && System.nanoTime() >= handoffDeadline) {
-        break;
-      }
+      waitForStartupObservation(process, appId, deadline, captureDeadline, now);
     }
     capturePostExitProcessTree(rootHandle, observedHandles, appId);
     observedHandles.addAll(snapshotProcessTree(List.of(rootHandle)));
     return aliveHandles(observedHandles);
   }
 
-  private boolean waitForProcess(Process process, long timeoutNanos, String appId)
+  private static boolean shouldStopStartupObservation(
+      ProcessHandle rootHandle, long now, long handoffDeadline) {
+    return !rootHandle.isAlive() || now >= handoffDeadline;
+  }
+
+  private void waitForStartupObservation(
+      Process process, String appId, long deadline, long captureDeadline, long now)
+      throws AppHostException {
+    long remainingNanos = deadline - now;
+    if (remainingNanos <= 0L) {
+      return;
+    }
+    long pollIntervalNanos =
+        now >= captureDeadline
+            ? STARTUP_HANDOFF_POLL_INTERVAL_NANOS
+            : STARTUP_PROCESS_POLL_INTERVAL_NANOS;
+    waitForProcess(process, Math.min(remainingNanos, pollIntervalNanos), appId);
+  }
+
+  private void waitForProcess(Process process, long timeoutNanos, String appId)
       throws AppHostException {
     try {
-      return process.waitFor(timeoutNanos, TimeUnit.NANOSECONDS);
+      process.waitFor(timeoutNanos, TimeUnit.NANOSECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new AppHostException("interrupted while starting app: " + appId, e);
     }
   }
 
-  private static boolean waitForProcessExit(Process process, Duration timeout)
+  private static void waitForProcessExit(Process process, Duration timeout)
       throws InterruptedException {
-    return process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS);
+    process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS);
   }
 
   private static void discardChildInput(Process process, String appId) throws IOException {
@@ -707,7 +673,7 @@ public final class LocalProcessAppHost implements AppHost {
           break;
         }
       }
-    } catch (InterruptedException e) {
+    } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
     } finally {
       refreshObservedProcessTree(appId, process);
@@ -810,8 +776,8 @@ public final class LocalProcessAppHost implements AppHost {
         "PATH",
         String.join(
             ";",
-            Path.of(systemRoot, "System32").toString(),
-            Path.of(systemRoot, "System32", "WindowsPowerShell", "v1.0").toString(),
+            Path.of(systemRoot, WINDOWS_SYSTEM32_DIRECTORY).toString(),
+            Path.of(systemRoot, WINDOWS_SYSTEM32_DIRECTORY, "WindowsPowerShell", "v1.0").toString(),
             systemRoot));
     copyHostEnvironmentValue(environment, "TEMP");
     copyHostEnvironmentValue(environment, "TMP");
@@ -1036,7 +1002,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static String windowsCommandInterpreter() {
-    return Path.of(resolveWindowsRoot(), "System32", "cmd.exe").toString();
+    return Path.of(resolveWindowsRoot(), WINDOWS_SYSTEM32_DIRECTORY, "cmd.exe").toString();
   }
 
   private static String safeUnixPath(AppEnv appEnv) {
@@ -1054,12 +1020,12 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static String resolveWindowsRoot() {
-    String systemRoot = firstNonBlankEnvironmentValue("SystemRoot", "SYSTEMROOT", "WINDIR");
+    String systemRoot = firstNonBlankWindowsRootEnvironmentValue();
     return systemRoot != null ? systemRoot : "C:\\Windows";
   }
 
-  private static String firstNonBlankEnvironmentValue(String... names) {
-    for (String name : names) {
+  private static String firstNonBlankWindowsRootEnvironmentValue() {
+    for (String name : WINDOWS_ROOT_ENVIRONMENT_NAMES) {
       String value = System.getenv(name);
       if (value != null && !value.isBlank()) {
         return value;
@@ -1162,8 +1128,8 @@ public final class LocalProcessAppHost implements AppHost {
           }
 
           @Override
-          public @NotNull FileVisitResult visitFileFailed(@NotNull Path file, IOException exc)
-              throws IOException {
+          public @NotNull FileVisitResult visitFileFailed(
+              @NotNull Path file, @NotNull IOException exc) throws IOException {
             if (Files.exists(file, LinkOption.NOFOLLOW_LINKS) && isAliasedPathEntry(file)) {
               Files.deleteIfExists(file);
               return FileVisitResult.CONTINUE;
@@ -1238,6 +1204,84 @@ public final class LocalProcessAppHost implements AppHost {
     return aliveHandles(processTree).isEmpty();
   }
 
+  private RunningProcess stopWithEscalation(
+      String normalizedAppId, String appId, RunningProcess trackedRunningProcess)
+      throws IOException {
+    RunningProcess current = trackedRunningProcess;
+    try {
+      if (destroyDescendantsAndWaitForExit(current, descendantReapGracePeriod())) {
+        return current;
+      }
+      current = refreshTrackedRunningProcess(normalizedAppId, current);
+      if (current == null || destroyRootAndWaitForExit(current, stopTimeout)) {
+        return current;
+      }
+      current = refreshTrackedRunningProcess(normalizedAppId, current);
+      if (current == null || destroyDescendantsForciblyAndWaitForExit(current, stopTimeout)) {
+        return current;
+      }
+      current = refreshTrackedRunningProcess(normalizedAppId, current);
+      if (current == null) {
+        return null;
+      }
+      return destroyRootForciblyAndWaitForExit(normalizedAppId, appId, current);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      boolean preserved = preserveRunningState(normalizedAppId, current);
+      if (!preserved) {
+        return null;
+      }
+      throw new AppHostException("interrupted while stopping app: " + appId, e);
+    }
+  }
+
+  private Duration descendantReapGracePeriod() {
+    return stopTimeout.compareTo(Duration.ofMillis(100)) > 0 ? Duration.ofMillis(100) : stopTimeout;
+  }
+
+  private static boolean destroyDescendantsAndWaitForExit(
+      RunningProcess runningProcess, Duration timeout) throws InterruptedException {
+    destroyProcessHandles(descendantHandles(runningProcess));
+    return waitForProcessTreeExit(runningProcess.processTree(), timeout);
+  }
+
+  private static boolean destroyRootAndWaitForExit(RunningProcess runningProcess, Duration timeout)
+      throws InterruptedException {
+    destroyRootProcess(runningProcess);
+    return waitForProcessTreeExit(runningProcess.processTree(), timeout);
+  }
+
+  private static boolean destroyDescendantsForciblyAndWaitForExit(
+      RunningProcess runningProcess, Duration timeout) throws InterruptedException {
+    destroyProcessHandlesForcibly(descendantHandles(runningProcess));
+    return waitForProcessTreeExit(runningProcess.processTree(), timeout);
+  }
+
+  private RunningProcess destroyRootForciblyAndWaitForExit(
+      String normalizedAppId, String appId, RunningProcess runningProcess)
+      throws IOException, InterruptedException {
+    destroyRootProcessForcibly(runningProcess);
+    waitForProcessExit(runningProcess.process(), stopTimeout);
+    if (waitForProcessTreeExit(runningProcess.processTree(), stopTimeout)) {
+      return runningProcess;
+    }
+    boolean preserved = preserveRunningState(normalizedAppId, runningProcess);
+    if (!preserved) {
+      return null;
+    }
+    throw new AppHostException("timed out stopping app: " + appId);
+  }
+
+  private void completeStop(
+      String normalizedAppId, String appId, RunningProcess trackedRunningProcess)
+      throws IOException {
+    if (refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess) != null) {
+      throw new AppHostException("timed out stopping app: " + appId);
+    }
+    trackedRunningProcess.exitCleanup().join();
+    runningApps.remove(normalizedAppId, trackedRunningProcess);
+  }
+
   private boolean preserveRunningState(String appId, RunningProcess runningProcess) {
     RunningProcess refreshedRunningProcess = runningProcess.refresh();
     if (refreshedRunningProcess == null) {
@@ -1254,7 +1298,7 @@ public final class LocalProcessAppHost implements AppHost {
       RunningProcess trackedRunningProcess = runningProcess.withProcessTree(processTree);
       runningApps.replace(appId, runningProcess, trackedRunningProcess);
       return trackedRunningProcess;
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException _) {
       runningProcess.exitCleanup().join();
       runningApps.remove(appId, runningProcess);
       return null;
@@ -1411,7 +1455,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static List<ProcessHandle> findTokenTrackedProcessesWithPs(String token, String appId) {
-    String psCommand = resolveTrustedUnixCommand("ps");
+    String psCommand = resolveTrustedPsCommand();
     if (psCommand == null) {
       return List.of();
     }
@@ -1432,7 +1476,7 @@ public final class LocalProcessAppHost implements AppHost {
     Process process;
     try {
       process = new ProcessBuilder(command).redirectErrorStream(true).start();
-    } catch (IOException e) {
+    } catch (IOException _) {
       return List.of();
     }
     try {
@@ -1488,15 +1532,15 @@ public final class LocalProcessAppHost implements AppHost {
     try {
       long pid = Long.parseLong(pidText);
       return ProcessHandle.of(pid);
-    } catch (NumberFormatException e) {
+    } catch (NumberFormatException _) {
       return Optional.empty();
     }
   }
 
-  private static String resolveTrustedUnixCommand(String command) {
+  private static String resolveTrustedPsCommand() {
     for (Path trustedDir :
         List.of(Path.of("/usr/bin"), Path.of("/bin"), Path.of("/usr/sbin"), Path.of("/sbin"))) {
-      Path candidate = trustedDir.resolve(command);
+      Path candidate = trustedDir.resolve("ps");
       if (Files.isExecutable(candidate)) {
         return candidate.toString();
       }
@@ -1537,11 +1581,11 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static boolean supportsProcEnvironmentScan() {
-    return Files.isReadable(Path.of("/proc", "self", "environ"));
+    return Files.isReadable(Path.of(PROC_ROOT, "self", "environ"));
   }
 
   private static boolean hasAppHostToken(long pid, String token, String appId) {
-    Path environmentFile = Path.of("/proc", Long.toString(pid), "environ");
+    Path environmentFile = Path.of(PROC_ROOT, Long.toString(pid), "environ");
     if (!Files.isReadable(environmentFile)) {
       return false;
     }
@@ -1594,7 +1638,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static boolean isZombieProcess(ProcessHandle processHandle) {
-    Path statFile = Path.of("/proc", Long.toString(processHandle.pid()), "stat");
+    Path statFile = Path.of(PROC_ROOT, Long.toString(processHandle.pid()), "stat");
     if (!Files.isReadable(statFile)) {
       return false;
     }
@@ -1620,7 +1664,7 @@ public final class LocalProcessAppHost implements AppHost {
   private static boolean isInterpreterManagedPosixLauncherUnchecked(Path executable) {
     try {
       return isInterpreterManagedPosixLauncher(executable);
-    } catch (IOException e) {
+    } catch (IOException _) {
       return false;
     }
   }
@@ -1657,6 +1701,7 @@ public final class LocalProcessAppHost implements AppHost {
         .pid();
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class RunningProcess {
     private final Process process;
     private final RunningAppSnapshot snapshot;

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -1,0 +1,1742 @@
+package network.crypta.platform.apphost.runtime;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import network.crypta.fs.AppEnv;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.InstalledAppPaths;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.manifest.AppManifestException;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Default AppHost implementation that launches installed apps out of process.
+ *
+ * <p>The runtime state remains in memory only. This v1 host does not attempt to restart recovery,
+ * sandboxing, or hard quota enforcement.
+ */
+public final class LocalProcessAppHost implements AppHost {
+  private static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofSeconds(5);
+  private static final String TEMP_INSTALL_PREFIX = "app-install-";
+  private static final int MAX_SHEBANG_PROBE_BYTES = 4096;
+  private static final int DOS_HEADER_SIZE = 64;
+  private static final int PE_POINTER_OFFSET = 0x3C;
+  private static final int COFF_HEADER_SIZE = 24;
+  private static final int IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002;
+  private static final int IMAGE_FILE_DLL = 0x2000;
+  private static final Duration STARTUP_EXIT_GRACE_PERIOD = Duration.ofSeconds(2);
+  private static final Duration STARTUP_PROCESS_CAPTURE_WINDOW = Duration.ofMillis(500);
+  private static final Duration STARTUP_POST_CAPTURE_HANDOFF_GRACE_PERIOD = Duration.ofMillis(200);
+  private static final Duration TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD =
+      Duration.ofMillis(200);
+  private static final Duration WINDOWS_BUNDLE_RECOVERY_WINDOW =
+      STARTUP_EXIT_GRACE_PERIOD.plus(TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD);
+  private static final Duration TRACKED_PROCESS_REFRESH_INTERVAL = Duration.ofMillis(100);
+  private static final long STARTUP_PROCESS_POLL_INTERVAL_NANOS =
+      TimeUnit.MICROSECONDS.toNanos(100);
+  private static final long STARTUP_HANDOFF_POLL_INTERVAL_NANOS = TimeUnit.MILLISECONDS.toNanos(5);
+  private static final List<String> BASE_UNIX_PATH_ENTRIES =
+      List.of(
+          Path.of("/usr", "bin").toString(),
+          Path.of("/bin").toString(),
+          Path.of("/usr", "sbin").toString(),
+          Path.of("/sbin").toString(),
+          Path.of("/usr", "local", "bin").toString(),
+          Path.of("/usr", "local", "sbin").toString());
+  private static final List<String> MAC_UNIX_PATH_ENTRIES =
+      List.of(
+          Path.of("/opt", "homebrew", "bin").toString(),
+          Path.of("/opt", "homebrew", "sbin").toString(),
+          Path.of("/opt", "local", "bin").toString(),
+          Path.of("/opt", "local", "sbin").toString());
+  private static final List<String> LINUX_UNIX_PATH_ENTRIES =
+      List.of(
+          Path.of("/home", "linuxbrew", ".linuxbrew", "bin").toString(),
+          Path.of("/home", "linuxbrew", ".linuxbrew", "sbin").toString());
+  private static final int TOKEN_BYTES = 32;
+
+  private final AppHostLayout layout;
+  private final Duration stopTimeout;
+  private final SecureRandom secureRandom;
+  private final AppEnv appEnv;
+  private final Map<String, RunningProcess> runningApps = new ConcurrentHashMap<>();
+
+  /**
+   * Creates a host bound to the supplied layout.
+   *
+   * @param layout filesystem layout managed by the host
+   */
+  public LocalProcessAppHost(AppHostLayout layout) {
+    this(layout, DEFAULT_STOP_TIMEOUT, new SecureRandom(), new AppEnv());
+  }
+
+  /**
+   * Creates a host with an explicit stop timeout and token generator.
+   *
+   * @param layout filesystem layout managed by the host
+   * @param stopTimeout bounded timeout used before the force-killing a child process
+   * @param secureRandom secure token generator
+   */
+  public LocalProcessAppHost(
+      AppHostLayout layout, Duration stopTimeout, SecureRandom secureRandom) {
+    this(layout, stopTimeout, secureRandom, new AppEnv());
+  }
+
+  LocalProcessAppHost(
+      AppHostLayout layout, Duration stopTimeout, SecureRandom secureRandom, AppEnv appEnv) {
+    this.layout = Objects.requireNonNull(layout, "layout");
+    this.stopTimeout = Objects.requireNonNull(stopTimeout, "stopTimeout");
+    this.secureRandom = Objects.requireNonNull(secureRandom, "secureRandom");
+    this.appEnv = Objects.requireNonNull(appEnv, "appEnv");
+    if (stopTimeout.isZero() || stopTimeout.isNegative()) {
+      throw new IllegalArgumentException("stopTimeout must be positive");
+    }
+  }
+
+  @Override
+  public synchronized InstalledAppSnapshot installFromDirectory(Path stagedAppDirectory)
+      throws IOException {
+    Path stagingRoot = normalizeExistingDirectory(stagedAppDirectory);
+    rejectOverlappingInstallTree(stagingRoot, layout.installedAppsDir());
+    Path installedAppsDir = layout.installedAppsDir();
+    ensureManagedDirectory(layout.dataDir(), installedAppsDir, "installedAppsDir");
+    Path temporaryInstallRoot = Files.createTempDirectory(installedAppsDir, TEMP_INSTALL_PREFIX);
+    try {
+      copyDirectoryTree(stagingRoot, temporaryInstallRoot);
+      AppManifest manifest = validateCopiedBundle(temporaryInstallRoot);
+      InstalledAppPaths paths = layout.pathsFor(manifest.appId());
+      rejectOverlappingMutableAppDirectories(stagingRoot, paths);
+      if (Files.exists(paths.installedRoot())) {
+        throw new AppHostException("app already installed: " + manifest.appId());
+      }
+      validateManagedMutableDirectories(paths);
+      paths.ensureMutableDirectories();
+      moveIntoPlace(temporaryInstallRoot, paths.installedRoot());
+      return new InstalledAppSnapshot(manifest, paths);
+    } catch (IOException | RuntimeException e) {
+      deleteRecursively(temporaryInstallRoot);
+      throw e;
+    }
+  }
+
+  @Override
+  public synchronized void uninstall(String appId) throws IOException {
+    validateInstalledAppsDirectory();
+    InstalledAppPaths paths = layout.pathsFor(appId);
+    if (liveRunningProcess(paths.appId()) != null) {
+      throw new AppHostException("cannot uninstall a running app: " + appId);
+    }
+    if (!Files.exists(paths.installedRoot())) {
+      throw new AppHostException("app is not installed: " + appId);
+    }
+
+    deleteRecursively(paths.installedRoot());
+    deleteRecursively(paths.dataDir());
+    deleteRecursively(paths.cacheDir());
+    deleteRecursively(paths.runDir());
+  }
+
+  @Override
+  public synchronized List<InstalledAppSnapshot> listInstalled() throws IOException {
+    Path installedAppsDir = validateInstalledAppsDirectory();
+    if (!Files.isDirectory(installedAppsDir, LinkOption.NOFOLLOW_LINKS)) {
+      return List.of();
+    }
+
+    List<InstalledAppSnapshot> installed = new ArrayList<>();
+    try (var children = Files.list(installedAppsDir)) {
+      for (Path appRoot :
+          children.sorted(Comparator.comparing(path -> path.getFileName().toString())).toList()) {
+        if (shouldSkipInstalledEntry(appRoot)) {
+          continue;
+        }
+        AppManifest manifest = readInstalledManifest(appRoot);
+        installed.add(new InstalledAppSnapshot(manifest, layout.pathsFor(manifest.appId())));
+      }
+    }
+    return List.copyOf(installed);
+  }
+
+  @Override
+  public synchronized Optional<InstalledAppSnapshot> describe(String appId) throws IOException {
+    validateInstalledAppsDirectory();
+    InstalledAppPaths paths = layout.pathsFor(appId);
+    if (!Files.isDirectory(paths.installedRoot(), LinkOption.NOFOLLOW_LINKS)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new InstalledAppSnapshot(readInstalledManifest(paths.installedRoot()), paths));
+  }
+
+  @Override
+  public synchronized RunningAppSnapshot start(String appId) throws IOException {
+    String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
+    if (liveRunningProcess(normalizedAppId) != null) {
+      throw new AppHostException("app is already running: " + appId);
+    }
+
+    InstalledAppSnapshot installation =
+        describe(normalizedAppId)
+            .orElseThrow(() -> new AppHostException("app is not installed: " + appId));
+    InstalledAppPaths paths = installation.paths();
+    validateManagedMutableDirectories(paths);
+    paths.ensureMutableDirectories();
+    Files.deleteIfExists(paths.processLogFile());
+
+    Path executable =
+        resolveBundleEntry(
+            paths.installedRoot(), installation.manifest().execPath(), "installed app.exec");
+    if (!Files.isRegularFile(executable, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppHostException(
+          "installed app.exec does not exist: " + installation.manifest().execPathText());
+    }
+
+    String token = generateToken();
+    List<String> command = launchCommand(executable, appEnv);
+    ProcessBuilder builder = new ProcessBuilder(command);
+    builder.directory(paths.installedRoot().toFile());
+    builder.redirectErrorStream(true);
+    builder.redirectOutput(ProcessBuilder.Redirect.appendTo(paths.processLogFile().toFile()));
+    populateEnvironment(builder.environment(), installation.manifest(), paths, token, appEnv);
+
+    Instant startedAt = Instant.now();
+    Process process = builder.start();
+    discardChildInput(process, appId);
+    List<ProcessHandle> startupProcessTree = observeStartupProcessTree(process, normalizedAppId);
+    if (startupProcessTree.isEmpty()) {
+      startupProcessTree =
+          recoverTrackedProcesses(
+              installation.manifest(),
+              paths,
+              token,
+              startedAt,
+              List.of(process.toHandle()),
+              ProcessHandle.allProcesses().toList());
+    }
+    if (startupProcessTree.isEmpty()) {
+      throw startupFailure(appId, process);
+    }
+    RunningAppSnapshot snapshot =
+        new RunningAppSnapshot(
+            installation.manifest(),
+            paths,
+            token,
+            representativePid(
+                startupProcessTree,
+                process.pid(),
+                preferDescendantPid(executable, startupProcessTree)),
+            startedAt);
+    CompletableFuture<Void> exitCleanup = new CompletableFuture<>();
+    RunningProcess runningProcess =
+        new RunningProcess(process, snapshot, exitCleanup, startupProcessTree);
+    runningApps.put(normalizedAppId, runningProcess);
+    startTrackedProcessTreeObserver(normalizedAppId, process, exitCleanup);
+    RunningProcess liveRunningProcess = liveRunningProcess(normalizedAppId);
+    if (liveRunningProcess == null) {
+      throw startupFailure(appId, process);
+    }
+    return liveRunningProcess.snapshot();
+  }
+
+  @Override
+  public synchronized boolean stop(String appId) throws IOException {
+    String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
+    RunningProcess runningProcess = liveRunningProcess(normalizedAppId);
+    if (runningProcess == null) {
+      return false;
+    }
+
+    RunningProcess trackedRunningProcess =
+        trackRunningProcessForStop(normalizedAppId, runningProcess);
+    if (trackedRunningProcess == null) {
+      return true;
+    }
+    List<ProcessHandle> processTree = trackedRunningProcess.processTree();
+    try {
+      Duration reapGracePeriod =
+          stopTimeout.compareTo(Duration.ofMillis(100)) > 0 ? Duration.ofMillis(100) : stopTimeout;
+
+      destroyProcessHandles(descendantHandles(trackedRunningProcess));
+      if (!waitForProcessTreeExit(processTree, reapGracePeriod)) {
+        trackedRunningProcess =
+            refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess);
+        if (trackedRunningProcess == null) {
+          return true;
+        }
+        processTree = trackedRunningProcess.processTree();
+        destroyRootProcess(trackedRunningProcess);
+        if (!waitForProcessTreeExit(processTree, stopTimeout)) {
+          trackedRunningProcess =
+              refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess);
+          if (trackedRunningProcess == null) {
+            return true;
+          }
+          processTree = trackedRunningProcess.processTree();
+          destroyProcessHandlesForcibly(descendantHandles(trackedRunningProcess));
+          if (!waitForProcessTreeExit(processTree, stopTimeout)) {
+            trackedRunningProcess =
+                refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess);
+            if (trackedRunningProcess == null) {
+              return true;
+            }
+            processTree = trackedRunningProcess.processTree();
+            destroyRootProcessForcibly(trackedRunningProcess);
+            waitForProcessExit(trackedRunningProcess.process(), stopTimeout);
+            if (!waitForProcessTreeExit(processTree, stopTimeout)) {
+              if (!preserveRunningState(normalizedAppId, trackedRunningProcess)) {
+                return true;
+              }
+              throw new AppHostException("timed out stopping app: " + appId);
+            }
+          }
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      if (!preserveRunningState(normalizedAppId, trackedRunningProcess)) {
+        return true;
+      }
+      throw new AppHostException("interrupted while stopping app: " + appId, e);
+    }
+    if (refreshTrackedRunningProcess(normalizedAppId, trackedRunningProcess) != null) {
+      throw new AppHostException("timed out stopping app: " + appId);
+    }
+    trackedRunningProcess.exitCleanup().join();
+    runningApps.remove(normalizedAppId, trackedRunningProcess);
+    return true;
+  }
+
+  @Override
+  public synchronized Optional<RunningAppSnapshot> status(String appId) {
+    RunningProcess runningProcess = liveRunningProcess(InstalledAppPaths.normalizeAppId(appId));
+    return runningProcess != null ? Optional.of(runningProcess.snapshot()) : Optional.empty();
+  }
+
+  @Override
+  public synchronized List<RunningAppSnapshot> listRunning() {
+    List<RunningAppSnapshot> running = new ArrayList<>();
+    List<String> appIds = new ArrayList<>(runningApps.keySet());
+    appIds.sort(String::compareTo);
+    for (String appId : appIds) {
+      RunningProcess runningProcess = liveRunningProcess(appId);
+      if (runningProcess != null) {
+        running.add(runningProcess.snapshot());
+      }
+    }
+    return List.copyOf(running);
+  }
+
+  private AppManifest readInstalledManifest(Path installedRoot) throws IOException {
+    Path manifestFile =
+        resolveBundleEntry(
+            installedRoot, Path.of(AppManifestParser.MANIFEST_FILE_NAME), "installed manifest");
+    AppManifest manifest = AppManifestParser.parse(manifestFile);
+    if (!installedRoot.getFileName().toString().equals(manifest.appId())) {
+      throw new AppManifestException(
+          "installed manifest app.id does not match directory name: "
+              + installedRoot.getFileName());
+    }
+    return manifest;
+  }
+
+  private AppManifest validateCopiedBundle(Path copiedRoot) throws IOException {
+    Path manifestFile =
+        resolveBundleEntry(
+            copiedRoot, Path.of(AppManifestParser.MANIFEST_FILE_NAME), "copied manifest");
+    if (!Files.isRegularFile(manifestFile, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppManifestException("missing manifest file: " + manifestFile);
+    }
+    AppManifest manifest = AppManifestParser.parse(manifestFile);
+    Path copiedExecutable = resolveBundleEntry(copiedRoot, manifest.execPath(), "copied app.exec");
+    if (!Files.isRegularFile(copiedExecutable, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppHostException(
+          "app.exec does not resolve to a file in copied bundle: " + manifest.execPathText());
+    }
+    validateLaunchableCopiedExecutable(copiedExecutable, manifest);
+    return manifest;
+  }
+
+  private void validateLaunchableCopiedExecutable(Path copiedExecutable, AppManifest manifest)
+      throws IOException {
+    if (appEnv.isWindows()) {
+      if (!isLaunchableWindowsExecutable(copiedExecutable)) {
+        throw new AppHostException(
+            "app.exec is not launchable on Windows: " + manifest.execPathText());
+      }
+      return;
+    }
+    if (!isInterpreterManagedPosixLauncher(copiedExecutable)
+        && !Files.isExecutable(copiedExecutable)) {
+      throw new AppHostException(
+          "app.exec is not launchable on POSIX without execute permission: "
+              + manifest.execPathText());
+    }
+  }
+
+  private RunningProcess liveRunningProcess(String appId) {
+    RunningProcess runningProcess = runningApps.get(appId);
+    if (runningProcess == null) {
+      return null;
+    }
+    RunningProcess refreshedRunningProcess = runningProcess.refresh();
+    if (refreshedRunningProcess == null) {
+      refreshedRunningProcess = recoverTrackedRunningProcess(runningProcess);
+    }
+    if (refreshedRunningProcess != null) {
+      runningApps.replace(appId, runningProcess, refreshedRunningProcess);
+      return refreshedRunningProcess;
+    }
+    runningProcess.exitCleanup().join();
+    runningApps.remove(appId, runningProcess);
+    return null;
+  }
+
+  private static Path normalizeExistingDirectory(Path directory) throws IOException {
+    Objects.requireNonNull(directory, "stagedAppDirectory");
+    Path normalized = directory.toAbsolutePath().normalize();
+    if (!Files.isDirectory(normalized)) {
+      throw new AppHostException("stagedAppDirectory must be an existing directory: " + normalized);
+    }
+    if (Files.isSymbolicLink(normalized) || isAliasedPathEntry(normalized)) {
+      throw new AppHostException(
+          "stagedAppDirectory must not be a symlink, reparse point, or alias: " + normalized);
+    }
+    return normalized;
+  }
+
+  private static void rejectOverlappingInstallTree(Path stagingRoot, Path installedAppsDir)
+      throws IOException {
+    if (pathsOverlap(stagingRoot, installedAppsDir)) {
+      throw new AppHostException(
+          "stagedAppDirectory must not overlap the installed app tree: " + stagingRoot);
+    }
+  }
+
+  private static void rejectOverlappingMutableAppDirectories(
+      Path stagingRoot, InstalledAppPaths paths) throws IOException {
+    rejectOverlappingManagedAppDirectory(stagingRoot, paths.dataDir(), "dataDir");
+    rejectOverlappingManagedAppDirectory(stagingRoot, paths.cacheDir(), "cacheDir");
+    rejectOverlappingManagedAppDirectory(stagingRoot, paths.runDir(), "runDir");
+  }
+
+  private static void rejectOverlappingManagedAppDirectory(
+      Path stagingRoot, Path managedDirectory, String label) throws IOException {
+    if (pathsOverlap(stagingRoot, managedDirectory)) {
+      throw new AppHostException(
+          "stagedAppDirectory must not overlap " + label + ": " + stagingRoot);
+    }
+  }
+
+  private static boolean pathsOverlap(Path firstPath, Path secondPath) throws IOException {
+    Path firstComparablePath = comparablePath(firstPath);
+    Path secondComparablePath = comparablePath(secondPath);
+    return firstComparablePath.startsWith(secondComparablePath)
+        || secondComparablePath.startsWith(firstComparablePath);
+  }
+
+  private static void ensureManagedDirectory(Path baseDirectory, Path directory, String label)
+      throws IOException {
+    Path normalized = directory.toAbsolutePath().normalize();
+    validateManagedPathPrefixes(baseDirectory, normalized, label);
+    Deque<Path> missingSegments = new ArrayDeque<>();
+    Path current = normalized;
+    while (current != null && !Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+      Path fileName = current.getFileName();
+      if (fileName != null) {
+        missingSegments.push(fileName);
+      }
+      current = current.getParent();
+    }
+    if (current == null) {
+      throw new AppHostException(label + " must resolve beneath an existing filesystem root");
+    }
+    validateManagedDirectoryEntry(current, label);
+    while (!missingSegments.isEmpty()) {
+      current = current.resolve(missingSegments.pop());
+      Files.createDirectory(current);
+    }
+    validateManagedDirectoryEntry(normalized, label);
+    if (!Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppHostException(label + " must be a directory: " + normalized);
+    }
+  }
+
+  private Path validateInstalledAppsDirectory() throws IOException {
+    Path installedAppsDir = layout.installedAppsDir().toAbsolutePath().normalize();
+    validateManagedPathPrefixes(layout.dataDir(), installedAppsDir, "installedAppsDir");
+    if (!Files.exists(installedAppsDir, LinkOption.NOFOLLOW_LINKS)) {
+      return installedAppsDir;
+    }
+    validateManagedDirectoryEntry(installedAppsDir, "installedAppsDir");
+    if (!Files.isDirectory(installedAppsDir, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppHostException("installedAppsDir must be a directory: " + installedAppsDir);
+    }
+    return installedAppsDir;
+  }
+
+  private static void validateManagedDirectoryEntry(Path entry, String label) throws IOException {
+    if (Files.exists(entry, LinkOption.NOFOLLOW_LINKS)
+        && (Files.isSymbolicLink(entry) || isAliasedPathEntry(entry))) {
+      throw new AppHostException(
+          label + " must not be a symlink, reparse point, or alias: " + entry);
+    }
+  }
+
+  private void validateManagedMutableDirectories(InstalledAppPaths paths) throws IOException {
+    validateManagedPathPrefixes(layout.dataDir(), paths.dataDir(), "dataDir");
+    validateManagedPathPrefixes(layout.cacheDir(), paths.cacheDir(), "cacheDir");
+    validateManagedPathPrefixes(layout.runDir(), paths.runDir(), "runDir");
+  }
+
+  private static void validateManagedPathPrefixes(Path baseDirectory, Path target, String label)
+      throws IOException {
+    Path normalizedBase = baseDirectory.toAbsolutePath().normalize();
+    Path normalizedTarget = target.toAbsolutePath().normalize();
+    if (!normalizedTarget.startsWith(normalizedBase)) {
+      throw new AppHostException(label + " must stay under the managed base directory");
+    }
+    Path current = normalizedBase;
+    if (Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+      validateManagedDirectoryEntry(current, label);
+    }
+    for (Path segment : normalizedBase.relativize(normalizedTarget)) {
+      current = current.resolve(segment);
+      if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+        break;
+      }
+      validateManagedDirectoryEntry(current, label);
+    }
+  }
+
+  private static boolean shouldSkipInstalledEntry(Path appRoot) throws IOException {
+    if (!Files.isDirectory(appRoot, LinkOption.NOFOLLOW_LINKS)) {
+      return true;
+    }
+    if (isTemporaryInstallDirectory(appRoot)) {
+      return true;
+    }
+    return !Files.isRegularFile(
+        appRoot.resolve(AppManifestParser.MANIFEST_FILE_NAME), LinkOption.NOFOLLOW_LINKS);
+  }
+
+  private static boolean isTemporaryInstallDirectory(Path appRoot) {
+    Path fileName = appRoot.getFileName();
+    return fileName != null && fileName.toString().startsWith(TEMP_INSTALL_PREFIX);
+  }
+
+  private static Path comparablePath(Path path) throws IOException {
+    Path normalized = path.toAbsolutePath().normalize();
+    Deque<Path> missingSegments = new ArrayDeque<>();
+    Path current = normalized;
+    while (current != null && !Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+      Path fileName = current.getFileName();
+      if (fileName != null) {
+        missingSegments.push(fileName);
+      }
+      current = current.getParent();
+    }
+    if (current == null) {
+      return normalized;
+    }
+    Path comparable = current.toRealPath();
+    while (!missingSegments.isEmpty()) {
+      comparable = comparable.resolve(missingSegments.pop());
+    }
+    return comparable.normalize();
+  }
+
+  private static Path resolveBundleEntry(Path bundleRoot, Path relativePath, String label)
+      throws IOException {
+    Path resolvedRoot = bundleRoot.toAbsolutePath().normalize();
+    validateBundleEntry(resolvedRoot, label);
+    Path current = resolvedRoot;
+    for (Path segment : relativePath) {
+      current = current.resolve(segment).normalize();
+      validateBundleEntry(current, label);
+    }
+    return current;
+  }
+
+  private static void validateBundleEntry(Path entry, String label) throws IOException {
+    if (Files.exists(entry, LinkOption.NOFOLLOW_LINKS)
+        && (Files.isSymbolicLink(entry) || isAliasedPathEntry(entry))) {
+      throw new AppHostException(
+          label + " must not resolve through symlinks or reparse points: " + entry);
+    }
+  }
+
+  private String generateToken() {
+    byte[] tokenBytes = new byte[TOKEN_BYTES];
+    secureRandom.nextBytes(tokenBytes);
+    return HexFormat.of().formatHex(tokenBytes);
+  }
+
+  private List<ProcessHandle> observeStartupProcessTree(Process process, String appId)
+      throws AppHostException {
+    ProcessHandle rootHandle = process.toHandle();
+    List<ProcessHandle> observedHandles = new ArrayList<>();
+    long deadline = System.nanoTime() + STARTUP_EXIT_GRACE_PERIOD.toNanos();
+    long captureDeadline = System.nanoTime() + STARTUP_PROCESS_CAPTURE_WINDOW.toNanos();
+    long handoffDeadline = captureDeadline + STARTUP_POST_CAPTURE_HANDOFF_GRACE_PERIOD.toNanos();
+    while (System.nanoTime() < deadline) {
+      observedHandles.addAll(snapshotProcessTree(startupSeedHandles(rootHandle, observedHandles)));
+      if (!rootHandle.isAlive()) {
+        break;
+      }
+      long now = System.nanoTime();
+      if (now >= handoffDeadline) {
+        break;
+      }
+      long remainingNanos = deadline - now;
+      if (remainingNanos <= 0L) {
+        break;
+      }
+      long pollIntervalNanos =
+          now >= captureDeadline
+              ? STARTUP_HANDOFF_POLL_INTERVAL_NANOS
+              : STARTUP_PROCESS_POLL_INTERVAL_NANOS;
+      long pollNanos = Math.min(remainingNanos, pollIntervalNanos);
+      boolean exited = waitForProcess(process, pollNanos, appId);
+      if (!exited && System.nanoTime() >= handoffDeadline) {
+        break;
+      }
+    }
+    capturePostExitProcessTree(rootHandle, observedHandles, appId);
+    observedHandles.addAll(snapshotProcessTree(List.of(rootHandle)));
+    return aliveHandles(observedHandles);
+  }
+
+  private boolean waitForProcess(Process process, long timeoutNanos, String appId)
+      throws AppHostException {
+    try {
+      return process.waitFor(timeoutNanos, TimeUnit.NANOSECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AppHostException("interrupted while starting app: " + appId, e);
+    }
+  }
+
+  private static boolean waitForProcessExit(Process process, Duration timeout)
+      throws InterruptedException {
+    return process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  private static void discardChildInput(Process process, String appId) throws IOException {
+    try {
+      process.getOutputStream().close();
+    } catch (IOException e) {
+      process.destroyForcibly();
+      throw new AppHostException("failed to close stdin for app: " + appId, e);
+    }
+  }
+
+  private static AppHostException startupFailure(String appId, Process process) {
+    return new AppHostException(
+        "app exited during startup: " + appId + " (exitCode=" + process.exitValue() + ")");
+  }
+
+  private void startTrackedProcessTreeObserver(
+      String appId, Process process, CompletableFuture<Void> exitCleanup) {
+    Thread.ofVirtual()
+        .name("apphost-process-observer-", 0)
+        .start(
+            () -> {
+              try {
+                observeTrackedProcessTreeUntilExit(appId, process);
+              } finally {
+                try {
+                  runningApps.computeIfPresent(
+                      appId,
+                      (ignoredAppId, activeProcess) ->
+                          activeProcess.process() == process && !activeProcess.isAlive()
+                              ? null
+                              : activeProcess);
+                } finally {
+                  exitCleanup.complete(null);
+                }
+              }
+            });
+  }
+
+  private void observeTrackedProcessTreeUntilExit(String appId, Process process) {
+    long startupTrackingDeadline = System.nanoTime() + STARTUP_EXIT_GRACE_PERIOD.toNanos();
+    try {
+      while (true) {
+        refreshObservedProcessTree(appId, process);
+        boolean exited =
+            process.waitFor(
+                trackedProcessRefreshIntervalNanos(startupTrackingDeadline), TimeUnit.NANOSECONDS);
+        if (exited) {
+          capturePostExitProcessTreeHandoff(appId, process);
+          break;
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } finally {
+      refreshObservedProcessTree(appId, process);
+    }
+  }
+
+  private void capturePostExitProcessTreeHandoff(String appId, Process process)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD.toNanos();
+    while (System.nanoTime() < deadline) {
+      refreshObservedProcessTree(appId, process);
+      TimeUnit.NANOSECONDS.sleep(STARTUP_PROCESS_POLL_INTERVAL_NANOS);
+    }
+  }
+
+  private void capturePostExitProcessTree(
+      ProcessHandle rootHandle, List<ProcessHandle> observedHandles, String appId)
+      throws AppHostException {
+    if (rootHandle.isAlive()) {
+      return;
+    }
+    long deadline = System.nanoTime() + TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD.toNanos();
+    while (System.nanoTime() < deadline) {
+      observedHandles.addAll(snapshotProcessTree(startupSeedHandles(rootHandle, observedHandles)));
+      try {
+        TimeUnit.NANOSECONDS.sleep(STARTUP_PROCESS_POLL_INTERVAL_NANOS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AppHostException("interrupted while starting app: " + appId, e);
+      }
+    }
+  }
+
+  private static List<ProcessHandle> startupSeedHandles(
+      ProcessHandle rootHandle, List<ProcessHandle> observedHandles) {
+    ArrayList<ProcessHandle> seedHandles = new ArrayList<>(observedHandles.size() + 1);
+    seedHandles.add(rootHandle);
+    seedHandles.addAll(observedHandles);
+    return seedHandles;
+  }
+
+  private static long trackedProcessRefreshIntervalNanos(long startupTrackingDeadline) {
+    if (System.nanoTime() < startupTrackingDeadline) {
+      return STARTUP_PROCESS_POLL_INTERVAL_NANOS;
+    }
+    return TRACKED_PROCESS_REFRESH_INTERVAL.toNanos();
+  }
+
+  private void refreshObservedProcessTree(String appId, Process process) {
+    runningApps.computeIfPresent(
+        appId,
+        (ignoredAppId, activeProcess) -> {
+          if (activeProcess.process() != process) {
+            return activeProcess;
+          }
+          RunningProcess refreshed = activeProcess.refresh();
+          if (refreshed == null) {
+            refreshed = recoverTrackedRunningProcess(activeProcess);
+          }
+          return refreshed != null ? refreshed : activeProcess;
+        });
+  }
+
+  static void populateEnvironment(
+      Map<String, String> environment,
+      AppManifest manifest,
+      InstalledAppPaths paths,
+      String token,
+      AppEnv appEnv) {
+    environment.clear();
+    populateBaseEnvironment(environment, appEnv);
+    environment.put("CRYPTAD_APP_ID", manifest.appId());
+    environment.put("CRYPTAD_APP_NAME", manifest.appName());
+    environment.put("CRYPTAD_APP_VERSION", manifest.appVersion());
+    environment.put("CRYPTAD_APP_DATA_DIR", paths.dataDir().toString());
+    environment.put("CRYPTAD_APP_CACHE_DIR", paths.cacheDir().toString());
+    environment.put("CRYPTAD_APP_RUN_DIR", paths.runDir().toString());
+    environment.put("CRYPTAD_APP_TOKEN", token);
+    environment.put("CRYPTAD_APP_PERMISSIONS", manifest.permissionsCsv());
+    if (manifest.uiEntry() != null) {
+      environment.put("CRYPTAD_APP_UI_ENTRY", manifest.uiEntry());
+    }
+  }
+
+  private static void populateBaseEnvironment(Map<String, String> environment, AppEnv appEnv) {
+    switch (appEnv.osKind()) {
+      case WINDOWS -> populateWindowsBaseEnvironment(environment);
+      case MAC, LINUX, OTHER -> environment.put("PATH", safeUnixPath(appEnv));
+    }
+  }
+
+  private static void populateWindowsBaseEnvironment(Map<String, String> environment) {
+    String systemRoot = resolveWindowsRoot();
+    environment.put("SystemRoot", systemRoot);
+    environment.put("SYSTEMROOT", systemRoot);
+    environment.put("WINDIR", systemRoot);
+    environment.put("ComSpec", windowsCommandInterpreter());
+    environment.put("COMSPEC", windowsCommandInterpreter());
+    environment.put(
+        "PATH",
+        String.join(
+            ";",
+            Path.of(systemRoot, "System32").toString(),
+            Path.of(systemRoot, "System32", "WindowsPowerShell", "v1.0").toString(),
+            systemRoot));
+    copyHostEnvironmentValue(environment, "TEMP");
+    copyHostEnvironmentValue(environment, "TMP");
+  }
+
+  static List<String> launchCommand(Path executable, AppEnv appEnv) throws IOException {
+    String executableText = executable.toString();
+    if (appEnv.isWindows() && isWindowsBatchScript(executable)) {
+      return List.of(
+          windowsCommandInterpreter(), "/d", "/c", quoteWindowsBatchCommand(executableText));
+    }
+    if (!appEnv.isWindows()) {
+      PosixLauncher posixLauncher = classifyPosixLauncher(executable);
+      if (posixLauncher != null) {
+        return posixLauncher.command(executable);
+      }
+    }
+    return List.of(executableText);
+  }
+
+  private static List<String> posixShellLaunchCommand(Path executable, List<String> interpreter) {
+    List<String> command = new ArrayList<>(interpreter);
+    command.add("-c");
+    command.add(
+        """
+        trap 'sleep %s' EXIT
+        set --
+        . "$0"
+        """
+            .formatted(posixShellExitTrapDelaySeconds()));
+    command.add(executable.toString());
+    return List.copyOf(command);
+  }
+
+  private static List<String> directInterpreterLaunchCommand(
+      Path executable, List<String> interpreter) {
+    List<String> command = new ArrayList<>(interpreter);
+    command.add(executable.toString());
+    return List.copyOf(command);
+  }
+
+  private static boolean isWindowsBatchScript(Path executable) {
+    String fileName = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+    return fileName.endsWith(".cmd") || fileName.endsWith(".bat");
+  }
+
+  private static boolean isLaunchableWindowsExecutable(Path executable) throws IOException {
+    return isWindowsBatchScript(executable)
+        || hasWindowsComExecutableSuffix(executable)
+        || hasLaunchablePortableExecutable(executable);
+  }
+
+  private static boolean hasWindowsComExecutableSuffix(Path executable) {
+    String fileName = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+    return fileName.endsWith(".com");
+  }
+
+  private static boolean hasLaunchablePortableExecutable(Path executable) throws IOException {
+    try (SeekableByteChannel channel = Files.newByteChannel(executable)) {
+      if (channel.size() < DOS_HEADER_SIZE) {
+        return false;
+      }
+      ByteBuffer dosHeader = ByteBuffer.allocate(DOS_HEADER_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+      if (channel.read(dosHeader) < DOS_HEADER_SIZE) {
+        return false;
+      }
+      dosHeader.flip();
+      if (dosHeader.get() != 'M' || dosHeader.get() != 'Z') {
+        return false;
+      }
+
+      int peHeaderOffset = dosHeader.getInt(PE_POINTER_OFFSET);
+      if (peHeaderOffset < DOS_HEADER_SIZE
+          || channel.size() < (long) peHeaderOffset + COFF_HEADER_SIZE) {
+        return false;
+      }
+
+      ByteBuffer coffHeader = ByteBuffer.allocate(COFF_HEADER_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+      channel.position(peHeaderOffset);
+      if (channel.read(coffHeader) < COFF_HEADER_SIZE) {
+        return false;
+      }
+      coffHeader.flip();
+      if (coffHeader.get() != 'P'
+          || coffHeader.get() != 'E'
+          || coffHeader.get() != 0
+          || coffHeader.get() != 0) {
+        return false;
+      }
+      coffHeader.position(22);
+      int characteristics = Short.toUnsignedInt(coffHeader.getShort());
+      return (characteristics & IMAGE_FILE_EXECUTABLE_IMAGE) != 0
+          && (characteristics & IMAGE_FILE_DLL) == 0;
+    }
+  }
+
+  private static String quoteWindowsBatchCommand(String executableText) {
+    return "\"" + executableText + "\"";
+  }
+
+  private static boolean hasPosixShellScriptSuffix(Path executable) {
+    String fileName = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+    return fileName.endsWith(".sh");
+  }
+
+  private static PosixLauncher classifyPosixLauncher(Path executable) throws IOException {
+    String shebang = readShebang(executable);
+    if (shebang.isBlank()) {
+      return hasPosixShellScriptSuffix(executable)
+          ? new PosixLauncher(List.of(posixShellInterpreter()), true)
+          : null;
+    }
+    List<String> interpreter = parseShebangInterpreter(shebang);
+    return new PosixLauncher(interpreter, isPosixShellInterpreter(interpreter));
+  }
+
+  private static String readShebang(Path executable) throws IOException {
+    try (var input = Files.newInputStream(executable)) {
+      if (input.read() != '#' || input.read() != '!') {
+        return "";
+      }
+      var shebangBytes = new ByteArrayOutputStream();
+      for (int bytesRead = 2; bytesRead < MAX_SHEBANG_PROBE_BYTES; bytesRead++) {
+        int nextByte = input.read();
+        if (nextByte < 0 || nextByte == '\n' || nextByte == '\r') {
+          break;
+        }
+        shebangBytes.write(nextByte);
+      }
+      return shebangBytes.toString(StandardCharsets.UTF_8).trim();
+    }
+  }
+
+  private static List<String> parseShebangInterpreter(String shebang) throws AppHostException {
+    int argumentOffset = firstWhitespaceOffset(shebang);
+    if (argumentOffset < 0) {
+      validateShebangInterpreter(shebang);
+      return List.of(shebang);
+    }
+    String interpreter = shebang.substring(0, argumentOffset);
+    validateShebangInterpreter(interpreter);
+    String interpreterArgument = shebang.substring(argumentOffset).trim();
+    if (interpreterArgument.isEmpty()) {
+      return List.of(interpreter);
+    }
+    return List.of(interpreter, interpreterArgument);
+  }
+
+  private static boolean isInterpreterManagedPosixLauncher(Path executable) throws IOException {
+    return classifyPosixLauncher(executable) != null;
+  }
+
+  private static boolean isPosixShellInterpreter(List<String> interpreter) {
+    if (interpreter.isEmpty()) {
+      return false;
+    }
+    String interpreterName = commandBasename(interpreter.getFirst());
+    if (isKnownPosixShellName(interpreterName)) {
+      return true;
+    }
+    if (!interpreterName.equals("env") || interpreter.size() < 2) {
+      return false;
+    }
+    return envInvokesPosixShell(interpreter.get(1));
+  }
+
+  private static boolean envInvokesPosixShell(String argumentText) {
+    String trimmed = argumentText.trim();
+    if (trimmed.isEmpty()) {
+      return false;
+    }
+    if (trimmed.startsWith("-S ")) {
+      trimmed = trimmed.substring(3).trim();
+    }
+    return isKnownPosixShellName(commandBasename(firstToken(trimmed)));
+  }
+
+  private static boolean isKnownPosixShellName(String commandName) {
+    return switch (commandName) {
+      case "sh", "ash", "bash", "dash", "ksh", "mksh", "zsh" -> true;
+      default -> false;
+    };
+  }
+
+  private static String firstToken(String text) {
+    int offset = firstWhitespaceOffset(text);
+    return offset < 0 ? text : text.substring(0, offset);
+  }
+
+  private static void validateShebangInterpreter(String interpreter) throws AppHostException {
+    if (commandBasename(interpreter).isEmpty()) {
+      throw new AppHostException("invalid shebang interpreter: " + interpreter);
+    }
+  }
+
+  private static String commandBasename(String command) {
+    if (command.isBlank()) {
+      return "";
+    }
+    Path fileName = Path.of(command).getFileName();
+    if (fileName == null) {
+      return "";
+    }
+    return fileName.toString().toLowerCase(Locale.ROOT);
+  }
+
+  private static int firstWhitespaceOffset(String text) {
+    for (int i = 0; i < text.length(); i++) {
+      if (Character.isWhitespace(text.charAt(i))) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static String posixShellInterpreter() {
+    return Path.of("/bin", "sh").toString();
+  }
+
+  private static String posixShellExitTrapDelaySeconds() {
+    return String.format(Locale.ROOT, "%.3f", STARTUP_PROCESS_CAPTURE_WINDOW.toMillis() / 1000.0d);
+  }
+
+  private static String windowsCommandInterpreter() {
+    return Path.of(resolveWindowsRoot(), "System32", "cmd.exe").toString();
+  }
+
+  private static String safeUnixPath(AppEnv appEnv) {
+    ArrayList<String> entries = new ArrayList<>(BASE_UNIX_PATH_ENTRIES);
+    switch (appEnv.osKind()) {
+      case MAC -> entries.addAll(MAC_UNIX_PATH_ENTRIES);
+      case LINUX -> entries.addAll(LINUX_UNIX_PATH_ENTRIES);
+      case OTHER -> {
+        entries.addAll(MAC_UNIX_PATH_ENTRIES);
+        entries.addAll(LINUX_UNIX_PATH_ENTRIES);
+      }
+      case WINDOWS -> throw new IllegalArgumentException("windows does not use a Unix PATH");
+    }
+    return String.join(":", entries);
+  }
+
+  private static String resolveWindowsRoot() {
+    String systemRoot = firstNonBlankEnvironmentValue("SystemRoot", "SYSTEMROOT", "WINDIR");
+    return systemRoot != null ? systemRoot : "C:\\Windows";
+  }
+
+  private static String firstNonBlankEnvironmentValue(String... names) {
+    for (String name : names) {
+      String value = System.getenv(name);
+      if (value != null && !value.isBlank()) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private static void copyHostEnvironmentValue(Map<String, String> environment, String name) {
+    String value = System.getenv(name);
+    if (value != null && !value.isBlank()) {
+      environment.put(name, value);
+    }
+  }
+
+  private static void moveIntoPlace(Path source, Path destination) throws IOException {
+    try {
+      Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
+    } catch (AtomicMoveNotSupportedException _) {
+      Files.move(source, destination);
+    }
+  }
+
+  private static void copyDirectoryTree(Path sourceRoot, Path targetRoot) throws IOException {
+    Path sourceRealRoot = sourceRoot.toRealPath();
+    Set<Path> visitedRealDirectories = ConcurrentHashMap.newKeySet();
+    Files.walkFileTree(
+        sourceRoot,
+        new SimpleFileVisitor<>() {
+          @Override
+          public @NotNull FileVisitResult preVisitDirectory(
+              @NotNull Path dir, @NotNull BasicFileAttributes attrs) throws IOException {
+            Path realDirectory = validateStagingEntry(sourceRoot, sourceRealRoot, dir);
+            if (!visitedRealDirectories.add(realDirectory)) {
+              throw new AppHostException(
+                  "staging directory must not revisit directories via links or reparse points: "
+                      + dir);
+            }
+            Files.createDirectories(targetRoot.resolve(sourceRoot.relativize(dir)));
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public @NotNull FileVisitResult visitFile(
+              @NotNull Path file, @NotNull BasicFileAttributes attrs) throws IOException {
+            validateStagingEntry(sourceRoot, sourceRealRoot, file);
+            if (!attrs.isRegularFile()) {
+              throw new AppHostException(
+                  "staging directory must contain only regular files: " + file);
+            }
+            Files.copy(
+                file,
+                targetRoot.resolve(sourceRoot.relativize(file)),
+                StandardCopyOption.COPY_ATTRIBUTES,
+                StandardCopyOption.REPLACE_EXISTING);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  private static Path validateStagingEntry(Path sourceRoot, Path sourceRealRoot, Path entry)
+      throws IOException {
+    if (entry.equals(sourceRoot)) {
+      return sourceRealRoot;
+    }
+    if (Files.isSymbolicLink(entry)) {
+      throw new AppHostException("staging directory must not contain symlinks: " + entry);
+    }
+    Path expectedRealPath = sourceRealRoot.resolve(sourceRoot.relativize(entry)).normalize();
+    Path actualRealPath = entry.toRealPath();
+    if (!actualRealPath.equals(expectedRealPath)) {
+      throw new AppHostException(
+          "staging directory must not contain links or reparse points: " + entry);
+    }
+    return actualRealPath;
+  }
+
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    Files.walkFileTree(
+        root,
+        new SimpleFileVisitor<>() {
+          @Override
+          public @NotNull FileVisitResult preVisitDirectory(
+              @NotNull Path dir, @NotNull BasicFileAttributes attrs) throws IOException {
+            if (isAliasedPathEntry(dir)) {
+              Files.deleteIfExists(dir);
+              return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public @NotNull FileVisitResult visitFile(
+              @NotNull Path file, @NotNull BasicFileAttributes attrs) throws IOException {
+            Files.deleteIfExists(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public @NotNull FileVisitResult visitFileFailed(@NotNull Path file, IOException exc)
+              throws IOException {
+            if (Files.exists(file, LinkOption.NOFOLLOW_LINKS) && isAliasedPathEntry(file)) {
+              Files.deleteIfExists(file);
+              return FileVisitResult.CONTINUE;
+            }
+            throw exc;
+          }
+
+          @Override
+          public @NotNull FileVisitResult postVisitDirectory(@NotNull Path dir, IOException exc)
+              throws IOException {
+            if (exc != null) {
+              throw exc;
+            }
+            Files.deleteIfExists(dir);
+            return FileVisitResult.CONTINUE;
+          }
+        });
+  }
+
+  private static boolean isAliasedPathEntry(Path entry) throws IOException {
+    if (Files.isSymbolicLink(entry)) {
+      return true;
+    }
+    Path parent = entry.getParent();
+    if (parent == null) {
+      return false;
+    }
+    Path expectedRealPath = parent.toRealPath().resolve(entry.getFileName()).normalize();
+    Path actualRealPath = entry.toRealPath();
+    return !actualRealPath.equals(expectedRealPath);
+  }
+
+  private static void destroyProcessHandles(List<ProcessHandle> processHandles) {
+    for (int i = processHandles.size() - 1; i >= 0; i--) {
+      ProcessHandle processHandle = processHandles.get(i);
+      if (processHandle.isAlive()) {
+        processHandle.destroy();
+      }
+    }
+  }
+
+  private static void destroyProcessHandlesForcibly(List<ProcessHandle> processHandles) {
+    for (int i = processHandles.size() - 1; i >= 0; i--) {
+      ProcessHandle processHandle = processHandles.get(i);
+      if (processHandle.isAlive()) {
+        processHandle.destroyForcibly();
+      }
+    }
+  }
+
+  private static void destroyRootProcess(RunningProcess runningProcess) {
+    if (runningProcess.process().isAlive()) {
+      runningProcess.process().destroy();
+    }
+  }
+
+  private static void destroyRootProcessForcibly(RunningProcess runningProcess) {
+    if (runningProcess.process().isAlive()) {
+      runningProcess.process().destroyForcibly();
+    }
+  }
+
+  private static boolean waitForProcessTreeExit(List<ProcessHandle> processTree, Duration timeout)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (aliveHandles(processTree).isEmpty()) {
+        return true;
+      }
+      TimeUnit.MILLISECONDS.sleep(10);
+    }
+    return aliveHandles(processTree).isEmpty();
+  }
+
+  private boolean preserveRunningState(String appId, RunningProcess runningProcess) {
+    RunningProcess refreshedRunningProcess = runningProcess.refresh();
+    if (refreshedRunningProcess == null) {
+      runningApps.remove(appId, runningProcess);
+      return false;
+    }
+    runningApps.put(appId, refreshedRunningProcess);
+    return true;
+  }
+
+  private RunningProcess trackRunningProcessForStop(String appId, RunningProcess runningProcess) {
+    List<ProcessHandle> processTree = runningProcess.processTree();
+    try {
+      RunningProcess trackedRunningProcess = runningProcess.withProcessTree(processTree);
+      runningApps.replace(appId, runningProcess, trackedRunningProcess);
+      return trackedRunningProcess;
+    } catch (IllegalArgumentException e) {
+      runningProcess.exitCleanup().join();
+      runningApps.remove(appId, runningProcess);
+      return null;
+    }
+  }
+
+  private RunningProcess refreshTrackedRunningProcess(String appId, RunningProcess runningProcess) {
+    RunningProcess refreshedRunningProcess = runningProcess.refresh();
+    if (refreshedRunningProcess == null) {
+      refreshedRunningProcess = recoverTrackedRunningProcess(runningProcess);
+    }
+    if (refreshedRunningProcess != null) {
+      runningApps.put(appId, refreshedRunningProcess);
+      return refreshedRunningProcess;
+    }
+    runningProcess.exitCleanup().join();
+    runningApps.remove(appId, runningProcess);
+    return null;
+  }
+
+  private static List<ProcessHandle> snapshotProcessTree(List<ProcessHandle> seedHandles) {
+    List<ProcessHandle> processTree = new ArrayList<>();
+    for (ProcessHandle seedHandle : deduplicateHandles(seedHandles)) {
+      processTree.add(seedHandle);
+      seedHandle.descendants().forEach(processTree::add);
+    }
+    return deduplicateHandles(processTree);
+  }
+
+  private static List<ProcessHandle> aliveHandles(List<ProcessHandle> processHandles) {
+    return deduplicateHandles(
+        processHandles.stream().filter(LocalProcessAppHost::isEffectivelyAlive).toList());
+  }
+
+  private RunningProcess recoverTrackedRunningProcess(RunningProcess runningProcess) {
+    List<ProcessHandle> recoveredHandles =
+        new ArrayList<>(
+            recoverTrackedProcesses(
+                runningProcess.snapshot().manifest(),
+                runningProcess.snapshot().paths(),
+                runningProcess.snapshot().token(),
+                runningProcess.snapshot().startedAt(),
+                runningProcess.seedHandles(),
+                ProcessHandle.allProcesses().toList()));
+    recoveredHandles = aliveHandles(recoveredHandles);
+    if (recoveredHandles.isEmpty()) {
+      return null;
+    }
+    return runningProcess.withProcessTree(recoveredHandles);
+  }
+
+  private List<ProcessHandle> recoverTrackedProcesses(
+      AppManifest manifest,
+      InstalledAppPaths paths,
+      String token,
+      Instant startedAt,
+      List<ProcessHandle> trackedHandles,
+      List<ProcessHandle> processCandidates) {
+    List<ProcessHandle> recoveredHandles =
+        new ArrayList<>(recoverTrackedDescendantProcesses(trackedHandles, processCandidates));
+    recoveredHandles.addAll(findTokenTrackedProcesses(token, manifest.appId()));
+    if (recoveredHandles.isEmpty() && appEnv.isWindows()) {
+      recoveredHandles.addAll(
+          recoverWindowsBundleProcesses(
+              paths, manifest, startedAt, trackedHandles, processCandidates));
+    }
+    return deduplicateHandles(recoveredHandles);
+  }
+
+  static List<ProcessHandle> recoverTrackedDescendantProcesses(
+      List<ProcessHandle> trackedHandles, List<ProcessHandle> processCandidates) {
+    List<Long> trackedPids =
+        deduplicateHandles(trackedHandles).stream().map(ProcessHandle::pid).sorted().toList();
+    if (trackedPids.isEmpty()) {
+      return List.of();
+    }
+    Map<Long, List<ProcessHandle>> childrenByParentPid = new LinkedHashMap<>();
+    for (ProcessHandle candidate : deduplicateHandles(processCandidates)) {
+      if (!isEffectivelyAlive(candidate)) {
+        continue;
+      }
+      candidate
+          .parent()
+          .ifPresent(
+              parent ->
+                  childrenByParentPid
+                      .computeIfAbsent(parent.pid(), ignoredPid -> new ArrayList<>())
+                      .add(candidate));
+    }
+    Deque<Long> pendingParentPids = new ArrayDeque<>(trackedPids);
+    LinkedHashMap<Long, ProcessHandle> recoveredHandlesByPid = new LinkedHashMap<>();
+    while (!pendingParentPids.isEmpty()) {
+      long parentPid = pendingParentPids.removeFirst();
+      for (ProcessHandle child : childrenByParentPid.getOrDefault(parentPid, List.of())) {
+        if (recoveredHandlesByPid.putIfAbsent(child.pid(), child) == null) {
+          pendingParentPids.addLast(child.pid());
+        }
+      }
+    }
+    return recoveredHandlesByPid.values().stream()
+        .sorted(Comparator.comparingLong(ProcessHandle::pid))
+        .toList();
+  }
+
+  static List<ProcessHandle> recoverWindowsBundleProcesses(
+      InstalledAppPaths paths,
+      AppManifest manifest,
+      Instant startedAt,
+      List<ProcessHandle> trackedHandles,
+      List<ProcessHandle> processCandidates) {
+    Path installedRoot = paths.installedRoot().toAbsolutePath().normalize();
+    Path executablePath = paths.executablePath(manifest).toAbsolutePath().normalize();
+    List<Long> trackedPids =
+        deduplicateHandles(trackedHandles).stream().map(ProcessHandle::pid).sorted().toList();
+    return deduplicateHandles(
+        processCandidates.stream()
+            .filter(LocalProcessAppHost::isEffectivelyAlive)
+            .filter(processHandle -> !trackedPids.contains(processHandle.pid()))
+            .filter(
+                processHandle ->
+                    startedWithinWindowsRecoveryWindow(processHandle, startedAt)
+                        && referencesInstalledBundle(processHandle, installedRoot, executablePath))
+            .sorted(Comparator.comparingLong(ProcessHandle::pid))
+            .toList());
+  }
+
+  private List<ProcessHandle> findTokenTrackedProcesses(String token, String appId) {
+    List<ProcessHandle> procMatches = List.of();
+    if (supportsProcEnvironmentScan()) {
+      procMatches = findTokenTrackedProcessesFromProc(token, appId);
+    }
+    List<ProcessHandle> psMatches =
+        appEnv.isWindows() || !procMatches.isEmpty()
+            ? List.of()
+            : findTokenTrackedProcessesWithPs(token, appId);
+    return mergeTokenTrackedProcesses(procMatches, psMatches, appEnv);
+  }
+
+  private static List<ProcessHandle> findTokenTrackedProcessesFromProc(String token, String appId) {
+    return ProcessHandle.allProcesses()
+        .filter(LocalProcessAppHost::isEffectivelyAlive)
+        .filter(processHandle -> hasAppHostToken(processHandle.pid(), token, appId))
+        .sorted(Comparator.comparingLong(ProcessHandle::pid))
+        .toList();
+  }
+
+  static List<ProcessHandle> mergeTokenTrackedProcesses(
+      List<ProcessHandle> procMatches, List<ProcessHandle> psMatches, AppEnv appEnv) {
+    List<ProcessHandle> deduplicatedProcMatches = deduplicateHandles(procMatches);
+    if (!deduplicatedProcMatches.isEmpty() || appEnv.isWindows()) {
+      return deduplicatedProcMatches;
+    }
+    return deduplicateHandles(psMatches);
+  }
+
+  private static List<ProcessHandle> findTokenTrackedProcessesWithPs(String token, String appId) {
+    String psCommand = resolveTrustedUnixCommand("ps");
+    if (psCommand == null) {
+      return List.of();
+    }
+    for (List<String> command :
+        List.of(
+            List.of(psCommand, "eww", "-e", "-o", "pid=", "-o", "command="),
+            List.of(psCommand, "eww", "-ax", "-o", "pid=", "-o", "command="))) {
+      List<ProcessHandle> processes = findTokenTrackedProcessesWithPsCommand(command, token, appId);
+      if (!processes.isEmpty()) {
+        return processes;
+      }
+    }
+    return List.of();
+  }
+
+  private static List<ProcessHandle> findTokenTrackedProcessesWithPsCommand(
+      List<String> command, String token, String appId) {
+    Process process;
+    try {
+      process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    } catch (IOException e) {
+      return List.of();
+    }
+    try {
+      List<ProcessHandle> processes = parseTokenTrackedProcesses(process, token, appId);
+      if (!process.waitFor(5, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return List.of();
+      }
+      if (process.exitValue() != 0) {
+        return List.of();
+      }
+      return processes;
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      process.destroyForcibly();
+      return List.of();
+    }
+  }
+
+  private static List<ProcessHandle> parseTokenTrackedProcesses(
+      Process process, String token, String appId) throws IOException {
+    List<ProcessHandle> processes = new ArrayList<>();
+    try (var reader = process.inputReader(StandardCharsets.UTF_8)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String trimmed = line.trim();
+        if (trimmed.isEmpty()) {
+          continue;
+        }
+        parsePsProcessHandle(trimmed, token, appId)
+            .filter(LocalProcessAppHost::isEffectivelyAlive)
+            .ifPresent(processes::add);
+      }
+    }
+    processes.sort(Comparator.comparingLong(ProcessHandle::pid));
+    return List.copyOf(processes);
+  }
+
+  private static Optional<ProcessHandle> parsePsProcessHandle(
+      String line, String token, String appId) {
+    int separator = firstWhitespaceOffset(line);
+    if (separator < 0) {
+      return Optional.empty();
+    }
+    String pidText = line.substring(0, separator).trim();
+    String commandAndEnvironment = line.substring(separator).trim();
+    if (!commandAndEnvironment.contains("CRYPTAD_APP_TOKEN=" + token)
+        || !commandAndEnvironment.contains("CRYPTAD_APP_ID=" + appId)) {
+      return Optional.empty();
+    }
+    try {
+      long pid = Long.parseLong(pidText);
+      return ProcessHandle.of(pid);
+    } catch (NumberFormatException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static String resolveTrustedUnixCommand(String command) {
+    for (Path trustedDir :
+        List.of(Path.of("/usr/bin"), Path.of("/bin"), Path.of("/usr/sbin"), Path.of("/sbin"))) {
+      Path candidate = trustedDir.resolve(command);
+      if (Files.isExecutable(candidate)) {
+        return candidate.toString();
+      }
+    }
+    return null;
+  }
+
+  private static boolean startedWithinWindowsRecoveryWindow(
+      ProcessHandle processHandle, Instant startedAt) {
+    return processHandle
+        .info()
+        .startInstant()
+        .map(
+            candidateStartedAt ->
+                !candidateStartedAt.isBefore(startedAt.minusSeconds(1))
+                    && !candidateStartedAt.isAfter(startedAt.plus(WINDOWS_BUNDLE_RECOVERY_WINDOW)))
+        .orElse(false);
+  }
+
+  private static boolean referencesInstalledBundle(
+      ProcessHandle processHandle, Path installedRoot, Path executablePath) {
+    String normalizedInstalledRoot = installedRoot.toString().toLowerCase(Locale.ROOT);
+    String normalizedExecutablePath = executablePath.toString().toLowerCase(Locale.ROOT);
+    ProcessHandle.Info info = processHandle.info();
+    String normalizedCommand =
+        info.command().map(command -> command.toLowerCase(Locale.ROOT)).orElse("");
+    if (!normalizedCommand.isEmpty()
+        && (normalizedCommand.equals(normalizedExecutablePath)
+            || normalizedCommand.startsWith(normalizedInstalledRoot + "\\")
+            || normalizedCommand.startsWith(normalizedInstalledRoot + "/"))) {
+      return true;
+    }
+    String normalizedCommandLine =
+        info.commandLine().map(commandLine -> commandLine.toLowerCase(Locale.ROOT)).orElse("");
+    return !normalizedCommandLine.isEmpty()
+        && (normalizedCommandLine.contains(normalizedExecutablePath)
+            || normalizedCommandLine.contains(normalizedInstalledRoot));
+  }
+
+  private static boolean supportsProcEnvironmentScan() {
+    return Files.isReadable(Path.of("/proc", "self", "environ"));
+  }
+
+  private static boolean hasAppHostToken(long pid, String token, String appId) {
+    Path environmentFile = Path.of("/proc", Long.toString(pid), "environ");
+    if (!Files.isReadable(environmentFile)) {
+      return false;
+    }
+    try {
+      String environment = Files.readString(environmentFile, StandardCharsets.UTF_8);
+      return hasEnvironmentEntry(environment, "CRYPTAD_APP_TOKEN", token)
+          && hasEnvironmentEntry(environment, "CRYPTAD_APP_ID", appId);
+    } catch (IOException | RuntimeException _) {
+      return false;
+    }
+  }
+
+  private static boolean hasEnvironmentEntry(String environment, String name, String value) {
+    String expectedEntry = name + "=" + value;
+    int start = 0;
+    while (start <= environment.length()) {
+      int end = environment.indexOf('\0', start);
+      if (end < 0) {
+        end = environment.length();
+      }
+      if (end - start == expectedEntry.length()
+          && environment.regionMatches(start, expectedEntry, 0, expectedEntry.length())) {
+        return true;
+      }
+      if (end == environment.length()) {
+        break;
+      }
+      start = end + 1;
+    }
+    return false;
+  }
+
+  private static List<ProcessHandle> descendantHandles(RunningProcess runningProcess) {
+    long rootPid = runningProcess.process().pid();
+    return aliveHandles(runningProcess.processTree()).stream()
+        .filter(processHandle -> processHandle.pid() != rootPid)
+        .toList();
+  }
+
+  private static List<ProcessHandle> deduplicateHandles(List<ProcessHandle> processHandles) {
+    LinkedHashMap<Long, ProcessHandle> handlesByPid = new LinkedHashMap<>();
+    for (ProcessHandle processHandle : processHandles) {
+      handlesByPid.putIfAbsent(processHandle.pid(), processHandle);
+    }
+    return List.copyOf(handlesByPid.values());
+  }
+
+  private static boolean isEffectivelyAlive(ProcessHandle processHandle) {
+    return processHandle.isAlive() && !isZombieProcess(processHandle);
+  }
+
+  private static boolean isZombieProcess(ProcessHandle processHandle) {
+    Path statFile = Path.of("/proc", Long.toString(processHandle.pid()), "stat");
+    if (!Files.isReadable(statFile)) {
+      return false;
+    }
+    try {
+      String stat = Files.readString(statFile);
+      int commandEnd = stat.lastIndexOf(')');
+      return commandEnd >= 0
+          && commandEnd + 2 < stat.length()
+          && stat.charAt(commandEnd + 2) == 'Z';
+    } catch (IOException _) {
+      return false;
+    }
+  }
+
+  private static boolean preferDescendantPid(Path executable, List<ProcessHandle> processTree) {
+    if (!(isInterpreterManagedPosixLauncherUnchecked(executable)
+        || isWindowsBatchScript(executable))) {
+      return false;
+    }
+    return processTree.size() > 1;
+  }
+
+  private static boolean isInterpreterManagedPosixLauncherUnchecked(Path executable) {
+    try {
+      return isInterpreterManagedPosixLauncher(executable);
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private record PosixLauncher(List<String> interpreter, boolean shellInterpreter) {
+    private PosixLauncher {
+      interpreter = List.copyOf(interpreter);
+    }
+
+    private List<String> command(Path executable) {
+      return shellInterpreter
+          ? posixShellLaunchCommand(executable, interpreter)
+          : directInterpreterLaunchCommand(executable, interpreter);
+    }
+  }
+
+  private static long representativePid(
+      List<ProcessHandle> processTree, long preferredPid, boolean preferDescendantPid) {
+    if (preferDescendantPid) {
+      OptionalLong descendantPid =
+          processTree.stream()
+              .mapToLong(ProcessHandle::pid)
+              .filter(pid -> pid != preferredPid)
+              .min();
+      if (descendantPid.isPresent()) {
+        return descendantPid.orElseThrow();
+      }
+    }
+    return processTree.stream()
+        .filter(processHandle -> processHandle.pid() == preferredPid)
+        .findFirst()
+        .or(() -> processTree.stream().min(Comparator.comparingLong(ProcessHandle::pid)))
+        .orElseThrow(() -> new IllegalArgumentException("processTree must not be empty"))
+        .pid();
+  }
+
+  private static final class RunningProcess {
+    private final Process process;
+    private final RunningAppSnapshot snapshot;
+    private final CompletableFuture<Void> exitCleanup;
+    private final List<ProcessHandle> trackedHandles;
+
+    private RunningProcess(
+        Process process,
+        RunningAppSnapshot snapshot,
+        CompletableFuture<Void> exitCleanup,
+        List<ProcessHandle> trackedHandles) {
+      this.process = Objects.requireNonNull(process, "process");
+      this.snapshot = Objects.requireNonNull(snapshot, "snapshot");
+      this.exitCleanup = Objects.requireNonNull(exitCleanup, "exitCleanup");
+      this.trackedHandles = List.copyOf(Objects.requireNonNull(trackedHandles, "trackedHandles"));
+    }
+
+    private Process process() {
+      return process;
+    }
+
+    private RunningAppSnapshot snapshot() {
+      return snapshot;
+    }
+
+    private CompletableFuture<Void> exitCleanup() {
+      return exitCleanup;
+    }
+
+    private boolean isAlive() {
+      return !aliveHandles(processTree()).isEmpty();
+    }
+
+    private List<ProcessHandle> processTree() {
+      return snapshotProcessTree(seedHandles());
+    }
+
+    private List<ProcessHandle> seedHandles() {
+      List<ProcessHandle> seedHandles = new ArrayList<>();
+      seedHandles.add(process.toHandle());
+      seedHandles.addAll(trackedHandles);
+      return deduplicateHandles(seedHandles);
+    }
+
+    private RunningProcess refresh() {
+      List<ProcessHandle> currentProcessTree = aliveHandles(processTree());
+      if (currentProcessTree.isEmpty()) {
+        return null;
+      }
+      return withProcessTree(currentProcessTree);
+    }
+
+    private RunningProcess withProcessTree(List<ProcessHandle> newProcessTree) {
+      List<ProcessHandle> aliveProcessTree = aliveHandles(newProcessTree);
+      if (aliveProcessTree.isEmpty()) {
+        throw new IllegalArgumentException("newProcessTree must contain a live process");
+      }
+      long updatedPid = representativePid(aliveProcessTree, snapshot.pid(), false);
+      RunningAppSnapshot updatedSnapshot =
+          updatedPid == snapshot.pid()
+              ? snapshot
+              : new RunningAppSnapshot(
+                  snapshot.manifest(),
+                  snapshot.paths(),
+                  snapshot.token(),
+                  updatedPid,
+                  snapshot.startedAt());
+      if (trackedHandlePids().equals(handlePids(aliveProcessTree))
+          && updatedPid == snapshot.pid()) {
+        return this;
+      }
+      return new RunningProcess(process, updatedSnapshot, exitCleanup, aliveProcessTree);
+    }
+
+    private List<Long> trackedHandlePids() {
+      return handlePids(trackedHandles);
+    }
+
+    private static List<Long> handlePids(List<ProcessHandle> processHandles) {
+      return processHandles.stream().map(ProcessHandle::pid).sorted().toList();
+    }
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -48,8 +48,16 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Default AppHost implementation that launches installed apps out of process.
  *
- * <p>The runtime state remains in memory only. This v1 host does not attempt to restart recovery,
- * sandboxing, or hard quota enforcement.
+ * <p>{@code LocalProcessAppHost} is the concrete AppHost v1 runtime that manages validated app
+ * bundles on the local filesystem and launches them as child processes of the current daemon. It
+ * owns the install-time copy flow, mutable directory preparation, launch environment injection,
+ * process-tree tracking, shutdown escalation, and best-effort recovery for wrapper and daemonizing
+ * launch patterns across supported platforms.
+ *
+ * <p>The implementation keeps the runtime state in memory only. It is intended to be the reusable
+ * local execution core beneath future shell and transport layers, not a full sandbox or persistent
+ * supervisor. It therefore does not attempt to restart recovery across daemon restarts or hard
+ * enforcement of manifest quota hints.
  */
 public final class LocalProcessAppHost implements AppHost {
   private static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofSeconds(5);
@@ -106,6 +114,9 @@ public final class LocalProcessAppHost implements AppHost {
   /**
    * Creates a host bound to the supplied layout.
    *
+   * <p>This convenience constructor uses the default stop timeout, a fresh secure token generator,
+   * and the ambient {@link AppEnv} for platform detection.
+   *
    * @param layout filesystem layout managed by the host
    */
   @SuppressWarnings("unused")
@@ -116,9 +127,13 @@ public final class LocalProcessAppHost implements AppHost {
   /**
    * Creates a host with an explicit stop timeout and token generator.
    *
+   * <p>This overload is primarily useful for tests and controlled embeddings that need a
+   * non-default shutdown policy or deterministic token generation while still using the ambient
+   * platform environment.
+   *
    * @param layout filesystem layout managed by the host
-   * @param stopTimeout bounded timeout used before the force-killing a child process
-   * @param secureRandom secure token generator
+   * @param stopTimeout bounded timeout used before force-killing a child process
+   * @param secureRandom secure token generator for launch-token generation
    */
   public LocalProcessAppHost(
       AppHostLayout layout, Duration stopTimeout, SecureRandom secureRandom) {
@@ -136,6 +151,19 @@ public final class LocalProcessAppHost implements AppHost {
     }
   }
 
+  /**
+   * Installs one app from a local staging directory.
+   *
+   * <p>The staging tree is treated as caller-controlled input. The host validates that tree and
+   * copies it into a temporary managed location. It then parses the copied manifest, validates the
+   * copied executable, provisions the mutable directories that belong to the derived app id, and
+   * moves the copied bundle into place atomically when possible.
+   *
+   * @param stagedAppDirectory staging directory containing {@code cryptad-app.properties}
+   * @return installed application snapshot describing the copied bundle and managed paths
+   * @throws IOException if the staging tree is unsafe, the bundle is invalid, host-owned path
+   *     boundaries are violated, or the copied bundle cannot be installed cleanly
+   */
   @Override
   public synchronized InstalledAppSnapshot installFromDirectory(Path stagedAppDirectory)
       throws IOException {
@@ -162,6 +190,16 @@ public final class LocalProcessAppHost implements AppHost {
     }
   }
 
+  /**
+   * Removes one installed app and its host-owned directories.
+   *
+   * <p>The host revalidates the managed installation tree before deletion and refuses to uninstall
+   * a live app, so callers do not remove files that a running process is still using.
+   *
+   * @param appId stable application identifier
+   * @throws IOException if the app is running, missing, outside the validated managed tree, or any
+   *     owned files cannot be removed
+   */
   @Override
   public synchronized void uninstall(String appId) throws IOException {
     validateInstalledAppsDirectory();
@@ -179,6 +217,16 @@ public final class LocalProcessAppHost implements AppHost {
     deleteRecursively(paths.runDir());
   }
 
+  /**
+   * Lists all installed apps.
+   *
+   * <p>The result is built from the validated managed installation tree and sorted by directory
+   * name. Temporary install leftovers and non-app entries are skipped so stale partial
+   * installations do not poison the whole listing operation.
+   *
+   * @return installed application snapshots sorted by app id
+   * @throws IOException if the managed installation tree cannot be validated or scanned safely
+   */
   @Override
   public synchronized List<InstalledAppSnapshot> listInstalled() throws IOException {
     Path installedAppsDir = validateInstalledAppsDirectory();
@@ -200,6 +248,15 @@ public final class LocalProcessAppHost implements AppHost {
     return List.copyOf(installed);
   }
 
+  /**
+   * Describes one installed app.
+   *
+   * @param appId stable application identifier
+   * @return installed snapshot when present, or {@link Optional#empty()} when the app is not
+   *     currently installed
+   * @throws IOException if the managed installation tree cannot be validated, or the installed
+   *     manifest cannot be read safely
+   */
   @Override
   public synchronized Optional<InstalledAppSnapshot> describe(String appId) throws IOException {
     validateInstalledAppsDirectory();
@@ -211,6 +268,19 @@ public final class LocalProcessAppHost implements AppHost {
         new InstalledAppSnapshot(readInstalledManifest(paths.installedRoot()), paths));
   }
 
+  /**
+   * Starts one installed app as a child process.
+   *
+   * <p>Launch revalidates the installed manifest and executable. It recreates mutable directories
+   * as needed, clears the previous process log, injects a fresh launch token into the child
+   * environment, and then observes the launched process tree long enough to reject immediate
+   * failures or capture a daemonized handoff.
+   *
+   * @param appId stable application identifier
+   * @return running snapshot including the launch token, representative pid, and start timestamp
+   * @throws IOException if the app is not installed, is already running, fails validation at launch
+   *     time, or cannot be launched and tracked as a live process
+   */
   @Override
   public synchronized RunningAppSnapshot start(String appId) throws IOException {
     String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
@@ -281,6 +351,19 @@ public final class LocalProcessAppHost implements AppHost {
     return liveRunningProcess.snapshot();
   }
 
+  /**
+   * Stops one running app if it is active.
+   *
+   * <p>The shutdown flow refreshes the tracked process tree, attempts graceful termination first,
+   * escalates when needed, and performs a final re-scan before reporting success so that recovered
+   * descendant processes are not left running silently.
+   *
+   * @param appId stable application identifier
+   * @return {@code true} when a running process was found and stopped, or {@code false} when the
+   *     host had no live process for that app id
+   * @throws IOException if a running process tree cannot be shut down cleanly within the configured
+   *     stop timeout
+   */
   @Override
   public synchronized boolean stop(String appId) throws IOException {
     String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
@@ -302,12 +385,30 @@ public final class LocalProcessAppHost implements AppHost {
     return true;
   }
 
+  /**
+   * Returns the current live process snapshot, if any.
+   *
+   * <p>This method refreshes the tracked runtime state before answering, so callers can still
+   * observe a recovered descendant after the original launcher process has exited.
+   *
+   * @param appId stable application identifier
+   * @return running snapshot when the host still tracks a live process for the app, or {@link
+   *     Optional#empty()} otherwise
+   */
   @Override
   public synchronized Optional<RunningAppSnapshot> status(String appId) {
     RunningProcess runningProcess = liveRunningProcess(InstalledAppPaths.normalizeAppId(appId));
     return runningProcess != null ? Optional.of(runningProcess.snapshot()) : Optional.empty();
   }
 
+  /**
+   * Lists all live child processes.
+   *
+   * <p>The returned list is built from the host's refreshed in-memory runtime view and sorted by
+   * normalized app id for deterministic display and test assertions.
+   *
+   * @return immutable list of running snapshots sorted by app id
+   */
   @Override
   public synchronized List<RunningAppSnapshot> listRunning() {
     List<RunningAppSnapshot> running = new ArrayList<>();

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/package-info.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Local out-of-process app-host runtime support.
+ *
+ * <p>This package contains the default host implementation used by the AppHost core. It launches
+ * installed apps as child processes, injects the launch context, captures stdout/stderr in the app
+ * run directory, and keeps only in-memory runtime state.
+ */
+package network.crypta.platform.apphost.runtime;

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/package-info.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/package-info.java
@@ -1,8 +1,14 @@
 /**
  * Local out-of-process app-host runtime support.
  *
- * <p>This package contains the default host implementation used by the AppHost core. It launches
- * installed apps as child processes, injects the launch context, captures stdout/stderr in the app
- * run directory, and keeps only in-memory runtime state.
+ * <p>This package contains the concrete local runtime used by the AppHost core. It is responsible
+ * for validating copied bundles at launch time, constructing the child-process command and
+ * environment, capturing process output in the managed run directory, and tracking live process
+ * state in memory.
+ *
+ * <p>The package intentionally stays below transport adapters and UI layers. Its job is to provide
+ * a portable local lifecycle manager for installed apps, including shutdown escalation and
+ * best-effort recovery for wrapper or daemonizing launchers, not to implement persistent
+ * supervision or sandboxing.
  */
 package network.crypta.platform.apphost.runtime;

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/AppHostBoundaryTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/AppHostBoundaryTest.java
@@ -155,11 +155,12 @@ class AppHostBoundaryTest {
   }
 
   private static Path repoRoot() throws IOException {
-    Path directory = Path.of("").toAbsolutePath().normalize();
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
     while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
       directory = directory.getParent();
     }
-    assertNotNull(directory, "Could not locate the repo root from " + Path.of("").toAbsolutePath());
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
     return directory.toRealPath();
   }
 }

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/AppHostBoundaryTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/AppHostBoundaryTest.java
@@ -1,0 +1,165 @@
+package network.crypta.platform.apphost;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AppHostBoundaryTest {
+  private static final String MODULE_NAME = "platform-apphost";
+  private static final Path ROOT_APPHOST_MAIN_JAVA =
+      Path.of("src", "main", "java", "network", "crypta", "platform", "apphost");
+  private static final Path APPHOST_MAIN_JAVA =
+      Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "platform", "apphost");
+  private static final Path OWNERSHIP_METADATA =
+      Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
+  private static final Set<String> FORBIDDEN_IMPORT_PREFIXES =
+      Set.of(
+          "network.crypta.clients.",
+          "network.crypta.runtime.",
+          "network.crypta.node.",
+          "network.crypta.client.",
+          "network.crypta.platform.api.",
+          "network.crypta.launcher.");
+
+  @Test
+  void mainSourceLayout_whenCheckingAppHostOwnership_expectLeafOwnsPackageTree()
+      throws IOException {
+    Path repoRoot = repoRoot();
+
+    assertTrue(
+        Files.isDirectory(repoRoot.resolve(APPHOST_MAIN_JAVA)),
+        ":platform-apphost must own network/crypta/platform/apphost main sources");
+    assertFalse(
+        Files.exists(repoRoot.resolve(ROOT_APPHOST_MAIN_JAVA)),
+        "Root project must not own network/crypta/platform/apphost main sources");
+  }
+
+  @Test
+  void buildWiring_whenCheckingSettingsAndOwnershipMetadata_expectLeafDeclaredAndOwned()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
+    String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String metadata = Files.readString(repoRoot.resolve(OWNERSHIP_METADATA));
+
+    assertTrue(settings.contains("\":platform-apphost\""));
+    assertTrue(build.contains("project(\":platform-apphost\")"));
+    assertTrue(metadata.contains("network/crypta/platform/apphost/**"));
+  }
+
+  @Test
+  void mainSources_whenScanningAppHostImports_expectNoRuntimeOrAdapterImports() throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+    Path mainJava = repoRoot.resolve(Path.of(MODULE_NAME, "src", "main", "java"));
+
+    for (Path sourceFile : findJavaSources(mainJava)) {
+      Set<String> imports = readForbiddenImports(sourceFile);
+      if (!imports.isEmpty()) {
+        violations.add(repoRoot.relativize(sourceFile) + " -> " + String.join(", ", imports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        ":platform-apphost main sources must stay free of runtime, adapter, launcher, client, "
+            + "node, and Platform API implementation imports."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void mainSources_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path mainJava = repoRoot.resolve(Path.of(MODULE_NAME, "src", "main", "java"));
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    assertTrue(
+        Files.isDirectory(repoRoot.resolve(APPHOST_MAIN_JAVA)),
+        ":platform-apphost main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(mainJava)) {
+      String fileName = sourceFile.getFileName().toString();
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(sourceFile.getParent());
+    }
+
+    for (Path packagePath : productionPackages) {
+      if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
+        missingPackageInfos.add(repoRoot.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every :platform-apphost main package with production Java files must declare "
+            + "package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
+  }
+
+  private static List<Path> findJavaSources(Path root) throws IOException {
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(AppHostBoundaryTest::isTrackedJavaSource)
+          .sorted(Comparator.comparing(Path::toString))
+          .toList();
+    }
+  }
+
+  private static boolean isTrackedJavaSource(Path path) {
+    String fileName = path.getFileName().toString();
+    return fileName.endsWith(".java") && !fileName.startsWith("._");
+  }
+
+  private static Set<String> readForbiddenImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .filter(line -> line.startsWith("import "))
+          .map(AppHostBoundaryTest::extractImportTarget)
+          .filter(importTarget -> !importTarget.isEmpty())
+          .filter(AppHostBoundaryTest::isForbiddenImport)
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static String extractImportTarget(String line) {
+    String importTarget = line.substring("import ".length()).trim();
+    if (importTarget.startsWith("static ")) {
+      importTarget = importTarget.substring("static ".length()).trim();
+    }
+    return importTarget.endsWith(";")
+        ? importTarget.substring(0, importTarget.length() - 1)
+        : importTarget;
+  }
+
+  private static boolean isForbiddenImport(String importTarget) {
+    return FORBIDDEN_IMPORT_PREFIXES.stream().anyMatch(importTarget::startsWith);
+  }
+
+  private static Path repoRoot() throws IOException {
+    Path directory = Path.of("").toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + Path.of("").toAbsolutePath());
+    return directory.toRealPath();
+  }
+}

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
@@ -9,16 +9,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InstalledAppPathsTest {
+  private static final String SAMPLE_APP_ID = "sample-app";
+
   @TempDir private Path tempDir;
 
   @Test
   void resolveInstalledPath_whenRelativePathEscapesInstalledRoot_expectFailure() {
     InstalledAppPaths paths = paths();
+    Path relativeEscape = Path.of("../outside");
 
     IllegalArgumentException exception =
         assertThrows(
-            IllegalArgumentException.class,
-            () -> paths.resolveInstalledPath(Path.of("../outside")));
+            IllegalArgumentException.class, () -> paths.resolveInstalledPath(relativeEscape));
 
     assertEquals("resolved path must stay under installedRoot: ../outside", exception.getMessage());
   }
@@ -29,7 +31,7 @@ class InstalledAppPathsTest {
     AppManifest manifest =
         new AppManifest(
             1,
-            "sample-app",
+            SAMPLE_APP_ID,
             "Sample App",
             "1.0",
             "/outside",
@@ -46,10 +48,10 @@ class InstalledAppPathsTest {
 
   private InstalledAppPaths paths() {
     return new InstalledAppPaths(
-        "sample-app",
-        tempDir.resolve("installed").resolve("sample-app"),
-        tempDir.resolve("data").resolve("sample-app"),
-        tempDir.resolve("cache").resolve("sample-app"),
-        tempDir.resolve("run").resolve("sample-app"));
+        SAMPLE_APP_ID,
+        tempDir.resolve("installed").resolve(SAMPLE_APP_ID),
+        tempDir.resolve("data").resolve(SAMPLE_APP_ID),
+        tempDir.resolve("cache").resolve(SAMPLE_APP_ID),
+        tempDir.resolve("run").resolve(SAMPLE_APP_ID));
   }
 }

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
@@ -1,0 +1,55 @@
+package network.crypta.platform.apphost;
+
+import java.nio.file.Path;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InstalledAppPathsTest {
+  @TempDir private Path tempDir;
+
+  @Test
+  void resolveInstalledPath_whenRelativePathEscapesInstalledRoot_expectFailure() {
+    InstalledAppPaths paths = paths();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> paths.resolveInstalledPath(Path.of("../outside")));
+
+    assertEquals("resolved path must stay under installedRoot: ../outside", exception.getMessage());
+  }
+
+  @Test
+  void executablePath_whenManifestExecPathIsAbsolute_expectFailure() {
+    InstalledAppPaths paths = paths();
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            "sample-app",
+            "Sample App",
+            "1.0",
+            "/outside",
+            null,
+            java.util.List.of(),
+            null,
+            null);
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> paths.executablePath(manifest));
+
+    assertEquals("resolved path must stay under installedRoot: /outside", exception.getMessage());
+  }
+
+  private InstalledAppPaths paths() {
+    return new InstalledAppPaths(
+        "sample-app",
+        tempDir.resolve("installed").resolve("sample-app"),
+        tempDir.resolve("data").resolve("sample-app"),
+        tempDir.resolve("cache").resolve("sample-app"),
+        tempDir.resolve("run").resolve("sample-app"));
+  }
+}

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
@@ -1,12 +1,16 @@
 package network.crypta.platform.apphost;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import network.crypta.fs.AppEnv;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InstalledAppPathsTest {
   private static final String SAMPLE_APP_ID = "sample-app";
@@ -44,6 +48,60 @@ class InstalledAppPathsTest {
         assertThrows(IllegalArgumentException.class, () -> paths.executablePath(manifest));
 
     assertEquals("resolved path must stay under installedRoot: /outside", exception.getMessage());
+  }
+
+  @Test
+  void normalizeAppId_whenValueHasUppercaseAndWhitespace_expectNormalized() {
+    assertEquals(SAMPLE_APP_ID, InstalledAppPaths.normalizeAppId("  Sample-App  "));
+  }
+
+  @Test
+  void ensureInstallParentDirectory_whenParentMissing_expectCreated() throws Exception {
+    InstalledAppPaths paths = paths();
+
+    paths.ensureInstallParentDirectory();
+
+    assertTrue(Files.isDirectory(paths.installedRoot().getParent()));
+  }
+
+  @Test
+  void ensureMutableDirectories_whenDirectoriesMissing_expectCreated() throws Exception {
+    InstalledAppPaths paths = paths();
+
+    paths.ensureMutableDirectories();
+
+    assertTrue(Files.isDirectory(paths.dataDir()));
+    assertTrue(Files.isDirectory(paths.cacheDir()));
+    assertTrue(Files.isDirectory(paths.runDir()));
+  }
+
+  @Test
+  void ensureMutableDirectories_whenManagedDirectoryIsFile_expectFailure() throws Exception {
+    InstalledAppPaths paths = paths();
+    Files.createDirectories(paths.dataDir().getParent());
+    Files.writeString(paths.dataDir(), "not-a-directory");
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, paths::ensureMutableDirectories);
+
+    assertEquals("dataDir must be a directory: " + paths.dataDir(), exception.getMessage());
+  }
+
+  @Test
+  void ensureMutableDirectories_whenManagedDirectoryIsSymlink_expectFailure() throws Exception {
+    Assumptions.assumeFalse(new AppEnv().isWindows());
+    InstalledAppPaths paths = paths();
+    Path targetDirectory = tempDir.resolve("symlink-target");
+    Files.createDirectories(targetDirectory);
+    Files.createDirectories(paths.runDir().getParent());
+    Files.createSymbolicLink(paths.runDir(), targetDirectory);
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, paths::ensureMutableDirectories);
+
+    assertEquals(
+        "runDir must not be a symlink, reparse point, or alias: " + paths.runDir(),
+        exception.getMessage());
   }
 
   private InstalledAppPaths paths() {

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/RunningAppSnapshotTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/RunningAppSnapshotTest.java
@@ -1,0 +1,53 @@
+package network.crypta.platform.apphost;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RunningAppSnapshotTest {
+  private static final String SAMPLE_APP_ID = "sample-app";
+  private static final AppManifest SAMPLE_MANIFEST =
+      new AppManifest(
+          1, SAMPLE_APP_ID, "Sample App", "1.0", "bin/start.sh", null, List.of(), null, null);
+
+  @TempDir Path tempDir;
+
+  @Test
+  void constructor_whenTokenIsBlank_expectFailure() {
+    InstalledAppPaths paths = paths();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new RunningAppSnapshot(SAMPLE_MANIFEST, paths, "  ", 123L, Instant.EPOCH));
+
+    assertEquals("token must not be blank", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenPidIsNonPositive_expectFailure() {
+    InstalledAppPaths paths = paths();
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new RunningAppSnapshot(SAMPLE_MANIFEST, paths, "token", 0L, Instant.EPOCH));
+
+    assertEquals("pid must be positive", exception.getMessage());
+  }
+
+  private InstalledAppPaths paths() {
+    return new InstalledAppPaths(
+        SAMPLE_APP_ID,
+        tempDir.resolve("installed").resolve(SAMPLE_APP_ID),
+        tempDir.resolve("data").resolve(SAMPLE_APP_ID),
+        tempDir.resolve("cache").resolve(SAMPLE_APP_ID),
+        tempDir.resolve("run").resolve(SAMPLE_APP_ID));
+  }
+}

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.apphost.manifest;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -14,14 +15,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AppManifestParserTest {
+  private static final String MANIFEST_VERSION_PROPERTY = "manifest.version";
+  private static final String APP_ID_PROPERTY = "app.id";
+  private static final String APP_NAME_PROPERTY = "app.name";
+  private static final String APP_VERSION_PROPERTY = "app.version";
+  private static final String APP_EXEC_PROPERTY = "app.exec";
+  private static final String APP_PERMISSIONS_PROPERTY = "app.permissions";
+  private static final String GENERATED_COMMENT = "generated";
   private static final String MANIFEST_VERSION = "1";
   private static final String SAMPLE_APP_ID = "sample-app";
   private static final String SAMPLE_APP_NAME = "Sample App";
   private static final String UTF8_APP_NAME = "Crýpta Console";
   private static final String APP_VERSION = "1.0";
+  private static final String LAUNCH_COMMAND_NAME = "launch.cmd";
+  private static final String READ_AND_OPEN_PERMISSIONS = "network.read, ui.open";
   private static final String START_SCRIPT = "bin/start.sh";
-  private static final String WINDOWS_SCRIPT = "bin\\launch.cmd";
-  private static final String NESTED_WINDOWS_SCRIPT = "bin\\tools\\launch.cmd";
+  private static final String UNICODE_START_SCRIPT = "bin/启动.sh";
+  private static final String UNICODE_BUNDLE_ROOT_START_SCRIPT = "launch-启动.sh";
+  private static final String WINDOWS_SCRIPT = "bin\\" + LAUNCH_COMMAND_NAME;
+  private static final String NESTED_WINDOWS_SCRIPT = "bin\\tools\\" + LAUNCH_COMMAND_NAME;
 
   @TempDir Path tempDir;
 
@@ -29,7 +41,17 @@ class AppManifestParserTest {
   void parseContent_whenReadingValidManifest_expectNormalizedValues() throws Exception {
     AppManifest manifest =
         AppManifestParser.parseContent(
-            fullManifest("Sample-App", SAMPLE_APP_NAME, "1.2.3", START_SCRIPT));
+            """
+            manifest.version=1
+            app.id=Sample-App
+            app.name=Sample App
+            app.version=1.2.3
+            app.exec=bin/start.sh
+            app.ui.entry=/
+            app.permissions=network.read, ui.open
+            quota.data.bytes=1048576
+            quota.cache.bytes=2048
+            """);
 
     assertEquals(1, manifest.manifestVersion());
     assertEquals(SAMPLE_APP_ID, manifest.appId());
@@ -46,8 +68,7 @@ class AppManifestParserTest {
   void parseContent_whenManifestContainsUtf8Text_expectNamePreserved() throws Exception {
     AppManifest manifest =
         AppManifestParser.parseContent(
-            minimalManifest(
-                MANIFEST_VERSION, SAMPLE_APP_ID, UTF8_APP_NAME, APP_VERSION, START_SCRIPT));
+            minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, UTF8_APP_NAME, START_SCRIPT));
 
     assertEquals(UTF8_APP_NAME, manifest.appName());
   }
@@ -57,11 +78,10 @@ class AppManifestParserTest {
       throws Exception {
     AppManifest manifest =
         AppManifestParser.parseContent(
-            minimalManifest(
-                MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, WINDOWS_SCRIPT));
+            minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, WINDOWS_SCRIPT));
 
-    assertEquals(Path.of("bin", "launch.cmd"), manifest.execPath());
-    assertEquals("bin/launch.cmd", manifest.execPathText());
+    assertEquals(Path.of("bin", LAUNCH_COMMAND_NAME), manifest.execPath());
+    assertEquals("bin/" + LAUNCH_COMMAND_NAME, manifest.execPathText());
   }
 
   @Test
@@ -70,14 +90,10 @@ class AppManifestParserTest {
     AppManifest manifest =
         AppManifestParser.parseContent(
             minimalManifest(
-                MANIFEST_VERSION,
-                SAMPLE_APP_ID,
-                SAMPLE_APP_NAME,
-                APP_VERSION,
-                NESTED_WINDOWS_SCRIPT));
+                MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, NESTED_WINDOWS_SCRIPT));
 
-    assertEquals(Path.of("bin", "tools", "launch.cmd"), manifest.execPath());
-    assertEquals("bin/tools/launch.cmd", manifest.execPathText());
+    assertEquals(Path.of("bin", "tools", LAUNCH_COMMAND_NAME), manifest.execPath());
+    assertEquals("bin/tools/" + LAUNCH_COMMAND_NAME, manifest.execPathText());
   }
 
   @Test
@@ -89,11 +105,10 @@ class AppManifestParserTest {
                 MANIFEST_VERSION,
                 SAMPLE_APP_ID,
                 SAMPLE_APP_NAME,
-                APP_VERSION,
-                "bin\\ui\\launch.cmd"));
+                "bin\\ui\\" + LAUNCH_COMMAND_NAME));
 
-    assertEquals(Path.of("bin", "ui", "launch.cmd"), manifest.execPath());
-    assertEquals("bin/ui/launch.cmd", manifest.execPathText());
+    assertEquals(Path.of("bin", "ui", LAUNCH_COMMAND_NAME), manifest.execPath());
+    assertEquals("bin/ui/" + LAUNCH_COMMAND_NAME, manifest.execPathText());
   }
 
   @Test
@@ -105,67 +120,42 @@ class AppManifestParserTest {
                 MANIFEST_VERSION,
                 SAMPLE_APP_ID,
                 SAMPLE_APP_NAME,
-                APP_VERSION,
-                "bin\\u1234\\launch.cmd"));
+                "bin\\u1234\\" + LAUNCH_COMMAND_NAME));
 
-    assertEquals(Path.of("bin", "u1234", "launch.cmd"), manifest.execPath());
-    assertEquals("bin/u1234/launch.cmd", manifest.execPathText());
+    assertEquals(Path.of("bin", "u1234", LAUNCH_COMMAND_NAME), manifest.execPath());
+    assertEquals("bin/u1234/" + LAUNCH_COMMAND_NAME, manifest.execPathText());
   }
 
   @Test
   void parseContent_whenManifestComesFromPropertiesStore_expectEscapesDecoded() throws Exception {
-    Properties properties = new Properties();
-    properties.setProperty("manifest.version", "1");
-    properties.setProperty("app.id", SAMPLE_APP_ID);
-    properties.setProperty("app.name", UTF8_APP_NAME);
-    properties.setProperty("app.version", APP_VERSION);
-    properties.setProperty("app.exec", WINDOWS_SCRIPT);
-    properties.setProperty("app.permissions", "network.read, ui.open");
-    StringWriter writer = new StringWriter();
-    properties.store(writer, "generated");
-
-    AppManifest manifest = AppManifestParser.parseContent(writer.toString());
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            storedManifestContent(UTF8_APP_NAME, WINDOWS_SCRIPT, READ_AND_OPEN_PERMISSIONS));
 
     assertEquals(UTF8_APP_NAME, manifest.appName());
-    assertEquals(Path.of("bin", "launch.cmd"), manifest.execPath());
-    assertEquals("bin/launch.cmd", manifest.execPathText());
+    assertEquals(Path.of("bin", LAUNCH_COMMAND_NAME), manifest.execPath());
+    assertEquals("bin/" + LAUNCH_COMMAND_NAME, manifest.execPathText());
     assertEquals(java.util.List.of("network.read", "ui.open"), manifest.permissions());
   }
 
   @Test
   void parseContent_whenPropertiesStoreEncodesUnicodeExecPath_expectEscapesDecoded()
       throws Exception {
-    Properties properties = new Properties();
-    properties.setProperty("manifest.version", "1");
-    properties.setProperty("app.id", SAMPLE_APP_ID);
-    properties.setProperty("app.name", SAMPLE_APP_NAME);
-    properties.setProperty("app.version", APP_VERSION);
-    properties.setProperty("app.exec", "bin/\u542F\u52A8.sh");
-    StringWriter writer = new StringWriter();
-    properties.store(writer, "generated");
+    AppManifest manifest =
+        AppManifestParser.parseContent(storedManifestContent(UNICODE_START_SCRIPT));
 
-    AppManifest manifest = AppManifestParser.parseContent(writer.toString());
-
-    assertEquals(Path.of("bin", "启动.sh"), manifest.execPath());
-    assertEquals("bin/启动.sh", manifest.execPathText());
+    assertEquals(Path.of(UNICODE_START_SCRIPT), manifest.execPath());
+    assertEquals(UNICODE_START_SCRIPT, manifest.execPathText());
   }
 
   @Test
   void parseContent_whenPropertiesStoreEncodesBundleRootUnicodeExec_expectEscapesDecoded()
       throws Exception {
-    Properties properties = new Properties();
-    properties.setProperty("manifest.version", "1");
-    properties.setProperty("app.id", SAMPLE_APP_ID);
-    properties.setProperty("app.name", SAMPLE_APP_NAME);
-    properties.setProperty("app.version", APP_VERSION);
-    properties.setProperty("app.exec", "launch-启动.sh");
-    StringWriter writer = new StringWriter();
-    properties.store(writer, "generated");
+    AppManifest manifest =
+        AppManifestParser.parseContent(storedManifestContent(UNICODE_BUNDLE_ROOT_START_SCRIPT));
 
-    AppManifest manifest = AppManifestParser.parseContent(writer.toString());
-
-    assertEquals(Path.of("launch-启动.sh"), manifest.execPath());
-    assertEquals("launch-启动.sh", manifest.execPathText());
+    assertEquals(Path.of(UNICODE_BUNDLE_ROOT_START_SCRIPT), manifest.execPath());
+    assertEquals(UNICODE_BUNDLE_ROOT_START_SCRIPT, manifest.execPathText());
   }
 
   @Test
@@ -173,8 +163,7 @@ class AppManifestParserTest {
     AppManifest manifest =
         AppManifestParser.parseContent(
             "\uFEFF"
-                + minimalManifest(
-                    MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT));
+                + minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT));
 
     assertEquals(1, manifest.manifestVersion());
     assertEquals(SAMPLE_APP_ID, manifest.appId());
@@ -186,8 +175,7 @@ class AppManifestParserTest {
     Path targetManifest = tempDir.resolve("target.properties");
     Files.writeString(
         targetManifest,
-        minimalManifest(
-            MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT),
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT),
         StandardCharsets.UTF_8);
     Path manifestSymlink = tempDir.resolve("cryptad-app.properties");
     Files.createSymbolicLink(manifestSymlink, targetManifest);
@@ -200,8 +188,7 @@ class AppManifestParserTest {
 
   @Test
   void parseContent_whenManifestVersionIsUnsupported_expectFailure() {
-    String invalidManifest =
-        minimalManifest("2", SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT);
+    String invalidManifest = minimalManifest("2", SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT);
     AppManifestException exception =
         assertThrows(
             AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
@@ -212,17 +199,16 @@ class AppManifestParserTest {
   @Test
   void parseContent_whenAppIdIsInvalid_expectFailure() {
     String invalidManifest =
-        minimalManifest(MANIFEST_VERSION, "Bad/Id", SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT);
+        minimalManifest(MANIFEST_VERSION, "Bad/Id", SAMPLE_APP_NAME, START_SCRIPT);
     assertThrows(AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
   }
 
   @Test
   void parseContent_whenAppExecIsAbsoluteOrTraversingParent_expectFailure() {
     String absolutePathManifest =
-        minimalManifest(
-            MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, "/tmp/app.sh");
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, "/tmp/app.sh");
     String parentTraversalManifest =
-        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, "../app.sh");
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, "../app.sh");
     assertThrows(
         AppManifestException.class, () -> AppManifestParser.parseContent(absolutePathManifest));
     assertThrows(
@@ -232,18 +218,17 @@ class AppManifestParserTest {
   @Test
   void parseContent_whenAppExecUsesWindowsDrivePrefix_expectFailure() {
     String invalidManifest =
-        minimalManifest(
-            MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, "C:launch.cmd");
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, "C:launch.cmd");
     assertThrows(AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
   }
 
   @Test
   void parseContent_whenQuotaValueIsMalformed_expectFailure() {
     String invalidDataQuotaManifest =
-        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT)
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT)
             + "quota.data.bytes=not-a-number\n";
     String invalidCacheQuotaManifest =
-        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT)
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT)
             + "quota.cache.bytes=-1\n";
     assertThrows(
         AppManifestException.class, () -> AppManifestParser.parseContent(invalidDataQuotaManifest));
@@ -252,24 +237,8 @@ class AppManifestParserTest {
         () -> AppManifestParser.parseContent(invalidCacheQuotaManifest));
   }
 
-  private static String fullManifest(
-      String appId, String appName, String appVersion, String execPath) {
-    return """
-    manifest.version=1
-    app.id=%s
-    app.name=%s
-    app.version=%s
-    app.exec=%s
-    app.ui.entry=/
-    app.permissions=network.read, ui.open
-    quota.data.bytes=1048576
-    quota.cache.bytes=2048
-    """
-        .formatted(appId, appName, appVersion, execPath);
-  }
-
   private static String minimalManifest(
-      String manifestVersion, String appId, String appName, String appVersion, String execPath) {
+      String manifestVersion, String appId, String appName, String execPath) {
     return """
     manifest.version=%s
     app.id=%s
@@ -277,6 +246,26 @@ class AppManifestParserTest {
     app.version=%s
     app.exec=%s
     """
-        .formatted(manifestVersion, appId, appName, appVersion, execPath);
+        .formatted(manifestVersion, appId, appName, APP_VERSION, execPath);
+  }
+
+  private static String storedManifestContent(String execPath) throws IOException {
+    return storedManifestContent(SAMPLE_APP_NAME, execPath, null);
+  }
+
+  private static String storedManifestContent(String appName, String execPath, String permissions)
+      throws IOException {
+    Properties properties = new Properties();
+    properties.setProperty(MANIFEST_VERSION_PROPERTY, MANIFEST_VERSION);
+    properties.setProperty(APP_ID_PROPERTY, SAMPLE_APP_ID);
+    properties.setProperty(APP_NAME_PROPERTY, appName);
+    properties.setProperty(APP_VERSION_PROPERTY, APP_VERSION);
+    properties.setProperty(APP_EXEC_PROPERTY, execPath);
+    if (permissions != null) {
+      properties.setProperty(APP_PERMISSIONS_PROPERTY, permissions);
+    }
+    StringWriter writer = new StringWriter();
+    properties.store(writer, GENERATED_COMMENT);
+    return writer.toString();
   }
 }

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
@@ -1,0 +1,282 @@
+package network.crypta.platform.apphost.manifest;
+
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import network.crypta.fs.AppEnv;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AppManifestParserTest {
+  private static final String MANIFEST_VERSION = "1";
+  private static final String SAMPLE_APP_ID = "sample-app";
+  private static final String SAMPLE_APP_NAME = "Sample App";
+  private static final String UTF8_APP_NAME = "Crýpta Console";
+  private static final String APP_VERSION = "1.0";
+  private static final String START_SCRIPT = "bin/start.sh";
+  private static final String WINDOWS_SCRIPT = "bin\\launch.cmd";
+  private static final String NESTED_WINDOWS_SCRIPT = "bin\\tools\\launch.cmd";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void parseContent_whenReadingValidManifest_expectNormalizedValues() throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            fullManifest("Sample-App", SAMPLE_APP_NAME, "1.2.3", START_SCRIPT));
+
+    assertEquals(1, manifest.manifestVersion());
+    assertEquals(SAMPLE_APP_ID, manifest.appId());
+    assertEquals(SAMPLE_APP_NAME, manifest.appName());
+    assertEquals("1.2.3", manifest.appVersion());
+    assertEquals(Path.of("bin", "start.sh"), manifest.execPath());
+    assertEquals("/", manifest.uiEntry());
+    assertEquals(java.util.List.of("network.read", "ui.open"), manifest.permissions());
+    assertEquals(Long.valueOf(1048576L), manifest.dataQuotaBytes());
+    assertEquals(Long.valueOf(2048L), manifest.cacheQuotaBytes());
+  }
+
+  @Test
+  void parseContent_whenManifestContainsUtf8Text_expectNamePreserved() throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            minimalManifest(
+                MANIFEST_VERSION, SAMPLE_APP_ID, UTF8_APP_NAME, APP_VERSION, START_SCRIPT));
+
+    assertEquals(UTF8_APP_NAME, manifest.appName());
+  }
+
+  @Test
+  void parseContent_whenAppExecUsesWindowsSeparators_expectNormalizedRelativePath()
+      throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            minimalManifest(
+                MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, WINDOWS_SCRIPT));
+
+    assertEquals(Path.of("bin", "launch.cmd"), manifest.execPath());
+    assertEquals("bin/launch.cmd", manifest.execPathText());
+  }
+
+  @Test
+  void parseContent_whenRawWindowsPathContainsControlEscapePrefix_expectBackslashesPreserved()
+      throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            minimalManifest(
+                MANIFEST_VERSION,
+                SAMPLE_APP_ID,
+                SAMPLE_APP_NAME,
+                APP_VERSION,
+                NESTED_WINDOWS_SCRIPT));
+
+    assertEquals(Path.of("bin", "tools", "launch.cmd"), manifest.execPath());
+    assertEquals("bin/tools/launch.cmd", manifest.execPathText());
+  }
+
+  @Test
+  void parseContent_whenRawWindowsPathContainsUnicodeEscapePrefix_expectBackslashesPreserved()
+      throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            minimalManifest(
+                MANIFEST_VERSION,
+                SAMPLE_APP_ID,
+                SAMPLE_APP_NAME,
+                APP_VERSION,
+                "bin\\ui\\launch.cmd"));
+
+    assertEquals(Path.of("bin", "ui", "launch.cmd"), manifest.execPath());
+    assertEquals("bin/ui/launch.cmd", manifest.execPathText());
+  }
+
+  @Test
+  void parseContent_whenRawWindowsPathContainsUnicodeDigits_expectBackslashesPreserved()
+      throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            minimalManifest(
+                MANIFEST_VERSION,
+                SAMPLE_APP_ID,
+                SAMPLE_APP_NAME,
+                APP_VERSION,
+                "bin\\u1234\\launch.cmd"));
+
+    assertEquals(Path.of("bin", "u1234", "launch.cmd"), manifest.execPath());
+    assertEquals("bin/u1234/launch.cmd", manifest.execPathText());
+  }
+
+  @Test
+  void parseContent_whenManifestComesFromPropertiesStore_expectEscapesDecoded() throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty("manifest.version", "1");
+    properties.setProperty("app.id", SAMPLE_APP_ID);
+    properties.setProperty("app.name", UTF8_APP_NAME);
+    properties.setProperty("app.version", APP_VERSION);
+    properties.setProperty("app.exec", WINDOWS_SCRIPT);
+    properties.setProperty("app.permissions", "network.read, ui.open");
+    StringWriter writer = new StringWriter();
+    properties.store(writer, "generated");
+
+    AppManifest manifest = AppManifestParser.parseContent(writer.toString());
+
+    assertEquals(UTF8_APP_NAME, manifest.appName());
+    assertEquals(Path.of("bin", "launch.cmd"), manifest.execPath());
+    assertEquals("bin/launch.cmd", manifest.execPathText());
+    assertEquals(java.util.List.of("network.read", "ui.open"), manifest.permissions());
+  }
+
+  @Test
+  void parseContent_whenPropertiesStoreEncodesUnicodeExecPath_expectEscapesDecoded()
+      throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty("manifest.version", "1");
+    properties.setProperty("app.id", SAMPLE_APP_ID);
+    properties.setProperty("app.name", SAMPLE_APP_NAME);
+    properties.setProperty("app.version", APP_VERSION);
+    properties.setProperty("app.exec", "bin/\u542F\u52A8.sh");
+    StringWriter writer = new StringWriter();
+    properties.store(writer, "generated");
+
+    AppManifest manifest = AppManifestParser.parseContent(writer.toString());
+
+    assertEquals(Path.of("bin", "启动.sh"), manifest.execPath());
+    assertEquals("bin/启动.sh", manifest.execPathText());
+  }
+
+  @Test
+  void parseContent_whenPropertiesStoreEncodesBundleRootUnicodeExec_expectEscapesDecoded()
+      throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty("manifest.version", "1");
+    properties.setProperty("app.id", SAMPLE_APP_ID);
+    properties.setProperty("app.name", SAMPLE_APP_NAME);
+    properties.setProperty("app.version", APP_VERSION);
+    properties.setProperty("app.exec", "launch-启动.sh");
+    StringWriter writer = new StringWriter();
+    properties.store(writer, "generated");
+
+    AppManifest manifest = AppManifestParser.parseContent(writer.toString());
+
+    assertEquals(Path.of("launch-启动.sh"), manifest.execPath());
+    assertEquals("launch-启动.sh", manifest.execPathText());
+  }
+
+  @Test
+  void parseContent_whenManifestBeginsWithUtf8Bom_expectVersionParsed() throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            "\uFEFF"
+                + minimalManifest(
+                    MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT));
+
+    assertEquals(1, manifest.manifestVersion());
+    assertEquals(SAMPLE_APP_ID, manifest.appId());
+  }
+
+  @Test
+  void parse_whenManifestPathIsSymlink_expectFailure() throws Exception {
+    Assumptions.assumeFalse(new AppEnv().isWindows());
+    Path targetManifest = tempDir.resolve("target.properties");
+    Files.writeString(
+        targetManifest,
+        minimalManifest(
+            MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT),
+        StandardCharsets.UTF_8);
+    Path manifestSymlink = tempDir.resolve("cryptad-app.properties");
+    Files.createSymbolicLink(manifestSymlink, targetManifest);
+
+    AppManifestException exception =
+        assertThrows(AppManifestException.class, () -> AppManifestParser.parse(manifestSymlink));
+
+    assertEquals("manifest file must not be a symlink: " + manifestSymlink, exception.getMessage());
+  }
+
+  @Test
+  void parseContent_whenManifestVersionIsUnsupported_expectFailure() {
+    String invalidManifest =
+        minimalManifest("2", SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT);
+    AppManifestException exception =
+        assertThrows(
+            AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
+
+    assertEquals("unsupported manifest.version: 2", exception.getMessage());
+  }
+
+  @Test
+  void parseContent_whenAppIdIsInvalid_expectFailure() {
+    String invalidManifest =
+        minimalManifest(MANIFEST_VERSION, "Bad/Id", SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT);
+    assertThrows(AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
+  }
+
+  @Test
+  void parseContent_whenAppExecIsAbsoluteOrTraversingParent_expectFailure() {
+    String absolutePathManifest =
+        minimalManifest(
+            MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, "/tmp/app.sh");
+    String parentTraversalManifest =
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, "../app.sh");
+    assertThrows(
+        AppManifestException.class, () -> AppManifestParser.parseContent(absolutePathManifest));
+    assertThrows(
+        AppManifestException.class, () -> AppManifestParser.parseContent(parentTraversalManifest));
+  }
+
+  @Test
+  void parseContent_whenAppExecUsesWindowsDrivePrefix_expectFailure() {
+    String invalidManifest =
+        minimalManifest(
+            MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, "C:launch.cmd");
+    assertThrows(AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
+  }
+
+  @Test
+  void parseContent_whenQuotaValueIsMalformed_expectFailure() {
+    String invalidDataQuotaManifest =
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT)
+            + "quota.data.bytes=not-a-number\n";
+    String invalidCacheQuotaManifest =
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, APP_VERSION, START_SCRIPT)
+            + "quota.cache.bytes=-1\n";
+    assertThrows(
+        AppManifestException.class, () -> AppManifestParser.parseContent(invalidDataQuotaManifest));
+    assertThrows(
+        AppManifestException.class,
+        () -> AppManifestParser.parseContent(invalidCacheQuotaManifest));
+  }
+
+  private static String fullManifest(
+      String appId, String appName, String appVersion, String execPath) {
+    return """
+    manifest.version=1
+    app.id=%s
+    app.name=%s
+    app.version=%s
+    app.exec=%s
+    app.ui.entry=/
+    app.permissions=network.read, ui.open
+    quota.data.bytes=1048576
+    quota.cache.bytes=2048
+    """
+        .formatted(appId, appName, appVersion, execPath);
+  }
+
+  private static String minimalManifest(
+      String manifestVersion, String appId, String appName, String appVersion, String execPath) {
+    return """
+    manifest.version=%s
+    app.id=%s
+    app.name=%s
+    app.version=%s
+    app.exec=%s
+    """
+        .formatted(manifestVersion, appId, appName, appVersion, execPath);
+  }
+}

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestTest.java
@@ -1,0 +1,75 @@
+package network.crypta.platform.apphost.manifest;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AppManifestTest {
+  private static final String SAMPLE_APP_ID = "sample-app";
+  private static final String SAMPLE_APP_NAME = "Sample App";
+  private static final String SAMPLE_APP_VERSION = "1.0";
+  private static final String SAMPLE_EXEC_PATH = "bin/start.sh";
+  private static final List<String> NO_PERMISSIONS = List.of();
+
+  @Test
+  void constructor_whenManifestVersionIsUnsupported_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new AppManifest(
+                    2,
+                    SAMPLE_APP_ID,
+                    SAMPLE_APP_NAME,
+                    SAMPLE_APP_VERSION,
+                    SAMPLE_EXEC_PATH,
+                    null,
+                    NO_PERMISSIONS,
+                    null,
+                    null));
+
+    assertEquals("unsupported manifest.version: 2", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenQuotaIsNegative_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new AppManifest(
+                    1,
+                    SAMPLE_APP_ID,
+                    SAMPLE_APP_NAME,
+                    SAMPLE_APP_VERSION,
+                    SAMPLE_EXEC_PATH,
+                    null,
+                    NO_PERMISSIONS,
+                    -1L,
+                    null));
+
+    assertEquals("quota.data.bytes must be >= 0", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenRequiredFieldIsBlank_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new AppManifest(
+                    1,
+                    SAMPLE_APP_ID,
+                    "  ",
+                    SAMPLE_APP_VERSION,
+                    SAMPLE_EXEC_PATH,
+                    null,
+                    NO_PERMISSIONS,
+                    null,
+                    null));
+
+    assertEquals("app.name must not be blank", exception.getMessage());
+  }
+}

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -1,0 +1,2868 @@
+package network.crypta.platform.apphost.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.fs.AppEnv;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.InstalledAppPaths;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalProcessAppHostTest {
+  private static final String SAMPLE_APP_ID = "sample-app";
+  private static final String RUNNER_APP_ID = "runner-app";
+  private static final String DUPLICATE_APP_ID = "duplicate-app";
+  private static final String MIXED_CASE_APP_ID = "MixedCase-App";
+  private static final String NORMALIZED_MIXED_CASE_APP_ID = "mixedcase-app";
+  private static final String APP_VERSION = "2.0.0";
+  private static final String DEFAULT_TOKEN = "token";
+  private static final String WRAPPER_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      ./bin/child.sh &
+      child=$!
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      wait "$child"
+      """;
+  private static final String CHILD_PROCESS_SCRIPT =
+      """
+      #!/bin/sh
+      trap '' TERM INT
+      while :; do
+        sleep 1
+      done
+      """;
+  private static final String DAEMONIZED_CHILD_PROCESS_SCRIPT =
+      """
+      #!/bin/sh
+      trap 'exit 0' TERM INT
+      while :; do
+        sleep 1
+      done
+      """;
+  private static final String DETACHED_CHILD_PROCESS_SCRIPT =
+      """
+      #!/bin/sh
+      trap '' HUP
+      trap 'exit 0' TERM INT
+      while :; do
+        sleep 1
+      done
+      """;
+  private static final String DAEMONIZING_WRAPPER_IMMEDIATE_EXIT_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      ./bin/child.sh &
+      child=$!
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      exit 0
+      """;
+  private static final String DAEMONIZING_WRAPPER_DELAYED_EXIT_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      echo "$$" > "$CRYPTAD_APP_RUN_DIR/wrapper.pid"
+      ./bin/child.sh &
+      child=$!
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      sleep 1
+      echo exited > "$CRYPTAD_APP_RUN_DIR/wrapper-exited.txt"
+      exit 0
+      """;
+  private static final String DAEMONIZING_WRAPPER_POST_CAPTURE_EXIT_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      sleep 0.53
+      ./bin/child.sh &
+      child=$!
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      exit 0
+      """;
+  private static final String DAEMONIZING_WRAPPER_VIA_HELPER_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      ./bin/helper.sh &
+      exit 0
+      """;
+  private static final String DELAYED_DAEMONIZING_HELPER_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      sleep 0.25
+      ./bin/child.sh &
+      child=$!
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      exit 0
+      """;
+  private static final String POST_CAPTURE_PYTHON_DAEMONIZER =
+      """
+      #!/usr/bin/env python3
+      import os
+      import pathlib
+      import subprocess
+      import time
+
+      time.sleep(0.53)
+      child = subprocess.Popen(["./bin/child.sh"])
+      pathlib.Path(os.environ["CRYPTAD_APP_RUN_DIR"], "child.pid").write_text(
+          f"{child.pid}\\n", encoding="utf-8")
+      """;
+  private static final String LATE_CHILD_DIRECT_EXECUTABLE =
+      """
+      #!/bin/sh
+      set -eu
+      sleep 1
+      ./bin/child.sh &
+      child=$!
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      sleep 0.2
+      echo exited > "$CRYPTAD_APP_RUN_DIR/wrapper-exited.txt"
+      exit 0
+      """;
+  private static final String STDIN_EOF_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      cat >/dev/null
+      echo closed > "$CRYPTAD_APP_RUN_DIR/stdin-closed.txt"
+      while :; do
+        sleep 1
+      done
+      """;
+  private static final String SINGLE_RUN_EXIT_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      count_file="$CRYPTAD_APP_RUN_DIR/run-count.txt"
+      count=1
+      if [ -f "$count_file" ]; then
+        count=$(( $(cat "$count_file") + 1 ))
+      fi
+      printf '%s\\n' "$count" > "$count_file"
+      exit 0
+      """;
+  private static final String DELAYED_STARTUP_EXIT_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      sleep 0.1
+      exit 0
+      """;
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void installFromDirectory_whenInstallingValidBundle_expectCopiedLayoutAndDescribe()
+      throws IOException {
+    AppHost host = host();
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    assertEquals(SAMPLE_APP_ID, installation.appId());
+    assertEquals(4096L, installation.manifest().dataQuotaBytes());
+    assertEquals(1024L, installation.manifest().cacheQuotaBytes());
+    assertTrue(Files.isRegularFile(installation.paths().manifestFile()));
+    assertTrue(
+        Files.isRegularFile(
+            installation.paths().resolveInstalledPath(installation.manifest().execPath())));
+    assertTrue(Files.isDirectory(installation.paths().dataDir()));
+    assertTrue(Files.isDirectory(installation.paths().cacheDir()));
+    assertTrue(Files.isDirectory(installation.paths().runDir()));
+    assertEquals(java.util.List.of(installation), host.listInstalled());
+    assertEquals(installation.manifest(), host.describe(SAMPLE_APP_ID).orElseThrow().manifest());
+  }
+
+  @Test
+  void installFromDirectory_whenAppAlreadyInstalled_expectFailure() throws IOException {
+    AppHost host = host();
+    Path stagedApp = stageInstalledApp(DUPLICATE_APP_ID);
+
+    host.installFromDirectory(stagedApp);
+
+    assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+  }
+
+  @Test
+  void installFromDirectory_whenInstalledAppsDirIsSymlink_expectFailure() throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Path dataDir = tempDir.resolve("data");
+    Path cacheDir = tempDir.resolve("cache");
+    Path runDir = tempDir.resolve("run");
+    AppHost host =
+        new LocalProcessAppHost(
+            new AppHostLayout(dataDir, cacheDir, runDir),
+            Duration.ofSeconds(1),
+            new java.security.SecureRandom());
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+    Path installParent = Files.createDirectories(dataDir.resolve("apps"));
+    Path externalInstalled = Files.createDirectories(tempDir.resolve("external-installed"));
+    Files.createSymbolicLink(
+        installParent.resolve("installed"), externalInstalled.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("installedAppsDir must not be a symlink"));
+    try (var children = Files.list(externalInstalled)) {
+      assertEquals(List.of(), children.toList());
+    }
+  }
+
+  @Test
+  void uninstall_whenInstalledAppsDirBecomesSymlink_expectFailureBeforeDeletingExternalBundle()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Path dataDir = tempDir.resolve("data");
+    Path cacheDir = tempDir.resolve("cache");
+    Path runDir = tempDir.resolve("run");
+    AppHost host =
+        new LocalProcessAppHost(
+            new AppHostLayout(dataDir, cacheDir, runDir),
+            Duration.ofSeconds(1),
+            new java.security.SecureRandom());
+
+    host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+
+    Path installParent = dataDir.resolve("apps");
+    Path installedAppsDir = installParent.resolve("installed");
+    Path externalInstalled = tempDir.resolve("external-installed");
+    Files.move(installedAppsDir, externalInstalled);
+    Files.createSymbolicLink(installedAppsDir, externalInstalled.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.uninstall(SAMPLE_APP_ID));
+
+    assertTrue(exception.getMessage().contains("installedAppsDir must not be a symlink"));
+    assertTrue(Files.isDirectory(externalInstalled.resolve(SAMPLE_APP_ID)));
+    assertTrue(
+        Files.isRegularFile(externalInstalled.resolve(SAMPLE_APP_ID).resolve("content.txt")));
+  }
+
+  @Test
+  void uninstall_whenInstalledAppsAncestorBecomesSymlink_expectFailureBeforeDeletingExternalBundle()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Path dataDir = tempDir.resolve("data");
+    Path cacheDir = tempDir.resolve("cache");
+    Path runDir = tempDir.resolve("run");
+    AppHost host =
+        new LocalProcessAppHost(
+            new AppHostLayout(dataDir, cacheDir, runDir),
+            Duration.ofSeconds(1),
+            new java.security.SecureRandom());
+
+    host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+
+    Path appsDir = dataDir.resolve("apps");
+    Path externalAppsDir = tempDir.resolve("external-apps");
+    Files.move(appsDir, externalAppsDir);
+    Files.createSymbolicLink(appsDir, externalAppsDir.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.uninstall(SAMPLE_APP_ID));
+
+    assertTrue(exception.getMessage().contains("installedAppsDir must not be a symlink"));
+    assertTrue(Files.isDirectory(externalAppsDir.resolve("installed").resolve(SAMPLE_APP_ID)));
+    assertTrue(
+        Files.isRegularFile(
+            externalAppsDir.resolve("installed").resolve(SAMPLE_APP_ID).resolve("content.txt")));
+  }
+
+  @Test
+  void listInstalled_whenStaleTemporaryInstallDirectoryExists_expectInstalledAppsOnly()
+      throws IOException {
+    AppHost host = host();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+    Path staleInstallDirectory =
+        tempDir.resolve("data").resolve("apps").resolve("installed").resolve("app-install-stale");
+    Files.createDirectories(staleInstallDirectory);
+    Files.writeString(
+        staleInstallDirectory.resolve("content.txt"), "stale", StandardCharsets.UTF_8);
+
+    assertEquals(List.of(installation), host.listInstalled());
+  }
+
+  @Test
+  void installFromDirectory_whenPosixDirectExecutableLacksExecutePermission_expectFailure()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    Path stagedApp =
+        stageInstalledExecutableApp(
+            "non-launchable-app",
+            "bin/launch",
+            """
+            exit 0
+            """,
+            Map.of(),
+            false);
+
+    Assumptions.assumeFalse(Files.isExecutable(stagedApp.resolve("bin/launch")));
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("without execute permission"));
+  }
+
+  @Test
+  void installFromDirectory_whenWindowsLauncherUsesUnsupportedScript_expectFailure()
+      throws IOException {
+    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "Windows 11"));
+    Path stagedApp =
+        stageInstalledExecutableApp(
+            "unsupported-windows-script-app", "bin/launch.ps1", "Write-Output 'hi'\n", Map.of());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("app.exec is not launchable on Windows"));
+  }
+
+  @Test
+  void installFromDirectory_whenWindowsLauncherIsGenericMzBlob_expectFailure() throws IOException {
+    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "Windows 11"));
+    Path stagedApp =
+        stageInstalledExecutableApp("generic-mz-app", "bin/fake.bin", "placeholder", Map.of());
+    byte[] fakeMz = new byte[64];
+    fakeMz[0] = 'M';
+    fakeMz[1] = 'Z';
+    Files.write(stagedApp.resolve("bin/fake.bin"), fakeMz);
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("app.exec is not launchable on Windows"));
+  }
+
+  @Test
+  void lifecycle_whenManifestUsesMixedCaseAppId_expectPublicApiAcceptsOriginalCase()
+      throws IOException {
+    AppHost host = host();
+    InstalledAppSnapshot installation =
+        host.installFromDirectory(stageInstalledApp(MIXED_CASE_APP_ID));
+
+    assertEquals(NORMALIZED_MIXED_CASE_APP_ID, installation.appId());
+    assertEquals(
+        installation.manifest(), host.describe(MIXED_CASE_APP_ID).orElseThrow().manifest());
+
+    RunningAppSnapshot running = host.start(MIXED_CASE_APP_ID);
+
+    assertEquals(NORMALIZED_MIXED_CASE_APP_ID, running.appId());
+    assertEquals(running.token(), host.status(MIXED_CASE_APP_ID).orElseThrow().token());
+    assertTrue(host.stop(MIXED_CASE_APP_ID));
+    host.uninstall(MIXED_CASE_APP_ID);
+    assertTrue(host.describe(NORMALIZED_MIXED_CASE_APP_ID).isEmpty());
+  }
+
+  @Test
+  void lifecycle_whenInstalledScriptRuns_expectEnvTokenStopAndUninstall() throws IOException {
+    AppHost host = host();
+    Path stagedApp = stageInstalledApp(RUNNER_APP_ID);
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+
+    assertFalse(running.token().isBlank());
+    assertEquals(RUNNER_APP_ID, running.appId());
+    assertEquals(running.token(), host.status(RUNNER_APP_ID).orElseThrow().token());
+    List<RunningAppSnapshot> runningSnapshots = host.listRunning();
+    assertEquals(1, runningSnapshots.size());
+    assertEquals(running.appId(), runningSnapshots.getFirst().appId());
+    assertEquals(running.token(), runningSnapshots.getFirst().token());
+
+    Path captureFile = installation.paths().runDir().resolve("captured-env.txt");
+    waitForFile(captureFile);
+    String capture = Files.readString(captureFile, StandardCharsets.UTF_8);
+    assertTrue(capture.contains("CRYPTAD_APP_ID=" + RUNNER_APP_ID));
+    assertTrue(capture.contains("CRYPTAD_APP_NAME=Runner App"));
+    assertTrue(capture.contains("CRYPTAD_APP_VERSION=" + APP_VERSION));
+    assertTrue(capture.contains("CRYPTAD_APP_DATA_DIR=" + installation.paths().dataDir()));
+    assertTrue(capture.contains("CRYPTAD_APP_CACHE_DIR=" + installation.paths().cacheDir()));
+    assertTrue(capture.contains("CRYPTAD_APP_RUN_DIR=" + installation.paths().runDir()));
+    assertTrue(capture.contains("CRYPTAD_APP_TOKEN=" + running.token()));
+    assertTrue(capture.contains("CRYPTAD_APP_PERMISSIONS=network.access,file.read"));
+    assertTrue(capture.contains("CRYPTAD_APP_UI_ENTRY=/"));
+
+    assertThrows(AppHostException.class, () -> host.uninstall(RUNNER_APP_ID));
+    assertTrue(host.stop(RUNNER_APP_ID));
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    assertTrue(host.listRunning().isEmpty());
+
+    RunningAppSnapshot secondRun = host.start(RUNNER_APP_ID);
+    assertNotEquals(running.token(), secondRun.token());
+    assertTrue(host.stop(RUNNER_APP_ID));
+
+    host.uninstall(RUNNER_APP_ID);
+    assertFalse(Files.exists(installation.paths().installedRoot()));
+    assertFalse(Files.exists(installation.paths().dataDir()));
+    assertFalse(Files.exists(installation.paths().cacheDir()));
+    assertFalse(Files.exists(installation.paths().runDir()));
+    assertTrue(host.listInstalled().isEmpty());
+  }
+
+  @Test
+  void start_whenInstalledProcessExitsImmediately_expectFailureAndNoRunningState()
+      throws IOException {
+    AppHost host = host();
+    host.installFromDirectory(
+        stageInstalledApp(RUNNER_APP_ID, immediateExitScriptContent(new AppEnv())));
+
+    Instant started = Instant.now();
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+    Duration elapsed = Duration.between(started, Instant.now());
+
+    assertTrue(exception.getMessage().contains("app exited during startup: " + RUNNER_APP_ID));
+    assertTrue(elapsed.compareTo(Duration.ofSeconds(3)) < 0);
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    assertTrue(host.listRunning().isEmpty());
+  }
+
+  @Test
+  void start_whenInstalledProcessExitsShortlyAfterLaunch_expectFailureAndNoRunningState()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID, DELAYED_STARTUP_EXIT_SCRIPT));
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+
+    assertTrue(exception.getMessage().contains("app exited during startup: " + RUNNER_APP_ID));
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    assertTrue(host.listRunning().isEmpty());
+  }
+
+  @Test
+  void start_whenInstalledExecParentBecomesSymlink_expectFailureBeforeExternalCodeRuns()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
+    Path externalBin = Files.createDirectories(tempDir.resolve("external-bin"));
+    Path externalLaunch = externalBin.resolve(scriptName(appEnv));
+    writeStageFile(
+        externalLaunch,
+        """
+        #!/bin/sh
+        printf 'escaped' > "$CRYPTAD_APP_RUN_DIR/escaped.txt"
+        while :; do
+          sleep 1
+        done
+        """,
+        appEnv);
+    Path installedBin = installation.paths().installedRoot().resolve("bin");
+    Path relocatedInstalledBin = installation.paths().installedRoot().resolve("bin-original");
+    Files.move(installedBin, relocatedInstalledBin);
+    Files.createSymbolicLink(installedBin, externalBin.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+
+    assertTrue(exception.getMessage().contains("symlinks or reparse points"));
+    assertFalse(Files.exists(installation.paths().runDir().resolve("escaped.txt")));
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+  }
+
+  @Test
+  void start_whenLauncherDaemonizesChildAndExitsImmediately_expectChildManagedAsRunningApp()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host(Duration.ofSeconds(1));
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            DAEMONIZING_WRAPPER_IMMEDIATE_EXIT_SCRIPT,
+            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    waitForFile(childPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    try {
+      assertEquals(childPid, running.pid());
+      RunningAppSnapshot current = waitForRunningApp(host, RUNNER_APP_ID);
+      assertEquals(running.appId(), current.appId());
+      assertEquals(running.token(), current.token());
+      assertTrue(
+          ProcessHandle.of(current.pid())
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertTrue(
+          ProcessHandle.of(childPid)
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertEquals(
+          "cannot uninstall a running app: " + RUNNER_APP_ID,
+          assertThrows(AppHostException.class, () -> host.uninstall(RUNNER_APP_ID)).getMessage());
+      assertTrue(host.stop(RUNNER_APP_ID));
+      waitForProcessExit(childPid);
+      assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void status_whenLauncherDaemonizesChildAndExitsLater_expectRunningSnapshotPreserved()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host(Duration.ofSeconds(1));
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            DAEMONIZING_WRAPPER_DELAYED_EXIT_SCRIPT,
+            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path wrapperPidFile = installation.paths().runDir().resolve("wrapper.pid");
+    waitForFile(childPidFile);
+    waitForFile(wrapperPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    long wrapperPid =
+        Long.parseLong(Files.readString(wrapperPidFile, StandardCharsets.UTF_8).trim());
+    Path wrapperExitedFile = installation.paths().runDir().resolve("wrapper-exited.txt");
+    waitForFile(wrapperExitedFile);
+    try {
+      assertEquals(childPid, running.pid());
+      waitForProcessExit(wrapperPid);
+      RunningAppSnapshot current = waitForRunningApp(host, RUNNER_APP_ID);
+      assertEquals(running.appId(), current.appId());
+      assertEquals(running.token(), current.token());
+      assertEquals(childPid, current.pid());
+      assertEquals(java.util.List.of(current), host.listRunning());
+      assertTrue(
+          ProcessHandle.of(current.pid())
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertTrue(
+          ProcessHandle.of(childPid)
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertTrue(host.stop(RUNNER_APP_ID));
+      waitForProcessExit(childPid);
+      assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+      ProcessHandle.of(wrapperPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void status_whenLauncherDaemonizesChildAfterStartupCapture_expectChildRetained()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host(Duration.ofSeconds(1));
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            DAEMONIZING_WRAPPER_POST_CAPTURE_EXIT_SCRIPT,
+            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    waitForFile(childPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    try {
+      RunningAppSnapshot current = waitForRunningPid(host, RUNNER_APP_ID, childPid);
+      assertEquals(running.appId(), current.appId());
+      assertEquals(running.token(), current.token());
+      assertEquals(childPid, current.pid());
+      assertTrue(
+          ProcessHandle.of(childPid)
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertTrue(host.stop(RUNNER_APP_ID));
+      waitForProcessExit(childPid);
+      assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void status_whenDirectInterpreterLauncherDaemonizesChildAfterStartupCapture_expectChildRetained()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Assumptions.assumeTrue(appEnv.onPath("python3"));
+    AppHost host = host(Duration.ofSeconds(1));
+    Path stagedApp =
+        stageInstalledExecutableApp(
+            "python-daemon-app",
+            "bin/launch",
+            POST_CAPTURE_PYTHON_DAEMONIZER,
+            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start("python-daemon-app");
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    waitForFile(childPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    try {
+      RunningAppSnapshot current = waitForRunningApp(host, "python-daemon-app");
+      assertEquals(running.appId(), current.appId());
+      assertEquals(running.token(), current.token());
+      assertEquals(childPid, current.pid());
+      assertTrue(
+          ProcessHandle.of(childPid)
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertEquals(java.util.List.of(current), host.listRunning());
+      assertTrue(host.stop("python-daemon-app"));
+      waitForProcessExit(childPid);
+      assertTrue(host.status("python-daemon-app").isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void status_whenMacHostLauncherDaemonizesViaIntermediateHelper_expectChildRetained()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "Mac OS X"));
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            DAEMONIZING_WRAPPER_VIA_HELPER_SCRIPT,
+            Map.of(
+                "bin/helper.sh", DELAYED_DAEMONIZING_HELPER_SCRIPT,
+                "bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    waitForFile(childPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    try {
+      RunningAppSnapshot current = waitForRunningPid(host, RUNNER_APP_ID, childPid);
+      assertEquals(running.appId(), current.appId());
+      assertEquals(running.token(), current.token());
+      assertEquals(childPid, current.pid());
+      assertTrue(
+          ProcessHandle.of(childPid)
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertTrue(host.stop(RUNNER_APP_ID));
+      waitForProcessExit(childPid);
+      assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void status_whenOtherUnixHostLauncherDaemonizesViaIntermediateHelper_expectChildRetained()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "FreeBSD"));
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            DAEMONIZING_WRAPPER_VIA_HELPER_SCRIPT,
+            Map.of(
+                "bin/helper.sh", DELAYED_DAEMONIZING_HELPER_SCRIPT,
+                "bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    waitForFile(childPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    try {
+      RunningAppSnapshot current = waitForRunningPid(host, RUNNER_APP_ID, childPid);
+      assertEquals(running.appId(), current.appId());
+      assertEquals(running.token(), current.token());
+      assertEquals(childPid, current.pid());
+      assertTrue(
+          ProcessHandle.of(childPid)
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertTrue(host.stop(RUNNER_APP_ID));
+      waitForProcessExit(childPid);
+      assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void recoverTrackedDescendantProcesses_whenWindowsWrapperExited_expectLiveChildRecovered() {
+    ProcessHandle wrapper = new ExitedProcessHandle(7100L);
+    ProcessHandle helper = new LinkedProcessHandle(7101L, wrapper, false);
+    ProcessHandle child = new LinkedProcessHandle(7102L, helper, true);
+    ProcessHandle grandchild = new LinkedProcessHandle(7103L, child, true);
+    ProcessHandle unrelated = new LinkedProcessHandle(8100L, new ExitedProcessHandle(8099L), true);
+
+    List<ProcessHandle> recovered =
+        LocalProcessAppHost.recoverTrackedDescendantProcesses(
+            List.of(wrapper, helper), List.of(child, grandchild, unrelated));
+
+    assertEquals(List.of(7102L, 7103L), recovered.stream().map(ProcessHandle::pid).toList());
+  }
+
+  @Test
+  void
+      recoverWindowsBundleProcesses_whenCommandLineReferencesInstalledBundle_expectLiveChildRecovered() {
+    InstalledAppPaths paths =
+        new AppHostLayout(tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"))
+            .pathsFor(RUNNER_APP_ID);
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            RUNNER_APP_ID,
+            displayName(RUNNER_APP_ID),
+            APP_VERSION,
+            "bin/launch.cmd",
+            "/",
+            java.util.List.of("network.access", "file.read"),
+            4096L,
+            1024L);
+    Instant startedAt = Instant.parse("2026-04-05T00:00:00Z");
+    ProcessHandle wrapper = new ExitedProcessHandle(7200L);
+    ProcessHandle staleBundleProcess =
+        new InfoProcessHandle(
+            7201L,
+            null,
+            true,
+            Optional.of(paths.installedRoot().resolve("bin").resolve("child.exe").toString()),
+            Optional.of("\"" + paths.installedRoot().resolve("bin").resolve("child.exe") + "\""),
+            Optional.of(startedAt.minusSeconds(5)));
+    ProcessHandle recoveredChild =
+        new InfoProcessHandle(
+            7202L,
+            null,
+            true,
+            Optional.empty(),
+            Optional.of(
+                "\"" + paths.installedRoot().resolve("bin").resolve("child.exe") + "\" --serve"),
+            Optional.of(startedAt.plusMillis(750)));
+
+    List<ProcessHandle> recovered =
+        LocalProcessAppHost.recoverWindowsBundleProcesses(
+            paths,
+            manifest,
+            startedAt,
+            List.of(wrapper),
+            List.of(staleBundleProcess, recoveredChild));
+
+    assertEquals(List.of(7202L), recovered.stream().map(ProcessHandle::pid).toList());
+  }
+
+  @Test
+  void parseTokenTrackedProcesses_whenReaderFails_expectCheckedIoException()
+      throws ReflectiveOperationException {
+    Process process =
+        new FailingInputProcess(
+            (ProcessHandle.current().pid()
+                    + " CRYPTAD_APP_TOKEN="
+                    + DEFAULT_TOKEN
+                    + " CRYPTAD_APP_ID="
+                    + RUNNER_APP_ID
+                    + "\n")
+                .getBytes(StandardCharsets.UTF_8));
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> invokeParseTokenTrackedProcesses(process, DEFAULT_TOKEN, RUNNER_APP_ID));
+
+    assertEquals("simulated ps stream failure", exception.getMessage());
+  }
+
+  @Test
+  void mergeTokenTrackedProcesses_whenProcReturnsEmptyOnUnix_expectPsFallback() {
+    ProcessHandle psRecovered = new LinkedProcessHandle(7205L, null, true);
+
+    List<ProcessHandle> recovered =
+        LocalProcessAppHost.mergeTokenTrackedProcesses(
+            List.of(), List.of(psRecovered), new AppEnv(Map.of(), "Linux"));
+
+    assertEquals(List.of(7205L), recovered.stream().map(ProcessHandle::pid).toList());
+  }
+
+  @Test
+  void recoverWindowsBundleProcesses_whenProcessStartsLongAfterLaunch_expectIgnored() {
+    InstalledAppPaths paths =
+        new AppHostLayout(tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"))
+            .pathsFor(RUNNER_APP_ID);
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            RUNNER_APP_ID,
+            displayName(RUNNER_APP_ID),
+            APP_VERSION,
+            "bin/launch.cmd",
+            "/",
+            java.util.List.of("network.access", "file.read"),
+            4096L,
+            1024L);
+    Instant startedAt = Instant.parse("2026-04-05T00:00:00Z");
+    ProcessHandle unrelatedLaterProcess =
+        new InfoProcessHandle(
+            7204L,
+            null,
+            true,
+            Optional.empty(),
+            Optional.of(
+                "\"" + paths.installedRoot().resolve("bin").resolve("child.exe") + "\" --serve"),
+            Optional.of(startedAt.plusSeconds(30)));
+
+    List<ProcessHandle> recovered =
+        LocalProcessAppHost.recoverWindowsBundleProcesses(
+            paths,
+            manifest,
+            startedAt,
+            List.of(new ExitedProcessHandle(7200L)),
+            List.of(unrelatedLaterProcess));
+
+    assertEquals(List.of(), recovered);
+  }
+
+  @Test
+  void status_whenDirectLauncherSpawnsChildAfterStartupGrace_expectChildRetained()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host(Duration.ofSeconds(1));
+    Path stagedApp =
+        stageInstalledExecutableApp(
+            "late-child-app",
+            "bin/launch",
+            LATE_CHILD_DIRECT_EXECUTABLE,
+            Map.of("bin/child.sh", DETACHED_CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    RunningAppSnapshot running = host.start("late-child-app");
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    waitForFile(childPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    Path wrapperExitedFile = installation.paths().runDir().resolve("wrapper-exited.txt");
+    waitForFile(wrapperExitedFile);
+    try {
+      RunningAppSnapshot current = waitForRunningApp(host, "late-child-app");
+      assertEquals(running.appId(), current.appId());
+      assertEquals(running.token(), current.token());
+      assertTrue(
+          ProcessHandle.of(childPid)
+              .map(LocalProcessAppHostTest::isEffectivelyAlive)
+              .orElse(false));
+      assertTrue(host.stop("late-child-app"));
+      waitForProcessExit(childPid);
+      assertTrue(host.status("late-child-app").isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void stop_whenProcessDoesNotExit_expectRunningStatePreserved()
+      throws ReflectiveOperationException {
+    LocalProcessAppHost host = host(Duration.ofMillis(10));
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+    injectRunningProcess(host, RUNNER_APP_ID, snapshot, new NonStoppingProcess(snapshot.pid()));
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.stop(RUNNER_APP_ID));
+
+    assertEquals("timed out stopping app: " + RUNNER_APP_ID, exception.getMessage());
+    assertEquals(snapshot, host.status(RUNNER_APP_ID).orElseThrow());
+    assertEquals(java.util.List.of(snapshot), host.listRunning());
+    assertEquals(
+        "cannot uninstall a running app: " + RUNNER_APP_ID,
+        assertThrows(AppHostException.class, () -> host.uninstall(RUNNER_APP_ID)).getMessage());
+    assertEquals(
+        "app is already running: " + RUNNER_APP_ID,
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID)).getMessage());
+  }
+
+  @Test
+  void stop_whenProcessExitsBetweenRefreshAndTracking_expectCleanSuccess()
+      throws IOException, ReflectiveOperationException {
+    LocalProcessAppHost host = host();
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+    injectRunningProcess(
+        host,
+        RUNNER_APP_ID,
+        snapshot,
+        new FadingProcess(snapshot.pid(), 2),
+        CompletableFuture.completedFuture(null));
+
+    assertTrue(host.stop(RUNNER_APP_ID));
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    assertTrue(host.listRunning().isEmpty());
+  }
+
+  @Test
+  void status_whenLiveProcessHandleOmitsOptionalMetadata_expectSnapshotRetained()
+      throws ReflectiveOperationException {
+    LocalProcessAppHost host = host();
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+    injectRunningProcess(host, RUNNER_APP_ID, snapshot, new NonStoppingProcess(snapshot.pid()));
+
+    assertEquals(snapshot, host.status(RUNNER_APP_ID).orElseThrow());
+    assertEquals(java.util.List.of(snapshot), host.listRunning());
+  }
+
+  @Test
+  void stop_whenWrapperScriptOwnsChildProcess_expectEntireProcessTreeTerminated()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host(Duration.ofSeconds(1));
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID, WRAPPER_SCRIPT, Map.of("bin/child.sh", CHILD_PROCESS_SCRIPT));
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    host.start(RUNNER_APP_ID);
+
+    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    waitForFile(childPidFile);
+    long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
+    try {
+      assertTrue(host.stop(RUNNER_APP_ID));
+      waitForProcessExit(childPid);
+      assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+      assertTrue(host.listRunning().isEmpty());
+    } finally {
+      ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
+    }
+  }
+
+  @Test
+  void stop_whenShutdownSpawnsReplacementChild_expectFailureAndRunningStatePreserved()
+      throws ReflectiveOperationException {
+    String appId = "shutdown-respawn-app";
+    long replacementChildPid = 84L;
+    LocalProcessAppHost host = host(Duration.ofMillis(200));
+    RunningAppSnapshot snapshot = runningSnapshot(appId);
+    injectRunningProcess(
+        host, appId, snapshot, new LateChildSpawningProcess(snapshot.pid(), replacementChildPid));
+
+    AppHostException exception = assertThrows(AppHostException.class, () -> host.stop(appId));
+
+    assertEquals("timed out stopping app: " + appId, exception.getMessage());
+    RunningAppSnapshot current = host.status(appId).orElseThrow();
+    assertEquals(appId, current.appId());
+    assertEquals(replacementChildPid, current.pid());
+  }
+
+  @Test
+  void launchCommand_whenWindowsBatchScript_expectQuotedCmdWrapper() throws IOException {
+    AppEnv windowsAppEnv = new AppEnv(Map.of(), "Windows 11");
+    Path batchScript = Path.of("C:/Users/Alice & Bob/Cryptad Apps^(1)/runner/bin/launch.cmd");
+    Path nativeExecutable = Path.of("C:/apps/runner/bin/runner.exe");
+
+    List<String> batchCommand = LocalProcessAppHost.launchCommand(batchScript, windowsAppEnv);
+
+    assertEquals(4, batchCommand.size());
+    assertTrue(batchCommand.get(0).toLowerCase(java.util.Locale.ROOT).endsWith("cmd.exe"));
+    assertEquals("/d", batchCommand.get(1));
+    assertEquals("/c", batchCommand.get(2));
+    assertEquals("\"" + batchScript + "\"", batchCommand.get(3));
+    assertEquals(
+        java.util.List.of(nativeExecutable.toString()),
+        LocalProcessAppHost.launchCommand(nativeExecutable, windowsAppEnv));
+  }
+
+  @Test
+  void launchCommand_whenShebangUsesEnvSplitString_expectInterpreterArgumentPreserved()
+      throws IOException {
+    AppEnv appEnv = new AppEnv(Map.of(), "Linux");
+    Path script = tempDir.resolve("env-shebang.sh");
+    Files.writeString(
+        script,
+        """
+        #!/usr/bin/env -S bash -euo pipefail
+        exit 0
+        """,
+        StandardCharsets.UTF_8);
+    assertTrue(script.toFile().setExecutable(true, false));
+
+    List<String> command = LocalProcessAppHost.launchCommand(script, appEnv);
+
+    assertEquals(Path.of("/usr/bin/env").toString(), command.get(0));
+    assertEquals("-S bash -euo pipefail", command.get(1));
+    assertEquals("-c", command.get(2));
+    assertEquals(script.toString(), command.get(4));
+  }
+
+  @Test
+  void installFromDirectory_whenShebangInterpreterIsFilesystemRoot_expectFailure()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    Path stagedApp =
+        stageInstalledExecutableApp(
+            "invalid-shebang-app",
+            "bin/start",
+            """
+            #!/
+            exit 0
+            """,
+            Map.of());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertEquals("invalid shebang interpreter: /", exception.getMessage());
+  }
+
+  @Test
+  void launchCommand_whenPythonShebangUsesShSuffix_expectInterpreterLaunch() throws IOException {
+    AppEnv appEnv = new AppEnv(Map.of(), "Linux");
+    Path script = tempDir.resolve("python-launch.sh");
+    Files.writeString(
+        script,
+        """
+        #!/usr/bin/env python3
+        print("ok")
+        """,
+        StandardCharsets.UTF_8);
+
+    List<String> command = LocalProcessAppHost.launchCommand(script, appEnv);
+
+    assertEquals(Path.of("/usr/bin/env").toString(), command.getFirst());
+    assertEquals("python3", command.get(1));
+    assertEquals(script.toString(), command.get(2));
+  }
+
+  @Test
+  void installFromDirectory_whenInterpreterManagedLauncherContainsNonUtf8Body_expectSuccess()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Assumptions.assumeTrue(appEnv.onPath("python3"));
+    AppHost host = host();
+    Path stagedApp =
+        stageInstalledExecutableApp(
+            "non-utf8-launcher-app",
+            "bin/start",
+            """
+            #!/usr/bin/env python3
+            pass
+            """,
+            Map.of(),
+            false);
+    Path script = stagedApp.resolve("bin/start");
+    try (OutputStream output = Files.newOutputStream(script)) {
+      output.write("#!/usr/bin/env python3\n".getBytes(StandardCharsets.US_ASCII));
+      output.write(new byte[] {(byte) 0xC3, (byte) 0x28, (byte) '\n'});
+    }
+
+    List<String> command = LocalProcessAppHost.launchCommand(script, appEnv);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    assertEquals(Path.of("/usr/bin/env").toString(), command.getFirst());
+    assertEquals("python3", command.get(1));
+    assertEquals(script.toString(), command.get(2));
+    assertEquals("non-utf8-launcher-app", installation.appId());
+  }
+
+  @Test
+  void start_whenPosixShellScriptRequiresShebangAndZeroArguments_expectSuccessfulLaunch()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Assumptions.assumeTrue(appEnv.onPath("bash"));
+    AppHost host = host();
+    InstalledAppSnapshot installation =
+        host.installFromDirectory(
+            stageInstalledApp(
+                RUNNER_APP_ID,
+                """
+                #!/usr/bin/env bash
+                set -euo pipefail
+                [[ $# -eq 0 ]]
+                letters=(alpha beta)
+                printf '%s' "${letters[0]}" > "$CRYPTAD_APP_RUN_DIR/shebang-ok.txt"
+                while :; do
+                  sleep 1
+                done
+                """));
+
+    host.start(RUNNER_APP_ID);
+
+    Path confirmationFile = installation.paths().runDir().resolve("shebang-ok.txt");
+    waitForFile(confirmationFile);
+    assertEquals("alpha", Files.readString(confirmationFile, StandardCharsets.UTF_8));
+    assertTrue(host.stop(RUNNER_APP_ID));
+  }
+
+  @Test
+  void start_whenExtensionlessShebangLauncherLacksExecuteBit_expectSuccessfulLaunch()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    InstalledAppSnapshot installation =
+        host.installFromDirectory(
+            stageInstalledExecutableApp(
+                "shell-noexec-app",
+                "bin/start",
+                """
+                #!/bin/sh
+                set -eu
+                printf '%s' "ok" > "$CRYPTAD_APP_RUN_DIR/noexec-ok.txt"
+                while :; do
+                  sleep 1
+                done
+                """,
+                Map.of(),
+                false));
+
+    host.start("shell-noexec-app");
+
+    Path confirmationFile = installation.paths().runDir().resolve("noexec-ok.txt");
+    waitForFile(confirmationFile);
+    assertEquals("ok", Files.readString(confirmationFile, StandardCharsets.UTF_8));
+    assertTrue(host.stop("shell-noexec-app"));
+  }
+
+  @Test
+  void start_whenLauncherWaitsForStandardInputEof_expectInitializationContinues()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    InstalledAppSnapshot installation =
+        host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID, STDIN_EOF_SCRIPT));
+
+    host.start(RUNNER_APP_ID);
+
+    Path confirmationFile = installation.paths().runDir().resolve("stdin-closed.txt");
+    waitForFile(confirmationFile);
+    assertEquals("closed\n", Files.readString(confirmationFile, StandardCharsets.UTF_8));
+    assertTrue(host.stop(RUNNER_APP_ID));
+  }
+
+  @Test
+  void start_whenShellLauncherExitsCleanlyWithoutChild_expectFailureAfterSingleExecution()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    InstalledAppSnapshot installation =
+        host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID, SINGLE_RUN_EXIT_SCRIPT));
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+
+    Path runCountFile = installation.paths().runDir().resolve("run-count.txt");
+    waitForFile(runCountFile);
+    assertEquals("1\n", Files.readString(runCountFile, StandardCharsets.UTF_8));
+    assertTrue(exception.getMessage().contains("app exited during startup: " + RUNNER_APP_ID));
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    assertTrue(host.listRunning().isEmpty());
+  }
+
+  @Test
+  void populateEnvironment_whenHostEnvironmentContainsSecrets_expectSanitizedChildEnvironment() {
+    Map<String, String> environment = new HashMap<>();
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+
+    environment.put("GITHUB_TOKEN", "secret");
+    environment.put("AWS_SECRET_ACCESS_KEY", "top-secret");
+
+    LocalProcessAppHost.populateEnvironment(
+        environment,
+        snapshot.manifest(),
+        snapshot.paths(),
+        DEFAULT_TOKEN,
+        new AppEnv(Map.of(), "Linux"));
+
+    assertFalse(environment.containsKey("GITHUB_TOKEN"));
+    assertFalse(environment.containsKey("AWS_SECRET_ACCESS_KEY"));
+    assertEquals(
+        "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin:"
+            + "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin",
+        environment.get("PATH"));
+    assertEquals(DEFAULT_TOKEN, environment.get("CRYPTAD_APP_TOKEN"));
+    assertEquals(RUNNER_APP_ID, environment.get("CRYPTAD_APP_ID"));
+  }
+
+  @Test
+  void populateEnvironment_whenMacBaseEnvironment_expectPackageManagerPrefixesPresent() {
+    Map<String, String> environment = new HashMap<>();
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+
+    LocalProcessAppHost.populateEnvironment(
+        environment,
+        snapshot.manifest(),
+        snapshot.paths(),
+        DEFAULT_TOKEN,
+        new AppEnv(Map.of(), "Mac OS X"));
+
+    assertEquals(
+        "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin:"
+            + "/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin",
+        environment.get("PATH"));
+  }
+
+  @Test
+  void populateEnvironment_whenWindowsBaseEnvironment_expectPowerShellDirectoryPresent() {
+    Map<String, String> environment = new HashMap<>();
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+
+    LocalProcessAppHost.populateEnvironment(
+        environment,
+        snapshot.manifest(),
+        snapshot.paths(),
+        DEFAULT_TOKEN,
+        new AppEnv(Map.of(), "Windows 11"));
+
+    List<String> pathEntries = List.of(environment.get("PATH").replace('\\', '/').split(";"));
+    assertTrue(pathEntries.stream().anyMatch(entry -> entry.endsWith("/System32")));
+    assertTrue(
+        pathEntries.stream().anyMatch(entry -> entry.endsWith("/System32/WindowsPowerShell/v1.0")));
+  }
+
+  @Test
+  void installFromDirectory_whenStagingContainsNamedPipe_expectFailureWithoutHanging()
+      throws Exception {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Assumptions.assumeTrue(appEnv.onPath("mkfifo"));
+    AppHost host = host();
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+    Path namedPipe = stagedApp.resolve("blocked.pipe");
+
+    Process mkfifo =
+        new ProcessBuilder(resolveTrustedCommand("mkfifo"), namedPipe.toString()).start();
+    assertEquals(0, waitForExit(mkfifo));
+
+    AppHostException exception = installExpectingAppHostException(host, stagedApp);
+
+    assertTrue(
+        exception.getMessage().contains("staging directory must contain only regular files"));
+  }
+
+  @Test
+  void installFromDirectory_whenManifestIsSymlink_expectFailureBeforeParsingExternalContent()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    Path stagedApp = Files.createDirectories(tempDir.resolve("stage").resolve("manifest-symlink"));
+    Path externalManifest = tempDir.resolve("outside-manifest.properties");
+    String externalContent = "outside-secret-data";
+    Files.writeString(externalManifest, externalContent, StandardCharsets.UTF_8);
+    Files.createSymbolicLink(
+        stagedApp.resolve("cryptad-app.properties"), externalManifest.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("symlink"));
+    assertFalse(exception.getMessage().contains(externalContent));
+  }
+
+  @Test
+  void installFromDirectory_whenStagingRootIsSymlink_expectFailure() throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+    Path linkedRoot = tempDir.resolve("linked-stage-root");
+    Files.createSymbolicLink(linkedRoot, stagedApp.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(linkedRoot));
+
+    assertTrue(exception.getMessage().contains("stagedAppDirectory must not be a symlink"));
+  }
+
+  @Test
+  void installFromDirectory_whenStagingRootHasAliasedAncestor_expectSuccess() throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    Path realStagingParent = Files.createDirectories(tempDir.resolve("real-staging-parent"));
+    Path aliasedParent = tempDir.resolve("aliased-staging-parent");
+    Files.createSymbolicLink(aliasedParent, realStagingParent.toAbsolutePath());
+    Path stagedApp =
+        stageInstalledAppAt(
+            aliasedParent.resolve(SAMPLE_APP_ID), SAMPLE_APP_ID, scriptContent(appEnv), Map.of());
+
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    assertEquals(SAMPLE_APP_ID, installation.appId());
+    assertTrue(Files.isRegularFile(installation.paths().manifestFile()));
+  }
+
+  @Test
+  void start_whenMutableRunDirectoryBecomesSymlink_expectFailureBeforeWritingOutsideLayout()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
+    Path externalRun = Files.createDirectories(tempDir.resolve("external-run"));
+    Files.delete(installation.paths().runDir());
+    Files.createSymbolicLink(installation.paths().runDir(), externalRun.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+
+    assertTrue(exception.getMessage().contains("runDir must not be a symlink"));
+    assertFalse(Files.exists(externalRun.resolve("process.log")));
+  }
+
+  @Test
+  void start_whenMutableRunAncestorBecomesSymlink_expectFailureBeforeWritingOutsideLayout()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = host();
+    host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
+    Path runAppsDir = tempDir.resolve("run").resolve("apps");
+    Path externalRunAppsDir = tempDir.resolve("external-run-apps");
+    Files.move(runAppsDir, externalRunAppsDir);
+    Files.createSymbolicLink(runAppsDir, externalRunAppsDir.toAbsolutePath());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+
+    assertTrue(exception.getMessage().contains("runDir must not be a symlink"));
+    assertFalse(Files.exists(externalRunAppsDir.resolve(RUNNER_APP_ID).resolve("process.log")));
+  }
+
+  @Test
+  void installFromDirectory_whenStagingRootOverlapsInstalledTree_expectCleanFailure()
+      throws IOException {
+    AppHost host = host();
+    Path stagedApp =
+        stageInstalledAppAt(
+            tempDir.resolve("data"), SAMPLE_APP_ID, scriptContent(new AppEnv()), Map.of());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("must not overlap the installed app tree"));
+    assertFalse(Files.exists(tempDir.resolve("data").resolve("apps").resolve("installed")));
+  }
+
+  @Test
+  void installFromDirectory_whenStagingRootCollidesWithRunDir_expectCleanFailure()
+      throws IOException {
+    AppHost host = host();
+    Path stagedApp =
+        stageInstalledAppAt(
+            tempDir.resolve("run").resolve("apps").resolve(SAMPLE_APP_ID),
+            SAMPLE_APP_ID,
+            scriptContent(new AppEnv()),
+            Map.of());
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("must not overlap runDir"));
+    assertTrue(Files.isRegularFile(stagedApp.resolve("cryptad-app.properties")));
+    assertTrue(Files.isRegularFile(stagedApp.resolve("content.txt")));
+  }
+
+  @Test
+  void installFromDirectory_whenWindowsJunctionEscapesStagingRoot_expectFailure() throws Exception {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeTrue(appEnv.isWindows());
+    AppHost host = host();
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+    Path externalRoot = Files.createDirectories(tempDir.resolve("outside-root"));
+    Path junction = stagedApp.resolve("outside-junction");
+
+    Process mklink =
+        new ProcessBuilder(
+                windowsCommandInterpreter(),
+                "/c",
+                "mklink",
+                "/J",
+                junction.toString(),
+                externalRoot.toString())
+            .start();
+    assertEquals(0, waitForExit(mklink));
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertTrue(exception.getMessage().contains("links or reparse points"));
+  }
+
+  @Test
+  void uninstall_whenWindowsJunctionExistsUnderAppData_expectTargetPreserved() throws Exception {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeTrue(appEnv.isWindows());
+    AppHost host = host();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+    Path externalRoot = Files.createDirectories(tempDir.resolve("outside-uninstall-root"));
+    Path externalFile = externalRoot.resolve("outside.txt");
+    Files.writeString(externalFile, "preserve", StandardCharsets.UTF_8);
+    Path junction = installation.paths().dataDir().resolve("outside-junction");
+
+    Process mklink =
+        new ProcessBuilder(
+                windowsCommandInterpreter(),
+                "/c",
+                "mklink",
+                "/J",
+                junction.toString(),
+                externalRoot.toString())
+            .start();
+    assertEquals(0, waitForExit(mklink));
+
+    host.uninstall(SAMPLE_APP_ID);
+
+    assertTrue(Files.exists(externalFile));
+    assertFalse(Files.exists(installation.paths().installedRoot()));
+    assertFalse(Files.exists(installation.paths().dataDir()));
+    assertFalse(Files.exists(installation.paths().cacheDir()));
+    assertFalse(Files.exists(installation.paths().runDir()));
+  }
+
+  @Test
+  void preserveRunningState_whenTrackedProcessAlreadyExited_expectEntryRemovedWithoutFailure()
+      throws ReflectiveOperationException {
+    LocalProcessAppHost host = host();
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+    injectRunningProcess(host, RUNNER_APP_ID, snapshot, new ExitedProcess(snapshot.pid()));
+
+    Object runningProcess = runningProcessEntry(host, RUNNER_APP_ID);
+    boolean preserved = invokePreserveRunningState(host, RUNNER_APP_ID, runningProcess);
+
+    assertFalse(preserved);
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    assertTrue(host.listRunning().isEmpty());
+  }
+
+  private LocalProcessAppHost host() {
+    return host(Duration.ofSeconds(1));
+  }
+
+  private LocalProcessAppHost host(Duration stopTimeout) {
+    return host(stopTimeout, new AppEnv());
+  }
+
+  private LocalProcessAppHost host(Duration stopTimeout, AppEnv appEnv) {
+    return new LocalProcessAppHost(
+        new AppHostLayout(
+            tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run")),
+        stopTimeout,
+        new java.security.SecureRandom(),
+        appEnv);
+  }
+
+  private Path stageInstalledApp(String appId) throws IOException {
+    return stageInstalledApp(appId, scriptContent(new AppEnv()), Map.of());
+  }
+
+  private Path stageInstalledApp(String appId, String scriptContent) throws IOException {
+    return stageInstalledApp(appId, scriptContent, Map.of());
+  }
+
+  private Path stageInstalledApp(String appId, String scriptContent, Map<String, String> extraFiles)
+      throws IOException {
+    Path stagedDir = tempDir.resolve("stage").resolve(appId);
+    return stageInstalledAppAt(stagedDir, appId, scriptContent, extraFiles);
+  }
+
+  private Path stageInstalledAppAt(
+      Path stagedDir, String appId, String scriptContent, Map<String, String> extraFiles)
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Files.createDirectories(stagedDir);
+    Path binDir = Files.createDirectories(stagedDir.resolve("bin"));
+    String scriptName = scriptName(appEnv);
+    Path scriptFile = binDir.resolve(scriptName);
+    writeStageFile(scriptFile, scriptContent, appEnv);
+    for (Map.Entry<String, String> extraFile : extraFiles.entrySet()) {
+      writeStageFile(stagedDir.resolve(extraFile.getKey()), extraFile.getValue(), appEnv);
+    }
+    Files.writeString(stagedDir.resolve("content.txt"), "payload", StandardCharsets.UTF_8);
+    Files.writeString(
+        stagedDir.resolve("cryptad-app.properties"),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=%s
+        app.version=%s
+        app.exec=bin/%s
+        app.ui.entry=/
+        app.permissions=network.access,file.read
+        quota.data.bytes=4096
+        quota.cache.bytes=1024
+        """
+            .formatted(appId, displayName(appId), APP_VERSION, scriptName),
+        StandardCharsets.UTF_8);
+    return stagedDir;
+  }
+
+  private Path stageInstalledExecutableApp(
+      String appId, String execRelativePath, String execContent, Map<String, String> extraFiles)
+      throws IOException {
+    return stageInstalledExecutableApp(appId, execRelativePath, execContent, extraFiles, true);
+  }
+
+  private Path stageInstalledExecutableApp(
+      String appId,
+      String execRelativePath,
+      String execContent,
+      Map<String, String> extraFiles,
+      boolean executable)
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Path stagedDir = Files.createDirectories(tempDir.resolve("stage").resolve(appId));
+    writeExecutableStageFile(stagedDir.resolve(execRelativePath), execContent, appEnv, executable);
+    for (Map.Entry<String, String> extraFile : extraFiles.entrySet()) {
+      writeStageFile(stagedDir.resolve(extraFile.getKey()), extraFile.getValue(), appEnv);
+    }
+    Files.writeString(stagedDir.resolve("content.txt"), "payload", StandardCharsets.UTF_8);
+    Files.writeString(
+        stagedDir.resolve("cryptad-app.properties"),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=%s
+        app.version=%s
+        app.exec=%s
+        app.ui.entry=/
+        app.permissions=network.access,file.read
+        quota.data.bytes=4096
+        quota.cache.bytes=1024
+        """
+            .formatted(appId, displayName(appId), APP_VERSION, execRelativePath),
+        StandardCharsets.UTF_8);
+    return stagedDir;
+  }
+
+  private RunningAppSnapshot runningSnapshot(String appId) {
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            appId,
+            displayName(appId),
+            APP_VERSION,
+            "bin/" + scriptName(new AppEnv()),
+            "/",
+            java.util.List.of("network.access", "file.read"),
+            4096L,
+            1024L);
+    InstalledAppPaths paths =
+        new AppHostLayout(tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"))
+            .pathsFor(appId);
+    return new RunningAppSnapshot(manifest, paths, DEFAULT_TOKEN, 42L, Instant.EPOCH);
+  }
+
+  @SuppressWarnings({"unchecked", "java:S3011"})
+  private static void injectRunningProcess(
+      LocalProcessAppHost host, String appId, RunningAppSnapshot snapshot, Process process)
+      throws ReflectiveOperationException {
+    injectRunningProcess(host, appId, snapshot, process, new CompletableFuture<>());
+  }
+
+  @SuppressWarnings({"unchecked", "java:S3011"})
+  private static void injectRunningProcess(
+      LocalProcessAppHost host,
+      String appId,
+      RunningAppSnapshot snapshot,
+      Process process,
+      CompletableFuture<Void> exitCleanup)
+      throws ReflectiveOperationException {
+    Field runningAppsField = LocalProcessAppHost.class.getDeclaredField("runningApps");
+    runningAppsField.setAccessible(true);
+    Map<String, Object> runningApps = (Map<String, Object>) runningAppsField.get(host);
+
+    Class<?> runningProcessClass =
+        Class.forName(LocalProcessAppHost.class.getName() + "$RunningProcess");
+    Constructor<?> constructor =
+        runningProcessClass.getDeclaredConstructor(
+            Process.class, RunningAppSnapshot.class, CompletableFuture.class, List.class);
+    constructor.setAccessible(true);
+    Object runningProcess =
+        constructor.newInstance(process, snapshot, exitCleanup, List.of(process.toHandle()));
+    runningApps.put(appId, runningProcess);
+  }
+
+  @SuppressWarnings({"unchecked", "java:S3011"})
+  private static Object runningProcessEntry(LocalProcessAppHost host, String appId)
+      throws ReflectiveOperationException {
+    Field runningAppsField = LocalProcessAppHost.class.getDeclaredField("runningApps");
+    runningAppsField.setAccessible(true);
+    Map<String, Object> runningApps = (Map<String, Object>) runningAppsField.get(host);
+    return runningApps.get(appId);
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static boolean invokePreserveRunningState(
+      LocalProcessAppHost host, String appId, Object runningProcess)
+      throws ReflectiveOperationException {
+    Class<?> runningProcessClass =
+        Class.forName(LocalProcessAppHost.class.getName() + "$RunningProcess");
+    Method preserveRunningState =
+        LocalProcessAppHost.class.getDeclaredMethod(
+            "preserveRunningState", String.class, runningProcessClass);
+    preserveRunningState.setAccessible(true);
+    return (boolean) preserveRunningState.invoke(host, appId, runningProcess);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<ProcessHandle> invokeParseTokenTrackedProcesses(
+      Process process, String token, String appId)
+      throws ReflectiveOperationException, IOException {
+    Method parseTokenTrackedProcesses =
+        LocalProcessAppHost.class.getDeclaredMethod(
+            "parseTokenTrackedProcesses", Process.class, String.class, String.class);
+    parseTokenTrackedProcesses.setAccessible(true);
+    try {
+      return (List<ProcessHandle>) parseTokenTrackedProcesses.invoke(null, process, token, appId);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException ioException) {
+        throw ioException;
+      }
+      if (cause instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      if (cause instanceof Error error) {
+        throw error;
+      }
+      throw e;
+    }
+  }
+
+  private static void writeStageFile(Path file, String content, AppEnv appEnv) throws IOException {
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+    if (!appEnv.isWindows() && file.getFileName().toString().endsWith(".sh")) {
+      assertTrue(file.toFile().setExecutable(true, false));
+    }
+  }
+
+  private static void writeExecutableStageFile(
+      Path file, String content, AppEnv appEnv, boolean executable) throws IOException {
+    Files.createDirectories(file.getParent());
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+    if (!appEnv.isWindows()) {
+      assertTrue(file.toFile().setExecutable(executable, false));
+    }
+  }
+
+  private static String displayName(String appId) {
+    return switch (appId) {
+      case RUNNER_APP_ID -> "Runner App";
+      case SAMPLE_APP_ID -> "Sample App";
+      case MIXED_CASE_APP_ID -> "Mixed Case App";
+      default -> "Duplicate App";
+    };
+  }
+
+  private static String scriptName(AppEnv appEnv) {
+    return appEnv.isWindows() ? "launch.cmd" : "launch.sh";
+  }
+
+  private static String scriptContent(AppEnv appEnv) {
+    if (appEnv.isWindows()) {
+      return """
+      @echo off
+      setlocal EnableExtensions
+      set > "%CRYPTAD_APP_RUN_DIR%\\captured-env.txt"
+      :loop
+      timeout /t 1 /nobreak >nul
+      goto loop
+      """;
+    }
+    return """
+    #!/bin/sh
+    set -eu
+    env > "$CRYPTAD_APP_RUN_DIR/captured-env.txt"
+    while :; do
+      sleep 1
+    done
+    """;
+  }
+
+  private static String immediateExitScriptContent(AppEnv appEnv) {
+    if (appEnv.isWindows()) {
+      return """
+      @echo off
+      exit /b 0
+      """;
+    }
+    return """
+    #!/bin/sh
+    exit 0
+    """;
+  }
+
+  private static AppHostException installExpectingAppHostException(AppHost host, Path stagedApp)
+      throws Exception {
+    ExecutorService executor =
+        Executors.newSingleThreadExecutor(
+            runnable -> {
+              Thread thread = new Thread(runnable, "apphost-install-test");
+              thread.setDaemon(true);
+              return thread;
+            });
+    try {
+      ExecutionException exception =
+          installFailure(executor.submit(() -> host.installFromDirectory(stagedApp)), stagedApp);
+      assertTrue(exception.getCause() instanceof AppHostException);
+      return (AppHostException) exception.getCause();
+    } catch (TimeoutException e) {
+      throw new AssertionError("installFromDirectory hung on named pipe: " + stagedApp, e);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static ExecutionException installFailure(
+      java.util.concurrent.Future<InstalledAppSnapshot> installFuture, Path stagedApp)
+      throws InterruptedException, TimeoutException {
+    try {
+      installFuture.get(5, TimeUnit.SECONDS);
+      throw new AssertionError("expected installFromDirectory() to fail for " + stagedApp);
+    } catch (ExecutionException e) {
+      return e;
+    }
+  }
+
+  private static int waitForExit(Process process) throws IOException, InterruptedException {
+    if (!process.waitFor(5, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      throw new IOException("timed out waiting for process to exit: " + process.pid());
+    }
+    return process.exitValue();
+  }
+
+  private static RunningAppSnapshot waitForRunningApp(AppHost host, String appId) {
+    long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (System.nanoTime() < deadline) {
+      Optional<RunningAppSnapshot> running = host.status(appId);
+      if (running.isPresent()) {
+        return running.orElseThrow();
+      }
+      try {
+        TimeUnit.MILLISECONDS.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("interrupted while waiting for app to be running: " + appId, e);
+      }
+    }
+    throw new AssertionError("timed out waiting for app to be running: " + appId);
+  }
+
+  private static RunningAppSnapshot waitForRunningPid(AppHost host, String appId, long pid) {
+    long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (System.nanoTime() < deadline) {
+      Optional<RunningAppSnapshot> running = host.status(appId);
+      if (running.isPresent() && running.orElseThrow().pid() == pid) {
+        return running.orElseThrow();
+      }
+      try {
+        TimeUnit.MILLISECONDS.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(
+            "interrupted while waiting for app " + appId + " to report pid " + pid, e);
+      }
+    }
+    throw new AssertionError("timed out waiting for app " + appId + " to report pid " + pid);
+  }
+
+  private static void waitForProcessExit(long pid) throws IOException {
+    ProcessHandle handle = ProcessHandle.of(pid).orElse(null);
+    if (handle == null || !isEffectivelyAlive(handle)) {
+      return;
+    }
+    try {
+      handle.onExit().get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted while waiting for process " + pid + " to exit", e);
+    } catch (ExecutionException e) {
+      throw new IOException("failed while waiting for process " + pid + " to exit", e);
+    } catch (TimeoutException e) {
+      throw new AssertionError("timed out waiting for child process " + pid + " to exit", e);
+    }
+  }
+
+  private static boolean isEffectivelyAlive(ProcessHandle handle) {
+    return handle.isAlive() && !isZombieProcess(handle);
+  }
+
+  private static boolean isZombieProcess(ProcessHandle handle) {
+    Path statFile = Path.of("/proc", Long.toString(handle.pid()), "stat");
+    if (!Files.isReadable(statFile)) {
+      return false;
+    }
+    try {
+      String stat = Files.readString(statFile);
+      int commandEnd = stat.lastIndexOf(')');
+      return commandEnd >= 0
+          && commandEnd + 2 < stat.length()
+          && stat.charAt(commandEnd + 2) == 'Z';
+    } catch (IOException _) {
+      return false;
+    }
+  }
+
+  private static String resolveTrustedCommand(String command) {
+    for (Path trustedDir :
+        List.of(Path.of("/usr/bin"), Path.of("/bin"), Path.of("/usr/sbin"), Path.of("/sbin"))) {
+      Path candidate = trustedDir.resolve(command);
+      if (Files.isExecutable(candidate)) {
+        return candidate.toString();
+      }
+    }
+    throw new AssertionError("trusted command not found: " + command);
+  }
+
+  private static String windowsCommandInterpreter() {
+    String comSpec = System.getenv("ComSpec");
+    return comSpec != null && !comSpec.isBlank() ? comSpec : "cmd.exe";
+  }
+
+  private static void waitForFile(Path file) throws IOException {
+    if (Files.isRegularFile(file)) {
+      return;
+    }
+
+    Path parent = file.getParent();
+    if (parent == null) {
+      throw new AssertionError("file has no parent: " + file);
+    }
+
+    long timeoutMillis = Duration.ofSeconds(10).toMillis();
+    try (WatchService watchService = parent.getFileSystem().newWatchService()) {
+      parent.register(
+          watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+      long deadline = System.nanoTime() + Duration.ofMillis(timeoutMillis).toNanos();
+      while (System.nanoTime() < deadline) {
+        WatchKey key = pollWatchKey(watchService, deadline, file);
+        if (Files.isRegularFile(file)) {
+          return;
+        }
+        if (key != null) {
+          if (isWatchedFilePresent(file, key)) {
+            return;
+          }
+          if (!key.reset()) {
+            throw new AssertionError("watch service closed before " + file + " appeared");
+          }
+        }
+      }
+      if (Files.isRegularFile(file)) {
+        return;
+      }
+    }
+    throw new AssertionError("timed out waiting for " + file);
+  }
+
+  private static WatchKey pollWatchKey(WatchService watchService, long deadline, Path file)
+      throws IOException {
+    long remainingNanos = deadline - System.nanoTime();
+    if (remainingNanos <= 0L) {
+      return null;
+    }
+    try {
+      return watchService.poll(remainingNanos, TimeUnit.NANOSECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted while waiting for " + file, e);
+    }
+  }
+
+  private static boolean isWatchedFilePresent(Path file, WatchKey key) {
+    for (WatchEvent<?> event : key.pollEvents()) {
+      if (event.context() instanceof Path changed
+          && changed.equals(file.getFileName())
+          && Files.isRegularFile(file)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static final class LateChildSpawningProcess extends Process {
+    private final long pid;
+    private final ProcessHandle handle;
+    private final ProcessHandle childHandle;
+    private boolean rootAlive = true;
+    private boolean childSpawned;
+
+    private LateChildSpawningProcess(long pid, long childPid) {
+      this.pid = pid;
+      this.handle = new LateChildSpawningProcessHandle();
+      this.childHandle = new LinkedProcessHandle(childPid, handle, true);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return !rootAlive;
+    }
+
+    @Override
+    public int exitValue() {
+      if (rootAlive) {
+        throw new IllegalThreadStateException("process is still running");
+      }
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      childSpawned = true;
+      rootAlive = false;
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      destroy();
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return rootAlive;
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public ProcessHandle toHandle() {
+      return handle;
+    }
+
+    private final class LateChildSpawningProcessHandle implements ProcessHandle {
+      @Override
+      public long pid() {
+        return pid;
+      }
+
+      @Override
+      public Info info() {
+        return new Info() {
+          @Override
+          public Optional<String> command() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<String> commandLine() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<String[]> arguments() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<Instant> startInstant() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<Duration> totalCpuDuration() {
+            return Optional.empty();
+          }
+
+          @Override
+          public Optional<String> user() {
+            return Optional.empty();
+          }
+        };
+      }
+
+      @Override
+      public CompletableFuture<ProcessHandle> onExit() {
+        return rootAlive ? new CompletableFuture<>() : CompletableFuture.completedFuture(this);
+      }
+
+      @Override
+      public boolean supportsNormalTermination() {
+        return true;
+      }
+
+      @Override
+      public boolean destroy() {
+        LateChildSpawningProcess.this.destroy();
+        return true;
+      }
+
+      @Override
+      public boolean destroyForcibly() {
+        LateChildSpawningProcess.this.destroy();
+        return true;
+      }
+
+      @Override
+      public boolean isAlive() {
+        return rootAlive;
+      }
+
+      @Override
+      public Optional<ProcessHandle> parent() {
+        return Optional.empty();
+      }
+
+      @Override
+      public java.util.stream.Stream<ProcessHandle> children() {
+        return childSpawned
+            ? java.util.stream.Stream.of(childHandle)
+            : java.util.stream.Stream.empty();
+      }
+
+      @Override
+      public java.util.stream.Stream<ProcessHandle> descendants() {
+        return children();
+      }
+
+      @Override
+      public int compareTo(ProcessHandle other) {
+        return Long.compare(pid, other.pid());
+      }
+    }
+  }
+
+  private static final class NonStoppingProcess extends Process {
+    private final long pid;
+    private final ProcessHandle handle;
+
+    private NonStoppingProcess(long pid) {
+      this.pid = pid;
+      this.handle = new NonStoppingProcessHandle(pid);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      throw new UnsupportedOperationException("waitFor() not used by this test");
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return false;
+    }
+
+    @Override
+    public int exitValue() {
+      throw new IllegalThreadStateException("process is still running");
+    }
+
+    @Override
+    public void destroy() {
+      // Intentionally blank: this fake process ignores graceful termination so stop() times out.
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return true;
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public ProcessHandle toHandle() {
+      return handle;
+    }
+  }
+
+  private record NonStoppingProcessHandle(long pid) implements ProcessHandle {
+    @Override
+    public Info info() {
+      return new Info() {
+        @Override
+        public java.util.Optional<String> command() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> commandLine() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String[]> arguments() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Instant> startInstant() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Duration> totalCpuDuration() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> user() {
+          return java.util.Optional.empty();
+        }
+      };
+    }
+
+    @Override
+    public CompletableFuture<ProcessHandle> onExit() {
+      return new CompletableFuture<>();
+    }
+
+    @Override
+    public boolean supportsNormalTermination() {
+      return true;
+    }
+
+    @Override
+    public boolean destroy() {
+      return false;
+    }
+
+    @Override
+    public boolean destroyForcibly() {
+      return false;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return true;
+    }
+
+    @Override
+    public java.util.Optional<ProcessHandle> parent() {
+      return java.util.Optional.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> children() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> descendants() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public int compareTo(ProcessHandle other) {
+      return Long.compare(pid, other.pid());
+    }
+  }
+
+  private static final class ExitedProcess extends Process {
+    private final long pid;
+    private final ProcessHandle handle;
+
+    private ExitedProcess(long pid) {
+      this.pid = pid;
+      this.handle = new ExitedProcessHandle(pid);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return true;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      // Intentionally blank: this fake process is already exited.
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return false;
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public ProcessHandle toHandle() {
+      return handle;
+    }
+  }
+
+  private static final class FadingProcess extends Process {
+    private final long pid;
+    private final ProcessHandle handle;
+
+    private FadingProcess(long pid, int aliveChecksBeforeExit) {
+      this.pid = pid;
+      this.handle = new FadingProcessHandle(pid, aliveChecksBeforeExit);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return !handle.isAlive();
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      // Intentionally blank: lifecycle is simulated by the handle.
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return handle.isAlive();
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public ProcessHandle toHandle() {
+      return handle;
+    }
+  }
+
+  private static final class FailingInputProcess extends Process {
+    private final InputStream inputStream;
+
+    private FailingInputProcess(byte[] prefixBytes) {
+      this.inputStream = new FailingInputStream(prefixBytes);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return inputStream;
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return true;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      // Intentionally blank: this fake process exists only to expose a failing input stream.
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return false;
+    }
+
+    @Override
+    public long pid() {
+      return 0L;
+    }
+
+    @Override
+    public ProcessHandle toHandle() {
+      return new ExitedProcessHandle(0L);
+    }
+  }
+
+  private static final class FailingInputStream extends InputStream {
+    private final byte[] prefixBytes;
+    private int offset;
+
+    private FailingInputStream(byte[] prefixBytes) {
+      this.prefixBytes = prefixBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (offset < prefixBytes.length) {
+        return prefixBytes[offset++] & 0xFF;
+      }
+      throw new IOException("simulated ps stream failure");
+    }
+
+    @Override
+    public int read(byte[] buffer, int off, int len) throws IOException {
+      if (offset < prefixBytes.length) {
+        int bytesToCopy = Math.min(len, prefixBytes.length - offset);
+        System.arraycopy(prefixBytes, offset, buffer, off, bytesToCopy);
+        offset += bytesToCopy;
+        return bytesToCopy;
+      }
+      throw new IOException("simulated ps stream failure");
+    }
+  }
+
+  private static final class LinkedProcessHandle implements ProcessHandle {
+    private final long pid;
+    private final ProcessHandle parent;
+    private final boolean alive;
+
+    private LinkedProcessHandle(long pid, ProcessHandle parent, boolean alive) {
+      this.pid = pid;
+      this.parent = parent;
+      this.alive = alive;
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public Info info() {
+      return new Info() {
+        @Override
+        public java.util.Optional<String> command() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> commandLine() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String[]> arguments() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Instant> startInstant() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Duration> totalCpuDuration() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> user() {
+          return java.util.Optional.empty();
+        }
+      };
+    }
+
+    @Override
+    public CompletableFuture<ProcessHandle> onExit() {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public boolean supportsNormalTermination() {
+      return true;
+    }
+
+    @Override
+    public boolean destroy() {
+      return false;
+    }
+
+    @Override
+    public boolean destroyForcibly() {
+      return false;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return alive;
+    }
+
+    @Override
+    public java.util.Optional<ProcessHandle> parent() {
+      return java.util.Optional.ofNullable(parent);
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> children() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> descendants() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public int compareTo(ProcessHandle other) {
+      return Long.compare(pid, other.pid());
+    }
+  }
+
+  private static final class InfoProcessHandle implements ProcessHandle {
+    private final long pid;
+    private final ProcessHandle parent;
+    private final boolean alive;
+    private final Optional<String> command;
+    private final Optional<String> commandLine;
+    private final Optional<Instant> startInstant;
+
+    private InfoProcessHandle(
+        long pid,
+        ProcessHandle parent,
+        boolean alive,
+        Optional<String> command,
+        Optional<String> commandLine,
+        Optional<Instant> startInstant) {
+      this.pid = pid;
+      this.parent = parent;
+      this.alive = alive;
+      this.command = command;
+      this.commandLine = commandLine;
+      this.startInstant = startInstant;
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public Info info() {
+      return new Info() {
+        @Override
+        public Optional<String> command() {
+          return command;
+        }
+
+        @Override
+        public Optional<String> commandLine() {
+          return commandLine;
+        }
+
+        @Override
+        public Optional<String[]> arguments() {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<Instant> startInstant() {
+          return startInstant;
+        }
+
+        @Override
+        public Optional<Duration> totalCpuDuration() {
+          return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> user() {
+          return Optional.empty();
+        }
+      };
+    }
+
+    @Override
+    public CompletableFuture<ProcessHandle> onExit() {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public boolean supportsNormalTermination() {
+      return true;
+    }
+
+    @Override
+    public boolean destroy() {
+      return false;
+    }
+
+    @Override
+    public boolean destroyForcibly() {
+      return false;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return alive;
+    }
+
+    @Override
+    public Optional<ProcessHandle> parent() {
+      return Optional.ofNullable(parent);
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> children() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> descendants() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public int compareTo(ProcessHandle other) {
+      return Long.compare(pid, other.pid());
+    }
+  }
+
+  private static final class FadingProcessHandle implements ProcessHandle {
+    private final long pid;
+    private final AtomicInteger remainingAliveChecks;
+
+    private FadingProcessHandle(long pid, int aliveChecksBeforeExit) {
+      this.pid = pid;
+      this.remainingAliveChecks = new AtomicInteger(aliveChecksBeforeExit);
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public Info info() {
+      return new Info() {
+        @Override
+        public java.util.Optional<String> command() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> commandLine() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String[]> arguments() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Instant> startInstant() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Duration> totalCpuDuration() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> user() {
+          return java.util.Optional.empty();
+        }
+      };
+    }
+
+    @Override
+    public CompletableFuture<ProcessHandle> onExit() {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public boolean supportsNormalTermination() {
+      return true;
+    }
+
+    @Override
+    public boolean destroy() {
+      return true;
+    }
+
+    @Override
+    public boolean destroyForcibly() {
+      return true;
+    }
+
+    @Override
+    public boolean isAlive() {
+      int checksRemaining = remainingAliveChecks.getAndUpdate(current -> Math.max(0, current - 1));
+      return checksRemaining > 0;
+    }
+
+    @Override
+    public java.util.Optional<ProcessHandle> parent() {
+      return java.util.Optional.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> children() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> descendants() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public int compareTo(ProcessHandle other) {
+      return Long.compare(pid, other.pid());
+    }
+  }
+
+  private record ExitedProcessHandle(long pid) implements ProcessHandle {
+    @Override
+    public Info info() {
+      return new Info() {
+        @Override
+        public java.util.Optional<String> command() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> commandLine() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String[]> arguments() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Instant> startInstant() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Duration> totalCpuDuration() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> user() {
+          return java.util.Optional.empty();
+        }
+      };
+    }
+
+    @Override
+    public CompletableFuture<ProcessHandle> onExit() {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public boolean supportsNormalTermination() {
+      return true;
+    }
+
+    @Override
+    public boolean destroy() {
+      return true;
+    }
+
+    @Override
+    public boolean destroyForcibly() {
+      return true;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return false;
+    }
+
+    @Override
+    public java.util.Optional<ProcessHandle> parent() {
+      return java.util.Optional.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> children() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> descendants() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public int compareTo(ProcessHandle other) {
+      return Long.compare(pid, other.pid());
+    }
+  }
+}

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -3,9 +3,11 @@ package network.crypta.platform.apphost.runtime;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -27,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import network.crypta.fs.AppEnv;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
@@ -35,12 +38,15 @@ import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,17 +57,46 @@ class LocalProcessAppHostTest {
   private static final String DUPLICATE_APP_ID = "duplicate-app";
   private static final String MIXED_CASE_APP_ID = "MixedCase-App";
   private static final String NORMALIZED_MIXED_CASE_APP_ID = "mixedcase-app";
+  private static final String PYTHON_DAEMON_APP_ID = "python-daemon-app";
   private static final String APP_VERSION = "2.0.0";
   private static final String DEFAULT_TOKEN = "token";
+  private static final String CACHE_DIR_NAME = "cache";
+  private static final String INSTALLED_DIR_NAME = "installed";
+  private static final String INSTALLED_APPS_DIR_SYMLINK_MESSAGE =
+      "installedAppsDir must not be a symlink";
+  private static final String CONTENT_FILE_NAME = "content.txt";
+  private static final String POSIX_LAUNCH_PATH = "bin/launch";
+  private static final String STARTUP_EXIT_MESSAGE_PREFIX = "app exited during startup: ";
+  private static final String WINDOWS_11 = "Windows 11";
+  private static final String LINUX_OS_NAME = "Linux";
+  private static final String PYTHON3_COMMAND = "python3";
+  private static final String SYSTEM_ENV_COMMAND = "/usr/bin/env";
+  private static final String CHILD_SCRIPT_PATH = "bin/child.sh";
+  private static final String CHILD_PID_FILE_NAME = "child.pid";
+  private static final String WINDOWS_CHILD_EXECUTABLE = "child.exe";
+  private static final String POSIX_START_PATH = "bin/start";
+  private static final String STAGE_DIR_NAME = "stage";
+  private static final String MANIFEST_FILE_NAME = "cryptad-app.properties";
+  private static final String MKFIFO_COMMAND = "mkfifo";
+  private static final String NETWORK_ACCESS_PERMISSION = "network.access";
+  private static final String FILE_READ_PERMISSION = "file.read";
+  private static final List<String> STANDARD_PERMISSIONS =
+      List.of(NETWORK_ACCESS_PERMISSION, FILE_READ_PERMISSION);
+  private static final String STANDARD_PERMISSIONS_TEXT =
+      NETWORK_ACCESS_PERMISSION + "," + FILE_READ_PERMISSION;
+  private static final long POLL_INTERVAL_NANOS = Duration.ofMillis(10).toNanos();
+  private static final String LATE_CHILD_APP_ID = "late-child-app";
+  private static final String SHELL_NOEXEC_APP_ID = "shell-noexec-app";
   private static final String WRAPPER_SCRIPT =
       """
       #!/bin/sh
       set -eu
-      ./bin/child.sh &
+      ./%s &
       child=$!
-      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       wait "$child"
-      """;
+      """
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String CHILD_PROCESS_SCRIPT =
       """
       #!/bin/sh
@@ -91,33 +126,36 @@ class LocalProcessAppHostTest {
       """
       #!/bin/sh
       set -eu
-      ./bin/child.sh &
+      ./%s &
       child=$!
-      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       exit 0
-      """;
+      """
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String DAEMONIZING_WRAPPER_DELAYED_EXIT_SCRIPT =
       """
       #!/bin/sh
       set -eu
       echo "$$" > "$CRYPTAD_APP_RUN_DIR/wrapper.pid"
-      ./bin/child.sh &
+      ./%s &
       child=$!
-      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       sleep 1
       echo exited > "$CRYPTAD_APP_RUN_DIR/wrapper-exited.txt"
       exit 0
-      """;
+      """
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String DAEMONIZING_WRAPPER_POST_CAPTURE_EXIT_SCRIPT =
       """
       #!/bin/sh
       set -eu
       sleep 0.53
-      ./bin/child.sh &
+      ./%s &
       child=$!
-      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       exit 0
-      """;
+      """
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String DAEMONIZING_WRAPPER_VIA_HELPER_SCRIPT =
       """
       #!/bin/sh
@@ -130,36 +168,39 @@ class LocalProcessAppHostTest {
       #!/bin/sh
       set -eu
       sleep 0.25
-      ./bin/child.sh &
+      ./%s &
       child=$!
-      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       exit 0
-      """;
+      """
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String POST_CAPTURE_PYTHON_DAEMONIZER =
       """
-      #!/usr/bin/env python3
+      #!/usr/bin/env %s
       import os
       import pathlib
       import subprocess
       import time
 
       time.sleep(0.53)
-      child = subprocess.Popen(["./bin/child.sh"])
-      pathlib.Path(os.environ["CRYPTAD_APP_RUN_DIR"], "child.pid").write_text(
+      child = subprocess.Popen(["./%s"])
+      pathlib.Path(os.environ["CRYPTAD_APP_RUN_DIR"], "%s").write_text(
           f"{child.pid}\\n", encoding="utf-8")
-      """;
+      """
+          .formatted(PYTHON3_COMMAND, CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String LATE_CHILD_DIRECT_EXECUTABLE =
       """
       #!/bin/sh
       set -eu
       sleep 1
-      ./bin/child.sh &
+      ./%s &
       child=$!
-      echo "$child" > "$CRYPTAD_APP_RUN_DIR/child.pid"
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       sleep 0.2
       echo exited > "$CRYPTAD_APP_RUN_DIR/wrapper-exited.txt"
       exit 0
-      """;
+      """
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String STDIN_EOF_SCRIPT =
       """
       #!/bin/sh
@@ -229,7 +270,7 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     Path dataDir = tempDir.resolve("data");
-    Path cacheDir = tempDir.resolve("cache");
+    Path cacheDir = tempDir.resolve(CACHE_DIR_NAME);
     Path runDir = tempDir.resolve("run");
     AppHost host =
         new LocalProcessAppHost(
@@ -240,12 +281,12 @@ class LocalProcessAppHostTest {
     Path installParent = Files.createDirectories(dataDir.resolve("apps"));
     Path externalInstalled = Files.createDirectories(tempDir.resolve("external-installed"));
     Files.createSymbolicLink(
-        installParent.resolve("installed"), externalInstalled.toAbsolutePath());
+        installParent.resolve(INSTALLED_DIR_NAME), externalInstalled.toAbsolutePath());
 
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
 
-    assertTrue(exception.getMessage().contains("installedAppsDir must not be a symlink"));
+    assertTrue(exception.getMessage().contains(INSTALLED_APPS_DIR_SYMLINK_MESSAGE));
     try (var children = Files.list(externalInstalled)) {
       assertEquals(List.of(), children.toList());
     }
@@ -257,7 +298,7 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     Path dataDir = tempDir.resolve("data");
-    Path cacheDir = tempDir.resolve("cache");
+    Path cacheDir = tempDir.resolve(CACHE_DIR_NAME);
     Path runDir = tempDir.resolve("run");
     AppHost host =
         new LocalProcessAppHost(
@@ -268,7 +309,7 @@ class LocalProcessAppHostTest {
     host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
 
     Path installParent = dataDir.resolve("apps");
-    Path installedAppsDir = installParent.resolve("installed");
+    Path installedAppsDir = installParent.resolve(INSTALLED_DIR_NAME);
     Path externalInstalled = tempDir.resolve("external-installed");
     Files.move(installedAppsDir, externalInstalled);
     Files.createSymbolicLink(installedAppsDir, externalInstalled.toAbsolutePath());
@@ -276,10 +317,10 @@ class LocalProcessAppHostTest {
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.uninstall(SAMPLE_APP_ID));
 
-    assertTrue(exception.getMessage().contains("installedAppsDir must not be a symlink"));
+    assertTrue(exception.getMessage().contains(INSTALLED_APPS_DIR_SYMLINK_MESSAGE));
     assertTrue(Files.isDirectory(externalInstalled.resolve(SAMPLE_APP_ID)));
     assertTrue(
-        Files.isRegularFile(externalInstalled.resolve(SAMPLE_APP_ID).resolve("content.txt")));
+        Files.isRegularFile(externalInstalled.resolve(SAMPLE_APP_ID).resolve(CONTENT_FILE_NAME)));
   }
 
   @Test
@@ -288,7 +329,7 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     Path dataDir = tempDir.resolve("data");
-    Path cacheDir = tempDir.resolve("cache");
+    Path cacheDir = tempDir.resolve(CACHE_DIR_NAME);
     Path runDir = tempDir.resolve("run");
     AppHost host =
         new LocalProcessAppHost(
@@ -306,11 +347,15 @@ class LocalProcessAppHostTest {
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.uninstall(SAMPLE_APP_ID));
 
-    assertTrue(exception.getMessage().contains("installedAppsDir must not be a symlink"));
-    assertTrue(Files.isDirectory(externalAppsDir.resolve("installed").resolve(SAMPLE_APP_ID)));
+    assertTrue(exception.getMessage().contains(INSTALLED_APPS_DIR_SYMLINK_MESSAGE));
+    assertTrue(
+        Files.isDirectory(externalAppsDir.resolve(INSTALLED_DIR_NAME).resolve(SAMPLE_APP_ID)));
     assertTrue(
         Files.isRegularFile(
-            externalAppsDir.resolve("installed").resolve(SAMPLE_APP_ID).resolve("content.txt")));
+            externalAppsDir
+                .resolve(INSTALLED_DIR_NAME)
+                .resolve(SAMPLE_APP_ID)
+                .resolve(CONTENT_FILE_NAME)));
   }
 
   @Test
@@ -319,10 +364,14 @@ class LocalProcessAppHostTest {
     AppHost host = host();
     InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Path staleInstallDirectory =
-        tempDir.resolve("data").resolve("apps").resolve("installed").resolve("app-install-stale");
+        tempDir
+            .resolve("data")
+            .resolve("apps")
+            .resolve(INSTALLED_DIR_NAME)
+            .resolve("app-install-stale");
     Files.createDirectories(staleInstallDirectory);
     Files.writeString(
-        staleInstallDirectory.resolve("content.txt"), "stale", StandardCharsets.UTF_8);
+        staleInstallDirectory.resolve(CONTENT_FILE_NAME), "stale", StandardCharsets.UTF_8);
 
     assertEquals(List.of(installation), host.listInstalled());
   }
@@ -336,14 +385,14 @@ class LocalProcessAppHostTest {
     Path stagedApp =
         stageInstalledExecutableApp(
             "non-launchable-app",
-            "bin/launch",
+            POSIX_LAUNCH_PATH,
             """
             exit 0
             """,
             Map.of(),
             false);
 
-    Assumptions.assumeFalse(Files.isExecutable(stagedApp.resolve("bin/launch")));
+    Assumptions.assumeFalse(Files.isExecutable(stagedApp.resolve(POSIX_LAUNCH_PATH)));
 
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
@@ -354,7 +403,7 @@ class LocalProcessAppHostTest {
   @Test
   void installFromDirectory_whenWindowsLauncherUsesUnsupportedScript_expectFailure()
       throws IOException {
-    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "Windows 11"));
+    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), WINDOWS_11));
     Path stagedApp =
         stageInstalledExecutableApp(
             "unsupported-windows-script-app", "bin/launch.ps1", "Write-Output 'hi'\n", Map.of());
@@ -367,7 +416,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void installFromDirectory_whenWindowsLauncherIsGenericMzBlob_expectFailure() throws IOException {
-    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "Windows 11"));
+    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), WINDOWS_11));
     Path stagedApp =
         stageInstalledExecutableApp("generic-mz-app", "bin/fake.bin", "placeholder", Map.of());
     byte[] fakeMz = new byte[64];
@@ -420,15 +469,7 @@ class LocalProcessAppHostTest {
     Path captureFile = installation.paths().runDir().resolve("captured-env.txt");
     waitForFile(captureFile);
     String capture = Files.readString(captureFile, StandardCharsets.UTF_8);
-    assertTrue(capture.contains("CRYPTAD_APP_ID=" + RUNNER_APP_ID));
-    assertTrue(capture.contains("CRYPTAD_APP_NAME=Runner App"));
-    assertTrue(capture.contains("CRYPTAD_APP_VERSION=" + APP_VERSION));
-    assertTrue(capture.contains("CRYPTAD_APP_DATA_DIR=" + installation.paths().dataDir()));
-    assertTrue(capture.contains("CRYPTAD_APP_CACHE_DIR=" + installation.paths().cacheDir()));
-    assertTrue(capture.contains("CRYPTAD_APP_RUN_DIR=" + installation.paths().runDir()));
-    assertTrue(capture.contains("CRYPTAD_APP_TOKEN=" + running.token()));
-    assertTrue(capture.contains("CRYPTAD_APP_PERMISSIONS=network.access,file.read"));
-    assertTrue(capture.contains("CRYPTAD_APP_UI_ENTRY=/"));
+    assertCapturedEnvironment(installation, running, capture);
 
     assertThrows(AppHostException.class, () -> host.uninstall(RUNNER_APP_ID));
     assertTrue(host.stop(RUNNER_APP_ID));
@@ -440,10 +481,7 @@ class LocalProcessAppHostTest {
     assertTrue(host.stop(RUNNER_APP_ID));
 
     host.uninstall(RUNNER_APP_ID);
-    assertFalse(Files.exists(installation.paths().installedRoot()));
-    assertFalse(Files.exists(installation.paths().dataDir()));
-    assertFalse(Files.exists(installation.paths().cacheDir()));
-    assertFalse(Files.exists(installation.paths().runDir()));
+    assertInstallationPathsRemoved(installation);
     assertTrue(host.listInstalled().isEmpty());
   }
 
@@ -451,15 +489,14 @@ class LocalProcessAppHostTest {
   void start_whenInstalledProcessExitsImmediately_expectFailureAndNoRunningState()
       throws IOException {
     AppHost host = host();
-    host.installFromDirectory(
-        stageInstalledApp(RUNNER_APP_ID, immediateExitScriptContent(new AppEnv())));
+    host.installFromDirectory(stageInstalledRunnerApp(immediateExitScriptContent(new AppEnv())));
 
     Instant started = Instant.now();
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
     Duration elapsed = Duration.between(started, Instant.now());
 
-    assertTrue(exception.getMessage().contains("app exited during startup: " + RUNNER_APP_ID));
+    assertTrue(exception.getMessage().contains(STARTUP_EXIT_MESSAGE_PREFIX + RUNNER_APP_ID));
     assertTrue(elapsed.compareTo(Duration.ofSeconds(3)) < 0);
     assertTrue(host.status(RUNNER_APP_ID).isEmpty());
     assertTrue(host.listRunning().isEmpty());
@@ -471,12 +508,12 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     AppHost host = host();
-    host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID, DELAYED_STARTUP_EXIT_SCRIPT));
+    host.installFromDirectory(stageInstalledRunnerApp(DELAYED_STARTUP_EXIT_SCRIPT));
 
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
 
-    assertTrue(exception.getMessage().contains("app exited during startup: " + RUNNER_APP_ID));
+    assertTrue(exception.getMessage().contains(STARTUP_EXIT_MESSAGE_PREFIX + RUNNER_APP_ID));
     assertTrue(host.status(RUNNER_APP_ID).isEmpty());
     assertTrue(host.listRunning().isEmpty());
   }
@@ -523,12 +560,12 @@ class LocalProcessAppHostTest {
         stageInstalledApp(
             RUNNER_APP_ID,
             DAEMONIZING_WRAPPER_IMMEDIATE_EXIT_SCRIPT,
-            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+            Map.of(CHILD_SCRIPT_PATH, DAEMONIZED_CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
     RunningAppSnapshot running = host.start(RUNNER_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     try {
@@ -565,12 +602,12 @@ class LocalProcessAppHostTest {
         stageInstalledApp(
             RUNNER_APP_ID,
             DAEMONIZING_WRAPPER_DELAYED_EXIT_SCRIPT,
-            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+            Map.of(CHILD_SCRIPT_PATH, DAEMONIZED_CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
     RunningAppSnapshot running = host.start(RUNNER_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     Path wrapperPidFile = installation.paths().runDir().resolve("wrapper.pid");
     waitForFile(childPidFile);
     waitForFile(wrapperPidFile);
@@ -614,16 +651,16 @@ class LocalProcessAppHostTest {
         stageInstalledApp(
             RUNNER_APP_ID,
             DAEMONIZING_WRAPPER_POST_CAPTURE_EXIT_SCRIPT,
-            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+            Map.of(CHILD_SCRIPT_PATH, DAEMONIZED_CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
     RunningAppSnapshot running = host.start(RUNNER_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     try {
-      RunningAppSnapshot current = waitForRunningPid(host, RUNNER_APP_ID, childPid);
+      RunningAppSnapshot current = waitForRunningPid(host, childPid);
       assertEquals(running.appId(), current.appId());
       assertEquals(running.token(), current.token());
       assertEquals(childPid, current.pid());
@@ -644,23 +681,23 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    Assumptions.assumeTrue(appEnv.onPath("python3"));
+    Assumptions.assumeTrue(appEnv.onPath(PYTHON3_COMMAND));
     AppHost host = host(Duration.ofSeconds(1));
     Path stagedApp =
         stageInstalledExecutableApp(
-            "python-daemon-app",
-            "bin/launch",
+            PYTHON_DAEMON_APP_ID,
+            POSIX_LAUNCH_PATH,
             POST_CAPTURE_PYTHON_DAEMONIZER,
-            Map.of("bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+            Map.of(CHILD_SCRIPT_PATH, DAEMONIZED_CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
-    RunningAppSnapshot running = host.start("python-daemon-app");
+    RunningAppSnapshot running = host.start(PYTHON_DAEMON_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     try {
-      RunningAppSnapshot current = waitForRunningApp(host, "python-daemon-app");
+      RunningAppSnapshot current = waitForRunningApp(host, PYTHON_DAEMON_APP_ID);
       assertEquals(running.appId(), current.appId());
       assertEquals(running.token(), current.token());
       assertEquals(childPid, current.pid());
@@ -669,9 +706,9 @@ class LocalProcessAppHostTest {
               .map(LocalProcessAppHostTest::isEffectivelyAlive)
               .orElse(false));
       assertEquals(java.util.List.of(current), host.listRunning());
-      assertTrue(host.stop("python-daemon-app"));
+      assertTrue(host.stop(PYTHON_DAEMON_APP_ID));
       waitForProcessExit(childPid);
-      assertTrue(host.status("python-daemon-app").isEmpty());
+      assertTrue(host.status(PYTHON_DAEMON_APP_ID).isEmpty());
     } finally {
       ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
     }
@@ -688,17 +725,19 @@ class LocalProcessAppHostTest {
             RUNNER_APP_ID,
             DAEMONIZING_WRAPPER_VIA_HELPER_SCRIPT,
             Map.of(
-                "bin/helper.sh", DELAYED_DAEMONIZING_HELPER_SCRIPT,
-                "bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+                "bin/helper.sh",
+                DELAYED_DAEMONIZING_HELPER_SCRIPT,
+                CHILD_SCRIPT_PATH,
+                DAEMONIZED_CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
     RunningAppSnapshot running = host.start(RUNNER_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     try {
-      RunningAppSnapshot current = waitForRunningPid(host, RUNNER_APP_ID, childPid);
+      RunningAppSnapshot current = waitForRunningPid(host, childPid);
       assertEquals(running.appId(), current.appId());
       assertEquals(running.token(), current.token());
       assertEquals(childPid, current.pid());
@@ -725,17 +764,19 @@ class LocalProcessAppHostTest {
             RUNNER_APP_ID,
             DAEMONIZING_WRAPPER_VIA_HELPER_SCRIPT,
             Map.of(
-                "bin/helper.sh", DELAYED_DAEMONIZING_HELPER_SCRIPT,
-                "bin/child.sh", DAEMONIZED_CHILD_PROCESS_SCRIPT));
+                "bin/helper.sh",
+                DELAYED_DAEMONIZING_HELPER_SCRIPT,
+                CHILD_SCRIPT_PATH,
+                DAEMONIZED_CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
     RunningAppSnapshot running = host.start(RUNNER_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     try {
-      RunningAppSnapshot current = waitForRunningPid(host, RUNNER_APP_ID, childPid);
+      RunningAppSnapshot current = waitForRunningPid(host, childPid);
       assertEquals(running.appId(), current.appId());
       assertEquals(running.token(), current.token());
       assertEquals(childPid, current.pid());
@@ -770,7 +811,8 @@ class LocalProcessAppHostTest {
   void
       recoverWindowsBundleProcesses_whenCommandLineReferencesInstalledBundle_expectLiveChildRecovered() {
     InstalledAppPaths paths =
-        new AppHostLayout(tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"))
+        new AppHostLayout(
+                tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run"))
             .pathsFor(RUNNER_APP_ID);
     AppManifest manifest =
         new AppManifest(
@@ -780,7 +822,7 @@ class LocalProcessAppHostTest {
             APP_VERSION,
             "bin/launch.cmd",
             "/",
-            java.util.List.of("network.access", "file.read"),
+            STANDARD_PERMISSIONS,
             4096L,
             1024L);
     Instant startedAt = Instant.parse("2026-04-05T00:00:00Z");
@@ -790,18 +832,19 @@ class LocalProcessAppHostTest {
             7201L,
             null,
             true,
-            Optional.of(paths.installedRoot().resolve("bin").resolve("child.exe").toString()),
-            Optional.of("\"" + paths.installedRoot().resolve("bin").resolve("child.exe") + "\""),
-            Optional.of(startedAt.minusSeconds(5)));
+            paths.installedRoot().resolve("bin").resolve(WINDOWS_CHILD_EXECUTABLE).toString(),
+            "\"" + paths.installedRoot().resolve("bin").resolve(WINDOWS_CHILD_EXECUTABLE) + "\"",
+            startedAt.minusSeconds(5));
     ProcessHandle recoveredChild =
         new InfoProcessHandle(
             7202L,
             null,
             true,
-            Optional.empty(),
-            Optional.of(
-                "\"" + paths.installedRoot().resolve("bin").resolve("child.exe") + "\" --serve"),
-            Optional.of(startedAt.plusMillis(750)));
+            null,
+            "\""
+                + paths.installedRoot().resolve("bin").resolve(WINDOWS_CHILD_EXECUTABLE)
+                + "\" --serve",
+            startedAt.plusMillis(750));
 
     List<ProcessHandle> recovered =
         LocalProcessAppHost.recoverWindowsBundleProcesses(
@@ -815,8 +858,7 @@ class LocalProcessAppHostTest {
   }
 
   @Test
-  void parseTokenTrackedProcesses_whenReaderFails_expectCheckedIoException()
-      throws ReflectiveOperationException {
+  void parseTokenTrackedProcesses_whenReaderFails_expectCheckedIoException() {
     Process process =
         new FailingInputProcess(
             (ProcessHandle.current().pid()
@@ -828,9 +870,7 @@ class LocalProcessAppHostTest {
                 .getBytes(StandardCharsets.UTF_8));
 
     IOException exception =
-        assertThrows(
-            IOException.class,
-            () -> invokeParseTokenTrackedProcesses(process, DEFAULT_TOKEN, RUNNER_APP_ID));
+        assertThrows(IOException.class, () -> invokeParseRunnerTokenTrackedProcesses(process));
 
     assertEquals("simulated ps stream failure", exception.getMessage());
   }
@@ -841,7 +881,7 @@ class LocalProcessAppHostTest {
 
     List<ProcessHandle> recovered =
         LocalProcessAppHost.mergeTokenTrackedProcesses(
-            List.of(), List.of(psRecovered), new AppEnv(Map.of(), "Linux"));
+            List.of(), List.of(psRecovered), new AppEnv(Map.of(), LINUX_OS_NAME));
 
     assertEquals(List.of(7205L), recovered.stream().map(ProcessHandle::pid).toList());
   }
@@ -849,7 +889,8 @@ class LocalProcessAppHostTest {
   @Test
   void recoverWindowsBundleProcesses_whenProcessStartsLongAfterLaunch_expectIgnored() {
     InstalledAppPaths paths =
-        new AppHostLayout(tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"))
+        new AppHostLayout(
+                tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run"))
             .pathsFor(RUNNER_APP_ID);
     AppManifest manifest =
         new AppManifest(
@@ -859,7 +900,7 @@ class LocalProcessAppHostTest {
             APP_VERSION,
             "bin/launch.cmd",
             "/",
-            java.util.List.of("network.access", "file.read"),
+            STANDARD_PERMISSIONS,
             4096L,
             1024L);
     Instant startedAt = Instant.parse("2026-04-05T00:00:00Z");
@@ -868,10 +909,11 @@ class LocalProcessAppHostTest {
             7204L,
             null,
             true,
-            Optional.empty(),
-            Optional.of(
-                "\"" + paths.installedRoot().resolve("bin").resolve("child.exe") + "\" --serve"),
-            Optional.of(startedAt.plusSeconds(30)));
+            null,
+            "\""
+                + paths.installedRoot().resolve("bin").resolve(WINDOWS_CHILD_EXECUTABLE)
+                + "\" --serve",
+            startedAt.plusSeconds(30));
 
     List<ProcessHandle> recovered =
         LocalProcessAppHost.recoverWindowsBundleProcesses(
@@ -892,30 +934,30 @@ class LocalProcessAppHostTest {
     AppHost host = host(Duration.ofSeconds(1));
     Path stagedApp =
         stageInstalledExecutableApp(
-            "late-child-app",
-            "bin/launch",
+            LATE_CHILD_APP_ID,
+            POSIX_LAUNCH_PATH,
             LATE_CHILD_DIRECT_EXECUTABLE,
-            Map.of("bin/child.sh", DETACHED_CHILD_PROCESS_SCRIPT));
+            Map.of(CHILD_SCRIPT_PATH, DETACHED_CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
-    RunningAppSnapshot running = host.start("late-child-app");
+    RunningAppSnapshot running = host.start(LATE_CHILD_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     Path wrapperExitedFile = installation.paths().runDir().resolve("wrapper-exited.txt");
     waitForFile(wrapperExitedFile);
     try {
-      RunningAppSnapshot current = waitForRunningApp(host, "late-child-app");
+      RunningAppSnapshot current = waitForRunningApp(host, LATE_CHILD_APP_ID);
       assertEquals(running.appId(), current.appId());
       assertEquals(running.token(), current.token());
       assertTrue(
           ProcessHandle.of(childPid)
               .map(LocalProcessAppHostTest::isEffectivelyAlive)
               .orElse(false));
-      assertTrue(host.stop("late-child-app"));
+      assertTrue(host.stop(LATE_CHILD_APP_ID));
       waitForProcessExit(childPid);
-      assertTrue(host.status("late-child-app").isEmpty());
+      assertTrue(host.status(LATE_CHILD_APP_ID).isEmpty());
     } finally {
       ProcessHandle.of(childPid).ifPresent(ProcessHandle::destroyForcibly);
     }
@@ -975,15 +1017,15 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(1));
+    AppHost host = host(Duration.ofSeconds(2));
     Path stagedApp =
         stageInstalledApp(
-            RUNNER_APP_ID, WRAPPER_SCRIPT, Map.of("bin/child.sh", CHILD_PROCESS_SCRIPT));
+            RUNNER_APP_ID, WRAPPER_SCRIPT, Map.of(CHILD_SCRIPT_PATH, CHILD_PROCESS_SCRIPT));
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
     host.start(RUNNER_APP_ID);
 
-    Path childPidFile = installation.paths().runDir().resolve("child.pid");
+    Path childPidFile = installation.paths().runDir().resolve(CHILD_PID_FILE_NAME);
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     try {
@@ -1016,7 +1058,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void launchCommand_whenWindowsBatchScript_expectQuotedCmdWrapper() throws IOException {
-    AppEnv windowsAppEnv = new AppEnv(Map.of(), "Windows 11");
+    AppEnv windowsAppEnv = new AppEnv(Map.of(), WINDOWS_11);
     Path batchScript = Path.of("C:/Users/Alice & Bob/Cryptad Apps^(1)/runner/bin/launch.cmd");
     Path nativeExecutable = Path.of("C:/apps/runner/bin/runner.exe");
 
@@ -1035,7 +1077,7 @@ class LocalProcessAppHostTest {
   @Test
   void launchCommand_whenShebangUsesEnvSplitString_expectInterpreterArgumentPreserved()
       throws IOException {
-    AppEnv appEnv = new AppEnv(Map.of(), "Linux");
+    AppEnv appEnv = new AppEnv(Map.of(), LINUX_OS_NAME);
     Path script = tempDir.resolve("env-shebang.sh");
     Files.writeString(
         script,
@@ -1048,7 +1090,7 @@ class LocalProcessAppHostTest {
 
     List<String> command = LocalProcessAppHost.launchCommand(script, appEnv);
 
-    assertEquals(Path.of("/usr/bin/env").toString(), command.get(0));
+    assertEquals(SYSTEM_ENV_COMMAND, command.get(0));
     assertEquals("-S bash -euo pipefail", command.get(1));
     assertEquals("-c", command.get(2));
     assertEquals(script.toString(), command.get(4));
@@ -1063,7 +1105,7 @@ class LocalProcessAppHostTest {
     Path stagedApp =
         stageInstalledExecutableApp(
             "invalid-shebang-app",
-            "bin/start",
+            POSIX_START_PATH,
             """
             #!/
             exit 0
@@ -1078,20 +1120,21 @@ class LocalProcessAppHostTest {
 
   @Test
   void launchCommand_whenPythonShebangUsesShSuffix_expectInterpreterLaunch() throws IOException {
-    AppEnv appEnv = new AppEnv(Map.of(), "Linux");
+    AppEnv appEnv = new AppEnv(Map.of(), LINUX_OS_NAME);
     Path script = tempDir.resolve("python-launch.sh");
     Files.writeString(
         script,
         """
-        #!/usr/bin/env python3
+        #!/usr/bin/env %s
         print("ok")
-        """,
+        """
+            .formatted(PYTHON3_COMMAND),
         StandardCharsets.UTF_8);
 
     List<String> command = LocalProcessAppHost.launchCommand(script, appEnv);
 
-    assertEquals(Path.of("/usr/bin/env").toString(), command.getFirst());
-    assertEquals("python3", command.get(1));
+    assertEquals(SYSTEM_ENV_COMMAND, command.getFirst());
+    assertEquals(PYTHON3_COMMAND, command.get(1));
     assertEquals(script.toString(), command.get(2));
   }
 
@@ -1100,29 +1143,31 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    Assumptions.assumeTrue(appEnv.onPath("python3"));
+    Assumptions.assumeTrue(appEnv.onPath(PYTHON3_COMMAND));
     AppHost host = host();
     Path stagedApp =
         stageInstalledExecutableApp(
             "non-utf8-launcher-app",
-            "bin/start",
+            POSIX_START_PATH,
             """
-            #!/usr/bin/env python3
+            #!/usr/bin/env %s
             pass
-            """,
+            """
+                .formatted(PYTHON3_COMMAND),
             Map.of(),
             false);
-    Path script = stagedApp.resolve("bin/start");
+    Path script = stagedApp.resolve(POSIX_START_PATH);
     try (OutputStream output = Files.newOutputStream(script)) {
-      output.write("#!/usr/bin/env python3\n".getBytes(StandardCharsets.US_ASCII));
+      output.write(
+          ("#!/usr/bin/env " + PYTHON3_COMMAND + "\n").getBytes(StandardCharsets.US_ASCII));
       output.write(new byte[] {(byte) 0xC3, (byte) 0x28, (byte) '\n'});
     }
 
     List<String> command = LocalProcessAppHost.launchCommand(script, appEnv);
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
 
-    assertEquals(Path.of("/usr/bin/env").toString(), command.getFirst());
-    assertEquals("python3", command.get(1));
+    assertEquals(SYSTEM_ENV_COMMAND, command.getFirst());
+    assertEquals(PYTHON3_COMMAND, command.get(1));
     assertEquals(script.toString(), command.get(2));
     assertEquals("non-utf8-launcher-app", installation.appId());
   }
@@ -1136,8 +1181,7 @@ class LocalProcessAppHostTest {
     AppHost host = host();
     InstalledAppSnapshot installation =
         host.installFromDirectory(
-            stageInstalledApp(
-                RUNNER_APP_ID,
+            stageInstalledRunnerApp(
                 """
                 #!/usr/bin/env bash
                 set -euo pipefail
@@ -1166,8 +1210,8 @@ class LocalProcessAppHostTest {
     InstalledAppSnapshot installation =
         host.installFromDirectory(
             stageInstalledExecutableApp(
-                "shell-noexec-app",
-                "bin/start",
+                SHELL_NOEXEC_APP_ID,
+                POSIX_START_PATH,
                 """
                 #!/bin/sh
                 set -eu
@@ -1179,12 +1223,12 @@ class LocalProcessAppHostTest {
                 Map.of(),
                 false));
 
-    host.start("shell-noexec-app");
+    host.start(SHELL_NOEXEC_APP_ID);
 
     Path confirmationFile = installation.paths().runDir().resolve("noexec-ok.txt");
     waitForFile(confirmationFile);
     assertEquals("ok", Files.readString(confirmationFile, StandardCharsets.UTF_8));
-    assertTrue(host.stop("shell-noexec-app"));
+    assertTrue(host.stop(SHELL_NOEXEC_APP_ID));
   }
 
   @Test
@@ -1194,7 +1238,7 @@ class LocalProcessAppHostTest {
     Assumptions.assumeFalse(appEnv.isWindows());
     AppHost host = host();
     InstalledAppSnapshot installation =
-        host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID, STDIN_EOF_SCRIPT));
+        host.installFromDirectory(stageInstalledRunnerApp(STDIN_EOF_SCRIPT));
 
     host.start(RUNNER_APP_ID);
 
@@ -1211,7 +1255,7 @@ class LocalProcessAppHostTest {
     Assumptions.assumeFalse(appEnv.isWindows());
     AppHost host = host();
     InstalledAppSnapshot installation =
-        host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID, SINGLE_RUN_EXIT_SCRIPT));
+        host.installFromDirectory(stageInstalledRunnerApp(SINGLE_RUN_EXIT_SCRIPT));
 
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
@@ -1219,7 +1263,7 @@ class LocalProcessAppHostTest {
     Path runCountFile = installation.paths().runDir().resolve("run-count.txt");
     waitForFile(runCountFile);
     assertEquals("1\n", Files.readString(runCountFile, StandardCharsets.UTF_8));
-    assertTrue(exception.getMessage().contains("app exited during startup: " + RUNNER_APP_ID));
+    assertTrue(exception.getMessage().contains(STARTUP_EXIT_MESSAGE_PREFIX + RUNNER_APP_ID));
     assertTrue(host.status(RUNNER_APP_ID).isEmpty());
     assertTrue(host.listRunning().isEmpty());
   }
@@ -1237,7 +1281,7 @@ class LocalProcessAppHostTest {
         snapshot.manifest(),
         snapshot.paths(),
         DEFAULT_TOKEN,
-        new AppEnv(Map.of(), "Linux"));
+        new AppEnv(Map.of(), LINUX_OS_NAME));
 
     assertFalse(environment.containsKey("GITHUB_TOKEN"));
     assertFalse(environment.containsKey("AWS_SECRET_ACCESS_KEY"));
@@ -1277,7 +1321,7 @@ class LocalProcessAppHostTest {
         snapshot.manifest(),
         snapshot.paths(),
         DEFAULT_TOKEN,
-        new AppEnv(Map.of(), "Windows 11"));
+        new AppEnv(Map.of(), WINDOWS_11));
 
     List<String> pathEntries = List.of(environment.get("PATH").replace('\\', '/').split(";"));
     assertTrue(pathEntries.stream().anyMatch(entry -> entry.endsWith("/System32")));
@@ -1290,13 +1334,13 @@ class LocalProcessAppHostTest {
       throws Exception {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    Assumptions.assumeTrue(appEnv.onPath("mkfifo"));
+    Assumptions.assumeTrue(appEnv.onPath(MKFIFO_COMMAND));
     AppHost host = host();
     Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
     Path namedPipe = stagedApp.resolve("blocked.pipe");
 
     Process mkfifo =
-        new ProcessBuilder(resolveTrustedCommand("mkfifo"), namedPipe.toString()).start();
+        new ProcessBuilder(resolveTrustedMkfifoCommand(), namedPipe.toString()).start();
     assertEquals(0, waitForExit(mkfifo));
 
     AppHostException exception = installExpectingAppHostException(host, stagedApp);
@@ -1311,12 +1355,13 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     AppHost host = host();
-    Path stagedApp = Files.createDirectories(tempDir.resolve("stage").resolve("manifest-symlink"));
+    Path stagedApp =
+        Files.createDirectories(tempDir.resolve(STAGE_DIR_NAME).resolve("manifest-symlink"));
     Path externalManifest = tempDir.resolve("outside-manifest.properties");
     String externalContent = "outside-secret-data";
     Files.writeString(externalManifest, externalContent, StandardCharsets.UTF_8);
     Files.createSymbolicLink(
-        stagedApp.resolve("cryptad-app.properties"), externalManifest.toAbsolutePath());
+        stagedApp.resolve(MANIFEST_FILE_NAME), externalManifest.toAbsolutePath());
 
     AppHostException exception =
         assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
@@ -1407,7 +1452,7 @@ class LocalProcessAppHostTest {
         assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
 
     assertTrue(exception.getMessage().contains("must not overlap the installed app tree"));
-    assertFalse(Files.exists(tempDir.resolve("data").resolve("apps").resolve("installed")));
+    assertFalse(Files.exists(tempDir.resolve("data").resolve("apps").resolve(INSTALLED_DIR_NAME)));
   }
 
   @Test
@@ -1425,8 +1470,8 @@ class LocalProcessAppHostTest {
         assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
 
     assertTrue(exception.getMessage().contains("must not overlap runDir"));
-    assertTrue(Files.isRegularFile(stagedApp.resolve("cryptad-app.properties")));
-    assertTrue(Files.isRegularFile(stagedApp.resolve("content.txt")));
+    assertTrue(Files.isRegularFile(stagedApp.resolve(MANIFEST_FILE_NAME)));
+    assertTrue(Files.isRegularFile(stagedApp.resolve(CONTENT_FILE_NAME)));
   }
 
   @Test
@@ -1493,8 +1538,8 @@ class LocalProcessAppHostTest {
     RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
     injectRunningProcess(host, RUNNER_APP_ID, snapshot, new ExitedProcess(snapshot.pid()));
 
-    Object runningProcess = runningProcessEntry(host, RUNNER_APP_ID);
-    boolean preserved = invokePreserveRunningState(host, RUNNER_APP_ID, runningProcess);
+    Object runningProcess = runnerProcessEntry(host);
+    boolean preserved = invokePreserveRunnerState(host, runningProcess);
 
     assertFalse(preserved);
     assertTrue(host.status(RUNNER_APP_ID).isEmpty());
@@ -1512,7 +1557,7 @@ class LocalProcessAppHostTest {
   private LocalProcessAppHost host(Duration stopTimeout, AppEnv appEnv) {
     return new LocalProcessAppHost(
         new AppHostLayout(
-            tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run")),
+            tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run")),
         stopTimeout,
         new java.security.SecureRandom(),
         appEnv);
@@ -1522,13 +1567,13 @@ class LocalProcessAppHostTest {
     return stageInstalledApp(appId, scriptContent(new AppEnv()), Map.of());
   }
 
-  private Path stageInstalledApp(String appId, String scriptContent) throws IOException {
-    return stageInstalledApp(appId, scriptContent, Map.of());
+  private Path stageInstalledRunnerApp(String scriptContent) throws IOException {
+    return stageInstalledApp(RUNNER_APP_ID, scriptContent, Map.of());
   }
 
   private Path stageInstalledApp(String appId, String scriptContent, Map<String, String> extraFiles)
       throws IOException {
-    Path stagedDir = tempDir.resolve("stage").resolve(appId);
+    Path stagedDir = tempDir.resolve(STAGE_DIR_NAME).resolve(appId);
     return stageInstalledAppAt(stagedDir, appId, scriptContent, extraFiles);
   }
 
@@ -1544,9 +1589,9 @@ class LocalProcessAppHostTest {
     for (Map.Entry<String, String> extraFile : extraFiles.entrySet()) {
       writeStageFile(stagedDir.resolve(extraFile.getKey()), extraFile.getValue(), appEnv);
     }
-    Files.writeString(stagedDir.resolve("content.txt"), "payload", StandardCharsets.UTF_8);
+    Files.writeString(stagedDir.resolve(CONTENT_FILE_NAME), "payload", StandardCharsets.UTF_8);
     Files.writeString(
-        stagedDir.resolve("cryptad-app.properties"),
+        stagedDir.resolve(MANIFEST_FILE_NAME),
         """
         manifest.version=1
         app.id=%s
@@ -1554,11 +1599,12 @@ class LocalProcessAppHostTest {
         app.version=%s
         app.exec=bin/%s
         app.ui.entry=/
-        app.permissions=network.access,file.read
+        app.permissions=%s
         quota.data.bytes=4096
         quota.cache.bytes=1024
         """
-            .formatted(appId, displayName(appId), APP_VERSION, scriptName),
+            .formatted(
+                appId, displayName(appId), APP_VERSION, scriptName, STANDARD_PERMISSIONS_TEXT),
         StandardCharsets.UTF_8);
     return stagedDir;
   }
@@ -1577,14 +1623,14 @@ class LocalProcessAppHostTest {
       boolean executable)
       throws IOException {
     AppEnv appEnv = new AppEnv();
-    Path stagedDir = Files.createDirectories(tempDir.resolve("stage").resolve(appId));
+    Path stagedDir = Files.createDirectories(tempDir.resolve(STAGE_DIR_NAME).resolve(appId));
     writeExecutableStageFile(stagedDir.resolve(execRelativePath), execContent, appEnv, executable);
     for (Map.Entry<String, String> extraFile : extraFiles.entrySet()) {
       writeStageFile(stagedDir.resolve(extraFile.getKey()), extraFile.getValue(), appEnv);
     }
-    Files.writeString(stagedDir.resolve("content.txt"), "payload", StandardCharsets.UTF_8);
+    Files.writeString(stagedDir.resolve(CONTENT_FILE_NAME), "payload", StandardCharsets.UTF_8);
     Files.writeString(
-        stagedDir.resolve("cryptad-app.properties"),
+        stagedDir.resolve(MANIFEST_FILE_NAME),
         """
         manifest.version=1
         app.id=%s
@@ -1592,11 +1638,16 @@ class LocalProcessAppHostTest {
         app.version=%s
         app.exec=%s
         app.ui.entry=/
-        app.permissions=network.access,file.read
+        app.permissions=%s
         quota.data.bytes=4096
         quota.cache.bytes=1024
         """
-            .formatted(appId, displayName(appId), APP_VERSION, execRelativePath),
+            .formatted(
+                appId,
+                displayName(appId),
+                APP_VERSION,
+                execRelativePath,
+                STANDARD_PERMISSIONS_TEXT),
         StandardCharsets.UTF_8);
     return stagedDir;
   }
@@ -1610,16 +1661,17 @@ class LocalProcessAppHostTest {
             APP_VERSION,
             "bin/" + scriptName(new AppEnv()),
             "/",
-            java.util.List.of("network.access", "file.read"),
+            STANDARD_PERMISSIONS,
             4096L,
             1024L);
     InstalledAppPaths paths =
-        new AppHostLayout(tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"))
+        new AppHostLayout(
+                tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run"))
             .pathsFor(appId);
     return new RunningAppSnapshot(manifest, paths, DEFAULT_TOKEN, 42L, Instant.EPOCH);
   }
 
-  @SuppressWarnings({"unchecked", "java:S3011"})
+  @SuppressWarnings({"java:S3011"})
   private static void injectRunningProcess(
       LocalProcessAppHost host, String appId, RunningAppSnapshot snapshot, Process process)
       throws ReflectiveOperationException {
@@ -1650,17 +1702,16 @@ class LocalProcessAppHostTest {
   }
 
   @SuppressWarnings({"unchecked", "java:S3011"})
-  private static Object runningProcessEntry(LocalProcessAppHost host, String appId)
+  private static Object runnerProcessEntry(LocalProcessAppHost host)
       throws ReflectiveOperationException {
     Field runningAppsField = LocalProcessAppHost.class.getDeclaredField("runningApps");
     runningAppsField.setAccessible(true);
     Map<String, Object> runningApps = (Map<String, Object>) runningAppsField.get(host);
-    return runningApps.get(appId);
+    return runningApps.get(RUNNER_APP_ID);
   }
 
   @SuppressWarnings("java:S3011")
-  private static boolean invokePreserveRunningState(
-      LocalProcessAppHost host, String appId, Object runningProcess)
+  private static boolean invokePreserveRunnerState(LocalProcessAppHost host, Object runningProcess)
       throws ReflectiveOperationException {
     Class<?> runningProcessClass =
         Class.forName(LocalProcessAppHost.class.getName() + "$RunningProcess");
@@ -1668,31 +1719,32 @@ class LocalProcessAppHostTest {
         LocalProcessAppHost.class.getDeclaredMethod(
             "preserveRunningState", String.class, runningProcessClass);
     preserveRunningState.setAccessible(true);
-    return (boolean) preserveRunningState.invoke(host, appId, runningProcess);
+    return (boolean) preserveRunningState.invoke(host, RUNNER_APP_ID, runningProcess);
   }
 
-  @SuppressWarnings("unchecked")
-  private static List<ProcessHandle> invokeParseTokenTrackedProcesses(
-      Process process, String token, String appId)
+  private static void invokeParseRunnerTokenTrackedProcesses(Process process)
       throws ReflectiveOperationException, IOException {
-    Method parseTokenTrackedProcesses =
-        LocalProcessAppHost.class.getDeclaredMethod(
-            "parseTokenTrackedProcesses", Process.class, String.class, String.class);
-    parseTokenTrackedProcesses.setAccessible(true);
+    MethodHandle parseTokenTrackedProcesses =
+        MethodHandles.privateLookupIn(LocalProcessAppHost.class, MethodHandles.lookup())
+            .findStatic(
+                LocalProcessAppHost.class,
+                "parseTokenTrackedProcesses",
+                MethodType.methodType(List.class, Process.class, String.class, String.class));
     try {
-      return (List<ProcessHandle>) parseTokenTrackedProcesses.invoke(null, process, token, appId);
-    } catch (InvocationTargetException e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof IOException ioException) {
-        throw ioException;
+      parseTokenTrackedProcesses.invoke(process, DEFAULT_TOKEN, RUNNER_APP_ID);
+    } catch (Throwable throwable) {
+      switch (throwable) {
+        case IOException ioException -> throw ioException;
+        case RuntimeException runtimeException -> throw runtimeException;
+        case Error error -> throw error;
+        case ReflectiveOperationException reflectiveOperationException ->
+            throw reflectiveOperationException;
+        default -> {
+          // do nothing
+        }
       }
-      if (cause instanceof RuntimeException runtimeException) {
-        throw runtimeException;
-      }
-      if (cause instanceof Error error) {
-        throw error;
-      }
-      throw e;
+      throw new ReflectiveOperationException(
+          "failed to invoke parseTokenTrackedProcesses", throwable);
     }
   }
 
@@ -1760,8 +1812,29 @@ class LocalProcessAppHostTest {
     """;
   }
 
+  private static void assertCapturedEnvironment(
+      InstalledAppSnapshot installation, RunningAppSnapshot running, String capture) {
+    assertTrue(capture.contains("CRYPTAD_APP_ID=" + RUNNER_APP_ID));
+    assertTrue(capture.contains("CRYPTAD_APP_NAME=Runner App"));
+    assertTrue(capture.contains("CRYPTAD_APP_VERSION=" + APP_VERSION));
+    assertTrue(capture.contains("CRYPTAD_APP_DATA_DIR=" + installation.paths().dataDir()));
+    assertTrue(capture.contains("CRYPTAD_APP_CACHE_DIR=" + installation.paths().cacheDir()));
+    assertTrue(capture.contains("CRYPTAD_APP_RUN_DIR=" + installation.paths().runDir()));
+    assertTrue(capture.contains("CRYPTAD_APP_TOKEN=" + running.token()));
+    assertTrue(capture.contains("CRYPTAD_APP_PERMISSIONS=" + STANDARD_PERMISSIONS_TEXT));
+    assertTrue(capture.contains("CRYPTAD_APP_UI_ENTRY=/"));
+  }
+
+  private static void assertInstallationPathsRemoved(InstalledAppSnapshot installation) {
+    assertFalse(Files.exists(installation.paths().installedRoot()));
+    assertFalse(Files.exists(installation.paths().dataDir()));
+    assertFalse(Files.exists(installation.paths().cacheDir()));
+    assertFalse(Files.exists(installation.paths().runDir()));
+  }
+
   private static AppHostException installExpectingAppHostException(AppHost host, Path stagedApp)
       throws Exception {
+    //noinspection resource
     ExecutorService executor =
         Executors.newSingleThreadExecutor(
             runnable -> {
@@ -1772,7 +1845,7 @@ class LocalProcessAppHostTest {
     try {
       ExecutionException exception =
           installFailure(executor.submit(() -> host.installFromDirectory(stagedApp)), stagedApp);
-      assertTrue(exception.getCause() instanceof AppHostException);
+      assertInstanceOf(AppHostException.class, exception.getCause());
       return (AppHostException) exception.getCause();
     } catch (TimeoutException e) {
       throw new AssertionError("installFromDirectory hung on named pipe: " + stagedApp, e);
@@ -1807,32 +1880,22 @@ class LocalProcessAppHostTest {
       if (running.isPresent()) {
         return running.orElseThrow();
       }
-      try {
-        TimeUnit.MILLISECONDS.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new AssertionError("interrupted while waiting for app to be running: " + appId, e);
-      }
+      pausePolling("interrupted while waiting for app to be running: " + appId);
     }
     throw new AssertionError("timed out waiting for app to be running: " + appId);
   }
 
-  private static RunningAppSnapshot waitForRunningPid(AppHost host, String appId, long pid) {
+  private static RunningAppSnapshot waitForRunningPid(AppHost host, long pid) {
     long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
     while (System.nanoTime() < deadline) {
-      Optional<RunningAppSnapshot> running = host.status(appId);
+      Optional<RunningAppSnapshot> running = host.status(RUNNER_APP_ID);
       if (running.isPresent() && running.orElseThrow().pid() == pid) {
         return running.orElseThrow();
       }
-      try {
-        TimeUnit.MILLISECONDS.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new AssertionError(
-            "interrupted while waiting for app " + appId + " to report pid " + pid, e);
-      }
+      pausePolling("interrupted while waiting for app " + RUNNER_APP_ID + " to report pid " + pid);
     }
-    throw new AssertionError("timed out waiting for app " + appId + " to report pid " + pid);
+    throw new AssertionError(
+        "timed out waiting for app " + RUNNER_APP_ID + " to report pid " + pid);
   }
 
   private static void waitForProcessExit(long pid) throws IOException {
@@ -1872,15 +1935,23 @@ class LocalProcessAppHostTest {
     }
   }
 
-  private static String resolveTrustedCommand(String command) {
+  private static void pausePolling(String interruptMessage) {
+    LockSupport.parkNanos(POLL_INTERVAL_NANOS);
+    if (Thread.interrupted()) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(interruptMessage, new InterruptedException(interruptMessage));
+    }
+  }
+
+  private static String resolveTrustedMkfifoCommand() {
     for (Path trustedDir :
         List.of(Path.of("/usr/bin"), Path.of("/bin"), Path.of("/usr/sbin"), Path.of("/sbin"))) {
-      Path candidate = trustedDir.resolve(command);
+      Path candidate = trustedDir.resolve(MKFIFO_COMMAND);
       if (Files.isExecutable(candidate)) {
         return candidate.toString();
       }
     }
-    throw new AssertionError("trusted command not found: " + command);
+    throw new AssertionError("trusted command not found: " + MKFIFO_COMMAND);
   }
 
   private static String windowsCommandInterpreter() {
@@ -2081,8 +2152,7 @@ class LocalProcessAppHostTest {
 
       @Override
       public boolean destroyForcibly() {
-        LateChildSpawningProcess.this.destroy();
-        return true;
+        return destroy();
       }
 
       @Override
@@ -2160,6 +2230,7 @@ class LocalProcessAppHostTest {
 
     @Override
     public Process destroyForcibly() {
+      destroy();
       return this;
     }
 
@@ -2302,7 +2373,7 @@ class LocalProcessAppHostTest {
 
     @Override
     public void destroy() {
-      // Intentionally blank: this fake process is already exited.
+      // Intentionally blank: this fake process already exits.
     }
 
     @Override
@@ -2367,7 +2438,7 @@ class LocalProcessAppHostTest {
 
     @Override
     public void destroy() {
-      // Intentionally blank: lifecycle is simulated by the handle.
+      // Intentionally blank: the handle simulates lifecycle.
     }
 
     @Override
@@ -2471,7 +2542,7 @@ class LocalProcessAppHostTest {
     }
 
     @Override
-    public int read(byte[] buffer, int off, int len) throws IOException {
+    public int read(byte @NonNull [] buffer, int off, int len) throws IOException {
       if (offset < prefixBytes.length) {
         int bytesToCopy = Math.min(len, prefixBytes.length - offset);
         System.arraycopy(prefixBytes, offset, buffer, off, bytesToCopy);
@@ -2583,17 +2654,17 @@ class LocalProcessAppHostTest {
     private final long pid;
     private final ProcessHandle parent;
     private final boolean alive;
-    private final Optional<String> command;
-    private final Optional<String> commandLine;
-    private final Optional<Instant> startInstant;
+    private final @Nullable String command;
+    private final @Nullable String commandLine;
+    private final @Nullable Instant startInstant;
 
     private InfoProcessHandle(
         long pid,
         ProcessHandle parent,
         boolean alive,
-        Optional<String> command,
-        Optional<String> commandLine,
-        Optional<Instant> startInstant) {
+        @Nullable String command,
+        @Nullable String commandLine,
+        @Nullable Instant startInstant) {
       this.pid = pid;
       this.parent = parent;
       this.alive = alive;
@@ -2612,12 +2683,12 @@ class LocalProcessAppHostTest {
       return new Info() {
         @Override
         public Optional<String> command() {
-          return command;
+          return Optional.ofNullable(command);
         }
 
         @Override
         public Optional<String> commandLine() {
-          return commandLine;
+          return Optional.ofNullable(commandLine);
         }
 
         @Override
@@ -2627,7 +2698,7 @@ class LocalProcessAppHostTest {
 
         @Override
         public Optional<Instant> startInstant() {
-          return startInstant;
+          return Optional.ofNullable(startInstant);
         }
 
         @Override
@@ -2688,6 +2759,7 @@ class LocalProcessAppHostTest {
     }
   }
 
+  @SuppressWarnings("ClassCanBeRecord")
   private static final class FadingProcessHandle implements ProcessHandle {
     private final long pid;
     private final AtomicInteger remainingAliveChecks;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include(
   ":kernel-routing",
   ":runtime-spi",
   ":platform-api",
+  ":platform-apphost",
   ":runtime-node",
   ":adapter-fcp",
   ":adapter-http-legacy-admin",


### PR DESCRIPTION
## Summary
- add a new `:platform-apphost` leaf with the transport-neutral AppHost v1 API, manifest model/parser, install layout, and `LocalProcessAppHost` runtime for local out-of-process apps
- wire the new leaf into the multi-project build, including ownership metadata, selective-prune handling, aggregate Sonar/JaCoCo/test-execution reporting, and related README/skill guidance
- add focused leaf-local coverage for runtime lifecycle behavior, manifest parsing, path/layout validation, and record-level constructor validation
- enrich the new public AppHost package Javadocs to document lifecycle expectations, filesystem ownership, and package responsibilities

## How to test
- `./gradlew :platform-apphost:test`
- `./gradlew compileJava compileTestJava`
- `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`
- `./gradlew prepareTestExecutionReport`
- `./gradlew jacocoTestReport`
- `./gradlew :platform-apphost:javadoc`
- `./gradlew cleanTest test`