### PR TITLE
fix(sonar): Exclude test resources from analysis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,14 @@ val internalLeafTestSourceDirs =
     .map { it.asFile }
     .filter { it.isDirectory }
 
+val rootSonarTestSourceDirs =
+  listOf(
+      layout.projectDirectory.dir("src/test/java"),
+      layout.projectDirectory.dir("src/test/kotlin"),
+    )
+    .map { it.asFile }
+    .filter { it.isDirectory }
+
 val internalLeafTestResultDirs =
   internalLeafProjectsWithLocalTests.map { leaf ->
     leaf.layout.buildDirectory.dir("test-results/test").get().asFile
@@ -159,16 +167,12 @@ val aggregatedSonarBinaryPaths =
     .joinToString(",") { it.absolutePath }
 
 val aggregatedSonarTestPaths =
-  (sourceSets.test.get().allSource.srcDirs + internalLeafTestSourceDirs).distinct().joinToString(
-    ","
-  ) {
+  (rootSonarTestSourceDirs + internalLeafTestSourceDirs).distinct().joinToString(",") {
     relativePath(it)
   }
 
 val aggregatedSonarTestInclusions =
-  (sourceSets.test.get().allSource.srcDirs + internalLeafTestSourceDirs).distinct().joinToString(
-    ","
-  ) {
+  (rootSonarTestSourceDirs + internalLeafTestSourceDirs).distinct().joinToString(",") {
     "${relativePath(it)}/**"
   }
 

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -738,7 +738,7 @@ class LocalProcessAppHostTest {
     waitForFile(childPidFile);
     long childPid = Long.parseLong(Files.readString(childPidFile, StandardCharsets.UTF_8).trim());
     try {
-      RunningAppSnapshot current = waitForRunningApp(host, PYTHON_DAEMON_APP_ID);
+      RunningAppSnapshot current = waitForRunningPid(host, PYTHON_DAEMON_APP_ID, childPid);
       assertEquals(running.appId(), current.appId());
       assertEquals(running.token(), current.token());
       assertEquals(childPid, current.pid());
@@ -1951,16 +1951,19 @@ class LocalProcessAppHostTest {
   }
 
   private static RunningAppSnapshot waitForRunningPid(AppHost host, long pid) {
+    return waitForRunningPid(host, RUNNER_APP_ID, pid);
+  }
+
+  private static RunningAppSnapshot waitForRunningPid(AppHost host, String appId, long pid) {
     long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
     while (System.nanoTime() < deadline) {
-      Optional<RunningAppSnapshot> running = host.status(RUNNER_APP_ID);
+      Optional<RunningAppSnapshot> running = host.status(appId);
       if (running.isPresent() && running.orElseThrow().pid() == pid) {
         return running.orElseThrow();
       }
-      pausePolling("interrupted while waiting for app " + RUNNER_APP_ID + " to report pid " + pid);
+      pausePolling("interrupted while waiting for app " + appId + " to report pid " + pid);
     }
-    throw new AssertionError(
-        "timed out waiting for app " + RUNNER_APP_ID + " to report pid " + pid);
+    throw new AssertionError("timed out waiting for app " + appId + " to report pid " + pid);
   }
 
   private static void waitForProcessExit(long pid) throws IOException {


### PR DESCRIPTION
## Summary
- limit the root aggregated Sonar test paths to `src/test/java` and `src/test/kotlin`
- stop inheriting `src/test/resources` through `sourceSets.test.allSource`
- prevent Sonar from decoding binary test fixtures as UTF-8 during the `sonar` task

This addresses the `Invalid character encountered in file ... for encoding UTF-8` warnings seen in GitHub Actions run `24074437320`, job `70219197586`, where Sonar reported the issue across binary fixtures under `src/test/resources`.

## How to test
- `./gradlew help`
- `./gradlew spotlessApply`
- `./gradlew spotlessCheck`
- rerun `./gradlew sonar` in CI or any environment with `SONAR_TOKEN` to confirm the warnings disappear
