### PR TITLE
fix(tooling): Resolve SpotBugs issues and speed tests

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRuntimeAdapters.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRuntimeAdapters.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.io.Serial;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import network.crypta.crypt.EntropySource;
@@ -157,6 +158,8 @@ final class FcpRuntimeAdapters {
    * non-owning views over a live runtime port.
    */
   private static final class RandomnessPortRandomSource extends RandomSource {
+    @Serial private static final long serialVersionUID = 1L;
+
     /**
      * Live runtime randomness capability backing this adapter.
      *

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.http;
 
 import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -97,7 +99,9 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * callers can reuse one comparator for ascending and descending views without allocating extra
    * helpers.
    */
-  protected static class ComparatorByStatus implements Comparator<PeerNodeStatus> {
+  protected static class ComparatorByStatus implements Comparator<PeerNodeStatus>, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
     /** Column key requested by the client, may be {@code null} for default ordering. */
     protected final String sortBy;
 

--- a/build-logic/spotbugs-exclude-test.xml
+++ b/build-logic/spotbugs-exclude-test.xml
@@ -213,4 +213,58 @@
     <Class name="network.crypta.runtime.alerts.DiskSpaceUserAlertTest"/>
     <Method name="isValid_boolean_noop_doesNotChangeValidity"/>
   </Match>
+
+  <!--
+    These tests intentionally embed absolute paths to verify parser and command-launch behavior
+    against already-resolved paths and trusted system binaries.
+  -->
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.launcher.LauncherUtilsTest"/>
+    <Method name="parseResolvedRunDirFromLine_whenPresent_expectParsedPath"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.platform.apphost.runtime.LocalProcessAppHostTest"/>
+    <Method name="launchCommand_whenWindowsBatchScript_expectQuotedCmdWrapper"/>
+  </Match>
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.platform.apphost.runtime.LocalProcessAppHostTest"/>
+    <Method name="resolveTrustedMkfifoCommand"/>
+  </Match>
+
+  <!--
+    These fixture builders intentionally keep LF-oriented text blocks for manifest/script content.
+    Converting them to platform-dependent %n output would add churn without improving test intent.
+  -->
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+    <Class name="network.crypta.platform.apphost.manifest.AppManifestParserTest"/>
+    <Method name="minimalManifest"/>
+  </Match>
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+    <Class name="network.crypta.runtime.updater.NodeUpdateManagerTest"/>
+    <Method name="maybeParseManifest_whenAutoUpdateEnabledAndVersionNewer_expectAutoDownloadStarted"/>
+  </Match>
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+    <Class name="network.crypta.runtime.updater.NodeUpdateManagerTest"/>
+    <Method name="maybeParseManifest_whenAutoUpdateEnabledAndVersionNotInteger_expectNoAutoDownload"/>
+  </Match>
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+    <Class name="network.crypta.runtime.updater.NodeUpdateManagerTest"/>
+    <Method name="setURI_whenPackageDownloadInProgress_expectActiveDownloadCancelled"/>
+  </Match>
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+    <Class name="network.crypta.runtime.updater.NodeUpdateManagerTest"/>
+    <Method name="setURI_whenScopeChanges_expectHasNewCorePackageReset"/>
+  </Match>
+  <Match>
+    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+    <Class name="network.crypta.platform.apphost.runtime.LocalProcessAppHostTest"/>
+  </Match>
 </FindBugsFilter>

--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -1798,4 +1798,99 @@
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
     <Class name="org.spaceroots.mantissa.utilities.IntervalsList"/>
   </Match>
+
+  <!--
+    These long-lived request and listener objects intentionally retain live callback/listener
+    references so persisted client requests can resume and in-process event producers can continue
+    dispatching to their registered observers. Marking the fields transient would break those
+    semantics without improving runtime safety.
+  -->
+  <Match>
+    <Bug pattern="SE_BAD_FIELD"/>
+    <Class name="network.crypta.client.async.ClientGetter"/>
+  </Match>
+  <Match>
+    <Bug pattern="SE_BAD_FIELD"/>
+    <Class name="network.crypta.client.async.ClientPutter"/>
+  </Match>
+  <Match>
+    <Bug pattern="SE_BAD_FIELD"/>
+    <Class name="network.crypta.client.events.SimpleEventProducer"/>
+  </Match>
+
+  <!--
+    The datehint terminal callback must remain a non-static inner class so serialized USK inserts
+    keep their enclosing-instance link across resume boundaries. Refactoring it to a static helper
+    would alter persisted state layout.
+  -->
+  <Match>
+    <Bug pattern="SE_INNER_CLASS"/>
+    <Class name="network.crypta.client.async.USKInserter$DateHintTerminalCallback"/>
+  </Match>
+
+  <!--
+    These runtime seam bundles intentionally carry live collaborators (ports, handlers, toadlets,
+    queue backends, and request-context owners). Defensive copying is either impossible or would
+    sever the shared lifecycle/identity that callers explicitly rely on.
+  -->
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    <Class name="~network\.crypta\.clients\.fcp\.bridge\.(?:FcpQueuePorts\$Bundle|FcpUserAlertFeedSubscriber)"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="~network\.crypta\.clients\.fcp\.bridge\.LegacyQueue(?:Completion|Download|Insert)Port"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    <Class name="~network\.crypta\.clients\.http\.(?:HttpShellFProxyBootstrap|QueueToadletRuntimePorts)"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    <Class name="network.crypta.clients.http.bridge.CoreHttpShellRuntimeSupport"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="network.crypta.clients.http.bridge.bookmark.CoreBookmarkRuntimeSupport"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="network.crypta.clients.http.filter.PushingTagReplacerCallback"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    <Class name="~network\.crypta\.runtime\.admin\.(?:AdminRuntimeBridgeInputs|AdminRuntimePortsBundle)"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="network.crypta.runtime.admin.LegacyQueueMutationPort"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="network.crypta.runtime.core.LegacyRequestQueuePort"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    <Class name="network.crypta.runtime.core.LegacyRuntimePorts"/>
+  </Match>
+
+  <!--
+    The config callback wrappers intentionally preserve the historic simple callback names while
+    adapting to the support-layer callback hierarchy. Renaming them would be pure churn and would
+    obscure their role as compatibility shims.
+  -->
+  <Match>
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS"/>
+    <Class name="~network\.crypta\.config\.(?:Boolean|Int|Long|Short|StringArr|String)Callback"/>
+  </Match>
+
+  <!--
+    AppHost runtime path probing intentionally uses a fixed allow-list of absolute OS paths for the
+    trusted shell, ps binary, proc filesystem, and baseline PATH entries. Those literals are part
+    of the platform-security contract rather than user-derived filenames.
+  -->
+  <Match>
+    <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    <Class name="network.crypta.platform.apphost.runtime.LocalProcessAppHost"/>
+  </Match>
 </FindBugsFilter>

--- a/launcher-desktop/src/main/java/network/crypta/launcher/LauncherController.java
+++ b/launcher-desktop/src/main/java/network/crypta/launcher/LauncherController.java
@@ -99,15 +99,22 @@ public class LauncherController {
   private static final String MAC_OPEN_EXECUTABLE = "/usr/bin/open";
   private static final String LINUX_XDG_OPEN_EXECUTABLE = "/usr/bin/xdg-open";
   private static final String LINUX_XDG_OPEN_EXECUTABLE_FALLBACK = "/bin/xdg-open";
-  private static final long TAIL_BASE_DELAY_MS = 200L;
-  private static final long TAIL_MAX_DELAY_MS = 1500L;
-  private static final long TAIL_CANCEL_POLL_MS = 50L;
+  static final TimingConfig DEFAULT_TIMING =
+      new TimingConfig(
+          200L,
+          1500L,
+          50L,
+          100L,
+          java.time.Duration.ofSeconds(25),
+          java.time.Duration.ofSeconds(20),
+          java.time.Duration.ofSeconds(5),
+          java.time.Duration.ofSeconds(2));
   private static final int TAIL_READ_CHUNK = 64 * 1024;
-  private static final long READINESS_POLL_MS = 100L;
   private static final String NODE_INITIALIZATION_COMPLETED_MARKER =
       "Node initialization completed";
   private final Supplier<Path> readinessFileResolver;
   private final Supplier<Path> daemonLogFileResolver;
+  private final TimingConfig timing;
 
   /**
    * Creates a controller rooted at the current working directory.
@@ -128,18 +135,32 @@ public class LauncherController {
     this(
         cwd,
         LauncherUtils::resolveConfiguredLauncherReadinessFile,
-        LauncherUtils::resolveConfiguredLauncherDaemonLogFile);
+        LauncherUtils::resolveConfiguredLauncherDaemonLogFile,
+        DEFAULT_TIMING);
   }
 
   LauncherController(Path cwd, Supplier<Path> readinessFileResolver) {
-    this(cwd, readinessFileResolver, LauncherUtils::resolveConfiguredLauncherDaemonLogFile);
+    this(
+        cwd,
+        readinessFileResolver,
+        LauncherUtils::resolveConfiguredLauncherDaemonLogFile,
+        DEFAULT_TIMING);
   }
 
   LauncherController(
       Path cwd, Supplier<Path> readinessFileResolver, Supplier<Path> daemonLogFileResolver) {
+    this(cwd, readinessFileResolver, daemonLogFileResolver, DEFAULT_TIMING);
+  }
+
+  LauncherController(
+      Path cwd,
+      Supplier<Path> readinessFileResolver,
+      Supplier<Path> daemonLogFileResolver,
+      TimingConfig timing) {
     this.cwd = Objects.requireNonNull(cwd);
     this.readinessFileResolver = Objects.requireNonNull(readinessFileResolver);
     this.daemonLogFileResolver = Objects.requireNonNull(daemonLogFileResolver);
+    this.timing = Objects.requireNonNull(timing);
   }
 
   /**
@@ -353,7 +374,7 @@ public class LauncherController {
 
   private boolean sleepForReadinessPoll() {
     try {
-      TimeUnit.MILLISECONDS.sleep(READINESS_POLL_MS);
+      TimeUnit.MILLISECONDS.sleep(timing.readinessPollMs());
       return true;
     } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
@@ -506,30 +527,30 @@ public class LauncherController {
       emitLog(ts() + " Sending SIGINT to wrapper tree (root PID " + pids.getFirst() + ") ...");
     }
     sendSignalToPids(pids, "INT");
-    if (waitForPidsToExit(pids, 20)) {
+    if (waitForPidsToExit(pids, timing.unixInterruptTimeout())) {
       return;
     }
 
     emitLog(ts() + " Escalating: sending SIGTERM to remaining processes ...");
     List<Long> alive = alivePids(pids);
     sendSignalToPids(alive, "TERM");
-    if (waitForPidsToExit(pids, 5)) {
+    if (waitForPidsToExit(pids, timing.unixTerminateTimeout())) {
       return;
     }
 
     emitLog(ts() + " Escalating: sending SIGKILL to remaining processes ...");
     sendSignalToPids(alivePids(pids), "KILL");
-    waitForPidsToExit(pids, 2);
+    waitForPidsToExit(pids, timing.forceKillTimeout());
   }
 
   private void stopProcessTreeWindows(long rootPid, List<Long> pids) {
     if (!tryWindowsGracefulStopViaAnchor(pids)) {
       runTaskkill(rootPid, false);
-      if (waitForPidsToExit(pids, 20)) {
+      if (waitForPidsToExit(pids, timing.unixInterruptTimeout())) {
         return;
       }
       runTaskkill(rootPid, true);
-      waitForPidsToExit(pids, 5);
+      waitForPidsToExit(pids, timing.unixTerminateTimeout());
     }
   }
 
@@ -594,7 +615,7 @@ public class LauncherController {
     }
   }
 
-  private boolean waitForPidsToExit(List<Long> pids, long timeoutSeconds) {
+  private boolean waitForPidsToExit(List<Long> pids, java.time.Duration timeout) {
     List<CompletableFuture<ProcessHandle>> exitFutures =
         pids.stream()
             .map(ProcessHandle::of)
@@ -608,7 +629,7 @@ public class LauncherController {
     CompletableFuture<Void> allExited =
         CompletableFuture.allOf(exitFutures.toArray(CompletableFuture[]::new));
     try {
-      allExited.get(timeoutSeconds, TimeUnit.SECONDS);
+      allExited.get(timeout.toNanos(), TimeUnit.NANOSECONDS);
       return true;
     } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
@@ -703,7 +724,7 @@ public class LauncherController {
       }
 
       try {
-        TimeUnit.MILLISECONDS.sleep(READINESS_POLL_MS);
+        TimeUnit.MILLISECONDS.sleep(timing.readinessPollMs());
       } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
         return;
@@ -1052,7 +1073,7 @@ public class LauncherController {
       }
       emitLog(
           ts() + " Requested graceful shutdown via anchor: " + anchorPath.getFileName() + " ...");
-      return waitForPidsToExit(pids, 25);
+      return waitForPidsToExit(pids, timing.windowsAnchorTimeout());
     } catch (Exception e) {
       emitLog(
           ts() + " WARN: Failed to delete anchor file at " + anchorPath + ": " + e.getMessage());
@@ -1126,7 +1147,7 @@ public class LauncherController {
       return;
     }
     try {
-      tailer.join(TAIL_MAX_DELAY_MS + TAIL_BASE_DELAY_MS);
+      tailer.join(timing.tailMaxDelayMs() + timing.tailBaseDelayMs());
     } catch (InterruptedException _) {
       Thread.currentThread().interrupt();
     }
@@ -1173,7 +1194,7 @@ public class LauncherController {
       if (worker.isInterrupted()) {
         return false;
       }
-      long chunk = Math.min(remaining, TAIL_CANCEL_POLL_MS);
+      long chunk = Math.min(remaining, timing.tailCancelPollMs());
       try {
         Thread.sleep(chunk);
       } catch (InterruptedException _) {
@@ -1187,8 +1208,8 @@ public class LauncherController {
 
   private long calcTailDelayMs(int idleCount) {
     int shifts = Math.min(idleCount, 3);
-    long delay = TAIL_BASE_DELAY_MS << shifts;
-    return Math.min(delay, TAIL_MAX_DELAY_MS);
+    long delay = timing.tailBaseDelayMs() << shifts;
+    return Math.min(delay, timing.tailMaxDelayMs());
   }
 
   private void resetTailOnError(TailState state) {
@@ -1470,6 +1491,29 @@ public class LauncherController {
       } catch (Exception e) {
         logDebug("Log listener failed", e);
       }
+    }
+  }
+
+  static record TimingConfig(
+      long tailBaseDelayMs,
+      long tailMaxDelayMs,
+      long tailCancelPollMs,
+      long readinessPollMs,
+      java.time.Duration windowsAnchorTimeout,
+      java.time.Duration unixInterruptTimeout,
+      java.time.Duration unixTerminateTimeout,
+      java.time.Duration forceKillTimeout) {
+    TimingConfig {
+      if (tailBaseDelayMs <= 0
+          || tailMaxDelayMs <= 0
+          || tailCancelPollMs <= 0
+          || readinessPollMs <= 0) {
+        throw new IllegalArgumentException("tail/readiness timing values must be positive");
+      }
+      Objects.requireNonNull(windowsAnchorTimeout, "windowsAnchorTimeout");
+      Objects.requireNonNull(unixInterruptTimeout, "unixInterruptTimeout");
+      Objects.requireNonNull(unixTerminateTimeout, "unixTerminateTimeout");
+      Objects.requireNonNull(forceKillTimeout, "forceKillTimeout");
     }
   }
 

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRequest.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRequest.java
@@ -53,6 +53,11 @@ public record PlatformApiRequest(
     return queryParameters.getOrDefault(name, List.of());
   }
 
+  @Override
+  public Map<String, List<String>> queryParameters() {
+    return immutableQueryParameters(this.queryParameters);
+  }
+
   /**
    * Copies query parameters into an immutable encounter-order-preserving map.
    *

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
@@ -78,6 +78,11 @@ public record PlatformApiResponse(
     return json(statusCode, headers, errorBody);
   }
 
+  @Override
+  public Map<String, String> headers() {
+    return immutableHeaders(this.headers);
+  }
+
   /**
    * Returns the standard reason phrase for one HTTP-style status code.
    *

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
@@ -134,7 +134,7 @@ public record InstalledAppPaths(
    */
   @SuppressWarnings("unused")
   public void ensureInstallParentDirectory() throws IOException {
-    Files.createDirectories(installedRoot.getParent());
+    Files.createDirectories(parentOrThrow(installedRoot, "installedRoot"));
   }
 
   /**
@@ -207,5 +207,13 @@ public record InstalledAppPaths(
     Path expectedRealPath = parent.toRealPath().resolve(entry.getFileName()).normalize();
     Path actualRealPath = entry.toRealPath();
     return !actualRealPath.equals(expectedRealPath);
+  }
+
+  private static Path parentOrThrow(Path path, String label) throws AppHostException {
+    Path parent = path.getParent();
+    if (parent == null) {
+      throw new AppHostException(label + " must not be a filesystem root: " + path);
+    }
+    return parent;
   }
 }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -74,17 +74,16 @@ public final class LocalProcessAppHost implements AppHost {
   private static final int COFF_HEADER_SIZE = 24;
   private static final int IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002;
   private static final int IMAGE_FILE_DLL = 0x2000;
-  private static final Duration STARTUP_EXIT_GRACE_PERIOD = Duration.ofSeconds(2);
-  private static final Duration STARTUP_PROCESS_CAPTURE_WINDOW = Duration.ofMillis(500);
-  private static final Duration STARTUP_POST_CAPTURE_HANDOFF_GRACE_PERIOD = Duration.ofMillis(200);
-  private static final Duration TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD =
-      Duration.ofMillis(200);
-  private static final Duration WINDOWS_BUNDLE_RECOVERY_WINDOW =
-      STARTUP_EXIT_GRACE_PERIOD.plus(TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD);
-  private static final Duration TRACKED_PROCESS_REFRESH_INTERVAL = Duration.ofMillis(100);
-  private static final long STARTUP_PROCESS_POLL_INTERVAL_NANOS =
-      TimeUnit.MICROSECONDS.toNanos(100);
-  private static final long STARTUP_HANDOFF_POLL_INTERVAL_NANOS = TimeUnit.MILLISECONDS.toNanos(5);
+  static final TimingConfig DEFAULT_TIMING =
+      new TimingConfig(
+          Duration.ofSeconds(2),
+          Duration.ofMillis(500),
+          Duration.ofMillis(200),
+          Duration.ofMillis(200),
+          Duration.ofMillis(100),
+          Duration.ofNanos(TimeUnit.MICROSECONDS.toNanos(100)),
+          Duration.ofMillis(5),
+          Duration.ofMillis(100));
   private static final List<String> BASE_UNIX_PATH_ENTRIES =
       List.of(
           Path.of("/usr", "bin").toString(),
@@ -109,6 +108,7 @@ public final class LocalProcessAppHost implements AppHost {
   private final Duration stopTimeout;
   private final SecureRandom secureRandom;
   private final AppEnv appEnv;
+  private final TimingConfig timing;
   private final Map<String, RunningProcess> runningApps = new ConcurrentHashMap<>();
 
   /**
@@ -137,15 +137,25 @@ public final class LocalProcessAppHost implements AppHost {
    */
   public LocalProcessAppHost(
       AppHostLayout layout, Duration stopTimeout, SecureRandom secureRandom) {
-    this(layout, stopTimeout, secureRandom, new AppEnv());
+    this(layout, stopTimeout, secureRandom, new AppEnv(), DEFAULT_TIMING);
   }
 
   LocalProcessAppHost(
       AppHostLayout layout, Duration stopTimeout, SecureRandom secureRandom, AppEnv appEnv) {
+    this(layout, stopTimeout, secureRandom, appEnv, DEFAULT_TIMING);
+  }
+
+  LocalProcessAppHost(
+      AppHostLayout layout,
+      Duration stopTimeout,
+      SecureRandom secureRandom,
+      AppEnv appEnv,
+      TimingConfig timing) {
     this.layout = Objects.requireNonNull(layout, "layout");
     this.stopTimeout = Objects.requireNonNull(stopTimeout, "stopTimeout");
     this.secureRandom = Objects.requireNonNull(secureRandom, "secureRandom");
     this.appEnv = Objects.requireNonNull(appEnv, "appEnv");
+    this.timing = Objects.requireNonNull(timing, "timing");
     if (stopTimeout.isZero() || stopTimeout.isNegative()) {
       throw new IllegalArgumentException("stopTimeout must be positive");
     }
@@ -305,7 +315,7 @@ public final class LocalProcessAppHost implements AppHost {
     }
 
     String token = generateToken();
-    List<String> command = launchCommand(executable, appEnv);
+    List<String> command = launchCommand(executable);
     ProcessBuilder builder = new ProcessBuilder(command);
     builder.directory(paths.installedRoot().toFile());
     builder.redirectErrorStream(true);
@@ -428,10 +438,10 @@ public final class LocalProcessAppHost implements AppHost {
         resolveBundleEntry(
             installedRoot, Path.of(AppManifestParser.MANIFEST_FILE_NAME), "installed manifest");
     AppManifest manifest = AppManifestParser.parse(manifestFile);
-    if (!installedRoot.getFileName().toString().equals(manifest.appId())) {
+    String installedDirectoryName = fileNameOrThrow(installedRoot, "installed manifest root");
+    if (!installedDirectoryName.equals(manifest.appId())) {
       throw new AppManifestException(
-          "installed manifest app.id does not match directory name: "
-              + installedRoot.getFileName());
+          "installed manifest app.id does not match directory name: " + installedDirectoryName);
     }
     return manifest;
   }
@@ -619,8 +629,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static boolean isTemporaryInstallDirectory(Path appRoot) {
-    Path fileName = appRoot.getFileName();
-    return fileName != null && fileName.toString().startsWith(TEMP_INSTALL_PREFIX);
+    return fileNameText(appRoot).startsWith(TEMP_INSTALL_PREFIX);
   }
 
   private static Path comparablePath(Path path) throws IOException {
@@ -674,9 +683,10 @@ public final class LocalProcessAppHost implements AppHost {
       throws AppHostException {
     ProcessHandle rootHandle = process.toHandle();
     List<ProcessHandle> observedHandles = new ArrayList<>();
-    long deadline = System.nanoTime() + STARTUP_EXIT_GRACE_PERIOD.toNanos();
-    long captureDeadline = System.nanoTime() + STARTUP_PROCESS_CAPTURE_WINDOW.toNanos();
-    long handoffDeadline = captureDeadline + STARTUP_POST_CAPTURE_HANDOFF_GRACE_PERIOD.toNanos();
+    long deadline = System.nanoTime() + timing.startupExitGracePeriod().toNanos();
+    long captureDeadline = System.nanoTime() + timing.startupProcessCaptureWindow().toNanos();
+    long handoffDeadline =
+        captureDeadline + timing.startupPostCaptureHandoffGracePeriod().toNanos();
     while (System.nanoTime() < deadline) {
       observedHandles.addAll(snapshotProcessTree(startupSeedHandles(rootHandle, observedHandles)));
       long now = System.nanoTime();
@@ -704,8 +714,8 @@ public final class LocalProcessAppHost implements AppHost {
     }
     long pollIntervalNanos =
         now >= captureDeadline
-            ? STARTUP_HANDOFF_POLL_INTERVAL_NANOS
-            : STARTUP_PROCESS_POLL_INTERVAL_NANOS;
+            ? timing.startupHandoffPollInterval().toNanos()
+            : timing.startupProcessPollInterval().toNanos();
     waitForProcess(process, Math.min(remainingNanos, pollIntervalNanos), appId);
   }
 
@@ -762,7 +772,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private void observeTrackedProcessTreeUntilExit(String appId, Process process) {
-    long startupTrackingDeadline = System.nanoTime() + STARTUP_EXIT_GRACE_PERIOD.toNanos();
+    long startupTrackingDeadline = System.nanoTime() + timing.startupExitGracePeriod().toNanos();
     try {
       while (true) {
         refreshObservedProcessTree(appId, process);
@@ -783,10 +793,10 @@ public final class LocalProcessAppHost implements AppHost {
 
   private void capturePostExitProcessTreeHandoff(String appId, Process process)
       throws InterruptedException {
-    long deadline = System.nanoTime() + TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD.toNanos();
+    long deadline = System.nanoTime() + timing.trackedProcessPostExitCaptureGracePeriod().toNanos();
     while (System.nanoTime() < deadline) {
       refreshObservedProcessTree(appId, process);
-      TimeUnit.NANOSECONDS.sleep(STARTUP_PROCESS_POLL_INTERVAL_NANOS);
+      TimeUnit.NANOSECONDS.sleep(timing.startupProcessPollInterval().toNanos());
     }
   }
 
@@ -796,11 +806,11 @@ public final class LocalProcessAppHost implements AppHost {
     if (rootHandle.isAlive()) {
       return;
     }
-    long deadline = System.nanoTime() + TRACKED_PROCESS_POST_EXIT_CAPTURE_GRACE_PERIOD.toNanos();
+    long deadline = System.nanoTime() + timing.trackedProcessPostExitCaptureGracePeriod().toNanos();
     while (System.nanoTime() < deadline) {
       observedHandles.addAll(snapshotProcessTree(startupSeedHandles(rootHandle, observedHandles)));
       try {
-        TimeUnit.NANOSECONDS.sleep(STARTUP_PROCESS_POLL_INTERVAL_NANOS);
+        TimeUnit.NANOSECONDS.sleep(timing.startupProcessPollInterval().toNanos());
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new AppHostException("interrupted while starting app: " + appId, e);
@@ -816,11 +826,11 @@ public final class LocalProcessAppHost implements AppHost {
     return seedHandles;
   }
 
-  private static long trackedProcessRefreshIntervalNanos(long startupTrackingDeadline) {
+  private long trackedProcessRefreshIntervalNanos(long startupTrackingDeadline) {
     if (System.nanoTime() < startupTrackingDeadline) {
-      return STARTUP_PROCESS_POLL_INTERVAL_NANOS;
+      return timing.startupProcessPollInterval().toNanos();
     }
-    return TRACKED_PROCESS_REFRESH_INTERVAL.toNanos();
+    return timing.trackedProcessRefreshInterval().toNanos();
   }
 
   private void refreshObservedProcessTree(String appId, Process process) {
@@ -885,6 +895,15 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   static List<String> launchCommand(Path executable, AppEnv appEnv) throws IOException {
+    return launchCommand(executable, appEnv, DEFAULT_TIMING);
+  }
+
+  private List<String> launchCommand(Path executable) throws IOException {
+    return launchCommand(executable, appEnv, timing);
+  }
+
+  private static List<String> launchCommand(Path executable, AppEnv appEnv, TimingConfig timing)
+      throws IOException {
     String executableText = executable.toString();
     if (appEnv.isWindows() && isWindowsBatchScript(executable)) {
       return List.of(
@@ -893,22 +912,19 @@ public final class LocalProcessAppHost implements AppHost {
     if (!appEnv.isWindows()) {
       PosixLauncher posixLauncher = classifyPosixLauncher(executable);
       if (posixLauncher != null) {
-        return posixLauncher.command(executable);
+        return posixLauncher.command(executable, timing);
       }
     }
     return List.of(executableText);
   }
 
-  private static List<String> posixShellLaunchCommand(Path executable, List<String> interpreter) {
+  private static List<String> posixShellLaunchCommand(
+      Path executable, List<String> interpreter, TimingConfig timing) {
     List<String> command = new ArrayList<>(interpreter);
     command.add("-c");
     command.add(
-        """
-        trap 'sleep %s' EXIT
-        set --
-        . "$0"
-        """
-            .formatted(posixShellExitTrapDelaySeconds()));
+        "trap 'sleep %s' EXIT%nset --%n. \"$0\"%n"
+            .formatted(posixShellExitTrapDelaySeconds(timing)));
     command.add(executable.toString());
     return List.copyOf(command);
   }
@@ -921,7 +937,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static boolean isWindowsBatchScript(Path executable) {
-    String fileName = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+    String fileName = fileNameLowercase(executable);
     return fileName.endsWith(".cmd") || fileName.endsWith(".bat");
   }
 
@@ -932,7 +948,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static boolean hasWindowsComExecutableSuffix(Path executable) {
-    String fileName = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+    String fileName = fileNameLowercase(executable);
     return fileName.endsWith(".com");
   }
 
@@ -980,7 +996,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static boolean hasPosixShellScriptSuffix(Path executable) {
-    String fileName = executable.getFileName().toString().toLowerCase(Locale.ROOT);
+    String fileName = fileNameLowercase(executable);
     return fileName.endsWith(".sh");
   }
 
@@ -1085,6 +1101,23 @@ public final class LocalProcessAppHost implements AppHost {
     return fileName.toString().toLowerCase(Locale.ROOT);
   }
 
+  private static String fileNameLowercase(Path path) {
+    return fileNameText(path).toLowerCase(Locale.ROOT);
+  }
+
+  private static String fileNameText(Path path) {
+    Path fileName = path.getFileName();
+    return fileName == null ? "" : fileName.toString();
+  }
+
+  private static String fileNameOrThrow(Path path, String label) throws AppHostException {
+    String fileName = fileNameText(path);
+    if (fileName.isEmpty()) {
+      throw new AppHostException(label + " must not be a filesystem root: " + path);
+    }
+    return fileName;
+  }
+
   private static int firstWhitespaceOffset(String text) {
     for (int i = 0; i < text.length(); i++) {
       if (Character.isWhitespace(text.charAt(i))) {
@@ -1098,8 +1131,9 @@ public final class LocalProcessAppHost implements AppHost {
     return Path.of("/bin", "sh").toString();
   }
 
-  private static String posixShellExitTrapDelaySeconds() {
-    return String.format(Locale.ROOT, "%.3f", STARTUP_PROCESS_CAPTURE_WINDOW.toMillis() / 1000.0d);
+  private static String posixShellExitTrapDelaySeconds(TimingConfig timing) {
+    return String.format(
+        Locale.ROOT, "%.3f", timing.startupProcessCaptureWindow().toMillis() / 1000.0d);
   }
 
   private static String windowsCommandInterpreter() {
@@ -1337,7 +1371,9 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private Duration descendantReapGracePeriod() {
-    return stopTimeout.compareTo(Duration.ofMillis(100)) > 0 ? Duration.ofMillis(100) : stopTimeout;
+    return stopTimeout.compareTo(timing.descendantReapGracePeriodLimit()) > 0
+        ? timing.descendantReapGracePeriodLimit()
+        : stopTimeout;
   }
 
   private static boolean destroyDescendantsAndWaitForExit(
@@ -1464,7 +1500,12 @@ public final class LocalProcessAppHost implements AppHost {
     if (recoveredHandles.isEmpty() && appEnv.isWindows()) {
       recoveredHandles.addAll(
           recoverWindowsBundleProcesses(
-              paths, manifest, startedAt, trackedHandles, processCandidates));
+              paths,
+              manifest,
+              startedAt,
+              trackedHandles,
+              processCandidates,
+              timing.windowsBundleRecoveryWindow()));
     }
     return deduplicateHandles(recoveredHandles);
   }
@@ -1510,6 +1551,22 @@ public final class LocalProcessAppHost implements AppHost {
       Instant startedAt,
       List<ProcessHandle> trackedHandles,
       List<ProcessHandle> processCandidates) {
+    return recoverWindowsBundleProcesses(
+        paths,
+        manifest,
+        startedAt,
+        trackedHandles,
+        processCandidates,
+        DEFAULT_TIMING.windowsBundleRecoveryWindow());
+  }
+
+  private static List<ProcessHandle> recoverWindowsBundleProcesses(
+      InstalledAppPaths paths,
+      AppManifest manifest,
+      Instant startedAt,
+      List<ProcessHandle> trackedHandles,
+      List<ProcessHandle> processCandidates,
+      Duration windowsBundleRecoveryWindow) {
     Path installedRoot = paths.installedRoot().toAbsolutePath().normalize();
     Path executablePath = paths.executablePath(manifest).toAbsolutePath().normalize();
     List<Long> trackedPids =
@@ -1520,7 +1577,8 @@ public final class LocalProcessAppHost implements AppHost {
             .filter(processHandle -> !trackedPids.contains(processHandle.pid()))
             .filter(
                 processHandle ->
-                    startedWithinWindowsRecoveryWindow(processHandle, startedAt)
+                    startedWithinWindowsRecoveryWindow(
+                            processHandle, startedAt, windowsBundleRecoveryWindow)
                         && referencesInstalledBundle(processHandle, installedRoot, executablePath))
             .sorted(Comparator.comparingLong(ProcessHandle::pid))
             .toList());
@@ -1650,14 +1708,14 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private static boolean startedWithinWindowsRecoveryWindow(
-      ProcessHandle processHandle, Instant startedAt) {
+      ProcessHandle processHandle, Instant startedAt, Duration windowsBundleRecoveryWindow) {
     return processHandle
         .info()
         .startInstant()
         .map(
             candidateStartedAt ->
                 !candidateStartedAt.isBefore(startedAt.minusSeconds(1))
-                    && !candidateStartedAt.isAfter(startedAt.plus(WINDOWS_BUNDLE_RECOVERY_WINDOW)))
+                    && !candidateStartedAt.isAfter(startedAt.plus(windowsBundleRecoveryWindow)))
         .orElse(false);
   }
 
@@ -1775,10 +1833,37 @@ public final class LocalProcessAppHost implements AppHost {
       interpreter = List.copyOf(interpreter);
     }
 
-    private List<String> command(Path executable) {
+    private List<String> command(Path executable, TimingConfig timing) {
       return shellInterpreter
-          ? posixShellLaunchCommand(executable, interpreter)
+          ? posixShellLaunchCommand(executable, interpreter, timing)
           : directInterpreterLaunchCommand(executable, interpreter);
+    }
+  }
+
+  static record TimingConfig(
+      Duration startupExitGracePeriod,
+      Duration startupProcessCaptureWindow,
+      Duration startupPostCaptureHandoffGracePeriod,
+      Duration trackedProcessPostExitCaptureGracePeriod,
+      Duration trackedProcessRefreshInterval,
+      Duration startupProcessPollInterval,
+      Duration startupHandoffPollInterval,
+      Duration descendantReapGracePeriodLimit) {
+    TimingConfig {
+      Objects.requireNonNull(startupExitGracePeriod, "startupExitGracePeriod");
+      Objects.requireNonNull(startupProcessCaptureWindow, "startupProcessCaptureWindow");
+      Objects.requireNonNull(
+          startupPostCaptureHandoffGracePeriod, "startupPostCaptureHandoffGracePeriod");
+      Objects.requireNonNull(
+          trackedProcessPostExitCaptureGracePeriod, "trackedProcessPostExitCaptureGracePeriod");
+      Objects.requireNonNull(trackedProcessRefreshInterval, "trackedProcessRefreshInterval");
+      Objects.requireNonNull(startupProcessPollInterval, "startupProcessPollInterval");
+      Objects.requireNonNull(startupHandoffPollInterval, "startupHandoffPollInterval");
+      Objects.requireNonNull(descendantReapGracePeriodLimit, "descendantReapGracePeriodLimit");
+    }
+
+    private Duration windowsBundleRecoveryWindow() {
+      return startupExitGracePeriod.plus(trackedProcessPostExitCaptureGracePeriod);
     }
   }
 

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/AppHostBoundaryTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/AppHostBoundaryTest.java
@@ -93,11 +93,11 @@ class AppHostBoundaryTest {
         ":platform-apphost main Java tree must exist");
 
     for (Path sourceFile : findJavaSources(mainJava)) {
-      String fileName = sourceFile.getFileName().toString();
+      String fileName = fileNameOrThrow(sourceFile);
       if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
         continue;
       }
-      productionPackages.add(sourceFile.getParent());
+      productionPackages.add(parentOrThrow(sourceFile));
     }
 
     for (Path packagePath : productionPackages) {
@@ -124,7 +124,7 @@ class AppHostBoundaryTest {
   }
 
   private static boolean isTrackedJavaSource(Path path) {
-    String fileName = path.getFileName().toString();
+    String fileName = fileNameOrThrow(path);
     return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
@@ -138,6 +138,18 @@ class AppHostBoundaryTest {
           .filter(AppHostBoundaryTest::isForbiddenImport)
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
   }
 
   private static String extractImportTarget(String line) {

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/InstalledAppPathsTest.java
@@ -78,7 +78,7 @@ class InstalledAppPathsTest {
   @Test
   void ensureMutableDirectories_whenManagedDirectoryIsFile_expectFailure() throws Exception {
     InstalledAppPaths paths = paths();
-    Files.createDirectories(paths.dataDir().getParent());
+    Files.createDirectories(parentOrThrow(paths.dataDir()));
     Files.writeString(paths.dataDir(), "not-a-directory");
 
     AppHostException exception =
@@ -93,7 +93,7 @@ class InstalledAppPathsTest {
     InstalledAppPaths paths = paths();
     Path targetDirectory = tempDir.resolve("symlink-target");
     Files.createDirectories(targetDirectory);
-    Files.createDirectories(paths.runDir().getParent());
+    Files.createDirectories(parentOrThrow(paths.runDir()));
     Files.createSymbolicLink(paths.runDir(), targetDirectory);
 
     AppHostException exception =
@@ -111,5 +111,11 @@ class InstalledAppPathsTest {
         tempDir.resolve("data").resolve(SAMPLE_APP_ID),
         tempDir.resolve("cache").resolve(SAMPLE_APP_ID),
         tempDir.resolve("run").resolve(SAMPLE_APP_ID));
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertTrue(parent != null, "Expected parent for path " + path);
+    return parent;
   }
 }

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -85,6 +85,33 @@ class LocalProcessAppHostTest {
   private static final String STANDARD_PERMISSIONS_TEXT =
       NETWORK_ACCESS_PERMISSION + "," + FILE_READ_PERMISSION;
   private static final long POLL_INTERVAL_NANOS = Duration.ofMillis(10).toNanos();
+  private static final LocalProcessAppHost.TimingConfig TEST_TIMING =
+      new LocalProcessAppHost.TimingConfig(
+          Duration.ofMillis(300),
+          Duration.ofMillis(80),
+          Duration.ofMillis(40),
+          Duration.ofMillis(40),
+          Duration.ofMillis(20),
+          Duration.ofMillis(1),
+          Duration.ofMillis(2),
+          Duration.ofMillis(20));
+  private static final Duration TEST_LOOP_SLEEP = Duration.ofMillis(50);
+  private static final Duration TEST_DELAYED_WRAPPER_EXIT = Duration.ofMillis(120);
+  private static final Duration TEST_POST_CAPTURE_DELAY =
+      TEST_TIMING.startupProcessCaptureWindow().plusMillis(10);
+  private static final Duration TEST_LATE_CHILD_DELAY =
+      TEST_TIMING.startupExitGracePeriod().plusMillis(25);
+  private static final Duration TEST_POST_SPAWN_EXIT_DELAY = Duration.ofMillis(40);
+  private static final Duration TEST_SHORT_EXIT_DELAY = Duration.ofMillis(50);
+  private static final String TEST_LOOP_SLEEP_SECONDS = secondsLiteral(TEST_LOOP_SLEEP);
+  private static final String TEST_DELAYED_WRAPPER_EXIT_SECONDS =
+      secondsLiteral(TEST_DELAYED_WRAPPER_EXIT);
+  private static final String TEST_POST_CAPTURE_DELAY_SECONDS =
+      secondsLiteral(TEST_POST_CAPTURE_DELAY);
+  private static final String TEST_LATE_CHILD_DELAY_SECONDS = secondsLiteral(TEST_LATE_CHILD_DELAY);
+  private static final String TEST_POST_SPAWN_EXIT_DELAY_SECONDS =
+      secondsLiteral(TEST_POST_SPAWN_EXIT_DELAY);
+  private static final String TEST_SHORT_EXIT_DELAY_SECONDS = secondsLiteral(TEST_SHORT_EXIT_DELAY);
   private static final String LATE_CHILD_APP_ID = "late-child-app";
   private static final String SHELL_NOEXEC_APP_ID = "shell-noexec-app";
   private static final String WRAPPER_SCRIPT =
@@ -102,26 +129,29 @@ class LocalProcessAppHostTest {
       #!/bin/sh
       trap '' TERM INT
       while :; do
-        sleep 1
+        sleep %s
       done
-      """;
+      """
+          .formatted(TEST_LOOP_SLEEP_SECONDS);
   private static final String DAEMONIZED_CHILD_PROCESS_SCRIPT =
       """
       #!/bin/sh
       trap 'exit 0' TERM INT
       while :; do
-        sleep 1
+        sleep %s
       done
-      """;
+      """
+          .formatted(TEST_LOOP_SLEEP_SECONDS);
   private static final String DETACHED_CHILD_PROCESS_SCRIPT =
       """
       #!/bin/sh
       trap '' HUP
       trap 'exit 0' TERM INT
       while :; do
-        sleep 1
+        sleep %s
       done
-      """;
+      """
+          .formatted(TEST_LOOP_SLEEP_SECONDS);
   private static final String DAEMONIZING_WRAPPER_IMMEDIATE_EXIT_SCRIPT =
       """
       #!/bin/sh
@@ -140,22 +170,22 @@ class LocalProcessAppHostTest {
       ./%s &
       child=$!
       echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
-      sleep 1
+      sleep %s
       echo exited > "$CRYPTAD_APP_RUN_DIR/wrapper-exited.txt"
       exit 0
       """
-          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME, TEST_DELAYED_WRAPPER_EXIT_SECONDS);
   private static final String DAEMONIZING_WRAPPER_POST_CAPTURE_EXIT_SCRIPT =
       """
       #!/bin/sh
       set -eu
-      sleep 0.53
+      sleep %s
       ./%s &
       child=$!
       echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       exit 0
       """
-          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
+          .formatted(TEST_POST_CAPTURE_DELAY_SECONDS, CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String DAEMONIZING_WRAPPER_VIA_HELPER_SCRIPT =
       """
       #!/bin/sh
@@ -167,13 +197,13 @@ class LocalProcessAppHostTest {
       """
       #!/bin/sh
       set -eu
-      sleep 0.25
+      sleep %s
       ./%s &
       child=$!
       echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
       exit 0
       """
-          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
+          .formatted(TEST_POST_CAPTURE_DELAY_SECONDS, CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
   private static final String POST_CAPTURE_PYTHON_DAEMONIZER =
       """
       #!/usr/bin/env %s
@@ -182,25 +212,33 @@ class LocalProcessAppHostTest {
       import subprocess
       import time
 
-      time.sleep(0.53)
+      time.sleep(%s)
       child = subprocess.Popen(["./%s"])
       pathlib.Path(os.environ["CRYPTAD_APP_RUN_DIR"], "%s").write_text(
           f"{child.pid}\\n", encoding="utf-8")
       """
-          .formatted(PYTHON3_COMMAND, CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
+          .formatted(
+              PYTHON3_COMMAND,
+              TEST_POST_CAPTURE_DELAY_SECONDS,
+              CHILD_SCRIPT_PATH,
+              CHILD_PID_FILE_NAME);
   private static final String LATE_CHILD_DIRECT_EXECUTABLE =
       """
       #!/bin/sh
       set -eu
-      sleep 1
+      sleep %s
       ./%s &
       child=$!
       echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
-      sleep 0.2
+      sleep %s
       echo exited > "$CRYPTAD_APP_RUN_DIR/wrapper-exited.txt"
       exit 0
       """
-          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
+          .formatted(
+              TEST_LATE_CHILD_DELAY_SECONDS,
+              CHILD_SCRIPT_PATH,
+              CHILD_PID_FILE_NAME,
+              TEST_POST_SPAWN_EXIT_DELAY_SECONDS);
   private static final String STDIN_EOF_SCRIPT =
       """
       #!/bin/sh
@@ -208,9 +246,10 @@ class LocalProcessAppHostTest {
       cat >/dev/null
       echo closed > "$CRYPTAD_APP_RUN_DIR/stdin-closed.txt"
       while :; do
-        sleep 1
+        sleep %s
       done
-      """;
+      """
+          .formatted(TEST_LOOP_SLEEP_SECONDS);
   private static final String SINGLE_RUN_EXIT_SCRIPT =
       """
       #!/bin/sh
@@ -227,9 +266,10 @@ class LocalProcessAppHostTest {
       """
       #!/bin/sh
       set -eu
-      sleep 0.1
+      sleep %s
       exit 0
-      """;
+      """
+          .formatted(TEST_SHORT_EXIT_DELAY_SECONDS);
 
   @TempDir private Path tempDir;
 
@@ -533,9 +573,10 @@ class LocalProcessAppHostTest {
         #!/bin/sh
         printf 'escaped' > "$CRYPTAD_APP_RUN_DIR/escaped.txt"
         while :; do
-          sleep 1
+          sleep %s
         done
-        """,
+        """
+            .formatted(TEST_LOOP_SLEEP_SECONDS),
         appEnv);
     Path installedBin = installation.paths().installedRoot().resolve("bin");
     Path relocatedInstalledBin = installation.paths().installedRoot().resolve("bin-original");
@@ -1187,11 +1228,12 @@ class LocalProcessAppHostTest {
                 set -euo pipefail
                 [[ $# -eq 0 ]]
                 letters=(alpha beta)
-                printf '%s' "${letters[0]}" > "$CRYPTAD_APP_RUN_DIR/shebang-ok.txt"
+                printf '%%s' "${letters[0]}" > "$CRYPTAD_APP_RUN_DIR/shebang-ok.txt"
                 while :; do
-                  sleep 1
+                  sleep %s
                 done
-                """));
+                """
+                    .formatted(TEST_LOOP_SLEEP_SECONDS)));
 
     host.start(RUNNER_APP_ID);
 
@@ -1215,11 +1257,12 @@ class LocalProcessAppHostTest {
                 """
                 #!/bin/sh
                 set -eu
-                printf '%s' "ok" > "$CRYPTAD_APP_RUN_DIR/noexec-ok.txt"
+                printf '%%s' "ok" > "$CRYPTAD_APP_RUN_DIR/noexec-ok.txt"
                 while :; do
-                  sleep 1
+                  sleep %s
                 done
-                """,
+                """
+                    .formatted(TEST_LOOP_SLEEP_SECONDS),
                 Map.of(),
                 false));
 
@@ -1560,7 +1603,8 @@ class LocalProcessAppHostTest {
             tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run")),
         stopTimeout,
         new java.security.SecureRandom(),
-        appEnv);
+        appEnv,
+        TEST_TIMING);
   }
 
   private Path stageInstalledApp(String appId) throws IOException {
@@ -1749,20 +1793,36 @@ class LocalProcessAppHostTest {
   }
 
   private static void writeStageFile(Path file, String content, AppEnv appEnv) throws IOException {
-    Files.createDirectories(file.getParent());
+    Files.createDirectories(parentOrThrow(file));
     Files.writeString(file, content, StandardCharsets.UTF_8);
-    if (!appEnv.isWindows() && file.getFileName().toString().endsWith(".sh")) {
+    if (!appEnv.isWindows() && fileNameOrThrow(file).endsWith(".sh")) {
       assertTrue(file.toFile().setExecutable(true, false));
     }
   }
 
   private static void writeExecutableStageFile(
       Path file, String content, AppEnv appEnv, boolean executable) throws IOException {
-    Files.createDirectories(file.getParent());
+    Files.createDirectories(parentOrThrow(file));
     Files.writeString(file, content, StandardCharsets.UTF_8);
     if (!appEnv.isWindows()) {
       assertTrue(file.toFile().setExecutable(executable, false));
     }
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    if (parent == null) {
+      throw new AssertionError("Expected parent for path " + path);
+    }
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    if (fileName == null) {
+      throw new AssertionError("Expected file name for path " + path);
+    }
+    return fileName.toString();
   }
 
   private static String displayName(String appId) {
@@ -1794,9 +1854,14 @@ class LocalProcessAppHostTest {
     set -eu
     env > "$CRYPTAD_APP_RUN_DIR/captured-env.txt"
     while :; do
-      sleep 1
+      sleep %s
     done
-    """;
+    """
+        .formatted(TEST_LOOP_SLEEP_SECONDS);
+  }
+
+  private static String secondsLiteral(Duration duration) {
+    return String.format(java.util.Locale.ROOT, "%.3f", duration.toNanos() / 1_000_000_000.0d);
   }
 
   private static String immediateExitScriptContent(AppEnv appEnv) {
@@ -2181,6 +2246,16 @@ class LocalProcessAppHostTest {
       public int compareTo(ProcessHandle other) {
         return Long.compare(pid, other.pid());
       }
+
+      @Override
+      public boolean equals(Object other) {
+        return other instanceof ProcessHandle handle && pid == handle.pid();
+      }
+
+      @Override
+      public int hashCode() {
+        return Long.hashCode(pid);
+      }
     }
   }
 
@@ -2329,6 +2404,16 @@ class LocalProcessAppHostTest {
     @Override
     public int compareTo(ProcessHandle other) {
       return Long.compare(pid, other.pid());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof ProcessHandle handle && pid == handle.pid();
+    }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(pid);
     }
   }
 
@@ -2648,6 +2733,16 @@ class LocalProcessAppHostTest {
     public int compareTo(ProcessHandle other) {
       return Long.compare(pid, other.pid());
     }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof ProcessHandle handle && pid == handle.pid();
+    }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(pid);
+    }
   }
 
   private static final class InfoProcessHandle implements ProcessHandle {
@@ -2757,6 +2852,16 @@ class LocalProcessAppHostTest {
     public int compareTo(ProcessHandle other) {
       return Long.compare(pid, other.pid());
     }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof ProcessHandle handle && pid == handle.pid();
+    }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(pid);
+    }
   }
 
   @SuppressWarnings("ClassCanBeRecord")
@@ -2853,6 +2958,16 @@ class LocalProcessAppHostTest {
     @Override
     public int compareTo(ProcessHandle other) {
       return Long.compare(pid, other.pid());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof ProcessHandle handle && pid == handle.pid();
+    }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(pid);
     }
   }
 

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBoundaryTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBoundaryTest.java
@@ -91,11 +91,11 @@ class WebShellBoundaryTest {
         ":platform-web-shell main Java tree must exist");
 
     for (Path sourceFile : findJavaSources(mainJava)) {
-      String fileName = sourceFile.getFileName().toString();
+      String fileName = fileNameOrThrow(sourceFile);
       if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
         continue;
       }
-      productionPackages.add(sourceFile.getParent());
+      productionPackages.add(parentOrThrow(sourceFile));
     }
 
     for (Path packagePath : productionPackages) {
@@ -115,7 +115,7 @@ class WebShellBoundaryTest {
   }
 
   private static boolean isTrackedJavaSource(Path path) {
-    String fileName = path.getFileName().toString();
+    String fileName = fileNameOrThrow(path);
     return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
@@ -129,6 +129,18 @@ class WebShellBoundaryTest {
           .filter(WebShellBoundaryTest::isForbiddenImport)
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
   }
 
   private static String extractImportTarget(String line) {

--- a/runtime-node/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/USKInserter.java
@@ -170,7 +170,7 @@ public final class USKInserter
   private String externalRequestIdentifierSnapshot;
 
   /** Active datehint insert phase; null when not currently inserting datehints. */
-  private transient DateHintPhase activeDateHintPhase;
+  private transient volatile DateHintPhase activeDateHintPhase;
 
   /** Monotonic identifier for datehint phases; helps ignore stale callbacks. */
   private transient long nextDateHintPhaseId = 1;
@@ -700,6 +700,13 @@ public final class USKInserter
 
   private synchronized long reserveDateHintPhaseId() {
     return nextDateHintPhaseId++;
+  }
+
+  @Serial
+  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    activeDateHintPhase = null;
+    nextDateHintPhaseId = 1L;
   }
 
   private synchronized void activateDateHintPhase(DateHintPhase phase) {

--- a/runtime-node/src/main/java/network/crypta/client/async/USKInserter.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/USKInserter.java
@@ -169,8 +169,8 @@ public final class USKInserter
    */
   private String externalRequestIdentifierSnapshot;
 
-  /** Active datehint insert phase; null when not currently inserting datehints. */
-  private transient volatile DateHintPhase activeDateHintPhase;
+  /** Active datehint insert phase; null when not currently inserting datehints. Guarded by this. */
+  private transient DateHintPhase activeDateHintPhase;
 
   /** Monotonic identifier for datehint phases; helps ignore stale callbacks. */
   private transient long nextDateHintPhaseId = 1;

--- a/runtime-node/src/main/java/network/crypta/node/DNSRequester.java
+++ b/runtime-node/src/main/java/network/crypta/node/DNSRequester.java
@@ -31,7 +31,7 @@ public class DNSRequester implements Runnable {
   private final Set<Double> recentNodeIdentitySet = new HashSet<>();
   private final Deque<Double> recentNodeIdentityQueue = new ArrayDeque<>();
   // For simulations/tests only; may be set by external harnesses when supported.
-  static boolean disable = false;
+  static volatile boolean disable = false;
   private boolean wakeRequested;
 
   public DNSRequester(Node node) {

--- a/runtime-node/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
+++ b/runtime-node/src/main/java/network/crypta/node/subsystem/NodeStorageSubsystem.java
@@ -2179,17 +2179,19 @@ public final class NodeStorageSubsystem {
     if (node.services().securityLevels().getPhysicalThreatLevel() == PHYSICAL_THREAT_LEVEL.MAXIMUM)
       LOG.error("Changing password while physical threat level is at MAXIMUM???");
     SecureRandom secureRandom = node.bootstrap().secureRandom();
+    MasterKeys activeKeys;
+    synchronized (node) {
+      activeKeys = keys;
+    }
     if (masterKeysFile.exists()) {
-      MasterKeys activeKeys = keys;
       if (activeKeys == null) {
-        activeKeys = MasterKeys.read(masterKeysFile, secureRandom, oldPassword);
+        MasterKeys loadedKeys = MasterKeys.read(masterKeysFile, secureRandom, oldPassword);
         synchronized (node) {
           if (keys == null) {
-            keys = activeKeys;
-            databaseKey = activeKeys.createDatabaseKey();
-          } else {
-            activeKeys = keys;
+            keys = loadedKeys;
+            databaseKey = loadedKeys.createDatabaseKey();
           }
+          activeKeys = keys;
         }
       }
       activeKeys.changePassword(masterKeysFile, newPassword, secureRandom);

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyConnectionsPagePort.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyConnectionsPagePort.java
@@ -1,5 +1,7 @@
 package network.crypta.runtime.admin;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1695,7 +1697,9 @@ final class LegacyConnectionsPagePort implements ConnectionsPagePort {
       return reversed ? ("?sortBy=" + type) : ("?sortBy=" + type + "&reversed");
     }
 
-    protected static class ComparatorByStatus implements Comparator<PeerNodeStatus> {
+    protected static class ComparatorByStatus implements Comparator<PeerNodeStatus>, Serializable {
+      @Serial private static final long serialVersionUID = 1L;
+
       protected final String sortBy;
       protected final boolean reversed;
 

--- a/runtime-node/src/main/java/network/crypta/runtime/alerts/feed/BookmarkUserAlertFeedEvent.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/alerts/feed/BookmarkUserAlertFeedEvent.java
@@ -64,6 +64,11 @@ public record BookmarkUserAlertFeedEvent(
    */
   public BookmarkUserAlertFeedEvent {
     Objects.requireNonNull(metadata, "metadata");
-    Objects.requireNonNull(uri, "uri");
+    uri = new FreenetURI(Objects.requireNonNull(uri, "uri"));
+  }
+
+  @Override
+  public FreenetURI uri() {
+    return new FreenetURI(uri);
   }
 }

--- a/runtime-node/src/main/java/network/crypta/runtime/alerts/feed/UriUserAlertFeedEvent.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/alerts/feed/UriUserAlertFeedEvent.java
@@ -57,6 +57,11 @@ public record UriUserAlertFeedEvent(
    */
   public UriUserAlertFeedEvent {
     Objects.requireNonNull(metadata, "metadata");
-    Objects.requireNonNull(uri, "uri");
+    uri = new FreenetURI(Objects.requireNonNull(uri, "uri"));
+  }
+
+  @Override
+  public FreenetURI uri() {
+    return new FreenetURI(uri);
   }
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigFieldSet.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigFieldSet.java
@@ -66,6 +66,16 @@ public record ConfigFieldSet(
     return directValues.isEmpty() && directSubsets.isEmpty();
   }
 
+  @Override
+  public Map<String, String> directValues() {
+    return immutableDirectValues(this.directValues);
+  }
+
+  @Override
+  public Map<String, ConfigFieldSet> directSubsets() {
+    return immutableDirectSubsets(this.directSubsets);
+  }
+
   private static Map<String, String> immutableDirectValues(Map<String, String> source) {
     Objects.requireNonNull(source, "directValues");
     if (source.isEmpty()) {

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConfigSnapshot.java
@@ -66,6 +66,11 @@ public record ConfigSnapshot(Map<ConfigSection, ConfigFieldSet> sections) {
     return sections.isEmpty();
   }
 
+  @Override
+  public Map<ConfigSection, ConfigFieldSet> sections() {
+    return immutableSections(this.sections);
+  }
+
   private static Map<ConfigSection, ConfigFieldSet> immutableSections(
       Map<ConfigSection, ConfigFieldSet> source) {
     Objects.requireNonNull(source, "sections");

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeFieldSet.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/NodeFieldSet.java
@@ -70,6 +70,16 @@ public record NodeFieldSet(
     return directValues.isEmpty() && directSubsets.isEmpty();
   }
 
+  @Override
+  public Map<String, String> directValues() {
+    return immutableDirectValues(this.directValues);
+  }
+
+  @Override
+  public Map<String, NodeFieldSet> directSubsets() {
+    return immutableDirectSubsets(this.directSubsets);
+  }
+
   private static Map<String, String> immutableDirectValues(Map<String, String> source) {
     Objects.requireNonNull(source, "directValues");
     if (source.isEmpty()) {

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerFieldSet.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/PeerFieldSet.java
@@ -69,6 +69,16 @@ public record PeerFieldSet(
     return directValues.isEmpty() && directSubsets.isEmpty();
   }
 
+  @Override
+  public Map<String, String> directValues() {
+    return immutableDirectValues(this.directValues);
+  }
+
+  @Override
+  public Map<String, PeerFieldSet> directSubsets() {
+    return immutableDirectSubsets(this.directSubsets);
+  }
+
   private static Map<String, String> immutableDirectValues(Map<String, String> source) {
     Objects.requireNonNull(source, "directValues");
     if (source.isEmpty()) {

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertOptions.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueInsertOptions.java
@@ -33,7 +33,8 @@ public final class QueueInsertOptions {
       boolean compress, String compatibilityMode, byte[] overrideSplitfileCryptoKey) {
     this.compress = compress;
     this.compatibilityMode = Objects.requireNonNull(compatibilityMode, "compatibilityMode");
-    this.overrideSplitfileCryptoKey = overrideSplitfileCryptoKey;
+    this.overrideSplitfileCryptoKey =
+        overrideSplitfileCryptoKey == null ? null : overrideSplitfileCryptoKey.clone();
   }
 
   /**
@@ -60,7 +61,7 @@ public final class QueueInsertOptions {
    * @return caller-supplied splitfile key bytes, or {@code null} when absent
    */
   public byte[] overrideSplitfileCryptoKey() {
-    return overrideSplitfileCryptoKey;
+    return overrideSplitfileCryptoKey == null ? null : overrideSplitfileCryptoKey.clone();
   }
 
   @Override

--- a/src/main/java/network/crypta/tools/CleanupTranslations.java
+++ b/src/main/java/network/crypta/tools/CleanupTranslations.java
@@ -66,26 +66,38 @@ public class CleanupTranslations {
    * @throws IOException if reading or writing translation files fails with an I/O error
    */
   public static void main() throws IOException {
+    int exitCode = run(new File("."), STDOUT, STDERR);
+    if (exitCode != 0) {
+      System.exit(exitCode);
+    }
+  }
+
+  static int run(File baseDir, PrintWriter stdout, PrintWriter stderr) throws IOException {
     Logging.bootstrap(Level.ERROR, "");
-    File engFile = new File("src/freenet/l10n/crypta.l10n.en.properties");
-    SimpleFieldSet english = SimpleFieldSet.readFrom(engFile, false, true);
-    File translationDir = new File("src/freenet/l10n");
-    File[] translations = translationDir.listFiles();
-    if (translations == null) {
-      fail(3, "Unable to list translation files in: " + translationDir);
-    } else {
-      for (File translation : translations) {
-        if (isTranslationFile(translation)) {
-          CleanupResult result = cleanupTranslationFile(translation, english);
-          if (result.changed()) {
-            try (FileOutputStream fos = new FileOutputStream(translation);
-                OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
-              osw.write(result.content());
+    try {
+      File engFile = new File(baseDir, "src/freenet/l10n/crypta.l10n.en.properties");
+      SimpleFieldSet english = SimpleFieldSet.readFrom(engFile, false, true);
+      File translationDir = new File(baseDir, "src/freenet/l10n");
+      File[] translations = translationDir.listFiles();
+      if (translations == null) {
+        fail(stderr, 3, "Unable to list translation files in: " + translationDir);
+      } else {
+        for (File translation : translations) {
+          if (isTranslationFile(translation)) {
+            CleanupResult result = cleanupTranslationFile(translation, english, stderr);
+            if (result.changed()) {
+              try (FileOutputStream fos = new FileOutputStream(translation);
+                  OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
+                osw.write(result.content());
+              }
+              stdout.println("Rewritten " + translation);
             }
-            STDOUT.println("Rewritten " + translation);
           }
         }
       }
+      return 0;
+    } catch (CleanupFailure failure) {
+      return failure.exitCode;
     }
   }
 
@@ -105,8 +117,8 @@ public class CleanupTranslations {
     return name.startsWith("crypta.l10n.") && !name.equals("crypta.1l0n.en.properties");
   }
 
-  private static CleanupResult cleanupTranslationFile(File file, SimpleFieldSet english)
-      throws IOException {
+  private static CleanupResult cleanupTranslationFile(
+      File file, SimpleFieldSet english, PrintWriter stderr) throws IOException {
     StringWriter output = new StringWriter();
     boolean changed = false;
 
@@ -118,13 +130,13 @@ public class CleanupTranslations {
       while (!finished) {
         String line = br.readLine();
         if (line == null) {
-          fail(4, "File does not end in End: " + file);
+          fail(stderr, 4, "File does not end in End: " + file);
         } else {
           int idx = line.indexOf('=');
           if (idx == -1) {
-            finished = handleEndLine(line, br, output, file);
+            finished = handleEndLine(line, br, output, file, stderr);
           } else {
-            changed |= handleKeyLine(line, idx, english, output, file);
+            changed |= handleKeyLine(line, idx, english, output, file, stderr);
           }
         }
       }
@@ -134,25 +146,34 @@ public class CleanupTranslations {
   }
 
   private static boolean handleEndLine(
-      String line, BufferedReader br, StringWriter output, File file) throws IOException {
+      String line, BufferedReader br, StringWriter output, File file, PrintWriter stderr)
+      throws IOException {
     if (!line.equals("End")) {
-      fail(1, "Line with no equals (file does not end in End???): " + file + " - \"" + line + "\"");
+      fail(
+          stderr,
+          1,
+          "Line with no equals (file does not end in End???): " + file + " - \"" + line + "\"");
     }
 
     output.append(line).append("\n");
     String extra = br.readLine();
     if (extra != null) {
-      fail(2, "Content after End: \"" + extra + "\"");
+      fail(stderr, 2, "Content after End: \"" + extra + "\"");
     }
 
     return true;
   }
 
   private static boolean handleKeyLine(
-      String line, int equalsIndex, SimpleFieldSet english, StringWriter output, File file) {
+      String line,
+      int equalsIndex,
+      SimpleFieldSet english,
+      StringWriter output,
+      File file,
+      PrintWriter stderr) {
     String key = line.substring(0, equalsIndex);
     if (english.get(key) == null) {
-      STDERR.println("Orphaned string: \"" + key + "\" in " + file);
+      stderr.println("Orphaned string: \"" + key + "\" in " + file);
       return true;
     }
 
@@ -160,11 +181,19 @@ public class CleanupTranslations {
     return false;
   }
 
-  private static void fail(int exitCode, String message) {
-    STDERR.println(message);
-    System.exit(exitCode);
-    throw new IllegalStateException(message);
+  private static void fail(PrintWriter stderr, int exitCode, String message) {
+    stderr.println(message);
+    throw new CleanupFailure(exitCode, message);
   }
 
   private record CleanupResult(boolean changed, String content) {}
+
+  private static final class CleanupFailure extends RuntimeException {
+    private final int exitCode;
+
+    private CleanupFailure(int exitCode, String message) {
+      super(message);
+      this.exitCode = exitCode;
+    }
+  }
 }

--- a/src/test/java/network/crypta/client/async/HealingDecisionSupplierTest.java
+++ b/src/test/java/network/crypta/client/async/HealingDecisionSupplierTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.function.Supplier;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -137,8 +138,10 @@ class HealingDecisionSupplierTest {
 
   @Test
   void shouldHeal_whenOpennetSupplierReturnsNull_throwsNullPointerException() {
+    Supplier<Boolean> opennetEnabledSupplier = Mockito.mock(Supplier.class);
+    Mockito.when(opennetEnabledSupplier.get()).thenReturn(null);
     HealingDecisionSupplier supplier =
-        new HealingDecisionSupplier(() -> 0.25, () -> null, () -> 0.2);
+        new HealingDecisionSupplier(() -> 0.25, opennetEnabledSupplier, () -> 0.2);
 
     assertThrows(NullPointerException.class, () -> supplier.shouldHeal(0.33));
   }

--- a/src/test/java/network/crypta/client/async/InsertCompressorTest.java
+++ b/src/test/java/network/crypta/client/async/InsertCompressorTest.java
@@ -132,6 +132,16 @@ class InsertCompressorTest {
       lastOutput = output;
       lastContext = context;
     }
+
+    @Override
+    public boolean equals(Object other) {
+      return this == other;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(this);
+    }
   }
 
   private static ClientContext makeContext(

--- a/src/test/java/network/crypta/client/async/SplitFileFetcherTest.java
+++ b/src/test/java/network/crypta/client/async/SplitFileFetcherTest.java
@@ -90,7 +90,7 @@ class SplitFileFetcherTest {
         raf.free();
       }
       rafField.set(fetcher, null);
-    } catch (Exception _) {
+    } catch (ReflectiveOperationException _) {
       // Best-effort cleanup to avoid leaking mapped files on Windows.
     }
     if (!tmp.delete() && tmp.exists()) {

--- a/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.io.Serial;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import network.crypta.client.InsertContext.CompatibilityMode;
@@ -281,7 +282,9 @@ class ClientPutBaseTest {
   }
 
   private static final class TestClientPutBase extends ClientPutBase {
-    private final FCPMessage tagMessage = new StaticFcpMessage("PersistentTag");
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final transient FCPMessage tagMessage = new StaticFcpMessage("PersistentTag");
     private int freeDataCalls;
     private int startCompressingCalls;
     private int stopCompressingCalls;

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDiskDirMessageTest.java
@@ -142,7 +142,9 @@ class ClientPutDiskDirMessageTest {
     verify(handler).startClientPutDir(eq(message), bucketsCaptor.capture(), eq(true));
     HashMap<String, Object> buckets = bucketsCaptor.getValue();
 
-    String hiddenFileName = hiddenFile.getFileName().toString();
+    Path hiddenFileNamePath = hiddenFile.getFileName();
+    assertNotNull(hiddenFileNamePath);
+    String hiddenFileName = hiddenFileNamePath.toString();
     if (hiddenFile.toFile().isHidden()) {
       assertFalse(buckets.containsKey(hiddenFileName));
     } else {
@@ -150,6 +152,7 @@ class ClientPutDiskDirMessageTest {
     }
 
     ManifestElement rootElement = (ManifestElement) buckets.get("index.html");
+    assertNotNull(rootElement);
     assertEquals("index.html", rootElement.fullName);
     assertEquals(Files.size(file), rootElement.getSize());
     FileBucket bucket = (FileBucket) rootElement.getData();
@@ -161,6 +164,7 @@ class ClientPutDiskDirMessageTest {
     HashMap<String, Object> nested = (HashMap<String, Object>) buckets.get("assets");
     assertNotNull(nested);
     ManifestElement nestedElement = (ManifestElement) nested.get("style.css");
+    assertNotNull(nestedElement);
     assertEquals("assets/style.css", nestedElement.fullName);
     assertEquals(Files.size(nestedFile), nestedElement.getSize());
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.io.Serial;
 import java.lang.reflect.Field;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
@@ -117,7 +118,9 @@ class ClientRequestRestartAsyncTest {
   }
 
   private static final class TestClientRequest extends ClientRequest {
-    private ClientContext lastRestartContext;
+    @Serial private static final long serialVersionUID = 1L;
+
+    private transient ClientContext lastRestartContext;
     private boolean lastDisableFilterData;
     private int restartCalls;
 

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serial;
 import java.lang.reflect.Field;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
@@ -418,8 +419,10 @@ class ClientRequestTest {
   private static final class OpaqueHandle implements PersistentRequestClientHandle {}
 
   private static final class TestClientRequest extends ClientRequest {
+    @Serial private static final long serialVersionUID = 1L;
+
     private final ClientRequester requester;
-    private ClientContext innerResumeContext;
+    private transient ClientContext innerResumeContext;
     private int freeDataCalls;
 
     private TestClientRequest(ConstructorInit init, ClientRequester requester) {

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
@@ -131,7 +131,7 @@ class QueueToadletPostMutationTest {
 
   @AfterEach
   void tearDown() {
-    SimpleToadletServer.noConfirmPanic = originalNoConfirmPanic;
+    setNoConfirmPanic(originalNoConfirmPanic);
   }
 
   @Test
@@ -256,7 +256,7 @@ class QueueToadletPostMutationTest {
   void handleMethodPOST_whenPanicSelectedAndNoConfirmPanic_callsSupportPortAndRendersBeforeFinish()
       throws Exception {
     QueueToadlet toadlet = createQueueToadlet(false);
-    SimpleToadletServer.noConfirmPanic = true;
+    setNoConfirmPanic(true);
     HTTPRequest request = createRequest(Map.of("panic", "yes"));
     ByteArrayOutputStream body = captureBody(ctx);
 
@@ -274,7 +274,7 @@ class QueueToadletPostMutationTest {
   void handleMethodPOST_whenConfirmPanicSelected_callsSupportPortAndRendersBeforeFinish()
       throws Exception {
     QueueToadlet toadlet = createQueueToadlet(false);
-    SimpleToadletServer.noConfirmPanic = false;
+    setNoConfirmPanic(false);
     HTTPRequest request = createRequest(Map.of("confirmpanic", "yes"));
     ByteArrayOutputStream body = captureBody(ctx);
 
@@ -359,6 +359,10 @@ class QueueToadletPostMutationTest {
                 darknetMessagingPort));
     toadlet.container = container;
     return toadlet;
+  }
+
+  private static void setNoConfirmPanic(boolean enabled) {
+    SimpleToadletServer.noConfirmPanic = enabled;
   }
 
   private ClientContext createClientContext() {

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -338,7 +338,7 @@ class SimpleToadletServerTest {
     server.setRuntimeSupport(runtimeSupport);
     boolean originalPanicButtonState = SimpleToadletServer.isPanicButtonToBeShown;
     try {
-      SimpleToadletServer.isPanicButtonToBeShown = true;
+      setPanicButtonToBeShown(true);
 
       server.finishStart();
 
@@ -373,8 +373,12 @@ class SimpleToadletServerTest {
               HttpShellRuntimeSupport.PhysicalThreatLevel.NORMAL);
       assertTrue(SimpleToadletServer.isPanicButtonToBeShown);
     } finally {
-      SimpleToadletServer.isPanicButtonToBeShown = originalPanicButtonState;
+      setPanicButtonToBeShown(originalPanicButtonState);
     }
+  }
+
+  private static void setPanicButtonToBeShown(boolean shown) {
+    SimpleToadletServer.isPanicButtonToBeShown = shown;
   }
 
   @Test

--- a/src/test/java/network/crypta/io/xfer/BulkTransmitterTest.java
+++ b/src/test/java/network/crypta/io/xfer/BulkTransmitterTest.java
@@ -1,6 +1,7 @@
 package network.crypta.io.xfer;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -91,9 +92,11 @@ class BulkTransmitterTest {
    * tests.
    */
   private static final class BlockingWriteBuffer extends ByteArrayRandomAccessBuffer {
+    @Serial private static final long serialVersionUID = 1L;
+
     private final long blockedOffset;
-    private final CountDownLatch writeStarted = new CountDownLatch(1);
-    private final CountDownLatch releaseWrite = new CountDownLatch(1);
+    private final transient CountDownLatch writeStarted = new CountDownLatch(1);
+    private final transient CountDownLatch releaseWrite = new CountDownLatch(1);
 
     BlockingWriteBuffer(byte[] initialData, long blockedOffset) {
       super(initialData);

--- a/src/test/java/network/crypta/launcher/LauncherControllerTest.java
+++ b/src/test/java/network/crypta/launcher/LauncherControllerTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Supplier;
 import network.crypta.fs.AppEnv;
 import network.crypta.fs.readiness.LauncherReadinessFiles;
 import network.crypta.fs.readiness.LauncherReadinessInfo;
@@ -32,14 +33,44 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SuppressWarnings({"java:S100"})
 @ExtendWith(MockitoExtension.class)
 class LauncherControllerTest {
+  private static final long POST_STARTUP_SETTLE_MS = 100L;
+  private static final Duration HEARTBEAT_STABLE_FOR = Duration.ofMillis(500);
+  private static final String SHELL_SLEEP_SHORT = "0.05";
+  private static final String SHELL_SLEEP_MEDIUM = "0.10";
+  private static final String SHELL_SLEEP_LONG = "0.20";
+  private static final String SHELL_SLEEP_LOOP = "0.05";
+  private static final LauncherController.TimingConfig TEST_TIMING =
+      new LauncherController.TimingConfig(
+          50L,
+          300L,
+          10L,
+          25L,
+          Duration.ofMillis(300),
+          Duration.ofMillis(300),
+          Duration.ofMillis(100),
+          Duration.ofMillis(50));
   private static final int TEST_PORT = 8888;
   private static final String SHELL_UI_ROOT = "/app/node/";
 
   @TempDir Path tempDir;
 
+  private LauncherController controller() {
+    return controller(LauncherUtils::resolveConfiguredLauncherReadinessFile);
+  }
+
+  private LauncherController controller(Supplier<Path> readinessFileResolver) {
+    return controller(readinessFileResolver, LauncherUtils::resolveConfiguredLauncherDaemonLogFile);
+  }
+
+  private LauncherController controller(
+      Supplier<Path> readinessFileResolver, Supplier<Path> daemonLogFileResolver) {
+    return new LauncherController(
+        tempDir, readinessFileResolver, daemonLogFileResolver, TEST_TIMING);
+  }
+
   @Test
   void start_whenCryptadMissing_logsErrorAndDoesNotRun() {
-    LauncherController controller = new LauncherController(tempDir);
+    LauncherController controller = controller();
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -57,8 +88,7 @@ class LauncherControllerTest {
     Path actualReadinessFile = createReadinessFilePath(tempDir, "configured-runtime");
     Path daemonLogFile = createDaemonLogFilePath(tempDir);
     Path legacyDetectedMarker = tempDir.resolve("legacy-detected.marker");
-    LauncherController controller =
-        new LauncherController(tempDir, () -> initialReadinessFile, () -> daemonLogFile);
+    LauncherController controller = controller(() -> initialReadinessFile, () -> daemonLogFile);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -106,8 +136,7 @@ class LauncherControllerTest {
     Path actualReadinessFile = createReadinessFilePath(tempDir, "configured-runtime");
     Path daemonLogFile = createDaemonLogFilePath(tempDir);
     Path legacyDetectedMarker = tempDir.resolve("legacy-detected.marker");
-    LauncherController controller =
-        new LauncherController(tempDir, () -> initialReadinessFile, () -> daemonLogFile);
+    LauncherController controller = controller(() -> initialReadinessFile, () -> daemonLogFile);
 
     writeWrapperConf(tempDir);
     writeStructuredReadinessCryptadScript(
@@ -166,8 +195,7 @@ class LauncherControllerTest {
   void start_whenStructuredReadinessPromotesFromDefaultRootToShellRoot_updatesUiRootToShellRoot()
       throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
-    LauncherController controller =
-        new LauncherController(tempDir, () -> readinessFile, () -> null);
+    LauncherController controller = controller(() -> readinessFile, () -> null);
 
     writeWrapperConf(tempDir);
     writeStructuredReadinessPromotionCryptadScript(
@@ -273,11 +301,10 @@ class LauncherControllerTest {
         new LauncherReadinessInfo(
             LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, 4321, "/");
     LauncherReadinessFiles.write(actualReadinessFile, existingReadiness);
-    LauncherController controller =
-        new LauncherController(tempDir, () -> initialReadinessFile, () -> daemonLogFile);
+    LauncherController controller = controller(() -> initialReadinessFile, () -> daemonLogFile);
 
     writeWrapperConf(tempDir);
-    writeNoReadinessCryptadScript(tempDir, actualReadinessFile.getParent(), daemonLogFile);
+    writeNoReadinessCryptadScript(tempDir, parentOrThrow(actualReadinessFile), daemonLogFile);
 
     controller.start();
 
@@ -296,7 +323,7 @@ class LauncherControllerTest {
 
   @Test
   void stop_whenNoTrackedProcess_noop() throws Exception {
-    LauncherController controller = new LauncherController(tempDir);
+    LauncherController controller = controller();
     AppState initial = new AppState(true, null, false, false);
     setPrivateStateField(controller, initial);
 
@@ -309,7 +336,7 @@ class LauncherControllerTest {
 
   @Test
   void launchBrowser_whenPortMissing_noop() throws Exception {
-    LauncherController controller = new LauncherController(tempDir);
+    LauncherController controller = controller();
     AppState initial = new AppState(false, null, false, false);
     setPrivateStateField(controller, initial);
 
@@ -321,7 +348,7 @@ class LauncherControllerTest {
 
   @Test
   void launchBrowser_whenRunningWithoutDetectedPort_noop() throws Exception {
-    LauncherController controller = new LauncherController(tempDir);
+    LauncherController controller = controller();
     AppState initial = new AppState(true, null, false, false);
     setPrivateStateField(controller, initial);
 
@@ -334,7 +361,7 @@ class LauncherControllerTest {
   @Test
   void stop_whenScriptRunsLong_processStopsAndStateClears() throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
 
     writeWrapperConf(tempDir);
     Path heartbeat = tempDir.resolve("heartbeat.log");
@@ -349,7 +376,7 @@ class LauncherControllerTest {
     AppState stopped = awaitState(controller, s -> !s.isRunning() && !s.isStopping());
     assertFalse(stopped.isRunning());
     assertFalse(stopped.isStopping());
-    awaitFileSizeStable(heartbeat, Duration.ofMillis(2500));
+    awaitFileSizeStable(heartbeat, HEARTBEAT_STABLE_FOR);
 
     controller.shutdownAndWait();
   }
@@ -357,7 +384,7 @@ class LauncherControllerTest {
   @Test
   void start_whenStructuredReadinessUnavailable_fallsBackToLegacyLogPortDetection()
       throws Exception {
-    LauncherController controller = new LauncherController(tempDir, () -> null, () -> null);
+    LauncherController controller = controller(() -> null, () -> null);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -382,8 +409,7 @@ class LauncherControllerTest {
       throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
     Path daemonLogFile = createDaemonLogFilePath(tempDir);
-    LauncherController controller =
-        new LauncherController(tempDir, () -> readinessFile, () -> daemonLogFile);
+    LauncherController controller = controller(() -> readinessFile, () -> daemonLogFile);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -410,8 +436,7 @@ class LauncherControllerTest {
       throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
     Path daemonLogFile = createDaemonLogFilePath(tempDir);
-    LauncherController controller =
-        new LauncherController(tempDir, () -> readinessFile, () -> daemonLogFile);
+    LauncherController controller = controller(() -> readinessFile, () -> daemonLogFile);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -454,7 +479,7 @@ class LauncherControllerTest {
 
     writeWrapperConf(tempDir);
     writeLegacyPortWithoutReadinessButWithRunDirCryptadScript(
-        tempDir, actualReadinessFile.getParent(), daemonLogFile);
+        tempDir, parentOrThrow(actualReadinessFile), daemonLogFile);
 
     controller.start();
 
@@ -486,8 +511,7 @@ class LauncherControllerTest {
       throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
     Path daemonLogFile = createDaemonLogFilePath(tempDir);
-    LauncherController controller =
-        new LauncherController(tempDir, () -> readinessFile, () -> daemonLogFile);
+    LauncherController controller = controller(() -> readinessFile, () -> daemonLogFile);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -604,8 +628,7 @@ class LauncherControllerTest {
   void start_whenCompletionInfoLogUnavailable_stdoutCompletionFallsBackToLegacyPort()
       throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
-    LauncherController controller =
-        new LauncherController(tempDir, () -> readinessFile, () -> null);
+    LauncherController controller = controller(() -> readinessFile, () -> null);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -633,8 +656,7 @@ class LauncherControllerTest {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
     Path wrongDaemonLogFile = tempDir.resolve("missing-logs").resolve("crypta-latest.log");
     Path wrapperLogFile = tempDir.resolve("logs").resolve("wrapper.log");
-    LauncherController controller =
-        new LauncherController(tempDir, () -> readinessFile, () -> wrongDaemonLogFile);
+    LauncherController controller = controller(() -> readinessFile, () -> wrongDaemonLogFile);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -660,7 +682,7 @@ class LauncherControllerTest {
   void start_whenStructuredReadinessPending_doesNotExposeLegacyPortOrAutoOpen() throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
     Path heartbeat = tempDir.resolve("heartbeat.log");
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     controller.addLogListener(logs::add);
 
@@ -672,7 +694,7 @@ class LauncherControllerTest {
     awaitState(controller, AppState::isRunning);
     awaitLog(logs, l -> l.contains("Starting FProxy on"));
     awaitHeartbeat(heartbeat);
-    sleepMillis(300L);
+    sleepMillis(POST_STARTUP_SETTLE_MS);
     assertNull(controller.getState().knownPort());
     assertFalse(isBrowserAutoOpened(controller));
 
@@ -696,7 +718,7 @@ class LauncherControllerTest {
     long launchStartedAtMillis = 17_000L;
     Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(launchStartedAtMillis));
 
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     setLaunchStartedAtMillis(controller, launchStartedAtMillis);
 
     assertFalse(controller.isCurrentLaunchReadinessFile(readinessFile));
@@ -708,7 +730,7 @@ class LauncherControllerTest {
   void isCurrentLaunchReadinessFile_whenMtimeEqualsLaunchStartAndLegacyPortMatches_returnsTrue()
       throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     setLaunchStartedAtMillis(controller, 17_000L);
     setPendingLegacyPort(controller);
     setTrackedReadinessTarget(controller, readinessFile);
@@ -727,7 +749,7 @@ class LauncherControllerTest {
   void isCurrentLaunchReadinessFile_whenFileChangesAfterTrackingButMtimeRoundsDown_returnsTrue()
       throws Exception {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     setLaunchStartedAtMillis(controller, 17_000L);
     setTrackedReadinessTarget(controller, readinessFile);
     LauncherReadinessFiles.write(
@@ -751,7 +773,7 @@ class LauncherControllerTest {
             LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, 4321, "/"));
     Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(16_000L));
 
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     setLaunchStartedAtMillis(controller, 17_000L);
     setTrackedReadinessTarget(controller, readinessFile);
     var staleSnapshot = LauncherReadinessFiles.readSnapshot(readinessFile).orElseThrow();
@@ -777,7 +799,7 @@ class LauncherControllerTest {
             LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
     Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(16_000L));
 
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     setLaunchStartedAtMillis(controller, 17_000L);
     setPendingLegacyPort(controller);
     markStartupCompletionObserved(controller);
@@ -794,7 +816,7 @@ class LauncherControllerTest {
     Path readinessFile = createReadinessFilePath(tempDir, "runtime");
     Files.deleteIfExists(readinessFile);
 
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     setLaunchStartedAtMillis(controller, 17_001L);
     setTrackedReadinessTarget(controller, readinessFile);
     LauncherReadinessFiles.write(
@@ -818,7 +840,7 @@ class LauncherControllerTest {
             LauncherReadinessInfo.VERSION_1, LauncherReadinessInfo.READY_STATE, TEST_PORT, "/"));
     Files.setLastModifiedTime(readinessFile, FileTime.fromMillis(17_000L));
 
-    LauncherController controller = new LauncherController(tempDir, () -> readinessFile);
+    LauncherController controller = controller(() -> readinessFile);
     setLaunchStartedAtMillis(controller, 17_000L);
     setPendingLegacyPort(controller);
     setTrackedReadinessTarget(controller, readinessFile);
@@ -830,7 +852,7 @@ class LauncherControllerTest {
 
   @Test
   void shutdown_setsShuttingDownFlagAndIsIdempotent() {
-    LauncherController controller = new LauncherController(tempDir);
+    LauncherController controller = controller();
 
     controller.shutdown();
     assertTrue(controller.getState().isShuttingDown());
@@ -843,7 +865,7 @@ class LauncherControllerTest {
 
   @Test
   void shutdownAndWait_whenNoProcess_setsShuttingDownFlag() {
-    LauncherController controller = new LauncherController(tempDir);
+    LauncherController controller = controller();
 
     controller.shutdownAndWait();
 
@@ -1124,8 +1146,9 @@ class LauncherControllerTest {
     Files.createDirectories(binDir);
     boolean isWindows = new AppEnv().isWindows();
     Path script = isWindows ? binDir.resolve("cryptad.bat") : binDir.resolve("cryptad");
-    String runDir = readinessFile.getParent().toAbsolutePath().toString();
-    Files.createDirectories(readinessFile.getParent());
+    Path readinessDir = parentOrThrow(readinessFile);
+    String runDir = readinessDir.toAbsolutePath().toString();
+    Files.createDirectories(readinessDir);
     String readinessPath = readinessFile.toAbsolutePath().toString();
     String daemonLogPath = daemonLogFile.toAbsolutePath().toString();
     String markerPath = legacyDetectedMarker.toAbsolutePath().toString();
@@ -1156,7 +1179,7 @@ class LauncherControllerTest {
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "printf 'legacy\\n' > \"" + markerPath + "\"",
               "printf '  Run dir:      " + runDir + "\\n' >> \"" + daemonLogPath + "\"",
-              "sleep 0.1",
+              "sleep " + SHELL_SLEEP_SHORT,
               "cat <<'EOF' > \"" + readinessPath + "\"",
               "version=" + LauncherReadinessInfo.VERSION_1,
               "state=" + LauncherReadinessInfo.READY_STATE,
@@ -1164,13 +1187,21 @@ class LauncherControllerTest {
               "ui.root=" + uiRoot,
               "EOF",
               "echo \"READY\"",
-              "sleep 0.2");
+              "sleep " + SHELL_SLEEP_MEDIUM);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
     if (!isWindows && !script.toFile().setExecutable(true)) {
       throw new AssertionError("Failed to mark script executable: " + script);
     }
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    if (parent == null) {
+      throw new AssertionError("Expected parent for path " + path);
+    }
+    return parent;
   }
 
   private static void writeStructuredReadinessPromotionCryptadScript(
@@ -1210,21 +1241,21 @@ class LauncherControllerTest {
               "\n",
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
-              "sleep 0.2",
+              "sleep " + SHELL_SLEEP_MEDIUM,
               "cat <<'EOF' > \"" + readinessPath + "\"",
               "version=" + LauncherReadinessInfo.VERSION_1,
               "state=" + LauncherReadinessInfo.READY_STATE,
               "ui.port=" + TEST_PORT,
               "ui.root=" + initialUiRoot,
               "EOF",
-              "sleep 0.3",
+              "sleep " + SHELL_SLEEP_LONG,
               "cat <<'EOF' > \"" + readinessPath + "\"",
               "version=" + LauncherReadinessInfo.VERSION_1,
               "state=" + LauncherReadinessInfo.READY_STATE,
               "ui.port=" + TEST_PORT,
               "ui.root=" + updatedUiRoot,
               "EOF",
-              "sleep 1.0");
+              "sleep " + SHELL_SLEEP_LONG);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1262,14 +1293,14 @@ class LauncherControllerTest {
               "\n",
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
-              "sleep 0.1",
+              "sleep " + SHELL_SLEEP_SHORT,
               "cat <<'EOF' > \"" + readinessPath + "\"",
               "version=" + LauncherReadinessInfo.VERSION_1,
               "state=" + LauncherReadinessInfo.READY_STATE,
               "ui.port=" + TEST_PORT,
               "ui.root=" + SHELL_UI_ROOT,
               "EOF",
-              "sleep 1.0");
+              "sleep " + SHELL_SLEEP_LONG);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1300,7 +1331,7 @@ class LauncherControllerTest {
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "echo \"READY\"",
-              "sleep 0.2");
+              "sleep " + SHELL_SLEEP_MEDIUM);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1333,7 +1364,7 @@ class LauncherControllerTest {
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "printf 'Node initialization completed\\n' >> \"" + daemonLogPath + "\"",
-              "sleep 0.3");
+              "sleep " + SHELL_SLEEP_LONG);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1369,7 +1400,7 @@ class LauncherControllerTest {
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "printf '  Run dir:      " + resolvedRunDir + "\\n' >> \"" + daemonLogPath + "\"",
               "printf 'Node initialization completed\\n' >> \"" + daemonLogPath + "\"",
-              "sleep 1.0");
+              "sleep " + SHELL_SLEEP_LONG);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1413,7 +1444,7 @@ class LauncherControllerTest {
               "ui.port=9999",
               "EOF",
               "printf 'Node initialization completed\\n' >> \"" + daemonLogPath + "\"",
-              "sleep 0.3");
+              "sleep " + SHELL_SLEEP_LONG);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1454,14 +1485,14 @@ class LauncherControllerTest {
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "printf 'Node initialization completed\\n' >> \"" + daemonLogPath + "\"",
-              "sleep 0.3",
+              "sleep " + SHELL_SLEEP_LONG,
               "cat <<'EOF' > \"" + readinessPath + "\"",
               "version=" + LauncherReadinessInfo.VERSION_1,
               "state=" + LauncherReadinessInfo.READY_STATE,
               "ui.port=" + TEST_PORT,
               "ui.root=" + SHELL_UI_ROOT,
               "EOF",
-              "sleep 1.0");
+              "sleep " + SHELL_SLEEP_LONG);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1494,9 +1525,9 @@ class LauncherControllerTest {
               "\n",
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
-              "sleep 0.2",
+              "sleep " + SHELL_SLEEP_MEDIUM,
               "printf 'Node initialization completed\\n' >> \"" + wrapperLogPath + "\"",
-              "sleep 0.2");
+              "sleep " + SHELL_SLEEP_MEDIUM);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1528,7 +1559,7 @@ class LauncherControllerTest {
               "#!/usr/bin/env sh",
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "echo \"Node initialization completed\"",
-              "sleep 0.3");
+              "sleep " + SHELL_SLEEP_LONG);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1562,7 +1593,7 @@ class LauncherControllerTest {
               "#!/usr/bin/env sh",
               "printf '  Run dir:      " + resolvedRunDir + "\\n' >> \"" + daemonLogPath + "\"",
               "echo \"BOOTING\"",
-              "sleep 0.2");
+              "sleep " + SHELL_SLEEP_MEDIUM);
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
 
@@ -1600,7 +1631,7 @@ class LauncherControllerTest {
               "echo \"Starting FProxy on 127.0.0.1:" + TEST_PORT + "\"",
               "while true; do",
               "  date +%s%N >> \"$HEARTBEAT\"",
-              "  sleep 1",
+              "  sleep " + SHELL_SLEEP_LOOP,
               "done");
     }
     Files.writeString(script, content, StandardCharsets.UTF_8);
@@ -1631,7 +1662,7 @@ class LauncherControllerTest {
         Path cwd,
         java.util.function.Supplier<Path> readinessFileResolver,
         java.util.function.Supplier<Path> daemonLogFileResolver) {
-      super(cwd, readinessFileResolver, daemonLogFileResolver);
+      super(cwd, readinessFileResolver, daemonLogFileResolver, TEST_TIMING);
     }
 
     @Override

--- a/src/test/java/network/crypta/node/NodeTest.java
+++ b/src/test/java/network/crypta/node/NodeTest.java
@@ -11,6 +11,7 @@ import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.http.HttpShellContainer;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.support.SimpleFieldSet;
+import network.crypta.testsupport.SpotBugsTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -171,13 +172,13 @@ class NodeTest {
     invokeFinishToadletsIfEnabled(node);
 
     var order = inOrder(toadlets);
-    order.verify(toadlets).isEnabled();
+    SpotBugsTestSupport.ignoreValue(order.verify(toadlets).isEnabled());
     order.verify(toadlets).setPrimaryUiRootListener(any());
     order.verify(toadlets).finishStart();
     order.verify(toadlets).createFproxy();
     order.verify(toadlets).removeStartupToadlet();
-    order.verify(toadlets).listenPort();
-    order.verify(toadlets).primaryUiRoot();
+    SpotBugsTestSupport.ignoreValue(order.verify(toadlets).listenPort());
+    SpotBugsTestSupport.ignoreValue(order.verify(toadlets).primaryUiRoot());
 
     Path readinessFile = LauncherReadinessFiles.resolve(tempDir);
     LauncherReadinessInfo actual = LauncherReadinessFiles.read(readinessFile).orElseThrow();
@@ -244,13 +245,13 @@ class NodeTest {
     invokeFinishToadletsIfEnabled(node);
 
     var order = inOrder(toadlets);
-    order.verify(toadlets).isEnabled();
+    SpotBugsTestSupport.ignoreValue(order.verify(toadlets).isEnabled());
     order.verify(toadlets).setPrimaryUiRootListener(any());
     order.verify(toadlets).finishStart();
     order.verify(toadlets).createFproxy();
     order.verify(toadlets).removeStartupToadlet();
-    order.verify(toadlets).listenPort();
-    order.verify(toadlets).primaryUiRoot();
+    SpotBugsTestSupport.ignoreValue(order.verify(toadlets).listenPort());
+    SpotBugsTestSupport.ignoreValue(order.verify(toadlets).primaryUiRoot());
     assertTrue(LauncherReadinessFiles.read(LauncherReadinessFiles.resolve(tempDir)).isEmpty());
   }
 }

--- a/src/test/java/network/crypta/platform/api/PlatformApiBoundaryTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiBoundaryTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
@@ -85,11 +86,11 @@ class PlatformApiBoundaryTest {
     assertTrue(Files.isDirectory(platformApiMain), ":platform-api main Java tree must exist");
 
     for (Path sourceFile : findJavaSources(platformApiMain)) {
-      String fileName = sourceFile.getFileName().toString();
+      String fileName = fileNameOrThrow(sourceFile);
       if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
         continue;
       }
-      productionPackages.add(sourceFile.getParent());
+      productionPackages.add(parentOrThrow(sourceFile));
     }
 
     for (Path packagePath : productionPackages) {
@@ -116,7 +117,7 @@ class PlatformApiBoundaryTest {
   }
 
   private static boolean isTrackedJavaSource(Path path) {
-    String fileName = path.getFileName().toString();
+    String fileName = fileNameOrThrow(path);
     return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
@@ -129,6 +130,18 @@ class PlatformApiBoundaryTest {
           .map(matcher -> matcher.group(1))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
   }
 
   private static Path repoRoot() throws IOException {

--- a/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
+++ b/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
@@ -83,11 +84,11 @@ class RuntimeNodeKernelSplitPrepBoundaryTest {
     assertTrue(Files.isDirectory(runtimeNodeMain), "runtime-node main Java tree must exist");
 
     for (Path sourceFile : findJavaSources(runtimeNodeMain)) {
-      String fileName = sourceFile.getFileName().toString();
+      String fileName = fileNameOrThrow(sourceFile);
       if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
         continue;
       }
-      productionPackages.add(sourceFile.getParent());
+      productionPackages.add(parentOrThrow(sourceFile));
     }
 
     for (Path packagePath : productionPackages) {
@@ -114,7 +115,7 @@ class RuntimeNodeKernelSplitPrepBoundaryTest {
   }
 
   private static boolean isTrackedJavaSource(Path path) {
-    String fileName = path.getFileName().toString();
+    String fileName = fileNameOrThrow(path);
     return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
@@ -127,6 +128,18 @@ class RuntimeNodeKernelSplitPrepBoundaryTest {
           .map(matcher -> matcher.group(1))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
   }
 
   private static Path repoRoot() throws IOException {

--- a/src/test/java/network/crypta/runtime/admin/LegacyDiagnosticPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyDiagnosticPortTest.java
@@ -25,6 +25,7 @@ import network.crypta.runtime.spi.DiagnosticReportSnapshot;
 import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
 import network.crypta.support.BandwidthStatsContainer;
+import network.crypta.testsupport.SpotBugsTestSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -121,7 +122,7 @@ class LegacyDiagnosticPortTest {
 
     InOrder inOrder = inOrder(bandwidthStatsPutter, collector);
     inOrder.verify(bandwidthStatsPutter).updateData(node);
-    inOrder.verify(collector).getTotalIO();
+    SpotBugsTestSupport.ignoreValue(inOrder.verify(collector).getTotalIO());
   }
 
   @Test

--- a/src/test/java/network/crypta/support/BinaryBloomFilterTest.java
+++ b/src/test/java/network/crypta/support/BinaryBloomFilterTest.java
@@ -263,14 +263,14 @@ class BinaryBloomFilterTest {
       if (!secureRoot.exists()) {
         assertTrue(secureRoot.mkdirs(), "Failed to create secure test temp root");
       }
-      secureRoot.setReadable(true, true);
-      secureRoot.setWritable(true, true);
-      secureRoot.setExecutable(true, true);
+      assertTrue(secureRoot.setReadable(true, true));
+      assertTrue(secureRoot.setWritable(true, true));
+      assertTrue(secureRoot.setExecutable(true, true));
 
       tempDir = Files.createTempDirectory(secureRoot.toPath(), "bbf-test-").toFile();
-      tempDir.setReadable(true, true);
-      tempDir.setWritable(true, true);
-      tempDir.setExecutable(true, true);
+      assertTrue(tempDir.setReadable(true, true));
+      assertTrue(tempDir.setWritable(true, true));
+      assertTrue(tempDir.setExecutable(true, true));
       tempDir.deleteOnExit();
     }
 

--- a/src/test/java/network/crypta/support/io/RandomAccessBufferTestBase.java
+++ b/src/test/java/network/crypta/support/io/RandomAccessBufferTestBase.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import network.crypta.support.api.RandomAccessBuffer;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -104,19 +105,16 @@ public abstract class RandomAccessBufferTestBase {
     if (len == 0) {
       return;
     }
-    byte[] tmp = new byte[len];
-    raf.pread(start, tmp, 0, len);
-    for (int i = 0; i < len; i++) {
-      assertEquals(tmp[i], buf[start + i]);
-    }
+    byte[] expected = Arrays.copyOfRange(buf, start, end);
+    byte[] actual = new byte[len];
+    raf.pread(start, actual, 0, len);
+    assertArrayEquals(expected, actual);
     if (!readOnly) {
       raf.pwrite(start, buf, start, len);
     }
-    Arrays.fill(tmp, (byte) 0);
-    raf.pread(start, tmp, 0, len);
-    for (int i = 0; i < len; i++) {
-      assertEquals(tmp[i], buf[start + i]);
-    }
+    Arrays.fill(actual, (byte) 0);
+    raf.pread(start, actual, 0, len);
+    assertArrayEquals(expected, actual);
   }
 
   /**
@@ -217,18 +215,14 @@ public abstract class RandomAccessBufferTestBase {
     while (x < sz) {
       int maxRead = (int) Math.min(BUFFER_SIZE, sz - x);
       int toRead = maxRead == 1 ? 1 : r.nextInt(maxRead - 1) + 1;
-      byte[] buf = new byte[toRead];
-      for (int i = 0; i < buf.length; i++) {
-        buf[i] = f.getByte(i + x);
+      byte[] expected = new byte[toRead];
+      for (int i = 0; i < expected.length; i++) {
+        expected[i] = f.getByte(i + x);
       }
-      raf.pwrite(x, buf, 0, toRead);
-      for (int i = 0; i < buf.length; i++) {
-        buf[i] = (byte) ~buf[i];
-      }
-      raf.pread(x, buf, 0, toRead);
-      for (int i = 0; i < buf.length; i++) {
-        assertEquals(buf[i], f.getByte(i + x));
-      }
+      raf.pwrite(x, expected, 0, toRead);
+      byte[] actual = new byte[toRead];
+      raf.pread(x, actual, 0, toRead);
+      assertArrayEquals(expected, actual);
       x += toRead;
     }
     // Read
@@ -236,11 +230,13 @@ public abstract class RandomAccessBufferTestBase {
     while (x < sz) {
       int maxRead = (int) Math.min(BUFFER_SIZE, sz - x);
       int toRead = maxRead == 1 ? 1 : r.nextInt(maxRead - 1) + 1;
-      byte[] buf = new byte[toRead];
-      raf.pread(x, buf, 0, toRead);
-      for (int i = 0; i < buf.length; i++) {
-        assertEquals(buf[i], f.getByte(i + x));
+      byte[] actual = new byte[toRead];
+      raf.pread(x, actual, 0, toRead);
+      byte[] expected = new byte[toRead];
+      for (int i = 0; i < expected.length; i++) {
+        expected[i] = f.getByte(i + x);
       }
+      assertArrayEquals(expected, actual);
       x += toRead;
     }
     raf.close();

--- a/src/test/java/network/crypta/tools/CleanupTranslationsTest.java
+++ b/src/test/java/network/crypta/tools/CleanupTranslationsTest.java
@@ -1,11 +1,12 @@
 package network.crypta.tools;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -158,28 +159,15 @@ class CleanupTranslationsTest {
     Files.writeString(file, content, StandardCharsets.UTF_8);
   }
 
-  private static ProcessResult runCleanupTranslations(Path workingDir)
-      throws IOException, InterruptedException {
-    String javaBin =
-        Path.of(System.getProperty("java.home")).resolve("bin").resolve("java").toString();
+  private static ProcessResult runCleanupTranslations(Path workingDir) throws IOException {
+    StringWriter stdoutBuffer = new StringWriter();
+    StringWriter stderrBuffer = new StringWriter();
+    PrintWriter stdout = new PrintWriter(stdoutBuffer, true);
+    PrintWriter stderr = new PrintWriter(stderrBuffer, true);
 
-    java.util.ArrayList<String> cmd = new java.util.ArrayList<>();
-    cmd.add(javaBin);
-    cmd.add("-cp");
-    cmd.add(System.getProperty("java.class.path"));
-    cmd.add("network.crypta.tools.CleanupTranslations");
+    int exitCode = CleanupTranslations.run(workingDir.toFile(), stdout, stderr);
 
-    Process process = new ProcessBuilder(cmd).directory(workingDir.toFile()).start();
-
-    boolean finished = process.waitFor(10, TimeUnit.SECONDS);
-    if (!finished) {
-      process.destroyForcibly();
-      throw new IllegalStateException("CleanupTranslations process did not exit within timeout");
-    }
-
-    String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-    String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-    return new ProcessResult(process.exitValue(), stdout, stderr);
+    return new ProcessResult(exitCode, stdoutBuffer.toString(), stderrBuffer.toString());
   }
 
   private record ProcessResult(int exitCode, String stdout, String stderr) {}


### PR DESCRIPTION
## Summary
- fix the remaining actionable SpotBugs findings in production code and add narrow suppressions for intentional collaborator and legacy-pattern cases
- speed up the slowest tests by replacing per-byte assertion loops, making AppHost and launcher timing configurable for tests, and removing the forked JVM from `CleanupTranslationsTest`
- update affected test helpers and fixtures so the faster timing profiles stay deterministic

## How to test
- `./gradlew spotlessApply`
- `./gradlew test`