### PR TITLE
refactor(http): Prepare legacy browse split seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,15 +797,16 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `/app/node/`, runtime-owned shell and password-prompt seams under
   `network.crypta.runtime.http` and `network.crypta.runtime.http.security`, and client-local
   helpers such as `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellFProxyBootstrap`,
-  and `FProxyRegistrarDependencies`. Concrete HTTP shell, bookmark, GeoIP, and security-page
-  adapters now live under `network.crypta.clients.http.bridge` in `:bridge-http-runtime`, and
-  that leaf also owns the legacy HTTP GeoIP helper package
+  and the shared HTTP route registrar seam. Concrete HTTP shell, bookmark, GeoIP, and
+  security-page adapters now live under `network.crypta.clients.http.bridge` in
+  `:bridge-http-runtime`, and that leaf also owns the legacy HTTP GeoIP helper package
   `network.crypta.clients.http.geoip`. The updater-action adapters remain under
   `network.crypta.clients.http.updater` in `:adapter-http-legacy-admin`. Root-local bridge
-  selection stays in `DefaultNodeRuntimeBridgeFactories`. The remaining legacy browse/FProxy tree
-  inside `:adapter-http-legacy-admin` is intentionally boundary-frozen until a later PR refines
-  it further, and production code outside the adapter should keep depending on runtime seams
-  rather than taking new `network.crypta.clients.http.*` dependencies. See
+  selection stays in `DefaultNodeRuntimeBridgeFactories`, which now installs the admin-owned HTTP
+  registrar implementation into the shared shell. The remaining legacy browse/FProxy tree inside
+  `:adapter-http-legacy-admin` is intentionally boundary-frozen until a later PR refines it
+  further, and production code outside the adapter should keep depending on runtime seams rather
+  than taking new `network.crypta.clients.http.*` dependencies. See
   [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
   boundary.
 - Runtime SPI (`network.crypta.runtime.spi`): JDK-only ports and detached DTOs such as

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyFetchInProgress.java
@@ -54,7 +54,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * requests can watch the same download safely. After creation the object stays valid for roughly
  * thirty seconds after last access unless {@link #requestImmediateCancel()} is invoked. The class
  * prefers cached data when safe, falls back to live network retrieval otherwise, and optionally
- * re-filters cached content according to the chosen {@link REFILTER_POLICY}.
+ * re-filters cached content according to the chosen {@link RefilterPolicy}.
  *
  * <ul>
  *   <li>Responsibilities: manage a single URI fetch, collect progress, and dispatch listener
@@ -70,29 +70,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class FProxyFetchInProgress implements ClientEventListener, ClientGetCallback {
   private static final Logger LOG = LoggerFactory.getLogger(FProxyFetchInProgress.class);
 
-  /**
-   * What to do when we find data which matches the request, but it has already been filtered,
-   * assuming we want a filtered copy.
-   */
-  public enum REFILTER_POLICY {
-    /**
-     * Re-run the content filter even when cached data was already filtered, usually forcing a new
-     * temporary bucket allocation to rebuild output with current rules.
-     */
-    RE_FILTER,
-    /**
-     * Reuse the previously filtered bytes without reprocessing; correctness depends on the filter
-     * version that produced the cached object and may skip newer safety fixes.
-     */
-    ACCEPT_OLD,
-    /**
-     * Discard any cached representation and perform a fresh fetch from the network to avoid stale
-     * filter artifacts at the cost of extra latency and bandwidth.
-     */
-    RE_FETCH
-  }
-
-  private final REFILTER_POLICY refilterPolicy;
+  private final RefilterPolicy refilterPolicy;
 
   // Legacy logMINOR removed; use LOG.isDebugEnabled() instead.
 
@@ -215,7 +193,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
       long identifier,
       ClientContext context,
       RequestClient rc,
-      REFILTER_POLICY refilter) {
+      RefilterPolicy refilter) {
     this.identifier = identifier;
     this.initialContext = context;
     this.refilterPolicy = refilter;
@@ -354,7 +332,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
       return false;
     }
 
-    if (result.alreadyFiltered && refilterPolicy == REFILTER_POLICY.ACCEPT_OLD) {
+    if (result.alreadyFiltered && refilterPolicy == RefilterPolicy.ACCEPT_OLD) {
       tracker.removeFetcher(this);
       onSuccess(result, null);
       return true;
@@ -389,7 +367,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
   }
 
   private boolean canReuseFilteredResult(CacheFetchResult result) {
-    if (refilterPolicy == REFILTER_POLICY.RE_FETCH || !fctx.getFilterData()) {
+    if (refilterPolicy == RefilterPolicy.RE_FETCH || !fctx.getFilterData()) {
       return false;
     }
     return shouldAcceptCachedFilteredData(fctx, result);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyFetchTracker.java
@@ -4,7 +4,6 @@ import java.util.List;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
 import network.crypta.client.async.ClientContext;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.support.MultiValueTable;
@@ -21,7 +20,7 @@ import org.slf4j.LoggerFactory;
  * state changes rely on {@link ClientContext#ticker} to avoid blocking the calling thread.
  *
  * <p>Typical call flow: a servlet asks for a fetcher via {@link #makeFetcher(FProxyFetchCriteria,
- * REFILTER_POLICY)}, gets a waiter, and later the tracker culls abandoned instances through {@link
+ * RefilterPolicy)}, gets a waiter, and later the tracker culls abandoned instances through {@link
  * #run()}. Instances are intentionally short-lived; they are canceled when a fetch completes, fails
  * fatally, or the scheduled cleanup fires.
  *
@@ -85,7 +84,7 @@ public class FProxyFetchTracker implements Runnable {
    * @throws FetchException if the underlying fetch cannot be started or the request client rejects
    *     the parameters.
    */
-  public FProxyFetchWaiter makeFetcher(FProxyFetchCriteria criteria, REFILTER_POLICY refilterPolicy)
+  public FProxyFetchWaiter makeFetcher(FProxyFetchCriteria criteria, RefilterPolicy refilterPolicy)
       throws FetchException {
     FProxyFetchInProgress progress;
     FProxyFetchCriteria effectiveCriteria = resolveCriteria(criteria);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -28,7 +28,7 @@ import static network.crypta.runtime.updater.UpdaterPaths.CORE_UPDATE_PATH;
  * Callers invoke it once during node startup to ensure all public endpoints for browsing, queue
  * management, configuration, alerts, and update actions are available before handling requests. The
  * registrar is intentionally package-private and stateless; it relies only on the narrow
- * dependencies bundle assembled by the HTTP shell.
+ * dependencies bundle assembled by the admin-owned registrar adapter.
  *
  * <p>Responsibilities include:
  *

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
@@ -7,13 +7,13 @@ import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
- * Narrow dependency bundle used to register the FProxy HTTP shell.
+ * Narrow dependency bundle used internally by the admin-owned HTTP registrar.
  *
- * <p>{@link SimpleToadletServer} assembles the live daemon collaborators needed for the root FProxy
- * endpoint, then hands that prebuilt state to {@link FProxyRegistrar}. The registrar can therefore
- * stay focused on HTTP concerns such as menu registration, toadlet registration, and wiring
- * already-created helpers into those routes. This record exists only to make that handoff explicit
- * and local to the HTTP package.
+ * <p>{@link LegacyAdminHttpRouteRegistrar} adapts the public shell-local route-registration seam to
+ * the existing {@link FProxyRegistrar} helper by assembling this package-private dependency bundle.
+ * The registrar can therefore stay focused on HTTP concerns such as menu registration, toadlet
+ * registration, and wiring already-created helpers into those routes. This record exists only to
+ * keep that adaptation explicit and local to the HTTP package.
  *
  * <p>The type is intentionally package-private. It is not a general runtime abstraction and does
  * not try to hide broader node relationships. It simply groups the collaborators that the registrar

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
@@ -1,0 +1,52 @@
+package network.crypta.clients.http;
+
+/**
+ * Adapts the shell-local route-registration seam to the current admin-owned HTTP registrar.
+ *
+ * <p>The shared legacy HTTP shell now depends on {@link LegacyHttpRouteRegistrar} instead of
+ * calling {@link FProxyRegistrar} directly. This concrete adapter keeps the existing registrar
+ * helper and its dependency bundle on the admin side of the boundary while still preserving the
+ * historical startup behavior. Production bridge wiring installs this type during shell creation,
+ * and tests may substitute a narrower fake registrar when they only need to observe delegation.
+ *
+ * <p>The adapter is intentionally stateless. It does not cache the bootstrap state, track
+ * registration progress, or change route order. Its only job is to translate the public {@link
+ * LegacyHttpRouteRegistrarContext} into the package-private dependency bundle expected by {@link
+ * FProxyRegistrar}, then hand control to that existing implementation.
+ */
+public final class LegacyAdminHttpRouteRegistrar implements LegacyHttpRouteRegistrar {
+  /**
+   * Creates a stateless registrar adapter for production or test bridge wiring.
+   *
+   * <p>Instances carry no mutable startup state, so callers may create them as needed without
+   * coordinating shared ownership. The explicit constructor exists, so this public type has
+   * complete Javadoc coverage under doclint.
+   */
+  public LegacyAdminHttpRouteRegistrar() {
+    // This adapter is intentionally stateless; construction needs no additional work.
+  }
+
+  /**
+   * Registers the concrete legacy HTTP routes for the supplied shell instance.
+   *
+   * <p>The provided context already contains the interactive client, runtime ports, configuration,
+   * AppHost bridge, and root FProxy toadlet prepared by the shared shell bootstrap path.
+   * Repackaging those collaborators here keeps the public seam small while letting the existing
+   * admin-owned registrar continue to own menu creation, toadlet instantiation, and registration
+   * order.
+   *
+   * @param context prepared bootstrap collaborators that the admin-owned registrar requires
+   * @param server shell instance that receives the registered menus and toadlets
+   */
+  @Override
+  public void registerRoutes(LegacyHttpRouteRegistrarContext context, SimpleToadletServer server) {
+    FProxyRegistrar.maybeCreateFProxyEtc(
+        new FProxyRegistrarDependencies(
+            context.client(),
+            context.runtimePorts(),
+            context.appHost(),
+            context.config(),
+            context.fproxy()),
+        server);
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrar.java
@@ -1,0 +1,36 @@
+package network.crypta.clients.http;
+
+/**
+ * Strategy interface for attaching the concrete legacy HTTP route set to a prepared shell.
+ *
+ * <p>{@link SimpleToadletServer} performs the shared bootstrap work that both browse-facing and
+ * admin-facing HTTP code depend on, but it should not know which concrete registrar owns the
+ * remaining route wiring. This seam keeps that ownership outside the shell. Production bridge
+ * wiring currently installs {@link LegacyAdminHttpRouteRegistrar}, while focused tests can inject a
+ * lightweight fake that records the prepared bootstrap context without instantiating the full HTTP
+ * surface.
+ *
+ * <p>Implementations are expected to treat registration as a one-shot startup operation for a
+ * single shell instance. They should preserve the established route order, avoid retaining the
+ * provided context after startup, and limit themselves to publishing menus, toadlets, and related
+ * shell-local wiring.
+ */
+@FunctionalInterface
+public interface LegacyHttpRouteRegistrar {
+
+  /**
+   * Registers the legacy HTTP routes for the supplied shell instance.
+   *
+   * <p>The supplied context contains the collaborators that the registrar may already need today:
+   * the shared interactive client, runtime ports, AppHost bridge, node configuration, and the
+   * prebuilt root FProxy toadlet. Implementations should use those values to complete their own
+   * startup wiring without re-fetching the broader daemon state from elsewhere. Callers invoke this
+   * method during the FProxy bootstrap path before request handling begins.
+   *
+   * @param context prepared bootstrap collaborators that registration may publish into routes and
+   *     helper pages
+   * @param server shell instance that should receive the registered menus, toadlets, and related
+   *     startup wiring
+   */
+  void registerRoutes(LegacyHttpRouteRegistrarContext context, SimpleToadletServer server);
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
@@ -1,0 +1,61 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.config.Config;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.runtime.spi.RuntimePorts;
+
+/**
+ * Immutable bootstrap context handed from the shared shell to a concrete route registrar.
+ *
+ * <p>{@link SimpleToadletServer#createFproxy()} assembles the shared collaborators that route
+ * registration still needs after the shell finishes its common startup work. This record packages
+ * those values into one small handoff object so the shell does not expose a wider bootstrap API
+ * just to support registrar-specific wiring. The type is public because bridge-owned production
+ * code installs registrar implementations from outside this package, but its contents stay focused
+ * on route registration rather than broader daemon lifecycle control.
+ *
+ * <p>The context is intentionally narrow and immutable. It carries only the collaborators needed to
+ * publish legacy HTTP routes today: the interactive client, detached runtime ports, AppHost bridge,
+ * node configuration, and the already-created root FProxy toadlet. Registrars should treat the
+ * record as a startup snapshot and avoid mutating or retaining it beyond registration.
+ *
+ * @param client shared interactive client that registered toadlets use for request-adjacent
+ *     operations
+ * @param runtimePorts detached runtime-spi ports surfaced to HTTP routes and helper pages
+ * @param appHost shared AppHost bridge that exposes the current Platform API runtime surface
+ * @param config node configuration view used when listing or filtering sub-config toadlets
+ * @param fproxy prebuilt root FProxy toadlet that anchors the registration pass at the legacy
+ *     browsing root
+ */
+public record LegacyHttpRouteRegistrarContext(
+    HighLevelSimpleClient client,
+    RuntimePorts runtimePorts,
+    AppHost appHost,
+    Config config,
+    FProxyToadlet fproxy) {
+
+  /**
+   * Creates a validated route-registration context.
+   *
+   * <p>Registration is an all-or-nothing startup step, so the constructor rejects the partially
+   * assembled state immediately instead of letting a registrar fail later while building menus or
+   * toadlets. The stored references are the same objects prepared by the shell bootstrap path; the
+   * constructor does not wrap, copy, or otherwise transform them.
+   *
+   * @param client shared interactive client that registered toadlets may call into during startup
+   * @param runtimePorts detached runtime-spi ports exposed to the HTTP registrar
+   * @param appHost shared AppHost bridge made visible through HTTP-owned routes
+   * @param config node configuration view that registration may inspect for sub-config pages
+   * @param fproxy prebuilt root FProxy toadlet registered at the browsing root
+   * @throws NullPointerException if any required collaborator is absent when the context is built
+   */
+  public LegacyHttpRouteRegistrarContext {
+    Objects.requireNonNull(client);
+    Objects.requireNonNull(runtimePorts);
+    Objects.requireNonNull(appHost);
+    Objects.requireNonNull(config);
+    Objects.requireNonNull(fproxy);
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/RefilterPolicy.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/RefilterPolicy.java
@@ -1,0 +1,45 @@
+package network.crypta.clients.http;
+
+/**
+ * Describes how FProxy should treat cached filtered content when serving a request.
+ *
+ * <p>The enum is HTTP-local on purpose. Shared shell types such as {@link ToadletContext}, {@link
+ * ToadletContainer}, and {@link SimpleToadletServer} need to expose and persist the policy without
+ * depending on the concrete fetch-tracker implementation that applies it. Keeping the type here
+ * makes that boundary explicit: shell code can talk about refiltering as a user-visible HTTP
+ * choice, while fetch execution code can consume the same value without owning the public contract.
+ *
+ * <p>The constant names are part of the persisted configuration round-trip used by the legacy HTTP
+ * shell. Callers store and restore them through {@link Enum#name()} and {@link Enum#valueOf(Class,
+ * String)}, so the identifiers must remain stable. The three values are ordered by increasing
+ * freshness requirements: reuse an already filtered cached result, re-run filtering against cached
+ * data, or bypass the cached representation and fetch fresh bytes from the network.
+ */
+public enum RefilterPolicy {
+  /**
+   * Reuse previously filtered bytes without re-running the filter.
+   *
+   * <p>This is the least disruptive option. It favors responsiveness and avoids extra temporary
+   * bucket churn when cached filtered output is already available, but it may preserve older
+   * filtering decisions instead of applying the latest filter rules.
+   */
+  ACCEPT_OLD,
+
+  /**
+   * Re-run filtering against the cached content.
+   *
+   * <p>This middle ground keeps the response aligned with current filtering rules while still
+   * avoiding a full network refetching when the cached source data is otherwise usable. It
+   * typically trades some local processing and temporary storage for better policy freshness.
+   */
+  RE_FILTER,
+
+  /**
+   * Discard the cached representation and refetch the content from the network.
+   *
+   * <p>This is the strongest refresh behavior. It avoids reusing any cached filtered output and can
+   * bypass stale cached source artifacts as well, at the cost of extra latency, bandwidth, and
+   * network dependency compared with the other policies.
+   */
+  RE_FETCH
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -14,7 +14,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import network.crypta.client.filter.HTMLFilter;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.PageMaker.THEME;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.clients.http.updateableelements.PushDataManager;
@@ -136,6 +135,9 @@ public final class SimpleToadletServer
 
   @SuppressWarnings("java:S3077")
   private volatile HttpShellRuntimeSupport runtimeSupport;
+
+  @SuppressWarnings("java:S3077")
+  private volatile LegacyHttpRouteRegistrar routeRegistrar;
 
   // HTTP Option
   private boolean doRobots;
@@ -440,7 +442,7 @@ public final class SimpleToadletServer
 
     @Override
     public String[] getPossibleValues() {
-      REFILTER_POLICY[] possible = REFILTER_POLICY.values();
+      RefilterPolicy[] possible = RefilterPolicy.values();
       String[] ret = new String[possible.length];
       for (int i = 0; i < possible.length; i++) ret[i] = possible[i].name();
       return ret;
@@ -453,7 +455,7 @@ public final class SimpleToadletServer
 
     @Override
     public void set(String val) {
-      refilterPolicy = REFILTER_POLICY.valueOf(val);
+      refilterPolicy = RefilterPolicy.valueOf(val);
     }
   }
 
@@ -465,15 +467,16 @@ public final class SimpleToadletServer
    * the active node. This method is idempotent; later calls are ignored after the first successful
    * invocation. It captures the current runtime support reference, wires the push managers to the
    * shared {@link Ticker}, assembles the daemon-only root FProxy collaborators, and delegates to
-   * {@link FProxyRegistrar} for the remaining HTTP shell registration.
+   * the configured {@link LegacyHttpRouteRegistrar} for the remaining HTTP shell registration.
    */
   public void createFproxy() {
+    HttpShellRuntimeSupport runtimeSupportRef = requireRuntimeSupport();
+    LegacyHttpRouteRegistrar routeRegistrarRef = requireRouteRegistrar();
     synchronized (this) {
       if (haveCalledFProxy) return;
       haveCalledFProxy = true;
     }
 
-    HttpShellRuntimeSupport runtimeSupportRef = requireRuntimeSupport();
     pushDataManager = new PushDataManager(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
     HttpShellFProxyBootstrap bootstrap =
@@ -482,8 +485,8 @@ public final class SimpleToadletServer
     RuntimePorts runtimePorts = runtimeSupportRef.runtimePorts();
     initializeFProxyRandom(runtimePorts.randomness());
 
-    FProxyRegistrar.maybeCreateFProxyEtc(
-        new FProxyRegistrarDependencies(
+    routeRegistrarRef.registerRoutes(
+        new LegacyHttpRouteRegistrarContext(
             bootstrap.client(),
             runtimePorts,
             runtimeSupportRef.appHost(),
@@ -576,6 +579,19 @@ public final class SimpleToadletServer
     this.runtimeSupport = runtimeSupport;
     RuntimePorts runtimePorts = runtimeSupport == null ? null : runtimeSupport.runtimePorts();
     pageMaker.setPageChromePort(runtimePorts == null ? null : runtimePorts.pageChrome());
+  }
+
+  /**
+   * Installs the route registrar used by {@link #createFproxy()}.
+   *
+   * <p>This seam keeps the shared HTTP shell free from direct knowledge of the current admin-owned
+   * registration helper. Bridge wiring should call this before FProxy creation so the shell can
+   * delegate the concrete route-registration pass.
+   *
+   * @param routeRegistrar registrar that will register the concrete legacy HTTP routes
+   */
+  public void setRouteRegistrar(LegacyHttpRouteRegistrar routeRegistrar) {
+    this.routeRegistrar = Objects.requireNonNull(routeRegistrar);
   }
 
   /**
@@ -1279,7 +1295,7 @@ public final class SimpleToadletServer
             "SimpleToadletServer.refilterPolicyLong"),
         new ReFilterCallback());
 
-    this.refilterPolicy = REFILTER_POLICY.valueOf(fproxyConfig.getString("refilterPolicy"));
+    this.refilterPolicy = RefilterPolicy.valueOf(fproxyConfig.getString("refilterPolicy"));
     return configItemOrder;
   }
 
@@ -1363,10 +1379,10 @@ public final class SimpleToadletServer
           // Otherwise, we do RE_FILTER.
           // But we don't change it unless it changes from LOW to not LOW.
           if (newLevel == HttpShellRuntimeSupport.NetworkThreatLevel.LOW && newLevel != oldLevel) {
-            refilterPolicy = REFILTER_POLICY.ACCEPT_OLD;
+            refilterPolicy = RefilterPolicy.ACCEPT_OLD;
           } else if (oldLevel == HttpShellRuntimeSupport.NetworkThreatLevel.LOW
               && newLevel != oldLevel) {
-            refilterPolicy = REFILTER_POLICY.RE_FILTER;
+            refilterPolicy = RefilterPolicy.RE_FILTER;
           }
         });
     runtimeSupportRef.addPhysicalThreatLevelListener(
@@ -1884,7 +1900,11 @@ public final class SimpleToadletServer
     return Objects.requireNonNull(runtimeSupport);
   }
 
-  private REFILTER_POLICY refilterPolicy;
+  private LegacyHttpRouteRegistrar requireRouteRegistrar() {
+    return Objects.requireNonNull(routeRegistrar);
+  }
+
+  private RefilterPolicy refilterPolicy;
 
   /**
    * Returns the active refilter policy applied to request processing.
@@ -1892,10 +1912,10 @@ public final class SimpleToadletServer
    * <p>The policy is updated in response to threat-level changes to balance usability with
    * security. Caller should treat the value as read-only.
    *
-   * @return current {@link REFILTER_POLICY} value.
+   * @return current {@link RefilterPolicy} value.
    */
   @Override
-  public REFILTER_POLICY getReFilterPolicy() {
+  public RefilterPolicy getReFilterPolicy() {
     return refilterPolicy;
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContainer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContainer.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.PageMaker.THEME;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.BucketFactory;
@@ -315,7 +314,7 @@ public interface ToadletContainer {
    *
    * @return the refilter policy governing how cached filtered content is handled
    */
-  REFILTER_POLICY getReFilterPolicy();
+  RefilterPolicy getReFilterPolicy();
 
   /**
    * Retrieve a file that overrides defaults for this container.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContext.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.support.HTMLNode;
@@ -20,12 +19,12 @@ import network.crypta.support.io.NoFreeBucket;
  * enforcing security policies such as form-password validation and access level checks. A {@code
  * ToadletContext} is typically created by the request dispatcher and passed into a {@link Toadlet}
  * handler; the handler uses it to send headers and body data, inspect cookies, manage response
- * cookies, and obtain helpers like {@link PageMaker}. Instances are short-lived and not
- * thread-safe: they represent one connection/request pair and should not be shared across threads
- * without external synchronization. Typical call flow is: validate permissions, send reply headers
- * tailored to the content type (static, FProxy, or dynamic), write the body via {@link
- * #writeData(byte[], int, int)}, and optionally adjust connection behavior with {@link
- * #forceDisconnect()}. Implementers must track connection state to prevent writes after closure.
+ * cookies, and get helpers like {@link PageMaker}. Instances are short-lived and not thread-safe:
+ * they represent one connection/request pair and should not be shared across threads without
+ * external synchronization. Typical call flow is: validate permissions, send reply headers tailored
+ * to the content type (static, FProxy, or dynamic), write the body via {@link #writeData(byte[],
+ * int, int)}, and optionally adjust connection behavior with {@link #forceDisconnect()}.
+ * Implementers must track connection state to prevent writes after closure.
  *
  * <p><strong>Responsibilities</strong>
  *
@@ -85,7 +84,7 @@ public interface ToadletContext {
    * Write reply headers for static resources while supplying an explicit last-modified timestamp to
    * support cache validation.
    *
-   * @param code HTTP status code such as 200 or 304; must align with the cache semantics desired.
+   * @param code HTTP status code such as 200 or 304, must align with the cache semantics desired.
    * @param desc Status description paired with {@code code}; required and non-empty.
    * @param mvt Extra headers to include; {@code null} permitted when no additional headers are
    *     needed.
@@ -131,7 +130,7 @@ public interface ToadletContext {
    * @param data Buffer containing response bytes; must not be {@code null}.
    * @param offset Starting index within {@code data} to write; zero or greater.
    * @param length Number of bytes to send from {@code data}; zero allowed for empty writes.
-   * @throws ToadletContextClosedException if the context is closed before or during the write.
+   * @throws ToadletContextClosedException if the context is closed before or during the writing.
    * @throws IOException if writing to the underlying stream fails.
    */
   void writeData(byte[] data, int offset, int length)
@@ -149,7 +148,7 @@ public interface ToadletContext {
    * length.
    *
    * @param data Complete response payload to send; must not be {@code null}.
-   * @throws ToadletContextClosedException if the context was closed before the write begins.
+   * @throws ToadletContextClosedException if the context was closed before the writing begins.
    * @throws IOException if the stream cannot be written due to network or socket errors.
    */
   void writeData(byte[] data) throws ToadletContextClosedException, IOException;
@@ -216,7 +215,7 @@ public interface ToadletContext {
   /**
    * Check a context for whether {@link #isAllowedFullAccess()} is true.
    *
-   * <p>If it is false, an error page is sent to the client, and false is returned. You can then
+   * <p>If it is false, an error page is sent to the client, and the false is returned. You can then
    * abort processing of the request.
    *
    * @return The return value of {@link #isAllowedFullAccess()}.
@@ -288,7 +287,7 @@ public interface ToadletContext {
 
   /**
    * Is this Toadlet allowed full access to the node, including the ability to reconfigure it,
-   * restart it etc.?
+   * restart it, etc.?
    *
    * @return {@code true} when the current request is authorized for full administrative access;
    *     {@code false} otherwise.
@@ -354,5 +353,5 @@ public interface ToadletContext {
    *
    * @return Policy describing whether to refilter, reuse, or skip cached filtered data.
    */
-  REFILTER_POLICY getReFilterPolicy();
+  RefilterPolicy getReFilterPolicy();
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.alerts.UserAlertManager;
@@ -1454,10 +1453,10 @@ public final class ToadletContextImpl implements ToadletContext {
    * value reflects container configuration and any per-request overrides captured when the context
    * was created.
    *
-   * @return {@link REFILTER_POLICY} indicating how the proxy should treat filtering behavior.
+   * @return {@link RefilterPolicy} indicating how the proxy should treat filtering behavior.
    */
   @Override
-  public REFILTER_POLICY getReFilterPolicy() {
+  public RefilterPolicy getReFilterPolicy() {
     return container.getReFilterPolicy();
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/package-info.java
@@ -24,10 +24,11 @@
  * security settings, translation, and bookmark management to cover the full administrative
  * workflow.
  *
- * <p>Code outside the HTTP adapter boundary should treat this package as legacy adapter-owned
+ * <p>Code outside the HTTP adapter boundary should treat this package as a legacy adapter-owned
  * implementation detail rather than as a new platform API. Runtime and bootstrap code should
  * continue to depend on runtime-owned seams and the narrow bridge/binding sites instead of growing
- * new direct dependencies on {@code network.crypta.clients.http.*}. In production, {@code
+ * new direct dependencies on {@code network.crypta.clients.http.*}. The shared shell now uses the
+ * HTTP-local route registrar seam and the top-level refilter policy type, while {@code
  * network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories} remains the bootstrap-owned
  * binding site for the concrete HTTP bridge implementations.
  *

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/ImageElement.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/ImageElement.java
@@ -8,12 +8,12 @@ import java.util.Map;
 import network.crypta.client.FetchException;
 import network.crypta.client.filter.HTMLFilter.ParsedTag;
 import network.crypta.clients.http.FProxyFetchCriteria;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchResult;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyFetchWaiter;
 import network.crypta.clients.http.FProxyToadlet;
+import network.crypta.clients.http.RefilterPolicy;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.keys.FreenetURI;
@@ -225,7 +225,7 @@ public class ImageElement extends BaseUpdatableElement {
                     ImageElement.this.tracker.makeFetcher(
                         new FProxyFetchCriteria(
                             ImageElement.this.key, ImageElement.this.maxSize, null),
-                        REFILTER_POLICY.RE_FILTER);
+                        RefilterPolicy.RE_FILTER);
                 ImageElement.this
                     .tracker
                     .getFetchInProgress(
@@ -246,7 +246,7 @@ public class ImageElement extends BaseUpdatableElement {
                         ImageElement.this.tracker.makeFetcher(
                             new FProxyFetchCriteria(
                                 ImageElement.this.key, ImageElement.this.maxSize, null),
-                            REFILTER_POLICY.RE_FILTER);
+                            RefilterPolicy.RE_FILTER);
                     ImageElement.this
                         .tracker
                         .getFetchInProgress(
@@ -354,8 +354,8 @@ public class ImageElement extends BaseUpdatableElement {
    * {@code true}, the JS-enabled branch points to {@code /imagecreator/} with an “initializing”
    * message and a minimal progress payload ({@code fetchedBlocks=0}, {@code requiredBlocks=1}).
    *
-   * <p>For non-initial updates, this method attempts to obtain a fast fetch result. If the fetch
-   * has completed successfully, it re-renders the original image. If the fetch is still running, it
+   * <p>For non-initial updates, this method attempts to get a fast fetch result. If the fetch has
+   * completed successfully, it re-renders the original image. If the fetch is still running, it
    * renders a progress image that encodes the percentage complete and emits hidden progress inputs.
    * Failures fall back to the original image tag.
    *
@@ -465,7 +465,7 @@ public class ImageElement extends BaseUpdatableElement {
     try {
       resources.waiter =
           tracker.makeFetcher(
-              new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER);
+              new FProxyFetchCriteria(key, maxSize, null), RefilterPolicy.RE_FILTER);
       resources.result = resources.waiter.getResultFast();
     } catch (FetchException _) {
       whenJsEnabled.addChild("div", "error");

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -29,6 +29,8 @@ class HttpLegacyAdminBoundaryTest {
       Path.of("src", "main", "resources", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_HTTP_MAIN_JAVA =
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "http");
+  private static final Path ADAPTER_SIMPLE_TOADLET_SERVER =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("SimpleToadletServer.java");
   private static final Path ADAPTER_N2NTM_TOADLET =
       ADAPTER_HTTP_MAIN_JAVA.resolve("N2NTMToadlet.java");
   private static final Path ADAPTER_QUEUE_TOADLET =
@@ -233,6 +235,32 @@ class HttpLegacyAdminBoundaryTest {
         bootstrapHttpImports,
         "DefaultNodeRuntimeBridgeFactories must remain the narrow bootstrap-owned HTTP binding "
             + "site");
+  }
+
+  @Test
+  void mainSources_whenCheckingSimpleToadletServerImports_expectHttpShellSeamsDetached()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path sourceFile = repoRoot.resolve(ADAPTER_SIMPLE_TOADLET_SERVER);
+    String source = Files.readString(sourceFile);
+    Set<String> imports = readImports(sourceFile);
+
+    assertFalse(
+        imports.contains("import network.crypta.clients.http.FProxyRegistrar;"),
+        "SimpleToadletServer must not import the admin-owned FProxyRegistrar helper anymore.");
+    assertFalse(
+        imports.contains("import network.crypta.clients.http.FProxyRegistrarDependencies;"),
+        "SimpleToadletServer must not import FProxyRegistrarDependencies anymore.");
+    assertFalse(
+        source.contains("FProxyRegistrar.maybeCreateFProxyEtc"),
+        "SimpleToadletServer must not call FProxyRegistrar.maybeCreateFProxyEtc anymore.");
+    assertFalse(
+        source.contains("new FProxyRegistrarDependencies("),
+        "SimpleToadletServer must not construct FProxyRegistrarDependencies anymore.");
+    assertFalse(
+        source.contains("FProxyFetchInProgress.REFILTER_POLICY"),
+        "SimpleToadletServer must use the HTTP-local refilter policy type instead of the nested "
+            + "FProxy enum.");
   }
 
   @Test

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/HttpShellContainers.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/HttpShellContainers.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http.bridge;
 
+import network.crypta.clients.http.LegacyAdminHttpRouteRegistrar;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.SubConfig;
@@ -44,7 +45,9 @@ public final class HttpShellContainers {
    */
   public static HttpShellContainer create(SubConfig fproxyConfig, PriorityAwareExecutor executor)
       throws InvalidConfigValueException {
-    return new SimpleToadletServerHttpShellContainer(
-        new SimpleToadletServer(fproxyConfig, new ArrayBucketFactory(), executor));
+    SimpleToadletServer server =
+        new SimpleToadletServer(fproxyConfig, new ArrayBucketFactory(), executor);
+    server.setRouteRegistrar(new LegacyAdminHttpRouteRegistrar());
+    return new SimpleToadletServerHttpShellContainer(server);
   }
 }

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/package-info.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/package-info.java
@@ -13,7 +13,8 @@
  * binding selection remains in {@code
  * network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories}, while runtime-owned packages
  * continue to treat these classes as adapter implementations rather than as part of the long-lived
- * runtime seam. The remaining browse/FProxy shell stays boundary-frozen in {@code
+ * runtime seam. This leaf also installs the admin-owned HTTP route registrar implementation into
+ * the shared shell. The remaining browse/FProxy shell stays boundary-frozen in {@code
  * :adapter-http-legacy-admin}, and {@code network.crypta.clients.http.updater} also remains in that
  * adapter leaf in this PR.
  */

--- a/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/HttpShellContainersTest.java
+++ b/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/HttpShellContainersTest.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import network.crypta.clients.http.LegacyAdminHttpRouteRegistrar;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.StartupToadlet;
 import network.crypta.config.SubConfig;
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
@@ -91,6 +93,7 @@ class HttpShellContainersTest {
 
       verify(server)
           .setRuntimeSupport((network.crypta.clients.http.HttpShellRuntimeSupport) runtimeSupport);
+      verify(server).setRouteRegistrar(isA(LegacyAdminHttpRouteRegistrar.class));
       verify(server).setBucketFactory(tempBucketFactory);
       verify(server).setPrimaryUiRootListener(primaryUiRootListener);
       verify(server).createFproxy();

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -17,8 +17,10 @@ The adapter leaf still carries three responsibilities:
 The boundary is intentional. Production code outside `:adapter-http-legacy-admin` and
 `:bridge-http-runtime` should keep depending on runtime-owned seams, `:platform-api`, or
 `:platform-web-shell` instead of growing new direct dependencies on
-`network.crypta.clients.http.*`. The bootstrap-owned binding site remains
-`src/main/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactories.java`.
+`network.crypta.clients.http.*`. The shared shell now routes through an HTTP-local registrar seam
+and a top-level refilter policy type, while the bootstrap-owned binding site remains
+`src/main/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactories.java` and now
+installs the admin-owned HTTP registrar implementation.
 
 Future browse/FProxy decomposition or replacement is explicitly deferred. This PR does not reopen
 that architecture; it only documents the long-term maintenance boundary around the existing legacy

--- a/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchInProgressTest.java
@@ -9,7 +9,6 @@ import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.events.SimpleEventProducer;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.support.api.Bucket;
@@ -134,7 +133,7 @@ class FProxyFetchInProgressTest {
 
     FProxyFetchCriteria criteria = new FProxyFetchCriteria(uri, 1024L, context);
     return new FProxyFetchInProgress(
-        tracker, criteria, 1L, clientContext, requestClient, REFILTER_POLICY.ACCEPT_OLD);
+        tracker, criteria, 1L, clientContext, requestClient, RefilterPolicy.ACCEPT_OLD);
   }
 
   private static FetchContext newFetchContext() {

--- a/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyFetchTrackerTest.java
@@ -117,8 +117,7 @@ class FProxyFetchTrackerTest {
 
     FProxyFetchWaiter result =
         tracker.makeFetcher(
-            new FProxyFetchCriteria(key, 1024L, fetchContext),
-            FProxyFetchInProgress.REFILTER_POLICY.RE_FETCH);
+            new FProxyFetchCriteria(key, 1024L, fetchContext), RefilterPolicy.RE_FETCH);
 
     assertSame(waiter, result);
     verify(fetch, never()).start(context);
@@ -150,8 +149,7 @@ class FProxyFetchTrackerTest {
               FetchException.class,
               () ->
                   tracker.makeFetcher(
-                      new FProxyFetchCriteria(key, 2048L, fetchContext),
-                      FProxyFetchInProgress.REFILTER_POLICY.RE_FILTER));
+                      new FProxyFetchCriteria(key, 2048L, fetchContext), RefilterPolicy.RE_FILTER));
 
       assertSame(failure, thrown);
       assertTrue(getFetchers(tracker).values().isEmpty(), "fetcher should be removed on failure");

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -31,6 +31,7 @@ import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -242,6 +244,22 @@ class FProxyRegistrarTest {
 
     assertFalse(webShellRegistration.callback().isEnabled(null));
     assertTrue(webShellRegistration.callback().isEnabled(null));
+  }
+
+  @Test
+  void registerRoutes_whenInvokedViaLegacyAdminRegistrar_forwardsEquivalentDependencies() {
+    LegacyHttpRouteRegistrarContext context =
+        new LegacyHttpRouteRegistrarContext(client, runtimePorts, appHost, config, fproxy);
+
+    try (MockedStatic<FProxyRegistrar> registrar = mockStatic(FProxyRegistrar.class)) {
+      new LegacyAdminHttpRouteRegistrar().registerRoutes(context, server);
+
+      registrar.verify(
+          () ->
+              FProxyRegistrar.maybeCreateFProxyEtc(
+                  new FProxyRegistrarDependencies(client, runtimePorts, appHost, config, fproxy),
+                  server));
+    }
   }
 
   private static void registerBandwidthOption(

--- a/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
@@ -413,8 +413,8 @@ class FileInsertWizardToadletTest {
     }
 
     @Override
-    public FProxyFetchInProgress.REFILTER_POLICY getReFilterPolicy() {
-      return FProxyFetchInProgress.REFILTER_POLICY.ACCEPT_OLD;
+    public RefilterPolicy getReFilterPolicy() {
+      return RefilterPolicy.ACCEPT_OLD;
     }
 
     int getStatusCode() {

--- a/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
+++ b/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
@@ -294,8 +294,8 @@ class HTTPRequestImplTest {
       }
 
       @Override
-      public FProxyFetchInProgress.REFILTER_POLICY getReFilterPolicy() {
-        return FProxyFetchInProgress.REFILTER_POLICY.ACCEPT_OLD;
+      public RefilterPolicy getReFilterPolicy() {
+        return RefilterPolicy.ACCEPT_OLD;
       }
 
       @Override

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
@@ -53,6 +52,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
@@ -246,27 +247,23 @@ class SimpleToadletServerTest {
     when(runtimePorts.randomness()).thenReturn(randomnessPort);
     when(client.getFetchContext()).thenReturn(fetchContext);
     server.setRuntimeSupport(new CoreHttpShellRuntimeSupport(core, appHost));
+    LegacyHttpRouteRegistrar routeRegistrar = mock(LegacyHttpRouteRegistrar.class);
+    server.setRouteRegistrar(routeRegistrar);
 
-    AtomicInteger registrarCalls = new AtomicInteger();
-    AtomicReference<FProxyRegistrarDependencies> dependenciesRef = new AtomicReference<>();
+    AtomicReference<LegacyHttpRouteRegistrarContext> routeRegistrarContextRef =
+        new AtomicReference<>();
     AtomicReference<List<Object>> bookmarkManagerCtorArgs = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              routeRegistrarContextRef.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(routeRegistrar)
+        .registerRoutes(any(LegacyHttpRouteRegistrarContext.class), same(server));
     try (MockedConstruction<BookmarkManager> bookmarkManagers =
-            mockConstruction(
-                BookmarkManager.class,
-                (_, context) -> bookmarkManagerCtorArgs.set(List.copyOf(context.arguments())));
-        MockedStatic<FProxyRegistrar> registrarMock = mockStatic(FProxyRegistrar.class)) {
-      registrarMock
-          .when(
-              () ->
-                  FProxyRegistrar.maybeCreateFProxyEtc(
-                      any(FProxyRegistrarDependencies.class), same(server)))
-          .thenAnswer(
-              invocation -> {
-                registrarCalls.incrementAndGet();
-                dependenciesRef.set(invocation.getArgument(0));
-                return null;
-              });
-
+        mockConstruction(
+            BookmarkManager.class,
+            (_, context) -> bookmarkManagerCtorArgs.set(List.copyOf(context.arguments())))) {
       server.createFproxy();
       server.createFproxy();
 
@@ -284,12 +281,25 @@ class SimpleToadletServerTest {
     verify(core, times(1)).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
     verify(core, times(1)).getAlerts();
     verify(core, never()).getRandom();
-    assertEquals(1, registrarCalls.get());
-    assertSame(client, dependenciesRef.get().client());
-    assertSame(runtimePorts, dependenciesRef.get().runtimePorts());
-    assertSame(appHost, dependenciesRef.get().appHost());
-    assertSame(nodeConfig, dependenciesRef.get().config());
-    assertInstanceOf(FProxyToadlet.class, dependenciesRef.get().fproxy());
+    verify(routeRegistrar, times(1))
+        .registerRoutes(any(LegacyHttpRouteRegistrarContext.class), same(server));
+    assertSame(client, routeRegistrarContextRef.get().client());
+    assertSame(runtimePorts, routeRegistrarContextRef.get().runtimePorts());
+    assertSame(appHost, routeRegistrarContextRef.get().appHost());
+    assertSame(nodeConfig, routeRegistrarContextRef.get().config());
+    assertInstanceOf(FProxyToadlet.class, routeRegistrarContextRef.get().fproxy());
+  }
+
+  @Test
+  void createFproxy_whenRouteRegistrarMissing_throwsNullPointerException() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
+    server.setRuntimeSupport(runtimeSupport);
+    clearInvocations(runtimeSupport);
+
+    assertThrows(NullPointerException.class, server::createFproxy);
+
+    verifyNoInteractions(runtimeSupport);
   }
 
   @Test
@@ -353,14 +363,14 @@ class SimpleToadletServerTest {
           .onChange(
               HttpShellRuntimeSupport.NetworkThreatLevel.NORMAL,
               HttpShellRuntimeSupport.NetworkThreatLevel.LOW);
-      assertEquals(FProxyFetchInProgress.REFILTER_POLICY.ACCEPT_OLD, server.getReFilterPolicy());
+      assertEquals(RefilterPolicy.ACCEPT_OLD, server.getReFilterPolicy());
 
       networkListener
           .get()
           .onChange(
               HttpShellRuntimeSupport.NetworkThreatLevel.LOW,
               HttpShellRuntimeSupport.NetworkThreatLevel.NORMAL);
-      assertEquals(FProxyFetchInProgress.REFILTER_POLICY.RE_FILTER, server.getReFilterPolicy());
+      assertEquals(RefilterPolicy.RE_FILTER, server.getReFilterPolicy());
 
       physicalListener
           .get()

--- a/src/test/java/network/crypta/clients/http/updateableelements/ImageElementTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/ImageElementTest.java
@@ -7,13 +7,13 @@ import java.util.List;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.clients.http.FProxyFetchCriteria;
-import network.crypta.clients.http.FProxyFetchInProgress.REFILTER_POLICY;
 import network.crypta.clients.http.FProxyFetchInProgress;
 import network.crypta.clients.http.FProxyFetchProgressCounts;
 import network.crypta.clients.http.FProxyFetchResult;
 import network.crypta.clients.http.FProxyFetchSnapshotInfo;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyFetchWaiter;
+import network.crypta.clients.http.RefilterPolicy;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
@@ -223,7 +223,7 @@ class ImageElementTest {
       throws FetchException {
     // Arrange
     ImageElement element = ImageElement.createImageElement(tracker, key, 123L, ctx, false);
-    when(tracker.makeFetcher(new FProxyFetchCriteria(key, 123L, null), REFILTER_POLICY.RE_FILTER))
+    when(tracker.makeFetcher(new FProxyFetchCriteria(key, 123L, null), RefilterPolicy.RE_FILTER))
         .thenThrow(new FetchException(FetchExceptionMode.DATA_NOT_FOUND));
 
     // Act
@@ -248,8 +248,7 @@ class ImageElementTest {
     when(bucket.size()).thenReturn(123L);
     FProxyFetchResult result = newFinishedResultWithData(progress, bucket);
 
-    when(tracker.makeFetcher(
-            new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER))
+    when(tracker.makeFetcher(new FProxyFetchCriteria(key, maxSize, null), RefilterPolicy.RE_FILTER))
         .thenReturn(waiter);
     when(waiter.getResultFast()).thenReturn(result);
     when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null)))
@@ -279,8 +278,7 @@ class ImageElementTest {
     FetchException failure = new FetchException(FetchExceptionMode.DATA_NOT_FOUND);
     FProxyFetchResult result = newProgressOrFailureResult(progress, 10, 1, failure);
 
-    when(tracker.makeFetcher(
-            new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER))
+    when(tracker.makeFetcher(new FProxyFetchCriteria(key, maxSize, null), RefilterPolicy.RE_FILTER))
         .thenReturn(waiter);
     when(waiter.getResultFast()).thenReturn(result);
     when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null)))
@@ -311,8 +309,7 @@ class ImageElementTest {
     FProxyFetchWaiter waiter = mock(FProxyFetchWaiter.class);
     FProxyFetchResult result = newProgressOrFailureResult(progress, 20, 5, null);
 
-    when(tracker.makeFetcher(
-            new FProxyFetchCriteria(key, maxSize, null), REFILTER_POLICY.RE_FILTER))
+    when(tracker.makeFetcher(new FProxyFetchCriteria(key, maxSize, null), RefilterPolicy.RE_FILTER))
         .thenReturn(waiter);
     when(waiter.getResultFast()).thenReturn(result);
     when(tracker.getFetchInProgress(new FProxyFetchCriteria(key, maxSize, null)))
@@ -473,8 +470,6 @@ class ImageElementTest {
   }
 
   private static LinkageError linkageError(String message, ReflectiveOperationException e) {
-    LinkageError error = new LinkageError(message);
-    error.initCause(e);
-    return error;
+    return new LinkageError(message, e);
   }
 }


### PR DESCRIPTION
## Summary
- extract the shared HTTP-local `RefilterPolicy` enum and switch the shell and FProxy fetch paths off `FProxyFetchInProgress.REFILTER_POLICY`
- introduce the `LegacyHttpRouteRegistrar` seam plus the admin-owned registrar adapter so `SimpleToadletServer` no longer constructs or calls the admin registrar path directly
- wire the production registrar through `bridge-http-runtime`, tighten the focused boundary tests, and update the legacy HTTP boundary docs and Javadoc for the new seam types

Implements PR-160.

## How to test
- `./gradlew :test --tests network.crypta.clients.http.SimpleToadletServerTest --tests network.crypta.clients.http.FProxyRegistrarTest`
- `./gradlew test`

## Notes
- Base branch: `develop`
- Branch: `feature/legacy-http-boundary-seams`