### PR TITLE
refactor(fcp): Introduce adapter-owned seam types

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpDarknetPeerHandle.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpDarknetPeerHandle.java
@@ -1,0 +1,92 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Adapter-owned handle for delivering feed items to a resolved darknet peer.
+ *
+ * <p>This interface is the narrow peer-facing contract that remains visible inside the {@code
+ * :adapter-fcp} leaf after peer lookup succeeds. FCP message handlers need to send only three kinds
+ * of feed items: plain text announcements, download suggestions, and bookmark suggestions. They do
+ * not need the broader {@code DarknetPeerNode} surface, nor should they know how the runtime
+ * locates, validates, or retains the backing peer object. Restricting the contract to these methods
+ * keeps the message package protocol-focused while still preserving the existing delivery flow and
+ * reply semantics.
+ *
+ * <p>Implementations are expected to be thin adapters around a live runtime peer. Calls should
+ * delegate immediately, should not reinterpret validated FCP data, and should return the same node
+ * status integers that the pre-seam direct calls returned so that {@link SentPeerMessage} remains
+ * wire-compatible. Implementations may be shared by concurrent connection handlers, so they should
+ * treat the backing peer reference as a live runtime state and preserve the daemon's thread-safety
+ * guarantees rather than layering their own caching or retry policy on top.
+ *
+ * <ul>
+ *   <li>Represents only peers that already passed the darknet-only eligibility check.
+ *   <li>Exposes only the feed operations needed by the residual FCP message handlers.
+ *   <li>Leaves peer discovery, authorization, and protocol branching outside the handle.
+ * </ul>
+ *
+ * @see FcpPeerLookupResult
+ * @see SentPeerMessage
+ */
+public interface FcpDarknetPeerHandle {
+
+  /**
+   * Sends a text feed item to the resolved darknet peer.
+   *
+   * <p>The supplied text is already decoded from the inbound FCP payload and has passed any
+   * protocol-level validation performed by the calling message handler. Implementations should
+   * enqueue or forward the text using the runtime peer's existing delivery path, preserve its
+   * current back-pressure and status behavior, and avoid performing additional protocol
+   * interpretation beyond what the peer runtime already does internally. The returned integer is an
+   * opaque node-status value that the adapter forwards back to the client unchanged.
+   *
+   * @param message UTF-8 text payload that should be queued for the peer feed, already validated by
+   *     the message layer and never {@code null}.
+   * @return peer status integer that remains suitable for the eventual {@link SentPeerMessage}
+   *     reply emitted on the FCP connection.
+   */
+  int sendTextFeed(String message);
+
+  /**
+   * Sends a download suggestion to the resolved darknet peer.
+   *
+   * <p>The message layer has already parsed the URI into canonical form and decoded the optional
+   * description bucket, so this method receives only runtime-ready values. Implementations should
+   * preserve the runtime peer's existing scheduling, queueing, and status reporting semantics for
+   * download feed items. A {@code null} description means the client intentionally omitted that
+   * field rather than supplying an empty string, so implementations should pass the distinction
+   * through unchanged.
+   *
+   * @param uri parsed URI to suggest to the peer, already accepted by FCP parsing and never {@code
+   *     null}.
+   * @param description optional human-readable description to attach to the suggestion; {@code
+   *     null} when the request carried no description payload.
+   * @return peer status integer that the adapter can return to the caller without translation in
+   *     the resulting {@link SentPeerMessage}.
+   */
+  int sendDownloadFeed(FreenetURI uri, String description);
+
+  /**
+   * Sends a bookmark suggestion to the resolved darknet peer.
+   *
+   * <p>The calling FCP message has already validated the bookmark title, parsed the URI, decoded
+   * the optional description, and interpreted the active-link flag. Implementations should pass
+   * those values through to the runtime peer without rewriting client intent, changing defaulting
+   * behavior, or collapsing the distinction between omitted and present description text. As with
+   * the other feed methods, the integer result is a runtime-defined status code that must remain
+   * stable enough for the FCP adapter to echo back to the client.
+   *
+   * @param uri parsed bookmark URI to share with the peer, already validated by the FCP request and
+   *     never {@code null}.
+   * @param name bookmark title supplied by the FCP client, already validated as present and never
+   *     {@code null}.
+   * @param description optional decoded description text; {@code null} when the request did not
+   *     carry a description bucket.
+   * @param hasActiveLink whether the bookmark should be marked as having an active link in the
+   *     downstream peer-visible feed item.
+   * @return peer status integer suitable for direct reuse in the eventual {@link SentPeerMessage}
+   *     response sent back over FCP.
+   */
+  int sendBookmarkFeed(FreenetURI uri, String name, String description, boolean hasActiveLink);
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
@@ -1,9 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.PeerNode;
-import network.crypta.node.probe.Listener;
-import network.crypta.node.probe.Type;
 
 /**
  * Narrow runtime support seam for residual message-level FCP operations.
@@ -20,7 +17,8 @@ import network.crypta.node.probe.Type;
  * runtime-spi}, and it is not intended to become a general daemon abstraction. Its job is narrower:
  * preserve existing node behavior while removing direct core dependencies from message-level
  * execution paths, so later refactors can adjust server bootstrap and configuration seams without
- * touching protocol handlers again.
+ * touching protocol handlers again. Peer lookup and probe execution use adapter-owned seam types,
+ * so the protocol package no longer imports concrete node peer or probe classes directly.
  *
  * <ul>
  *   <li>Exposes only the runtime actions still needed by residual message classes.
@@ -79,14 +77,15 @@ public interface FcpMessageRuntimeSupport {
    * Resolves a peer node by its FCP node identifier.
    *
    * <p>This lookup is used by message handlers that still need node-level peer routing decisions
-   * but should no longer navigate from the server into the core and network objects directly. A
-   * {@code null} result indicates that no matching peer is currently known and lets the caller keep
-   * its existing protocol behavior for unknown-node replies.
+   * but should no longer navigate from the server into the core and network objects directly. The
+   * returned value tells the caller whether the identifier is unknown, refers to a non-darknet
+   * peer, or yields a usable adapter-owned darknet peer handle.
    *
    * @param nodeIdentifier peer identifier supplied by the inbound message
-   * @return matching peer node, or {@code null} when the identifier is not currently known
+   * @return adapter-owned lookup result describing whether the peer is unknown, non-darknet, or a
+   *     darknet peer handle
    */
-  PeerNode findPeer(String nodeIdentifier);
+  FcpPeerLookupResult findPeer(String nodeIdentifier);
 
   /**
    * Starts a probe request using the live node network subsystem.
@@ -99,8 +98,8 @@ public interface FcpMessageRuntimeSupport {
    *
    * @param hopsToLive probe hop limit to submit to the node network
    * @param uid probe UID chosen by the caller for correlation and reply matching
-   * @param probeType probe type to execute against the live network
-   * @param listener callback listener that receives probe results and failures
+   * @param probeType adapter-owned probe type to execute against the live network
+   * @param listener adapter-owned callback listener that receives probe results and failures
    */
-  void startProbe(byte hopsToLive, long uid, Type probeType, Listener listener);
+  void startProbe(byte hopsToLive, long uid, FcpProbeType probeType, FcpProbeListener listener);
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpPeerLookupResult.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpPeerLookupResult.java
@@ -1,0 +1,188 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+
+/**
+ * Immutable outcome of resolving an FCP node identifier through the adapter-runtime seam.
+ *
+ * <p>This value object captures exactly the peer lookup distinctions that the residual FCP message
+ * handlers need to preserve their pre-refactor behavior. A lookup may fail entirely, may resolve a
+ * peer that exists but cannot participate in darknet-only feed operations, or may resolve a darknet
+ * peer that is safe to expose through the narrow {@link FcpDarknetPeerHandle} contract. By making
+ * those states explicit, the adapter can keep its protocol branching readable without importing
+ * runtime-owned peer types back into {@code :adapter-fcp}.
+ *
+ * <p>The class is intentionally small and immutable. Unknown and non-darknet outcomes are shared
+ * singleton instances because they carry no per-request state. Darknet outcomes wrap a validated
+ * handle supplied by the bridge layer. Callers usually inspect {@link #kind()} or one of the
+ * convenience predicates and then either emit the existing protocol response or continue with feed
+ * delivery. The result does not cache peer metadata beyond what the message layer already needs.
+ *
+ * <ul>
+ *   <li>{@link Kind#UNKNOWN} still maps naturally to {@link UnknownNodeIdentifierMessage}.
+ *   <li>{@link Kind#NON_DARKNET} still leads to the existing {@code DARKNET_ONLY} protocol error.
+ *   <li>{@link Kind#DARKNET} exposes only the feed operations the message layer may invoke.
+ * </ul>
+ *
+ * @see FcpMessageRuntimeSupport#findPeer(String)
+ * @see FcpDarknetPeerHandle
+ */
+public final class FcpPeerLookupResult {
+
+  /**
+   * High-level categories of peer lookup outcomes visible to the message layer.
+   *
+   * <p>The enum mirrors protocol-visible behavior instead of daemon internals. It lets callers make
+   * explicit decisions about reply handling without depending on concrete runtime peer classes.
+   * Most call sites should branch on these values only at the outer protocol boundary and then use
+   * the convenience methods or {@link #requireDarknetPeerHandle()} for the happy path.
+   */
+  public enum Kind {
+    /** No currently known peer matched the supplied FCP node identifier. */
+    UNKNOWN,
+    /** A matching peer exists but does not support darknet-only feed operations. */
+    NON_DARKNET,
+    /** A matching darknet peer was found and exposed as an adapter-owned handle. */
+    DARKNET
+  }
+
+  private static final FcpPeerLookupResult UNKNOWN_RESULT =
+      new FcpPeerLookupResult(Kind.UNKNOWN, null);
+  private static final FcpPeerLookupResult NON_DARKNET_RESULT =
+      new FcpPeerLookupResult(Kind.NON_DARKNET, null);
+
+  private final Kind kind;
+  private final FcpDarknetPeerHandle darknetPeerHandle;
+
+  private FcpPeerLookupResult(Kind kind, FcpDarknetPeerHandle darknetPeerHandle) {
+    this.kind = Objects.requireNonNull(kind);
+    if (kind == Kind.DARKNET) {
+      this.darknetPeerHandle = Objects.requireNonNull(darknetPeerHandle);
+    } else if (darknetPeerHandle != null) {
+      throw new IllegalArgumentException("Only darknet lookup results may carry a peer handle");
+    } else {
+      this.darknetPeerHandle = null;
+    }
+  }
+
+  /**
+   * Returns the shared lookup result representing an unknown peer identifier.
+   *
+   * <p>This outcome means the current peer table does not contain any matching identifier at the
+   * time of lookup. Callers typically translate it into {@link UnknownNodeIdentifierMessage}
+   * instead of throwing because the condition is protocol-visible and not exceptional.
+   *
+   * @return immutable singleton result indicating that the peer identifier could not be resolved.
+   */
+  public static FcpPeerLookupResult unknown() {
+    return UNKNOWN_RESULT;
+  }
+
+  /**
+   * Returns the shared lookup result representing a known non-darknet peer.
+   *
+   * <p>This outcome means the identifier resolved to a live peer, but the peer does not satisfy the
+   * darknet-only requirement enforced by the relevant FCP message. Callers generally preserve the
+   * existing protocol behavior by reporting a {@code DARKNET_ONLY} error instead of attempting any
+   * feed delivery through the resolved peer.
+   *
+   * @return immutable singleton result indicating that a peer exists but is not eligible for
+   *     darknet-only feed operations.
+   */
+  public static FcpPeerLookupResult nonDarknet() {
+    return NON_DARKNET_RESULT;
+  }
+
+  /**
+   * Creates a lookup result for a resolved darknet peer handle.
+   *
+   * <p>This factory is used when lookup succeeded, and the bridge layer has already confirmed that
+   * the peer supports the feed operations that the FCP message layer may invoke. The supplied
+   * handle is retained as-is and becomes the only peer-facing object visible to adapter-owned
+   * message code.
+   *
+   * @param darknetPeerHandle adapter-owned handle exposing the permitted darknet peer feed
+   *     operations and never {@code null}.
+   * @return immutable lookup result wrapping the supplied handle for the successful darknet path.
+   * @throws NullPointerException if {@code darknetPeerHandle} is {@code null}, because a darknet
+   *     result without a usable handle would be internally inconsistent.
+   */
+  public static FcpPeerLookupResult darknet(FcpDarknetPeerHandle darknetPeerHandle) {
+    return new FcpPeerLookupResult(Kind.DARKNET, darknetPeerHandle);
+  }
+
+  /**
+   * Returns the coarse lookup category represented by this result.
+   *
+   * <p>This method is the most explicit way to branch on protocol-visible peer state. Callers
+   * should prefer it when a switch expression clarifies the resulting control flow than a chain of
+   * predicate calls.
+   *
+   * @return non-null category describing whether the peer was unknown, non-darknet, or darknet at
+   *     lookup time.
+   */
+  public Kind kind() {
+    return kind;
+  }
+
+  /**
+   * Reports whether the lookup failed to resolve any current peer.
+   *
+   * <p>This predicate is a convenience wrapper around {@link #kind()} for call sites that only care
+   * whether the identifier was missing and do not need to distinguish the other outcomes inline.
+   *
+   * @return {@code true} when no matching peer was found in the current runtime peer table; {@code
+   *     false} otherwise.
+   */
+  public boolean isUnknown() {
+    return kind == Kind.UNKNOWN;
+  }
+
+  /**
+   * Reports whether the lookup resolved a non-darknet peer.
+   *
+   * <p>This is a convenience wrapper for the intermediate failure case where the identifier exists,
+   * but the peer is not eligible for darknet-only feed delivery.
+   *
+   * @return {@code true} when a peer was found but does not support darknet-only feed operations;
+   *     {@code false} otherwise.
+   */
+  @SuppressWarnings("unused")
+  public boolean isNonDarknet() {
+    return kind == Kind.NON_DARKNET;
+  }
+
+  /**
+   * Reports whether the lookup resolved a darknet peer handle.
+   *
+   * <p>This predicate is typically used before calling {@link #requireDarknetPeerHandle()} when the
+   * caller prefers simple guard-style code instead of switching on {@link #kind()}.
+   *
+   * @return {@code true} when a validated darknet peer handle is available for feed delivery;
+   *     {@code false} otherwise.
+   */
+  public boolean isDarknet() {
+    return kind == Kind.DARKNET;
+  }
+
+  /**
+   * Returns the resolved darknet peer handle when this result represents a darknet peer.
+   *
+   * <p>Callers should invoke this only after checking {@link #isDarknet()} or branching on {@link
+   * #kind()}. The method throws for unknown and non-darknet outcomes to prevent the message layer
+   * from silently assuming a handle exists when protocol branching should occur instead. In other
+   * words, this accessor is deliberately strict: a failed lookup should remain explicit in the
+   * caller's control flow rather than degrading into a late {@code null}-handling bug.
+   *
+   * @return non-null handle exposing the permitted darknet peer operations for the successful
+   *     lookup case.
+   * @throws IllegalStateException if this lookup result does not represent a darknet peer and
+   *     therefore has no valid peer handle to return.
+   */
+  public FcpDarknetPeerHandle requireDarknetPeerHandle() {
+    if (!isDarknet()) {
+      throw new IllegalStateException("Lookup result does not contain a darknet peer handle");
+    }
+    return darknetPeerHandle;
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeDefaults.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeDefaults.java
@@ -1,0 +1,36 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Adapter-owned defaults for FCP probe message handling.
+ *
+ * <p>This helper holds the small set of literal defaults that the FCP adapter must preserve even
+ * after the probe-facing seam moved away from runtime-owned types. At the moment it contains only
+ * the fallback hop budget used by {@link ProbeRequest}, but keeping that constant in an
+ * adapter-owned class still matters because it documents which values are part of adapter-visible
+ * behavior rather than an incidental implementation detail of the runtime probe package.
+ *
+ * <p>The intent is compatibility, not policy expansion. When an inbound probe request omits {@code
+ * HopsToLive}, the adapter should continue to behave exactly as it did before the seam refactor.
+ * Centralizing the default here makes that relationship obvious and avoids reintroducing runtime
+ * probe imports solely to fetch a single fallback constant.
+ */
+final class FcpProbeDefaults {
+  /**
+   * Default hop budget used when an inbound {@code ProbeRequest} omits {@code HopsToLive}.
+   *
+   * <p>The value intentionally stays aligned with the daemon's current probe default so that
+   * adapter-side requests keep their established reach and reply characteristics when clients leave
+   * the field unspecified.
+   */
+  static final byte MAX_HTL = 70;
+
+  /**
+   * Prevents instantiation of this constants-only helper.
+   *
+   * <p>The class exists solely as a namespace for adapter-owned probe defaults and is not intended
+   * to participate in object lifecycles.
+   */
+  private FcpProbeDefaults() {
+    throw new AssertionError("No instances");
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeError.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeError.java
@@ -1,0 +1,48 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Adapter-owned enumeration of probe error categories emitted over FCP.
+ *
+ * <p>This enum defines the stable error vocabulary that the adapter-side probe request and response
+ * classes can use without importing the runtime-owned probe error type directly. Its constants are
+ * intentionally named to match the long-standing FCP {@code ProbeError} field values, which means
+ * the adapter can continue serializing the same wire strings even though the bridge layer now owns
+ * the conversion between adapter and runtime types.
+ *
+ * <p>The enum is protocol-facing rather than implementation-facing. Each value represents a failure
+ * category that an FCP client may already understand and react to, such as a timeout, overload, or
+ * forwarding failure. Bridge code is responsible for converting live runtime failures into these
+ * adapter-owned values before the message layer creates a {@link ProbeError} response.
+ *
+ * @see FcpProbeListener#onError(FcpProbeError, Byte, boolean)
+ * @see ProbeError
+ */
+public enum FcpProbeError {
+  /** The probe disconnected before a terminal result arrived. */
+  DISCONNECTED,
+  /** The probe was rejected because a local overload guard was active. */
+  OVERLOAD,
+  /** The probe timed out before a terminal result arrived. */
+  TIMEOUT,
+  /** The probe reported an unknown error code. */
+  UNKNOWN,
+  /** The probe type was not recognized by the responding node. */
+  UNRECOGNIZED_TYPE,
+  /** The probe could not be forwarded to a suitable next hop. */
+  CANNOT_FORWARD;
+
+  /**
+   * Returns the exact FCP field value used on the wire for this error category.
+   *
+   * <p>The result is currently identical to {@link #name()}, but this method keeps call sites
+   * explicit about their intent: they want the protocol field value, not merely the Java enum name.
+   * That leaves room for future adapter-local representation changes while preserving a narrow
+   * serialization contract today.
+   *
+   * @return stable field value string that preserves the existing protocol-visible error token for
+   *     this category.
+   */
+  public String fieldValue() {
+    return name();
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeListener.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeListener.java
@@ -1,0 +1,159 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Adapter-owned listener for probe callbacks delivered back into the FCP message layer.
+ *
+ * <p>{@link ProbeRequest} uses this listener as the adapter-visible contract for receiving probe
+ * results and terminal failures. The interface mirrors the runtime probe callback surface closely
+ * enough that the bridge layer can translate events with minimal policy, but it remains owned by
+ * {@code :adapter-fcp} so message classes no longer depend directly on runtime probe types. Each
+ * callback corresponds to a concrete FCP response shape or terminal control path.
+ *
+ * <p>Implementations are typically short-lived and bound to one inbound FCP request. Callbacks may
+ * arrive asynchronously on whatever threading model the underlying network subsystem uses.
+ * Implementers should not assume caller affinity. They should not rely on a mutable shared state
+ * without synchronization. They should also preserve the distinction between terminal errors,
+ * refusals, and successful result payloads. The listener itself does not impose retry or
+ * deduplication policy; it simply receives translated probe events.
+ *
+ * <ul>
+ *   <li>Owns the adapter-side vocabulary for all currently supported probe outcomes.
+ *   <li>Lets the bridge map runtime callbacks back into FCP responses without leaking runtime APIs.
+ *   <li>Assumes request-scoped implementations rather than long-lived shared observers.
+ * </ul>
+ *
+ * @see ProbeRequest
+ * @see FcpMessageRuntimeSupport#startProbe(byte, long, FcpProbeType, FcpProbeListener)
+ */
+public interface FcpProbeListener {
+
+  /**
+   * Reports that the probe finished with an error.
+   *
+   * <p>This callback represents a terminal failure path. The probe will not subsequently report a
+   * successful value result for the same request. Implementations should usually translate the
+   * event directly into a {@link ProbeError} response, preserving the adapter-owned error category,
+   * optional raw code, and locality flag so clients can distinguish local failures from remote
+   * verdicts.
+   *
+   * @param error adapter-owned error category describing the terminal failure and never {@code
+   *     null}.
+   * @param code optional raw probe error code preserved for wire-compatible serialization when the
+   *     runtime exposes one; {@code null} when no extra numeric code applies.
+   * @param local whether the failure originated on the local node rather than being relayed from a
+   *     remote peer.
+   */
+  void onError(FcpProbeError error, Byte code, boolean local);
+
+  /**
+   * Reports that the probe was refused before a value result was produced.
+   *
+   * <p>This is distinct from {@link #onError(FcpProbeError, Byte, boolean)} because refusal is a
+   * first-class protocol outcome with its own FCP response type. Implementations should treat it as
+   * terminal for the current request unless the surrounding runtime explicitly documents otherwise.
+   */
+  void onRefused();
+
+  /**
+   * Reports the probe's output bandwidth result.
+   *
+   * <p>This callback delivers the probe result for bandwidth-oriented requests. Implementations
+   * should preserve the reported numeric value as-is when converting it into the corresponding FCP
+   * response so clients see the same float precision and units that the runtime supplied.
+   *
+   * @param outputBandwidth reported output bandwidth value from the runtime probe subsystem.
+   */
+  void onOutputBandwidth(float outputBandwidth);
+
+  /**
+   * Reports the probe's build result.
+   *
+   * <p>The reported build number is the runtime value returned by the probe target and should
+   * generally be forwarded unchanged into the adapter response message.
+   *
+   * @param build reported build number for the probed node or route endpoint.
+   */
+  void onBuild(int build);
+
+  /**
+   * Reports the probe's identifier result.
+   *
+   * <p>This callback delivers both the probed identifier and the associated uptime percentage that
+   * goes with that result shape. Implementations should preserve the pairing rather than treating
+   * either value as independently optional.
+   *
+   * @param probeIdentifier reported probe identifier value supplied by the runtime probe result.
+   * @param percentageUptime reported percentage uptime associated with the identifier result.
+   */
+  void onIdentifier(long probeIdentifier, byte percentageUptime);
+
+  /**
+   * Reports the probe's link-lengths result.
+   *
+   * <p>The array contents are already arranged in the runtime-provided order. Implementations
+   * should preserve that ordering when encoding the eventual FCP response and should not mutate the
+   * array unless they first copy it for defensive isolation.
+   *
+   * @param linkLengths reported link-length values for the current probe result and never {@code
+   *     null}.
+   */
+  void onLinkLengths(float[] linkLengths);
+
+  /**
+   * Reports the probe's location result.
+   *
+   * <p>This callback carries the location value exactly as reported by the runtime probe path. It
+   * is typically forwarded directly into the matching FCP response message.
+   *
+   * @param location reported location value for the completed probe request.
+   */
+  void onLocation(float location);
+
+  /**
+   * Reports the probe's datastore size result.
+   *
+   * <p>The datastore size value is already normalized according to the runtime probe subsystem's
+   * conventions. Implementations should preserve the float value as supplied instead of applying
+   * adapter-local rounding or formatting decisions here.
+   *
+   * @param storeSize reported datastore size value for the completed probe request.
+   */
+  void onStoreSize(float storeSize);
+
+  /**
+   * Reports the probe's uptime result.
+   *
+   * <p>This callback carries the runtime-reported uptime percentage for the selected probe type.
+   * Implementations should forward the value directly and let the response serializer decide how it
+   * appears on the wire.
+   *
+   * @param uptimePercent reported uptime percentage for the completed probe request.
+   */
+  void onUptime(float uptimePercent);
+
+  /**
+   * Reports the probe's reject-stats result.
+   *
+   * <p>The statistics array is a structured payload whose element ordering is part of the runtime
+   * result contract. Implementations should preserve that ordering and byte values when converting
+   * the result into the FCP response representation.
+   *
+   * @param stats reported reject-statistics payload for the completed probe request and never
+   *     {@code null}.
+   */
+  void onRejectStats(byte[] stats);
+
+  /**
+   * Reports the probe's overall bulk output capacity usage result.
+   *
+   * <p>This callback carries both the coarse bandwidth class used for grouping and the associated
+   * capacity-usage value. Implementations should preserve the pairing because the class provides
+   * the context clients need to interpret the reported usage number correctly.
+   *
+   * @param bandwidthClassForCapacityUsage reported bandwidth class used for coarse capacity
+   *     grouping in the runtime probe result.
+   * @param capacityUsage reported overall bulk output capacity usage value associated with that
+   *     bandwidth class.
+   */
+  void onOverallBulkOutputCapacity(byte bandwidthClassForCapacityUsage, float capacityUsage);
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeType.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpProbeType.java
@@ -1,0 +1,72 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Adapter-owned enumeration of probe types accepted by FCP probe messages.
+ *
+ * <p>This enum is the adapter-side vocabulary for probe requests and probe result routing. Its
+ * constant names intentionally match the long-standing FCP {@code Type} field values so that
+ * parsing and serialization remain wire-compatible even though the message layer no longer imports
+ * the runtime-owned probe type enum directly. The bridge layer is responsible for translating these
+ * adapter-visible names into whatever runtime representation the live daemon currently expects.
+ *
+ * <p>Only the protocol-stable names belong here. Runtime numeric codes, hop routing behavior, and
+ * probe execution policy remain outside the adapter leaf. That separation keeps FCP parsing logic
+ * easy to reason about while letting the runtime evolve behind a narrow conversion boundary.
+ *
+ * @see ProbeRequest
+ * @see FcpMessageRuntimeSupport#startProbe(byte, long, FcpProbeType, FcpProbeListener)
+ */
+public enum FcpProbeType {
+  /** Requests or reports probe bandwidth information. */
+  BANDWIDTH,
+  /** Requests or reports the node build number. */
+  BUILD,
+  /** Requests or reports the node identifier. */
+  IDENTIFIER,
+  /** Requests or reports link-length summary information. */
+  LINK_LENGTHS,
+  /** Requests or reports the node location value. */
+  LOCATION,
+  /** Requests or reports datastore size information. */
+  STORE_SIZE,
+  /** Requests or reports 48-hour uptime information. */
+  UPTIME_48H,
+  /** Requests or reports 7-day uptime information. */
+  UPTIME_7D,
+  /** Requests or reports bulk reject statistics. */
+  REJECT_STATS,
+  /** Requests or reports overall bulk output capacity usage. */
+  OVERALL_BULK_OUTPUT_CAPACITY_USAGE;
+
+  /**
+   * Returns the exact FCP field value used on the wire for this probe type.
+   *
+   * <p>The result is currently identical to {@link #name()}, but exposing it through a dedicated
+   * method makes serialization intent explicit and avoids scattering enum-name assumptions through
+   * the message code.
+   *
+   * @return stable field value string that preserves the existing protocol-visible probe type name.
+   */
+  @SuppressWarnings("unused")
+  public String fieldValue() {
+    return name();
+  }
+
+  /**
+   * Parses an FCP {@code Type} field into the matching adapter-owned probe type.
+   *
+   * <p>The accepted strings intentionally remain identical to the current enum constant names, so
+   * callers preserve existing parsing behavior and error messages. This method forms the adapter's
+   * protocol parsing boundary for probe types: inbound field data becomes an adapter-owned enum
+   * value here, and only later does the bridge map that value to a runtime probe type.
+   *
+   * @param fieldValue raw {@code Type} field value supplied by the inbound FCP message and expected
+   *     to match one of the adapter-owned enum constant names exactly.
+   * @return matching adapter-owned probe type for the supplied wire field value.
+   * @throws IllegalArgumentException if {@code fieldValue} does not name a supported probe type and
+   *     therefore cannot be represented within the adapter-owned probe vocabulary.
+   */
+  public static FcpProbeType fromFieldValue(String fieldValue) {
+    return valueOf(fieldValue);
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ProbeError.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ProbeError.java
@@ -1,8 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.probe.Error;
-import network.crypta.node.probe.Listener;
-
 /**
  * Immutable response envelope emitted whenever a running probe fails.
  *
@@ -25,7 +22,7 @@ import network.crypta.node.probe.Listener;
  *   <li><strong>Notable behavior:</strong> stores the error type, optional vendor-specific code,
  *       and locality flag so clients know whether to retry or escalate.
  *   <li><strong>Concurrency:</strong> instances are confined to a single thread; no synchronization
- *       is performed and no mutable state escapes after serialization.
+ *       is performed, and no mutable state escapes after serialization.
  * </ul>
  */
 public class ProbeError extends FCPResponse {
@@ -40,24 +37,26 @@ public class ProbeError extends FCPResponse {
    *
    * <pre>{@code
    * // Example: emit a remote timeout back to the client
-   * var response = new ProbeError(id, Error.TIMEOUT, null, false);
+   * var response = new ProbeError(id, FcpProbeError.TIMEOUT, null, false);
    * handler.send(response);
    * }</pre>
    *
    * @param fcpIdentifier identifier correlating this response to the originating probe request;
    *     {@code null} skips the {@code Identifier} key entirely for one-shot notifications.
-   * @param error type-safe categorization of the failure, aligned with {@link Listener#onError} and
-   *     serialized via {@link Error#name()}.
+   * @param error type-safe categorization of the failure, aligned with {@link
+   *     FcpProbeListener#onError(FcpProbeError, Byte, boolean)} and serialized via {@link
+   *     FcpProbeError#fieldValue()}.
    * @param code optional vendor or remote numeric code preserved only when non-{@code null}; use
-   *     when reporting {@link Error#UNKNOWN} or {@link Error#UNRECOGNIZED_TYPE} variants.
+   *     when reporting {@link FcpProbeError#UNKNOWN} or {@link FcpProbeError#UNRECOGNIZED_TYPE}
+   *     variants.
    * @param local {@code true} when the node itself originated the failure and {@code false} when it
    *     merely relayed a remote peer's verdict.
-   * @see Listener#onError(Error, Byte, boolean)
-   * @see Error
+   * @see FcpProbeListener#onError(FcpProbeError, Byte, boolean)
+   * @see FcpProbeError
    */
-  public ProbeError(String fcpIdentifier, Error error, Byte code, boolean local) {
+  public ProbeError(String fcpIdentifier, FcpProbeError error, Byte code, boolean local) {
     super(fcpIdentifier);
-    fs.putOverwrite(TYPE, error.name());
+    fs.putOverwrite(TYPE, error.fieldValue());
     if (code != null) fs.put(CODE, code);
     fs.put(LOCAL, local);
   }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ProbeRequest.java
@@ -1,10 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.node.FSParseException;
-import network.crypta.node.probe.Error;
-import network.crypta.node.probe.Listener;
-import network.crypta.node.probe.Probe;
-import network.crypta.node.probe.Type;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -19,21 +15,20 @@ import network.crypta.support.SimpleFieldSet;
  * response messages that omit the {@code Identifier} field.
  *
  * <p>Execution requires full-access credentials. When authorized, {@link
- * #run(FCPConnectionHandler)} constructs a {@link Listener} that adapts probe callbacks into
- * concrete {@link FCPMessage} responses, gets a secure probe UID from the handler's server runtime,
- * and delegates to {@code node.network().startProbe(...)}. The method does not block for
- * completion; responses arrive asynchronously via the handler.
+ * #run(FCPConnectionHandler)} constructs a {@link FcpProbeListener} that adapts probe callbacks
+ * into concrete {@link FCPMessage} responses, gets a secure probe UID from the handler's server
+ * runtime, and delegates to the message-runtime seam. The method does not block for completion;
+ * responses arrive asynchronously via the handler.
  *
  * <ul>
  *   <li><strong>Responsibilities:</strong> validate fields, enforce access, and bridge callbacks.
- *   <li><strong>Notable behaviors:</strong> defaults {@code HopsToLive} to {@link Probe#MAX_HTL}
- *       and rejects negative values.
+ *   <li><strong>Notable behaviors:</strong> defaults {@code HopsToLive} to {@link
+ *       FcpProbeDefaults#MAX_HTL} and rejects negative values.
  *   <li><strong>Thread-safety:</strong> immutable after construction; no internal synchronization.
  * </ul>
  *
- * @see Probe
- * @see Type
- * @see Listener
+ * @see FcpProbeType
+ * @see FcpProbeListener
  * @see FCPConnectionHandler
  */
 public final class ProbeRequest extends FCPMessage {
@@ -48,7 +43,7 @@ public final class ProbeRequest extends FCPMessage {
   public static final String NAME = "ProbeRequest";
 
   private final String requestIdentifier;
-  private final Type probeType;
+  private final FcpProbeType probeType;
   private final byte hopsToLive;
 
   /**
@@ -56,9 +51,9 @@ public final class ProbeRequest extends FCPMessage {
    *
    * <p>The constructor reads the optional {@code Identifier}, the mandatory {@code Type}, and an
    * optional {@code HopsToLive} value. When the hop budget is missing, it defaults to {@link
-   * Probe#MAX_HTL}; negative values are rejected. Any parsing or validation failure results in a
-   * {@link MessageInvalidException} with {@link ProtocolErrorMessage#INVALID_MESSAGE}, which the
-   * caller should translate into an FCP protocol error response.
+   * FcpProbeDefaults#MAX_HTL}; negative values are rejected. Any parsing or validation failure
+   * results in a {@link MessageInvalidException} with {@link ProtocolErrorMessage#INVALID_MESSAGE},
+   * which the caller should translate into an FCP protocol error response.
    *
    * <pre>{@code
    * SimpleFieldSet fields = ...;
@@ -75,10 +70,10 @@ public final class ProbeRequest extends FCPMessage {
     this.requestIdentifier = fs.get(IDENTIFIER);
 
     try {
-      this.probeType = Type.valueOf(fs.get(TYPE));
+      this.probeType = FcpProbeType.fromFieldValue(fs.get(TYPE));
 
       // If HTL is not specified default to MAX_HTL.
-      this.hopsToLive = fs.get(HTL) == null ? Probe.MAX_HTL : fs.getByte(HTL);
+      this.hopsToLive = fs.get(HTL) == null ? FcpProbeDefaults.MAX_HTL : fs.getByte(HTL);
 
       if (this.hopsToLive < 0) {
         throw new MessageInvalidException(
@@ -136,10 +131,10 @@ public final class ProbeRequest extends FCPMessage {
    *
    * <p>The handler must have full access; otherwise a {@link MessageInvalidException} with {@link
    * ProtocolErrorMessage#ACCESS_DENIED} is thrown and no probe is started. When authorized, this
-   * method builds a {@link Listener} that maps each callback to the corresponding {@link
-   * FCPResponse} message and then delegates to {@code node.network().startProbe(...)} using the
-   * stored hop budget and a fresh secure random UID from the server runtime. The call is
-   * non-blocking and returns immediately while responses are emitted asynchronously via {@link
+   * method builds a {@link FcpProbeListener} that maps each callback to the corresponding {@link
+   * FCPResponse} message and then delegates to the message-runtime seam using the stored hop budget
+   * and a fresh secure random UID from the server runtime. The call is non-blocking and returns
+   * immediately while responses are emitted asynchronously via {@link
    * FCPConnectionHandler#send(FCPMessage)}.
    *
    * @param handler connection handler used to authorize and send probe responses.
@@ -155,10 +150,10 @@ public final class ProbeRequest extends FCPMessage {
           false);
     }
 
-    Listener listener =
-        new Listener() {
+    FcpProbeListener listener =
+        new FcpProbeListener() {
           @Override
-          public void onError(Error error, Byte code, boolean local) {
+          public void onError(FcpProbeError error, Byte code, boolean local) {
             handler.send(new ProbeError(requestIdentifier, error, code, local));
           }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendBookmarkMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendBookmarkMessage.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.BucketTools;
 
@@ -14,15 +13,16 @@ import network.crypta.support.io.BucketTools;
  * <p>Instances parse a {@link SimpleFieldSet} payload received from a client connection and hold
  * the resolved {@link FreenetURI}, bookmark title, and the caller's intention about exposing an
  * active link to peers. After construction the object becomes immutable and can be safely handed to
- * the dispatch thread that interacts with {@link DarknetPeerNode} instances. Subclasses of {@link
- * SendPeerMessage} are short-lived, so this implementation avoids retaining unnecessary references
- * and directly reuses the bucket created by {@link #readFrom} in the base class. The class is not
- * thread-safe; each instance should be used by at most one handler thread.
+ * the dispatch thread that interacts with {@link FcpDarknetPeerHandle} instances. Subclasses of
+ * {@link SendPeerMessage} are short-lived, so this implementation avoids retaining unnecessary
+ * references and directly reuses the bucket created by {@link #readFrom} in the base class. The
+ * class is not thread-safe; each instance should be used by at most one handler thread.
  *
  * <p>Typical usage occurs when an FCP client requests that a bookmark be shared. The connection
  * handler creates this message with the parsed field set, invokes {@link #run} on the parent class,
- * and lets {@link #handleFeed(DarknetPeerNode)} stream the optional description to the peer. The
- * response status returned by the peer is forwarded to the client through {@link SentPeerMessage}.
+ * and lets {@link #handleFeed(FcpDarknetPeerHandle)} stream the optional description to the peer.
+ * The response status returned by the peer is forwarded to the client through {@link
+ * SentPeerMessage}.
  *
  * <ul>
  *   <li><strong>Responsibilities:</strong> validate inputs, prepare serialization fields, and
@@ -49,11 +49,11 @@ public final class SendBookmarkMessage extends SendPeerMessage {
    * <p>The constructor validates that a bookmark name exists, parses the {@code URI} field using
    * {@link FreenetURI}, and records whether the caller advertises an active link. The instance does
    * not read any associated bucket data here, so callers may defer payload streaming until the
-   * message reaches {@link #handleFeed(DarknetPeerNode)}.
+   * message reaches {@link #handleFeed(FcpDarknetPeerHandle)}.
    *
    * @param fs parsed field set describing the bookmark request; must contain at least {@code Name}
    *     and {@code URI} entries in addition to the identifiers handled by {@link SendPeerMessage}.
-   * @throws MessageInvalidException if the bookmark name is absent or if the URI cannot be parsed
+   * @throws MessageInvalidException if the bookmark name is absent, or if the URI cannot be parsed
    *     by {@link FreenetURI}, in which case the constructor propagates a descriptive protocol
    *     error.
    */
@@ -117,23 +117,23 @@ public final class SendBookmarkMessage extends SendPeerMessage {
    * <p>If a payload bucket is present, the method reads it entirely, interprets it as UTF-8 text,
    * and delivers the description along with the metadata. When no payload is attached, the peer is
    * informed with a {@code null} description. The returned integer mirrors the peer status provided
-   * by {@link DarknetPeerNode#sendBookmarkFeed(FreenetURI, String, String, boolean)}.
+   * by {@link FcpDarknetPeerHandle#sendBookmarkFeed(FreenetURI, String, String, boolean)}.
    *
-   * @param pn validated darknet peer that should receive the bookmark information; never null when
-   *     invoked by {@link SendPeerMessage#run}.
+   * @param peerHandle validated darknet peer handle that should receive the bookmark information;
+   *     never null when invoked by {@link SendPeerMessage#run}
    * @return peer-reported status integer that will be relayed to the originating client once the
    *     send operation completes.
    * @throws MessageInvalidException if reading the payload fails with {@link IOException}, allowing
    *     the caller to surface a protocol error back to the client.
    */
   @Override
-  protected int handleFeed(DarknetPeerNode pn) throws MessageInvalidException {
+  protected int handleFeed(FcpDarknetPeerHandle peerHandle) throws MessageInvalidException {
     try {
       if (dataLength() > 0) {
         byte[] description = BucketTools.toByteArray(bucket);
-        return pn.sendBookmarkFeed(
+        return peerHandle.sendBookmarkFeed(
             uri, bookmarkName, new String(description, StandardCharsets.UTF_8), hasAnAnActiveLink);
-      } else return pn.sendBookmarkFeed(uri, bookmarkName, null, hasAnAnActiveLink);
+      } else return peerHandle.sendBookmarkFeed(uri, bookmarkName, null, hasAnAnActiveLink);
     } catch (IOException _) {
       throw new MessageInvalidException(ProtocolErrorMessage.INVALID_MESSAGE, "", null, false);
     }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendPeerMessage.java
@@ -1,7 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
 
 /**
@@ -11,8 +9,9 @@ import network.crypta.support.SimpleFieldSet;
  * reply, queue update, or diagnostic snapshot to a known peer without exposing the common routing
  * boilerplate in each concrete message. Subclasses parse their payload up front, then invoke {@link
  * #run(FCPConnectionHandler)} to resolve the peer, enforce darknet-only constraints, and finally
- * call {@link #handleFeed(DarknetPeerNode)} to transmit data. Instances are stateful because they
- * cache identifiers and the optional data length reported to peers during capability negotiation.
+ * call {@link #handleFeed(FcpDarknetPeerHandle)} to transmit data. Instances are stateful because
+ * they cache identifiers and the optional data length reported to peers during capability
+ * negotiation.
  *
  * <p>Implementations are expected to be short-lived and not thread-safe; callers should create a
  * fresh instance per inbound FCP command. The base class never mutates shared node structures
@@ -112,13 +111,13 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
 
   /**
    * Resolves the peer node, enforces darknet-only access, and delegates the actual payload
-   * transmission to {@link #handleFeed(DarknetPeerNode)}.
+   * transmission to {@link #handleFeed(FcpDarknetPeerHandle)}.
    *
    * <p>The handler is expected to represent the active connection issuing this request, and the
-   * provided node is the authoritative routing context. When the peer is unknown, a descriptive
-   * error message is sent automatically; when the peer is not part of the darknet, the method
-   * throws {@link MessageInvalidException}. Subclasses should avoid heavy computation inside {@code
-   * handleFeed} because it runs on whatever thread the handler uses for message dispatch.
+   * resolved peer result is the authoritative routing context. When the peer is unknown, a
+   * descriptive error message is sent automatically; when the peer is not part of the darknet, the
+   * method throws {@link MessageInvalidException}. Subclasses should avoid heavy computation inside
+   * {@code handleFeed} because it runs on whatever thread the handler uses for message dispatch.
    *
    * @param handler connection handler responsible for sending replies back to the client; must not
    *     be {@code null} and should already be authenticated.
@@ -127,19 +126,23 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
    */
   @Override
   public void run(FCPConnectionHandler handler) throws MessageInvalidException {
-    PeerNode pn = handler.getServer().messageRuntimeSupport().findPeer(nodeIdentifier);
-    if (pn == null) {
-      FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
-      handler.send(msg);
-    } else if (!(pn instanceof DarknetPeerNode darknetPeerNode)) {
-      throw new MessageInvalidException(
-          ProtocolErrorMessage.DARKNET_ONLY,
-          getName() + " only available for darknet peers",
-          identifier,
-          false);
-    } else {
-      int nodeStatus = handleFeed(darknetPeerNode);
-      handler.send(new SentPeerMessage(identifier, nodeStatus));
+    FcpPeerLookupResult lookupResult =
+        handler.getServer().messageRuntimeSupport().findPeer(nodeIdentifier);
+    switch (lookupResult.kind()) {
+      case UNKNOWN -> {
+        FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
+        handler.send(msg);
+      }
+      case NON_DARKNET ->
+          throw new MessageInvalidException(
+              ProtocolErrorMessage.DARKNET_ONLY,
+              getName() + " only available for darknet peers",
+              identifier,
+              false);
+      case DARKNET -> {
+        int nodeStatus = handleFeed(lookupResult.requireDarknetPeerHandle());
+        handler.send(new SentPeerMessage(identifier, nodeStatus));
+      }
     }
   }
 
@@ -151,12 +154,12 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
    * should document the meaning of their status codes and ensure that any thrown exception provides
    * actionable details.
    *
-   * @param pn darknet peer reference already registered on the node and guaranteed non-null.
+   * @param peerHandle adapter-owned darknet peer handle already validated and guaranteed non-null
    * @return integer status communicated to the client; the subclass defines semantic range.
    * @throws MessageInvalidException if the payload cannot be accepted or violates protocol
    *     invariants enforced by the subclass.
    */
-  protected abstract int handleFeed(DarknetPeerNode pn) throws MessageInvalidException;
+  protected abstract int handleFeed(FcpDarknetPeerHandle peerHandle) throws MessageInvalidException;
 
   @Override
   String getIdentifier() {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendTextMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendTextMessage.java
@@ -2,36 +2,36 @@ package network.crypta.clients.fcp;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.BucketTools;
 
 /**
- * Handles text-only FCP peer messages flowing from a remote client into a {@link DarknetPeerNode}.
+ * Handles text-only FCP peer messages flowing from a remote client into a {@link
+ * FcpDarknetPeerHandle}.
  *
  * <p>Instances wrap the parsed {@link SimpleFieldSet} supplied by the FCP dispatcher and translate
  * the attached data bucket into a UTF-8 string before handing it to {@link
- * DarknetPeerNode#sendTextFeed(String)}. The class is stateless and short-lived; each instance
+ * FcpDarknetPeerHandle#sendTextFeed(String)}. The class is stateless and short-lived; each instance
  * processes a single inbound payload and is expected to be discarded afterward. Although the
  * transport can theoretically carry arbitrary binary blobs, this implementation enforces a text
  * contract and therefore validates that some payload bytes were provided before forwarding the
  * request.
  *
  * <p>Because the surrounding infrastructure can submit feeds from multiple threads, callers should
- * ensure they provide thread-safe {@link DarknetPeerNode} implementations. The message itself does
- * not maintain mutable state and can therefore be reused only if the caller guarantees sequential
- * access.
+ * ensure they provide thread-safe {@link FcpDarknetPeerHandle} implementations. The message itself
+ * does not maintain a mutable state and can therefore be reused only if the caller guarantees
+ * sequential access.
  *
  * <ul>
  *   <li>Responsibility: convert bucket data to text and delegate to the peer.
  *   <li>Error handling: raises {@link MessageInvalidException} when the payload is missing or when
  *       the bucket cannot be read.
- *   <li>Lifecycle: constructed, handled once via {@link #handleFeed(DarknetPeerNode)}, then
+ *   <li>Lifecycle: constructed, handled once via {@link #handleFeed(FcpDarknetPeerHandle)}, then
  *       eligible for garbage collection.
  * </ul>
  *
  * @see SendPeerMessage
- * @see DarknetPeerNode#sendTextFeed(String)
+ * @see FcpDarknetPeerHandle#sendTextFeed(String)
  */
 public final class SendTextMessage extends SendPeerMessage {
 
@@ -72,23 +72,23 @@ public final class SendTextMessage extends SendPeerMessage {
    * <p>The method expects that {@link #dataLength()} is strictly positive; otherwise it fails fast
    * with a {@link MessageInvalidException} to ensure empty writes are never persisted. The payload
    * is loaded fully into memory via {@link BucketTools#toByteArray} before invoking {@link
-   * DarknetPeerNode#sendTextFeed(String)}, so upstream callers should avoid attaching unbounded
-   * data streams. Any {@link IOException} raised while reading the bucket is translated into {@link
-   * ProtocolErrorMessage#INVALID_MESSAGE} to keep protocol semantics consistent.
+   * FcpDarknetPeerHandle#sendTextFeed(String)}, so upstream callers should avoid attaching
+   * unbounded data streams. Any {@link IOException} raised while reading the bucket is translated
+   * into {@link ProtocolErrorMessage#INVALID_MESSAGE} to keep protocol semantics consistent.
    *
-   * @param pn peer connection that ultimately transmits the text; must support concurrent feed
-   *     delivery if used by multiple SendTextMessage instances.
-   * @return the status code returned from {@link DarknetPeerNode#sendTextFeed(String)}, preserving
-   *     the peer's decision about success, retries, or throttling.
+   * @param peerHandle peer connection that ultimately transmits the text; must support concurrent
+   *     feed delivery if used by multiple SendTextMessage instances
+   * @return the status code returned from {@link FcpDarknetPeerHandle#sendTextFeed(String)},
+   *     preserving the peer's decision about success, retries, or throttling.
    * @throws MessageInvalidException if the payload is empty, unreadable, or otherwise violates the
    *     SendText contract defined by the protocol.
    */
   @Override
-  protected int handleFeed(DarknetPeerNode pn) throws MessageInvalidException {
+  protected int handleFeed(FcpDarknetPeerHandle peerHandle) throws MessageInvalidException {
     try {
       if (dataLength() > 0) {
         byte[] text = BucketTools.toByteArray(bucket);
-        return pn.sendTextFeed(new String(text, StandardCharsets.UTF_8));
+        return peerHandle.sendTextFeed(new String(text, StandardCharsets.UTF_8));
       } else {
         throw new MessageInvalidException(
             ProtocolErrorMessage.INVALID_FIELD, "Invalid data length", null, false);

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendURIMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/SendURIMessage.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.io.BucketTools;
 
@@ -19,10 +18,10 @@ import network.crypta.support.io.BucketTools;
  * semantics so peers can authenticate and queue downloads consistently.
  *
  * <p>Senders should create a new instance per outgoing transaction, enqueue it on the peer
- * scheduler, and rely on {@link #handleFeed(DarknetPeerNode)} to forward optional descriptive text
- * while honoring UTF-8 encoding. The type performs no retries or throttling; upstream code must
- * handle pacing, persistence, and error logging. Instances are thread-safe because they expose only
- * effectively final state once construction completes.
+ * scheduler, and rely on {@link #handleFeed(FcpDarknetPeerHandle)} to forward optional descriptive
+ * text while honoring UTF-8 encoding. The type performs no retries or throttling; upstream code
+ * must handle pacing, persistence, and error logging. Instances are thread-safe because they expose
+ * only effectively final state once construction completes.
  *
  * <ul>
  *   <li>Parses and validates URIs supplied via {@code SimpleFieldSet} structures.
@@ -31,7 +30,7 @@ import network.crypta.support.io.BucketTools;
  * </ul>
  *
  * @see SendPeerMessage
- * @see DarknetPeerNode#sendDownloadFeed(FreenetURI, String)
+ * @see FcpDarknetPeerHandle#sendDownloadFeed(FreenetURI, String)
  */
 public final class SendURIMessage extends SendPeerMessage {
 
@@ -50,9 +49,9 @@ public final class SendURIMessage extends SendPeerMessage {
    * network boundary. Callers should already have verified the surrounding message type, but they
    * do not need to sanitize whitespace because {@link FreenetURI#FreenetURI(String)} handles
    * canonical parsing. The underlying bucket remains untouched until {@link
-   * #handleFeed(DarknetPeerNode)} is invoked, so large payloads stay in-place.
+   * #handleFeed(FcpDarknetPeerHandle)} is invoked, so large payloads stay in-place.
    *
-   * @param fs field set containing at least one {@code URI} entry with canonical string form.
+   * @param fs field set containing at least one {@code URI} entry with a canonical string form.
    * @throws MessageInvalidException if the {@code URI} entry is missing or fails to parse cleanly.
    */
   public SendURIMessage(SimpleFieldSet fs) throws MessageInvalidException {
@@ -70,8 +69,8 @@ public final class SendURIMessage extends SendPeerMessage {
    *
    * <p>The field set mirrors {@link SendPeerMessage}'s base values and injects the stored URI in
    * canonical text form so receiving peers can rehydrate it without ambiguity. No transient fields
-   * are included, therefore the result is deterministic for identical inputs and safe to reuse as a
-   * cached snapshot while preparing multiple sends.
+   * are included. Therefore, the result is deterministic for identical inputs and safe to reuse as
+   * a cached snapshot while preparing multiple sends.
    *
    * @return mutable {@link SimpleFieldSet} populated with basic headers plus the {@code URI} entry.
    */
@@ -85,8 +84,8 @@ public final class SendURIMessage extends SendPeerMessage {
   /**
    * Exposes the protocol-level message identifier string shared across SendURI transmissions.
    *
-   * <p>The constant name is used by dispatch tables and logging so the value must remain stable and
-   * uppercase. Callers can rely on it for switch statements or to allocate queues dedicated to
+   * <p>The constant name is used by dispatch tables and logging, so the value must remain stable
+   * and uppercase. Callers can rely on it for switch statements or to allocate queues dedicated to
    * specific FCP verbs without re-validating the payload contents.
    *
    * @return literal {@link #NAME} constant describing the SendURI protocol verb.
@@ -109,18 +108,19 @@ public final class SendURIMessage extends SendPeerMessage {
    * <p>This method is not idempotent with respect to peer state; callers should invoke it exactly
    * once per outbound transaction and rely on higher layers for retries or deduplication.
    *
-   * @param pn darknet peer that ultimately receives the URI and optional description, never null.
-   * @return opaque code from {@link DarknetPeerNode#sendDownloadFeed(FreenetURI, String)} conveying
-   *     scheduling outcomes.
+   * @param peerHandle darknet peer handle that ultimately receives the URI and optional
+   *     description, never null
+   * @return opaque code from {@link FcpDarknetPeerHandle#sendDownloadFeed(FreenetURI, String)}
+   *     conveying scheduling outcomes.
    * @throws MessageInvalidException if payload bytes cannot be decoded or the peer rejects input.
    */
   @Override
-  protected int handleFeed(DarknetPeerNode pn) throws MessageInvalidException {
+  protected int handleFeed(FcpDarknetPeerHandle peerHandle) throws MessageInvalidException {
     try {
       if (dataLength() > 0) {
         byte[] description = BucketTools.toByteArray(bucket);
-        return pn.sendDownloadFeed(uri, new String(description, StandardCharsets.UTF_8));
-      } else return pn.sendDownloadFeed(uri, null);
+        return peerHandle.sendDownloadFeed(uri, new String(description, StandardCharsets.UTF_8));
+      } else return peerHandle.sendDownloadFeed(uri, null);
     } catch (IOException _) {
       throw new MessageInvalidException(ProtocolErrorMessage.INVALID_MESSAGE, "", null, false);
     }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/package-info.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/package-info.java
@@ -9,8 +9,10 @@
  * or response is represented by a concrete {@link network.crypta.clients.fcp.FCPMessage} subtype;
  * the hierarchy distinguishes download/insert commands, node stats, and connection control.
  * Persistent requests, bandwidth probes, and peer-management commands maintain explicit identifiers
- * so clients can survive reconnects without duplicating work. The concrete bridge layer that binds
- * this protocol tree to runtime-owned seams now lives in {@code :bridge-fcp-runtime}.
+ * so clients can survive reconnections without duplicating work. This package also owns the
+ * adapter-side peer/probe seam used by residual message handlers, while the concrete bridge layer
+ * that binds those abstractions back to live node peers and probe listeners lives in {@code
+ * :bridge-fcp-runtime}.
  *
  * <p>Messages are designed for streaming and back-pressure: {@link
  * network.crypta.clients.fcp.FCPConnectionInputHandler} parses frames incrementally, while {@link

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -57,6 +57,10 @@ class AdapterFcpBoundaryTest {
       Path.of("src", "main", "java", "network", "crypta", "tools", "AddRef.java");
   private static final Pattern FCP_IMPORT_PATTERN =
       Pattern.compile("^import(?:\\s+static)?\\s+(network\\.crypta\\.clients\\.fcp\\.[^;]+);$");
+  private static final Pattern FORBIDDEN_RUNTIME_NODE_IMPORT_PATTERN =
+      Pattern.compile(
+          "^import\\s+(network\\.crypta\\.node\\.(?:PeerNode|DarknetPeerNode)|"
+              + "network\\.crypta\\.node\\.probe\\.[^;]+);$");
   private static final Set<String> EXPECTED_DEFAULT_BRIDGE_FACTORIES_IMPORTS =
       Set.of(
           "network.crypta.clients.fcp.bridge.FcpPersistentRequestServices",
@@ -176,6 +180,36 @@ class AdapterFcpBoundaryTest {
         "Every :adapter-fcp main package with production Java files must declare package-info.java."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), missingPackageInfos));
+  }
+
+  @Test
+  void adapterFcpMain_whenScanningForbiddenRuntimeImports_expectNoPeerOrProbeLeaks()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+    Path adapterFcpMain = repoRoot.resolve(ADAPTER_FCP_MAIN_JAVA);
+
+    for (Path sourceFile : findJavaSources(adapterFcpMain)) {
+      try (Stream<String> lines = Files.lines(sourceFile)) {
+        List<String> forbiddenImports =
+            lines
+                .map(String::trim)
+                .map(FORBIDDEN_RUNTIME_NODE_IMPORT_PATTERN::matcher)
+                .filter(Matcher::matches)
+                .map(matcher -> matcher.group(1))
+                .toList();
+        if (!forbiddenImports.isEmpty()) {
+          violations.add(
+              repoRoot.relativize(sourceFile) + " -> " + String.join(", ", forbiddenImports));
+        }
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        ":adapter-fcp main sources must not import PeerNode, DarknetPeerNode, or node.probe.*"
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
   }
 
   private static List<Path> findJavaSources(Path root) throws IOException {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/FcpPeerLookupResultTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/FcpPeerLookupResultTest.java
@@ -1,0 +1,93 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class FcpPeerLookupResultTest {
+
+  private static final FcpDarknetPeerHandle DARKNET_PEER_HANDLE =
+      new FcpDarknetPeerHandle() {
+        @Override
+        public int sendTextFeed(String message) {
+          return 0;
+        }
+
+        @Override
+        public int sendDownloadFeed(FreenetURI uri, String description) {
+          return 0;
+        }
+
+        @Override
+        public int sendBookmarkFeed(
+            FreenetURI uri, String name, String description, boolean hasActiveLink) {
+          return 0;
+        }
+      };
+
+  @Test
+  void unknown_whenCalled_returnsSharedUnknownSingleton() {
+    FcpPeerLookupResult first = FcpPeerLookupResult.unknown();
+    FcpPeerLookupResult second = FcpPeerLookupResult.unknown();
+
+    assertSame(first, second);
+    assertEquals(FcpPeerLookupResult.Kind.UNKNOWN, first.kind());
+    assertTrue(first.isUnknown());
+    assertFalse(first.isNonDarknet());
+    assertFalse(first.isDarknet());
+  }
+
+  @Test
+  void unknown_whenDarknetHandleRequired_throwsIllegalStateException() {
+    FcpPeerLookupResult result = FcpPeerLookupResult.unknown();
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, result::requireDarknetPeerHandle);
+
+    assertEquals("Lookup result does not contain a darknet peer handle", exception.getMessage());
+  }
+
+  @Test
+  void nonDarknet_whenCalled_returnsSharedNonDarknetSingleton() {
+    FcpPeerLookupResult first = FcpPeerLookupResult.nonDarknet();
+    FcpPeerLookupResult second = FcpPeerLookupResult.nonDarknet();
+
+    assertSame(first, second);
+    assertEquals(FcpPeerLookupResult.Kind.NON_DARKNET, first.kind());
+    assertFalse(first.isUnknown());
+    assertTrue(first.isNonDarknet());
+    assertFalse(first.isDarknet());
+  }
+
+  @Test
+  void nonDarknet_whenDarknetHandleRequired_throwsIllegalStateException() {
+    FcpPeerLookupResult result = FcpPeerLookupResult.nonDarknet();
+
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, result::requireDarknetPeerHandle);
+
+    assertEquals("Lookup result does not contain a darknet peer handle", exception.getMessage());
+  }
+
+  @Test
+  void darknet_whenHandleProvided_returnsDarknetResultWithHandle() {
+    FcpPeerLookupResult result = FcpPeerLookupResult.darknet(DARKNET_PEER_HANDLE);
+
+    assertEquals(FcpPeerLookupResult.Kind.DARKNET, result.kind());
+    assertFalse(result.isUnknown());
+    assertFalse(result.isNonDarknet());
+    assertTrue(result.isDarknet());
+    assertSame(DARKNET_PEER_HANDLE, result.requireDarknetPeerHandle());
+  }
+
+  @Test
+  void darknet_whenHandleNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> FcpPeerLookupResult.darknet(null));
+  }
+}

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupport.java
@@ -4,9 +4,17 @@ import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpDarknetPeerHandle;
 import network.crypta.clients.fcp.FcpMessageRuntimeSupport;
+import network.crypta.clients.fcp.FcpPeerLookupResult;
+import network.crypta.clients.fcp.FcpProbeError;
+import network.crypta.clients.fcp.FcpProbeListener;
+import network.crypta.clients.fcp.FcpProbeType;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerNode;
+import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Type;
 
@@ -27,7 +35,7 @@ import network.crypta.node.probe.Type;
  * <ul>
  *   <li>Preserves existing core-backed semantics for client creation and peer lookups.
  *   <li>Delegates feed watching and shutdown to the same node subsystems used before the refactor.
- *   <li>Starts probes through the live network path without changing UID or callback handling.
+ *   <li>Maps adapter-owned peer and probe seam types back to the live node runtime types.
  * </ul>
  *
  * @param core live daemon core backing the FCP message paths
@@ -107,31 +115,154 @@ record CoreFcpMessageRuntimeSupport(NodeClientCore core) implements FcpMessageRu
    * Resolves a peer from the node network reachable through the retained core.
    *
    * <p>No caching or translation is added here. Callers observe the current peer table at the time
-   * of the lookup and receive {@code null} when the identifier is unknown, allowing message code to
-   * preserve its existing unknown-peer and darknet-only protocol behavior.
+   * of the lookup and receive an adapter-owned result describing whether the peer is unknown,
+   * non-darknet, or a valid darknet target. That keeps message-layer branching behavior unchanged
+   * while preventing runtime peer types from leaking back into {@code :adapter-fcp}.
    *
    * @param nodeIdentifier peer identifier supplied by the message handler
-   * @return matching peer node, or {@code null} when no current peer matches the identifier
+   * @return adapter-owned lookup result describing the current peer state
    */
   @Override
-  public PeerNode findPeer(String nodeIdentifier) {
-    return core.getNode().network().getPeerNode(nodeIdentifier);
+  public FcpPeerLookupResult findPeer(String nodeIdentifier) {
+    PeerNode peerNode = core.getNode().network().getPeerNode(nodeIdentifier);
+    if (peerNode == null) {
+      return FcpPeerLookupResult.unknown();
+    }
+    if (peerNode instanceof DarknetPeerNode darknetPeerNode) {
+      return FcpPeerLookupResult.darknet(new CoreFcpDarknetPeerHandle(darknetPeerNode));
+    }
+    return FcpPeerLookupResult.nonDarknet();
   }
 
   /**
    * Starts a probe through the node network associated with the retained core.
    *
-   * <p>The adapter does not alter probe parameters, generate IDs, or wrap callbacks. It simply
-   * passes the validated hop limit, UID, probe type, and listener to the same runtime path that
-   * message handlers previously called directly, preserving asynchronous probe execution semantics.
+   * <p>The adapter does not alter probe parameters or generate IDs. It maps the adapter-owned probe
+   * type and listener back to the runtime probe equivalents, then delegates to the same network
+   * path that message handlers previously called directly. That preserves asynchronous probe
+   * execution semantics while keeping the runtime probe package out of {@code :adapter-fcp}.
    *
    * @param hopsToLive probe hop limit to submit to the network
    * @param uid probe UID selected by the caller for correlation
-   * @param probeType probe type to execute
-   * @param listener callback listener that receives probe results and failures
+   * @param probeType adapter-owned probe type to execute
+   * @param listener adapter-owned callback listener that receives probe results and failures
    */
   @Override
-  public void startProbe(byte hopsToLive, long uid, Type probeType, Listener listener) {
-    core.getNode().network().startProbe(hopsToLive, uid, probeType, listener);
+  public void startProbe(
+      byte hopsToLive, long uid, FcpProbeType probeType, FcpProbeListener listener) {
+    core.getNode()
+        .network()
+        .startProbe(hopsToLive, uid, toRuntimeProbeType(probeType), toRuntimeListener(listener));
+  }
+
+  private static Type toRuntimeProbeType(FcpProbeType probeType) {
+    return switch (probeType) {
+      case BANDWIDTH -> Type.BANDWIDTH;
+      case BUILD -> Type.BUILD;
+      case IDENTIFIER -> Type.IDENTIFIER;
+      case LINK_LENGTHS -> Type.LINK_LENGTHS;
+      case LOCATION -> Type.LOCATION;
+      case STORE_SIZE -> Type.STORE_SIZE;
+      case UPTIME_48H -> Type.UPTIME_48H;
+      case UPTIME_7D -> Type.UPTIME_7D;
+      case REJECT_STATS -> Type.REJECT_STATS;
+      case OVERALL_BULK_OUTPUT_CAPACITY_USAGE -> Type.OVERALL_BULK_OUTPUT_CAPACITY_USAGE;
+    };
+  }
+
+  private static FcpProbeError toAdapterProbeError(Error error) {
+    return switch (error) {
+      case DISCONNECTED -> FcpProbeError.DISCONNECTED;
+      case OVERLOAD -> FcpProbeError.OVERLOAD;
+      case TIMEOUT -> FcpProbeError.TIMEOUT;
+      case UNKNOWN -> FcpProbeError.UNKNOWN;
+      case UNRECOGNIZED_TYPE -> FcpProbeError.UNRECOGNIZED_TYPE;
+      case CANNOT_FORWARD -> FcpProbeError.CANNOT_FORWARD;
+    };
+  }
+
+  private static Listener toRuntimeListener(FcpProbeListener listener) {
+    Objects.requireNonNull(listener);
+    return new Listener() {
+      @Override
+      public void onError(Error error, Byte code, boolean local) {
+        listener.onError(toAdapterProbeError(error), code, local);
+      }
+
+      @Override
+      public void onRefused() {
+        listener.onRefused();
+      }
+
+      @Override
+      public void onOutputBandwidth(float outputBandwidth) {
+        listener.onOutputBandwidth(outputBandwidth);
+      }
+
+      @Override
+      public void onBuild(int build) {
+        listener.onBuild(build);
+      }
+
+      @Override
+      public void onIdentifier(long probeIdentifier, byte percentageUptime) {
+        listener.onIdentifier(probeIdentifier, percentageUptime);
+      }
+
+      @Override
+      public void onLinkLengths(float[] linkLengths) {
+        listener.onLinkLengths(linkLengths);
+      }
+
+      @Override
+      public void onLocation(float location) {
+        listener.onLocation(location);
+      }
+
+      @Override
+      public void onStoreSize(float storeSize) {
+        listener.onStoreSize(storeSize);
+      }
+
+      @Override
+      public void onUptime(float uptimePercent) {
+        listener.onUptime(uptimePercent);
+      }
+
+      @Override
+      public void onRejectStats(byte[] stats) {
+        listener.onRejectStats(stats);
+      }
+
+      @Override
+      public void onOverallBulkOutputCapacity(
+          byte bandwidthClassForCapacityUsage, float capacityUsage) {
+        listener.onOverallBulkOutputCapacity(bandwidthClassForCapacityUsage, capacityUsage);
+      }
+    };
+  }
+
+  private record CoreFcpDarknetPeerHandle(DarknetPeerNode peerNode)
+      implements FcpDarknetPeerHandle {
+
+    private CoreFcpDarknetPeerHandle {
+      Objects.requireNonNull(peerNode);
+    }
+
+    @Override
+    public int sendTextFeed(String text) {
+      return peerNode.sendTextFeed(text);
+    }
+
+    @Override
+    public int sendDownloadFeed(FreenetURI uri, String description) {
+      return peerNode.sendDownloadFeed(uri, description);
+    }
+
+    @Override
+    public int sendBookmarkFeed(
+        FreenetURI uri, String bookmarkName, String description, boolean hasAnActiveLink) {
+      return peerNode.sendBookmarkFeed(uri, bookmarkName, description, hasAnActiveLink);
+    }
   }
 }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/package-info.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/package-info.java
@@ -14,7 +14,8 @@
  * production binding and then hands only seam types upstream. This package keeps the concrete
  * runtime-binding behavior behind that boundary, so the current FCP startup sequence,
  * persistent-request recovery path, queue semantics, and alert delivery behavior remain unchanged
- * while ownership is made explicit for later extraction work.
+ * while ownership is made explicit for later extraction work. It also owns the concrete mapping
+ * between adapter-owned FCP peer/probe seam types and the live node peer/probe runtime classes.
  *
  * <ul>
  *   <li>Owns the concrete persistent-request bundle and recovery adapters for FCP-backed state.

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupportTest.java
@@ -2,10 +2,18 @@ package network.crypta.clients.fcp.bridge;
 
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.fcp.FCPConnectionHandler;
+import network.crypta.clients.fcp.FcpDarknetPeerHandle;
+import network.crypta.clients.fcp.FcpPeerLookupResult;
+import network.crypta.clients.fcp.FcpProbeError;
+import network.crypta.clients.fcp.FcpProbeListener;
+import network.crypta.clients.fcp.FcpProbeType;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerNode;
 import network.crypta.node.RequestStarter;
+import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Type;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
@@ -22,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +42,7 @@ class CoreFcpMessageRuntimeSupportTest {
   @Mock private HighLevelSimpleClient client;
   @Mock private Node node;
   @Mock private NodeNetworkSubsystem network;
+  @Mock private DarknetPeerNode darknetPeerNode;
   @Mock private PeerNode peerNode;
   @Mock private FCPConnectionHandler handler;
 
@@ -122,29 +132,147 @@ class CoreFcpMessageRuntimeSupportTest {
   }
 
   @Test
-  void findPeer_whenCalled_returnsPeerNode() {
+  void findPeer_whenPeerUnknown_returnsUnknownResult() {
+    when(core.getNode()).thenReturn(node);
+    when(node.network()).thenReturn(network);
+    when(network.getPeerNode("peer-1")).thenReturn(null);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    FcpPeerLookupResult actual = support.findPeer("peer-1");
+
+    assertEquals(FcpPeerLookupResult.Kind.UNKNOWN, actual.kind());
+  }
+
+  @Test
+  void findPeer_whenPeerIsNotDarknet_returnsNonDarknetResult() {
     when(core.getNode()).thenReturn(node);
     when(node.network()).thenReturn(network);
     when(network.getPeerNode("peer-1")).thenReturn(peerNode);
     CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
 
-    PeerNode actual = support.findPeer("peer-1");
+    FcpPeerLookupResult actual = support.findPeer("peer-1");
 
-    assertSame(peerNode, actual);
+    assertEquals(FcpPeerLookupResult.Kind.NON_DARKNET, actual.kind());
   }
 
   @Test
-  void startProbe_whenCalled_delegatesToNetwork() {
+  void findPeer_whenPeerIsDarknet_returnsDarknetHandleResult() throws Exception {
+    when(core.getNode()).thenReturn(node);
+    when(node.network()).thenReturn(network);
+    when(network.getPeerNode("peer-1")).thenReturn(darknetPeerNode);
+    when(darknetPeerNode.sendTextFeed("hello")).thenReturn(17);
+    FreenetURI uri = new FreenetURI("KSK@test");
+    when(darknetPeerNode.sendDownloadFeed(uri, "description")).thenReturn(23);
+    when(darknetPeerNode.sendBookmarkFeed(uri, "bookmark", "description", true)).thenReturn(31);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    FcpPeerLookupResult actual = support.findPeer("peer-1");
+    FcpDarknetPeerHandle handle = actual.requireDarknetPeerHandle();
+
+    assertEquals(FcpPeerLookupResult.Kind.DARKNET, actual.kind());
+    assertEquals(17, handle.sendTextFeed("hello"));
+    assertEquals(23, handle.sendDownloadFeed(uri, "description"));
+    assertEquals(31, handle.sendBookmarkFeed(uri, "bookmark", "description", true));
+    verify(darknetPeerNode).sendTextFeed("hello");
+    verify(darknetPeerNode).sendDownloadFeed(uri, "description");
+    verify(darknetPeerNode).sendBookmarkFeed(uri, "bookmark", "description", true);
+  }
+
+  @Test
+  void startProbe_whenCalled_mapsEveryProbeTypeToRuntimeType() {
     when(core.getNode()).thenReturn(node);
     when(node.network()).thenReturn(network);
     CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
-    Listener listener = org.mockito.Mockito.mock(Listener.class);
-    ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+    FcpProbeListener listener = org.mockito.Mockito.mock(FcpProbeListener.class);
 
-    support.startProbe((byte) 5, 42L, Type.BUILD, listener);
+    for (FcpProbeType probeType : FcpProbeType.values()) {
+      ArgumentCaptor<Type> typeCaptor = ArgumentCaptor.forClass(Type.class);
+      ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+
+      support.startProbe((byte) 5, 42L, probeType, listener);
+
+      verify(network)
+          .startProbe(eq((byte) 5), eq(42L), typeCaptor.capture(), listenerCaptor.capture());
+      assertEquals(expectedRuntimeType(probeType), typeCaptor.getValue());
+      assertNotNull(listenerCaptor.getValue());
+      clearInvocations(network);
+    }
+  }
+
+  @Test
+  void startProbe_whenRuntimeCallbacksArrive_forwardsThemToAdapterListener() {
+    when(core.getNode()).thenReturn(node);
+    when(node.network()).thenReturn(network);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    FcpProbeListener listener = org.mockito.Mockito.mock(FcpProbeListener.class);
+    ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+    float[] linkLengths = new float[] {1.5f, 2.5f};
+    byte[] rejectStats = new byte[] {3, 4, 5};
+
+    support.startProbe((byte) 5, 42L, FcpProbeType.BUILD, listener);
 
     verify(network).startProbe(eq((byte) 5), eq(42L), eq(Type.BUILD), listenerCaptor.capture());
-    assertNotNull(listenerCaptor.getValue());
-    assertSame(listener, listenerCaptor.getValue());
+    Listener runtimeListener = listenerCaptor.getValue();
+    assertNotNull(runtimeListener);
+
+    runtimeListener.onError(Error.DISCONNECTED, (byte) 1, true);
+    runtimeListener.onError(Error.OVERLOAD, (byte) 2, false);
+    runtimeListener.onError(Error.TIMEOUT, (byte) 3, true);
+    runtimeListener.onError(Error.UNKNOWN, (byte) 4, false);
+    runtimeListener.onError(Error.UNRECOGNIZED_TYPE, (byte) 5, true);
+    runtimeListener.onError(Error.CANNOT_FORWARD, (byte) 6, false);
+    runtimeListener.onRefused();
+    runtimeListener.onOutputBandwidth(7.5f);
+    runtimeListener.onBuild(8);
+    runtimeListener.onIdentifier(9L, (byte) 10);
+    runtimeListener.onLinkLengths(linkLengths);
+    runtimeListener.onLocation(11.5f);
+    runtimeListener.onStoreSize(12.5f);
+    runtimeListener.onUptime(13.5f);
+    runtimeListener.onRejectStats(rejectStats);
+    runtimeListener.onOverallBulkOutputCapacity((byte) 14, 15.5f);
+
+    verify(listener).onError(FcpProbeError.DISCONNECTED, (byte) 1, true);
+    verify(listener).onError(FcpProbeError.OVERLOAD, (byte) 2, false);
+    verify(listener).onError(FcpProbeError.TIMEOUT, (byte) 3, true);
+    verify(listener).onError(FcpProbeError.UNKNOWN, (byte) 4, false);
+    verify(listener).onError(FcpProbeError.UNRECOGNIZED_TYPE, (byte) 5, true);
+    verify(listener).onError(FcpProbeError.CANNOT_FORWARD, (byte) 6, false);
+    verify(listener).onRefused();
+    verify(listener).onOutputBandwidth(7.5f);
+    verify(listener).onBuild(8);
+    verify(listener).onIdentifier(9L, (byte) 10);
+    verify(listener).onLinkLengths(linkLengths);
+    verify(listener).onLocation(11.5f);
+    verify(listener).onStoreSize(12.5f);
+    verify(listener).onUptime(13.5f);
+    verify(listener).onRejectStats(rejectStats);
+    verify(listener).onOverallBulkOutputCapacity((byte) 14, 15.5f);
+  }
+
+  @Test
+  void startProbe_whenListenerNull_throwsNullPointerException() {
+    when(core.getNode()).thenReturn(node);
+    when(node.network()).thenReturn(network);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+
+    assertThrows(
+        NullPointerException.class,
+        () -> support.startProbe((byte) 5, 42L, FcpProbeType.BUILD, null));
+  }
+
+  private static Type expectedRuntimeType(FcpProbeType probeType) {
+    return switch (probeType) {
+      case BANDWIDTH -> Type.BANDWIDTH;
+      case BUILD -> Type.BUILD;
+      case IDENTIFIER -> Type.IDENTIFIER;
+      case LINK_LENGTHS -> Type.LINK_LENGTHS;
+      case LOCATION -> Type.LOCATION;
+      case STORE_SIZE -> Type.STORE_SIZE;
+      case UPTIME_48H -> Type.UPTIME_48H;
+      case UPTIME_7D -> Type.UPTIME_7D;
+      case REJECT_STATS -> Type.REJECT_STATS;
+      case OVERALL_BULK_OUTPUT_CAPACITY_USAGE -> Type.OVERALL_BULK_OUTPUT_CAPACITY_USAGE;
+    };
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ProbeErrorTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProbeErrorTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.node.probe.Error;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 
@@ -13,38 +12,38 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ProbeErrorTest {
   @Test
   void constructor_whenCodeProvided_expectFieldsIncludeCode() {
-    ProbeError message = new ProbeError("req-1", Error.UNKNOWN, (byte) 101, true);
+    ProbeError message = new ProbeError("req-1", FcpProbeError.UNKNOWN, (byte) 101, true);
 
     SimpleFieldSet fields = message.getFieldSet();
 
     assertEquals("req-1", fields.get(FCPMessage.IDENTIFIER));
-    assertEquals(Error.UNKNOWN.name(), fields.get(FCPMessage.TYPE));
+    assertEquals(FcpProbeError.UNKNOWN.name(), fields.get(FCPMessage.TYPE));
     assertEquals("101", fields.get(FCPMessage.CODE));
     assertTrue(fields.getBoolean(FCPMessage.LOCAL, false));
   }
 
   @Test
   void constructor_whenCodeMissing_expectCodeOmitted() {
-    ProbeError message = new ProbeError("req-2", Error.TIMEOUT, null, false);
+    ProbeError message = new ProbeError("req-2", FcpProbeError.TIMEOUT, null, false);
 
     SimpleFieldSet fields = message.getFieldSet();
 
     assertEquals("req-2", fields.get(FCPMessage.IDENTIFIER));
-    assertEquals(Error.TIMEOUT.name(), fields.get(FCPMessage.TYPE));
+    assertEquals(FcpProbeError.TIMEOUT.name(), fields.get(FCPMessage.TYPE));
     assertNull(fields.get(FCPMessage.CODE));
     assertFalse(fields.getBoolean(FCPMessage.LOCAL, true));
   }
 
   @Test
   void constructor_whenIdentifierMissing_expectIdentifierOmitted() {
-    ProbeError message = new ProbeError(null, Error.DISCONNECTED, null, true);
+    ProbeError message = new ProbeError(null, FcpProbeError.DISCONNECTED, null, true);
 
     assertNull(message.getFieldSet().get(FCPMessage.IDENTIFIER));
   }
 
   @Test
   void getName_whenInvoked_expectProtocolName() {
-    ProbeError message = new ProbeError("any", Error.CANNOT_FORWARD, null, true);
+    ProbeError message = new ProbeError("any", FcpProbeError.CANNOT_FORWARD, null, true);
 
     assertEquals("ProbeError", message.getName());
   }

--- a/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ProbeRequestTest.java
@@ -3,10 +3,7 @@ package network.crypta.clients.fcp;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.node.FSParseException;
-import network.crypta.node.probe.Error;
-import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Probe;
-import network.crypta.node.probe.Type;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
@@ -59,7 +56,7 @@ class ProbeRequestTest {
 
   @Test
   void constructor_whenHtlNegative_expectMessageInvalidException() {
-    SimpleFieldSet fieldSet = fieldSet("probe-1", Type.BUILD, (byte) -1);
+    SimpleFieldSet fieldSet = fieldSet("probe-1", FcpProbeType.BUILD, (byte) -1);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> new ProbeRequest(fieldSet));
@@ -70,7 +67,7 @@ class ProbeRequestTest {
 
   @Test
   void constructor_whenHtlNotNumber_expectMessageInvalidException() {
-    SimpleFieldSet fieldSet = fieldSet("probe-1", Type.BUILD.name(), "not-a-number");
+    SimpleFieldSet fieldSet = fieldSet("probe-1", FcpProbeType.BUILD.name(), "not-a-number");
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> new ProbeRequest(fieldSet));
@@ -82,7 +79,7 @@ class ProbeRequestTest {
 
   @Test
   void getFieldSet_whenCalled_returnsIndependentEmptyFieldSet() throws MessageInvalidException {
-    SimpleFieldSet input = fieldSet("probe-1", Type.BUILD, (byte) 5);
+    SimpleFieldSet input = fieldSet("probe-1", FcpProbeType.BUILD, (byte) 5);
     ProbeRequest request = new ProbeRequest(input);
 
     SimpleFieldSet result = request.getFieldSet();
@@ -94,7 +91,7 @@ class ProbeRequestTest {
 
   @Test
   void getName_whenCalled_returnsProbeRequestConstant() throws MessageInvalidException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 5));
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.BUILD, (byte) 5));
 
     assertEquals(ProbeRequest.NAME, request.getName());
   }
@@ -102,7 +99,7 @@ class ProbeRequestTest {
   @Test
   void run_whenHandlerWithoutFullAccess_expectAccessDeniedException()
       throws MessageInvalidException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 5));
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.BUILD, (byte) 5));
     when(handler.hasFullAccess()).thenReturn(false);
 
     MessageInvalidException exception =
@@ -112,52 +109,56 @@ class ProbeRequestTest {
     assertEquals("probe-1", exception.ident);
     assertEquals("Probe requires full access.", exception.getMessage());
     verify(messageRuntimeSupport, never())
-        .startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
+        .startProbe(anyByte(), anyLong(), any(FcpProbeType.class), any(FcpProbeListener.class));
   }
 
   @Test
   void run_whenHtlMissing_usesProbeMaxHtl() throws MessageInvalidException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, null));
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.BUILD, null));
     when(handler.hasFullAccess()).thenReturn(true);
     when(handler.getServer()).thenReturn(server);
     when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
-    ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+    ArgumentCaptor<FcpProbeListener> listenerCaptor =
+        ArgumentCaptor.forClass(FcpProbeListener.class);
 
     request.run(handler);
 
     verify(messageRuntimeSupport)
-        .startProbe(eq(Probe.MAX_HTL), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
+        .startProbe(
+            eq(Probe.MAX_HTL), eq(REQUEST_UID), eq(FcpProbeType.BUILD), listenerCaptor.capture());
     assertNotNull(listenerCaptor.getValue());
   }
 
   @Test
   void run_whenHtlProvided_usesProvidedValue() throws MessageInvalidException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 12));
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.BUILD, (byte) 12));
     when(handler.hasFullAccess()).thenReturn(true);
     when(handler.getServer()).thenReturn(server);
     when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
-    ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+    ArgumentCaptor<FcpProbeListener> listenerCaptor =
+        ArgumentCaptor.forClass(FcpProbeListener.class);
 
     request.run(handler);
 
     verify(messageRuntimeSupport)
-        .startProbe(eq((byte) 12), eq(REQUEST_UID), eq(Type.BUILD), listenerCaptor.capture());
+        .startProbe(
+            eq((byte) 12), eq(REQUEST_UID), eq(FcpProbeType.BUILD), listenerCaptor.capture());
     assertNotNull(listenerCaptor.getValue());
   }
 
   @Test
   void run_whenProbeErrors_sendsProbeError() throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BANDWIDTH, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.BANDWIDTH, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
     Byte code = (byte) 7;
 
-    listener.onError(Error.TIMEOUT, code, true);
+    listener.onError(FcpProbeError.TIMEOUT, code, true);
 
     ArgumentCaptor<FCPMessage> captor = ArgumentCaptor.forClass(FCPMessage.class);
     verify(handler).send(captor.capture());
@@ -165,15 +166,15 @@ class ProbeRequestTest {
     assertInstanceOf(ProbeError.class, sent);
     SimpleFieldSet fields = sent.getFieldSet();
     assertEquals("probe-1", fields.get(FCPMessage.IDENTIFIER));
-    assertEquals(Error.TIMEOUT.name(), fields.get(FCPMessage.TYPE));
+    assertEquals(FcpProbeError.TIMEOUT.name(), fields.get(FCPMessage.TYPE));
     assertEquals(code.byteValue(), fields.getByte(FCPMessage.CODE));
     assertTrue(fields.getBoolean(FCPMessage.LOCAL));
   }
 
   @Test
   void run_whenProbeRefused_sendsProbeRefused() throws MessageInvalidException {
-    ProbeRequest request = new ProbeRequest(fieldSet(null, Type.BANDWIDTH, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet(null, FcpProbeType.BANDWIDTH, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onRefused();
 
@@ -187,8 +188,8 @@ class ProbeRequestTest {
   @Test
   void run_whenProbeOutputsBandwidth_sendsProbeBandwidth()
       throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BANDWIDTH, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.BANDWIDTH, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onOutputBandwidth(12.5f);
 
@@ -204,8 +205,8 @@ class ProbeRequestTest {
   @Test
   void run_whenProbeBuildReported_sendsProbeBuild()
       throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.BUILD, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.BUILD, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onBuild(123456);
 
@@ -221,8 +222,8 @@ class ProbeRequestTest {
   @Test
   void run_whenProbeIdentifierReported_sendsProbeIdentifier()
       throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.IDENTIFIER, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.IDENTIFIER, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onIdentifier(99L, (byte) 42);
 
@@ -238,8 +239,9 @@ class ProbeRequestTest {
 
   @Test
   void run_whenProbeLinkLengthsReported_sendsProbeLinkLengths() throws MessageInvalidException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.LINK_LENGTHS, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request =
+        new ProbeRequest(fieldSet("probe-1", FcpProbeType.LINK_LENGTHS, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
     float[] lengths = new float[] {1.25f, 2.5f, 3.75f};
 
     listener.onLinkLengths(lengths);
@@ -262,8 +264,8 @@ class ProbeRequestTest {
   @Test
   void run_whenProbeLocationReported_sendsProbeLocation()
       throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.LOCATION, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.LOCATION, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onLocation(0.75f);
 
@@ -279,8 +281,8 @@ class ProbeRequestTest {
   @Test
   void run_whenProbeStoreSizeReported_sendsProbeStoreSize()
       throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.STORE_SIZE, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.STORE_SIZE, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onStoreSize(512.5f);
 
@@ -296,8 +298,8 @@ class ProbeRequestTest {
   @Test
   void run_whenProbeUptimeReported_sendsProbeUptime()
       throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.UPTIME_7D, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", FcpProbeType.UPTIME_7D, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onUptime(99.5f);
 
@@ -313,8 +315,9 @@ class ProbeRequestTest {
   @Test
   void run_whenProbeRejectStatsReported_sendsProbeRejectStats()
       throws MessageInvalidException, FSParseException {
-    ProbeRequest request = new ProbeRequest(fieldSet("probe-1", Type.REJECT_STATS, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+    ProbeRequest request =
+        new ProbeRequest(fieldSet("probe-1", FcpProbeType.REJECT_STATS, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
     byte[] stats = new byte[] {1, 2, 3, 4};
 
     listener.onRejectStats(stats);
@@ -335,8 +338,9 @@ class ProbeRequestTest {
   void run_whenProbeOverallBulkCapacityReported_sendsProbeOverallBulkOutputCapacityUsage()
       throws MessageInvalidException, FSParseException {
     ProbeRequest request =
-        new ProbeRequest(fieldSet("probe-1", Type.OVERALL_BULK_OUTPUT_CAPACITY_USAGE, (byte) 5));
-    Listener listener = runAndCaptureListener(request);
+        new ProbeRequest(
+            fieldSet("probe-1", FcpProbeType.OVERALL_BULK_OUTPUT_CAPACITY_USAGE, (byte) 5));
+    FcpProbeListener listener = runAndCaptureListener(request);
 
     listener.onOverallBulkOutputCapacity((byte) 3, 0.67f);
 
@@ -350,21 +354,22 @@ class ProbeRequestTest {
     assertEquals(0.67d, fields.getDouble(FCPMessage.OVERALL_BULK_OUTPUT_CAPACITY_USAGE), 0.0001d);
   }
 
-  private Listener runAndCaptureListener(ProbeRequest request) throws MessageInvalidException {
+  private FcpProbeListener runAndCaptureListener(ProbeRequest request)
+      throws MessageInvalidException {
     when(handler.hasFullAccess()).thenReturn(true);
     when(handler.getServer()).thenReturn(server);
     when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     stubProbeUid(randomnessPort);
-    AtomicReference<Listener> listenerRef = new AtomicReference<>();
+    AtomicReference<FcpProbeListener> listenerRef = new AtomicReference<>();
     doAnswer(
             invocation -> {
               listenerRef.set(invocation.getArgument(3));
               return null;
             })
         .when(messageRuntimeSupport)
-        .startProbe(anyByte(), anyLong(), any(Type.class), any(Listener.class));
+        .startProbe(anyByte(), anyLong(), any(FcpProbeType.class), any(FcpProbeListener.class));
 
     request.run(handler);
 
@@ -383,7 +388,7 @@ class ProbeRequestTest {
         .fillSecureRandom(any(byte[].class));
   }
 
-  private static SimpleFieldSet fieldSet(String identifier, Type type, Byte htl) {
+  private static SimpleFieldSet fieldSet(String identifier, FcpProbeType type, Byte htl) {
     return fieldSet(
         identifier, type == null ? null : type.name(), htl == null ? null : Byte.toString(htl));
   }

--- a/src/test/java/network/crypta/clients/fcp/SendBookmarkMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendBookmarkMessageTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
@@ -28,7 +27,7 @@ class SendBookmarkMessageTest {
   private static final String VALID_URI = "KSK@Bookmarks";
   private static final String BOOKMARK_NAME = "crypta-home";
 
-  @Mock private DarknetPeerNode darknetPeerNode;
+  @Mock private FcpDarknetPeerHandle darknetPeerNode;
 
   @Test
   void constructor_whenNameMissing_expectMessageInvalidException() {

--- a/src/test/java/network/crypta/clients/fcp/SendTextMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendTextMessageTest.java
@@ -2,8 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import network.crypta.node.DarknetPeerNode;
-import network.crypta.node.PeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
@@ -28,11 +26,10 @@ class SendTextMessageTest {
   private static final String IDENTIFIER = "test-identifier";
   private static final String NODE_IDENTIFIER = "peer-node-1";
 
-  @Mock private DarknetPeerNode darknetPeerNode;
+  @Mock private FcpDarknetPeerHandle darknetPeerNode;
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
   @Mock private FcpMessageRuntimeSupport messageRuntimeSupport;
-  @Mock private PeerNode peerNode;
 
   @Test
   void getName_whenCalled_returnsSendText() throws MessageInvalidException {
@@ -88,7 +85,7 @@ class SendTextMessageTest {
     SendTextMessage message = new SendTextMessage(baseFieldSet());
     when(handler.getServer()).thenReturn(server);
     when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
-    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER)).thenReturn(null);
+    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER)).thenReturn(FcpPeerLookupResult.unknown());
     ArgumentCaptor<FCPMessage> sentCaptor = ArgumentCaptor.forClass(FCPMessage.class);
 
     message.run(handler);
@@ -105,7 +102,8 @@ class SendTextMessageTest {
     SendTextMessage message = new SendTextMessage(baseFieldSet());
     when(handler.getServer()).thenReturn(server);
     when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
-    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER)).thenReturn(peerNode);
+    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER))
+        .thenReturn(FcpPeerLookupResult.nonDarknet());
 
     MessageInvalidException ex =
         assertThrows(MessageInvalidException.class, () -> message.run(handler));
@@ -124,7 +122,8 @@ class SendTextMessageTest {
     message.bucket = new ArrayBucket(payload);
     when(handler.getServer()).thenReturn(server);
     when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
-    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER)).thenReturn(darknetPeerNode);
+    when(messageRuntimeSupport.findPeer(NODE_IDENTIFIER))
+        .thenReturn(FcpPeerLookupResult.darknet(darknetPeerNode));
     when(darknetPeerNode.sendTextFeed(text)).thenReturn(123);
     ArgumentCaptor<FCPMessage> sentCaptor = ArgumentCaptor.forClass(FCPMessage.class);
 

--- a/src/test/java/network/crypta/clients/fcp/SendURIMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SendURIMessageTest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.DarknetPeerNode;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucket;
@@ -32,7 +31,7 @@ class SendURIMessageTest {
   private static final String NODE_IDENTIFIER = "peer-node";
   private static final String VALID_URI = "KSK@keyword";
 
-  @Mock private DarknetPeerNode peerNode;
+  @Mock private FcpDarknetPeerHandle peerNode;
 
   @Test
   void constructor_whenUriInvalid_expectMessageInvalidException() {


### PR DESCRIPTION
## Summary
- introduce adapter-owned seam types for darknet peer handles, peer lookup results, probe defaults, probe errors, probe listeners, and probe types
- update the FCP adapter and bridge runtime support to route peer and probe behavior through the new adapter-owned contracts instead of direct runtime peer/probe types
- expand unit coverage for the seam behavior and enrich Javadoc on the new adapter APIs

## How to test
- `./gradlew :adapter-fcp:test --tests 'network.crypta.clients.fcp.AdapterFcpBoundaryTest' --tests 'network.crypta.clients.fcp.FcpPeerLookupResultTest' :bridge-fcp-runtime:test --tests 'network.crypta.clients.fcp.bridge.CoreFcpMessageRuntimeSupportTest' :test --tests 'network.crypta.clients.fcp.ProbeErrorTest' --tests 'network.crypta.clients.fcp.ProbeRequestTest' --tests 'network.crypta.clients.fcp.SendBookmarkMessageTest' --tests 'network.crypta.clients.fcp.SendTextMessageTest' --tests 'network.crypta.clients.fcp.SendURIMessageTest'`
- `./gradlew test`