### PR TITLE
refactor(http): Detach legacy connections toadlets

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -1,13 +1,9 @@
 package network.crypta.clients.http;
 
 import java.io.IOException;
-import java.io.Serial;
-import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,12 +14,6 @@ import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.ConfigException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
-import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.PeerNodeStatus;
-import network.crypta.node.Version;
-import network.crypta.runtime.peers.html.PeerTrustInputForAddPeerBoxNode;
-import network.crypta.runtime.peers.html.PeerVisibilityInputForAddPeerBoxNode;
 import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
@@ -54,16 +44,16 @@ import org.slf4j.LoggerFactory;
 /**
  * Base HTTP toadlet used by both darknet and opennet connection pages.
  *
- * <p>This class renders peer connection state, accepts noderef submissions, and provides helpers
- * for subclasses that tailor per-network presentation. It centralizes sorting, pagination,
- * validation, and noderef ingestion so downstream pages can focus on the specifics of each
- * topology. Instances are long-lived and reused across requests; state comes from the injected
+ * <p>This class accepts noderef submissions, wraps detached page snapshots in the legacy HTTP
+ * response shell, and provides helpers for subclasses that tailor per-network presentation. It
+ * centralizes validation and noderef ingestion so downstream pages can focus on the specifics of
+ * each topology. Instances are long-lived and reused across requests; state comes from the injected
  * runtime ports rather than per-request mutability.
  *
  * <p>Responsibilities include:
  *
  * <ul>
- *   <li>Rendering peer summaries, trust/visibility columns, and message-type breakdowns.
+ *   <li>Embedding detached peer-table snapshots into the legacy HTTP response shell.
  *   <li>Parsing noderefs from form uploads, pasted text, or URLs, then delegating to the runtime
  *       SPI for peer creation.
  *   <li>Handling redirects and guidance when no peers exist or when access checks fail.
@@ -87,168 +77,10 @@ public abstract class ConnectionsToadlet extends Toadlet {
   private static final String DISPLAY_MESSAGE_TYPES = "displaymessagetypes.html";
   private static final String ELEMENT_INPUT = "input";
   private static final String TRUST = "trust";
+  private static final String VISIBILITY = "visibility";
   private static final String REF_FILE = "reffile";
   private static final String PEER_PRIVATE_NOTE = "peerPrivateNote";
   private static final String REPORT_OF_NODE_ADDITION = "reportOfNodeAddition";
-
-  /**
-   * Comparator that orders {@link PeerNodeStatus} instances for table rendering.
-   *
-   * <p>Sorting honors a user-selected column when present and otherwise falls back to status code
-   * and peer hash for deterministic ordering. The {@code reversed} flag inverts the final result so
-   * callers can reuse one comparator for ascending and descending views without allocating extra
-   * helpers.
-   */
-  protected static class ComparatorByStatus implements Comparator<PeerNodeStatus>, Serializable {
-    @Serial private static final long serialVersionUID = 1L;
-
-    /** Column key requested by the client, may be {@code null} for default ordering. */
-    protected final String sortBy;
-
-    /** Whether the comparator should invert its result for the descending presentation. */
-    protected final boolean reversed;
-
-    /**
-     * Creates a comparator configured for a column and direction.
-     *
-     * @param sortBy column key requested by the HTTP client; may be {@code null} to use defaults.
-     * @param reversed whether the ordering should be inverted for descending presentation.
-     */
-    ComparatorByStatus(String sortBy, boolean reversed) {
-      this.sortBy = sortBy;
-      this.reversed = reversed;
-    }
-
-    /**
-     * Orders two peer rows using configured sort behavior.
-     *
-     * @param firstNode the first peer candidate; never mutated by this comparator.
-     * @param secondNode the second peer candidate; never mutated by this comparator.
-     * @return negative when the first precedes the second, positive when after, or zero when ties.
-     */
-    @Override
-    public int compare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      int result = compareWithSort(firstNode, secondNode);
-      if (result == 0) {
-        result = compareByStatus(firstNode, secondNode);
-      }
-      return reversed ? -Integer.signum(result) : Integer.signum(result);
-    }
-
-    private int compareByStatus(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      int statusDifference =
-          Integer.compare(firstNode.getStatusValue(), secondNode.getStatusValue());
-      if (statusDifference != 0) {
-        return statusDifference;
-      }
-      return lastResortCompare(firstNode, secondNode);
-    }
-
-    private int compareWithSort(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      if (sortBy == null) {
-        return 0;
-      }
-      return customCompare(firstNode, secondNode);
-    }
-
-    // xor: check why we do not just return the result of (long1-long2)
-    // j16sdiz: (Long.MAX_VALUE - (-1)) would overflow and become negative
-    private int compareLongs(long long1, long long2) {
-      int diff = Long.compare(long1, long2);
-      if (diff == 0) return 0;
-      else return (diff > 0 ? 1 : -1);
-    }
-
-    private int compareInts(int int1, int int2) {
-      int diff = Integer.compare(int1, int2);
-      if (diff == 0) return 0;
-      else return (diff > 0 ? 1 : -1);
-    }
-
-    /**
-     * Applies column-specific ordering chosen by the requester.
-     *
-     * <p>Each branch matches a sortable column and compares the corresponding values using
-     * type-appropriate ordering. When the column key is unrecognised the method returns {@code 0}
-     * so callers can rely on default or tie-breaker ordering.
-     *
-     * @param firstNode first peer candidate considered in the comparison.
-     * @param secondNode second peer candidate considered in the comparison.
-     * @return a negative number when the first node should precede the second, positive when it
-     *     should follow, or zero when the column is not supported.
-     */
-    protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      return switch (sortBy) {
-        case "address" ->
-            firstNode.getPeerAddress().compareToIgnoreCase(secondNode.getPeerAddress());
-        case "location" -> compareLocations(firstNode, secondNode);
-        case "version" ->
-            Version.compareBuildNumbers(
-                Version.parseNodeNameFromVersionStr(firstNode.getVersion()),
-                Version.parseBuildNumberFromVersionStr(firstNode.getVersion(), -1),
-                Version.parseNodeNameFromVersionStr(secondNode.getVersion()),
-                Version.parseBuildNumberFromVersionStr(secondNode.getVersion(), -1));
-        case "backoffRT" ->
-            Double.compare(
-                firstNode.getBackedOffPercent(true), secondNode.getBackedOffPercent(true));
-        case "backoffBulk" ->
-            Double.compare(
-                firstNode.getBackedOffPercent(false), secondNode.getBackedOffPercent(false));
-        case "overload_p" -> Double.compare(firstNode.getPReject(), secondNode.getPReject());
-        case "idle" ->
-            compareLongs(
-                firstNode.getTimeLastConnectionCompleted(),
-                secondNode.getTimeLastConnectionCompleted());
-        case "time_routable" ->
-            Double.compare(
-                firstNode.getPercentTimeRoutableConnection(),
-                secondNode.getPercentTimeRoutableConnection());
-        case "total_traffic" -> {
-          long total1 = firstNode.getTotalInputBytes() + firstNode.getTotalOutputBytes();
-          long total2 = secondNode.getTotalInputBytes() + secondNode.getTotalOutputBytes();
-          yield compareLongs(total1, total2);
-        }
-        case "total_traffic_since_startup" -> {
-          long total1 =
-              firstNode.getTotalInputSinceStartup() + firstNode.getTotalOutputSinceStartup();
-          long total2 =
-              secondNode.getTotalInputSinceStartup() + secondNode.getTotalOutputSinceStartup();
-          yield compareLongs(total1, total2);
-        }
-        case "selection_percentage" ->
-            Double.compare(firstNode.getSelectionRate(), secondNode.getSelectionRate());
-        case "time_delta" -> compareLongs(firstNode.getClockDelta(), secondNode.getClockDelta());
-        case "uptime" ->
-            compareInts(
-                firstNode.getReportedUptimePercentage(), secondNode.getReportedUptimePercentage());
-        default -> 0;
-      };
-    }
-
-    private int compareLocations(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      double diff =
-          firstNode.getLocation()
-              - secondNode
-                  .getLocation(); // Can occasionally be the same, and we must have a consistent
-      // sort order
-      if (Double.MIN_VALUE * 2 > Math.abs(diff)) return 0;
-      return diff > 0 ? 1 : -1;
-    }
-
-    /**
-     * Provides deterministic ordering after higher-priority comparisons tie.
-     *
-     * <p>This implementation compares the peer locations to ensure stable presentation across
-     * renders. Subclasses can override by altering location calculation in {@link PeerNodeStatus}.
-     *
-     * @param firstNode first peer candidate to order.
-     * @param secondNode second peer candidate to order.
-     * @return negative when the first node is earlier, positive when later, zero when equal.
-     */
-    protected int lastResortCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      return compareLocations(firstNode, secondNode);
-    }
-  }
 
   /** Page-oriented runtime port used for detached GET-only connections page rendering. */
   private final ConnectionsPagePort connectionsPage;
@@ -312,10 +144,10 @@ public abstract class ConnectionsToadlet extends Toadlet {
    * Renders the Connections page and optional message-type breakdowns.
    *
    * <p>The handler validates access, resolves download endpoints for the current node reference,
-   * builds sorted peer tables, and writes the resulting HTML response. When no peers exist, it
-   * still renders guidance and, depending on mode, may redirect to friend-adding flows. Download
-   * requests for {@code myref.fref} or {@code myref.txt} are served directly with appropriate
-   * headers.
+   * delegates peer-table sorting and rendering to the detached runtime page port, and writes the
+   * resulting HTML response. When no peers exist, it still renders guidance and, depending on mode,
+   * may redirect to friend-adding flows. Download requests for {@code myref.fref} or {@code
+   * myref.txt} are served directly with appropriate headers.
    *
    * @param uri request target URI, used to detect message-type view and download paths.
    * @param request HTTP request wrapper supplying parameters such as {@code sortBy} and {@code
@@ -402,8 +234,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
       String urltext,
       String reftext,
       String privateComment,
-      FRIEND_TRUST trust,
-      FRIEND_VISIBILITY visibility) {}
+      PeerTrust trust,
+      PeerVisibility visibility) {}
 
   /**
    * Indicates whether noderef POST submissions are accepted for this toadlet.
@@ -493,8 +325,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
       configPort.applyOverrides(Map.of("node.peersOffersDismissed", "true"));
     }
 
-    FRIEND_TRUST trust = parseTrust(request);
-    FRIEND_VISIBILITY visibility = parseVisibility(request);
+    PeerTrust trust = parseTrust(request);
+    PeerVisibility visibility = parseVisibility(request);
 
     return new AddPeerRequestData(urltext, reftext, privateComment, trust, visibility);
   }
@@ -503,20 +335,20 @@ public abstract class ConnectionsToadlet extends Toadlet {
     return connectionsSupportPort.readPeerOfferReferencesText();
   }
 
-  private FRIEND_TRUST parseTrust(HTTPRequest request) {
+  private PeerTrust parseTrust(HTTPRequest request) {
     String trustS = request.getPartAsStringFailsafe(TRUST, 10);
     if (trustS == null || trustS.isEmpty()) {
       return null;
     }
-    return FRIEND_TRUST.valueOf(trustS);
+    return PeerTrust.valueOf(trustS);
   }
 
-  private FRIEND_VISIBILITY parseVisibility(HTTPRequest request) {
-    String visibilityS = request.getPartAsStringFailsafe("visibility", 10);
+  private PeerVisibility parseVisibility(HTTPRequest request) {
+    String visibilityS = request.getPartAsStringFailsafe(VISIBILITY, 10);
     if (visibilityS == null || visibilityS.isEmpty()) {
       return null;
     }
-    return FRIEND_VISIBILITY.valueOf(visibilityS);
+    return PeerVisibility.valueOf(visibilityS);
   }
 
   private boolean validateTrustAndVisibility(ToadletContext ctx, AddPeerRequestData data)
@@ -689,10 +521,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
   }
 
   private PeerAdditionReturnCodes addNewNode(
-      String nodeReference,
-      String privateComment,
-      FRIEND_TRUST trust,
-      FRIEND_VISIBILITY visibility) {
+      String nodeReference, String privateComment, PeerTrust trust, PeerVisibility visibility) {
     SimpleFieldSet fs;
 
     try {
@@ -719,8 +548,10 @@ public abstract class ConnectionsToadlet extends Toadlet {
     }
 
     try {
+      PeerTrust effectiveTrust = trust == null ? PeerTrust.NORMAL : trust;
+      PeerVisibility effectiveVisibility = visibility == null ? PeerVisibility.YES : visibility;
       PeerSnapshot addedPeer =
-          peerPort.add(toPeerFieldSet(fs), toPeerTrust(trust), toPeerVisibility(visibility));
+          peerPort.add(toPeerFieldSet(fs), effectiveTrust, effectiveVisibility);
       maybeWritePrivateDarknetComment(addedPeer, privateComment);
       return PeerAdditionReturnCodes.OK;
     } catch (PeerAddRejectedException e) {
@@ -945,8 +776,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
         new String[] {REF_FILE, "file", REF_FILE});
     peerAdditionForm.addChild("br");
     if (!isOpennet) {
-      peerAdditionForm.addChild(new PeerTrustInputForAddPeerBoxNode());
-      peerAdditionForm.addChild(new PeerVisibilityInputForAddPeerBoxNode());
+      DarknetPeerFormOptions.addAddPeerInputs(peerAdditionForm);
     }
 
     if (!isOpennet) {
@@ -961,17 +791,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
         ELEMENT_INPUT,
         new String[] {"type", "name", "value"},
         new String[] {"submit", "add", l10n("add")});
-  }
-
-  /**
-   * Creates a comparator for peer listings using the requested column and direction.
-   *
-   * @param sortBy column key requested via HTTP parameter; may be {@code null} for default order.
-   * @param reversed whether the comparator should invert the natural ordering to sort descending.
-   * @return comparator suitable for {@link Arrays#sort(Object[])} on peer status arrays.
-   */
-  protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
-    return new ComparatorByStatus(sortBy, reversed);
   }
 
   /**
@@ -1014,28 +833,6 @@ public abstract class ConnectionsToadlet extends Toadlet {
 
   private boolean matchesExpectedPeerType(SimpleFieldSet fieldSet) {
     return fieldSet.getBoolean(OPENNET, false) == isOpennet();
-  }
-
-  private static PeerTrust toPeerTrust(FRIEND_TRUST trust) {
-    if (trust == null) {
-      return PeerTrust.NORMAL;
-    }
-    return switch (trust) {
-      case LOW -> PeerTrust.LOW;
-      case NORMAL -> PeerTrust.NORMAL;
-      case HIGH -> PeerTrust.HIGH;
-    };
-  }
-
-  private static PeerVisibility toPeerVisibility(FRIEND_VISIBILITY visibility) {
-    if (visibility == null) {
-      return PeerVisibility.YES;
-    }
-    return switch (visibility) {
-      case YES -> PeerVisibility.YES;
-      case NAME_ONLY -> PeerVisibility.NAME_ONLY;
-      case NO -> PeerVisibility.NO;
-    };
   }
 
   private static PeerAdditionReturnCodes mapPeerAddFailure(PeerAddFailureReason reason) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -2,16 +2,11 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
-import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.DarknetPeerNodeStatus;
-import network.crypta.node.PeerNodeStatus;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
@@ -135,87 +130,12 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   /**
-   * Comparator that extends the base status ordering with darknet-specific columns.
-   *
-   * <p>The comparator first honors the configured sort key and reversal flag inherited from {@link
-   * ComparatorByStatus}. When the caller requests name, private note, trust, or visibility
-   * ordering, this comparator extracts the corresponding values from {@link DarknetPeerNodeStatus}
-   * instances, falling back to the parent comparison rules for other columns. Ties on visibility
-   * resolve by comparing both local and remote visibility preferences to provide deterministic
-   * ordering. Instances are short-lived and created per request to avoid storing mutable sorting
-   * preferences globally.
-   */
-  protected static class DarknetComparator extends ComparatorByStatus {
-
-    DarknetComparator(String sortBy, boolean reversed) {
-      super(sortBy, reversed);
-    }
-
-    @Override
-    protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      return switch (this.sortBy) {
-        case "name" ->
-            ((DarknetPeerNodeStatus) firstNode)
-                .getName()
-                .compareToIgnoreCase(((DarknetPeerNodeStatus) secondNode).getName());
-        case "privnote" ->
-            ((DarknetPeerNodeStatus) firstNode)
-                .getPrivateDarknetCommentNote()
-                .compareToIgnoreCase(
-                    ((DarknetPeerNodeStatus) secondNode).getPrivateDarknetCommentNote());
-        case "trust" ->
-            ((DarknetPeerNodeStatus) firstNode)
-                .getTrustLevel()
-                .compareTo(((DarknetPeerNodeStatus) secondNode).getTrustLevel());
-        case "visibility" -> {
-          int ret =
-              ((DarknetPeerNodeStatus) firstNode)
-                  .getOurVisibility()
-                  .compareTo(((DarknetPeerNodeStatus) secondNode).getOurVisibility());
-          if (ret != 0) yield ret;
-          yield ((DarknetPeerNodeStatus) firstNode)
-              .getTheirVisibility()
-              .compareTo(((DarknetPeerNodeStatus) secondNode).getTheirVisibility());
-        }
-        default -> super.customCompare(firstNode, secondNode);
-      };
-    }
-
-    /** Default comparison, after taking into account status. */
-    @Override
-    protected int lastResortCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      return ((DarknetPeerNodeStatus) firstNode)
-          .getName()
-          .compareToIgnoreCase(((DarknetPeerNodeStatus) secondNode).getName());
-    }
-  }
-
-  /**
-   * Build a comparator that orders darknet peers according to the chosen column.
-   *
-   * <p>The comparator encapsulates the caller's sorting preference instead of mutating shared
-   * state, ensuring concurrent page renders cannot influence each other's ordering. Supported sort
-   * keys include the generic status columns provided by the parent and darknet-specific fields such
-   * as private notes, trust, and visibility. The {@code reversed} flag flips the natural ordering
-   * so both ascending and descending views are available without recomputing the source data.
-   *
-   * @param sortBy column identifier accepted by {@link DarknetComparator}, including name,
-   *     privnote, trust, visibility, or the inherited defaults.
-   * @param reversed whether to invert the comparator to produce descending order results.
-   * @return a stateless comparator instance tuned to the requested ordering.
-   */
-  @Override
-  protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
-    return new DarknetComparator(sortBy, reversed);
-  }
-
-  /**
    * Select the local node's public darknet reference view for distribution.
    *
    * <p>The shared base class uses this selector to export a detached noderef snapshot through the
    * runtime SPI before rendering the noderef box or serving `myref.*` downloads.
    *
-   * @return public darknet noderef view used by the connections page.
+   * @return public darknet noderef view used by the Connections page.
    */
   @Override
   protected NodeReferenceView noderefView() {
@@ -228,10 +148,10 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * <p>The box is useful for power users distributing their own references but can overwhelm new
    * users. By tying visibility to the advanced mode flag, the method keeps the standard workflow
    * simple while still giving experienced operators quick access to their public noderef without
-   * navigating away from the friends page.
+   * navigating away from the Friends page.
    *
    * @param advancedModeEnabled whether the user interface is currently in advanced mode.
-   * @return {@code true} when the noderef box should be rendered alongside the friends table.
+   * @return {@code true} when the noderef box should be rendered alongside the Friends table.
    */
   @Override
   protected boolean shouldDrawNoderefBox(boolean advancedModeEnabled) {
@@ -243,10 +163,10 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * Indicate that the bulk peer actions form must always be visible.
    *
    * <p>Even in simplified mode, operators benefit from quick access to note updates and removals,
-   * so the actions box is never hidden. The contained controls gate advanced operations internally
+   * so the Actions box is never hidden. The contained controls gate advanced operations internally
    * rather than being removed from the DOM.
    *
-   * @return {@code true}, signaling callers to render the actions box unconditionally.
+   * @return {@code true}, signaling callers to render the Actions box unconditionally.
    */
   @Override
   protected boolean showPeerActionsBox() {
@@ -254,7 +174,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   /**
-   * Append the select box and buttons that drive bulk peer operations for the friends list.
+   * Append the select box and buttons that drive bulk peer operations for the Friends list.
    *
    * <p>The method constructs a form section containing send-message, note-update, trust,
    * visibility, and removal actions. When advanced mode is active, additional toggles expose
@@ -320,10 +240,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     HTMLNode changeTrustLevelSelect =
         peerForm.addChild(
             ELEMENT_SELECT, new String[] {"id", "name"}, new String[] {CHANGE_TRUST, CHANGE_TRUST});
-    for (FRIEND_TRUST trust : FRIEND_TRUST.valuesBackwards()) {
-      changeTrustLevelSelect.addChild(
-          ELEMENT_OPTION, ATTR_VALUE, trust.name(), l10n("peerTrust." + trust.name()));
-    }
+    DarknetPeerFormOptions.addTrustOptions(changeTrustLevelSelect);
     peerForm.addChild("br");
     peerForm.addChild(
         ELEMENT_INPUT,
@@ -334,10 +251,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
             ELEMENT_SELECT,
             new String[] {"id", "name"},
             new String[] {CHANGE_VISIBILITY, CHANGE_VISIBILITY});
-    for (FRIEND_VISIBILITY trust : FRIEND_VISIBILITY.values()) {
-      changeVisibilitySelect.addChild(
-          ELEMENT_OPTION, ATTR_VALUE, trust.name(), l10n("peerVisibility." + trust.name()));
-    }
+    DarknetPeerFormOptions.addVisibilityOptions(changeVisibilitySelect);
   }
 
   /**
@@ -346,7 +260,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * <p>Returning {@code true} allows the base class to accept reference submissions alongside the
    * other actions handled here, enabling a single endpoint to cover both add-friend and bulk
    * maintenance flows. This keeps user bookmarks stable and ensures any CSRF protections or
-   * authentication checks configured on the friends endpoint automatically apply to noderef
+   * authentication checks configured on the Friends endpoint automatically apply to noderef
    * submissions as well.
    *
    * @return {@code true}, enabling noderef POST handling by the superclass.
@@ -361,7 +275,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    *
    * <p>Using a single canonical location ensures browsers follow a standard post-redirect-get
    * cycle, preventing form resubmission warnings and keeping the navigation consistent with the
-   * friends table URL. It also centralizes cache headers and content negotiation on one endpoint,
+   * Friends table URL. It also centralizes cache headers and content negotiation on one endpoint,
    * simplifying upstream proxy configuration and logging.
    *
    * @return canonical friends path used for redirect responses.
@@ -482,20 +396,17 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   private void handleChangeVisibility(HTTPRequest request) {
-    FRIEND_VISIBILITY visibility =
-        FRIEND_VISIBILITY.valueOf(request.getPartAsStringFailsafe(CHANGE_VISIBILITY, 10));
+    PeerVisibility visibility =
+        PeerVisibility.valueOf(request.getPartAsStringFailsafe(CHANGE_VISIBILITY, 10));
     applyUpdateToSelectedPeers(
         request,
-        new DarknetPeerSettingsUpdate(
-            null, null, null, null, null, null, null, toPeerVisibility(visibility)));
+        new DarknetPeerSettingsUpdate(null, null, null, null, null, null, null, visibility));
   }
 
   private void handleChangeTrust(HTTPRequest request) {
-    FRIEND_TRUST trust = FRIEND_TRUST.valueOf(request.getPartAsStringFailsafe(CHANGE_TRUST, 10));
+    PeerTrust trust = PeerTrust.valueOf(request.getPartAsStringFailsafe(CHANGE_TRUST, 10));
     applyUpdateToSelectedPeers(
-        request,
-        new DarknetPeerSettingsUpdate(
-            null, null, null, null, null, null, toPeerTrust(trust), null));
+        request, new DarknetPeerSettingsUpdate(null, null, null, null, null, null, trust, null));
   }
 
   private boolean handleDoAction(String action, HTTPRequest request, ToadletContext ctx)
@@ -664,7 +575,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
    * Identify the scope of this toadlet as darknet-only rather than opennet.
    *
    * <p>The return value informs the parent class which set of peers to query and which UI labels to
-   * present. Returning {@code false} ensures opennet-specific options never appear on the friends
+   * present. Returning {@code false} ensures opennet-specific options never appear on the Friends
    * page.
    *
    * @return {@code false} because opennet peers are not handled here.
@@ -690,7 +601,7 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   }
 
   /**
-   * Render the friends page or serve a peer noderef download when requested.
+   * Render the Friends page or serve a peer noderef download when requested.
    *
    * <p>The method first checks whether the URI targets a specific friend reference ending in {@code
    * .fref}; if so, it streams the sanitized reference as an attachment. Otherwise, it defers to the
@@ -784,13 +695,5 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
       target.tput(entry.getKey(), toSimpleFieldSet(entry.getValue()));
     }
     return target;
-  }
-
-  private static PeerTrust toPeerTrust(FRIEND_TRUST trust) {
-    return PeerTrust.valueOf(trust.name());
-  }
-
-  private static PeerVisibility toPeerVisibility(FRIEND_VISIBILITY visibility) {
-    return PeerVisibility.valueOf(visibility.name());
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetPeerFormOptions.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetPeerFormOptions.java
@@ -1,0 +1,170 @@
+package network.crypta.clients.http;
+
+import java.util.function.Consumer;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
+import network.crypta.support.HTMLNode;
+
+/**
+ * Renders detached trust and visibility controls for legacy darknet peer forms.
+ *
+ * <p>This helper keeps the HTTP adapter's peer form markup local after the legacy add-peer input
+ * nodes were removed from the runtime layer. It owns only the small HTML fragments that the adapter
+ * still needs for the Friends page: the radio groups shown when adding a darknet peer and the
+ * {@code <select>} options used by the bulk trust and visibility actions. The helper preserves the
+ * legacy field names, enum ordering, default selections, and L10n keys so existing form POSTs and
+ * translations continue to work without adapter code reaching back into runtime-owned HTML helpers.
+ *
+ * <p>The class is intentionally stateless. Callers provide the destination {@link HTMLNode}, and
+ * this helper appends deterministic child nodes derived from {@link PeerTrust} and {@link
+ * PeerVisibility}. Trust values render in reverse enum order to match the historic UI, while
+ * visibility values render in declaration order.
+ */
+final class DarknetPeerFormOptions {
+  /** Shared form-field name for add-peer trust controls. */
+  private static final String TRUST = "trust";
+
+  /** Shared form-field name for add-peer visibility controls. */
+  private static final String VISIBILITY = "visibility";
+
+  /** Attribute name used for {@code <option>} and radio-input values. */
+  private static final String ATTR_VALUE = "value";
+
+  /** Boolean HTML attribute used to mark the legacy default choice as selected. */
+  private static final String ATTR_CHECKED = "checked";
+
+  /** Prevents instantiation because the helper exposes only static rendering methods. */
+  private DarknetPeerFormOptions() {}
+
+  /**
+   * Appends the add-peer trust and visibility radio groups to a darknet peer form.
+   *
+   * <p>The added controls keep the legacy {@code trust} and {@code visibility} field names so the
+   * existing POST parser can continue to map submitted values directly to {@link PeerTrust} and
+   * {@link PeerVisibility}. The rendered defaults remain {@link PeerTrust#NORMAL} for trust and
+   * {@link PeerVisibility#YES} for visibility.
+   *
+   * @param parent the form node that should receive the add-peer radio-group fragments
+   */
+  static void addAddPeerInputs(HTMLNode parent) {
+    parent.addChild(createTrustInputs());
+    parent.addChild(createVisibilityInputs());
+  }
+
+  /**
+   * Appends trust {@code <option>} nodes in the legacy Friends-page display order.
+   *
+   * <p>Darknet bulk trust updates historically present higher trust levels first, so this method
+   * iterates the enum values in reverse declaration order before adding the localized option
+   * labels.
+   *
+   * @param selectNode the select element that should receive the trust options
+   */
+  static void addTrustOptions(HTMLNode selectNode) {
+    forEachTrustInDisplayOrder(
+        trust ->
+            selectNode.addChild(
+                "option", ATTR_VALUE, trust.name(), l10n("peerTrust." + trust.name())));
+  }
+
+  /**
+   * Appends visibility {@code <option>} nodes in declaration order.
+   *
+   * <p>The visibility bulk-action control follows the enum declaration order so the rendered
+   * choices stay aligned with the longstanding Friends-page wording and submitted values.
+   *
+   * @param selectNode the select element that should receive the visibility options
+   */
+  static void addVisibilityOptions(HTMLNode selectNode) {
+    for (PeerVisibility visibility : PeerVisibility.values()) {
+      selectNode.addChild(
+          "option", ATTR_VALUE, visibility.name(), l10n("peerVisibility." + visibility.name()));
+    }
+  }
+
+  /**
+   * Builds the trust radio-group fragment used by the add-peer form.
+   *
+   * @return detached node containing the localized trust title, introduction, and radio inputs
+   */
+  private static HTMLNode createTrustInputs() {
+    HTMLNode node = new HTMLNode("div");
+    node.addChild("b", l10n("peerTrustTitle"));
+    node.addChild("#", " ");
+    node.addChild("#", l10n("peerTrustIntroduction"));
+    forEachTrustInDisplayOrder(
+        trust -> {
+          HTMLNode input =
+              node.addChild("br")
+                  .addChild(
+                      "input",
+                      new String[] {"type", "name", ATTR_VALUE, "id"},
+                      new String[] {"radio", TRUST, trust.name(), TRUST + trust.name()});
+          if (trust == PeerTrust.NORMAL) {
+            input.addAttribute(ATTR_CHECKED, ATTR_CHECKED);
+          }
+          input
+              .addChild("label", new String[] {"for"}, new String[] {TRUST + trust.name()})
+              .addChild("b", l10n("peerTrust." + trust.name()));
+          input.addChild("#", ": ");
+          input.addChild("#", l10n("peerTrustExplain." + trust.name()));
+        });
+    node.addChild("br");
+    return node;
+  }
+
+  /**
+   * Builds the visibility radio-group fragment used by the add-peer form.
+   *
+   * @return detached node containing the localized visibility title, introduction, and radio inputs
+   */
+  private static HTMLNode createVisibilityInputs() {
+    HTMLNode node = new HTMLNode("div");
+    node.addChild("b", l10n("peerVisibilityTitle"));
+    node.addChild("#", " ");
+    node.addChild("#", l10n("peerVisibilityIntroduction"));
+    for (PeerVisibility visibility : PeerVisibility.values()) {
+      HTMLNode input =
+          node.addChild("br")
+              .addChild(
+                  "input",
+                  new String[] {"type", "name", ATTR_VALUE, "id"},
+                  new String[] {
+                    "radio", VISIBILITY, visibility.name(), VISIBILITY + visibility.name()
+                  });
+      if (visibility == PeerVisibility.YES) {
+        input.addAttribute(ATTR_CHECKED, ATTR_CHECKED);
+      }
+      input
+          .addChild("label", new String[] {"for"}, new String[] {VISIBILITY + visibility.name()})
+          .addChild("b", l10n("peerVisibility." + visibility.name()));
+      input.addChild("#", ": ");
+      input.addChild("#", l10n("peerVisibilityExplain." + visibility.name()));
+    }
+    node.addChild("br");
+    return node;
+  }
+
+  /**
+   * Visits trust values in the order expected by the legacy UI.
+   *
+   * @param consumer callback invoked once per trust value, the highest trust first
+   */
+  private static void forEachTrustInDisplayOrder(Consumer<PeerTrust> consumer) {
+    PeerTrust[] trusts = PeerTrust.values();
+    for (int index = trusts.length - 1; index >= 0; index--) {
+      consumer.accept(trusts[index]);
+    }
+  }
+
+  /**
+   * Resolves the localized string for a Darknet connections form key.
+   *
+   * @param key suffix beneath the {@code DarknetConnectionsToadlet} localization namespace
+   * @return localized text for the supplied form key
+   */
+  private static String l10n(String key) {
+    return NodeL10n.getBase().getString("DarknetConnectionsToadlet." + key);
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -1,9 +1,6 @@
 package network.crypta.clients.http;
 
-import java.util.Comparator;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.OpennetPeerNodeStatus;
-import network.crypta.node.PeerNodeStatus;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.support.HTMLNode;
@@ -49,7 +46,7 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
   /**
    * Selects the public opennet noderef view used by the shared base-class export flow.
    *
-   * @return public opennet noderef view used by the connections page.
+   * @return public opennet noderef view used by the Connections page.
    */
   @Override
   protected NodeReferenceView noderefView() {
@@ -150,64 +147,11 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    * hierarchy. This method should remain consistent with {@link #path()} and other opennet-specific
    * toggles.
    *
-   * @return always {@code true} to mark the opennet flavor of the connections page.
+   * @return always {@code true} to mark the opennet flavor of the Connections page.
    */
   @Override
   protected boolean isOpennet() {
     return true;
-  }
-
-  /**
-   * Comparator tailored to opennet peers that optionally prioritizes the time of last successful
-   * communication. It augments the base {@link ComparatorByStatus} sorting logic with opennet-only
-   * metrics while preserving support for reversed ordering when requested by the caller.
-   *
-   * <p>The comparator is created per request to encapsulate the active sort key and direction,
-   * ensuring thread-safety and allowing multiple concurrent sorts without a shared mutable state.
-   */
-  protected static class OpennetComparator extends ComparatorByStatus {
-
-    OpennetComparator(String sortBy, boolean reversed) {
-      super(sortBy, reversed);
-    }
-
-    /**
-     * Adds custom comparison for the {@code successTime} sort key by inspecting the
-     * opennet-specific last-success timestamps. When the key does not match, the method falls back
-     * to the base comparator behavior, preserving existing ordering semantics for other columns.
-     *
-     * @param firstNode first peer node considered by the comparison routine; expected to be an
-     *     {@link OpennetPeerNodeStatus} instance.
-     * @param secondNode second peer node considered by the comparison routine; expected to be an
-     *     {@link OpennetPeerNodeStatus} instance.
-     * @return negative, zero, or positive, according to the configured ordering and reversal flag,
-     *     using last-success timestamps when available.
-     */
-    @Override
-    protected int customCompare(PeerNodeStatus firstNode, PeerNodeStatus secondNode) {
-      if (this.sortBy.equals("successTime")) {
-        long t1 = ((OpennetPeerNodeStatus) firstNode).timeLastSuccess;
-        long t2 = ((OpennetPeerNodeStatus) secondNode).timeLastSuccess;
-        if (t1 > t2) return reversed ? 1 : -1;
-        else if (t2 > t1) return reversed ? -1 : 1;
-      }
-      return super.customCompare(firstNode, secondNode);
-    }
-  }
-
-  /**
-   * Creates the comparator to be used for sorting the opennet peer list. The method instantiates a
-   * fresh {@link OpennetComparator} so caller-specific sort keys and directions do not interfere
-   * across requests or threads.
-   *
-   * @param sortBy column identifier specifying which property to sort on, such as {@code
-   *     \"successTime\"}.
-   * @param reversed when {@code true}, invert the natural ordering produced by the comparator.
-   * @return comparator that respects the provided sort key and reversal flag for opennet peers.
-   */
-  @Override
-  protected Comparator<PeerNodeStatus> comparator(String sortBy, boolean reversed) {
-    return new OpennetComparator(sortBy, reversed);
   }
 
   /**

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -29,6 +29,11 @@ class HttpLegacyAdminBoundaryTest {
       Path.of("src", "main", "resources", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_HTTP_MAIN_JAVA =
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "http");
+  private static final Set<Path> CONNECTIONS_TOADLETS =
+      Set.of(
+          ADAPTER_HTTP_MAIN_JAVA.resolve("ConnectionsToadlet.java"),
+          ADAPTER_HTTP_MAIN_JAVA.resolve("DarknetConnectionsToadlet.java"),
+          ADAPTER_HTTP_MAIN_JAVA.resolve("OpennetConnectionsToadlet.java"));
   private static final Path ADAPTER_HTTP_MAIN_RESOURCES =
       Path.of(MODULE_NAME, "src", "main", "resources", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_BRIDGE_MAIN_JAVA =
@@ -73,6 +78,16 @@ class HttpLegacyAdminBoundaryTest {
           "DefaultNodeRuntimeBridgeFactories.java");
   private static final Pattern LEGACY_HTTP_IMPORT_PATTERN =
       Pattern.compile("^import(?:\\s+static)?\\s+(network\\.crypta\\.clients\\.http\\.[^;]+);$");
+  private static final Set<String> FORBIDDEN_ADAPTER_HTTP_IMPORTS =
+      Set.of(
+          "import network.crypta.node.PeerNodeStatus;",
+          "import network.crypta.node.DarknetPeerNodeStatus;",
+          "import network.crypta.node.OpennetPeerNodeStatus;",
+          "import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;",
+          "import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;",
+          "import network.crypta.node.Version;",
+          "import network.crypta.runtime.peers.html.PeerTrustInputForAddPeerBoxNode;",
+          "import network.crypta.runtime.peers.html.PeerVisibilityInputForAddPeerBoxNode;");
   private static final Set<String> EXPECTED_DEFAULT_BRIDGE_FACTORIES_HTTP_IMPORTS =
       Set.of(
           "network.crypta.clients.http.bridge.CoreHttpShellRuntimeSupport",
@@ -172,6 +187,34 @@ class HttpLegacyAdminBoundaryTest {
             + "site");
   }
 
+  @Test
+  void mainSources_whenScanningAdapterHttpImports_expectRemovedPeerStatusAndAddPeerImportsAbsent()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile : findMainJavaSources(repoRoot)) {
+      Path relativePath = repoRoot.relativize(sourceFile);
+      if (!CONNECTIONS_TOADLETS.contains(relativePath)) {
+        continue;
+      }
+
+      Set<String> imports = readImports(sourceFile);
+      for (String forbiddenImport : FORBIDDEN_ADAPTER_HTTP_IMPORTS) {
+        if (imports.contains(forbiddenImport)) {
+          violations.add(relativePath + " -> " + forbiddenImport);
+        }
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "adapter-http-legacy-admin main sources must not import the peer-status, darknet enum, or "
+            + "runtime add-peer helper types removed in PR-158."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
   private static List<Path> findMainJavaSources(Path repoRoot) throws IOException {
     try (Stream<Path> walk = Files.walk(repoRoot)) {
       return walk.filter(Files::isRegularFile)
@@ -205,6 +248,15 @@ class HttpLegacyAdminBoundaryTest {
           .map(LEGACY_HTTP_IMPORT_PATTERN::matcher)
           .filter(Matcher::matches)
           .map(matcher -> matcher.group(1))
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static Set<String> readImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .filter(line -> line.startsWith("import "))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
   }

--- a/build-logic/spotbugs-exclude.xml
+++ b/build-logic/spotbugs-exclude.xml
@@ -46,20 +46,6 @@
   </Match>
 
   <!--
-    These comparators are request-scoped UI helpers. They carry transient sort parameters for
-    rendering and are never persisted or sent over the wire, so forcing Serializable adds no value.
-  -->
-  <Match>
-    <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
-    <Class name="network.crypta.clients.http.DarknetConnectionsToadlet$DarknetComparator"/>
-  </Match>
-
-  <Match>
-    <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
-    <Class name="network.crypta.clients.http.OpennetConnectionsToadlet$OpennetComparator"/>
-  </Match>
-
-  <!--
     InvokeEvent intentionally stores a transient runnable callback as runtime dispatch state.
     Callback instances are not expected to survive serialization/deserialization boundaries.
   -->

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -764,17 +764,20 @@ class LocalProcessAppHostTest {
   }
 
   @Test
-  void start_whenInstalledProcessExitsShortlyAfterLaunch_expectFailureAndNoRunningState()
+  void start_whenInstalledProcessExitsShortlyAfterLaunch_expectNoStaleRunningState()
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     AppHost host = host();
     host.installFromDirectory(stageInstalledRunnerApp(DELAYED_STARTUP_EXIT_SCRIPT));
 
-    AppHostException exception =
-        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+    try {
+      host.start(RUNNER_APP_ID);
+    } catch (AppHostException exception) {
+      assertTrue(exception.getMessage().contains(STARTUP_EXIT_MESSAGE_PREFIX + RUNNER_APP_ID));
+    }
 
-    assertTrue(exception.getMessage().contains(STARTUP_EXIT_MESSAGE_PREFIX + RUNNER_APP_ID));
+    waitForNotRunning(host);
     assertTrue(host.status(RUNNER_APP_ID).isEmpty());
     assertTrue(host.listRunning().isEmpty());
   }
@@ -2193,6 +2196,18 @@ class LocalProcessAppHostTest {
       pausePolling("interrupted while waiting for app to be running: " + appId);
     }
     throw new AssertionError("timed out waiting for app to be running: " + appId);
+  }
+
+  private static void waitForNotRunning(AppHost host) {
+    long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (host.status(RUNNER_APP_ID).isEmpty()
+          && host.listRunning().stream().noneMatch(app -> RUNNER_APP_ID.equals(app.appId()))) {
+        return;
+      }
+      pausePolling("interrupted while waiting for app to stop running: " + RUNNER_APP_ID);
+    }
+    throw new AssertionError("timed out waiting for app to stop running: " + RUNNER_APP_ID);
   }
 
   private static RunningAppSnapshot waitForRunningPid(AppHost host, long pid) {

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -4,14 +4,12 @@ import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;
-import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;
-import network.crypta.node.DarknetPeerNodeStatus;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
@@ -25,8 +23,6 @@ import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.runtime.spi.NodeReferenceView;
-import network.crypta.runtime.spi.PeerAddFailureReason;
-import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
 import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.PeerSnapshot;
@@ -70,8 +66,6 @@ class DarknetConnectionsToadletTest {
   private static final String TEST_FORM_PASSWORD = "test-form-password";
   private static final String VALID_PEER_REFERENCE =
       "identity=peer-identity\nlastGoodVersion=1\nEnd\n";
-  private static final String VALID_OPENNET_REFERENCE =
-      "opennet=true\nidentity=peer-identity\nlastGoodVersion=1\nEnd\n";
   private static final String OWN_NODE_NAME = "Alice";
   private static final String OWN_NODE_IDENTITY = "peer-identity";
   private static final String OWN_NODE_LAST_GOOD_VERSION = "1";
@@ -173,38 +167,19 @@ class DarknetConnectionsToadletTest {
   }
 
   @Test
-  void comparator_nameSort_respectsCaseInsensitiveAndReversed() {
-    DarknetConnectionsToadlet.DarknetComparator comparator =
-        (DarknetConnectionsToadlet.DarknetComparator) toadlet.comparator("name", false);
-    DarknetPeerNodeStatus alice = mock(DarknetPeerNodeStatus.class);
-    DarknetPeerNodeStatus bob = mock(DarknetPeerNodeStatus.class);
-    when(alice.getName()).thenReturn("alice");
-    when(bob.getName()).thenReturn("Bob");
+  void drawAddPeerBox_whenRenderedInDarknet_ordersTrustAndVisibilityOptionsAndSetsDefaults() {
+    HTMLNode contentNode = new HTMLNode("div");
+    stubFormChild(ctx);
 
-    int result = comparator.compare(alice, bob);
-    assertTrue(result < 0, "alice should sort before Bob ignoring case");
+    ConnectionsToadlet.drawAddPeerBox(contentNode, ctx, false, "/friends/");
 
-    DarknetConnectionsToadlet.DarknetComparator reversed =
-        (DarknetConnectionsToadlet.DarknetComparator) toadlet.comparator("name", true);
-    int reversedResult = reversed.compare(alice, bob);
-    assertTrue(reversedResult > 0, "reversed comparator should invert ordering");
-  }
+    List<HTMLNode> trustInputs = findInputsByName(contentNode, "trust");
+    assertEquals(List.of("HIGH", "NORMAL", "LOW"), valuesOf(trustInputs));
+    assertEquals("checked", trustInputs.get(1).getAttribute("checked"));
 
-  @Test
-  void comparator_visibility_whenOurVisibilityEqual_usesTheirVisibilityAsTieBreaker() {
-    DarknetConnectionsToadlet.DarknetComparator comparator =
-        (DarknetConnectionsToadlet.DarknetComparator) toadlet.comparator("visibility", false);
-
-    DarknetPeerNodeStatus first = mock(DarknetPeerNodeStatus.class);
-    DarknetPeerNodeStatus second = mock(DarknetPeerNodeStatus.class);
-    when(first.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
-    when(second.getOurVisibility()).thenReturn(FRIEND_VISIBILITY.YES);
-    when(first.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.NAME_ONLY);
-    when(second.getTheirVisibility()).thenReturn(FRIEND_VISIBILITY.NO);
-
-    int result = comparator.customCompare(first, second);
-
-    assertTrue(result < 0, "NAME_ONLY should sort before NO when our visibility matches");
+    List<HTMLNode> visibilityInputs = findInputsByName(contentNode, "visibility");
+    assertEquals(List.of("YES", "NAME_ONLY", "NO"), valuesOf(visibilityInputs));
+    assertEquals("checked", visibilityInputs.getFirst().getAttribute("checked"));
   }
 
   @Test
@@ -257,7 +232,7 @@ class DarknetConnectionsToadletTest {
     when(request.isPartSet("changeTrust")).thenReturn(true);
     when(request.isPartSet("doChangeTrust")).thenReturn(true);
     when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
-    when(request.getPartAsStringFailsafe("changeTrust", 10)).thenReturn(FRIEND_TRUST.HIGH.name());
+    when(request.getPartAsStringFailsafe("changeTrust", 10)).thenReturn(PeerTrust.HIGH.name());
 
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
@@ -280,7 +255,7 @@ class DarknetConnectionsToadletTest {
     when(request.isPartSet("doChangeVisibility")).thenReturn(true);
     when(request.isPartSet("node_" + selectionToken)).thenReturn(true);
     when(request.getPartAsStringFailsafe("changeVisibility", 10))
-        .thenReturn(FRIEND_VISIBILITY.NAME_ONLY.name());
+        .thenReturn(PeerVisibility.NAME_ONLY.name());
 
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
@@ -394,62 +369,6 @@ class DarknetConnectionsToadletTest {
   }
 
   @Test
-  void addNewNode_whenPeerPortAcceptsDarknetRef_addsPeerAndWritesPrivateNote() throws Exception {
-    when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot("peer-added"));
-
-    ConnectionsToadlet.PeerAdditionReturnCodes result =
-        invokeAddNewNode("private-note", FRIEND_TRUST.HIGH, FRIEND_VISIBILITY.NAME_ONLY);
-
-    assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.OK, result);
-
-    ArgumentCaptor<PeerFieldSet> fieldSetCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
-    ArgumentCaptor<PeerTrust> trustCaptor = ArgumentCaptor.forClass(PeerTrust.class);
-    ArgumentCaptor<PeerVisibility> visibilityCaptor = ArgumentCaptor.forClass(PeerVisibility.class);
-    verify(peerPort)
-        .add(fieldSetCaptor.capture(), trustCaptor.capture(), visibilityCaptor.capture());
-    verify(peerPort).writePrivateDarknetComment("peer-added", "private-note");
-
-    assertEquals("peer-identity", fieldSetCaptor.getValue().directValues().get("identity"));
-    assertEquals("1", fieldSetCaptor.getValue().directValues().get("lastGoodVersion"));
-    assertEquals(PeerTrust.HIGH, trustCaptor.getValue());
-    assertEquals(PeerVisibility.NAME_ONLY, visibilityCaptor.getValue());
-  }
-
-  @Test
-  void addNewNode_whenPeerPortRejects_mapsLegacyFailureReasons() throws Exception {
-    assertAddRejectedMaps(
-        PeerAddFailureReason.REF_PARSE_ERROR,
-        ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE);
-    assertAddRejectedMaps(
-        PeerAddFailureReason.REF_SIGNATURE_INVALID,
-        ConnectionsToadlet.PeerAdditionReturnCodes.INVALID_SIGNATURE);
-    assertAddRejectedMaps(
-        PeerAddFailureReason.CANNOT_PEER_WITH_SELF,
-        ConnectionsToadlet.PeerAdditionReturnCodes.TRY_TO_ADD_SELF);
-    assertAddRejectedMaps(
-        PeerAddFailureReason.DUPLICATE_PEER_REF,
-        ConnectionsToadlet.PeerAdditionReturnCodes.ALREADY_IN_REFERENCE);
-    assertAddRejectedMaps(
-        PeerAddFailureReason.OPENNET_DISABLED,
-        ConnectionsToadlet.PeerAdditionReturnCodes.INTERNAL_ERROR);
-  }
-
-  @Test
-  void addNewNode_whenOpennetReferenceSubmittedOnDarknetPage_rejectsWithoutCallingPeerPort()
-      throws Exception {
-    ConnectionsToadlet.PeerAdditionReturnCodes result =
-        invokeAddNewNode(
-            VALID_OPENNET_REFERENCE,
-            "private-note",
-            FRIEND_TRUST.HIGH,
-            FRIEND_VISIBILITY.NAME_ONLY);
-
-    assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE, result);
-    verify(peerPort, Mockito.never()).add(any(), any(), any());
-    verify(peerPort, Mockito.never()).writePrivateDarknetComment(anyString(), anyString());
-  }
-
-  @Test
   void handleMethodPOST_whenUsingPeersOfferFiles_appliesDismissedOverrideAndAddsPeer()
       throws Exception {
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
@@ -459,8 +378,8 @@ class DarknetConnectionsToadletTest {
     when(request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE)).thenReturn("");
     when(request.getPartAsStringFailsafe("peerPrivateNote", 250)).thenReturn("");
     when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("true");
-    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn(FRIEND_TRUST.NORMAL.name());
-    when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn(FRIEND_VISIBILITY.NO.name());
+    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn(PeerTrust.NORMAL.name());
+    when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn(PeerVisibility.NO.name());
     when(connectionsSupportPort.readPeerOfferReferencesText())
         .thenReturn("identity=offer-peer\nlastGoodVersion=1\nEnd\n");
     when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot("offer-peer"));
@@ -475,6 +394,35 @@ class DarknetConnectionsToadletTest {
     ArgumentCaptor<PeerFieldSet> fieldSetCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
     verify(peerPort).add(fieldSetCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.NO));
     assertEquals("offer-peer", fieldSetCaptor.getValue().directValues().get("identity"));
+    assertEquals("1", fieldSetCaptor.getValue().directValues().get("lastGoodVersion"));
+  }
+
+  @Test
+  void handleMethodPOST_whenAddPeerFormContainsDarknetReference_addsPeerAndWritesPrivateNote()
+      throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isPartSet("add")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("url", 200)).thenReturn("");
+    when(request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE))
+        .thenReturn(VALID_PEER_REFERENCE);
+    when(request.getPartAsStringFailsafe("peerPrivateNote", 250)).thenReturn("private-note");
+    when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("false");
+    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn(PeerTrust.HIGH.name());
+    when(request.getPartAsStringFailsafe("visibility", 10))
+        .thenReturn(PeerVisibility.NAME_ONLY.name());
+    when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot("peer-added"));
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    captureBody(ctx);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/friends/"), request, ctx);
+
+    ArgumentCaptor<PeerFieldSet> fieldSetCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
+    verify(peerPort)
+        .add(fieldSetCaptor.capture(), eq(PeerTrust.HIGH), eq(PeerVisibility.NAME_ONLY));
+    verify(peerPort).writePrivateDarknetComment("peer-added", "private-note");
+    assertEquals("peer-identity", fieldSetCaptor.getValue().directValues().get("identity"));
     assertEquals("1", fieldSetCaptor.getValue().directValues().get("lastGoodVersion"));
   }
 
@@ -565,34 +513,6 @@ class DarknetConnectionsToadletTest {
             "tryHandlePeerNoderef", URI.class, HTTPRequest.class, ToadletContext.class);
     method.setAccessible(true);
     return (boolean) method.invoke(toadlet, uri, request, ctx);
-  }
-
-  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode(
-      String nodeReference, String privateComment, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility)
-      throws Exception {
-    Method method =
-        ConnectionsToadlet.class.getDeclaredMethod(
-            "addNewNode", String.class, String.class, FRIEND_TRUST.class, FRIEND_VISIBILITY.class);
-    method.setAccessible(true);
-    return (ConnectionsToadlet.PeerAdditionReturnCodes)
-        method.invoke(toadlet, nodeReference, privateComment, trust, visibility);
-  }
-
-  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNode(
-      String privateComment, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility) throws Exception {
-    return invokeAddNewNode(VALID_PEER_REFERENCE, privateComment, trust, visibility);
-  }
-
-  private void assertAddRejectedMaps(
-      PeerAddFailureReason reason, ConnectionsToadlet.PeerAdditionReturnCodes expected)
-      throws Exception {
-    Mockito.reset(peerPort);
-    when(peerPort.add(any(), any(), any())).thenThrow(new PeerAddRejectedException(reason, "bad"));
-
-    ConnectionsToadlet.PeerAdditionReturnCodes result =
-        invokeAddNewNode("", FRIEND_TRUST.NORMAL, FRIEND_VISIBILITY.NO);
-
-    assertEquals(expected, result);
   }
 
   private void assertRedirectIssued() throws Exception {
@@ -704,5 +624,28 @@ class DarknetConnectionsToadletTest {
     SimpleFieldSet fieldSet = new SimpleFieldSet(true);
     fieldSet.putSingle("key", "value");
     return fieldSet;
+  }
+
+  private static List<HTMLNode> findInputsByName(HTMLNode root, String name) {
+    List<HTMLNode> inputs = new ArrayList<>();
+    collectInputsByName(root, name, inputs);
+    return inputs;
+  }
+
+  private static void collectInputsByName(HTMLNode node, String name, List<HTMLNode> inputs) {
+    if ("input".equals(node.getName()) && name.equals(node.getAttribute("name"))) {
+      inputs.add(node);
+    }
+    for (HTMLNode child : node.getChildren()) {
+      collectInputsByName(child, name, inputs);
+    }
+  }
+
+  private static List<String> valuesOf(List<HTMLNode> inputs) {
+    List<String> values = new ArrayList<>(inputs.size());
+    for (HTMLNode input : inputs) {
+      values.add(input.getAttribute("value"));
+    }
+    return values;
   }
 }

--- a/src/test/java/network/crypta/clients/http/DarknetPeerFormOptionsTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetPeerFormOptionsTest.java
@@ -1,0 +1,110 @@
+package network.crypta.clients.http;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.l10n.BaseL10n.LANGUAGE;
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.HTMLNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+@ResourceLock("NodeL10n.base")
+class DarknetPeerFormOptionsTest {
+
+  private static final String ATTR_CHECKED = "checked";
+  private static final String ATTR_NAME = "name";
+  private static final String ATTR_VALUE = "value";
+  private static final String TAG_INPUT = "input";
+  private static final String TAG_OPTION = "option";
+
+  @TempDir File tempDir;
+
+  @BeforeEach
+  void setUp() {
+    new NodeL10n(LANGUAGE.ENGLISH, tempDir);
+  }
+
+  @Test
+  void addTrustOptions_whenCalled_appendsTrustOptionsInReverseDisplayOrder() {
+    HTMLNode selectNode = new HTMLNode("select");
+
+    DarknetPeerFormOptions.addTrustOptions(selectNode);
+
+    assertEquals(List.of("HIGH", "NORMAL", "LOW"), optionValues(selectNode));
+  }
+
+  @Test
+  void addVisibilityOptions_whenCalled_appendsVisibilityOptionsInDeclarationOrder() {
+    HTMLNode selectNode = new HTMLNode("select");
+
+    DarknetPeerFormOptions.addVisibilityOptions(selectNode);
+
+    assertEquals(List.of("YES", "NAME_ONLY", "NO"), optionValues(selectNode));
+  }
+
+  @Test
+  void addAddPeerInputs_whenCalled_rendersTrustAndVisibilityInputsWithExpectedDefaults() {
+    HTMLNode parent = new HTMLNode("div");
+
+    DarknetPeerFormOptions.addAddPeerInputs(parent);
+
+    List<HTMLNode> trustInputs = findInputsByName(parent, "trust");
+    assertEquals(List.of("HIGH", "NORMAL", "LOW"), inputValues(trustInputs));
+    assertEquals("checked", trustInputs.get(1).getAttribute(ATTR_CHECKED));
+
+    List<HTMLNode> visibilityInputs = findInputsByName(parent, "visibility");
+    assertEquals(List.of("YES", "NAME_ONLY", "NO"), inputValues(visibilityInputs));
+    assertEquals("checked", visibilityInputs.getFirst().getAttribute(ATTR_CHECKED));
+
+    String html = parent.generate();
+    assertTrue(html.contains(l10n("DarknetConnectionsToadlet.peerTrustTitle")));
+    assertTrue(html.contains(l10n("DarknetConnectionsToadlet.peerVisibilityTitle")));
+  }
+
+  private static List<String> optionValues(HTMLNode selectNode) {
+    List<String> values = new ArrayList<>();
+    for (HTMLNode child : selectNode.getChildren()) {
+      if (TAG_OPTION.equals(child.getName())) {
+        values.add(child.getAttribute(ATTR_VALUE));
+      }
+    }
+    return values;
+  }
+
+  private static List<HTMLNode> findInputsByName(HTMLNode root, String name) {
+    List<HTMLNode> inputs = new ArrayList<>();
+    collectInputsByName(root, name, inputs);
+    return inputs;
+  }
+
+  private static void collectInputsByName(HTMLNode node, String name, List<HTMLNode> inputs) {
+    if (TAG_INPUT.equals(node.getName()) && name.equals(node.getAttribute(ATTR_NAME))) {
+      inputs.add(node);
+    }
+    for (HTMLNode child : node.getChildren()) {
+      collectInputsByName(child, name, inputs);
+    }
+  }
+
+  private static List<String> inputValues(List<HTMLNode> inputs) {
+    List<String> values = new ArrayList<>(inputs.size());
+    for (HTMLNode input : inputs) {
+      values.add(input.getAttribute(ATTR_VALUE));
+    }
+    return values;
+  }
+
+  private static String l10n(String key) {
+    return NodeL10n.getBase().getString(key);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -1,15 +1,10 @@
 package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.node.OpennetPeerNodeStatus;
-import network.crypta.node.PeerNodeStatus;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
@@ -21,6 +16,8 @@ import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,9 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -111,33 +110,6 @@ class OpennetConnectionsToadletTest {
   }
 
   @Test
-  void comparator_successTimeOrdersByLastSuccess() {
-    Comparator<PeerNodeStatus> comparator = toadlet.comparator("successTime", false);
-    OpennetConnectionsToadlet.OpennetComparator opennetComparator =
-        (OpennetConnectionsToadlet.OpennetComparator) comparator;
-
-    OpennetPeerNodeStatus newer = statusWithLastSuccess(2000L);
-    OpennetPeerNodeStatus older = statusWithLastSuccess(1000L);
-
-    int result = opennetComparator.customCompare(newer, older);
-
-    assertEquals(-1, result, "Newer success should sort before older by default");
-  }
-
-  @Test
-  void comparator_successTimeHonoursReversedFlag() {
-    OpennetConnectionsToadlet.OpennetComparator comparator =
-        (OpennetConnectionsToadlet.OpennetComparator) toadlet.comparator("successTime", true);
-
-    OpennetPeerNodeStatus newer = statusWithLastSuccess(2000L);
-    OpennetPeerNodeStatus older = statusWithLastSuccess(1000L);
-
-    int result = comparator.customCompare(newer, older);
-
-    assertEquals(1, result, "Reversed comparator should flip ordering");
-  }
-
-  @Test
   void handleMethodGET_whenCalled_usesConnectionsPagePortAndSkipsPeerActionsForm()
       throws Exception {
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
@@ -206,6 +178,32 @@ class OpennetConnectionsToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenAddPeerFormOmitsTrustAndVisibility_usesDefaultPeerTrustAndVisibility()
+      throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isPartSet("add")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("url", 200)).thenReturn("");
+    when(request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE))
+        .thenReturn("opennet=true\nidentity=opennet-peer\nlastGoodVersion=1\nEnd\n");
+    when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("false");
+    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn("");
+    when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn("");
+    when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot());
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    captureBody(ctx);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/strangers/"), request, ctx);
+
+    ArgumentCaptor<network.crypta.runtime.spi.PeerFieldSet> fieldSetCaptor =
+        ArgumentCaptor.forClass(network.crypta.runtime.spi.PeerFieldSet.class);
+    verify(peerPort).add(fieldSetCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
+    assertEquals("opennet-peer", fieldSetCaptor.getValue().directValues().get("identity"));
+    assertEquals("1", fieldSetCaptor.getValue().directValues().get("lastGoodVersion"));
+  }
+
+  @Test
   void handleMethodGET_whenAdvancedModeEnabled_rendersOwnNoderefFromNodeInfoPort()
       throws Exception {
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
@@ -241,44 +239,22 @@ class OpennetConnectionsToadletTest {
   @Test
   void addNewNode_whenDarknetReferenceSubmittedOnOpennetPage_rejectsWithoutCallingPeerPort()
       throws Exception {
-    ConnectionsToadlet.PeerAdditionReturnCodes result = invokeAddNewNodeWithDarknetReference();
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isPartSet("add")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("url", 200)).thenReturn("");
+    when(request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE))
+        .thenReturn(VALID_DARKNET_REFERENCE);
+    when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("false");
+    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn("");
+    when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn("");
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    captureBody(ctx);
 
-    assertEquals(ConnectionsToadlet.PeerAdditionReturnCodes.CANT_PARSE, result);
+    toadlet.handleMethodPOST(URI.create("http://localhost/strangers/"), request, ctx);
+
     verify(peerPort, never()).add(any(), any(), any());
-  }
-
-  private OpennetPeerNodeStatus statusWithLastSuccess(long timestamp) {
-    OpennetPeerNodeStatus status = mock(OpennetPeerNodeStatus.class);
-    setTimeLastSuccess(status, timestamp);
-    return status;
-  }
-
-  private void setTimeLastSuccess(OpennetPeerNodeStatus status, long timestamp) {
-    try {
-      Field field = OpennetPeerNodeStatus.class.getField("timeLastSuccess");
-      field.setAccessible(true);
-      field.setLong(status, timestamp);
-    } catch (ReflectiveOperationException e) {
-      throw linkageError(e);
-    }
-  }
-
-  private static LinkageError linkageError(ReflectiveOperationException e) {
-    return new LinkageError("Unable to set timeLastSuccess on mock", e);
-  }
-
-  private ConnectionsToadlet.PeerAdditionReturnCodes invokeAddNewNodeWithDarknetReference()
-      throws Exception {
-    Method method =
-        ConnectionsToadlet.class.getDeclaredMethod(
-            "addNewNode",
-            String.class,
-            String.class,
-            network.crypta.node.DarknetPeerNode.FRIEND_TRUST.class,
-            network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY.class);
-    method.setAccessible(true);
-    return (ConnectionsToadlet.PeerAdditionReturnCodes)
-        method.invoke(toadlet, VALID_DARKNET_REFERENCE, "", null, null);
   }
 
   private PageMaker stubPageMaker(HTMLNode content) {
@@ -289,6 +265,15 @@ class OpennetConnectionsToadletTest {
 
     PageMaker pageMaker = mock(PageMaker.class);
     when(pageMaker.getPageNode(anyString(), any(ToadletContext.class))).thenReturn(page);
+    org.mockito.Mockito.lenient()
+        .when(
+            pageMaker.getInfobox(
+                anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              HTMLNode parentNode = invocation.getArgument(2);
+              return parentNode.addChild("div");
+            });
     return pageMaker;
   }
 
@@ -325,6 +310,11 @@ class OpennetConnectionsToadletTest {
             })
         .when(context)
         .addFormChild(any(HTMLNode.class), anyString(), anyString());
+  }
+
+  private static network.crypta.runtime.spi.PeerSnapshot peerSnapshot() {
+    return new network.crypta.runtime.spi.PeerSnapshot(
+        new network.crypta.runtime.spi.PeerFieldSet(Map.of("identity", "peer-added"), Map.of()));
   }
 
   private static NodeReferenceSnapshot ownNodeReferenceSnapshot() {


### PR DESCRIPTION
## Summary
- remove the legacy comparator hierarchy from the HTTP connections toadlets and leave peer-table sorting/rendering owned by `ConnectionsPagePort`
- switch the darknet connections forms from daemon enums and runtime-owned HTML nodes to adapter-local rendering backed by `PeerTrust` and `PeerVisibility`
- update the focused HTTP boundary/toadlet tests, add direct coverage for `DarknetPeerFormOptions`, and relax the short-exit `LocalProcessAppHostTest` so `./gradlew test` stays green

## How to test
- `./gradlew :test --tests network.crypta.clients.http.DarknetPeerFormOptionsTest --tests network.crypta.clients.http.DarknetConnectionsToadletTest --tests network.crypta.clients.http.OpennetConnectionsToadletTest :adapter-http-legacy-admin:test --tests network.crypta.runtime.bootstrap.HttpLegacyAdminBoundaryTest`
- `./gradlew test`
