### PR TITLE
feat(platform): Add staged local app updates

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -57,6 +57,10 @@ Use this skill when you need to:
     `BaseRequestThrottle`, `LowLevelGetException`, `LowLevelPutException`, `RequestClient`,
     `PeerStatusCounts`, `RecentlyFailedReturn`, and `SendableRequestItem*`
   - `:runtime-spi` → `network.crypta.runtime.spi` (JDK-only runtime/config boundary)
+  - `:platform-api` → `network.crypta.platform.api` (transport-neutral Platform API v1)
+  - `:platform-apphost` → `network.crypta.platform.apphost` (transport-neutral out-of-process
+    AppHost core)
+  - `:platform-web-shell` → `network.crypta.platform.webshell` (browser-facing Web Shell v1)
   - `:runtime-node` → extracted daemon runtime body across the remaining cyclic/high-level
     `network.crypta.client` body, the remaining peer/request/routing-engine and transport-heavy
     `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled
@@ -94,9 +98,12 @@ Use this skill when you need to:
   `:kernel-content` owns the compile-neutral phase-1 client/content slice,
   `:kernel-transport` owns the compile-neutral phase-1 transport helper slice,
   `:kernel-routing` owns the compile-neutral phase-1 routing/helper slice,
-  `:runtime-node` owns the remaining runtime/node/client/support body, `:adapter-fcp` owns the
-  FCP adapter tree, `:adapter-http-legacy-admin` owns the legacy HTTP adapter tree and resources,
-  and the root project keeps tests, packaging, tool entrypoints, and remaining composition glue.
+  `:platform-api` owns the transport-neutral Platform API surface, `:platform-apphost` owns the
+  transport-neutral AppHost core, `:platform-web-shell` owns the browser-facing node-management
+  shell, `:runtime-node` owns the remaining runtime/node/client/support body, `:adapter-fcp`
+  owns the FCP adapter tree, `:adapter-http-legacy-admin` owns the legacy HTTP adapter tree and
+  resources, and the root project keeps tests, packaging, tool entrypoints, and remaining
+  composition glue.
 - The wire split is intentionally narrow:
   `:interop-wire` owns the message/schema nucleus, `:kernel-transport` owns the compile-neutral
   transport helper slice (`AllowedHosts`, `NetworkInterface`, `IOStatisticCollector`,
@@ -117,9 +124,10 @@ Use this skill when you need to:
   `:foundation-store-contracts` just as much as any future extraction.
 - Root boundary tests now freeze the extracted layout. In particular,
   `RuntimeNodeKernelSplitPrepBoundaryTest`, `KernelContentBoundaryTest`,
-  `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, and
-  `HttpLegacyAdminBoundaryTest` guard leaf ownership/import rules, and the runtime/kernel-content
-  tests require `package-info.java` in every production package under those leaves.
+  `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, `PlatformApiBoundaryTest`,
+  `AppHostBoundaryTest`, `WebShellBoundaryTest`, and `HttpLegacyAdminBoundaryTest` guard leaf
+  ownership/import rules. The runtime/kernel-content/platform tests also require
+  `package-info.java` in every production package under those leaves.
 
 ## Architecture overview (by package)
 ### Core network layer (`network.crypta.node`)
@@ -247,6 +255,18 @@ Use this skill when you need to:
   - `N2NTMToadlet` uses `DarknetConnectionsPort` and `DarknetMessagingPort` for selected-peer
     lookup, transfer confirmations, and compose/send actions.
 
+### Platform control/UI modules
+- `:platform-api` owns the transport-neutral Platform API v1 under `network.crypta.platform.api`.
+  It exposes node/config/peer/connectivity/security snapshots plus the local AppHost control
+  plane and is currently mounted at `/api/v1/` by the legacy HTTP adapter.
+- `:platform-apphost` owns the transport-neutral out-of-process AppHost v1 under
+  `network.crypta.platform.apphost`. It validates staged local app bundles, owns the immutable
+  installed-bundle layout plus mutable data/cache/run directories, and provides local
+  install/list/describe/start/stop/update/uninstall operations.
+- `:platform-web-shell` owns the first browser-facing Web Shell v1 under
+  `network.crypta.platform.webshell`. It provides the current node-management shell route
+  constants, bootstrap payload, renderer, and static browser assets mounted at `/app/node/`.
+
 ### Runtime SPI (`network.crypta.runtime.spi`)
 - Aggregate boundary: `RuntimePorts`
 - Small ports include: `ExecutionPort`, `RandomnessPort`, `TransferAccessPort`, `LifecyclePort`,
@@ -343,6 +363,9 @@ Use this skill when you need to:
 - `:kernel-routing`: compile-neutral phase-1 routing/helper slice across selected
   `network.crypta.node` helper/value types
 - `:runtime-spi`: `network.crypta.runtime.spi`
+- `:platform-api`: `network.crypta.platform.api`
+- `:platform-apphost`: `network.crypta.platform.apphost`
+- `:platform-web-shell`: `network.crypta.platform.webshell`
 - `:runtime-node`: extracted daemon runtime body across the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine
   `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -21,9 +21,10 @@ Use this skill when you need to:
 - Current leaf projects are `:foundation-support`, `:foundation-store`,
   `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
   `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
-  `:kernel-transport`, `:kernel-routing`, `:runtime-spi`,
-  `:runtime-node`, `:adapter-fcp`, `:adapter-http-legacy-admin`, `:thirdparty-onion`,
-  `:thirdparty-legacy`, and `:launcher-desktop`.
+  `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
+  `:platform-apphost`, `:platform-web-shell`, `:runtime-node`, `:adapter-fcp`,
+  `:adapter-http-legacy-admin`, `:thirdparty-onion`, `:thirdparty-legacy`, and
+  `:launcher-desktop`.
 - The extracted leaf projects compile separately, but `buildJar`, `run`, `runLauncher`,
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
 - `:foundation-support` owns the current stable generic support subset under
@@ -66,14 +67,21 @@ Use this skill when you need to:
 - When moving additional main classes/resources from root into any extracted leaf, update that
   leaf's `owned-output-patterns.txt` and validate with
   `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`.
-- Root boundary tests now freeze the current extracted layout. `RuntimeNodeKernelSplitPrepBoundaryTest`,
-  `KernelContentBoundaryTest`, `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, and
-  `HttpLegacyAdminBoundaryTest` are the focused regression checks for leaf ownership/import
-  boundaries, and the
-  runtime/kernel-content tests enforce `package-info.java` coverage for production packages in
-  those leaves.
+- Root and leaf boundary tests now freeze the current extracted layout.
+  `RuntimeNodeKernelSplitPrepBoundaryTest`, `KernelContentBoundaryTest`,
+  `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, `PlatformApiBoundaryTest`,
+  `AppHostBoundaryTest`, `WebShellBoundaryTest`, and `HttpLegacyAdminBoundaryTest` are the
+  focused regression checks for leaf ownership/import boundaries. The runtime, kernel-content,
+  and platform boundary suites also enforce `package-info.java` coverage for production packages
+  in those leaves.
 - `:runtime-spi` is the JDK-only runtime/config API leaf. Its focused unit tests still live in the
   root test tree and run through the root build.
+- `:platform-api` owns the transport-neutral Platform API v1. Its focused tests still live in the
+  root test tree and run through the root `:test` task.
+- `:platform-apphost` owns the transport-neutral out-of-process AppHost core plus its focused leaf
+  tests under `platform-apphost/src/test/java`.
+- `:platform-web-shell` owns the browser-facing Web Shell leaf and its focused leaf tests under
+  `platform-web-shell/src/test/java`.
 - `:runtime-node` is the extracted daemon runtime leaf. It now owns the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine side of
   `network.crypta.node`, the retained node-coupled transport/message execution code in
@@ -86,8 +94,9 @@ Use this skill when you need to:
   those resources often resolve from the leaf JAR, so tests must treat them as classpath resources
   rather than assume a plain filesystem `Path`.
 - Most tests still live in the root project and compile against the leaf subprojects through the
-  root build, but `:platform-apphost` now keeps its focused AppHost tests under
-  `platform-apphost/src/test/java` and they run via `:platform-apphost:test`.
+  root build, but `:platform-apphost`, `:platform-web-shell`, and
+  `:adapter-http-legacy-admin` now keep focused leaf tests under their own `src/test/java`
+  trees.
 - File-system-based l10n tests still run from the root project and use
   `foundation-config/src/main/resources/network/crypta/l10n/` as the main resource path.
 
@@ -114,8 +123,18 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew test --tests *TestClassName`
 - Run one test method:
   - `./gradlew test --tests *TestClassName.methodName`
+- Run the focused AppHost leaf tests:
+  - `./gradlew :platform-apphost:test`
+- Run the focused Web Shell leaf tests:
+  - `./gradlew :platform-web-shell:test`
+- Run the focused legacy HTTP adapter leaf tests:
+  - `./gradlew :adapter-http-legacy-admin:test`
+- Run the focused Platform API root tests:
+  - `./gradlew :test --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest`
 - For extracted-leaf or boundary work, run the focused boundary tests:
-  - `./gradlew test --tests *KernelTransportBoundaryTest --tests *KernelContentBoundaryTest --tests *KernelRoutingBoundaryTest --tests *RuntimeNodeKernelSplitPrepBoundaryTest --tests *HttpLegacyAdminBoundaryTest`
+  - `./gradlew test --tests *KernelTransportBoundaryTest --tests *KernelContentBoundaryTest --tests *KernelRoutingBoundaryTest --tests *RuntimeNodeKernelSplitPrepBoundaryTest --tests *HttpLegacyAdminBoundaryTest --tests *PlatformApiBoundaryTest`
+  - `./gradlew :platform-apphost:test --tests *AppHostBoundaryTest`
+  - `./gradlew :platform-web-shell:test --tests *WebShellBoundaryTest`
 
 ## Compile-only / quick checks
 - Compile only:
@@ -149,6 +168,12 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew :kernel-routing:compileJava`
 - Compile only the runtime SPI leaf when you touched just that JDK-only API surface:
   - `./gradlew :runtime-spi:compileJava`
+- Compile the Platform API leaf when you touched `network.crypta.platform.api`:
+  - `./gradlew :platform-api:compileJava`
+- Compile the AppHost leaf when you touched `network.crypta.platform.apphost`:
+  - `./gradlew :platform-apphost:compileJava`
+- Compile the Web Shell leaf when you touched `network.crypta.platform.webshell`:
+  - `./gradlew :platform-web-shell:compileJava`
 - Compile the extracted runtime-node leaf when you touched daemon runtime, node, client, xfer, or
   remaining support code that now lives there:
   - `./gradlew :runtime-node:compileJava`

--- a/.agents/skills/cryptad-packaging/SKILL.md
+++ b/.agents/skills/cryptad-packaging/SKILL.md
@@ -22,9 +22,11 @@ Use this skill when working on:
   `runLauncher`, and jpackage tasks.
 - Current contributing leaf modules are `:foundation-support`, `:foundation-store`,
   `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
-  `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:runtime-spi`,
-  `:runtime-node`, `:adapter-fcp`, `:adapter-http-legacy-admin`, `:thirdparty-onion`,
-  `:thirdparty-legacy`, and `:launcher-desktop`.
+  `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
+  `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
+  `:platform-apphost`, `:platform-web-shell`, `:runtime-node`, `:adapter-fcp`,
+  `:adapter-http-legacy-admin`, `:thirdparty-onion`, `:thirdparty-legacy`, and
+  `:launcher-desktop`.
 - Extracted leaf modules contribute jars and resources through the root runtime classpath.
 - `:foundation-support` and `:foundation-store-contracts` contribute shared runtime classes via
   their leaf JARs like the other extracted modules.
@@ -36,6 +38,10 @@ Use this skill when working on:
   and re-exports `:foundation-support` and `:foundation-fs` where public APIs expose those types.
 - The `:runtime-spi` JAR is packaged like the other leaf artifacts; packaging still produces one
   daemon distribution rooted at `:cryptad`.
+- The `:platform-api` JAR contributes the transport-neutral Platform API v1 surface, and the
+  `:platform-apphost` JAR contributes the transport-neutral local AppHost core used by that API.
+- The `:platform-web-shell` JAR contributes the browser-facing node-management shell HTML, CSS,
+  JavaScript, and bootstrap resources that the legacy HTTP adapter mounts at `/app/node/`.
 - The `:runtime-node` JAR now carries a large extracted daemon runtime/node/client/support subset
   and participates in the root runtime classpath and packaged distribution like the other leaf
   artifacts.
@@ -43,7 +49,8 @@ Use this skill when working on:
 - The `:adapter-http-legacy-admin` JAR carries the current legacy HTTP adapter classes plus the
   matching `network/crypta/clients/http/**` resources. Static files and templates now ship from
   that leaf JAR on the runtime classpath, so packaged/runtime code must treat them as classpath
-  resources rather than plain files.
+  resources rather than plain files. This adapter also hosts the current `/api/v1/` bridge for
+  `:platform-api` and the `/app/node/` bridge for `:platform-web-shell`.
 - Packaging does not have separate entrypoints per leaf project; it still assembles a single daemon
   artifact and distribution layout from the root build.
 

--- a/.agents/skills/cryptad-style-docs/SKILL.md
+++ b/.agents/skills/cryptad-style-docs/SKILL.md
@@ -16,10 +16,11 @@ Use this skill when you:
 
 ## Java layout rules
 - Java sources go under `src/*/java/` (for example `src/main/java`, `src/test/java`).
-- For extracted production leaves such as `runtime-node`, `kernel-content`, and the adapter
-  modules, keep `package-info.java` in each production package you add or move. The root boundary
-  tests currently enforce this for `:runtime-node` and `:kernel-content`, and the adapter packages
-  are following the same convention.
+- For extracted production leaves such as `:runtime-node`, `:kernel-content`, `:platform-api`,
+  `:platform-apphost`, `:platform-web-shell`, and the adapter modules, keep `package-info.java`
+  in each production package you add or move. Boundary tests currently enforce this for
+  `:runtime-node`, `:kernel-content`, `:platform-api`, `:platform-apphost`, and
+  `:platform-web-shell`, and the adapter packages are following the same convention.
 
 ## Style guides
 - Java: follow the Google Java Style Guide.

--- a/README.md
+++ b/README.md
@@ -217,12 +217,12 @@ Cryptad now uses a partial multi-project Gradle build.
   and the minimal local AppHost control surface as JSON-oriented responses, and is currently
   mounted at `/api/v1/` through a thin legacy HTTP bridge in `:adapter-http-legacy-admin`. The
   current surface covers node info, peers, config export, connectivity, security-level snapshots,
-  and local app install/start/stop/uninstall routes; `GET /api/v1/config` defaults to the
+  and local app install/start/stop/update/uninstall routes; `GET /api/v1/config` defaults to the
   effective `CURRENT` section when `sections=` is omitted.
 - `:platform-apphost` owns the transport-neutral out-of-process AppHost v1 core under
   `network.crypta.platform.apphost`. It defines the local manifest, installed-app layout, process
   lifecycle, and per-start launch-token plumbing for local apps while staying separate from future
-  Web Shell, application-UI, and app update-channel work.
+  Web Shell, application-UI, and remote update-channel work.
 - `:platform-web-shell` owns the first browser-facing Web Shell v1 under
   `network.crypta.platform.webshell`. It keeps the node-management shell's route constants,
   bootstrap payload, HTML renderer, and plain browser assets self-owned while staying separate
@@ -244,7 +244,7 @@ Cryptad now uses a partial multi-project Gradle build.
   remaining legacy browse/FProxy shell inside this leaf is boundary-frozen until a later PR
   refines it further. That shell now also hosts the temporary `/api/v1/` mount for
   `:platform-api` plus the first `/app/node/` Web Shell bridge for `:platform-web-shell`; future
-  AppHost UI and app-update work remain separate.
+  AppHost UI and remote update-channel work remain separate.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
@@ -309,8 +309,21 @@ ownership and import rules:
 ./gradlew test --tests *KernelTransportBoundaryTest --tests *KernelContentBoundaryTest --tests *KernelRoutingBoundaryTest --tests *RuntimeNodeKernelSplitPrepBoundaryTest --tests *HttpLegacyAdminBoundaryTest
 ```
 
-Those tests also enforce the current extracted-leaf documentation convention that production
-packages in `:kernel-content` and `:runtime-node` keep a `package-info.java`.
+Those boundary suites also enforce the current extracted-leaf documentation convention that
+production packages in `:runtime-node`, `:kernel-content`, `:platform-api`,
+`:platform-apphost`, and `:platform-web-shell` keep a `package-info.java`.
+
+Focused platform test slices live in a mix of leaf and root tasks:
+
+```bash
+./gradlew :platform-apphost:test
+./gradlew :platform-web-shell:test
+./gradlew :adapter-http-legacy-admin:test
+./gradlew :test --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest
+```
+
+Platform boundary checks also include `PlatformApiBoundaryTest` in the root test tree plus the
+leaf-owned `AppHostBoundaryTest` and `WebShellBoundaryTest`.
 
 ## Code Quality
 
@@ -586,7 +599,8 @@ Root build also includes:
 - `:platform-api`: transport-neutral Platform API v1 built on top of `:runtime-spi` and
   `:platform-apphost`, currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
 - `:platform-apphost`: transport-neutral out-of-process AppHost v1 core for installed local apps.
-  Future Web Shell, app UI, and update-channel work remain separate and later.
+  Local staged app updates now flow through this core; future Web Shell, app UI, and remote
+  update-channel work remain separate and later.
 - `:platform-web-shell`: browser-facing Web Shell v1 leaf owning the node-management shell route
   descriptors, bootstrap payload, and static browser assets that the legacy HTTP adapter mounts at
   `/app/node/`.
@@ -643,6 +657,10 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 - Installing the OS package is a user/OS action. On Linux, the UI may hand off to the system’s software center or PackageKit. On macOS/Windows, follow the platform guidance shown in the UI.
 - JAR Update‑over‑Mandatory (UOM) for the core is disabled in favor of the package flow.
 - For developer testing, replacing `build/libs/cryptad.jar` manually (as noted above) is fine; for production use CoreUpdater and platform packages.
+- Local app lifecycle work is separate from CoreUpdater. The current platform can install, start,
+  stop, uninstall, and replace an installed app bundle from a caller-supplied local staged
+  directory through `:platform-apphost` and the Platform API v1. Remote catalogs, signed app
+  channels, and background app-update fetching remain future work.
 
 ## Architecture Overview
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -43,6 +43,7 @@ public final class PlatformApiToadlet extends Toadlet {
   /** JSON media type advertised for every Platform API response emitted through the bridge. */
   private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
+  private static final String DELETE_METHOD = "DELETE";
   private static final String FORM_PASSWORD_PARAMETER = "formPassword";
   private static final String STAGED_DIR_PARAMETER = "stagedDir";
   private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = 4096;
@@ -171,7 +172,7 @@ public final class PlatformApiToadlet extends Toadlet {
    */
   public void handleMethodDELETE(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    writePlatformApiResponse("DELETE", uri, request, ctx);
+    writePlatformApiResponse(DELETE_METHOD, uri, request, ctx);
   }
 
   /**
@@ -296,7 +297,7 @@ public final class PlatformApiToadlet extends Toadlet {
    * @return {@code true} when the request must present the legacy form password
    */
   private static boolean requiresFormPassword(String method, URI uri) {
-    if (!"POST".equals(method) && !"DELETE".equals(method)) {
+    if (!"POST".equals(method) && !DELETE_METHOD.equals(method)) {
       return false;
     }
 
@@ -310,14 +311,16 @@ public final class PlatformApiToadlet extends Toadlet {
     if (pathSegments.isEmpty() || !"apps".equals(pathSegments.getFirst())) {
       return false;
     }
-    if ("DELETE".equals(method)) {
+    if (DELETE_METHOD.equals(method)) {
       return pathSegments.size() == 2;
     }
     if (pathSegments.size() == 2 && "install".equals(pathSegments.get(1))) {
       return true;
     }
     return pathSegments.size() == 3
-        && ("start".equals(pathSegments.get(2)) || "stop".equals(pathSegments.get(2)));
+        && ("start".equals(pathSegments.get(2))
+            || "stop".equals(pathSegments.get(2))
+            || "update".equals(pathSegments.get(2)));
   }
 
   /**
@@ -354,9 +357,9 @@ public final class PlatformApiToadlet extends Toadlet {
    *
    * <p>Query parameters preserve encounter order and repeated values so the router can apply its
    * own validation without depending on the legacy HTTP request type. The bridge excludes the
-   * legacy admin {@code formPassword} from that map and also lifts the small set of scalar form
-   * fields currently needed by Platform API v1 into the same map, because the transport-neutral
-   * request model intentionally does not define a separate body contract yet.
+   * legacy admin {@code formPassword} from that map. It also lifts the small set of scalar form
+   * fields currently needed by Platform API v1 into the same map. The transport-neutral request
+   * model intentionally does not define a separate body contract yet.
    *
    * @param method HTTP method name forwarded into the router
    * @param uri request target supplied by the legacy HTTP shell
@@ -374,29 +377,29 @@ public final class PlatformApiToadlet extends Toadlet {
       }
       queryParameters.put(parameterName, List.of(request.getMultipleParam(parameterName)));
     }
-    copyStringPartIfPresent(request, queryParameters, STAGED_DIR_PARAMETER);
+    copyStagedDirPartIfPresent(request, queryParameters);
     return new PlatformApiRequest(method, relativeApiPath(requestPath(uri)), queryParameters);
   }
 
   /**
-   * Copies one scalar form part into the query-like parameter map when present.
+   * Copies the staged-directory form part into the query-like parameter map when present.
    *
-   * <p>This keeps the bridge compatible with legacy authenticated form submissions while preserving
+   * <p>This keeps the bridge compatible with legacy-authenticated form submissions while preserving
    * the transport-neutral request model expected by the Platform API router.
    *
    * @param request decoded legacy HTTP request wrapper
    * @param queryParameters query-like parameter map being assembled for the router
-   * @param parameterName parameter or part name to copy
    */
-  private static void copyStringPartIfPresent(
-      HTTPRequest request, Map<String, List<String>> queryParameters, String parameterName) {
-    if (queryParameters.containsKey(parameterName) || !request.isPartSet(parameterName)) {
+  private static void copyStagedDirPartIfPresent(
+      HTTPRequest request, Map<String, List<String>> queryParameters) {
+    if (queryParameters.containsKey(STAGED_DIR_PARAMETER)
+        || !request.isPartSet(STAGED_DIR_PARAMETER)) {
       return;
     }
     String value =
-        request.getPartAsStringFailsafe(parameterName, MAX_PLATFORM_API_FORM_FIELD_LENGTH);
+        request.getPartAsStringFailsafe(STAGED_DIR_PARAMETER, MAX_PLATFORM_API_FORM_FIELD_LENGTH);
     if (!value.isEmpty()) {
-      queryParameters.put(parameterName, List.of(value));
+      queryParameters.put(STAGED_DIR_PARAMETER, List.of(value));
     }
   }
 

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -150,7 +150,7 @@ public final class PlatformApiRouter {
     return switch (segments.size()) {
       case 1 -> routeAppsCollection(request.method());
       case 2 -> routeAppsResource(segments.get(1), request);
-      case 3 -> routeAppsAction(segments.get(1), segments.get(2), request.method());
+      case 3 -> routeAppsAction(segments.get(1), segments.get(2), request);
       default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
     };
   }
@@ -234,17 +234,22 @@ public final class PlatformApiRouter {
    * Routes app lifecycle actions beneath {@code /apps/{appId}/...}.
    *
    * @param appId normalized app identifier segment
-   * @param action lifecycle action segment
-   * @param method HTTP-style request method
+   * @param action lifecycle action segment such as {@code start}, {@code stop}, or {@code update}
+   * @param request full request metadata, including query parameters
    * @return JSON response for the selected app action
    */
-  private PlatformApiResponse routeAppsAction(String appId, String action, String method) {
+  private PlatformApiResponse routeAppsAction(
+      String appId, String action, PlatformApiRequest request) {
+    String method = request.method();
     if (!"POST".equals(method)) {
       return methodNotAllowed("POST", "Platform API v1 supports POST requests only.");
     }
     return switch (action) {
       case "start" -> PlatformApiResponse.ok(envelope("app", appsApiHandler.start(appId)));
       case "stop" -> PlatformApiResponse.ok(envelope("app", appsApiHandler.stop(appId)));
+      case "update" ->
+          PlatformApiResponse.ok(
+              envelope("app", appsApiHandler.update(appId, request.queryParameters())));
       default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
     };
   }

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -41,12 +41,14 @@ import network.crypta.platform.apphost.manifest.AppManifestParser;
  *
  * <ul>
  *   <li>Inventory reads merge installed and running state into one summary shape.
- *   <li>Mutation routes stay local and explicit: install, start, stop, and uninstall.
+ *   <li>Mutation routes stay local and explicit: install, start, update, stop, and uninstall.
  *   <li>Cleanup flows keep working even when installed manifests have become unreadable.
  * </ul>
  */
 public final class AppsApiHandler {
   private static final String APP_ALREADY_INSTALLED_PREFIX = "app already installed: ";
+  private static final String APP_NOT_INSTALLED_PREFIX = "app is not installed: ";
+  private static final String CANNOT_UPDATE_RUNNING_APP_PREFIX = "cannot update a running app: ";
 
   /** Detached AppHost core used for app lifecycle and inventory operations. */
   private final AppHost appHost;
@@ -130,6 +132,45 @@ public final class AppsApiHandler {
       throw installFailure(manifest.appId(), e);
     } catch (IOException _) {
       throw internalError("Failed to install app.");
+    }
+  }
+
+  /**
+   * Replaces one installed app with a staged bundle and returns the updated summary.
+   *
+   * <p>The update flow is intentionally conservative. It accepts the same local staged-directory
+   * input as install, but it only proceeds when the target app is not currently running. The staged
+   * bundle must target the same app id as the installed bundle, and the host-owned mutable
+   * directories remain untouched.
+   *
+   * <p>Unlike read-heavy inventory routes, update does not require the current installed manifest
+   * to be readable before it delegates to the AppHost. That keeps staged replacement available as a
+   * repair path for damaged installations whose immutable bundle can still be replaced safely.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @param queryParameters decoded query parameters for the current request
+   * @return JSON-compatible app summary for the updated bundle
+   */
+  public Map<String, Object> update(String appId, Map<String, List<String>> queryParameters) {
+    String normalizedAppId = normalizeAppId(appId);
+    Path stagedDir = parseStagedDirectory(queryParameters);
+    AppManifest manifest = parseManifest(stagedDir);
+    if (appHost.status(normalizedAppId).isPresent()) {
+      throw conflict(CANNOT_UPDATE_RUNNING_APP_PREFIX + normalizedAppId);
+    }
+
+    if (!normalizedAppId.equals(manifest.appId())) {
+      throw invalidBundle(
+          "staged app bundle app.id does not match target app: " + manifest.appId());
+    }
+
+    try {
+      InstalledAppSnapshot updated = appHost.updateFromDirectory(normalizedAppId, stagedDir);
+      return summarize(updated.manifest(), true, null);
+    } catch (AppHostException e) {
+      throw updateFailure(normalizedAppId, e);
+    } catch (IOException _) {
+      throw internalError("Failed to update app.");
     }
   }
 
@@ -468,6 +509,41 @@ public final class AppsApiHandler {
   }
 
   /**
+   * Maps update-time AppHost contract failures onto stable client-facing status codes.
+   *
+   * <p>Update uses the same conflict and not-found contract as the other lifecycle operations.
+   * Bundle validation failures stay in the {@code 400} family, while unexpected host-side errors
+   * remain internal server failures.
+   *
+   * @param appId normalized application identifier for the current request
+   * @param failure AppHost contract failure thrown during update
+   * @return structured Platform API exception
+   */
+  private PlatformApiException updateFailure(String appId, AppHostException failure) {
+    if (isRunningUpdateFailure(failure) || appHost.status(appId).isPresent()) {
+      return conflict(CANNOT_UPDATE_RUNNING_APP_PREFIX + appId);
+    }
+    if (isMissingAppFailure(failure)) {
+      return appNotFound();
+    }
+    if (isInvalidAppBundleFailure(failure)) {
+      return invalidBundle(
+          messageOrDefault(failure, "Staged app bundle failed AppHost validation."));
+    }
+    return internalError("Failed to update app.");
+  }
+
+  private static boolean isRunningUpdateFailure(AppHostException failure) {
+    String message = failure.getMessage();
+    return message != null && message.startsWith(CANNOT_UPDATE_RUNNING_APP_PREFIX);
+  }
+
+  private static boolean isMissingAppFailure(AppHostException failure) {
+    String message = failure.getMessage();
+    return message != null && message.startsWith(APP_NOT_INSTALLED_PREFIX);
+  }
+
+  /**
    * Returns whether an install-time AppHost failure was caused by caller-supplied bundle input.
    *
    * <p>Install failures span both staged-bundle validation and host-managed layout validation. The
@@ -490,7 +566,8 @@ public final class AppsApiHandler {
         || message.startsWith("staging directory ")
         || message.startsWith("copied manifest ")
         || message.startsWith("copied app.exec ")
-        || message.startsWith("app.exec ");
+        || message.startsWith("app.exec ")
+        || message.startsWith("staged app bundle ");
   }
 
   /**

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
@@ -38,6 +38,29 @@ public interface AppHost {
   InstalledAppSnapshot installFromDirectory(Path stagedAppDirectory) throws IOException;
 
   /**
+   * Replaces one installed app bundle from a local staging directory.
+   *
+   * <p>The supplied staging directory is validated using the same caller-owned input rules as
+   * installation, but the staged manifest must target the already-installed app being updated.
+   * Implementations replace only the immutable installed bundle contents. The host-owned data,
+   * cache, and run directories remain attached to the existing app id and are preserved across the
+   * update.
+   *
+   * <p>AppHost v1 keeps update semantics intentionally narrow and explicit: the target app must
+   * already be installed and must not be running. Implementations should therefore reject updates
+   * for missing or live apps rather than attempting implicit stop/start choreography.
+   *
+   * @param appId stable application identifier
+   * @param stagedAppDirectory staging directory containing {@code cryptad-app.properties} and the
+   *     files referenced by the manifest
+   * @return installed application snapshot describing the replaced bundle and preserved host paths
+   * @throws IOException if validation fails, the staged bundle targets a different app id, the app
+   *     is missing or still running, or the replacement cannot be completed safely
+   */
+  InstalledAppSnapshot updateFromDirectory(String appId, Path stagedAppDirectory)
+      throws IOException;
+
+  /**
    * Removes one installed app and its host-owned directories.
    *
    * <p>This operation removes both the immutable installed bundle and the mutable per-app data,

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -62,6 +62,7 @@ import org.jetbrains.annotations.NotNull;
 public final class LocalProcessAppHost implements AppHost {
   private static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofSeconds(5);
   private static final String TEMP_INSTALL_PREFIX = "app-install-";
+  private static final String TEMP_UPDATE_BACKUP_PREFIX = TEMP_INSTALL_PREFIX + "backup-";
   private static final String LOCAL_DIRECTORY_NAME = "local";
   private static final String INSTALLED_APPS_DIR_LABEL = "installedAppsDir";
   private static final String WINDOWS_SYSTEM32_DIRECTORY = "System32";
@@ -109,6 +110,7 @@ public final class LocalProcessAppHost implements AppHost {
   private final SecureRandom secureRandom;
   private final AppEnv appEnv;
   private final TimingConfig timing;
+  private final ManagedTreeDeleter managedTreeDeleter;
   private final Map<String, RunningProcess> runningApps = new ConcurrentHashMap<>();
 
   /**
@@ -151,11 +153,22 @@ public final class LocalProcessAppHost implements AppHost {
       SecureRandom secureRandom,
       AppEnv appEnv,
       TimingConfig timing) {
+    this(layout, stopTimeout, secureRandom, appEnv, timing, LocalProcessAppHost::deleteRecursively);
+  }
+
+  LocalProcessAppHost(
+      AppHostLayout layout,
+      Duration stopTimeout,
+      SecureRandom secureRandom,
+      AppEnv appEnv,
+      TimingConfig timing,
+      ManagedTreeDeleter managedTreeDeleter) {
     this.layout = Objects.requireNonNull(layout, "layout");
     this.stopTimeout = Objects.requireNonNull(stopTimeout, "stopTimeout");
     this.secureRandom = Objects.requireNonNull(secureRandom, "secureRandom");
     this.appEnv = Objects.requireNonNull(appEnv, "appEnv");
     this.timing = Objects.requireNonNull(timing, "timing");
+    this.managedTreeDeleter = Objects.requireNonNull(managedTreeDeleter, "managedTreeDeleter");
     if (stopTimeout.isZero() || stopTimeout.isNegative()) {
       throw new IllegalArgumentException("stopTimeout must be positive");
     }
@@ -196,6 +209,57 @@ public final class LocalProcessAppHost implements AppHost {
       return new InstalledAppSnapshot(manifest, paths);
     } catch (IOException | RuntimeException e) {
       deleteRecursively(temporaryInstallRoot);
+      throw e;
+    }
+  }
+
+  /**
+   * Replaces one installed app bundle from a local staging directory.
+   *
+   * <p>The update flow deliberately reuses the installation model: the caller provides a local
+   * staged directory, the host copies and validates that bundle under managed storage, and the
+   * staged manifest must target the same normalized app id as the existing installation. Only the
+   * immutable installed bundle root is replaced. The host-owned data, cache, and run directories
+   * remain in place and are preserved.
+   *
+   * <p>AppHost v1 keeps replacement conservative and explicit. The target app must already be
+   * installed and stopped before any filesystem mutation occurs.
+   *
+   * @param appId stable application identifier
+   * @param stagedAppDirectory staging directory containing {@code cryptad-app.properties}
+   * @return installed application snapshot describing the replaced bundle and preserved host paths
+   * @throws IOException if the app is missing or still running, the staged bundle is invalid or
+   *     targets a different app id, or the replacement cannot be completed safely
+   */
+  @Override
+  public synchronized InstalledAppSnapshot updateFromDirectory(
+      String appId, Path stagedAppDirectory) throws IOException {
+    String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
+    Path stagingRoot = normalizeExistingDirectory(stagedAppDirectory);
+    Path installedAppsDir = validateInstalledAppsDirectory();
+    rejectOverlappingInstallTree(stagingRoot, installedAppsDir);
+    InstalledAppPaths paths = layout.pathsFor(normalizedAppId);
+    rejectOverlappingMutableAppDirectories(stagingRoot, paths);
+    if (liveRunningProcess(normalizedAppId) != null) {
+      throw new AppHostException("cannot update a running app: " + normalizedAppId);
+    }
+    if (!Files.isDirectory(paths.installedRoot(), LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppHostException("app is not installed: " + normalizedAppId);
+    }
+    validateManagedMutableDirectories(paths);
+    paths.ensureMutableDirectories();
+
+    Path temporaryInstallRoot = Files.createTempDirectory(installedAppsDir, TEMP_INSTALL_PREFIX);
+    Path backupInstallRoot =
+        temporaryManagedPath(installedAppsDir, TEMP_UPDATE_BACKUP_PREFIX + normalizedAppId + "-");
+    try {
+      copyDirectoryTree(stagingRoot, temporaryInstallRoot);
+      AppManifest manifest = validateCopiedBundle(temporaryInstallRoot);
+      requireMatchingUpdateTarget(normalizedAppId, manifest);
+      replaceInstalledBundle(paths.installedRoot(), temporaryInstallRoot, backupInstallRoot);
+      return new InstalledAppSnapshot(manifest, paths);
+    } catch (IOException | RuntimeException e) {
+      deleteScratchTreeIfPresent(temporaryInstallRoot);
       throw e;
     }
   }
@@ -438,7 +502,7 @@ public final class LocalProcessAppHost implements AppHost {
         resolveBundleEntry(
             installedRoot, Path.of(AppManifestParser.MANIFEST_FILE_NAME), "installed manifest");
     AppManifest manifest = AppManifestParser.parse(manifestFile);
-    String installedDirectoryName = fileNameOrThrow(installedRoot, "installed manifest root");
+    String installedDirectoryName = installedDirectoryNameOrThrow(installedRoot);
     if (!installedDirectoryName.equals(manifest.appId())) {
       throw new AppManifestException(
           "installed manifest app.id does not match directory name: " + installedDirectoryName);
@@ -461,6 +525,14 @@ public final class LocalProcessAppHost implements AppHost {
     }
     validateLaunchableCopiedExecutable(copiedExecutable, manifest);
     return manifest;
+  }
+
+  private static void requireMatchingUpdateTarget(String requestedAppId, AppManifest manifest)
+      throws AppManifestException {
+    if (!requestedAppId.equals(manifest.appId())) {
+      throw new AppManifestException(
+          "staged manifest app.id does not match requested app.id: " + requestedAppId);
+    }
   }
 
   private void validateLaunchableCopiedExecutable(Path copiedExecutable, AppManifest manifest)
@@ -1110,10 +1182,10 @@ public final class LocalProcessAppHost implements AppHost {
     return fileName == null ? "" : fileName.toString();
   }
 
-  private static String fileNameOrThrow(Path path, String label) throws AppHostException {
+  private static String installedDirectoryNameOrThrow(Path path) throws AppHostException {
     String fileName = fileNameText(path);
     if (fileName.isEmpty()) {
-      throw new AppHostException(label + " must not be a filesystem root: " + path);
+      throw new AppHostException("installed manifest root must not be a filesystem root: " + path);
     }
     return fileName;
   }
@@ -1173,6 +1245,50 @@ public final class LocalProcessAppHost implements AppHost {
     String value = System.getenv(name);
     if (value != null && !value.isBlank()) {
       environment.put(name, value);
+    }
+  }
+
+  private Path temporaryManagedPath(Path parent, String prefix) throws IOException {
+    for (int attempt = 0; attempt < 8; attempt++) {
+      Path candidate = parent.resolve(prefix + generateToken());
+      if (!Files.exists(candidate, LinkOption.NOFOLLOW_LINKS)) {
+        return candidate;
+      }
+    }
+    throw new AppHostException("failed to allocate temporary managed path under: " + parent);
+  }
+
+  private void replaceInstalledBundle(Path installedRoot, Path replacementRoot, Path backupRoot)
+      throws IOException {
+    moveIntoPlace(installedRoot, backupRoot);
+    try {
+      moveIntoPlace(replacementRoot, installedRoot);
+    } catch (IOException updateFailure) {
+      restoreInstalledBundle(installedRoot, backupRoot, updateFailure);
+      throw updateFailure;
+    }
+    deleteBackupAfterSuccessfulReplacement(backupRoot);
+  }
+
+  private void deleteBackupAfterSuccessfulReplacement(Path backupRoot) {
+    try {
+      managedTreeDeleter.deleteRecursively(backupRoot);
+    } catch (IOException _) {
+      // The replacement is already committed; a skipped temp backup is safer than a false failure.
+    }
+  }
+
+  private static void restoreInstalledBundle(
+      Path installedRoot, Path backupRoot, IOException updateFailure) {
+    try {
+      deleteScratchTreeIfPresent(installedRoot);
+    } catch (IOException cleanupFailure) {
+      updateFailure.addSuppressed(cleanupFailure);
+    }
+    try {
+      moveIntoPlace(backupRoot, installedRoot);
+    } catch (IOException restoreFailure) {
+      updateFailure.addSuppressed(restoreFailure);
     }
   }
 
@@ -1236,6 +1352,13 @@ public final class LocalProcessAppHost implements AppHost {
           "staging directory must not contain links or reparse points: " + entry);
     }
     return actualRealPath;
+  }
+
+  private static void deleteScratchTreeIfPresent(Path root) throws IOException {
+    if (!Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    deleteRecursively(root);
   }
 
   private static void deleteRecursively(Path root) throws IOException {
@@ -1840,7 +1963,12 @@ public final class LocalProcessAppHost implements AppHost {
     }
   }
 
-  static record TimingConfig(
+  @FunctionalInterface
+  interface ManagedTreeDeleter {
+    void deleteRecursively(Path root) throws IOException;
+  }
+
+  record TimingConfig(
       Duration startupExitGracePeriod,
       Duration startupProcessCaptureWindow,
       Duration startupPostCaptureHandoffGracePeriod,

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -38,6 +38,7 @@ import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.manifest.AppManifestException;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assumptions;
@@ -303,6 +304,226 @@ class LocalProcessAppHostTest {
     host.installFromDirectory(stagedApp);
 
     assertThrows(AppHostException.class, () -> host.installFromDirectory(stagedApp));
+  }
+
+  @Test
+  void
+      updateFromDirectory_whenInstalledStoppedApp_expectManifestAndExecutableReplacedPreservingMutableDirs()
+          throws IOException {
+    AppHost host = host();
+    Path installedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-installed").resolve(SAMPLE_APP_ID),
+            SAMPLE_APP_ID,
+            APP_VERSION,
+            """
+            #!/bin/sh
+            printf 'old\\n'
+            """,
+            Map.of("bundle-only.txt", "old-bundle\n"));
+    InstalledAppSnapshot installation = host.installFromDirectory(installedStage);
+    Path dataSentinel =
+        Files.writeString(
+            installation.paths().dataDir().resolve("preserve-data.txt"),
+            "keep-data",
+            StandardCharsets.UTF_8);
+    Path cacheSentinel =
+        Files.writeString(
+            installation.paths().cacheDir().resolve("preserve-cache.txt"),
+            "keep-cache",
+            StandardCharsets.UTF_8);
+    Path runSentinel =
+        Files.writeString(
+            installation.paths().runDir().resolve("preserve-run.txt"),
+            "keep-run",
+            StandardCharsets.UTF_8);
+    Path updatedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
+            SAMPLE_APP_ID,
+            "3.0.0",
+            """
+            #!/bin/sh
+            printf 'new\\n'
+            """,
+            Map.of("new-bundle.txt", "new-bundle\n"));
+
+    InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
+
+    assertEquals("3.0.0", updated.manifest().appVersion());
+    assertEquals(installation.paths(), updated.paths());
+    assertEquals("keep-data", Files.readString(dataSentinel, StandardCharsets.UTF_8));
+    assertEquals("keep-cache", Files.readString(cacheSentinel, StandardCharsets.UTF_8));
+    assertEquals("keep-run", Files.readString(runSentinel, StandardCharsets.UTF_8));
+    assertFalse(Files.exists(updated.paths().installedRoot().resolve("bundle-only.txt")));
+    assertEquals(
+        "new-bundle\n",
+        Files.readString(
+            updated.paths().installedRoot().resolve("new-bundle.txt"), StandardCharsets.UTF_8));
+    assertEquals(
+        """
+        #!/bin/sh
+        printf 'new\\n'
+        """,
+        Files.readString(
+            updated.paths().executablePath(updated.manifest()), StandardCharsets.UTF_8));
+    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(List.of(updated), host.listInstalled());
+  }
+
+  @Test
+  void updateFromDirectory_whenInstalledManifestMissing_expectBundleRepaired() throws IOException {
+    AppHost host = host();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+    Files.delete(installation.paths().manifestFile());
+    Path updatedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-repair").resolve(SAMPLE_APP_ID),
+            SAMPLE_APP_ID,
+            "3.0.0",
+            """
+            #!/bin/sh
+            printf 'repaired\\n'
+            """,
+            Map.of("repair-bundle.txt", "repair-bundle\n"));
+
+    InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
+
+    assertEquals("3.0.0", updated.manifest().appVersion());
+    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(
+        "repair-bundle\n",
+        Files.readString(
+            updated.paths().installedRoot().resolve("repair-bundle.txt"), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void updateFromDirectory_whenStagedManifestTargetsDifferentApp_expectFailure()
+      throws IOException {
+    AppHost host = host();
+    host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+    Path mismatchedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-update").resolve(DUPLICATE_APP_ID),
+            DUPLICATE_APP_ID,
+            "3.0.0",
+            scriptContent(new AppEnv()),
+            Map.of());
+
+    AppManifestException exception =
+        assertThrows(
+            AppManifestException.class,
+            () -> host.updateFromDirectory(SAMPLE_APP_ID, mismatchedStage));
+
+    assertTrue(exception.getMessage().contains("does not match requested app.id"));
+    assertEquals(APP_VERSION, host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+  }
+
+  @Test
+  void updateFromDirectory_whenAppNotInstalled_expectFailure() throws IOException {
+    AppHost host = host();
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+
+    AppHostException exception =
+        assertThrows(
+            AppHostException.class, () -> host.updateFromDirectory(SAMPLE_APP_ID, stagedApp));
+
+    assertEquals("app is not installed: " + SAMPLE_APP_ID, exception.getMessage());
+  }
+
+  @Test
+  void updateFromDirectory_whenInstalledManifestUnreadable_expectReplacementRepairsBundle()
+      throws IOException {
+    AppHost host = host();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+    Files.delete(installation.paths().manifestFile());
+    Path updatedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
+            SAMPLE_APP_ID,
+            "3.0.0",
+            scriptContent(new AppEnv()),
+            Map.of("new-bundle.txt", "new-bundle\n"));
+
+    assertThrows(IOException.class, () -> host.describe(SAMPLE_APP_ID));
+
+    InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
+
+    assertEquals("3.0.0", updated.manifest().appVersion());
+    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(
+        "new-bundle\n",
+        Files.readString(
+            updated.paths().installedRoot().resolve("new-bundle.txt"), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void updateFromDirectory_whenBackupCleanupFails_expectSuccessfulReplacementAndReadableInstall()
+      throws IOException {
+    LocalProcessAppHost host =
+        host(
+            Duration.ofSeconds(1),
+            new AppEnv(),
+            _ -> {
+              throw new IOException("simulated backup cleanup failure");
+            });
+    host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+    Path updatedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
+            SAMPLE_APP_ID,
+            "3.0.0",
+            scriptContent(new AppEnv()),
+            Map.of("new-bundle.txt", "new-bundle\n"));
+
+    InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
+
+    assertEquals("3.0.0", updated.manifest().appVersion());
+    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    try (var entries = Files.list(updated.paths().installedRoot().getParent())) {
+      assertTrue(
+          entries.anyMatch(
+              path ->
+                  path.getFileName()
+                      .toString()
+                      .startsWith("app-install-backup-" + SAMPLE_APP_ID + "-")));
+    }
+    assertEquals(List.of(updated), host.listInstalled());
+  }
+
+  @Test
+  void updateFromDirectory_whenAppIsRunning_expectFailure() throws IOException {
+    AppHost host = host();
+    host.installFromDirectory(stageInstalledRunnerApp(DAEMONIZED_CHILD_PROCESS_SCRIPT));
+    host.start(RUNNER_APP_ID);
+
+    try {
+      AppHostException exception =
+          assertThrows(
+              AppHostException.class,
+              () ->
+                  host.updateFromDirectory(
+                      RUNNER_APP_ID, tempDir.resolve(STAGE_DIR_NAME).resolve(RUNNER_APP_ID)));
+
+      assertEquals("cannot update a running app: " + RUNNER_APP_ID, exception.getMessage());
+      assertEquals(APP_VERSION, host.describe(RUNNER_APP_ID).orElseThrow().manifest().appVersion());
+    } finally {
+      host.stop(RUNNER_APP_ID);
+    }
+  }
+
+  @Test
+  void updateFromDirectory_whenStagedDirectoryInvalid_expectFailure() throws IOException {
+    AppHost host = host();
+    host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+
+    AppHostException exception =
+        assertThrows(
+            AppHostException.class,
+            () -> host.updateFromDirectory(SAMPLE_APP_ID, tempDir.resolve("missing-stage")));
+
+    assertTrue(exception.getMessage().contains("stagedAppDirectory must be an existing directory"));
+    assertEquals(APP_VERSION, host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
   }
 
   @Test
@@ -1607,6 +1828,20 @@ class LocalProcessAppHostTest {
         TEST_TIMING);
   }
 
+  private LocalProcessAppHost host(
+      Duration stopTimeout,
+      AppEnv appEnv,
+      LocalProcessAppHost.ManagedTreeDeleter managedTreeDeleter) {
+    return new LocalProcessAppHost(
+        new AppHostLayout(
+            tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run")),
+        stopTimeout,
+        new java.security.SecureRandom(),
+        appEnv,
+        TEST_TIMING,
+        managedTreeDeleter);
+  }
+
   private Path stageInstalledApp(String appId) throws IOException {
     return stageInstalledApp(appId, scriptContent(new AppEnv()), Map.of());
   }
@@ -1623,6 +1858,16 @@ class LocalProcessAppHostTest {
 
   private Path stageInstalledAppAt(
       Path stagedDir, String appId, String scriptContent, Map<String, String> extraFiles)
+      throws IOException {
+    return stageInstalledAppAt(stagedDir, appId, APP_VERSION, scriptContent, extraFiles);
+  }
+
+  private Path stageInstalledAppAt(
+      Path stagedDir,
+      String appId,
+      String appVersion,
+      String scriptContent,
+      Map<String, String> extraFiles)
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Files.createDirectories(stagedDir);
@@ -1648,7 +1893,7 @@ class LocalProcessAppHostTest {
         quota.cache.bytes=1024
         """
             .formatted(
-                appId, displayName(appId), APP_VERSION, scriptName, STANDARD_PERMISSIONS_TEXT),
+                appId, displayName(appId), appVersion, scriptName, STANDARD_PERMISSIONS_TEXT),
         StandardCharsets.UTF_8);
     return stagedDir;
   }
@@ -2252,7 +2497,7 @@ class LocalProcessAppHostTest {
 
       @Override
       public boolean equals(Object other) {
-        return other instanceof ProcessHandle handle && pid == handle.pid();
+        return other instanceof ProcessHandle otherHandle && pid == otherHandle.pid();
       }
 
       @Override

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -93,6 +93,43 @@ class PlatformApiToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenAppUpdateRequested_routesDecodedUpdateRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of("stagedDir"));
+    when(request.getMultipleParam("stagedDir")).thenReturn(new String[] {"/tmp/staged"});
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/alpha/update"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("apps", "alpha", "update"),
+                Map.of("stagedDir", List.of("/tmp/staged"))));
+  }
+
+  @Test
+  void handleMethodPOST_whenAppUpdateUsesFormPart_routesUpdateRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(request.isPartSet("stagedDir")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("stagedDir", 4096)).thenReturn("/tmp/staged");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/alpha/update"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("apps", "alpha", "update"),
+                Map.of("stagedDir", List.of("/tmp/staged"))));
+  }
+
+  @Test
   void handleMethodPOST_whenNonAppsRoute_expectRouterJson405WithoutPasswordCheck()
       throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);

--- a/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
@@ -32,17 +32,17 @@ class PlatformApiAppsIntegrationTest {
 
   @TempDir private Path tempDir;
 
+  private AppHostLayout appHostLayout;
   private PlatformApiRouter router;
 
   @BeforeEach
   void setUp() {
     RuntimePorts runtimePorts = mock(RuntimePorts.class, Answers.RETURNS_DEEP_STUBS);
+    appHostLayout =
+        new AppHostLayout(
+            tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"));
     AppHost appHost =
-        new LocalProcessAppHost(
-            new AppHostLayout(
-                tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run")),
-            Duration.ofSeconds(2),
-            new SecureRandom());
+        new LocalProcessAppHost(appHostLayout, Duration.ofSeconds(2), new SecureRandom());
     router = new PlatformApiRouter(runtimePorts, appHost);
   }
 
@@ -92,6 +92,71 @@ class PlatformApiAppsIntegrationTest {
   }
 
   @Test
+  void route_whenStoppedInstalledAppUpdated_expectStableJsonAndPreservedMutableLayout()
+      throws Exception {
+    Path stagedV1 = stageApp("staged-v1", "1.0.0");
+    Path stagedV2 = stageApp("staged-v2", "9.9.9");
+
+    PlatformApiResponse installResponse =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedV1.toString()))));
+    assertEquals(201, installResponse.statusCode());
+
+    Files.writeString(tempDir.resolve("data/apps/data/" + APP_ID + "/sentinel.txt"), "data");
+    Files.writeString(tempDir.resolve("cache/apps/" + APP_ID + "/sentinel.txt"), "cache");
+    Files.writeString(tempDir.resolve("run/apps/" + APP_ID + "/sentinel.txt"), "run");
+
+    PlatformApiResponse updateResponse =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedV2.toString()))));
+
+    assertEquals(200, updateResponse.statusCode());
+    assertTrue(updateResponse.body().contains("\"version\":\"9.9.9\""));
+    assertTrue(updateResponse.body().contains("\"installed\":true"));
+    assertTrue(updateResponse.body().contains("\"running\":false"));
+    assertEquals(
+        "data", Files.readString(tempDir.resolve("data/apps/data/" + APP_ID + "/sentinel.txt")));
+    assertEquals(
+        "cache", Files.readString(tempDir.resolve("cache/apps/" + APP_ID + "/sentinel.txt")));
+    assertEquals("run", Files.readString(tempDir.resolve("run/apps/" + APP_ID + "/sentinel.txt")));
+  }
+
+  @Test
+  void route_whenInstalledManifestMissingDuringUpdate_expectRepairResponse() throws Exception {
+    Path stagedV1 = stageApp("staged-v1", "1.0.0");
+    Path stagedV2 = stageApp("staged-v2", "9.9.9");
+
+    PlatformApiResponse installResponse =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedV1.toString()))));
+    assertEquals(201, installResponse.statusCode());
+    Files.delete(appHostLayout.pathsFor(APP_ID).manifestFile());
+
+    PlatformApiResponse updateResponse =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedV2.toString()))));
+    PlatformApiResponse getResponse =
+        router.route(request("GET", List.of("apps", APP_ID), Map.of()));
+
+    assertEquals(200, updateResponse.statusCode());
+    assertTrue(updateResponse.body().contains("\"version\":\"9.9.9\""));
+    assertEquals(200, getResponse.statusCode());
+    assertTrue(getResponse.body().contains("\"version\":\"9.9.9\""));
+  }
+
+  @Test
   void route_whenAppMissing_expect404() {
     PlatformApiResponse response =
         router.route(request("GET", List.of("apps", "missing"), Map.of()));
@@ -136,9 +201,13 @@ class PlatformApiAppsIntegrationTest {
   }
 
   private Path stageApp() throws Exception {
+    return stageApp("staged", APP_VERSION);
+  }
+
+  private Path stageApp(String stagedDirectoryName, String appVersion) throws Exception {
     AppEnv appEnv = new AppEnv();
     String scriptName = appEnv.isWindows() ? "launch.cmd" : "launch.sh";
-    Path stagedDir = Files.createDirectories(tempDir.resolve("staged").resolve(APP_ID));
+    Path stagedDir = Files.createDirectories(tempDir.resolve(stagedDirectoryName).resolve(APP_ID));
     Path binDir = Files.createDirectories(stagedDir.resolve("bin"));
     Path launcher = binDir.resolve(scriptName);
     Files.writeString(launcher, scriptContent(appEnv), StandardCharsets.UTF_8);
@@ -158,7 +227,7 @@ class PlatformApiAppsIntegrationTest {
         quota.data.bytes=4096
         quota.cache.bytes=1024
         """
-            .formatted(APP_ID, APP_NAME, APP_VERSION, scriptName, UI_ENTRY),
+            .formatted(APP_ID, APP_NAME, appVersion, scriptName, UI_ENTRY),
         StandardCharsets.UTF_8);
     return stagedDir;
   }

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -503,6 +503,138 @@ class PlatformApiRouterTest {
   }
 
   @Test
+  void route_whenInstalledManifestUnreadableAndUpdateRequested_expectUpdatedSummaryJson()
+      throws Exception {
+    Path stagedDir = stageApp("9.9.9", APP_ID, APP_NAME);
+    InstalledAppSnapshot updated = installedSnapshot(APP_ID, APP_NAME, "9.9.9", APP_UI_ENTRY);
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.updateFromDirectory(APP_ID, stagedDir)).thenReturn(updated);
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            Map.of(
+                "app",
+                summaryFor(APP_ID, APP_NAME, "9.9.9", APP_UI_ENTRY, true, false, null, null))),
+        response.body());
+    verify(appHost, never()).describe(APP_ID);
+  }
+
+  @Test
+  void route_whenAppUpdateTargetMissing_expectNotFoundJson() throws Exception {
+    Path stagedDir = stageApp("9.9.9", APP_ID, APP_NAME);
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.updateFromDirectory(APP_ID, stagedDir))
+        .thenThrow(new AppHostException("app is not installed: alpha"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(404, response.statusCode());
+    assertEquals("Not Found", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+    verify(appHost, never()).describe(APP_ID);
+    verify(appHost).updateFromDirectory(APP_ID, stagedDir);
+  }
+
+  @Test
+  void route_whenAppUpdateRequestedWhileRunning_expectConflictJson() throws Exception {
+    Path stagedDir = stageApp("9.9.9", APP_ID, APP_NAME);
+    when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"cannot update a running app:"
+            + " alpha\"}}",
+        response.body());
+    verify(appHost, never()).describe(APP_ID);
+    verify(appHost, never()).updateFromDirectory(APP_ID, stagedDir);
+  }
+
+  @Test
+  void route_whenAppUpdateStagedBundleTargetsDifferentApp_expectBadRequestJson() throws Exception {
+    Path stagedDir = stageApp("9.9.9", "beta", "Beta App");
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(400, response.statusCode());
+    assertEquals("Bad Request", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_app_bundle\",\"message\":\"staged app bundle app.id"
+            + " does not match target app: beta\"}}",
+        response.body());
+    verify(appHost, never()).describe(APP_ID);
+    verify(appHost, never()).updateFromDirectory(APP_ID, stagedDir);
+  }
+
+  @Test
+  void route_whenInstalledManifestUnreadableAndUpdateBundleInvalid_expectBadRequestJson()
+      throws Exception {
+    Path stagedDir = stageApp("9.9.9", APP_ID, APP_NAME);
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.updateFromDirectory(APP_ID, stagedDir))
+        .thenThrow(
+            new AppHostException(
+                "app.exec does not resolve to a file in copied bundle: bin/launch"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(400, response.statusCode());
+    assertEquals("Bad Request", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_app_bundle\",\"message\":\"app.exec does not resolve"
+            + " to a file in copied bundle: bin/launch\"}}",
+        response.body());
+    verify(appHost, never()).describe(APP_ID);
+    verify(appHost).updateFromDirectory(APP_ID, stagedDir);
+  }
+
+  @Test
+  void route_whenAppUpdateMissingStagedDir_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "update"), Map.of()));
+
+    assertEquals(400, response.statusCode());
+    assertEquals("Bad Request", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_query_parameter\",\"message\":\"Missing required query"
+            + " parameter 'stagedDir'.\"}}",
+        response.body());
+    verifyNoInteractions(appHost);
+  }
+
+  @Test
   void route_whenAppInstallMissingStagedDir_expectBadRequestJson() {
     PlatformApiResponse response =
         router.route(request("POST", List.of("apps", "install"), Map.of()));
@@ -832,6 +964,10 @@ class PlatformApiRouterTest {
   }
 
   private Path stageApp() throws Exception {
+    return stageApp(APP_VERSION, APP_ID, APP_NAME);
+  }
+
+  private Path stageApp(String appVersion, String appId, String appName) throws Exception {
     Path stagedDir = Files.createTempDirectory(tempDir, "staged-");
     Files.writeString(
         stagedDir.resolve("cryptad-app.properties"),
@@ -846,7 +982,7 @@ class PlatformApiRouterTest {
         quota.data.bytes=4096
         quota.cache.bytes=8192
         """
-            .formatted(APP_ID, APP_NAME, APP_VERSION, APP_UI_ENTRY));
+            .formatted(appId, appName, appVersion, APP_UI_ENTRY));
     return stagedDir;
   }
 


### PR DESCRIPTION
## Summary
- add a staged local app update flow to `:platform-apphost` and expose it through Platform API v1 plus the legacy HTTP bridge
- cover update success, invalid staged input, damaged-install recovery, and post-swap backup-cleanup behavior across AppHost, Platform API, and bridge tests
- refresh README and local agent skills to reflect the current platform leaves, focused test entry points, and the separation between local staged app updates and future remote update channels

## How to test
- `./gradlew :platform-apphost:test --tests "network.crypta.platform.apphost.runtime.LocalProcessAppHostTest"`
- `./gradlew :test --tests "network.crypta.platform.api.PlatformApiRouterTest" --tests "network.crypta.platform.api.PlatformApiAppsIntegrationTest" --tests "network.crypta.clients.http.PlatformApiToadletTest"`
- `./gradlew test`

## Notes
- PR includes two commits: the staged app-update feature and a follow-up refresh of repo skill documentation.
- base branch: `develop`.
