### PR TITLE
refactor(fcp): Narrow AddPeer peer-reference seam

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/AddPeer.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/AddPeer.java
@@ -12,10 +12,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import network.crypta.client.FetchException;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
-import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.PeerAddFailureReason;
 import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
@@ -155,44 +152,6 @@ public final class AddPeer extends FCPMessage {
   }
 
   /**
-   * Delegates to the neutral peer-reference text loader for regular URLs.
-   *
-   * <p>The returned buffer and newline-joining behavior match the runtime-owned loader used by the
-   * HTTP and console adapters.
-   *
-   * @param url absolute URL pointing to a textual peer reference document; must not be {@code null}
-   * @return mutable buffer containing the full textual contents of the response, including trailing
-   *     newline characters if present
-   * @throws IOException if establishing the connection or reading the response body fails for any
-   *     reason, including network errors or unexpected end-of-stream conditions
-   */
-  public static StringBuilder getReferenceFromURL(URL url) throws IOException {
-    return PeerReferenceTextLoader.readFromUrl(url);
-  }
-
-  /**
-   * Delegates to the neutral peer-reference text loader for Freenet URIs.
-   *
-   * <p>The supplied client still performs the legacy 31,000-byte fetch, and the returned text keeps
-   * the same newline-joining behavior as the URL path.
-   *
-   * @param uri Freenet URI locating the remotely stored peer reference document; must not be {@code
-   *     null}
-   * @param client high-level client instance used to perform the fetch within the appropriate
-   *     request priority class and security context; must be configured for the target node
-   * @return mutable buffer containing the full textual contents of the fetched document, including
-   *     any trailing newline characters
-   * @throws IOException if reading the fetched data from the node fails due to I/O errors in the
-   *     underlying stream
-   * @throws FetchException if the URI cannot be fetched successfully, for example, due to routing
-   *     failures, timeouts, or protocol-level error responses
-   */
-  public static StringBuilder getReferenceFromFreenetURI(
-      FreenetURI uri, HighLevelSimpleClient client) throws IOException, FetchException {
-    return PeerReferenceTextLoader.readFromFreenetUri(uri, client);
-  }
-
-  /**
    * Executes the AddPeer request against the supplied node.
    *
    * <p>The method first enforces that the originating FCP connection has full-access permissions,
@@ -296,16 +255,15 @@ public final class AddPeer extends FCPMessage {
       throws IOException {
     try {
       FreenetURI refUri = new FreenetURI(urlString);
-      HighLevelSimpleClient client =
-          handler
-              .getServer()
-              .messageRuntimeSupport()
-              .makeClient(FcpPriorityClasses.IMMEDIATE_SPLITFILE, true, true);
-      return getReferenceFromFreenetURI(refUri, client);
-    } catch (MalformedURLException | FetchException _) {
+      return handler
+          .getServer()
+          .messageRuntimeSupport()
+          .readPeerReferenceFromCryptaUri(
+              refUri, FcpPriorityClasses.IMMEDIATE_SPLITFILE, true, true);
+    } catch (MalformedURLException | FcpPeerReferenceFetchException _) {
       LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urlString);
       URL url = createUrlFromString(urlString);
-      return getReferenceFromURL(url);
+      return handler.getServer().messageRuntimeSupport().readPeerReferenceFromUrl(url);
     }
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.HighLevelSimpleClient;
+import java.io.IOException;
+import java.net.URL;
+import network.crypta.keys.FreenetURI;
 
 /**
  * Narrow runtime support seam for residual message-level FCP operations.
@@ -17,8 +19,9 @@ import network.crypta.client.HighLevelSimpleClient;
  * runtime-spi}, and it is not intended to become a general daemon abstraction. Its job is narrower:
  * preserve existing node behavior while removing direct core dependencies from message-level
  * execution paths, so later refactors can adjust server bootstrap and configuration seams without
- * touching protocol handlers again. Peer lookup and probe execution use adapter-owned seam types,
- * so the protocol package no longer imports concrete node peer or probe classes directly.
+ * touching protocol handlers again. Peer lookup, probe execution, and AddPeer peer-reference
+ * loading now use adapter-owned seam types, so the protocol package no longer imports concrete node
+ * peer, probe, or client/fetch classes directly.
  *
  * <ul>
  *   <li>Exposes only the runtime actions still needed by residual message classes.
@@ -31,21 +34,39 @@ import network.crypta.client.HighLevelSimpleClient;
 public interface FcpMessageRuntimeSupport {
 
   /**
-   * Creates a client with the supplied message-level queue and store behavior.
+   * Reads peer-reference text from a regular URL.
    *
-   * <p>Implementations should preserve the same queue-selection and store-visibility behavior that
-   * message handlers historically received from the backing node core. Callers typically use this
-   * when a message needs a short-lived high-level client to fetch or inspect a noderef while still
-   * keeping client creation behind a package-local seam. The returned client is live and may hold
-   * node resources, so callers should avoid caching it beyond the handling flow that requested it.
+   * <p>This operation exists so {@link AddPeer} can keep URL parsing, fallback policy, and protocol
+   * error mapping in the adapter layer while delegating the concrete I/O to the runtime-backed
+   * bridge. Implementations should preserve the historical newline-joining behavior and character
+   * decoding used when reading noderef text from ordinary URLs.
    *
-   * @param priorityClass client priority class requested by the caller for this operation
-   * @param forceDontIgnoreStore whether the caller requires explicit store-visibility behavior
-   * @param forceMixedQueue whether the caller requires mixed-queue behavior for the created client
-   * @return live high-level client backed by the daemon runtime and configured for the request
+   * @param url absolute URL pointing to a textual peer reference document
+   * @return mutable buffer containing the fetched peer-reference text
+   * @throws IOException if opening or reading the URL fails
    */
-  HighLevelSimpleClient makeClient(
-      short priorityClass, boolean forceDontIgnoreStore, boolean forceMixedQueue);
+  StringBuilder readPeerReferenceFromUrl(URL url) throws IOException;
+
+  /**
+   * Reads peer-reference text from a Crypta/Freenet URI using message-specified request policy.
+   *
+   * <p>Implementations should create and use the same short-lived high-level client behavior that
+   * AddPeer historically received from the backing core for this fetch path. Fetch-level failures
+   * for an otherwise valid URI are reported through {@link FcpPeerReferenceFetchException} so the
+   * message layer can preserve its existing fallback-to-URL behavior, while I/O failures that occur
+   * after a successful fetch continue to surface as {@link IOException}.
+   *
+   * @param uri Crypta/Freenet URI locating the remotely stored peer reference
+   * @param priorityClass client priority class requested by the message handler
+   * @param forceDontIgnoreStore whether explicit store-visibility behavior should be forced
+   * @param forceMixedQueue whether mixed-queue behavior should be forced on the created client
+   * @return mutable buffer containing the fetched peer-reference text
+   * @throws IOException if the URI fetch succeeds but the returned data cannot be read fully
+   * @throws FcpPeerReferenceFetchException if the URI is valid but the fetch itself fails
+   */
+  StringBuilder readPeerReferenceFromCryptaUri(
+      FreenetURI uri, short priorityClass, boolean forceDontIgnoreStore, boolean forceMixedQueue)
+      throws IOException, FcpPeerReferenceFetchException;
 
   /**
    * Enables or disables feed watching for a connection handler.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpPeerReferenceFetchException.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpPeerReferenceFetchException.java
@@ -1,0 +1,34 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Signals that AddPeer failed to fetch a noderef from a valid Crypta/Freenet URI.
+ *
+ * <p>This checked exception is owned by {@code :adapter-fcp} so the AddPeer message path can keep
+ * its fallback policy in the protocol layer without importing runtime-owned fetch types such as
+ * {@code FetchException}. A caller uses this type only to distinguish "the URI parsed correctly,
+ * but the fetch failed" from other cases such as malformed URI parsing or ordinary URL I/O
+ * failures. That distinction preserves the existing behavior where AddPeer retries the same input
+ * as a regular URL after valid-URI fetch failures, while still surfacing post-fetch read failures
+ * as plain {@link java.io.IOException}.
+ *
+ * <p>The exception carries the original cause unchanged, so bridge implementations and tests can
+ * still inspect the lower-level failure when needed. It does not add transport-specific state or
+ * protocol codes because those remain the responsibility of the message layer.
+ */
+public final class FcpPeerReferenceFetchException extends Exception {
+
+  /**
+   * Creates a new adapter-owned wrapper for a fetch failure on a valid Crypta/Freenet URI.
+   *
+   * <p>Callers typically provide a short bridge-level message and the original runtime exception as
+   * the cause. The constructed exception is then propagated back to the AddPeer message handler,
+   * which decides whether to fall back to ordinary URL loading or translate the failure into a
+   * protocol error.
+   *
+   * @param message human-readable summary of the fetch failure context
+   * @param cause original runtime exception that caused the fetch to fail
+   */
+  public FcpPeerReferenceFetchException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/package-info.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/package-info.java
@@ -10,9 +10,9 @@
  * the hierarchy distinguishes download/insert commands, node stats, and connection control.
  * Persistent requests, bandwidth probes, and peer-management commands maintain explicit identifiers
  * so clients can survive reconnections without duplicating work. This package also owns the
- * adapter-side peer/probe seam used by residual message handlers, while the concrete bridge layer
- * that binds those abstractions back to live node peers and probe listeners lives in {@code
- * :bridge-fcp-runtime}.
+ * adapter-side peer, probe, and peer-reference loading seams used by residual message handlers,
+ * while the concrete bridge layer that binds those abstractions back to live node peers, probe
+ * listeners, and runtime-backed noderef loading lives in {@code :bridge-fcp-runtime}.
  *
  * <p>Messages are designed for streaming and back-pressure: {@link
  * network.crypta.clients.fcp.FCPConnectionInputHandler} parses frames incrementally, while {@link

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -28,6 +28,9 @@ class AdapterFcpBoundaryTest {
       Path.of("src", "main", "java", "network", "crypta", "clients", "fcp", "bridge");
   private static final Path ADAPTER_FCP_MAIN_JAVA =
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "fcp");
+  private static final Path ADD_PEER_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("AddPeer.java");
+  private static final Path FCP_MESSAGE_RUNTIME_SUPPORT_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FcpMessageRuntimeSupport.java");
   private static final Path BRIDGE_FCP_RUNTIME_MAIN_JAVA =
       Path.of(
           "bridge-fcp-runtime",
@@ -210,6 +213,29 @@ class AdapterFcpBoundaryTest {
         ":adapter-fcp main sources must not import PeerNode, DarknetPeerNode, or node.probe.*"
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void adapterFcpMain_whenCheckingAddPeerSeam_expectNoRuntimeClientFetchOrLoaderLeak()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    String addPeerSource = Files.readString(repoRoot.resolve(ADD_PEER_SOURCE));
+    String messageRuntimeSupportSource =
+        Files.readString(repoRoot.resolve(FCP_MESSAGE_RUNTIME_SUPPORT_SOURCE));
+
+    assertFalse(
+        addPeerSource.contains("import network.crypta.client.HighLevelSimpleClient;"),
+        "AddPeer must not import HighLevelSimpleClient directly");
+    assertFalse(
+        addPeerSource.contains("import network.crypta.client.FetchException;"),
+        "AddPeer must not import FetchException directly");
+    assertFalse(
+        addPeerSource.contains(
+            "import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;"),
+        "AddPeer must not import PeerReferenceTextLoader directly");
+    assertFalse(
+        messageRuntimeSupportSource.contains(" makeClient("),
+        "FcpMessageRuntimeSupport must not expose raw makeClient(...) anymore");
   }
 
   private static List<Path> findJavaSources(Path root) throws IOException {

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupport.java
@@ -1,12 +1,15 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.FetchException;
 import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.FcpDarknetPeerHandle;
 import network.crypta.clients.fcp.FcpMessageRuntimeSupport;
 import network.crypta.clients.fcp.FcpPeerLookupResult;
+import network.crypta.clients.fcp.FcpPeerReferenceFetchException;
 import network.crypta.clients.fcp.FcpProbeError;
 import network.crypta.clients.fcp.FcpProbeListener;
 import network.crypta.clients.fcp.FcpProbeType;
@@ -17,6 +20,7 @@ import network.crypta.node.PeerNode;
 import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Type;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 
 /**
  * Core-backed implementation of {@link FcpMessageRuntimeSupport}.
@@ -33,7 +37,7 @@ import network.crypta.node.probe.Type;
  * delegation rather than becoming a second policy layer.
  *
  * <ul>
- *   <li>Preserves existing core-backed semantics for client creation and peer lookups.
+ *   <li>Preserves existing core-backed semantics for peer-reference loading and peer lookups.
  *   <li>Delegates feed watching and shutdown to the same node subsystems used before the refactor.
  *   <li>Maps adapter-owned peer and probe seam types back to the live node runtime types.
  * </ul>
@@ -57,23 +61,21 @@ record CoreFcpMessageRuntimeSupport(NodeClientCore core) implements FcpMessageRu
     this.core = Objects.requireNonNull(core);
   }
 
-  /**
-   * Creates a high-level client through the retained node core.
-   *
-   * <p>This implementation forwards directly to {@link NodeClientCore#makeClient(short, boolean,
-   * boolean)} so message handlers receive the same priority, store, and queue behavior they used
-   * before the adapter existed. The method adds no caching or wrapping; it simply returns the live
-   * client created by the underlying core for the current request path.
-   *
-   * @param priorityClass client priority class requested by the message handler
-   * @param forceDontIgnoreStore whether store-visibility behavior should be forced on the client
-   * @param forceMixedQueue whether mixed-queue behavior should be forced on the client
-   * @return live high-level client created by the retained node core
-   */
   @Override
-  public HighLevelSimpleClient makeClient(
-      short priorityClass, boolean forceDontIgnoreStore, boolean forceMixedQueue) {
-    return core.makeClient(priorityClass, forceDontIgnoreStore, forceMixedQueue);
+  public StringBuilder readPeerReferenceFromUrl(URL url) throws IOException {
+    return PeerReferenceTextLoader.readFromUrl(url);
+  }
+
+  @Override
+  public StringBuilder readPeerReferenceFromCryptaUri(
+      FreenetURI uri, short priorityClass, boolean forceDontIgnoreStore, boolean forceMixedQueue)
+      throws IOException, FcpPeerReferenceFetchException {
+    try {
+      return PeerReferenceTextLoader.readFromFreenetUri(
+          uri, core.makeClient(priorityClass, forceDontIgnoreStore, forceMixedQueue));
+    } catch (FetchException e) {
+      throw new FcpPeerReferenceFetchException("Failed to fetch peer reference from Crypta URI", e);
+    }
   }
 
   /**

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/package-info.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/package-info.java
@@ -15,7 +15,9 @@
  * runtime-binding behavior behind that boundary, so the current FCP startup sequence,
  * persistent-request recovery path, queue semantics, and alert delivery behavior remain unchanged
  * while ownership is made explicit for later extraction work. It also owns the concrete mapping
- * between adapter-owned FCP peer/probe seam types and the live node peer/probe runtime classes.
+ * between adapter-owned FCP peer/probe seam types and the live node peer/probe runtime classes,
+ * plus the AddPeer noderef-loading bridge that still requires live client and runtime loader
+ * access.
  *
  * <ul>
  *   <li>Owns the concrete persistent-request bundle and recovery adapters for FCP-backed state.

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupportTest.java
@@ -1,9 +1,15 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FcpDarknetPeerHandle;
 import network.crypta.clients.fcp.FcpPeerLookupResult;
+import network.crypta.clients.fcp.FcpPeerReferenceFetchException;
 import network.crypta.clients.fcp.FcpProbeError;
 import network.crypta.clients.fcp.FcpProbeListener;
 import network.crypta.clients.fcp.FcpProbeType;
@@ -12,17 +18,18 @@ import network.crypta.node.DarknetPeerNode;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.PeerNode;
-import network.crypta.node.RequestStarter;
 import network.crypta.node.probe.Error;
 import network.crypta.node.probe.Listener;
 import network.crypta.node.probe.Type;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.alerts.feed.UserAlertFeedSubscriber;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +47,6 @@ import static org.mockito.Mockito.when;
 class CoreFcpMessageRuntimeSupportTest {
 
   @Mock private NodeClientCore core;
-  @Mock private HighLevelSimpleClient client;
   @Mock private Node node;
   @Mock private NodeNetworkSubsystem network;
   @Mock private DarknetPeerNode darknetPeerNode;
@@ -71,16 +78,92 @@ class CoreFcpMessageRuntimeSupportTest {
   }
 
   @Test
-  void makeClient_whenCalled_delegatesToCore() {
-    when(core.makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true))
-        .thenReturn(client);
+  void readPeerReferenceFromUrl_whenCalled_delegatesToPeerReferenceTextLoader() throws Exception {
+    URL url = URI.create("https://example.invalid/peer.txt").toURL();
+    StringBuilder reference = referenceText("identity=peer-url\n");
     CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
 
-    HighLevelSimpleClient actual =
-        support.makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
+        org.mockito.Mockito.mockStatic(PeerReferenceTextLoader.class)) {
+      mockedLoader.when(() -> PeerReferenceTextLoader.readFromUrl(url)).thenReturn(reference);
 
-    assertSame(client, actual);
-    verify(core).makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+      StringBuilder actual = support.readPeerReferenceFromUrl(url);
+
+      assertSame(reference, actual);
+      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromUrl(url));
+    }
+  }
+
+  @Test
+  void readPeerReferenceFromCryptaUri_whenCalled_delegatesToCoreClientAndLoader() throws Exception {
+    FreenetURI uri = new FreenetURI("KSK@test");
+    StringBuilder reference = referenceText("identity=peer-uri\n");
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+
+    when(core.makeClient((short) 2, true, true)).thenReturn(client);
+    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
+        org.mockito.Mockito.mockStatic(PeerReferenceTextLoader.class)) {
+      mockedLoader
+          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client))
+          .thenReturn(reference);
+
+      StringBuilder actual = support.readPeerReferenceFromCryptaUri(uri, (short) 2, true, true);
+
+      assertSame(reference, actual);
+      verify(core).makeClient((short) 2, true, true);
+      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client));
+    }
+  }
+
+  @Test
+  void readPeerReferenceFromCryptaUri_whenFetchFails_wrapsFetchFailure() throws Exception {
+    FreenetURI uri = new FreenetURI("KSK@test");
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    FetchException fetchException = new FetchException(FetchExceptionMode.INTERNAL_ERROR);
+
+    when(core.makeClient((short) 2, true, true)).thenReturn(client);
+    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
+        org.mockito.Mockito.mockStatic(PeerReferenceTextLoader.class)) {
+      mockedLoader
+          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client))
+          .thenThrow(fetchException);
+
+      FcpPeerReferenceFetchException actual =
+          assertThrows(
+              FcpPeerReferenceFetchException.class,
+              () -> support.readPeerReferenceFromCryptaUri(uri, (short) 2, true, true));
+
+      assertSame(fetchException, actual.getCause());
+      verify(core).makeClient((short) 2, true, true);
+      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client));
+    }
+  }
+
+  @Test
+  void readPeerReferenceFromCryptaUri_whenReadFailsWithIo_propagatesIoException() throws Exception {
+    FreenetURI uri = new FreenetURI("KSK@test");
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    IOException ioException = new IOException("bucket read failed");
+
+    when(core.makeClient((short) 2, true, true)).thenReturn(client);
+    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
+        org.mockito.Mockito.mockStatic(PeerReferenceTextLoader.class)) {
+      mockedLoader
+          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client))
+          .thenThrow(ioException);
+
+      IOException actual =
+          assertThrows(
+              IOException.class,
+              () -> support.readPeerReferenceFromCryptaUri(uri, (short) 2, true, true));
+
+      assertSame(ioException, actual);
+      verify(core).makeClient((short) 2, true, true);
+      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client));
+    }
   }
 
   @Test
@@ -274,5 +357,9 @@ class CoreFcpMessageRuntimeSupportTest {
       case REJECT_STATS -> Type.REJECT_STATS;
       case OVERALL_BULK_OUTPUT_CAPACITY_USAGE -> Type.OVERALL_BULK_OUTPUT_CAPACITY_USAGE;
     };
+  }
+
+  private static StringBuilder referenceText(String text) {
+    return new StringBuilder().append(text);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/AddPeerTest.java
@@ -1,16 +1,12 @@
 package network.crypta.clients.fcp;
 
-import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
-import network.crypta.node.RequestStarter;
-import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.PeerAddFailureReason;
 import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
@@ -25,18 +21,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -135,38 +127,7 @@ class AddPeerTest {
   }
 
   @Test
-  void getReferenceFromURL_whenCalled_delegatesToPeerReferenceTextLoader() throws IOException {
-    URL url = mock(URL.class);
-    StringBuilder reference = mock(StringBuilder.class);
-
-    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
-        Mockito.mockStatic(PeerReferenceTextLoader.class)) {
-      mockedLoader.when(() -> PeerReferenceTextLoader.readFromUrl(url)).thenReturn(reference);
-
-      assertSame(reference, AddPeer.getReferenceFromURL(url));
-      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromUrl(url));
-    }
-  }
-
-  @Test
-  void getReferenceFromFreenetURI_whenCalled_delegatesToPeerReferenceTextLoader() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    FreenetURI uri = mock(FreenetURI.class);
-    StringBuilder reference = mock(StringBuilder.class);
-
-    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
-        Mockito.mockStatic(PeerReferenceTextLoader.class)) {
-      mockedLoader
-          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client))
-          .thenReturn(reference);
-
-      assertSame(reference, AddPeer.getReferenceFromFreenetURI(uri, client));
-      mockedLoader.verify(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, client));
-    }
-  }
-
-  @Test
-  void run_whenUrlUsesCryptaUri_usesMessageRuntimeSupportClient() throws Exception {
+  void run_whenUrlUsesCryptaUri_usesMessageRuntimeSupportLoadingSeam() throws Exception {
     SimpleFieldSet fs = minimalValidFieldSet();
     fs.putSingle("URL", "KSK@keyword");
     AddPeer addPeer = new AddPeer(fs);
@@ -179,29 +140,50 @@ class AddPeerTest {
     when(runtimePorts.peer()).thenReturn(peerPort);
     when(peerPort.add(any(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES))).thenReturn(snapshot);
 
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    StringBuilder reference = new StringBuilder();
+    reference.append("identity=peer-url\n");
+    when(messageRuntimeSupport.readPeerReferenceFromCryptaUri(
+            any(FreenetURI.class), eq(FcpPriorityClasses.IMMEDIATE_SPLITFILE), eq(true), eq(true)))
+        .thenReturn(reference);
 
-    try (MockedStatic<PeerReferenceTextLoader> mockedLoader =
-        Mockito.mockStatic(PeerReferenceTextLoader.class)) {
-      StringBuilder reference = new StringBuilder();
-      reference.append("identity=peer-url\n");
-      mockedLoader
-          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(any(FreenetURI.class), eq(client)))
-          .thenReturn(reference);
-      when(messageRuntimeSupport.makeClient(
-              RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true))
-          .thenReturn(client);
-
-      addPeer.run(handler);
-    }
+    addPeer.run(handler);
 
     verify(messageRuntimeSupport)
-        .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
+        .readPeerReferenceFromCryptaUri(
+            any(FreenetURI.class), eq(FcpPriorityClasses.IMMEDIATE_SPLITFILE), eq(true), eq(true));
     verify(peerPort).add(any(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
   }
 
   @Test
-  void run_whenUrlUsesStandardUrl_readsReferenceWithoutMessageRuntimeSupport(@TempDir Path tempDir)
+  void run_whenCryptaUriFetchFails_fallsBackToUrlLoading() throws Exception {
+    String urlString = "https://host.example/freenet:KSK@keyword";
+    AddPeer addPeer = new AddPeer(addReferenceFields(urlString));
+    PeerSnapshot snapshot = peerSnapshot("peer-fallback");
+    stubPeerPort();
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(handler.getServer()).thenReturn(server);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
+    when(server.runtime()).thenReturn(runtimePorts);
+    when(runtimePorts.peer()).thenReturn(peerPort);
+    when(peerPort.add(any(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES))).thenReturn(snapshot);
+    when(messageRuntimeSupport.readPeerReferenceFromCryptaUri(
+            any(FreenetURI.class), eq(FcpPriorityClasses.IMMEDIATE_SPLITFILE), eq(true), eq(true)))
+        .thenThrow(new FcpPeerReferenceFetchException("fetch failed", new java.io.IOException()));
+    StringBuilder reference = new StringBuilder();
+    reference.append("identity=peer-fallback\n");
+    when(messageRuntimeSupport.readPeerReferenceFromUrl(any(URL.class))).thenReturn(reference);
+
+    addPeer.run(handler);
+
+    verify(messageRuntimeSupport)
+        .readPeerReferenceFromCryptaUri(
+            any(FreenetURI.class), eq(FcpPriorityClasses.IMMEDIATE_SPLITFILE), eq(true), eq(true));
+    verify(messageRuntimeSupport).readPeerReferenceFromUrl(any(URL.class));
+    verify(peerPort).add(any(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
+  }
+
+  @Test
+  void run_whenUrlUsesStandardUrl_readsReferenceThroughMessageRuntimeSupport(@TempDir Path tempDir)
       throws Exception {
     Path file = tempDir.resolve("peer-ref.txt");
     Files.writeString(file, "identity=peer-file\n", StandardCharsets.UTF_8);
@@ -212,15 +194,42 @@ class AddPeerTest {
     PeerSnapshot snapshot = peerSnapshot("peer-file");
     stubPeerPort();
     when(handler.hasFullAccess()).thenReturn(true);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
     when(peerPort.add(any(PeerFieldSet.class), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES)))
         .thenReturn(snapshot);
+    URL url = file.toUri().toURL();
+    StringBuilder reference = new StringBuilder();
+    reference.append("identity=peer-file\n");
+    when(messageRuntimeSupport.readPeerReferenceFromUrl(url)).thenReturn(reference);
 
     addPeer.run(handler);
 
     ArgumentCaptor<PeerFieldSet> referenceCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
     verify(peerPort).add(referenceCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
     assertEquals("peer-file", referenceCaptor.getValue().directValues().get("identity"));
-    verifyNoInteractions(messageRuntimeSupport);
+    verify(messageRuntimeSupport).readPeerReferenceFromUrl(url);
+  }
+
+  @Test
+  void run_whenCryptaUriReadFailsWithIo_mapsUrlParseErrorWithoutUrlFallback() throws Exception {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.putSingle("URL", "KSK@keyword");
+    AddPeer addPeer = new AddPeer(fs);
+    when(handler.hasFullAccess()).thenReturn(true);
+    when(handler.getServer()).thenReturn(server);
+    when(server.messageRuntimeSupport()).thenReturn(messageRuntimeSupport);
+    when(messageRuntimeSupport.readPeerReferenceFromCryptaUri(
+            any(FreenetURI.class), eq(FcpPriorityClasses.IMMEDIATE_SPLITFILE), eq(true), eq(true)))
+        .thenThrow(new java.io.IOException("bucket read failed"));
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> addPeer.run(handler));
+
+    assertEquals(ProtocolErrorMessage.URL_PARSE_ERROR, exception.protocolCode);
+    verify(messageRuntimeSupport)
+        .readPeerReferenceFromCryptaUri(
+            any(FreenetURI.class), eq(FcpPriorityClasses.IMMEDIATE_SPLITFILE), eq(true), eq(true));
+    verifyNoInteractions(runtimePorts, peerPort, node);
   }
 
   @Test
@@ -346,6 +355,12 @@ class AddPeerTest {
     when(handler.getServer()).thenReturn(server);
     when(server.runtime()).thenReturn(runtimePorts);
     when(runtimePorts.peer()).thenReturn(peerPort);
+  }
+
+  private SimpleFieldSet addReferenceFields(String url) {
+    SimpleFieldSet fs = minimalValidFieldSet();
+    fs.putSingle("URL", url);
+    return fs;
   }
 
   private SimpleFieldSet minimalValidFieldSet() {

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
@@ -11,7 +10,6 @@ import network.crypta.clients.fcp.bridge.CoreFcpServerDependenciesFactory;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
-import network.crypta.node.RequestStarter;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -44,7 +42,6 @@ class FCPServerTest {
   @Mock private TempBucketFactory tempBucketFactory;
   @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
   @Mock private RandomSource randomSource;
-  @Mock private HighLevelSimpleClient highLevelSimpleClient;
 
   private FCPServer newServer(boolean assumeDownloadAllowed, boolean assumeUploadAllowed) {
     FcpServerConfig config =
@@ -214,21 +211,6 @@ class FCPServerTest {
 
     assertNotNull(first);
     assertSame(first, second);
-  }
-
-  @Test
-  void messageRuntimeSupport_whenMakeClientInvoked_delegatesToCore() {
-    when(core.makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true))
-        .thenReturn(highLevelSimpleClient);
-    FCPServer server = newServer(false, false);
-
-    HighLevelSimpleClient actual =
-        server
-            .messageRuntimeSupport()
-            .makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
-
-    assertSame(highLevelSimpleClient, actual);
-    verify(core).makeClient(RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS, true, true);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- remove the raw `makeClient(...)` leak from `FcpMessageRuntimeSupport` and replace it with AddPeer-specific peer-reference loading methods
- keep `NodeClientCore.makeClient(...)` and `PeerReferenceTextLoader` usage inside `CoreFcpMessageRuntimeSupport`, using `FcpPeerReferenceFetchException` to preserve the existing AddPeer fallback behavior
- update the focused FCP boundary, bridge, and message tests, including direct coverage for the fetch-failure versus post-fetch-IO split

## How to test

- `./gradlew spotlessApply`
- `./gradlew :adapter-fcp:test --tests "network.crypta.clients.fcp.AdapterFcpBoundaryTest"`
- `./gradlew :bridge-fcp-runtime:test --tests "network.crypta.clients.fcp.bridge.CoreFcpMessageRuntimeSupportTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.AddPeerTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.FCPServerTest"`
- `./gradlew test`