### PR TITLE
feat(platform-api): Expose AppHost control surface via v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,12 @@ Cryptad now uses a partial multi-project Gradle build.
   by higher layers, including detached FCP peer management plus the admin-HTTP config,
   connectivity, connections, queue, security-levels, shared page-chrome, core-update action,
   first-time-wizard, symlinker, and welcome-page slices.
-- `:platform-api` owns the transport-neutral read-only Platform API v1 under
+- `:platform-api` owns the transport-neutral Platform API v1 under
   `network.crypta.platform.api`. It sits above `:runtime-spi`, exposes detached runtime snapshots
-  as JSON-oriented responses, and is currently mounted at `/api/v1/` through a thin legacy HTTP
-  bridge in `:adapter-http-legacy-admin`. The initial read-only surface covers node info, peers,
-  config export, connectivity, and security-level snapshots; `GET /api/v1/config` defaults to the
+  and the minimal local AppHost control surface as JSON-oriented responses, and is currently
+  mounted at `/api/v1/` through a thin legacy HTTP bridge in `:adapter-http-legacy-admin`. The
+  current surface covers node info, peers, config export, connectivity, security-level snapshots,
+  and local app install/start/stop/uninstall routes; `GET /api/v1/config` defaults to the
   effective `CURRENT` section when `sections=` is omitted.
 - `:platform-apphost` owns the transport-neutral out-of-process AppHost v1 core under
   `network.crypta.platform.apphost`. It defines the local manifest, installed-app layout, process
@@ -582,8 +583,8 @@ Root build also includes:
   `PeerStatusCounts`, and `SendableRequestItem*`.
 - `:runtime-spi`: JDK-only runtime ports plus immutable config snapshot/value types used by FCP
   and other infrastructure code.
-- `:platform-api`: transport-neutral read-only Platform API v1 built on top of `:runtime-spi`,
-  currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
+- `:platform-api`: transport-neutral Platform API v1 built on top of `:runtime-spi` and
+  `:platform-apphost`, currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
 - `:platform-apphost`: transport-neutral out-of-process AppHost v1 core for installed local apps.
   Future Web Shell, app UI, and update-channel work remain separate and later.
 - `:platform-web-shell`: browser-facing Web Shell v1 leaf owning the node-management shell route
@@ -704,7 +705,7 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.clients.http` now lives in `:adapter-http-legacy-admin` together with its
   `staticfiles/**` and `templates/**` resources. The migrated HTTP management and shell slices
   cross the boundary in three layers: `RuntimePorts` for JDK-only detached runtime state,
-  `:platform-api` for the read-only Platform API v1 router and JSON surface currently mounted at
+  `:platform-api` for the Platform API v1 router and JSON surface currently mounted at
   `/api/v1/`, `:platform-web-shell` for the first browser-facing node-management shell currently
   mounted at `/app/node/`,
   runtime-owned shell and password-prompt seams under `network.crypta.runtime.http` and
@@ -769,8 +770,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.io*` helpers; `:kernel-routing` provides the compile-neutral phase-1
   `network.crypta.node` helper slice across selected request/routing value, exception, callback,
   and request-item types; `:runtime-spi` provides `network.crypta.runtime.spi`;
-  `:platform-api` provides the transport-neutral read-only Platform API v1; `:platform-apphost`
-  provides the transport-neutral out-of-process AppHost v1 core for installed local apps;
+  `:platform-api` provides the transport-neutral Platform API v1 plus the minimal AppHost
+  control-plane routes; `:platform-apphost` provides the transport-neutral out-of-process AppHost
+  v1 core for installed local apps;
   `:platform-web-shell` provides the browser-facing Web Shell v1 node-management assets and
   bootstrap contract; `:runtime-node`
   provides the extracted daemon runtime body across the remaining cyclic/high-level

--- a/adapter-http-legacy-admin/build.gradle.kts
+++ b/adapter-http-legacy-admin/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   implementation(project(":kernel-routing"))
   implementation(project(":runtime-spi"))
   implementation(project(":platform-api"))
+  implementation(project(":platform-apphost"))
   implementation(project(":platform-web-shell"))
   implementation(project(":runtime-node"))
   implementation(project(":thirdparty-onion"))

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -369,7 +369,8 @@ final class FProxyRegistrar {
             true,
             ignored -> WebShellPaths.SHELL_ROOT.equals(server.primaryUiRoot())));
 
-    PlatformApiToadlet platformApiToadlet = new PlatformApiToadlet(client, runtimePorts);
+    PlatformApiToadlet platformApiToadlet =
+        new PlatformApiToadlet(client, runtimePorts, dependencies.appHost());
     server.register(
         platformApiToadlet,
         ToadletRegistration.basic(null, PlatformApiToadlet.MOUNT_PATH, true, true));

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http;
 import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
+import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
@@ -21,11 +22,16 @@ import network.crypta.runtime.spi.RuntimePorts;
  *
  * @param client shared interactive client used by registered HTTP toadlets
  * @param runtimePorts detached runtime ports exposed to the HTTP shell
+ * @param appHost shared AppHost instance exposed through the Platform API bridge
  * @param config node configuration used to list sub-config toadlets
  * @param fproxy prebuilt root FProxy toadlet handed to the registrar for root-path registration
  */
 record FProxyRegistrarDependencies(
-    HighLevelSimpleClient client, RuntimePorts runtimePorts, Config config, FProxyToadlet fproxy) {
+    HighLevelSimpleClient client,
+    RuntimePorts runtimePorts,
+    AppHost appHost,
+    Config config,
+    FProxyToadlet fproxy) {
   /**
    * Creates a validated dependency bundle for {@link FProxyRegistrar}.
    *
@@ -35,6 +41,7 @@ record FProxyRegistrarDependencies(
    *
    * @param client shared interactive client used by registered HTTP toadlets during registration
    * @param runtimePorts runtime-spi ports exposed to HTTP-layer toadlets and helper pages
+   * @param appHost shared AppHost instance exposed through the Platform API bridge
    * @param config node configuration used to list and filter sub-config toadlets
    * @param fproxy prebuilt root FProxy toadlet that is registered at the HTTP root path
    * @throws NullPointerException if any required collaborator is absent at construction time
@@ -42,6 +49,7 @@ record FProxyRegistrarDependencies(
   FProxyRegistrarDependencies {
     Objects.requireNonNull(client);
     Objects.requireNonNull(runtimePorts);
+    Objects.requireNonNull(appHost);
     Objects.requireNonNull(config);
     Objects.requireNonNull(fproxy);
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellFProxyBootstrap.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellFProxyBootstrap.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http;
 import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.platform.apphost.AppHost;
 
 /**
  * Bundles the daemon-built collaborators that the HTTP shell needs after root FProxy bootstrap.
@@ -10,18 +11,23 @@ import network.crypta.clients.http.bookmark.BookmarkManager;
  * <p>{@link SimpleToadletServer} creates the root FProxy stack only once and then reuses the
  * resulting collaborators when it registers child toadlets and bookmark-dependent views. This
  * record keeps that handoff explicit and minimal: the bookmark manager carries the daemon-backed
- * bookmark runtime, the interactive client is shared by HTTP toadlets, and the root {@link
- * FProxyToadlet} is returned directly to the shell bootstrap path for registration.
+ * bookmark runtime, the interactive client is shared by HTTP toadlets, the shared AppHost instance
+ * is retained for the platform control plane, and the root {@link FProxyToadlet} is returned
+ * directly to the shell bootstrap path for registration.
  *
  * <p>This record is public only, so runtime-owned HTTP bootstrap adapters can construct and return
  * the bundle from outside {@code network.crypta.clients.http}. It is not a new platform API.
  *
  * @param bookmarkManager bookmark manager wired against the daemon-backed bookmark runtime support
  * @param client interactive client shared by HTTP toadlets created during shell startup
+ * @param appHost shared AppHost instance used by the Platform API control plane
  * @param fproxy root FProxy toadlet constructed during bootstrap and handed to the registrar flow
  */
 public record HttpShellFProxyBootstrap(
-    BookmarkManager bookmarkManager, HighLevelSimpleClient client, FProxyToadlet fproxy) {
+    BookmarkManager bookmarkManager,
+    HighLevelSimpleClient client,
+    AppHost appHost,
+    FProxyToadlet fproxy) {
 
   /**
    * Creates the bundle while keeping {@link FProxyToadlet}'s constructor package-owned.
@@ -31,6 +37,7 @@ public record HttpShellFProxyBootstrap(
    *
    * @param bookmarkManager bookmark manager used by the surrounding shell bootstrap
    * @param client interactive client shared by FProxy and sibling toadlets
+   * @param appHost shared AppHost instance used by the platform control plane
    * @param runtimeSupport FProxy runtime adapter used by the root toadlet
    * @param fetchTracker fetch tracker shared by root FProxy request handling
    * @return bootstrap bundle containing the constructed root FProxy toadlet
@@ -38,10 +45,11 @@ public record HttpShellFProxyBootstrap(
   public static HttpShellFProxyBootstrap create(
       BookmarkManager bookmarkManager,
       HighLevelSimpleClient client,
+      AppHost appHost,
       FProxyRuntimeSupport runtimeSupport,
       FProxyFetchTracker fetchTracker) {
     return new HttpShellFProxyBootstrap(
-        bookmarkManager, client, new FProxyToadlet(client, runtimeSupport, fetchTracker));
+        bookmarkManager, client, appHost, new FProxyToadlet(client, runtimeSupport, fetchTracker));
   }
 
   /**
@@ -52,6 +60,7 @@ public record HttpShellFProxyBootstrap(
   public HttpShellFProxyBootstrap {
     Objects.requireNonNull(bookmarkManager);
     Objects.requireNonNull(client);
+    Objects.requireNonNull(appHost);
     Objects.requireNonNull(fproxy);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.io.File;
 import network.crypta.config.Config;
+import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Ticker;
@@ -39,6 +40,16 @@ public interface HttpShellRuntimeSupport {
    * @return live configuration object used by HTTP shell callbacks and startup checks
    */
   Config config();
+
+  /**
+   * Returns the long-lived AppHost instance used by the platform control plane.
+   *
+   * <p>The returned host is shared across the current node lifecycle. Callers should treat it as a
+   * managed runtime service rather than constructing new AppHost instances per request.
+   *
+   * @return shared AppHost instance used by Platform API app-management routes
+   */
+  AppHost appHost();
 
   /**
    * Returns the ticker used for shell tasks that rely on the daemon scheduler.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -6,12 +6,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.platform.api.PlatformApiPaths;
 import network.crypta.platform.api.PlatformApiRequest;
 import network.crypta.platform.api.PlatformApiResponse;
 import network.crypta.platform.api.PlatformApiRouter;
+import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.URLDecoder;
@@ -21,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Thin legacy-HTTP bridge for the read-only Platform API v1.
+ * Thin legacy-HTTP bridge for Platform API v1.
  *
  * <p>This toadlet keeps all transport-neutral routing and JSON construction inside {@code
  * :platform-api}. Its responsibility is limited to enforcing the existing full-access expectation
@@ -41,6 +43,10 @@ public final class PlatformApiToadlet extends Toadlet {
   /** JSON media type advertised for every Platform API response emitted through the bridge. */
   private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
+  private static final String FORM_PASSWORD_PARAMETER = "formPassword";
+  private static final String STAGED_DIR_PARAMETER = "stagedDir";
+  private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = 4096;
+
   /**
    * Transport-neutral router that owns endpoint selection, validation, and JSON payload creation.
    */
@@ -57,11 +63,24 @@ public final class PlatformApiToadlet extends Toadlet {
   }
 
   /**
+   * Creates a platform API toadlet backed by runtime ports and AppHost.
+   *
+   * @param client high-level client helper retained by the toadlet base type
+   * @param runtimePorts detached runtime ports exposed to the platform API leaf
+   * @param appHost detached AppHost exposed through the app-management control surface
+   */
+  public PlatformApiToadlet(
+      HighLevelSimpleClient client, RuntimePorts runtimePorts, AppHost appHost) {
+    this(client, new PlatformApiRouter(runtimePorts, appHost));
+  }
+
+  /**
    * Creates a platform API toadlet backed by an already constructed router.
    *
    * <p>This constructor exists for tests and narrow composition sites that need to inject a router
    * with controlled behavior. Production wiring normally uses {@link
-   * #PlatformApiToadlet(HighLevelSimpleClient, RuntimePorts)} so the bridge owns router creation.
+   * #PlatformApiToadlet(HighLevelSimpleClient, RuntimePorts, AppHost)} so the bridge owns router
+   * creation.
    *
    * @param client high-level client helper retained by the toadlet base type
    * @param router transport-neutral router that handles request validation and response generation
@@ -78,11 +97,7 @@ public final class PlatformApiToadlet extends Toadlet {
   }
 
   /**
-   * Returns a JSON {@code 405} error for unsupported POST requests.
-   *
-   * <p>The Platform API v1 surface is read-only. POST still routes through the shared Platform API
-   * error handling path, so callers receive the same JSON error shape and {@code Allow: GET} header
-   * that they would see for other unsupported verbs.
+   * Routes POST requests through the Platform API router.
    *
    * @param uri request target as seen by the legacy HTTP shell
    * @param request decoded legacy HTTP request wrapper
@@ -118,7 +133,7 @@ public final class PlatformApiToadlet extends Toadlet {
    * Returns a JSON {@code 405} error for unsupported OPTIONS requests.
    *
    * <p>The bridge forwards OPTIONS through the router when the legacy shell dispatches it. That
-   * keeps the Platform API method advertisement consistent with the read-only v1 contract.
+   * keeps the Platform API method advertisement consistent with the mounted v1 contract.
    *
    * @param uri request target as seen by the legacy HTTP shell
    * @param request decoded legacy HTTP request wrapper
@@ -146,7 +161,7 @@ public final class PlatformApiToadlet extends Toadlet {
   }
 
   /**
-   * Returns a JSON {@code 405} error for unsupported DELETE requests.
+   * Routes DELETE requests through the Platform API router.
    *
    * @param uri request target as seen by the legacy HTTP shell
    * @param request decoded legacy HTTP request wrapper
@@ -192,6 +207,13 @@ public final class PlatformApiToadlet extends Toadlet {
     return MOUNT_PATH;
   }
 
+  /**
+   * Keeps the container from applying its POST-only password gate ahead of the bridge.
+   *
+   * <p>The bridge enforces the legacy form password explicitly after it has checked full-access
+   * permissions, which preserves the Platform API's JSON {@code 403} behavior for non-full-access
+   * callers and extends the same password requirement to DELETE.
+   */
   @Override
   public boolean allowPOSTWithoutPassword() {
     return true;
@@ -219,11 +241,11 @@ public final class PlatformApiToadlet extends Toadlet {
   /**
    * Routes a request through the Platform API and writes either a full or header-only reply.
    *
-   * <p>Legacy HTTP integration keeps full-access enforcement at the bridge boundary. Requests that
-   * pass the access check are converted into a transport-neutral {@link PlatformApiRequest} and
-   * delegated to the router. Unexpected runtime failures are converted into a structured {@code
-   * 500} response so callers keep the Platform API JSON contract even when the bridge logs the
-   * underlying error.
+   * <p>Legacy HTTP integration keeps full-access enforcement at the bridge boundary. Mutating
+   * requests then pass through the legacy form-password check before the bridge converts them into
+   * a transport-neutral {@link PlatformApiRequest} and delegates to the router. Unexpected runtime
+   * failures are converted into a structured {@code 500} response so callers keep the Platform API
+   * JSON contract even when the bridge logs the underlying error.
    *
    * @param method HTTP method name forwarded into the Platform API router
    * @param uri request target supplied by the legacy HTTP shell
@@ -243,6 +265,9 @@ public final class PlatformApiToadlet extends Toadlet {
       writeJsonReply(ctx, response, includeBody);
       return;
     }
+    if (!authorizeMutationRequest(method, uri, request, ctx)) {
+      return;
+    }
 
     try {
       response = router.route(toPlatformApiRequest(method, uri, request));
@@ -259,10 +284,84 @@ public final class PlatformApiToadlet extends Toadlet {
   }
 
   /**
+   * Returns whether the current request targets one of the mutating app-management routes.
+   *
+   * <p>The legacy shell only auto-checks form passwords for POST before dispatch. The Platform API
+   * bridge keeps full-access checks ahead of password checks and applies the same legacy password
+   * guard to DELETE so mutating app-management routes stay protected without changing their public
+   * route shape.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param uri request target supplied by the legacy HTTP shell
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresFormPassword(String method, URI uri) {
+    if (!"POST".equals(method) && !"DELETE".equals(method)) {
+      return false;
+    }
+
+    List<String> pathSegments;
+    try {
+      pathSegments = relativeApiPath(requestPath(uri));
+    } catch (URLEncodedFormatException _) {
+      return false;
+    }
+
+    if (pathSegments.isEmpty() || !"apps".equals(pathSegments.getFirst())) {
+      return false;
+    }
+    if ("DELETE".equals(method)) {
+      return pathSegments.size() == 2;
+    }
+    if (pathSegments.size() == 2 && "install".equals(pathSegments.get(1))) {
+      return true;
+    }
+    return pathSegments.size() == 3
+        && ("start".equals(pathSegments.get(2)) || "stop".equals(pathSegments.get(2)));
+  }
+
+  /**
+   * Enforces the legacy form-password requirement for mutating requests.
+   *
+   * <p>POST continues to use the existing toadlet-context helper unchanged. DELETE requires the
+   * same body-carried form password, but authentication failures are reported as structured JSON
+   * {@code 403} responses instead of redirects so clients cannot mistake a followed GET for a
+   * successful uninstall.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param uri request target supplied by the legacy HTTP shell
+   * @param request decoded legacy HTTP request wrapper
+   * @param ctx current toadlet context used for password validation and response writes
+   * @return {@code true} when the request is authorized to mutate state
+   * @throws ToadletContextClosedException if the client disconnects while an auth failure is sent
+   * @throws IOException if the legacy HTTP shell fails while writing the auth failure
+   */
+  private boolean authorizeMutationRequest(
+      String method, URI uri, HTTPRequest request, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (!requiresFormPassword(method, uri)) {
+      return true;
+    }
+    String redirectTarget = requestPath(uri);
+    if ("POST".equals(method)) {
+      return ctx.checkFormPassword(request, redirectTarget);
+    }
+    if (ctx.hasFormPassword(request)) {
+      return true;
+    }
+    writeJsonReply(
+        ctx, PlatformApiResponse.error(403, "forbidden", "Valid form password is required."), true);
+    return false;
+  }
+
+  /**
    * Converts legacy HTTP request state into the transport-neutral Platform API request model.
    *
    * <p>Query parameters preserve encounter order and repeated values so the router can apply its
-   * own validation without depending on the legacy HTTP request type.
+   * own validation without depending on the legacy HTTP request type. The bridge excludes the
+   * legacy admin {@code formPassword} from that map and also lifts the small set of scalar form
+   * fields currently needed by Platform API v1 into the same map, because the transport-neutral
+   * request model intentionally does not define a separate body contract yet.
    *
    * @param method HTTP method name forwarded into the router
    * @param uri request target supplied by the legacy HTTP shell
@@ -275,9 +374,35 @@ public final class PlatformApiToadlet extends Toadlet {
     LinkedHashMap<String, List<String>> queryParameters =
         LinkedHashMap.newLinkedHashMap(request.getParameterNames().size());
     for (String parameterName : request.getParameterNames()) {
+      if (FORM_PASSWORD_PARAMETER.equals(parameterName)) {
+        continue;
+      }
       queryParameters.put(parameterName, List.of(request.getMultipleParam(parameterName)));
     }
+    copyStringPartIfPresent(request, queryParameters, STAGED_DIR_PARAMETER);
     return new PlatformApiRequest(method, relativeApiPath(requestPath(uri)), queryParameters);
+  }
+
+  /**
+   * Copies one scalar form part into the query-like parameter map when present.
+   *
+   * <p>This keeps the bridge compatible with legacy authenticated form submissions while preserving
+   * the transport-neutral request model expected by the Platform API router.
+   *
+   * @param request decoded legacy HTTP request wrapper
+   * @param queryParameters query-like parameter map being assembled for the router
+   * @param parameterName parameter or part name to copy
+   */
+  private static void copyStringPartIfPresent(
+      HTTPRequest request, Map<String, List<String>> queryParameters, String parameterName) {
+    if (queryParameters.containsKey(parameterName) || !request.isPartSet(parameterName)) {
+      return;
+    }
+    String value =
+        request.getPartAsStringFailsafe(parameterName, MAX_PLATFORM_API_FORM_FIELD_LENGTH);
+    if (!value.isEmpty()) {
+      queryParameters.put(parameterName, List.of(value));
+    }
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -323,10 +323,9 @@ public final class PlatformApiToadlet extends Toadlet {
   /**
    * Enforces the legacy form-password requirement for mutating requests.
    *
-   * <p>POST continues to use the existing toadlet-context helper unchanged. DELETE requires the
-   * same body-carried form password, but authentication failures are reported as structured JSON
-   * {@code 403} responses instead of redirects so clients cannot mistake a followed GET for a
-   * successful uninstall.
+   * <p>App-management mutations keep the legacy body-carried form password requirement, but the
+   * bridge handles failures itself so callers always receive structured JSON {@code 403} responses
+   * instead of legacy redirects.
    *
    * @param method HTTP method name forwarded into the router
    * @param uri request target supplied by the legacy HTTP shell
@@ -341,10 +340,6 @@ public final class PlatformApiToadlet extends Toadlet {
       throws ToadletContextClosedException, IOException {
     if (!requiresFormPassword(method, uri)) {
       return true;
-    }
-    String redirectTarget = requestPath(uri);
-    if ("POST".equals(method)) {
-      return ctx.checkFormPassword(request, redirectTarget);
     }
     if (ctx.hasFormPassword(request)) {
       return true;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -484,7 +484,11 @@ public final class SimpleToadletServer
 
     FProxyRegistrar.maybeCreateFProxyEtc(
         new FProxyRegistrarDependencies(
-            bootstrap.client(), runtimePorts, runtimeSupportRef.config(), bootstrap.fproxy()),
+            bootstrap.client(),
+            runtimePorts,
+            runtimeSupportRef.appHost(),
+            runtimeSupportRef.config(),
+            bootstrap.fproxy()),
         this);
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.http.bridge;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.FProxyFetchTracker;
@@ -16,9 +17,16 @@ import network.crypta.node.RequestClientBuilder;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
+import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Ticker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Adapts {@link NodeClientCore} to the narrow runtime surface used by {@link SimpleToadletServer}.
@@ -27,13 +35,16 @@ import network.crypta.support.Ticker;
  * instead of letting the server reach directly into the daemon core. Callers normally create one
  * instance during a server bootstrap and then treat it as an immutable delegate. The adapter is
  * intentionally HTTP-local rather than a reusable platform API: it still exposes alerts, config
- * storage, upload permission checks, and FProxy bootstrap work because those behaviors remain part
- * of the HTTP shell in the current architecture.
+ * storage, upload permission checks, AppHost access, and FProxy bootstrap work because those
+ * behaviors remain part of the HTTP shell in the current architecture.
  *
  * @param core daemon core that backs delegated shell services and FProxy bootstrap wiring
+ * @param appHost shared AppHost instance used by the platform control plane
  */
-public record CoreHttpShellRuntimeSupport(NodeClientCore core)
+public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
     implements network.crypta.runtime.http.HttpShellRuntimeSupport, HttpShellRuntimeSupport {
+  private static final Logger LOG = LoggerFactory.getLogger(CoreHttpShellRuntimeSupport.class);
+
   /**
    * Creates a core-backed HTTP runtime adapter.
    *
@@ -44,7 +55,19 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core)
    * @throws NullPointerException if {@code core} is {@code null}
    */
   public CoreHttpShellRuntimeSupport(NodeClientCore core) {
-    this.core = Objects.requireNonNull(core);
+    this(core, createManagedAppHost(Objects.requireNonNull(core, "core")));
+  }
+
+  /**
+   * Creates a core-backed HTTP runtime adapter with an explicit AppHost.
+   *
+   * @param core daemon core that supplies the shell-level runtime services
+   * @param appHost shared AppHost instance used by the platform control plane
+   * @throws NullPointerException if {@code core} or {@code appHost} is {@code null}
+   */
+  public CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost) {
+    this.core = Objects.requireNonNull(core, "core");
+    this.appHost = Objects.requireNonNull(appHost, "appHost");
   }
 
   @Override
@@ -55,6 +78,11 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core)
   @Override
   public Config config() {
     return core.getNode().getConfig();
+  }
+
+  @Override
+  public AppHost appHost() {
+    return appHost;
   }
 
   @Override
@@ -125,7 +153,7 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core)
             new RequestClientBuilder().realTime().build());
     FProxyRuntimeSupport fproxyRuntimeSupport = new CoreFProxyRuntimeSupport(core);
     return HttpShellFProxyBootstrap.create(
-        bookmarkManager, client, fproxyRuntimeSupport, fetchTracker);
+        bookmarkManager, client, appHost, fproxyRuntimeSupport, fetchTracker);
   }
 
   /**
@@ -156,5 +184,66 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core)
       case HIGH -> PhysicalThreatLevel.HIGH;
       case MAXIMUM -> PhysicalThreatLevel.MAXIMUM;
     };
+  }
+
+  /**
+   * Creates the shared AppHost instance and registers its shutdown cleanup.
+   *
+   * @param core daemon core that exposes the current node and temp-directory layout
+   * @return managed AppHost instance rooted in the current node layout
+   */
+  private static AppHost createManagedAppHost(NodeClientCore core) {
+    AppHost appHost = createAppHost(core);
+    SemiOrderedShutdownHook.get().addEarlyJob(createAppHostShutdownJob(appHost));
+    return appHost;
+  }
+
+  /**
+   * Creates the single AppHost instance shared by the current HTTP bridge.
+   *
+   * <p>The host is rooted in the live node/core directories that the current daemon instance has
+   * already selected. That keeps app installs, cache data, and run files attached to this node
+   * rather than a fresh global directory lookup that could ignore per-instance overrides.
+   *
+   * @param core daemon core that exposes the current node and temp-directory layout
+   * @return long-lived AppHost instance rooted in the current node layout
+   */
+  private static AppHost createAppHost(NodeClientCore core) {
+    return new LocalProcessAppHost(
+        new AppHostLayout(
+            core.getNode().nodeDir().dir().toPath(),
+            core.getPersistentTempDir().toPath(),
+            core.getNode().runDir().dir().toPath()));
+  }
+
+  /**
+   * Creates the shutdown job that stops any AppHost-managed child processes on node exit.
+   *
+   * <p>The shared AppHost is otherwise only reachable through the HTTP runtime support. Registering
+   * this early shutdown job keeps app processes from surviving node shutdown and leaving stale run
+   * state behind for the next boot.
+   *
+   * @param appHost shared AppHost instance used by the platform control plane
+   * @return unstarted shutdown thread suitable for {@link SemiOrderedShutdownHook}
+   */
+  static Thread createAppHostShutdownJob(AppHost appHost) {
+    Objects.requireNonNull(appHost, "appHost");
+    return new Thread(() -> stopRunningAppsOnShutdown(appHost), "Shutdown AppHost");
+  }
+
+  private static void stopRunningAppsOnShutdown(AppHost appHost) {
+    for (RunningAppSnapshot runningApp : appHost.listRunning()) {
+      stopRunningAppOnShutdown(appHost, runningApp);
+    }
+  }
+
+  private static void stopRunningAppOnShutdown(AppHost appHost, RunningAppSnapshot runningApp) {
+    try {
+      appHost.stop(runningApp.appId());
+    } catch (IOException e) {
+      LOG.warn("Failed to stop app during shutdown: {}", runningApp.appId(), e);
+    } catch (RuntimeException e) {
+      LOG.warn("Unexpected app shutdown failure: {}", runningApp.appId(), e);
+    }
   }
 }

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -8,6 +8,7 @@ version = rootProject.version
 
 dependencies {
   api(project(":runtime-spi"))
+  api(project(":platform-apphost"))
 
   compileOnly(libs.jetbrainsAnnotations)
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiParameters.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiParameters.java
@@ -43,6 +43,21 @@ public final class PlatformApiParameters {
   }
 
   /**
+   * Reads one required string query parameter.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @return supplied value
+   */
+  public static String requireString(Map<String, List<String>> queryParameters, String name) {
+    String raw = readSingle(queryParameters, name);
+    if (raw == null || raw.isBlank()) {
+      throw invalidQuery("Missing required query parameter '" + name + "'.");
+    }
+    return raw;
+  }
+
+  /**
    * Reads one required enum query parameter using the enum's exact {@link Enum#name()} values.
    *
    * @param queryParameters decoded query parameter map

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiPaths.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiPaths.java
@@ -3,11 +3,11 @@ package network.crypta.platform.api;
 /**
  * Canonical path constants for the Platform API.
  *
- * <p>The initial read-only API is mounted under one versioned prefix, so transport-specific bridges
- * can expose it consistently without duplicating the route string throughout the codebase.
+ * <p>The Platform API is mounted under one versioned prefix, so transport-specific bridges can
+ * expose it consistently without duplicating the route string throughout the codebase.
  */
 public final class PlatformApiPaths {
-  /** The current versioned mount prefix for the read-only Platform API v1. */
+  /** The current versioned mount prefix for Platform API v1. */
   public static final String API_V1_PREFIX = "/api/v1/";
 
   /** Prevents instantiation of this constants-only type. */

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
@@ -48,6 +48,16 @@ public record PlatformApiResponse(
   }
 
   /**
+   * Builds a {@code 201 Created} JSON response for the supplied body value.
+   *
+   * @param value JSON-compatible body value to serialize
+   * @return {@code 201 Created} response carrying the serialized body
+   */
+  public static PlatformApiResponse created(Object value) {
+    return json(201, Map.of(), value);
+  }
+
+  /**
    * Builds a JSON error response using the standard Platform API error shape.
    *
    * @param statusCode transport-level status code to return
@@ -91,11 +101,13 @@ public record PlatformApiResponse(
    */
   static String reasonPhrase(int statusCode) {
     return switch (statusCode) {
+      case 201 -> "Created";
       case 200 -> "OK";
       case 400 -> "Bad Request";
       case 403 -> "Forbidden";
       case 404 -> "Not Found";
       case 405 -> "Method Not Allowed";
+      case 409 -> "Conflict";
       case 500 -> "Internal Server Error";
       default -> "Platform API";
     };

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -3,18 +3,20 @@ package network.crypta.platform.api;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import network.crypta.platform.api.apps.AppsApiHandler;
 import network.crypta.platform.api.config.ConfigApiHandler;
 import network.crypta.platform.api.connectivity.ConnectivityApiHandler;
 import network.crypta.platform.api.node.NodeApiHandler;
 import network.crypta.platform.api.peers.PeersApiHandler;
 import network.crypta.platform.api.security.SecurityLevelsApiHandler;
+import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
  * Routes transport-neutral Platform API requests onto detached runtime ports.
  *
- * <p>The router keeps the initial Platform API v1 surface small and predictable. It accepts one
- * request descriptor, validates the method and relative path beneath {@link
+ * <p>The router keeps the Platform API v1 surface small and predictable. It accepts one request
+ * descriptor, validates the method and relative path beneath {@link
  * PlatformApiPaths#API_V1_PREFIX}, delegates to the relevant endpoint family, and emits a JSON
  * response with stable status codes for malformed requests and missing resources.
  */
@@ -37,6 +39,9 @@ public final class PlatformApiRouter {
   /** Handler for the {@code /security-levels} endpoint. */
   private final SecurityLevelsApiHandler securityLevelsApiHandler;
 
+  /** Handler for the {@code /apps/...} endpoint family, when AppHost support is available. */
+  private final AppsApiHandler appsApiHandler;
+
   /**
    * Creates a router backed by the supplied runtime ports.
    *
@@ -44,12 +49,24 @@ public final class PlatformApiRouter {
    * @throws NullPointerException if {@code runtimePorts} is {@code null}
    */
   public PlatformApiRouter(RuntimePorts runtimePorts) {
+    this(runtimePorts, null);
+  }
+
+  /**
+   * Creates a router backed by the supplied runtime ports and AppHost instance.
+   *
+   * @param runtimePorts detached runtime-port aggregate used to resolve API requests
+   * @param appHost detached AppHost used by the app-management endpoint family
+   * @throws NullPointerException if {@code runtimePorts} is {@code null}
+   */
+  public PlatformApiRouter(RuntimePorts runtimePorts, AppHost appHost) {
     Objects.requireNonNull(runtimePorts, "runtimePorts");
     nodeApiHandler = new NodeApiHandler(runtimePorts.nodeInfo());
     peersApiHandler = new PeersApiHandler(runtimePorts.peer());
     configApiHandler = new ConfigApiHandler(runtimePorts.config());
     connectivityApiHandler = new ConnectivityApiHandler(runtimePorts.connectivity());
     securityLevelsApiHandler = new SecurityLevelsApiHandler(runtimePorts.securityLevels());
+    appsApiHandler = appHost == null ? null : new AppsApiHandler(appHost);
   }
 
   /**
@@ -80,6 +97,16 @@ public final class PlatformApiRouter {
    * @return JSON response for the routed endpoint or a structured error response
    */
   private PlatformApiResponse routeInternal(PlatformApiRequest request) {
+    List<String> segments = request.pathSegments();
+    if (segments.isEmpty()) {
+      throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    }
+
+    String firstSegment = segments.getFirst();
+    if ("apps".equals(firstSegment)) {
+      return routeAppsRequest(segments, request);
+    }
+
     if (!"GET".equals(request.method())) {
       return PlatformApiResponse.error(
           405,
@@ -88,12 +115,6 @@ public final class PlatformApiRouter {
           "Platform API v1 supports GET requests only.");
     }
 
-    List<String> segments = request.pathSegments();
-    if (segments.isEmpty()) {
-      throw new PlatformApiException(404, "not_found", "Platform API route not found.");
-    }
-
-    String firstSegment = segments.getFirst();
     if ("node".equals(firstSegment)) {
       return routeNodeRequest(segments, request);
     }
@@ -111,6 +132,121 @@ public final class PlatformApiRouter {
     }
 
     throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /apps} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected app-management endpoint
+   * @throws PlatformApiException if the path or method does not identify a supported app endpoint
+   */
+  private PlatformApiResponse routeAppsRequest(List<String> segments, PlatformApiRequest request) {
+    if (appsApiHandler == null) {
+      throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    }
+
+    return switch (segments.size()) {
+      case 1 -> routeAppsCollection(request.method());
+      case 2 -> routeAppsResource(segments.get(1), request);
+      case 3 -> routeAppsAction(segments.get(1), segments.get(2), request.method());
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  /**
+   * Routes the {@code /apps} collection endpoint.
+   *
+   * @param method HTTP-style request method
+   * @return JSON response for the app collection
+   */
+  private PlatformApiResponse routeAppsCollection(String method) {
+    if (!"GET".equals(method)) {
+      return methodNotAllowed("GET", "Platform API v1 supports GET requests only.");
+    }
+    return PlatformApiResponse.ok(envelope("apps", appsApiHandler.list()));
+  }
+
+  /**
+   * Routes either one installed-app resource or the installation endpoint.
+   *
+   * @param resourceSegment second path segment beneath {@code /apps}
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected app endpoint
+   */
+  private PlatformApiResponse routeAppsResource(
+      String resourceSegment, PlatformApiRequest request) {
+    if ("install".equals(resourceSegment) && !targetsInstalledAppResource(request.method())) {
+      return routeAppsInstall(request);
+    }
+    return routeInstalledApp(resourceSegment, request.method());
+  }
+
+  /**
+   * Routes the {@code /apps/install} endpoint.
+   *
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the installation operation
+   */
+  private PlatformApiResponse routeAppsInstall(PlatformApiRequest request) {
+    if (!"POST".equals(request.method())) {
+      return methodNotAllowed("POST", "Platform API v1 supports POST requests only.");
+    }
+    return PlatformApiResponse.created(
+        envelope("app", appsApiHandler.install(request.queryParameters())));
+  }
+
+  /**
+   * Routes one installed app resource at {@code /apps/{appId}}.
+   *
+   * @param appId normalized app identifier segment
+   * @param method HTTP-style request method
+   * @return JSON response for the requested app resource
+   */
+  private PlatformApiResponse routeInstalledApp(String appId, String method) {
+    if ("GET".equals(method)) {
+      return PlatformApiResponse.ok(envelope("app", appsApiHandler.get(appId)));
+    }
+    if ("DELETE".equals(method)) {
+      return PlatformApiResponse.ok(envelope("app", appsApiHandler.uninstall(appId)));
+    }
+    return methodNotAllowed(
+        "GET, DELETE", "Platform API v1 supports GET and DELETE requests only.");
+  }
+
+  /**
+   * Returns whether the current method should target an installed-app resource rather than the
+   * reserved installation endpoint.
+   *
+   * <p>The id {@code install} remains valid for the app-resource routes on GET and DELETE, while
+   * method discovery and unsupported-method handling for {@code /apps/install} continue to
+   * advertise the installation endpoint's POST contract.
+   *
+   * @param method HTTP-style request method
+   * @return {@code true} when the request should be treated as {@code /apps/{appId}}
+   */
+  private static boolean targetsInstalledAppResource(String method) {
+    return "GET".equals(method) || "DELETE".equals(method);
+  }
+
+  /**
+   * Routes app lifecycle actions beneath {@code /apps/{appId}/...}.
+   *
+   * @param appId normalized app identifier segment
+   * @param action lifecycle action segment
+   * @param method HTTP-style request method
+   * @return JSON response for the selected app action
+   */
+  private PlatformApiResponse routeAppsAction(String appId, String action, String method) {
+    if (!"POST".equals(method)) {
+      return methodNotAllowed("POST", "Platform API v1 supports POST requests only.");
+    }
+    return switch (action) {
+      case "start" -> PlatformApiResponse.ok(envelope("app", appsApiHandler.start(appId)));
+      case "stop" -> PlatformApiResponse.ok(envelope("app", appsApiHandler.stop(appId)));
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
   }
 
   /**
@@ -148,5 +284,29 @@ public final class PlatformApiRouter {
           peersApiHandler.get(segments.get(1), request.queryParameters()));
     }
     throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Builds a small single-entry JSON envelope.
+   *
+   * @param key envelope field name
+   * @param value envelope value
+   * @return ordered JSON-compatible envelope object
+   */
+  private static Map<String, Object> envelope(String key, Object value) {
+    java.util.LinkedHashMap<String, Object> envelope = java.util.LinkedHashMap.newLinkedHashMap(1);
+    envelope.put(key, value);
+    return envelope;
+  }
+
+  /**
+   * Creates a structured 405 response with a stable Allow header.
+   *
+   * @param allow allowed methods for the current route
+   * @param message human-readable error message
+   * @return structured platform API response
+   */
+  private static PlatformApiResponse methodNotAllowed(String allow, String message) {
+    return PlatformApiResponse.error(405, Map.of("Allow", allow), "method_not_allowed", message);
   }
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -1,0 +1,574 @@
+package network.crypta.platform.api.apps;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
+
+/**
+ * App-management endpoint family for Platform API v1.
+ *
+ * <p>The handler keeps the transport-neutral AppHost surface small and explicit. It performs
+ * request-parameter validation, maps AppHost snapshots onto stable JSON-friendly summaries, and
+ * leaves the legacy HTTP bridge responsible only for authentication and byte-level response I/O.
+ *
+ * <p>Callers typically reach this type through {@code PlatformApiRouter} when servicing {@code
+ * /api/v1/apps/...} requests. The handler does not parse request bodies or manage authentication
+ * state. Instead, it accepts already-decoded path and query inputs, applies the minimal validation
+ * needed for the app-management contract, and delegates lifecycle work to the shared {@link
+ * AppHost}. That split keeps the Platform API surface transport-neutral while still exposing local
+ * AppHost control operations through stable HTTP-style semantics.
+ *
+ * <p>The returned maps are deliberately conservative operator-facing projections. They merge
+ * installation metadata with live process state, preserve deterministic field ordering for JSON
+ * serialization, and avoid leaking AppHost-internal details such as launch tokens or filesystem
+ * layout. Error mapping follows the Platform API v1 contract: malformed inputs become structured
+ * {@code 400} responses, missing apps become {@code 404}, lifecycle conflicts become {@code 409},
+ * and unexpected host-side failures remain {@code 500}.
+ *
+ * <ul>
+ *   <li>Inventory reads merge installed and running state into one summary shape.
+ *   <li>Mutation routes stay local and explicit: install, start, stop, and uninstall.
+ *   <li>Cleanup flows keep working even when installed manifests have become unreadable.
+ * </ul>
+ */
+public final class AppsApiHandler {
+  private static final String APP_ALREADY_INSTALLED_PREFIX = "app already installed: ";
+
+  /** Detached AppHost core used for app lifecycle and inventory operations. */
+  private final AppHost appHost;
+
+  /**
+   * Creates an app-management handler backed by the supplied AppHost.
+   *
+   * <p>The supplied host is expected to be a long-lived shared instance owned by bootstrap or
+   * composition code rather than a per-request object. This handler keeps only a reference to that
+   * dependency and performs no additional caching, so later AppHost reads always reflect the
+   * current host view of installed and running applications.
+   *
+   * @param appHost detached AppHost core used for app lifecycle operations
+   */
+  public AppsApiHandler(AppHost appHost) {
+    this.appHost = Objects.requireNonNull(appHost, "appHost");
+  }
+
+  /**
+   * Lists all installed apps with their merged running-state summary.
+   *
+   * <p>The returned list is suitable for the {@code {"apps":[...]}} Platform API envelope. Each
+   * entry starts from the AppHost-installed snapshot and then overlays live process information, if
+   * present, so callers do not need a second status request to determine whether an app is
+   * currently running.
+   *
+   * @return ordered list of app summaries suitable for JSON serialization
+   */
+  public List<Map<String, Object>> list() {
+    try {
+      Map<String, RunningAppSnapshot> runningByAppId = runningByAppId(appHost.listRunning());
+      return appHost.listInstalled().stream()
+          .map(
+              snapshot ->
+                  summarize(snapshot.manifest(), true, runningByAppId.get(snapshot.appId())))
+          .toList();
+    } catch (IOException _) {
+      throw internalError("Failed to list installed apps.");
+    }
+  }
+
+  /**
+   * Describes one installed app with its merged running-state summary.
+   *
+   * <p>The supplied identifier is normalized into the canonical AppHost form before lookup. A
+   * missing installation therefore reports the stable Platform API {@code app_not_found} error
+   * regardless of whether the original path segment differed only by case or formatting.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @return JSON-compatible app summary
+   */
+  public Map<String, Object> get(String appId) {
+    String normalizedAppId = normalizeAppId(appId);
+    InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
+    return summarize(installed.manifest(), true, appHost.status(normalizedAppId).orElse(null));
+  }
+
+  /**
+   * Installs one staged app bundle and returns the installed summary.
+   *
+   * <p>AppHost v1 installs only from a caller-supplied local staging directory. This method
+   * validates the {@code stagedDir} query parameter, parses the staged manifest early so conflicts
+   * can be reported before mutation, and returns a summary for the installed copy rather than the
+   * staging directory. Client-fixable bundle problems stay in the {@code 400} family, while
+   * concurrent reinstallation and already-installed cases are reported as {@code 409} conflicts.
+   *
+   * @param queryParameters decoded query parameters for the current request
+   * @return JSON-compatible app summary for the installed bundle
+   */
+  public Map<String, Object> install(Map<String, List<String>> queryParameters) {
+    Path stagedDir = parseStagedDirectory(queryParameters);
+    AppManifest manifest = parseManifest(stagedDir);
+    if (installed(manifest.appId())) {
+      throw conflict(APP_ALREADY_INSTALLED_PREFIX + manifest.appId());
+    }
+
+    try {
+      InstalledAppSnapshot installed = appHost.installFromDirectory(stagedDir);
+      return summarize(installed.manifest(), true, null);
+    } catch (AppHostException e) {
+      throw installFailure(manifest.appId(), e);
+    } catch (IOException _) {
+      throw internalError("Failed to install app.");
+    }
+  }
+
+  /**
+   * Starts one installed app and returns the running summary without exposing the launch token.
+   *
+   * <p>The method checks live status before it requires a readable installed manifest. That keeps
+   * repeated start requests idempotent from the caller's perspective even when a running app's
+   * installed manifest later becomes unreadable. On success, the summary is derived from the
+   * returned {@link RunningAppSnapshot}, so the response reflects the bundle that actually
+   * launched.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @return JSON-compatible app summary for the running app
+   */
+  public Map<String, Object> start(String appId) {
+    String normalizedAppId = normalizeAppId(appId);
+    if (appHost.status(normalizedAppId).isPresent()) {
+      throw conflict("app is already running: " + normalizedAppId);
+    }
+    requireInstalled(normalizedAppId);
+
+    try {
+      RunningAppSnapshot running = appHost.start(normalizedAppId);
+      return summarize(running.manifest(), true, running);
+    } catch (AppHostException e) {
+      throw startFailure(normalizedAppId, e);
+    } catch (IOException _) {
+      throw internalError("Failed to start app.");
+    }
+  }
+
+  /**
+   * Stops one running app and returns the installed summary.
+   *
+   * <p>This path anchors on the live {@link RunningAppSnapshot} first, which allows callers to stop
+   * a damaged-but-running app even if its installed manifest can no longer be read safely. When no
+   * live process exists, the method still distinguishes "not running" from "not installed" so
+   * callers receive the stable conflict or not-found contract instead of a generic internal error.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @return JSON-compatible app summary after the app has stopped
+   */
+  public Map<String, Object> stop(String appId) {
+    String normalizedAppId = normalizeAppId(appId);
+    RunningAppSnapshot running = appHost.status(normalizedAppId).orElse(null);
+    if (running == null) {
+      requireInstalled(normalizedAppId);
+      throw conflict("app is not running: " + normalizedAppId);
+    }
+
+    try {
+      if (!appHost.stop(normalizedAppId)) {
+        throw conflict("app is not running: " + normalizedAppId);
+      }
+      return summarize(running.manifest(), true, null);
+    } catch (IOException _) {
+      throw internalError("Failed to stop app.");
+    }
+  }
+
+  /**
+   * Uninstalls one stopped app and returns the final summary.
+   *
+   * <p>The response prefers the last readable installed snapshot, so callers get the normal summary
+   * shape after a successful uninstallation. If the installed manifest is already unreadable, the
+   * method still delegates to the AppHost uninstall path and falls back to a summary with
+   * manifest-derived fields set to {@code null}. That keeps cleanup flows available for corrupted
+   * installations without changing the top-level response envelope.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @return JSON-compatible app summary with {@code installed=false}
+   */
+  public Map<String, Object> uninstall(String appId) {
+    String normalizedAppId = normalizeAppId(appId);
+    if (appHost.status(normalizedAppId).isPresent()) {
+      throw conflict("cannot uninstall a running app: " + normalizedAppId);
+    }
+    InstalledAppSnapshot installed = describeForUninstallSummary(normalizedAppId);
+
+    try {
+      appHost.uninstall(normalizedAppId);
+      return installed != null
+          ? summarize(installed.manifest(), false, null)
+          : summarizeUnknown(normalizedAppId);
+    } catch (AppHostException e) {
+      throw uninstallFailure(normalizedAppId, e);
+    } catch (IOException _) {
+      throw internalError("Failed to uninstall app.");
+    }
+  }
+
+  /**
+   * Requires that one app is installed and returns its installed snapshot.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @return installed snapshot for the requested app
+   */
+  private InstalledAppSnapshot requireInstalled(String appId) {
+    try {
+      return appHost.describe(appId).orElseThrow(AppsApiHandler::appNotFound);
+    } catch (IOException _) {
+      throw internalError("Failed to read installed apps.");
+    }
+  }
+
+  /**
+   * Returns whether an app is already installed.
+   *
+   * @param appId stable application identifier
+   * @return {@code true} when the app is already installed
+   */
+  private boolean installed(String appId) {
+    try {
+      return appHost.describe(appId).isPresent();
+    } catch (IOException _) {
+      throw internalError("Failed to read installed apps.");
+    }
+  }
+
+  /**
+   * Attempts to read the installed snapshot for uninstallation response shaping.
+   *
+   * <p>Uninstall remains callable by app id even when the installed manifest is unreadable. This
+   * helper therefore treats read failures as "summary unavailable" rather than aborting the
+   * operation up front.
+   *
+   * @param appId stable application identifier
+   * @return installed snapshot when it can be read safely, otherwise {@code null}
+   */
+  private InstalledAppSnapshot describeForUninstallSummary(String appId) {
+    try {
+      return appHost.describe(appId).orElse(null);
+    } catch (IOException _) {
+      return null;
+    }
+  }
+
+  /**
+   * Converts the running-app list into a lookup keyed by app id.
+   *
+   * @param running running snapshots returned by the AppHost
+   * @return encounter-order-preserving running snapshot lookup
+   */
+  private static Map<String, RunningAppSnapshot> runningByAppId(List<RunningAppSnapshot> running) {
+    LinkedHashMap<String, RunningAppSnapshot> runningByAppId =
+        LinkedHashMap.newLinkedHashMap(running.size());
+    for (RunningAppSnapshot snapshot : running) {
+      runningByAppId.put(snapshot.appId(), snapshot);
+    }
+    return runningByAppId;
+  }
+
+  /**
+   * Extracts and validates the local staging directory from the request query.
+   *
+   * @param queryParameters decoded query parameters for the current request
+   * @return absolute staging directory path
+   */
+  private static Path parseStagedDirectory(Map<String, List<String>> queryParameters) {
+    String raw = PlatformApiParameters.requireString(queryParameters, "stagedDir");
+    try {
+      Path stagedDir = Path.of(raw).normalize();
+      if (!stagedDir.isAbsolute()) {
+        throw invalidQuery("Query parameter 'stagedDir' must be an absolute filesystem path.");
+      }
+      if (!Files.isDirectory(stagedDir, LinkOption.NOFOLLOW_LINKS)) {
+        throw invalidQuery("Query parameter 'stagedDir' must reference an existing directory.");
+      }
+      return stagedDir;
+    } catch (InvalidPathException _) {
+      throw invalidQuery("Query parameter 'stagedDir' must be a valid absolute filesystem path.");
+    }
+  }
+
+  /**
+   * Parses the staged app manifest so install requests can be rejected before mutation when the
+   * target app is already installed.
+   *
+   * @param stagedDir caller-supplied staged bundle directory
+   * @return parsed manifest for the staged bundle
+   */
+  private static AppManifest parseManifest(Path stagedDir) {
+    try {
+      return AppManifestParser.parse(stagedDir.resolve(AppManifestParser.MANIFEST_FILE_NAME));
+    } catch (IOException _) {
+      throw invalidQuery("Query parameter 'stagedDir' must reference a valid staged app bundle.");
+    }
+  }
+
+  /**
+   * Builds one JSON-friendly app summary from the manifest and optional running snapshot.
+   *
+   * @param manifest normalized application manifest
+   * @param installed whether the app is still installed
+   * @param running running snapshot when the app is live, or {@code null}
+   * @return ordered JSON-compatible summary map
+   */
+  private static Map<String, Object> summarize(
+      AppManifest manifest, boolean installed, RunningAppSnapshot running) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(10);
+    json.put("appId", manifest.appId());
+    json.put("name", manifest.appName());
+    json.put("version", manifest.appVersion());
+    json.put("uiEntry", manifest.uiEntry());
+    json.put("permissions", manifest.permissions());
+    json.put("quota", quota(manifest));
+    json.put("installed", installed);
+    json.put("running", running != null);
+    json.put("pid", running == null ? null : running.pid());
+    json.put("startedAt", running == null ? null : running.startedAt().toString());
+    return json;
+  }
+
+  /**
+   * Builds a fallback summary for operations that succeed after manifest reads already failed.
+   *
+   * <p>This keeps the response envelope stable for operator cleanup flows such as uninstalling a
+   * damaged app bundle whose manifest can no longer be parsed.
+   *
+   * @param appId normalized application identifier
+   * @return ordered JSON-compatible summary map with unknown manifest fields set to {@code null}
+   */
+  private static Map<String, Object> summarizeUnknown(String appId) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(10);
+    json.put("appId", appId);
+    json.put("name", null);
+    json.put("version", null);
+    json.put("uiEntry", null);
+    json.put("permissions", List.of());
+    json.put("quota", unknownQuota());
+    json.put("installed", false);
+    json.put("running", false);
+    json.put("pid", null);
+    json.put("startedAt", null);
+    return json;
+  }
+
+  /**
+   * Builds the quota sub-object for one app manifest.
+   *
+   * @param manifest normalized application manifest
+   * @return ordered JSON-compatible quota map
+   */
+  private static Map<String, Object> quota(AppManifest manifest) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("dataBytes", manifest.dataQuotaBytes());
+    json.put("cacheBytes", manifest.cacheQuotaBytes());
+    return json;
+  }
+
+  private static Map<String, Object> unknownQuota() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("dataBytes", null);
+    json.put("cacheBytes", null);
+    return json;
+  }
+
+  /**
+   * Creates the standard 400 error for malformed app-management requests.
+   *
+   * @param message validation failure message
+   * @return structured Platform API exception
+   */
+  private static PlatformApiException invalidQuery(String message) {
+    return new PlatformApiException(400, "invalid_query_parameter", message);
+  }
+
+  /**
+   * Creates the standard 400 error for staged bundles that fail AppHost validation.
+   *
+   * @param message validation failure message from the AppHost
+   * @return structured Platform API exception
+   */
+  private static PlatformApiException invalidBundle(String message) {
+    return new PlatformApiException(400, "invalid_app_bundle", message);
+  }
+
+  /**
+   * Creates the standard 404 error for missing app identifiers.
+   *
+   * @return structured Platform API exception
+   */
+  private static PlatformApiException appNotFound() {
+    return new PlatformApiException(404, "app_not_found", "App not found.");
+  }
+
+  /**
+   * Normalizes one path-supplied app identifier into the canonical AppHost form.
+   *
+   * @param appId raw application identifier extracted from the request path
+   * @return normalized lower-case app identifier
+   */
+  private static String normalizeAppId(String appId) {
+    try {
+      return AppManifest.normalizeAppId(appId);
+    } catch (IllegalArgumentException _) {
+      throw new PlatformApiException(
+          400, "invalid_app_id", "App identifier is not a valid AppHost id.");
+    }
+  }
+
+  /**
+   * Creates the standard 409 error for app state conflicts.
+   *
+   * @param message conflict message
+   * @return structured Platform API exception
+   */
+  private static PlatformApiException conflict(String message) {
+    return new PlatformApiException(409, "app_conflict", message);
+  }
+
+  /**
+   * Maps install-time AppHost contract failures onto stable client-facing status codes.
+   *
+   * <p>AppHost validation failures are caller-fixable 4xx responses. A concurrent reinstalling race
+   * is still reported as a conflict when the app became installed before the failed installation
+   * returned.
+   *
+   * @param appId manifest-derived application identifier for the staged bundle
+   * @param failure AppHost contract failure thrown during installation
+   * @return structured Platform API exception
+   */
+  private PlatformApiException installFailure(String appId, AppHostException failure) {
+    if (isAlreadyInstalledFailure(failure)) {
+      return conflict(messageOrDefault(failure, "App already installed."));
+    }
+    if (installed(appId)) {
+      return conflict(APP_ALREADY_INSTALLED_PREFIX + appId);
+    }
+    if (isInvalidAppBundleFailure(failure)) {
+      return invalidBundle(
+          messageOrDefault(failure, "Staged app bundle failed AppHost validation."));
+    }
+    return internalError("Failed to install app.");
+  }
+
+  /**
+   * Returns whether an install-time AppHost failure was caused by caller-supplied bundle input.
+   *
+   * <p>Install failures span both staged-bundle validation and host-managed layout validation. The
+   * API keeps only the former in the {@code 400 invalid_app_bundle} class; broken managed
+   * directories remain server-side {@code 500} errors so operators and automation do not treat them
+   * as caller-fixable input problems.
+   *
+   * @param failure AppHost contract failure thrown during installation
+   * @return {@code true} when the failure reflects staged-bundle or copied-bundle validation
+   */
+  private static boolean isInvalidAppBundleFailure(AppHostException failure) {
+    if (failure instanceof network.crypta.platform.apphost.manifest.AppManifestException) {
+      return true;
+    }
+    String message = failure.getMessage();
+    if (message == null || message.isBlank()) {
+      return false;
+    }
+    return message.startsWith("stagedAppDirectory ")
+        || message.startsWith("staging directory ")
+        || message.startsWith("copied manifest ")
+        || message.startsWith("copied app.exec ")
+        || message.startsWith("app.exec ");
+  }
+
+  /**
+   * Returns whether an install-time AppHost failure reported a concrete installation conflict.
+   *
+   * <p>This classifier trusts the AppHost failure that occurred during the actual installation
+   * attempt, which avoids reclassifying concurrent staged-directory swaps against a stale
+   * pre-validated app id from an earlier manifest parse.
+   *
+   * @param failure AppHost contract failure thrown during installation
+   * @return {@code true} when the failure explicitly reports an installed-app conflict
+   */
+  private static boolean isAlreadyInstalledFailure(AppHostException failure) {
+    String message = failure.getMessage();
+    return message != null && message.startsWith(APP_ALREADY_INSTALLED_PREFIX);
+  }
+
+  /**
+   * Maps start-time AppHost contract failures onto stable client-facing status codes.
+   *
+   * <p>Concurrent lifecycle races are reclassified from AppHost exceptions into the same 404/409
+   * API responses that precondition checks already use. Other start failures remain internal server
+   * errors.
+   *
+   * @param appId normalized application identifier for the current request
+   * @param failure AppHost contract failure thrown during start
+   * @return structured Platform API exception
+   */
+  private PlatformApiException startFailure(String appId, AppHostException failure) {
+    if (!installed(appId)) {
+      return appNotFound();
+    }
+    if (appHost.status(appId).isPresent()) {
+      return conflict("app is already running: " + appId);
+    }
+    return internalError(messageOrDefault(failure, "Failed to start app."));
+  }
+
+  /**
+   * Maps uninstall-time AppHost contract failures onto stable client-facing status codes.
+   *
+   * <p>Concurrent uninstall or restart races are reclassified into the existing 404/409 contract
+   * when the post-failure AppHost state is unambiguous. Other uninstall failures remain internal
+   * server errors.
+   *
+   * @param appId normalized application identifier for the current request
+   * @param failure AppHost contract failure thrown during uninstallation
+   * @return structured Platform API exception
+   */
+  private PlatformApiException uninstallFailure(String appId, AppHostException failure) {
+    if (!installed(appId)) {
+      return appNotFound();
+    }
+    if (appHost.status(appId).isPresent()) {
+      return conflict("cannot uninstall a running app: " + appId);
+    }
+    return internalError(messageOrDefault(failure, "Failed to uninstall app."));
+  }
+
+  /**
+   * Returns the failure message when present, otherwise a caller-supplied fallback.
+   *
+   * @param failure failure that may or may not include a human-readable message
+   * @param fallback fallback text for blank exception messages
+   * @return non-blank message suitable for the API error response
+   */
+  private static String messageOrDefault(Throwable failure, String fallback) {
+    String message = failure.getMessage();
+    return message == null || message.isBlank() ? fallback : message;
+  }
+
+  /**
+   * Creates the standard 500 error for unexpected AppHost failures.
+   *
+   * @param message operator-facing failure message
+   * @return structured Platform API exception
+   */
+  private static PlatformApiException internalError(String message) {
+    return new PlatformApiException(500, "internal_error", message);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -520,11 +520,11 @@ public final class AppsApiHandler {
    * @return structured Platform API exception
    */
   private PlatformApiException startFailure(String appId, AppHostException failure) {
-    if (!installed(appId)) {
-      return appNotFound();
-    }
     if (appHost.status(appId).isPresent()) {
       return conflict("app is already running: " + appId);
+    }
+    if (!installed(appId)) {
+      return appNotFound();
     }
     return internalError(messageOrDefault(failure, "Failed to start app."));
   }
@@ -541,11 +541,11 @@ public final class AppsApiHandler {
    * @return structured Platform API exception
    */
   private PlatformApiException uninstallFailure(String appId, AppHostException failure) {
-    if (!installed(appId)) {
-      return appNotFound();
-    }
     if (appHost.status(appId).isPresent()) {
       return conflict("cannot uninstall a running app: " + appId);
+    }
+    if (!installed(appId)) {
+      return appNotFound();
     }
     return internalError(messageOrDefault(failure, "Failed to uninstall app."));
   }

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * App-management Platform API handlers.
+ *
+ * <p>This package owns the minimal AppHost control surface for Platform API v1. It translates
+ * detached AppHost snapshots and lifecycle actions into stable JSON shapes for app listing,
+ * description, installation, start, stop, and uninstall flows.
+ *
+ * <p>The package is intentionally transport-neutral. It validates already-decoded request inputs,
+ * projects AppHost data onto operator-facing response maps, and leaves authentication and
+ * byte-level HTTP handling to the legacy bridge layer. That split lets the existing {@code
+ * /api/v1/apps/...} routes expose local AppHost control operations without pushing filesystem,
+ * process, or serialization concerns back into the router or toadlet adapters.
+ *
+ * <p>AppHost v1 remains deliberately narrow here: install operations come from a local staged
+ * directory, lifecycle commands stay local/admin-only, and summary payloads expose only stable
+ * inventory and running-state fields needed by the Platform API contract.
+ */
+package network.crypta.platform.api.apps;

--- a/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiJsonWriter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/json/PlatformApiJsonWriter.java
@@ -5,10 +5,9 @@ import java.util.Map;
 /**
  * Minimal JSON writer used by the initial Platform API surface.
  *
- * <p>The writer supports the limited set of JSON value types required by the read-only Platform API
- * v1: strings, booleans, integers/longs, {@code null}, arrays, and nested objects. Callers are
- * expected to supply already-structured JDK values such as {@link Map}, {@link Iterable}, and
- * scalar types.
+ * <p>The writer supports the limited set of JSON value types required by Platform API v1: strings,
+ * booleans, integers/longs, {@code null}, arrays, and nested objects. Callers are expected to
+ * supply already-structured JDK values such as {@link Map}, {@link Iterable}, and scalar types.
  */
 public final class PlatformApiJsonWriter {
   /** Prevents instantiation of this static helper type. */
@@ -35,17 +34,22 @@ public final class PlatformApiJsonWriter {
    * @throws IllegalArgumentException if {@code value} has an unsupported type
    */
   private static void appendValue(Object value, StringBuilder json) {
-    if (value == null) {
-      json.append("null");
-      return;
-    }
-    if (value instanceof String stringValue) {
-      appendString(stringValue, json);
-      return;
-    }
-    if (value instanceof Boolean booleanValue) {
-      json.append(booleanValue);
-      return;
+    switch (value) {
+      case null -> {
+        json.append("null");
+        return;
+      }
+      case String stringValue -> {
+        appendString(stringValue, json);
+        return;
+      }
+      case Boolean booleanValue -> {
+        json.append(booleanValue);
+        return;
+      }
+      default -> {
+        // no ops
+      }
     }
     if (value instanceof Integer
         || value instanceof Long
@@ -54,25 +58,30 @@ public final class PlatformApiJsonWriter {
       json.append(value);
       return;
     }
-    if (value instanceof Float floatValue) {
-      appendFloatingPoint(floatValue, json);
-      return;
-    }
-    if (value instanceof Double doubleValue) {
-      appendFloatingPoint(doubleValue, json);
-      return;
-    }
-    if (value instanceof Enum<?> enumValue) {
-      appendString(enumValue.name(), json);
-      return;
-    }
-    if (value instanceof Map<?, ?> mapValue) {
-      appendObject(mapValue, json);
-      return;
-    }
-    if (value instanceof Iterable<?> iterableValue) {
-      appendArray(iterableValue, json);
-      return;
+    switch (value) {
+      case Float floatValue -> {
+        appendFloatingPoint(floatValue, json);
+        return;
+      }
+      case Double doubleValue -> {
+        appendFloatingPoint(doubleValue, json);
+        return;
+      }
+      case Enum<?> enumValue -> {
+        appendString(enumValue.name(), json);
+        return;
+      }
+      case Map<?, ?> mapValue -> {
+        appendObject(mapValue, json);
+        return;
+      }
+      case Iterable<?> iterableValue -> {
+        appendArray(iterableValue, json);
+        return;
+      }
+      default -> {
+        // no ops
+      }
     }
 
     throw new IllegalArgumentException(

--- a/platform-api/src/main/java/network/crypta/platform/api/json/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/json/package-info.java
@@ -2,7 +2,7 @@
  * Small JSON encoding helpers for the Platform API.
  *
  * <p>This package owns the lightweight JSON writer and snapshot-to-JSON mappers used by {@code
- * :platform-api}. It intentionally supports only the data shapes required by the initial read-only
- * API surface, avoiding any new heavyweight serialization dependency.
+ * :platform-api}. It intentionally supports only the data shapes required by the Platform API
+ * surface, avoiding any new heavyweight serialization dependency.
  */
 package network.crypta.platform.api.json;

--- a/platform-api/src/main/java/network/crypta/platform/api/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/package-info.java
@@ -1,13 +1,13 @@
 /**
  * Transport-neutral core for the first Platform API surface.
  *
- * <p>This leaf owns the read-only Platform API v1 that sits on top of {@code runtime-spi} and below
- * any future web-shell or application-host work. Code in this package family accepts simple request
- * metadata, routes it to detached runtime ports, and produces JSON payloads without taking
- * dependencies on legacy HTTP toadlets, FCP message types, or daemon-only runtime classes.
+ * <p>This leaf owns Platform API v1, including the read-only node, peers, config, connectivity, and
+ * security-level routes plus the minimal app-management control surface backed by AppHost v1. Code
+ * in this package family accepts simple request metadata, routes it to detached runtime ports or
+ * AppHost snapshots, and produces JSON payloads without taking dependencies on legacy HTTP
+ * toadlets, FCP message types, or daemon-only runtime classes.
  *
- * <p>The API is intentionally narrow for the first platform-layer PR. It exposes small, immediately
- * useful read-only resources such as node info, peers, configuration exports, connectivity
- * snapshots, and security levels while preserving the extracted runtime boundary.
+ * <p>The API remains intentionally narrow. It exposes small, immediately useful control-plane
+ * resources while preserving the extracted runtime boundary.
  */
 package network.crypta.platform.api;

--- a/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
+++ b/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
@@ -18,7 +18,7 @@ import network.crypta.platform.webshell.routes.WebShellPaths;
  * @param shellDescription short description of the shell purpose
  * @param shellRoot canonical mount path for the shell page
  * @param assetRoot canonical mount path for shell-owned static assets
- * @param platformApiRoot read-only Platform API v1 root used by the browser-side fetches
+ * @param platformApiRoot Platform API v1 root used by the browser-side fetches
  * @param legacyRoot legacy HTTP root used for deep links back to existing pages
  * @param legacyLinks user-visible deep links back to the legacy admin pages
  */
@@ -37,7 +37,7 @@ public record WebShellBootstrap(
   public static final String DEFAULT_SHELL_DESCRIPTION =
       "Read-only node management powered by Platform API v1.";
 
-  /** Default read-only Platform API v1 root. */
+  /** Default Platform API v1 root used by the shell bootstrap payload. */
   public static final String DEFAULT_PLATFORM_API_ROOT = "/api/v1/";
 
   /** Default root for legacy deep links. */

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -10,6 +10,7 @@ import network.crypta.config.IntCallback;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.fs.readiness.LauncherReadinessInfo;
+import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -52,6 +53,7 @@ class FProxyRegistrarTest {
   private RuntimePorts runtimePorts;
 
   @Mock private HighLevelSimpleClient client;
+  @Mock private AppHost appHost;
   @Mock private FProxyToadlet fproxy;
   @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private WelcomePagePort welcomePagePort;
@@ -98,7 +100,7 @@ class FProxyRegistrarTest {
   @Test
   void maybeCreateFProxyEtc_whenInvoked_registersMenusSetsFProxyAndStartsQueueCompletion() {
     FProxyRegistrar.maybeCreateFProxyEtc(
-        new FProxyRegistrarDependencies(client, runtimePorts, config, fproxy), server);
+        new FProxyRegistrarDependencies(client, runtimePorts, appHost, config, fproxy), server);
 
     verify(server)
         .registerMenu("/", FProxyToadlet.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");
@@ -206,7 +208,7 @@ class FProxyRegistrarTest {
   @Test
   void maybeCreateFProxyEtc_whenSecurityLevelsSubconfigPresent_skipsSecurityLevelsConfigToadlet() {
     FProxyRegistrar.maybeCreateFProxyEtc(
-        new FProxyRegistrarDependencies(client, runtimePorts, config, fproxy), server);
+        new FProxyRegistrarDependencies(client, runtimePorts, appHost, config, fproxy), server);
 
     Set<String> configToadletPrefixes =
         capturedRegistrations().stream()
@@ -226,7 +228,7 @@ class FProxyRegistrarTest {
         .thenReturn(LauncherReadinessInfo.DEFAULT_UI_ROOT, WebShellPaths.SHELL_ROOT);
 
     FProxyRegistrar.maybeCreateFProxyEtc(
-        new FProxyRegistrarDependencies(client, runtimePorts, config, fproxy), server);
+        new FProxyRegistrarDependencies(client, runtimePorts, appHost, config, fproxy), server);
 
     ToadletRegistration webShellRegistration =
         capturedRegistrations().stream()

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,6 +57,86 @@ class PlatformApiToadletTest {
     assertEquals("GET", captor.getValue().method());
     assertEquals(List.of("peers", "alice/bob"), captor.getValue().pathSegments());
     assertEquals(Map.of(), captor.getValue().queryParameters());
+  }
+
+  @Test
+  void handleMethodPOST_whenAppInstallRequested_routesDecodedInstallRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.checkFormPassword(request, "/api/v1/apps/install")).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of("stagedDir"));
+    when(request.getMultipleParam("stagedDir")).thenReturn(new String[] {"/tmp/staged"});
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/install"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST", List.of("apps", "install"), Map.of("stagedDir", List.of("/tmp/staged"))));
+  }
+
+  @Test
+  void handleMethodPOST_whenAppInstallUsesFormPart_routesInstallRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.checkFormPassword(request, "/api/v1/apps/install")).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(request.isPartSet("stagedDir")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("stagedDir", 4096)).thenReturn("/tmp/staged");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/install"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST", List.of("apps", "install"), Map.of("stagedDir", List.of("/tmp/staged"))));
+  }
+
+  @Test
+  void handleMethodPOST_whenNonAppsRoute_expectRouterJson405WithoutPasswordCheck()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    PlatformApiResponse response =
+        PlatformApiResponse.error(
+            405,
+            Map.of("Allow", "GET"),
+            "method_not_allowed",
+            "Platform API v1 supports GET requests only.");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(response);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/node/greeting"), request, ctx);
+
+    verify(router).route(new PlatformApiRequest("POST", List.of("node", "greeting"), Map.of()));
+    verify(ctx, never()).checkFormPassword(request, "/api/v1/node/greeting");
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(405, replyHeaders.statusCode());
+    assertEquals("Method Not Allowed", replyHeaders.reasonPhrase());
+    assertEquals("GET", replyHeaders.headers().getFirst("Allow"));
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(response.body(), bodyWrite.bodyText());
+  }
+
+  @Test
+  void handleMethodPOST_whenMalformedAppsPath_expectRouterJson404WithoutPasswordCheck()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    PlatformApiResponse response =
+        PlatformApiResponse.error(404, "not_found", "Platform API route not found.");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(response);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/apps/alpha/restart"), request, ctx);
+
+    verify(router)
+        .route(new PlatformApiRequest("POST", List.of("apps", "alpha", "restart"), Map.of()));
+    verify(ctx, never()).checkFormPassword(request, "/api/v1/apps/alpha/restart");
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(404, replyHeaders.statusCode());
+    assertEquals("Not Found", replyHeaders.reasonPhrase());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(response.body(), bodyWrite.bodyText());
   }
 
   @Test
@@ -115,6 +196,89 @@ class PlatformApiToadletTest {
     assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
     assertEquals(response.body().getBytes(StandardCharsets.UTF_8).length, replyHeaders.length());
     verify(ctx, never()).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void handleMethodDELETE_whenAppRemovalRequested_routesDecodedDeleteRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodDELETE(URI.create("http://localhost/api/v1/apps/alpha"), request, ctx);
+
+    verify(router).route(new PlatformApiRequest("DELETE", List.of("apps", "alpha"), Map.of()));
+    verify(ctx, never()).checkFormPassword(request, "/api/v1/apps/alpha");
+  }
+
+  @Test
+  void handleMethodPOST_whenFullAccessMissing_expectJson403WithoutRouting() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(false);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/install"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals("Forbidden", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"forbidden\",\"message\":\"Full access is required.\"}}",
+        bodyWrite.bodyText());
+  }
+
+  @Test
+  void handleMethodPOST_whenFormPasswordMissing_expectNoRouting() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.checkFormPassword(request, "/api/v1/apps/install")).thenReturn(false);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/install"), request, ctx);
+
+    verify(ctx).checkFormPassword(request, "/api/v1/apps/install");
+    verifyNoInteractions(router);
+  }
+
+  @Test
+  void handleMethodDELETE_whenFormPasswordMissing_expectJson403WithoutRouting() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(false);
+
+    toadlet.handleMethodDELETE(URI.create("http://localhost/api/v1/apps/alpha"), request, ctx);
+
+    verifyNoInteractions(router);
+    verify(ctx, never()).checkFormPassword(request, "/api/v1/apps/alpha");
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals("Forbidden", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"forbidden\",\"message\":\"Valid form password is required.\"}}",
+        bodyWrite.bodyText());
+  }
+
+  @Test
+  void handleMethodDELETE_whenQueryFormPasswordProvided_expectJson403WithoutRouting()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(false);
+
+    toadlet.handleMethodDELETE(
+        URI.create("http://localhost/api/v1/apps/alpha?formPassword=secret"), request, ctx);
+
+    verifyNoInteractions(router);
+    verify(ctx, never()).checkFormPassword(request, "/api/v1/apps/alpha");
+    verify(ctx, never()).getFormPassword();
+    verify(request, never()).getParam("formPassword");
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals("Forbidden", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"forbidden\",\"message\":\"Valid form password is required.\"}}",
+        bodyWrite.bodyText());
   }
 
   private ReplyHeadersCapture captureReplyHeaders() throws Exception {

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -62,7 +62,7 @@ class PlatformApiToadletTest {
   @Test
   void handleMethodPOST_whenAppInstallRequested_routesDecodedInstallRequest() throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
-    when(ctx.checkFormPassword(request, "/api/v1/apps/install")).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
     when(request.getParameterNames()).thenReturn(List.of("stagedDir"));
     when(request.getMultipleParam("stagedDir")).thenReturn(new String[] {"/tmp/staged"});
     when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
@@ -78,7 +78,7 @@ class PlatformApiToadletTest {
   @Test
   void handleMethodPOST_whenAppInstallUsesFormPart_routesInstallRequest() throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
-    when(ctx.checkFormPassword(request, "/api/v1/apps/install")).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
     when(request.getParameterNames()).thenReturn(List.of());
     when(request.isPartSet("stagedDir")).thenReturn(true);
     when(request.getPartAsStringFailsafe("stagedDir", 4096)).thenReturn("/tmp/staged");
@@ -229,14 +229,22 @@ class PlatformApiToadletTest {
   }
 
   @Test
-  void handleMethodPOST_whenFormPasswordMissing_expectNoRouting() throws Exception {
+  void handleMethodPOST_whenFormPasswordMissing_expectJson403WithoutRouting() throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
-    when(ctx.checkFormPassword(request, "/api/v1/apps/install")).thenReturn(false);
+    when(ctx.hasFormPassword(request)).thenReturn(false);
 
     toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/install"), request, ctx);
 
-    verify(ctx).checkFormPassword(request, "/api/v1/apps/install");
     verifyNoInteractions(router);
+    verify(ctx, never()).checkFormPassword(request, "/api/v1/apps/install");
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals("Forbidden", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"forbidden\",\"message\":\"Valid form password is required.\"}}",
+        bodyWrite.bodyText());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -22,6 +22,7 @@ import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
+import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.RandomnessPort;
@@ -234,6 +235,7 @@ class SimpleToadletServerTest {
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
     NodeClientCore core = mock(NodeClientCore.class, Answers.RETURNS_DEEP_STUBS);
+    AppHost appHost = mock(AppHost.class);
     UserAlertManager alerts = mock(UserAlertManager.class);
     when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
     when(core.getClientContext()).thenReturn(clientContext);
@@ -243,7 +245,7 @@ class SimpleToadletServerTest {
     when(core.getNode().network().ticker()).thenReturn(ticker);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     when(client.getFetchContext()).thenReturn(fetchContext);
-    server.setRuntimeSupport(new CoreHttpShellRuntimeSupport(core));
+    server.setRuntimeSupport(new CoreHttpShellRuntimeSupport(core, appHost));
 
     AtomicInteger registrarCalls = new AtomicInteger();
     AtomicReference<FProxyRegistrarDependencies> dependenciesRef = new AtomicReference<>();
@@ -285,6 +287,7 @@ class SimpleToadletServerTest {
     assertEquals(1, registrarCalls.get());
     assertSame(client, dependenciesRef.get().client());
     assertSame(runtimePorts, dependenciesRef.get().runtimePorts());
+    assertSame(appHost, dependenciesRef.get().appHost());
     assertSame(nodeConfig, dependenciesRef.get().config());
     assertInstanceOf(FProxyToadlet.class, dependenciesRef.get().fproxy());
   }

--- a/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
+++ b/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
@@ -1,6 +1,10 @@
 package network.crypta.clients.http.bridge;
 
 import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -16,35 +20,48 @@ import network.crypta.clients.http.bridge.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.config.PersistentConfig;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.ProgramDirectory;
 import network.crypta.node.RequestStarter;
 import network.crypta.node.SecurityLevelListener;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels;
+import network.crypta.node.SemiOrderedShutdownHook;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.InstalledAppPaths;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Ticker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -63,7 +80,7 @@ class CoreHttpShellRuntimeSupportTest {
     NodeClientCore core = mock(NodeClientCore.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     when(core.getRuntimePorts()).thenReturn(runtimePorts);
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     RuntimePorts actualRuntimePorts = runtimeSupport.runtimePorts();
 
@@ -77,7 +94,7 @@ class CoreHttpShellRuntimeSupportTest {
     PersistentConfig config = mock(PersistentConfig.class);
     when(core.getNode()).thenReturn(node);
     when(node.getConfig()).thenReturn(config);
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     PersistentConfig actualConfig = (PersistentConfig) runtimeSupport.config();
 
@@ -93,7 +110,7 @@ class CoreHttpShellRuntimeSupportTest {
     when(core.getNode()).thenReturn(node);
     when(node.network()).thenReturn(network);
     when(network.ticker()).thenReturn(ticker);
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     Ticker actualTicker = runtimeSupport.ticker();
 
@@ -105,7 +122,7 @@ class CoreHttpShellRuntimeSupportTest {
     NodeClientCore core = mock(NodeClientCore.class);
     UserAlertManager alerts = mock(UserAlertManager.class);
     when(core.getAlerts()).thenReturn(alerts);
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     UserAlertManager actualAlerts = runtimeSupport.userAlerts();
 
@@ -116,7 +133,7 @@ class CoreHttpShellRuntimeSupportTest {
   void formPassword_whenCoreProvidesPassword_returnsSamePassword() {
     NodeClientCore core = mock(NodeClientCore.class);
     when(core.getFormPassword()).thenReturn("secret-token");
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     String formPassword = runtimeSupport.formPassword();
 
@@ -129,7 +146,7 @@ class CoreHttpShellRuntimeSupportTest {
     NodeClientCore core = mock(NodeClientCore.class);
     File uploadTarget = new File("allowed-upload.txt");
     when(core.allowUploadFrom(uploadTarget)).thenReturn(allowed);
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     boolean uploadAllowed = runtimeSupport.allowUploadFrom(uploadTarget);
 
@@ -143,7 +160,7 @@ class CoreHttpShellRuntimeSupportTest {
     PersistentConfig config = mock(PersistentConfig.class);
     when(core.getNode()).thenReturn(node);
     when(node.getConfig()).thenReturn(config);
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     runtimeSupport.storeConfig();
 
@@ -152,8 +169,7 @@ class CoreHttpShellRuntimeSupportTest {
 
   @Test
   void canRedirectToWizard_whenUsingCoreRuntime_returnsTrue() {
-    CoreHttpShellRuntimeSupport runtimeSupport =
-        new CoreHttpShellRuntimeSupport(mock(NodeClientCore.class));
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(mock(NodeClientCore.class));
 
     boolean canRedirect = runtimeSupport.canRedirectToWizard();
 
@@ -162,8 +178,7 @@ class CoreHttpShellRuntimeSupportTest {
 
   @Test
   void addNetworkThreatLevelListener_whenListenerIsNull_throwsNullPointerException() {
-    CoreHttpShellRuntimeSupport runtimeSupport =
-        new CoreHttpShellRuntimeSupport(mock(NodeClientCore.class));
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(mock(NodeClientCore.class));
 
     assertThrows(
         NullPointerException.class, () -> runtimeSupport.addNetworkThreatLevelListener(null));
@@ -171,11 +186,45 @@ class CoreHttpShellRuntimeSupportTest {
 
   @Test
   void addPhysicalThreatLevelListener_whenListenerIsNull_throwsNullPointerException() {
-    CoreHttpShellRuntimeSupport runtimeSupport =
-        new CoreHttpShellRuntimeSupport(mock(NodeClientCore.class));
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(mock(NodeClientCore.class));
 
     assertThrows(
         NullPointerException.class, () -> runtimeSupport.addPhysicalThreatLevelListener(null));
+  }
+
+  @Test
+  void appHost_whenConstructedFromCore_usesCurrentNodeDirectories(@TempDir Path tempDir) {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path expectedDataDir = tempDir.resolve("node");
+    Path expectedCacheDir = tempDir.resolve("persistent-temp");
+    Path expectedRunDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(expectedDataDir.toFile());
+    when(runDir.dir()).thenReturn(expectedRunDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(expectedCacheDir.toFile());
+
+    CoreHttpShellRuntimeSupport runtimeSupport;
+    try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+        mockStatic(SemiOrderedShutdownHook.class)) {
+      shutdownHooks
+          .when(() -> assertNotSame(shutdownHook, SemiOrderedShutdownHook.get()))
+          .thenReturn(shutdownHook);
+      runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    }
+
+    LocalProcessAppHost appHost =
+        assertInstanceOf(LocalProcessAppHost.class, runtimeSupport.appHost());
+    AppHostLayout layout = readLayout(appHost);
+    assertEquals(expectedDataDir.toAbsolutePath(), layout.dataDir());
+    assertEquals(expectedCacheDir.toAbsolutePath(), layout.cacheDir());
+    assertEquals(expectedRunDir.toAbsolutePath(), layout.runDir());
+    verify(shutdownHook).addEarlyJob(any(Thread.class));
   }
 
   @ParameterizedTest
@@ -246,7 +295,7 @@ class CoreHttpShellRuntimeSupportTest {
     when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true)).thenReturn(client);
     when(core.getClientContext()).thenReturn(clientContext);
     when(client.getFetchContext()).thenReturn(fetchContext);
-    CoreHttpShellRuntimeSupport runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
     try (MockedConstruction<BookmarkManager> bookmarkManagers =
             mockConstruction(
@@ -277,9 +326,26 @@ class CoreHttpShellRuntimeSupportTest {
       assertSame(fetchTrackers.constructed().getFirst(), fproxyArguments.get().get(2));
       assertSame(bookmarkManagers.constructed().getFirst(), bootstrap.bookmarkManager());
       assertSame(client, bootstrap.client());
+      assertSame(runtimeSupport.appHost(), bootstrap.appHost());
       assertSame(fproxies.constructed().getFirst(), bootstrap.fproxy());
       verify(core, never()).getEndpoints();
     }
+  }
+
+  @Test
+  void createAppHostShutdownJob_whenAppsRunning_stopsEachRunningApp() throws Exception {
+    AppHost appHost = mock(AppHost.class);
+    when(appHost.listRunning())
+        .thenReturn(List.of(runningAppSnapshot("alpha"), runningAppSnapshot("beta")));
+    when(appHost.stop("alpha")).thenReturn(true);
+    doThrow(new IOException("boom")).when(appHost).stop("beta");
+
+    Thread shutdownJob = CoreHttpShellRuntimeSupport.createAppHostShutdownJob(appHost);
+    shutdownJob.start();
+    shutdownJob.join();
+
+    verify(appHost).stop("alpha");
+    verify(appHost).stop("beta");
   }
 
   private static Stream<Arguments> networkThreatLevelMappings() {
@@ -346,7 +412,7 @@ class CoreHttpShellRuntimeSupportTest {
             })
         .when(securityLevels)
         .addNetworkThreatLevelListener(any());
-    return new NetworkListenerContext(new CoreHttpShellRuntimeSupport(core), listener);
+    return new NetworkListenerContext(runtimeSupport(core), listener);
   }
 
   private static PhysicalListenerContext newPhysicalListenerContext() {
@@ -366,7 +432,44 @@ class CoreHttpShellRuntimeSupportTest {
             })
         .when(securityLevels)
         .addPhysicalThreatLevelListener(any());
-    return new PhysicalListenerContext(new CoreHttpShellRuntimeSupport(core), listener);
+    return new PhysicalListenerContext(runtimeSupport(core), listener);
+  }
+
+  private static CoreHttpShellRuntimeSupport runtimeSupport(NodeClientCore core) {
+    return new CoreHttpShellRuntimeSupport(core, mock(AppHost.class));
+  }
+
+  private static AppHostLayout readLayout(LocalProcessAppHost appHost) {
+    try {
+      Field field = appHost.getClass().getDeclaredField("layout");
+      field.setAccessible(true);
+      return (AppHostLayout) field.get(appHost);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed reading field 'layout'", e);
+    }
+  }
+
+  private static RunningAppSnapshot runningAppSnapshot(String appId) {
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            appId,
+            "Demo App",
+            "1.0.0",
+            "bin/launch",
+            "/",
+            List.of("network.access"),
+            1024L,
+            512L);
+    InstalledAppPaths paths =
+        new InstalledAppPaths(
+            appId,
+            Path.of("build", "test-runtime", "apphost", "installed", appId).toAbsolutePath(),
+            Path.of("build", "test-runtime", "apphost", "data", appId).toAbsolutePath(),
+            Path.of("build", "test-runtime", "apphost", "cache", appId).toAbsolutePath(),
+            Path.of("build", "test-runtime", "apphost", "run", appId).toAbsolutePath());
+    return new RunningAppSnapshot(
+        manifest, paths, "token-" + appId, 4242L, Instant.parse("2024-01-02T03:04:05Z"));
   }
 
   private record NetworkListenerContext(

--- a/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
@@ -1,0 +1,183 @@
+package network.crypta.platform.api;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import network.crypta.fs.AppEnv;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
+import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
+import network.crypta.runtime.spi.RuntimePorts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@SuppressWarnings("java:S100")
+class PlatformApiAppsIntegrationTest {
+  private static final String APP_ID = "demo-app";
+  private static final String APP_NAME = "Demo App";
+  private static final String APP_VERSION = "1.2.3";
+  private static final String UI_ENTRY = "/";
+
+  @TempDir private Path tempDir;
+
+  private PlatformApiRouter router;
+
+  @BeforeEach
+  void setUp() {
+    RuntimePorts runtimePorts = mock(RuntimePorts.class, Answers.RETURNS_DEEP_STUBS);
+    AppHost appHost =
+        new LocalProcessAppHost(
+            new AppHostLayout(
+                tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run")),
+            Duration.ofSeconds(2),
+            new SecureRandom());
+    router = new PlatformApiRouter(runtimePorts, appHost);
+  }
+
+  @Test
+  void route_whenLifecycleRunsAgainstRealAppHost_expectStableJsonShapes() throws Exception {
+    assertEquals("{\"apps\":[]}", router.route(request("GET", List.of("apps"), Map.of())).body());
+
+    Path stagedDir = stageApp();
+
+    PlatformApiResponse installResponse =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(201, installResponse.statusCode());
+    assertTrue(installResponse.body().contains("\"appId\":\"demo-app\""));
+    assertTrue(installResponse.body().contains("\"installed\":true"));
+    assertTrue(installResponse.body().contains("\"running\":false"));
+    assertFalse(installResponse.body().contains("token"));
+
+    PlatformApiResponse startResponse =
+        router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    assertEquals(200, startResponse.statusCode());
+    assertTrue(startResponse.body().contains("\"running\":true"));
+    assertTrue(startResponse.body().contains("\"pid\":"));
+    assertTrue(startResponse.body().contains("\"startedAt\":\""));
+    assertFalse(startResponse.body().contains("token"));
+
+    PlatformApiResponse stopResponse =
+        router.route(request("POST", List.of("apps", APP_ID, "stop"), Map.of()));
+
+    assertEquals(200, stopResponse.statusCode());
+    assertTrue(stopResponse.body().contains("\"running\":false"));
+    assertFalse(stopResponse.body().contains("token"));
+
+    PlatformApiResponse deleteResponse =
+        router.route(request("DELETE", List.of("apps", APP_ID), Map.of()));
+
+    assertEquals(200, deleteResponse.statusCode());
+    assertTrue(deleteResponse.body().contains("\"installed\":false"));
+    assertTrue(deleteResponse.body().contains("\"running\":false"));
+
+    assertEquals("{\"apps\":[]}", router.route(request("GET", List.of("apps"), Map.of())).body());
+  }
+
+  @Test
+  void route_whenAppMissing_expect404() {
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("apps", "missing"), Map.of()));
+
+    assertEquals(404, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+  }
+
+  @Test
+  void route_whenInstallAndStartRepeated_expectConflictResponses() throws Exception {
+    Path stagedDir = stageApp();
+
+    router.route(
+        request(
+            "POST",
+            List.of("apps", "install"),
+            Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    PlatformApiResponse reinstallResponse =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(409, reinstallResponse.statusCode());
+    assertTrue(reinstallResponse.body().contains("\"code\":\"app_conflict\""));
+
+    router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    PlatformApiResponse repeatedStartResponse =
+        router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    assertEquals(409, repeatedStartResponse.statusCode());
+    assertTrue(repeatedStartResponse.body().contains("\"code\":\"app_conflict\""));
+  }
+
+  private PlatformApiRequest request(
+      String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
+    return new PlatformApiRequest(method, pathSegments, queryParameters);
+  }
+
+  private Path stageApp() throws Exception {
+    AppEnv appEnv = new AppEnv();
+    String scriptName = appEnv.isWindows() ? "launch.cmd" : "launch.sh";
+    Path stagedDir = Files.createDirectories(tempDir.resolve("staged").resolve(APP_ID));
+    Path binDir = Files.createDirectories(stagedDir.resolve("bin"));
+    Path launcher = binDir.resolve(scriptName);
+    Files.writeString(launcher, scriptContent(appEnv), StandardCharsets.UTF_8);
+    if (!appEnv.isWindows()) {
+      assertTrue(launcher.toFile().setExecutable(true, false));
+    }
+    Files.writeString(
+        stagedDir.resolve(AppManifestParser.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=%s
+        app.version=%s
+        app.exec=bin/%s
+        app.ui.entry=%s
+        app.permissions=network.access,file.read
+        quota.data.bytes=4096
+        quota.cache.bytes=1024
+        """
+            .formatted(APP_ID, APP_NAME, APP_VERSION, scriptName, UI_ENTRY),
+        StandardCharsets.UTF_8);
+    return stagedDir;
+  }
+
+  private static String scriptContent(AppEnv appEnv) {
+    if (appEnv.isWindows()) {
+      return """
+      @echo off
+      :loop
+      timeout /t 1 /nobreak >nul
+      goto loop
+      """;
+    }
+    return """
+    #!/bin/sh
+    trap 'exit 0' TERM INT
+    while :; do
+      sleep 0.1
+    done
+    """;
+  }
+}

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -1,9 +1,21 @@
 package network.crypta.platform.api;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import network.crypta.platform.api.json.PlatformApiJsonWriter;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.InstalledAppPaths;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.runtime.spi.ConfigFieldSet;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConfigSection;
@@ -34,11 +46,14 @@ import network.crypta.runtime.spi.UnknownPeerException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -46,6 +61,13 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class PlatformApiRouterTest {
+  private static final Instant STARTED_AT = Instant.parse("2024-01-02T03:04:05Z");
+  private static final String APP_ID = "alpha";
+  private static final String INSTALL_ROUTE_APP_ID = "install";
+  private static final String APP_NAME = "Alpha App";
+  private static final String APP_VERSION = "2.1.0";
+  private static final String APP_UI_ENTRY = "ui/index.html";
+  private static final long APP_PID = 4242L;
 
   @Mock private RuntimePorts runtimePorts;
   @Mock private NodeInfoPort nodeInfoPort;
@@ -53,6 +75,9 @@ class PlatformApiRouterTest {
   @Mock private ConfigPort configPort;
   @Mock private ConnectivityPort connectivityPort;
   @Mock private SecurityLevelsPort securityLevelsPort;
+  @Mock private AppHost appHost;
+
+  @TempDir private Path tempDir;
 
   private PlatformApiRouter router;
 
@@ -63,7 +88,7 @@ class PlatformApiRouterTest {
     when(runtimePorts.config()).thenReturn(configPort);
     when(runtimePorts.connectivity()).thenReturn(connectivityPort);
     when(runtimePorts.securityLevels()).thenReturn(securityLevelsPort);
-    router = new PlatformApiRouter(runtimePorts);
+    router = new PlatformApiRouter(runtimePorts, appHost);
   }
 
   @Test
@@ -328,8 +353,530 @@ class PlatformApiRouterTest {
         "{\"CURRENT\":{\"enabled\":\"true\",\"node\":{\"name\":\"alpha\"}}}", response.body());
   }
 
+  @Test
+  void route_whenAppsListRequested_expectAppsEnvelopeAndMergedRunningState() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    RunningAppSnapshot running = runningSnapshot();
+    when(appHost.listInstalled()).thenReturn(List.of(installed));
+    when(appHost.listRunning()).thenReturn(List.of(running));
+
+    PlatformApiResponse response = router.route(request("GET", List.of("apps"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            Map.of("apps", List.of(summary(true, true, APP_PID, STARTED_AT)))),
+        response.body());
+  }
+
+  @Test
+  void route_whenAppsDescribeRequested_expectAppEnvelopeAndMergedRunningState() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    RunningAppSnapshot running = runningSnapshot();
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
+    when(appHost.status(APP_ID)).thenReturn(Optional.of(running));
+
+    PlatformApiResponse response = router.route(request("GET", List.of("apps", APP_ID), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", summary(true, true, APP_PID, STARTED_AT))),
+        response.body());
+  }
+
+  @Test
+  void route_whenAppIdMatchesInstallRoute_expectDescribeJson() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot(INSTALL_ROUTE_APP_ID);
+    when(appHost.describe(INSTALL_ROUTE_APP_ID)).thenReturn(Optional.of(installed));
+    when(appHost.status(INSTALL_ROUTE_APP_ID)).thenReturn(Optional.empty());
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("apps", INSTALL_ROUTE_APP_ID), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", installRouteSummary(true))), response.body());
+  }
+
+  @Test
+  void route_whenAppIdMatchesInstallRouteAndDeleteRequested_expectUninstallJson() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot(INSTALL_ROUTE_APP_ID);
+    when(appHost.describe(INSTALL_ROUTE_APP_ID)).thenReturn(Optional.of(installed));
+    when(appHost.status(INSTALL_ROUTE_APP_ID)).thenReturn(Optional.empty());
+
+    PlatformApiResponse response =
+        router.route(request("DELETE", List.of("apps", INSTALL_ROUTE_APP_ID), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", installRouteSummary(false))), response.body());
+  }
+
+  @Test
+  void route_whenInstallOptionsRequested_expectMethodNotAllowedWithAllowPost() {
+    PlatformApiResponse response =
+        router.route(request("OPTIONS", List.of("apps", "install"), Map.of()));
+
+    assertEquals(405, response.statusCode());
+    assertEquals("Method Not Allowed", response.reasonPhrase());
+    assertEquals(Map.of("Allow", "POST"), response.headers());
+    assertEquals(
+        "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Platform API v1 supports POST"
+            + " requests only.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenInstallHeadRequested_expectMethodNotAllowedWithAllowPost() {
+    PlatformApiResponse response =
+        router.route(request("HEAD", List.of("apps", "install"), Map.of()));
+
+    assertEquals(405, response.statusCode());
+    assertEquals("Method Not Allowed", response.reasonPhrase());
+    assertEquals(Map.of("Allow", "POST"), response.headers());
+    assertEquals(
+        "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Platform API v1 supports POST"
+            + " requests only.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAppMissing_expectJson404() throws Exception {
+    when(appHost.describe("missing")).thenReturn(Optional.empty());
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("apps", "missing"), Map.of()));
+
+    assertEquals(404, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+  }
+
+  @Test
+  void route_whenAppStartRequested_expectRunningSummaryWithoutToken() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    InstalledAppSnapshot launched = installedSnapshot(APP_ID, "Alpha App 2", "2.2.0", "ui/v2.html");
+    RunningAppSnapshot running = runningSnapshot(launched);
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.start(APP_ID)).thenReturn(running);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            Map.of(
+                "app",
+                summaryFor(
+                    APP_ID,
+                    "Alpha App 2",
+                    "2.2.0",
+                    "ui/v2.html",
+                    true,
+                    true,
+                    APP_PID,
+                    STARTED_AT))),
+        response.body());
+  }
+
+  @Test
+  void route_whenAppInstallRequested_expectCreatedJsonAndNoLaunchToken() throws Exception {
+    Path stagedDir = stageApp();
+    InstalledAppSnapshot installed = installedSnapshot();
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.installFromDirectory(stagedDir)).thenReturn(installed);
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(201, response.statusCode());
+    assertEquals("Created", response.reasonPhrase());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", summary(true, false, null, null))),
+        response.body());
+  }
+
+  @Test
+  void route_whenAppInstallMissingStagedDir_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", "install"), Map.of()));
+
+    assertEquals(400, response.statusCode());
+    assertEquals("Bad Request", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_query_parameter\",\"message\":\"Missing required query"
+            + " parameter 'stagedDir'.\"}}",
+        response.body());
+    verifyNoInteractions(appHost);
+  }
+
+  @Test
+  void route_whenAppInstallStagedDirBlank_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(
+            request("POST", List.of("apps", "install"), Map.of("stagedDir", List.of("   "))));
+
+    assertEquals(400, response.statusCode());
+    assertEquals("Bad Request", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_query_parameter\",\"message\":\"Missing required query"
+            + " parameter 'stagedDir'.\"}}",
+        response.body());
+    verifyNoInteractions(appHost);
+  }
+
+  @Test
+  void route_whenAppInstallValidationFails_expectBadRequestJson() throws Exception {
+    Path stagedDir = stageApp();
+    when(appHost.describe(APP_ID)).thenAnswer(_ -> Optional.empty());
+    when(appHost.installFromDirectory(stagedDir))
+        .thenThrow(new AppHostException("staging directory must not contain symlinks: bad-link"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(400, response.statusCode());
+    assertEquals("Bad Request", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_app_bundle\",\"message\":\"staging directory must not"
+            + " contain symlinks: bad-link\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAppInstallManagedLayoutFails_expectInternalErrorJson() throws Exception {
+    Path stagedDir = stageApp();
+    when(appHost.describe(APP_ID)).thenAnswer(_ -> Optional.empty());
+    when(appHost.installFromDirectory(stagedDir))
+        .thenThrow(
+            new AppHostException(
+                "installedAppsDir must not be a symlink, reparse point, or alias:"
+                    + " /srv/node/apps/installed"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(500, response.statusCode());
+    assertEquals("Internal Server Error", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"internal_error\",\"message\":\"Failed to install app.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAppStartRepeated_expectConflictJson() {
+    when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app is already running: alpha\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAppAlreadyRunningAndManifestUnreadable_expectConflictJson() throws Exception {
+    when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app is already running: alpha\"}}",
+        response.body());
+    verify(appHost).status(APP_ID);
+    verify(appHost, never()).describe(APP_ID);
+    verify(appHost, never()).start(APP_ID);
+  }
+
+  @Test
+  void route_whenAppStartRacesToRunning_expectConflictJson() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    when(appHost.describe(APP_ID)).thenAnswer(_ -> Optional.of(installed));
+    when(appHost.status(APP_ID)).thenAnswer(new TwoStepOptionalAnswer<>(null, runningSnapshot()));
+    when(appHost.start(APP_ID)).thenThrow(new AppHostException("app is already running: alpha"));
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app is already running: alpha\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAppStopRequested_expectStoppedSummaryJson() throws Exception {
+    when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
+    when(appHost.stop(APP_ID)).thenReturn(true);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "stop"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", summary(true, false, null, null))),
+        response.body());
+  }
+
+  @Test
+  void route_whenRunningAppManifestUnreadableDuringStop_expectStoppedSummaryJson()
+      throws Exception {
+    when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
+    when(appHost.stop(APP_ID)).thenReturn(true);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "stop"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals("OK", response.reasonPhrase());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", summary(true, false, null, null))),
+        response.body());
+  }
+
+  @Test
+  void route_whenAppUninstallRequested_expectInstalledFalseSummaryJson() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    PlatformApiResponse response =
+        router.route(request("DELETE", List.of("apps", APP_ID), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", summary(false, false, null, null))),
+        response.body());
+  }
+
+  @Test
+  void route_whenAppManifestUnreadableDuringUninstall_expectCleanupSummaryJson() throws Exception {
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenThrow(new IOException("corrupt manifest"));
+
+    PlatformApiResponse response =
+        router.route(request("DELETE", List.of("apps", APP_ID), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals("OK", response.reasonPhrase());
+    assertEquals(PlatformApiJsonWriter.write(Map.of("app", unknownSummary())), response.body());
+  }
+
+  @Test
+  void route_whenAppUninstallRacesToMissing_expectNotFoundJson() throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    when(appHost.describe(APP_ID)).thenAnswer(new TwoStepOptionalAnswer<>(installed, null));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    doThrow(new AppHostException("app is not installed: alpha")).when(appHost).uninstall(APP_ID);
+
+    PlatformApiResponse response =
+        router.route(request("DELETE", List.of("apps", APP_ID), Map.of()));
+
+    assertEquals(404, response.statusCode());
+    assertEquals("Not Found", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+  }
+
+  @Test
+  void route_whenAppInstallRepeated_expectConflictJson() throws Exception {
+    Path stagedDir = stageApp();
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app already installed: alpha\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenInstallRacesToDifferentAlreadyInstalledApp_expectConflictJson() throws Exception {
+    Path stagedDir = stageApp();
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.installFromDirectory(stagedDir))
+        .thenThrow(new AppHostException("app already installed: beta"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app already installed: beta\"}}",
+        response.body());
+  }
+
   private static PlatformApiRequest request(
       String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
     return new PlatformApiRequest(method, pathSegments, queryParameters);
+  }
+
+  private InstalledAppSnapshot installedSnapshot() {
+    return installedSnapshot(APP_ID);
+  }
+
+  private InstalledAppSnapshot installedSnapshot(String appId) {
+    return installedSnapshot(appId, APP_NAME, APP_VERSION, APP_UI_ENTRY);
+  }
+
+  private InstalledAppSnapshot installedSnapshot(
+      String appId, String appName, String appVersion, String appUiEntry) {
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            appId,
+            appName,
+            appVersion,
+            "bin/launch",
+            appUiEntry,
+            List.of("network.access", "file.read"),
+            4096L,
+            8192L);
+    InstalledAppPaths paths =
+        new InstalledAppPaths(
+            appId,
+            tempDir.resolve("installed").resolve(appId),
+            tempDir.resolve("data").resolve(appId),
+            tempDir.resolve("cache").resolve(appId),
+            tempDir.resolve("run").resolve(appId));
+    return new InstalledAppSnapshot(manifest, paths);
+  }
+
+  private RunningAppSnapshot runningSnapshot() {
+    InstalledAppSnapshot installed = installedSnapshot();
+    return runningSnapshot(installed);
+  }
+
+  private RunningAppSnapshot runningSnapshot(InstalledAppSnapshot installed) {
+    return new RunningAppSnapshot(
+        installed.manifest(),
+        installed.paths(),
+        "token-" + installed.manifest().appId(),
+        APP_PID,
+        STARTED_AT);
+  }
+
+  private Path stageApp() throws Exception {
+    Path stagedDir = Files.createTempDirectory(tempDir, "staged-");
+    Files.writeString(
+        stagedDir.resolve("cryptad-app.properties"),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=%s
+        app.version=%s
+        app.exec=bin/launch
+        app.ui.entry=%s
+        app.permissions=network.access,file.read
+        quota.data.bytes=4096
+        quota.cache.bytes=8192
+        """
+            .formatted(APP_ID, APP_NAME, APP_VERSION, APP_UI_ENTRY));
+    return stagedDir;
+  }
+
+  private static Map<String, Object> summary(
+      boolean installed, boolean running, Long pid, Instant startedAt) {
+    return summaryFor(
+        APP_ID, APP_NAME, APP_VERSION, APP_UI_ENTRY, installed, running, pid, startedAt);
+  }
+
+  private static Map<String, Object> installRouteSummary(boolean installed) {
+    return summaryFor(
+        INSTALL_ROUTE_APP_ID, APP_NAME, APP_VERSION, APP_UI_ENTRY, installed, false, null, null);
+  }
+
+  private static Map<String, Object> summaryFor(
+      String appId,
+      String appName,
+      String appVersion,
+      String appUiEntry,
+      boolean installed,
+      boolean running,
+      Long pid,
+      Instant startedAt) {
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(10);
+    summary.put("appId", appId);
+    summary.put("name", appName);
+    summary.put("version", appVersion);
+    summary.put("uiEntry", appUiEntry);
+    summary.put("permissions", List.of("network.access", "file.read"));
+    LinkedHashMap<String, Object> quota = LinkedHashMap.newLinkedHashMap(2);
+    quota.put("dataBytes", 4096L);
+    quota.put("cacheBytes", 8192L);
+    summary.put("quota", quota);
+    summary.put("installed", installed);
+    summary.put("running", running);
+    summary.put("pid", pid);
+    summary.put("startedAt", startedAt == null ? null : startedAt.toString());
+    return summary;
+  }
+
+  private static Map<String, Object> unknownSummary() {
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(10);
+    summary.put("appId", APP_ID);
+    summary.put("name", null);
+    summary.put("version", null);
+    summary.put("uiEntry", null);
+    summary.put("permissions", List.of());
+    LinkedHashMap<String, Object> quota = LinkedHashMap.newLinkedHashMap(2);
+    quota.put("dataBytes", null);
+    quota.put("cacheBytes", null);
+    summary.put("quota", quota);
+    summary.put("installed", false);
+    summary.put("running", false);
+    summary.put("pid", null);
+    summary.put("startedAt", null);
+    return summary;
+  }
+
+  private static final class TwoStepOptionalAnswer<T>
+      implements org.mockito.stubbing.Answer<Optional<T>> {
+    private T current;
+    private final T next;
+
+    private TwoStepOptionalAnswer(T current, T next) {
+      this.current = current;
+      this.next = next;
+    }
+
+    @Override
+    public Optional<T> answer(org.mockito.invocation.InvocationOnMock invocation) {
+      T result = current;
+      current = next;
+      return Optional.ofNullable(result);
+    }
   }
 }

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -626,6 +626,26 @@ class PlatformApiRouterTest {
   }
 
   @Test
+  void route_whenAppStartRaceFindsRunningAfterManifestBecomesUnreadable_expectConflictJson()
+      throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    when(appHost.describe(APP_ID))
+        .thenReturn(Optional.of(installed))
+        .thenThrow(new IOException("corrupt manifest"));
+    when(appHost.status(APP_ID)).thenAnswer(new TwoStepOptionalAnswer<>(null, runningSnapshot()));
+    when(appHost.start(APP_ID)).thenThrow(new AppHostException("app is already running: alpha"));
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "start"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app is already running: alpha\"}}",
+        response.body());
+  }
+
+  @Test
   void route_whenAppStopRequested_expectStoppedSummaryJson() throws Exception {
     when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
     when(appHost.stop(APP_ID)).thenReturn(true);
@@ -697,6 +717,29 @@ class PlatformApiRouterTest {
     assertEquals("Not Found", response.reasonPhrase());
     assertEquals(
         "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+  }
+
+  @Test
+  void route_whenAppUninstallRaceFindsRunningAfterManifestBecomesUnreadable_expectConflictJson()
+      throws Exception {
+    InstalledAppSnapshot installed = installedSnapshot();
+    when(appHost.describe(APP_ID))
+        .thenReturn(Optional.of(installed))
+        .thenThrow(new IOException("corrupt manifest"));
+    when(appHost.status(APP_ID)).thenAnswer(new TwoStepOptionalAnswer<>(null, runningSnapshot()));
+    doThrow(new AppHostException("cannot uninstall a running app: alpha"))
+        .when(appHost)
+        .uninstall(APP_ID);
+
+    PlatformApiResponse response =
+        router.route(request("DELETE", List.of("apps", APP_ID), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"cannot uninstall a running app:"
+            + " alpha\"}}",
+        response.body());
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactoriesTest.java
+++ b/src/test/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactoriesTest.java
@@ -15,6 +15,7 @@ import network.crypta.config.SubConfig;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.ProgramDirectory;
+import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
 import network.crypta.runtime.fcp.PersistentRequestEndpointServices;
 import network.crypta.runtime.http.HttpShellContainer;
@@ -89,6 +90,7 @@ class DefaultNodeRuntimeBridgeFactoriesTest {
     assertInstanceOf(network.crypta.clients.http.HttpShellRuntimeSupport.class, runtimeSupport);
     assertInstanceOf(CorePasswordFormPageRenderer.class, passwordFormPageRenderer);
     assertSame(fixture.core(), coreRuntimeSupport.core());
+    assertInstanceOf(AppHost.class, coreRuntimeSupport.appHost());
   }
 
   private static Object readField(Object target, String fieldName) {
@@ -105,8 +107,15 @@ class DefaultNodeRuntimeBridgeFactoriesTest {
     private Fixture() {
       this(mock(Node.class), mock(NodeClientCore.class), new File("run/IpToCountry.dat"));
 
+      ProgramDirectory nodeDir = mock(ProgramDirectory.class);
       ProgramDirectory runDir = mock(ProgramDirectory.class);
+      when(core.getNode()).thenReturn(node);
+      when(node.nodeDir()).thenReturn(nodeDir);
       when(node.runDir()).thenReturn(runDir);
+      when(nodeDir.dir()).thenReturn(new File("build/test-runtime/apphost/data/node"));
+      when(runDir.dir()).thenReturn(new File("build/test-runtime/apphost/run"));
+      when(core.getPersistentTempDir())
+          .thenReturn(new File("build/test-runtime/apphost/cache/persistent-temp"));
       when(runDir.file("IpToCountry.dat")).thenReturn(geoIpDb);
     }
 


### PR DESCRIPTION
## Summary
- add a new `network.crypta.platform.api.apps` family and expose `/api/v1/apps` install, list, describe, start, stop, and uninstall routes through Platform API v1
- wire a single long-lived `AppHost` through the legacy admin HTTP composition path and keep app-mutation routes behind the existing local full-access plus form-password expectations
- extend router, bridge, bootstrap, and integration coverage for app lifecycle flows, conflict mapping, shutdown handling, and the new HTTP contract, while updating docs/Javadocs that previously described Platform API v1 as read-only

## How to test
- `./gradlew :platform-apphost:test`
- `./gradlew :test --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest --tests *PlatformApiToadletTest --tests *FProxyRegistrarTest --tests *CoreHttpShellRuntimeSupportTest --tests *DefaultNodeRuntimeBridgeFactoriesTest --tests *PlatformApiBoundaryTest --tests *HttpLegacyAdminBoundaryTest`
- `./gradlew test`

## Notes
- this PR intentionally keeps Web Shell UI changes out of scope and only establishes the control-plane surface for AppHost v1
- the legacy bridge continues to return JSON error responses for non-app Platform API routes while requiring form-password checks for the new app-mutation routes