### PR TITLE
refactor(architecture): Finalize leaf boundary cleanup

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -91,8 +91,8 @@ Use this skill when you need to:
     `network.crypta.runtime.admin.queue` and `network.crypta.runtime.admin.queue.page`.
     Queue completion/download/insert bridges plus the remaining concrete FCP bridge
     implementations now live under `network.crypta.clients.fcp.bridge`.
-  - The root project keeps application composition, packaging/runtime tasks, tests, tools, and
-    root-local bridge selection in
+  - The root project keeps application composition, packaging/runtime tasks, most broad tests,
+    tools, and root-local bridge selection in
     `network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories`.
 - The daemon runtime body now spans extracted leaves plus a thin root composition layer:
   `:kernel-content` owns the compile-neutral phase-1 client/content slice,
@@ -122,12 +122,13 @@ Use this skill when you need to:
 - Update that metadata whenever a leaf starts owning additional main classes/resources that root
   used to compile/package. This applies to existing leaves such as `:foundation-support` and
   `:foundation-store-contracts` just as much as any future extraction.
-- Root boundary tests now freeze the extracted layout. In particular,
+- Focused leaf-local boundary tests now freeze the extracted layout. In particular,
   `RuntimeNodeKernelSplitPrepBoundaryTest`, `KernelContentBoundaryTest`,
   `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, `PlatformApiBoundaryTest`,
-  `AppHostBoundaryTest`, `WebShellBoundaryTest`, and `HttpLegacyAdminBoundaryTest` guard leaf
-  ownership/import rules. The runtime/kernel-content/platform tests also require
-  `package-info.java` in every production package under those leaves.
+  `AdapterFcpBoundaryTest`, `AppHostBoundaryTest`, `WebShellBoundaryTest`, and
+  `HttpLegacyAdminBoundaryTest` guard leaf ownership/import rules. The runtime, kernel, platform,
+  and adapter-fcp boundary suites also require `package-info.java` in the production packages they
+  own.
 
 ## Architecture overview (by package)
 ### Core network layer (`network.crypta.node`)

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -67,17 +67,17 @@ Use this skill when you need to:
 - When moving additional main classes/resources from root into any extracted leaf, update that
   leaf's `owned-output-patterns.txt` and validate with
   `./gradlew verifySelectiveLeafOwnershipMetadata buildJar`.
-- Root and leaf boundary tests now freeze the current extracted layout.
+- Focused leaf-local boundary tests now freeze the current extracted layout.
   `RuntimeNodeKernelSplitPrepBoundaryTest`, `KernelContentBoundaryTest`,
   `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, `PlatformApiBoundaryTest`,
-  `AppHostBoundaryTest`, `WebShellBoundaryTest`, and `HttpLegacyAdminBoundaryTest` are the
-  focused regression checks for leaf ownership/import boundaries. The runtime, kernel-content,
-  and platform boundary suites also enforce `package-info.java` coverage for production packages
-  in those leaves.
+  `AdapterFcpBoundaryTest`, `AppHostBoundaryTest`, `WebShellBoundaryTest`, and
+  `HttpLegacyAdminBoundaryTest` are the focused regression checks for leaf ownership/import
+  boundaries. The runtime, kernel, platform, and adapter-fcp boundary suites also enforce
+  `package-info.java` coverage for the production packages they own.
 - `:runtime-spi` is the JDK-only runtime/config API leaf. Its focused unit tests still live in the
   root test tree and run through the root build.
-- `:platform-api` owns the transport-neutral Platform API v1. Its focused tests still live in the
-  root test tree and run through the root `:test` task.
+- `:platform-api` owns the transport-neutral Platform API v1. Its focused leaf tests now live
+  under `platform-api/src/test/java`.
 - `:platform-apphost` owns the transport-neutral out-of-process AppHost core plus its focused leaf
   tests under `platform-apphost/src/test/java`.
 - `:platform-web-shell` owns the browser-facing Web Shell leaf and its focused leaf tests under
@@ -94,9 +94,8 @@ Use this skill when you need to:
   those resources often resolve from the leaf JAR, so tests must treat them as classpath resources
   rather than assume a plain filesystem `Path`.
 - Most tests still live in the root project and compile against the leaf subprojects through the
-  root build, but `:platform-apphost`, `:platform-web-shell`, and
-  `:adapter-http-legacy-admin` now keep focused leaf tests under their own `src/test/java`
-  trees.
+  root build, but the extracted boundary suites now live with their owning leaves under each
+  module's `src/test/java` tree.
 - File-system-based l10n tests still run from the root project and use
   `foundation-config/src/main/resources/network/crypta/l10n/` as the main resource path.
 
@@ -123,18 +122,18 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew test --tests *TestClassName`
 - Run one test method:
   - `./gradlew test --tests *TestClassName.methodName`
-- Run the focused AppHost leaf tests:
+- Run the focused leaf-local boundary suites:
+  - `./gradlew :platform-api:test`
   - `./gradlew :platform-apphost:test`
-- Run the focused Web Shell leaf tests:
   - `./gradlew :platform-web-shell:test`
-- Run the focused legacy HTTP adapter leaf tests:
+  - `./gradlew :kernel-content:test`
+  - `./gradlew :kernel-transport:test`
+  - `./gradlew :kernel-routing:test`
+  - `./gradlew :runtime-node:test`
+  - `./gradlew :adapter-fcp:test`
   - `./gradlew :adapter-http-legacy-admin:test`
-- Run the focused Platform API root tests:
-  - `./gradlew :test --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest`
-- For extracted-leaf or boundary work, run the focused boundary tests:
-  - `./gradlew test --tests *KernelTransportBoundaryTest --tests *KernelContentBoundaryTest --tests *KernelRoutingBoundaryTest --tests *RuntimeNodeKernelSplitPrepBoundaryTest --tests *HttpLegacyAdminBoundaryTest --tests *PlatformApiBoundaryTest`
-  - `./gradlew :platform-apphost:test --tests *AppHostBoundaryTest`
-  - `./gradlew :platform-web-shell:test --tests *WebShellBoundaryTest`
+- Run the remaining root-owned Platform API/bootstrap slice explicitly against the root project:
+  - `./gradlew :test --tests *DefaultNodeRuntimeBridgeFactoriesTest --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest`
 
 ## Compile-only / quick checks
 - Compile only:

--- a/README.md
+++ b/README.md
@@ -244,15 +244,18 @@ Cryptad now uses a partial multi-project Gradle build.
   remaining legacy browse/FProxy shell inside this leaf is boundary-frozen until a later PR
   refines it further. That shell now also hosts the temporary `/api/v1/` mount for
   `:platform-api` plus the first `/app/node/` Web Shell bridge for `:platform-web-shell`; future
-  AppHost UI and remote update-channel work remain separate.
+  AppHost UI and remote update-channel work remain separate. See
+  [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
+  boundary.
 - `:thirdparty-onion` owns `com.onionnetworks` and `lib/fec.properties`.
 - `:thirdparty-legacy` owns `org.bitpedia`, `org.sevenzip`, and `org.spaceroots`.
 - `:launcher-desktop` owns `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, and launcher
   resources.
 - The daemon runtime body now spans extracted leaves plus a thin root composition layer. The root
-  project still owns the daemon/application build, packaging/runtime tasks, all tests,
-  `network.crypta.tools`, and root-local composition code such as
-  `network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories`.
+  project still owns the daemon/application build, packaging/runtime tasks, most broad
+  functional/unit/integration tests, `network.crypta.tools`, and root-local composition code such
+  as `network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories`. The extracted leaves now
+  keep their own focused boundary suites alongside the code they protect.
 - Every extracted leaf keeps its aggregated-output ownership metadata in
   `<leaf>/gradle/owned-output-patterns.txt`. When you move main classes or resources between root
   and a leaf, or between leaves, update that metadata and validate it with
@@ -302,28 +305,39 @@ The wrapper validates the distribution URL (`validateDistributionUrl=true` in
 ./gradlew test --tests *TestClassName.methodName
 ```
 
-For extraction and boundary work, run the focused root boundary tests that freeze current leaf
-ownership and import rules:
+For extraction and boundary work, run the focused leaf-local boundary suites that freeze current
+leaf ownership and import rules:
 
 ```bash
-./gradlew test --tests *KernelTransportBoundaryTest --tests *KernelContentBoundaryTest --tests *KernelRoutingBoundaryTest --tests *RuntimeNodeKernelSplitPrepBoundaryTest --tests *HttpLegacyAdminBoundaryTest
-```
-
-Those boundary suites also enforce the current extracted-leaf documentation convention that
-production packages in `:runtime-node`, `:kernel-content`, `:platform-api`,
-`:platform-apphost`, and `:platform-web-shell` keep a `package-info.java`.
-
-Focused platform test slices live in a mix of leaf and root tasks:
-
-```bash
+./gradlew :platform-api:test
 ./gradlew :platform-apphost:test
 ./gradlew :platform-web-shell:test
+./gradlew :kernel-content:test
+./gradlew :kernel-transport:test
+./gradlew :kernel-routing:test
+./gradlew :runtime-node:test
+./gradlew :adapter-fcp:test
+./gradlew :adapter-http-legacy-admin:test
+```
+
+Those boundary suites also enforce the current extracted-leaf documentation convention that the
+production packages they own keep the required `package-info.java`.
+
+Run the remaining root-owned composition and router slice against the root project explicitly:
+
+```bash
+./gradlew :test --tests *DefaultNodeRuntimeBridgeFactoriesTest --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest
+```
+
+Additional root and mixed verification slices remain available:
+
+```bash
 ./gradlew :adapter-http-legacy-admin:test
 ./gradlew :test --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest
 ```
 
-Platform boundary checks also include `PlatformApiBoundaryTest` in the root test tree plus the
-leaf-owned `AppHostBoundaryTest` and `WebShellBoundaryTest`.
+Platform boundary checks now live in `:platform-api`, `:platform-apphost`, and
+`:platform-web-shell`.
 
 ## Code Quality
 
@@ -615,7 +629,9 @@ Root build also includes:
   `network/crypta/clients/http/**` main resources. The root project no longer owns that main
   HTTP source/resource tree, and the remaining browse/FProxy shell in this adapter is
   boundary-frozen for now. It currently hosts both the temporary `/api/v1/` bridge for
-  `:platform-api` and the initial `/app/node/` bridge for `:platform-web-shell`.
+  `:platform-api` and the initial `/app/node/` bridge for `:platform-web-shell`. See
+  [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
+  boundary.
 - `:foundation-fs` and `:foundation-compat`: extracted filesystem/environment and compatibility
   leaf modules used by the root daemon. `:foundation-compat` also carries the wizard-neutral
   bandwidth-detection helpers now used by first-time setup flows.
@@ -666,8 +682,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 
 - Build/module layout:
   - Root project `:cryptad` remains the daemon/application build and still owns the strongly
-    coupled composition layer, all tests, packaging/runtime tasks, root-local bridge selection,
-    and `network.crypta.tools`.
+    coupled composition layer, most broad functional/unit/integration tests, packaging/runtime
+    tasks, root-local bridge selection, and `network.crypta.tools`. Focused extracted-leaf
+    boundary suites now live in the owning leaf modules.
   - Leaf subprojects are `:foundation-support`, `:foundation-store`,
     `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
     `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
@@ -735,7 +752,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `DefaultNodeRuntimeBridgeFactories`. The remaining legacy browse/FProxy tree inside
   `:adapter-http-legacy-admin` is intentionally boundary-frozen until a later PR refines it
   further, and production code outside the adapter should keep depending on runtime seams rather
-  than taking new `network.crypta.clients.http.*` dependencies.
+  than taking new `network.crypta.clients.http.*` dependencies. See
+  [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
+  boundary.
 - Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and detached DTOs such as
   `RuntimePorts`, `ConfigPort`, `NodeInfoPort`, `PeerPort`, `ConnectionsPagePort`,
   `ConnectionsSupportPort`, `DarknetConnectionsPort`, `DarknetMessagingPort`, `QueuePagePort`,

--- a/adapter-fcp/build.gradle.kts
+++ b/adapter-fcp/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 
 version = rootProject.version
 
+val mainSourceSet = sourceSets.named("main")
+
 dependencies {
   implementation(project(":foundation-support"))
   implementation(project(":foundation-config"))
@@ -20,4 +22,9 @@ dependencies {
   implementation(files(rootProject.file("libs/wrapper.jar")))
 
   compileOnly(libs.jetbrainsAnnotations)
+
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -1,0 +1,216 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AdapterFcpBoundaryTest {
+  private static final String MODULE_NAME = "adapter-fcp";
+  private static final Path ROOT_FCP_MAIN_JAVA =
+      Path.of("src", "main", "java", "network", "crypta", "clients", "fcp");
+  private static final Path ADAPTER_FCP_MAIN_JAVA =
+      Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "fcp");
+  private static final Path OWNERSHIP_METADATA =
+      Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
+  private static final Path DEFAULT_BRIDGE_FACTORIES =
+      Path.of(
+          "src",
+          "main",
+          "java",
+          "network",
+          "crypta",
+          "runtime",
+          "bootstrap",
+          "DefaultNodeRuntimeBridgeFactories.java");
+  private static final Path ADD_REF =
+      Path.of("src", "main", "java", "network", "crypta", "tools", "AddRef.java");
+  private static final Pattern FCP_IMPORT_PATTERN =
+      Pattern.compile("^import(?:\\s+static)?\\s+(network\\.crypta\\.clients\\.fcp\\.[^;]+);$");
+  private static final Set<String> EXPECTED_DEFAULT_BRIDGE_FACTORIES_IMPORTS =
+      Set.of(
+          "network.crypta.clients.fcp.bridge.FcpPersistentRequestServices",
+          "network.crypta.clients.fcp.bridge.FcpQueuePorts");
+  private static final Set<String> EXPECTED_ADD_REF_IMPORTS =
+      Set.of(
+          "network.crypta.clients.fcp.AddPeer",
+          "network.crypta.clients.fcp.FCPMessage",
+          "network.crypta.clients.fcp.FCPServer",
+          "network.crypta.clients.fcp.MessageInvalidException",
+          "network.crypta.clients.fcp.NodeHelloMessage");
+
+  @Test
+  void mainSourceLayout_whenCheckingFcpOwnership_expectLeafOwnsPackageTree() throws IOException {
+    Path repoRoot = repoRoot();
+
+    assertTrue(
+        Files.isDirectory(repoRoot.resolve(ADAPTER_FCP_MAIN_JAVA)),
+        "adapter-fcp must own network/crypta/clients/fcp main sources");
+    assertFalse(
+        Files.exists(repoRoot.resolve(ROOT_FCP_MAIN_JAVA)),
+        "Root project must not re-own network/crypta/clients/fcp main sources");
+  }
+
+  @Test
+  void buildWiring_whenCheckingLeafMetadata_expectOwnedOutputPatternDeclared() throws IOException {
+    Path repoRoot = repoRoot();
+    String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
+    String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String metadata = Files.readString(repoRoot.resolve(OWNERSHIP_METADATA));
+
+    assertTrue(settings.contains("\":adapter-fcp\""));
+    assertTrue(build.contains("project(\":adapter-fcp\")"));
+    assertTrue(metadata.contains("network/crypta/clients/fcp/**"));
+  }
+
+  @Test
+  void mainSources_whenScanningFcpImports_expectOnlyBootstrapAndToolBindingSitesOutsideAdapter()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+    Set<String> bootstrapImports = readFcpImports(repoRoot.resolve(DEFAULT_BRIDGE_FACTORIES));
+    Set<String> addRefImports = readFcpImports(repoRoot.resolve(ADD_REF));
+
+    for (Path sourceFile : findMainJavaSources(repoRoot)) {
+      Path relativePath = repoRoot.relativize(sourceFile);
+      if (relativePath.equals(DEFAULT_BRIDGE_FACTORIES) || relativePath.equals(ADD_REF)) {
+        continue;
+      }
+
+      Set<String> imports = readFcpImports(sourceFile);
+      if (!imports.isEmpty() && !relativePath.startsWith(ADAPTER_FCP_MAIN_JAVA)) {
+        violations.add(relativePath + " -> " + String.join(", ", imports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Only :adapter-fcp main sources may import network.crypta.clients.fcp.*, except the "
+            + "bootstrap binding site and the AddRef tool."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+    assertEquals(
+        EXPECTED_DEFAULT_BRIDGE_FACTORIES_IMPORTS,
+        bootstrapImports,
+        "DefaultNodeRuntimeBridgeFactories must remain the narrow bootstrap-owned FCP binding "
+            + "site");
+    assertEquals(
+        EXPECTED_ADD_REF_IMPORTS,
+        addRefImports,
+        "AddRef must remain the narrow tool-owned FCP exception");
+  }
+
+  @Test
+  void adapterFcpMain_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path adapterFcpMain = repoRoot.resolve(Path.of(MODULE_NAME, "src", "main", "java"));
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(adapterFcpMain), ":adapter-fcp main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(adapterFcpMain)) {
+      String fileName = fileNameOrThrow(sourceFile);
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(parentOrThrow(sourceFile));
+    }
+
+    for (Path packagePath : productionPackages) {
+      if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
+        missingPackageInfos.add(repoRoot.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every :adapter-fcp main package with production Java files must declare package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
+  }
+
+  private static List<Path> findJavaSources(Path root) throws IOException {
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(AdapterFcpBoundaryTest::isTrackedJavaSource)
+          .sorted(Comparator.comparing(Path::toString))
+          .toList();
+    }
+  }
+
+  private static List<Path> findMainJavaSources(Path repoRoot) throws IOException {
+    try (Stream<Path> walk = Files.walk(repoRoot)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(AdapterFcpBoundaryTest::isTrackedJavaSource)
+          .filter(path -> isMainJavaSource(repoRoot.relativize(path)))
+          .sorted(Comparator.comparing(path -> repoRoot.relativize(path).toString()))
+          .toList();
+    }
+  }
+
+  private static boolean isTrackedJavaSource(Path path) {
+    String fileName = fileNameOrThrow(path);
+    return fileName.endsWith(".java") && !fileName.startsWith("._");
+  }
+
+  private static boolean isMainJavaSource(Path relativePath) {
+    String normalized = relativePath.toString().replace(File.separatorChar, '/');
+    return !normalized.startsWith("build/")
+        && !normalized.contains("/build/")
+        && !normalized.startsWith(".gradle/")
+        && !normalized.contains("/.gradle/")
+        && !normalized.startsWith(".git/")
+        && !normalized.contains("/.git/")
+        && (normalized.startsWith("src/main/java/") || normalized.contains("/src/main/java/"));
+  }
+
+  private static Set<String> readFcpImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .map(FCP_IMPORT_PATTERN::matcher)
+          .filter(Matcher::matches)
+          .map(matcher -> matcher.group(1))
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
+  }
+
+  private static Path repoRoot() throws IOException {
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -15,34 +16,22 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class HttpLegacyAdminBoundaryTest {
+  private static final String MODULE_NAME = "adapter-http-legacy-admin";
   private static final Path ROOT_HTTP_MAIN_JAVA =
       Path.of("src", "main", "java", "network", "crypta", "clients", "http");
   private static final Path ROOT_HTTP_MAIN_RESOURCES =
       Path.of("src", "main", "resources", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_HTTP_MAIN_JAVA =
-      Path.of(
-          "adapter-http-legacy-admin",
-          "src",
-          "main",
-          "java",
-          "network",
-          "crypta",
-          "clients",
-          "http");
+      Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_HTTP_MAIN_RESOURCES =
-      Path.of(
-          "adapter-http-legacy-admin",
-          "src",
-          "main",
-          "resources",
-          "network",
-          "crypta",
-          "clients",
-          "http");
+      Path.of(MODULE_NAME, "src", "main", "resources", "network", "crypta", "clients", "http");
+  private static final Path OWNERSHIP_METADATA =
+      Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
   private static final Path DEFAULT_BRIDGE_FACTORIES =
       Path.of(
           "src",
@@ -82,6 +71,18 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   @Test
+  void buildWiring_whenCheckingLeafMetadata_expectOwnedOutputPatternDeclared() throws IOException {
+    Path repoRoot = repoRoot();
+    String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
+    String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String metadata = Files.readString(repoRoot.resolve(OWNERSHIP_METADATA));
+
+    assertTrue(settings.contains("\":adapter-http-legacy-admin\""));
+    assertTrue(build.contains("project(\":adapter-http-legacy-admin\")"));
+    assertTrue(metadata.contains("network/crypta/clients/http/**"));
+  }
+
+  @Test
   void mainSources_whenScanningLegacyHttpImports_expectOnlyBootstrapBindingSiteOutsideAdapter()
       throws IOException {
     Path repoRoot = repoRoot();
@@ -117,12 +118,16 @@ class HttpLegacyAdminBoundaryTest {
   private static List<Path> findMainJavaSources(Path repoRoot) throws IOException {
     try (Stream<Path> walk = Files.walk(repoRoot)) {
       return walk.filter(Files::isRegularFile)
-          .filter(path -> path.getFileName().toString().endsWith(".java"))
-          .filter(path -> !path.getFileName().toString().startsWith("._"))
+          .filter(HttpLegacyAdminBoundaryTest::isTrackedJavaSource)
           .filter(path -> isMainJavaSource(repoRoot.relativize(path)))
           .sorted(Comparator.comparing(path -> repoRoot.relativize(path).toString()))
           .toList();
     }
+  }
+
+  private static boolean isTrackedJavaSource(Path path) {
+    String fileName = fileNameOrThrow(path);
+    return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
   private static boolean isMainJavaSource(Path relativePath) {
@@ -143,13 +148,23 @@ class HttpLegacyAdminBoundaryTest {
           .map(LEGACY_HTTP_IMPORT_PATTERN::matcher)
           .filter(Matcher::matches)
           .map(matcher -> matcher.group(1))
-          .collect(java.util.stream.Collectors.toUnmodifiableSet());
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
   }
 
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
+  }
+
   private static Path repoRoot() throws IOException {
-    Path repoRoot = Path.of("").toAbsolutePath().normalize();
-    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
-    return repoRoot.toRealPath();
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 }

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -1,0 +1,19 @@
+# Legacy HTTP Boundary
+
+`:adapter-http-legacy-admin` owns the boundary-frozen legacy `network.crypta.clients.http` tree
+and the matching `network/crypta/clients/http/**` main resources.
+
+This leaf still carries three responsibilities:
+
+- the remaining browse and FProxy shell,
+- the thin `/api/v1/` bridge that mounts `:platform-api`,
+- the thin `/app/node/` bridge that mounts `:platform-web-shell`.
+
+The boundary is intentional. Production code outside `:adapter-http-legacy-admin` should keep
+depending on runtime-owned seams, `:platform-api`, or `:platform-web-shell` instead of growing new
+direct dependencies on `network.crypta.clients.http.*`. The bootstrap-owned binding site remains
+`src/main/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactories.java`.
+
+Future browse/FProxy decomposition or replacement is explicitly deferred. This PR does not reopen
+that architecture; it only documents the long-term maintenance boundary around the existing legacy
+HTTP adapter leaf.

--- a/kernel-content/build.gradle.kts
+++ b/kernel-content/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 
 version = rootProject.version
 
+val mainSourceSet = sourceSets.named("main")
+
 dependencies {
   api(project(":foundation-support"))
   api(project(":foundation-crypto-keys"))
@@ -13,4 +15,9 @@ dependencies {
   implementation(libs.slf4jApi)
 
   compileOnly(libs.jetbrainsAnnotations)
+
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/kernel-content/src/main/java/network/crypta/client/events/package-info.java
+++ b/kernel-content/src/main/java/network/crypta/client/events/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Immutable client event values extracted into {@code :kernel-content}.
+ *
+ * <p>These event records describe fetch and insert progress without owning scheduling, alert
+ * rendering, or other runtime-node concerns.
+ */
+package network.crypta.client.events;

--- a/kernel-content/src/main/java/network/crypta/client/filter/package-info.java
+++ b/kernel-content/src/main/java/network/crypta/client/filter/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Compile-neutral content filtering helpers extracted into {@code :kernel-content}.
+ *
+ * <p>This package keeps parser and filter helper types available to content-facing code while
+ * staying free of runtime-node, FCP, and legacy HTTP adapter execution dependencies.
+ */
+package network.crypta.client.filter;

--- a/kernel-content/src/main/java/network/crypta/client/package-info.java
+++ b/kernel-content/src/main/java/network/crypta/client/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Compile-neutral client content helpers extracted into {@code :kernel-content}.
+ *
+ * <p>This package owns archive metadata, MIME-adjacent helpers, and other leaf-safe client value
+ * types that higher layers can use without pulling in the runtime-node request engine.
+ */
+package network.crypta.client;

--- a/kernel-content/src/main/java/network/crypta/support/package-info.java
+++ b/kernel-content/src/main/java/network/crypta/support/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Content-slice support helpers extracted into {@code :kernel-content}.
+ *
+ * <p>The package currently anchors MIME helper ownership for {@link
+ * network.crypta.support.MediaType} so content and filter code can share it without depending on
+ * runtime-node.
+ */
+package network.crypta.support;

--- a/kernel-content/src/test/java/network/crypta/runtime/KernelContentBoundaryTest.java
+++ b/kernel-content/src/test/java/network/crypta/runtime/KernelContentBoundaryTest.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
@@ -84,9 +86,41 @@ class KernelContentBoundaryTest {
     assertTrue(
         Files.isRegularFile(repoRoot.resolve(KERNEL_CONTENT_MEDIA_TYPE)),
         "kernel-content must own network.crypta.support.MediaType for the MIME helper cluster");
-    assertTrue(
-        !Files.exists(repoRoot.resolve(RUNTIME_NODE_MEDIA_TYPE)),
+    assertFalse(
+        Files.exists(repoRoot.resolve(RUNTIME_NODE_MEDIA_TYPE)),
         "runtime-node must not retain network.crypta.support.MediaType after extraction");
+  }
+
+  @Test
+  void kernelContentMain_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path kernelContentMain = repoRoot.resolve(KERNEL_CONTENT_MAIN_JAVA);
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(kernelContentMain), "kernel-content main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(kernelContentMain)) {
+      String fileName = fileNameOrThrow(sourceFile);
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(parentOrThrow(sourceFile));
+    }
+
+    for (Path packagePath : productionPackages) {
+      if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
+        missingPackageInfos.add(repoRoot.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every :kernel-content main package with production Java files must declare "
+            + "package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
   }
 
   private static List<Path> findJavaSources(Path root) throws IOException {
@@ -99,7 +133,7 @@ class KernelContentBoundaryTest {
   }
 
   private static boolean isTrackedJavaSource(Path path) {
-    String fileName = path.getFileName().toString();
+    String fileName = fileNameOrThrow(path);
     return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
@@ -114,9 +148,25 @@ class KernelContentBoundaryTest {
     }
   }
 
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
+  }
+
   private static Path repoRoot() throws IOException {
-    Path repoRoot = Path.of("").toAbsolutePath().normalize();
-    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
-    return repoRoot.toRealPath();
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 }

--- a/kernel-routing/build.gradle.kts
+++ b/kernel-routing/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 
 version = rootProject.version
 
+val mainSourceSet = sourceSets.named("main")
+
 dependencies {
   api(project(":foundation-support"))
   api(project(":foundation-crypto-keys"))
@@ -13,4 +15,9 @@ dependencies {
   implementation(libs.slf4jApi)
 
   compileOnly(libs.jetbrainsAnnotations)
+
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/kernel-routing/src/main/java/network/crypta/node/package-info.java
+++ b/kernel-routing/src/main/java/network/crypta/node/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Compile-neutral routing helpers extracted into {@code :kernel-routing}.
+ *
+ * <p>This package owns request metadata, low-level routing exceptions, and sendable-request item
+ * helpers, while the node execution engine stays in {@code :runtime-node}.
+ */
+package network.crypta.node;

--- a/kernel-routing/src/test/java/network/crypta/runtime/KernelRoutingBoundaryTest.java
+++ b/kernel-routing/src/test/java/network/crypta/runtime/KernelRoutingBoundaryTest.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
@@ -100,24 +102,51 @@ class KernelRoutingBoundaryTest {
     Path repoRoot = repoRoot();
 
     for (String className : PHASE_ONE_MOVED_CLASSES) {
-      Path kernelRoutingSource =
-          repoRoot.resolve(
-              KERNEL_ROUTING_MAIN_JAVA.resolve(
-                  Path.of("network", "crypta", "node", className + ".java")));
-      Path runtimeNodeSource =
-          repoRoot.resolve(
-              RUNTIME_NODE_MAIN_JAVA.resolve(
-                  Path.of("network", "crypta", "node", className + ".java")));
+      Path path = Path.of("network", "crypta", "node", className + ".java");
+      Path kernelRoutingSource = repoRoot.resolve(KERNEL_ROUTING_MAIN_JAVA.resolve(path));
+      Path runtimeNodeSource = repoRoot.resolve(RUNTIME_NODE_MAIN_JAVA.resolve(path));
 
       assertTrue(
           Files.isRegularFile(kernelRoutingSource),
           "kernel-routing must own network.crypta.node." + className + " in phase 1");
-      assertTrue(
-          !Files.exists(runtimeNodeSource),
+      assertFalse(
+          Files.exists(runtimeNodeSource),
           "runtime-node must not retain network.crypta.node."
               + className
               + " after phase-1 extraction");
     }
+  }
+
+  @Test
+  void kernelRoutingMain_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path kernelRoutingMain = repoRoot.resolve(KERNEL_ROUTING_MAIN_JAVA);
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    assertTrue(Files.isDirectory(kernelRoutingMain), "kernel-routing main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(kernelRoutingMain)) {
+      String fileName = fileNameOrThrow(sourceFile);
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(parentOrThrow(sourceFile));
+    }
+
+    for (Path packagePath : productionPackages) {
+      if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
+        missingPackageInfos.add(repoRoot.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every :kernel-routing main package with production Java files must declare "
+            + "package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
   }
 
   private static List<Path> findJavaSources(Path root) throws IOException {
@@ -130,7 +159,7 @@ class KernelRoutingBoundaryTest {
   }
 
   private static boolean isTrackedJavaSource(Path path) {
-    String fileName = path.getFileName().toString();
+    String fileName = fileNameOrThrow(path);
     return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
@@ -145,9 +174,25 @@ class KernelRoutingBoundaryTest {
     }
   }
 
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
+  }
+
   private static Path repoRoot() throws IOException {
-    Path repoRoot = Path.of("").toAbsolutePath().normalize();
-    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
-    return repoRoot.toRealPath();
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 }

--- a/kernel-transport/build.gradle.kts
+++ b/kernel-transport/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 
 version = rootProject.version
 
+val mainSourceSet = sourceSets.named("main")
+
 dependencies {
   api(project(":foundation-support"))
 
@@ -13,4 +15,9 @@ dependencies {
   implementation(files(rootProject.file("libs/wrapper.jar")))
 
   compileOnly(libs.jetbrainsAnnotations)
+
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/kernel-transport/src/main/java/network/crypta/io/comm/package-info.java
+++ b/kernel-transport/src/main/java/network/crypta/io/comm/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Leaf-safe transport coordination helpers extracted into {@code :kernel-transport}.
+ *
+ * <p>The package currently owns statistics collection and socket-handler abstractions, while active
+ * peer/message execution remains in {@code :runtime-node}.
+ */
+package network.crypta.io.comm;

--- a/kernel-transport/src/main/java/network/crypta/io/package-info.java
+++ b/kernel-transport/src/main/java/network/crypta/io/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Compile-neutral transport helpers extracted into {@code :kernel-transport}.
+ *
+ * <p>This package owns address matching, allow-list parsing, and listener abstractions that remain
+ * free of runtime-node peer execution and adapter code.
+ */
+package network.crypta.io;

--- a/kernel-transport/src/main/java/network/crypta/io/xfer/package-info.java
+++ b/kernel-transport/src/main/java/network/crypta/io/xfer/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Compile-neutral transfer helpers extracted into {@code :kernel-transport}.
+ *
+ * <p>This package owns throttling and partially received block assembly without taking
+ * runtime-owned peer or request execution dependencies.
+ */
+package network.crypta.io.xfer;

--- a/kernel-transport/src/test/java/network/crypta/runtime/KernelTransportBoundaryTest.java
+++ b/kernel-transport/src/test/java/network/crypta/runtime/KernelTransportBoundaryTest.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
@@ -130,24 +132,57 @@ class KernelTransportBoundaryTest {
         Files.isRegularFile(repoRoot.resolve(KERNEL_TRANSPORT_PARTIALLY_RECEIVED_BLOCK)),
         "kernel-transport must own network.crypta.io.xfer.PartiallyReceivedBlock in phase 1");
 
-    assertTrue(
-        !Files.exists(repoRoot.resolve(RUNTIME_NODE_ALLOWED_HOSTS)),
+    assertFalse(
+        Files.exists(repoRoot.resolve(RUNTIME_NODE_ALLOWED_HOSTS)),
         "runtime-node must not retain network.crypta.io.AllowedHosts after phase-1 extraction");
-    assertTrue(
-        !Files.exists(repoRoot.resolve(RUNTIME_NODE_NETWORK_INTERFACE)),
+    assertFalse(
+        Files.exists(repoRoot.resolve(RUNTIME_NODE_NETWORK_INTERFACE)),
         "runtime-node must not retain network.crypta.io.NetworkInterface after phase-1 extraction");
-    assertTrue(
-        !Files.exists(repoRoot.resolve(RUNTIME_NODE_IO_STATISTIC_COLLECTOR)),
+    assertFalse(
+        Files.exists(repoRoot.resolve(RUNTIME_NODE_IO_STATISTIC_COLLECTOR)),
         "runtime-node must not retain network.crypta.io.comm.IOStatisticCollector after phase-1"
             + " extraction");
-    assertTrue(
-        !Files.exists(repoRoot.resolve(RUNTIME_NODE_PACKET_THROTTLE)),
+    assertFalse(
+        Files.exists(repoRoot.resolve(RUNTIME_NODE_PACKET_THROTTLE)),
         "runtime-node must not retain network.crypta.io.xfer.PacketThrottle after phase-1"
             + " extraction");
-    assertTrue(
-        !Files.exists(repoRoot.resolve(RUNTIME_NODE_PARTIALLY_RECEIVED_BLOCK)),
+    assertFalse(
+        Files.exists(repoRoot.resolve(RUNTIME_NODE_PARTIALLY_RECEIVED_BLOCK)),
         "runtime-node must not retain network.crypta.io.xfer.PartiallyReceivedBlock after phase-1"
             + " extraction");
+  }
+
+  @Test
+  void kernelTransportMain_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path kernelTransportMain = repoRoot.resolve(KERNEL_TRANSPORT_MAIN_JAVA);
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    assertTrue(
+        Files.isDirectory(kernelTransportMain), "kernel-transport main Java tree must exist");
+
+    for (Path sourceFile : findJavaSources(kernelTransportMain)) {
+      String fileName = fileNameOrThrow(sourceFile);
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(parentOrThrow(sourceFile));
+    }
+
+    for (Path packagePath : productionPackages) {
+      if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
+        missingPackageInfos.add(repoRoot.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every :kernel-transport main package with production Java files must declare "
+            + "package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
   }
 
   private static List<Path> findJavaSources(Path root) throws IOException {
@@ -160,7 +195,7 @@ class KernelTransportBoundaryTest {
   }
 
   private static boolean isTrackedJavaSource(Path path) {
-    String fileName = path.getFileName().toString();
+    String fileName = fileNameOrThrow(path);
     return fileName.endsWith(".java") && !fileName.startsWith("._");
   }
 
@@ -175,9 +210,25 @@ class KernelTransportBoundaryTest {
     }
   }
 
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
+  }
+
   private static Path repoRoot() throws IOException {
-    Path repoRoot = Path.of("").toAbsolutePath().normalize();
-    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
-    return repoRoot.toRealPath();
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 }

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -6,9 +6,16 @@ plugins {
 
 version = rootProject.version
 
+val mainSourceSet = sourceSets.named("main")
+
 dependencies {
   api(project(":runtime-spi"))
   api(project(":platform-apphost"))
 
   compileOnly(libs.jetbrainsAnnotations)
+
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/platform-api/src/test/java/network/crypta/platform/api/PlatformApiBoundaryTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/PlatformApiBoundaryTest.java
@@ -19,15 +19,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class PlatformApiBoundaryTest {
+  private static final String MODULE_NAME = "platform-api";
   private static final Path ROOT_PLATFORM_API_PACKAGE =
       Path.of("src", "main", "java", "network", "crypta", "platform", "api");
-  private static final Path PLATFORM_API_MAIN_JAVA = Path.of("platform-api", "src", "main", "java");
+  private static final Path PLATFORM_API_MAIN_JAVA = Path.of(MODULE_NAME, "src", "main", "java");
   private static final Path PLATFORM_API_PACKAGE =
-      Path.of("platform-api", "src", "main", "java", "network", "crypta", "platform", "api");
+      PLATFORM_API_MAIN_JAVA.resolve(Path.of("network", "crypta", "platform", "api"));
   private static final Path PLATFORM_API_ROUTER =
       PLATFORM_API_PACKAGE.resolve("PlatformApiRouter.java");
   private static final Path PLATFORM_API_JSON_ENCODER =
       PLATFORM_API_PACKAGE.resolve("json").resolve("PlatformApiJsonEncoder.java");
+  private static final Path OWNERSHIP_METADATA =
+      Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
   private static final Pattern FORBIDDEN_IMPORT_PATTERN =
       Pattern.compile(
           "^import(?:\\s+static)?\\s+(network\\.crypta\\.(?:clients\\.(?:http|fcp)|node|client|runtime\\.(?:bootstrap|core|admin|endpoints))\\.[^;]+);$");
@@ -49,6 +52,18 @@ class PlatformApiBoundaryTest {
     assertTrue(
         Files.isRegularFile(repoRoot.resolve(PLATFORM_API_JSON_ENCODER)),
         ":platform-api must provide the Platform API JSON encoder");
+  }
+
+  @Test
+  void buildWiring_whenCheckingLeafMetadata_expectOwnedOutputPatternDeclared() throws IOException {
+    Path repoRoot = repoRoot();
+    String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
+    String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String metadata = Files.readString(repoRoot.resolve(OWNERSHIP_METADATA));
+
+    assertTrue(settings.contains("\":platform-api\""));
+    assertTrue(build.contains("project(\":platform-api\")"));
+    assertTrue(metadata.contains("network/crypta/platform/api/**"));
   }
 
   @Test
@@ -95,7 +110,7 @@ class PlatformApiBoundaryTest {
 
     for (Path packagePath : productionPackages) {
       if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
-        missingPackageInfos.add(platformApiMain.relativize(packagePath).toString());
+        missingPackageInfos.add(repoRoot.relativize(packagePath).toString());
       }
     }
 
@@ -145,8 +160,12 @@ class PlatformApiBoundaryTest {
   }
 
   private static Path repoRoot() throws IOException {
-    Path repoRoot = Path.of("").toAbsolutePath().normalize();
-    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
-    return repoRoot.toRealPath();
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 }

--- a/runtime-node/build.gradle.kts
+++ b/runtime-node/build.gradle.kts
@@ -36,30 +36,7 @@ dependencies {
 }
 
 dependencies {
-  implementation(project(":foundation-support"))
-  implementation(project(":foundation-store"))
-  implementation(project(":foundation-store-contracts"))
-  implementation(project(":foundation-crypto-keys"))
-  implementation(project(":interop-wire"))
-  implementation(project(":foundation-config"))
-  implementation(project(":foundation-fs"))
-  implementation(project(":foundation-compat"))
-  implementation(project(":kernel-content"))
-  implementation(project(":kernel-transport"))
-  implementation(project(":kernel-routing"))
-  implementation(project(":runtime-spi"))
-  implementation(project(":thirdparty-onion"))
-  implementation(project(":thirdparty-legacy"))
-  implementation(libs.slf4jApi)
-  implementation(libs.bcprov)
-  implementation(libs.bcpkix)
-  implementation(libs.jna)
-  implementation(libs.jnaPlatform)
-  implementation(libs.commonsCompress)
-  implementation(libs.commonsLang3)
-  implementation(libs.picocli)
-  implementation(files(rootProject.file("libs/wrapper.jar")))
-
-  compileOnly(libs.logbackClassic)
-  compileOnly(libs.jetbrainsAnnotations)
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/runtime-node/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
+++ b/runtime-node/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
@@ -143,8 +143,12 @@ class RuntimeNodeKernelSplitPrepBoundaryTest {
   }
 
   private static Path repoRoot() throws IOException {
-    Path repoRoot = Path.of("").toAbsolutePath().normalize();
-    assertTrue(Files.isRegularFile(repoRoot.resolve("settings.gradle.kts")));
-    return repoRoot.toRealPath();
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 }


### PR DESCRIPTION
## Summary
- move the remaining extracted-module boundary suites out of the root test tree and into their owning leaves
- add the missing `:adapter-fcp` boundary test, add the missing kernel `package-info.java` files, and keep the root main surface explicitly thin
- update README/testing guidance, document the frozen legacy HTTP boundary, and clean the duplicated `runtime-node` dependency wiring while adding minimal leaf-local test dependencies

## How to test
- `./gradlew :platform-api:test :kernel-content:test :kernel-transport:test :kernel-routing:test :runtime-node:test :adapter-fcp:test :adapter-http-legacy-admin:test`
- `./gradlew :test --tests *DefaultNodeRuntimeBridgeFactoriesTest --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest`
- `./gradlew :test --tests *PlatformApi* --tests *DefaultNodeRuntimeBridgeFactoriesTest`