### PR TITLE
refactor(legacy-http): Neutralize shared-shell seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,9 @@ Root build also includes:
 - `:adapter-http-legacy-admin`: extracted legacy `network.crypta.clients.http` adapter code plus
   `network/crypta/clients/http/**` main resources. The root project no longer owns that main
   HTTP source/resource tree, and the remaining browse/FProxy shell in this adapter is
-  boundary-frozen for now. It currently hosts both the temporary `/api/v1/` bridge for
+  boundary-frozen for now. The shared shell now crosses neutral bookmark, push, and client-side
+  localization seams instead of importing the concrete browse-owned collaborators directly. It
+  currently hosts both the temporary `/api/v1/` bridge for
   `:platform-api` and the initial `/app/node/` bridge for `:platform-web-shell`. See
   [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
   boundary.
@@ -797,8 +799,10 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `/app/node/`, runtime-owned shell and password-prompt seams under
   `network.crypta.runtime.http` and `network.crypta.runtime.http.security`, and client-local
   helpers such as `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellBrowseBootstrap`,
-  and the shared HTTP route registrar seam. Concrete HTTP shell, bookmark, GeoIP, and
-  security-page adapters now live under `network.crypta.clients.http.bridge` in
+  and the shared HTTP route registrar seam. The shared legacy shell now also uses neutral bookmark,
+  push, and client-side script seams instead of importing browse-owned collaborator classes
+  directly. Concrete HTTP shell, bookmark, GeoIP, and security-page adapters now live under
+  `network.crypta.clients.http.bridge` in
   `:bridge-http-runtime`, and that leaf also owns the legacy HTTP GeoIP helper package
   `network.crypta.clients.http.geoip`. The updater-action adapters remain under
   `network.crypta.clients.http.updater` in `:adapter-http-legacy-admin`. Root-local bridge

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/BookmarkManagerHandle.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/BookmarkManagerHandle.java
@@ -1,0 +1,36 @@
+package network.crypta.clients.http;
+
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Neutral handle for the legacy HTTP shell's bookmark collaborator.
+ *
+ * <p>This interface gives the shared-shell code a stable type that can cross the current
+ * browse/admin boundary without importing the browse-owned bookmark package directly. The shared
+ * shell only needs a narrow read-oriented view: it can carry a bookmark collaborator through
+ * request and server wiring, and it can ask for the current bookmark targets when rendering
+ * shell-owned UI. Richer bookmark editing, persistence, and tree-management behavior stays on the
+ * concrete browse side for now.
+ *
+ * <p>Implementations are free to build the returned URI array from a live state or from a cached
+ * snapshot, but callers should treat the result as request-time data rather than a mutable backing
+ * collection. This keeps the seam small while preserving the current runtime wiring for the later
+ * module split work.
+ */
+public interface BookmarkManagerHandle {
+  /**
+   * Returns the bookmark URIs visible to the shared shell.
+   *
+   * <p>The returned array is the only bookmark-specific data currently required by the shared
+   * shell. It is used for legacy rendering and request wiring where the shell needs bookmark
+   * targets but does not need access to browse-owned editing or organization APIs.
+   *
+   * <p>Implementations should return an empty array when no bookmarks are available. Callers should
+   * not assume ownership of the returned array beyond the immediate read operation, and they should
+   * not rely on array identity remaining stable across calls.
+   *
+   * @return current bookmark URIs visible to the shared shell or an empty array when none are
+   *     stored
+   */
+  FreenetURI[] getBookmarkURIs();
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellBrowseBootstrap.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellBrowseBootstrap.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
@@ -21,7 +20,7 @@ import network.crypta.runtime.spi.RuntimePorts;
  * collaborators are live runtime objects with shared identity, so the record preserves references
  * rather than copying or wrapping them.
  *
- * @param bookmarkManager bookmark manager wired against the daemon-backed bookmark runtime support
+ * @param bookmarkManager bookmark handle wired against the daemon-backed bookmark runtime support
  *     for the surrounding shell lifecycle
  * @param client interactive client shared by HTTP toadlets created during shell startup and route
  *     registration
@@ -31,7 +30,7 @@ import network.crypta.runtime.spi.RuntimePorts;
  *     for root-path registration
  */
 public record HttpShellBrowseBootstrap(
-    BookmarkManager bookmarkManager,
+    BookmarkManagerHandle bookmarkManager,
     HighLevelSimpleClient client,
     AppHost appHost,
     Toadlet browseRoot) {
@@ -43,7 +42,7 @@ public record HttpShellBrowseBootstrap(
    * retained as-is; this method performs no additional browse-specific initialization beyond the
    * record's null checks.
    *
-   * @param bookmarkManager bookmark manager used by the surrounding shell bootstrap to populate
+   * @param bookmarkManager bookmark handle used by the surrounding shell bootstrap to populate
    *     bookmark-backed routes
    * @param client interactive client shared by shell toadlets that are registered during startup
    * @param appHost shared AppHost instance used by the platform control plane and related routes
@@ -51,7 +50,7 @@ public record HttpShellBrowseBootstrap(
    * @return browse-neutral bootstrap bundle containing the supplied collaborators and browse root
    */
   public static HttpShellBrowseBootstrap create(
-      BookmarkManager bookmarkManager,
+      BookmarkManagerHandle bookmarkManager,
       HighLevelSimpleClient client,
       AppHost appHost,
       Toadlet browseRoot) {
@@ -69,7 +68,7 @@ public record HttpShellBrowseBootstrap(
    * random state; the shared shell owns that initialization step, so alternative runtime-support
    * implementations receive the same guarantee.
    *
-   * @param bookmarkManager bookmark manager used by the surrounding shell bootstrap to populate
+   * @param bookmarkManager bookmark handle used by the surrounding shell bootstrap to populate
    *     bookmark-backed routes
    * @param client interactive client shared by shell toadlets that are registered during startup
    * @param appHost shared AppHost instance used by the platform control plane and related routes
@@ -78,7 +77,7 @@ public record HttpShellBrowseBootstrap(
    * @return browse-neutral bootstrap bundle containing the constructed root browse toadlet
    */
   public static HttpShellBrowseBootstrap create(
-      BookmarkManager bookmarkManager,
+      BookmarkManagerHandle bookmarkManager,
       HighLevelSimpleClient client,
       AppHost appHost,
       FProxyRuntimeSupport runtimeSupport,

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/IntervalPusherManager.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/IntervalPusherManager.java
@@ -2,8 +2,6 @@ package network.crypta.clients.http;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import network.crypta.clients.http.updateableelements.BaseUpdatableElement;
-import network.crypta.clients.http.updateableelements.PushDataManager;
 import network.crypta.support.Ticker;
 
 /**
@@ -14,9 +12,9 @@ import network.crypta.support.Ticker;
  * context, register elements as they become visible to the UI, and allow the manager to keep those
  * elements fresh without bespoke timers. The internal {@link CopyOnWriteArrayList} permits safe
  * iteration from the refresher while callers add or remove elements concurrently. When the list is
- * empty no further jobs are queued, so idle nodes avoid unnecessary wakeups. The manager is
- * intentionally minimal: it delegates all data retrieval to {@link PushDataManager} and uses each
- * element's updater identifier to trigger the appropriate push logic.
+ * empty, no further jobs are queued, so idle nodes avoid unnecessary wakeups. The manager is
+ * intentionally minimal: it delegates all data retrieval to {@link PushDataManagerHandle} and uses
+ * each element's updater identifier to trigger the appropriate push logic.
  *
  * <ul>
  *   <li>Registers UI elements that expect recurring server pushes.
@@ -25,28 +23,28 @@ import network.crypta.support.Ticker;
  * </ul>
  *
  * @see Ticker
- * @see PushDataManager
- * @see BaseUpdatableElement
+ * @see PushDataManagerHandle
+ * @see PushUpdatableElement
  */
 public class IntervalPusherManager {
 
   /** The interval when the elements will be pushed */
   private static final int REFRESH_PERIOD = 10000;
 
-  /** The PushDataManager object */
-  private final PushDataManager pushDataManager;
+  /** The push/update manager handle. */
+  private final PushDataManagerHandle pushDataManager;
 
   /** The Ticker to schedule the interval */
   private final Ticker ticker;
 
-  /** The job, that will refresh the elements */
+  /** The job that will refresh the elements */
   private final Runnable refresherJob =
       new Runnable() {
 
         @Override
         public void run() {
           // Updating
-          for (BaseUpdatableElement element : elements) {
+          for (PushUpdatableElement element : elements) {
             pushDataManager.updateElement(element.getUpdaterId(null));
           }
 
@@ -58,7 +56,7 @@ public class IntervalPusherManager {
       };
 
   /** The elements that are pushed at a fixed interval */
-  private final List<BaseUpdatableElement> elements = new CopyOnWriteArrayList<>();
+  private final List<PushUpdatableElement> elements = new CopyOnWriteArrayList<>();
 
   /**
    * Creates a manager that schedules update pushes with the supplied ticker.
@@ -72,7 +70,7 @@ public class IntervalPusherManager {
    * @param ticker non-null ticker that handles delayed job scheduling
    * @param pushDataManager manager that performs element updates when jobs run
    */
-  public IntervalPusherManager(Ticker ticker, PushDataManager pushDataManager) {
+  public IntervalPusherManager(Ticker ticker, PushDataManagerHandle pushDataManager) {
     this.ticker = ticker;
     this.pushDataManager = pushDataManager;
   }
@@ -85,13 +83,13 @@ public class IntervalPusherManager {
    * manager immediately schedules the refresher job, which subsequently requeues itself every
    * {@value #REFRESH_PERIOD} milliseconds while the list remains non-empty. Duplicate registrations
    * are not deduplicated and result in multiple update calls. The element must expose a stable
-   * updater identifier because the manager forwards that value to {@link PushDataManager} without
-   * further validation.
+   * updater identifier because the manager forwards that value to {@link PushDataManagerHandle}
+   * without further validation.
    *
    * @param element element to track; must not be null
    */
   @SuppressWarnings("unused")
-  public void registerUpdateableElement(BaseUpdatableElement element) {
+  public void registerUpdateableElement(PushUpdatableElement element) {
     boolean needsStart = elements.isEmpty();
     elements.add(element);
     // If this is the first element, then it starts the ticker
@@ -109,10 +107,10 @@ public class IntervalPusherManager {
    * stopping periodic updates until a new element is registered. The method tolerates removal of
    * elements that were not previously registered; in that case it performs no work.
    *
-   * @param element element to remove from recurring update schedule
+   * @param element element to remove from the recurring update schedule
    */
   @SuppressWarnings("unused")
-  public void deregisterUpdateableElement(BaseUpdatableElement element) {
+  public void deregisterUpdateableElement(PushUpdatableElement element) {
     elements.remove(element);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import network.crypta.clients.http.filter.PushingTagReplacerCallback;
+import network.crypta.clients.http.utils.ClientSideLocalizationScript;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.PageChromePort;
@@ -591,7 +591,7 @@ public final class PageMaker {
             TAG_SCRIPT,
             new String[] {ATTR_TYPE, ATTR_LANGUAGE},
             new String[] {MIME_TEXT_JAVASCRIPT, JAVASCRIPT})
-        .addChild("%", PushingTagReplacerCallback.getClientSideLocalizationScript());
+        .addChild("%", ClientSideLocalizationScript.getClientSideLocalizationScript());
   }
 
   private void renderStatusBar(

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushDataManagerHandle.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushDataManagerHandle.java
@@ -1,0 +1,111 @@
+package network.crypta.clients.http;
+
+/**
+ * Shared-shell view of the legacy HTTP push-data manager.
+ *
+ * <p>This handle represents the server-side coordination point for the legacy push/update flow used
+ * by the HTTP shell. Shared-shell code registers rendered elements, reports later changes by
+ * updater id, and polls for queued notifications without depending directly on the concrete
+ * browse-owned push implementation. That keeps the current behavior intact while giving the shared
+ * shell a stable, browse-neutral contract for the later physical split.
+ *
+ * <p>The interface models the full request lifecycle for pushed pages: render-time registration,
+ * change propagation, leader failover, poll keepalives, and explicit teardown when a page leaves
+ * the system. Implementations are stateful and are expected to manage any synchronization,
+ * deduplication, and cleanup policy internally.
+ */
+public interface PushDataManagerHandle {
+
+  /**
+   * Notifies the manager that an element was rendered for the given request.
+   *
+   * <p>Implementations use this callback to associate a rendered element with a request or page
+   * identifier so later update notifications can be routed back to the correct server-side state.
+   * The shared shell calls this after an element has produced its initial markup and is ready to
+   * participate in the push lifecycle.
+   *
+   * @param requestUniqueId request or page identifier that rendered the element and will later poll
+   *     for updates
+   * @param element rendered element to track for future update lookups and cleanup
+   */
+  void elementRendered(String requestUniqueId, PushUpdatableElement element);
+
+  /**
+   * Marks an element as changed and schedules any waiting notifications.
+   *
+   * <p>This method is the write-side signal used by interval refreshers and other producers. The
+   * caller supplies the stable updater id for the changed element; the implementation is
+   * responsible for finding interesting requests, deduplicating queued events where appropriate,
+   * and waking any blocked pollers.
+   *
+   * @param id updater id of the element whose rendered state changed
+   */
+  void updateElement(String id);
+
+  /**
+   * Returns a previously rendered element for the supplied request and element id.
+   *
+   * <p>This is the read-side lookup used when a poll response tells the client to refresh a single
+   * element. Implementations may refresh the element state before returning it, so callers can
+   * immediately serialize the current markup without a second coordination step.
+   *
+   * @param requestId request or page identifier that originally rendered the element
+   * @param id stable updater id for the element within that request
+   * @return tracked updatable element for the supplied request and id, or {@code null} when the
+   *     element is no longer available
+   */
+  PushUpdatableElement getRenderedElement(String requestId, String id);
+
+  /**
+   * Moves queued notifications from one request id to another.
+   *
+   * <p>This operation supports the legacy notion of a polling leader. When leadership changes, the
+   * implementation can move any queued notifications from the original request id to the new one so
+   * pending updates are not lost.
+   *
+   * @param originalRequestId request id whose queued notifications should be transferred away
+   * @param newRequestId request id that should receive the transferred notification queue
+   * @return {@code true} when a queued notification list was migrated, or {@code false} when the
+   *     original request id was not tracked
+   */
+  boolean failover(String originalRequestId, String newRequestId);
+
+  /**
+   * Retrieves the next notification for the supplied request.
+   *
+   * <p>Implementations may block until a queued notification becomes available, the request stops
+   * being tracked, or the underlying wait is interrupted. Callers should therefore treat a {@code
+   * null} return as "no event is available right now" rather than assuming a specific cause.
+   *
+   * @param requestId polling request identifier currently waiting for the next push event
+   * @return next queued update event for the request, or {@code null} when no event can be
+   *     delivered
+   */
+  PushUpdateEvent getNextNotification(String requestId);
+
+  /**
+   * Notes that a polling request is still alive.
+   *
+   * <p>This method refreshes the liveness signal for a tracked polling request so the
+   * implementation's cleanup policy does not discard it as stale. Implementations may also use the
+   * first successful keepalive as a gate before releasing pending notifications.
+   *
+   * @param requestUniqueId request identifier to mark as still alive
+   * @return {@code true} when the request remains tracked, or {@code false} when it has already
+   *     been removed
+   */
+  boolean keepAliveReceived(String requestUniqueId);
+
+  /**
+   * Marks a request as leaving the push system.
+   *
+   * <p>This gives the HTTP shell an explicit teardown hook for request completion and client
+   * navigation. Implementations should release tracked elements, discard queued notifications as
+   * needed, and stop treating the request as active.
+   *
+   * @param requestId request identifier leaving the push system
+   * @return {@code true} when tracked state was removed, or {@code false} when the request was
+   *     already absent
+   */
+  boolean leaving(String requestId);
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushDataManagerHandles.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushDataManagerHandles.java
@@ -1,0 +1,35 @@
+package network.crypta.clients.http;
+
+import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.support.Ticker;
+
+/**
+ * Factory for the legacy HTTP push-data manager handle.
+ *
+ * <p>This utility centralizes the one place where shared-shell wiring turns a neutral {@link
+ * PushDataManagerHandle} dependency into the current concrete browse-owned implementation. That
+ * keeps constructor and bootstrap code in the shared shell free from direct imports of {@link
+ * network.crypta.clients.http.updateableelements.PushDataManager} while preserving the existing
+ * runtime behavior and object graph.
+ *
+ * <p>The class is intentionally tiny and stateless. It exists to mark the seam explicitly, not to
+ * add lifecycle or caching behavior of its own.
+ */
+public final class PushDataManagerHandles {
+
+  private PushDataManagerHandles() {}
+
+  /**
+   * Creates the concrete push-data manager used by the legacy shell.
+   *
+   * <p>The returned instance is the current production implementation for the legacy push flow. It
+   * is exposed as a neutral handle, so shared-shell code can keep working against the seam while
+   * the concrete class remains browse-owned during the split-preparation phase.
+   *
+   * @param ticker scheduler used by the push manager for keepalive cleanup and related timed work
+   * @return concrete legacy push-data manager instance exposed through the shared-shell handle
+   */
+  public static PushDataManagerHandle create(Ticker ticker) {
+    return new PushDataManager(ticker);
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushUpdatableElement.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushUpdatableElement.java
@@ -1,0 +1,74 @@
+package network.crypta.clients.http;
+
+/**
+ * Shared-shell view of an element that can be re-rendered through the legacy push/update flow.
+ *
+ * <p>An implementation represents one server-side DOM fragment that can be rendered during the
+ * initial page response and later refreshed in place after the server detects a state change. The
+ * shared shell only needs a small contract for that lifecycle: refresh the element's internal
+ * state, identify it with a stable updater id and updater type, serialize its children, and clean
+ * up any resources when the request leaves the push system.
+ *
+ * <p>The interface deliberately avoids browse-owned base classes, so schedulers, toadlets, and
+ * request services can work against a neutral type. Implementations remain mutable request-scoped
+ * objects. Callers should assume they are tied to a single render/update lifecycle rather than
+ * reusable across unrelated requests.
+ */
+public interface PushUpdatableElement {
+
+  /**
+   * Refreshes the element state before it is read or re-rendered.
+   *
+   * <p>Implementations should rebuild or recalculate any transient state needed for rendering so
+   * that a subsequent call to {@link #generateChildren()} reflects the current server-side view.
+   * The {@code initial} flag distinguishes the first render from later push-driven refreshes when
+   * an implementation needs slightly different setup behavior.
+   *
+   * @param initial {@code true} when invoked for the initial render of the element instance, or
+   *     {@code false} for a later refresh
+   */
+  void updateState(boolean initial);
+
+  /**
+   * Returns the stable updater id used for server-side lookup and DOM targeting.
+   *
+   * <p>The returned identifier is used as the key that links server-side element tracking to the
+   * browser-side updater logic. Implementations should produce a value that remains stable for the
+   * lifetime of the element within the supplied request or page.
+   *
+   * @param requestId request or page identifier used to scope the updater id
+   * @return stable updater identifier for this element within the supplied request
+   */
+  String getUpdaterId(String requestId);
+
+  /**
+   * Returns the client-side updater type identifier for this element.
+   *
+   * <p>This value tells the browser-side update code which updater implementation should interpret
+   * the serialized payload for this element. Implementations should return the same logical type
+   * for every refresh of the same element kind.
+   *
+   * @return updater type identifier understood by the client-side update code
+   */
+  String getUpdaterType();
+
+  /**
+   * Generates the serialized child markup for the current element state.
+   *
+   * <p>Callers use this after {@link #updateState(boolean)} to build the payload returned by the
+   * push endpoints. The result should represent the current child markup for the element, ready to
+   * send back to the browser without additional element-specific transformation.
+   *
+   * @return serialized child markup for the element's current state
+   */
+  String generateChildren();
+
+  /**
+   * Releases resources held by this element.
+   *
+   * <p>This is the teardown hook for request completion and push cleanup. Implementations should
+   * detach listeners, cancel auxiliary work, and drop references that should not survive after the
+   * element is no longer tracked.
+   */
+  void dispose();
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushUpdateEvent.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PushUpdateEvent.java
@@ -1,0 +1,39 @@
+package network.crypta.clients.http;
+
+/**
+ * Shared-shell view of one pending push/update notification.
+ *
+ * <p>An event tells the legacy push client which server-side page/request and which tracked element
+ * need to be refreshed next. The polling endpoint returns these notifications after the push
+ * manager observes a state change and decides that a client should ask for updated markup. The
+ * event is intentionally small because the actual HTML payload is fetched separately through the
+ * element lookup path.
+ *
+ * <p>Implementations typically behave like immutable value objects. Callers should treat the
+ * request identifier and element identifier together as the routing key for the next refresh step,
+ * not as independent data points with separate lifecycles.
+ */
+public interface PushUpdateEvent {
+
+  /**
+   * Returns the request/page identifier that should apply the update.
+   *
+   * <p>This identifies the tracked page or request whose rendered state should be consulted for the
+   * next refresh. In the legacy system, the polling request that receives the event can differ from
+   * the page/request that originally rendered the changed element.
+   *
+   * @return target request or page identifier that should apply the update
+   */
+  String getRequestId();
+
+  /**
+   * Returns the updater element identifier that changed.
+   *
+   * <p>Callers use this identifier together with {@link #getRequestId()} to resolve the matching
+   * {@link PushUpdatableElement} and fetch the latest serialized child markup for the browser-side
+   * updater.
+   *
+   * @return updater element identifier for the changed element
+   */
+  String getElementId();
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -15,8 +15,6 @@ import java.util.function.Consumer;
 import network.crypta.client.filter.HTMLFilter;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.http.PageMaker.THEME;
-import network.crypta.clients.http.bookmark.BookmarkManager;
-import network.crypta.clients.http.updateableelements.PushDataManager;
 import network.crypta.config.BooleanCallback;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.IntCallback;
@@ -158,7 +156,7 @@ public final class SimpleToadletServer
     noConfirmPanic = value;
   }
 
-  private BookmarkManager bookmarkManager; // move to WelcomeToadlet / BookmarkEditorToadlet?
+  private BookmarkManagerHandle bookmarkManager; // move to WelcomeToadlet / BookmarkEditorToadlet?
   private volatile boolean fProxyJavascriptEnabled; // ugh?
   private volatile boolean fProxyWebPushingEnabled; // ugh?
   private volatile boolean fproxyHasCompletedWizard; // hmmm..
@@ -173,8 +171,8 @@ public final class SimpleToadletServer
 
   private StartupToadlet startupToadlet;
 
-  /** The PushDataManager handles all the pushing tasks. */
-  private PushDataManager pushDataManager;
+  /** The push/update manager handle coordinates all legacy-pushing tasks. */
+  private PushDataManagerHandle pushDataManager;
 
   /** The IntervalPusherManager handles interval pushing */
   private IntervalPusherManager intervalPushManager;
@@ -476,7 +474,7 @@ public final class SimpleToadletServer
       haveCalledFProxy = true;
     }
 
-    pushDataManager = new PushDataManager(getTicker());
+    pushDataManager = PushDataManagerHandles.create(getTicker());
     intervalPushManager = new IntervalPusherManager(getTicker(), pushDataManager);
     HttpShellBrowseBootstrap bootstrap =
         runtimeSupportRef.createBrowseBootstrap(publicGatewayMode());
@@ -1786,9 +1784,9 @@ public final class SimpleToadletServer
    * components. Once available, it manages storage, import/export, and UI synchronization for saved
    * bookmarks. Callers should treat the reference as owned by the server.
    *
-   * @return {@link BookmarkManager} instance or {@code null} when not yet available.
+   * @return {@link BookmarkManagerHandle} instance or {@code null} when not yet available.
    */
-  public BookmarkManager getBookmarkManager() {
+  public BookmarkManagerHandle getBookmarkManager() {
     return bookmarkManager;
   }
 
@@ -1797,9 +1795,9 @@ public final class SimpleToadletServer
    *
    * <p>Provided for compatibility with older call sites that referenced the shorter name.
    *
-   * @return bookmark manager instance or {@code null}.
+   * @return bookmark handle instance or {@code null}.
    */
-  public BookmarkManager getBookmarks() {
+  public BookmarkManagerHandle getBookmarks() {
     return getBookmarkManager();
   }
 
@@ -1987,10 +1985,10 @@ public final class SimpleToadletServer
    * <p>Supports one-off push transmissions triggered by toadlets. Like the interval manager, this
    * object is created during {@link #createFproxy()} and owned by the server.
    *
-   * @return {@link PushDataManager} instance or {@code null} if initialization has not yet created
-   *     one.
+   * @return {@link PushDataManagerHandle} instance or {@code null} if initialization has not yet
+   *     created one.
    */
-  public PushDataManager getPushDataManager() {
+  public PushDataManagerHandle getPushDataManager() {
     return pushDataManager;
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContext.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
-import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
@@ -39,6 +38,7 @@ import network.crypta.support.io.NoFreeBucket;
  * @see ToadletContainer
  * @see PageMaker
  */
+@SuppressWarnings("TypeParameterUnusedInFormals")
 public interface ToadletContext {
 
   /**
@@ -233,11 +233,11 @@ public interface ToadletContext {
   UserAlertManager getAlertManager();
 
   /**
-   * Access the {@link BookmarkManager} used to read or update bookmarks within this request.
+   * Access the {@link BookmarkManagerHandle} used to read or update bookmarks within this request.
    *
-   * @return Non-null bookmark manager instance.
+   * @return non-null bookmark handle instance.
    */
-  BookmarkManager getBookmarkManager();
+  <T extends BookmarkManagerHandle> T getBookmarkManager();
 
   /**
    * Obtain the {@link BucketFactory} used to create buckets for reading request bodies or composing

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.core.SSL;
@@ -100,7 +99,7 @@ public final class ToadletContextImpl implements ToadletContext {
   private final BucketFactory bf;
   private final ToadletContainer container;
   private final UserAlertManager userAlertManager;
-  private final BookmarkManager bookmarkManager;
+  private final BookmarkManagerHandle bookmarkManager;
   private final InetAddress remoteAddr;
   private Exception firstReplySendingException;
   private final AtomicReference<Toadlet> activeToadlet = new AtomicReference<>();
@@ -575,11 +574,12 @@ public final class ToadletContextImpl implements ToadletContext {
    * localization support so individual handlers can focus on user flows rather than storage
    * details.
    *
-   * @return Bookmark manager configured for the running node; never {@code null}.
+   * @return bookmark handle configured for the running node; never {@code null}.
    */
   @Override
-  public BookmarkManager getBookmarkManager() {
-    return bookmarkManager;
+  @SuppressWarnings({"TypeParameterUnusedInFormals", "unchecked"})
+  public <T extends BookmarkManagerHandle> T getBookmarkManager() {
+    return (T) bookmarkManager;
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletRequestServices.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletRequestServices.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.http;
 
-import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.runtime.alerts.UserAlertManager;
 
 /**
@@ -13,10 +12,10 @@ import network.crypta.runtime.alerts.UserAlertManager;
  * @param container the owning toadlet container that enforces request policies
  * @param pageMaker shared page renderer used by UI toadlets
  * @param userAlertManager manager used to surface user-facing alerts
- * @param bookmarkManager bookmark subsystem access point for request handlers
+ * @param bookmarkManager bookmark subsystem handle for request handlers
  */
 public record ToadletRequestServices(
     ToadletContainer container,
     PageMaker pageMaker,
     UserAlertManager userAlertManager,
-    BookmarkManager bookmarkManager) {}
+    BookmarkManagerHandle bookmarkManager) {}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.PushUpdatableElement;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
-import network.crypta.clients.http.updateableelements.BaseUpdatableElement;
 import network.crypta.clients.http.updateableelements.UpdaterConstants;
 import network.crypta.support.Base64;
 import network.crypta.support.api.HTTPRequest;
@@ -29,9 +29,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>On success, the reply body is formatted as {@code SUCCESS:<type>:<children>} where {@code
  * <type>} is the UTF-8 Base64 encoding of {@link
- * network.crypta.clients.http.updateableelements.BaseUpdatableElement#getUpdaterType()} and {@code
- * <children>} is the UTF-8 Base64 encoding of {@link
- * network.crypta.clients.http.updateableelements.BaseUpdatableElement#generateChildren()}.
+ * network.crypta.clients.http.PushUpdatableElement#getUpdaterType()} and {@code <children>} is the
+ * UTF-8 Base64 encoding of {@link
+ * network.crypta.clients.http.PushUpdatableElement#generateChildren()}.
  *
  * <ul>
  *   <li>Responsibilities: translate request parameters into a rendered-element lookup and return a
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @see network.crypta.clients.http.updateableelements.PushDataManager
- * @see network.crypta.clients.http.updateableelements.BaseUpdatableElement
+ * @see network.crypta.clients.http.PushUpdatableElement
  * @see network.crypta.clients.http.updateableelements.UpdaterConstants
  */
 public class PushDataToadlet extends Toadlet {
@@ -99,7 +99,7 @@ public class PushDataToadlet extends Toadlet {
         elementId.replace(
             " ", "+"); // This is needed, because BASE64 has '+', but it is an HTML escape for ' '
     if (LOG.isDebugEnabled()) LOG.debug("Fetching push data for elementId={}", elementId);
-    BaseUpdatableElement node =
+    PushUpdatableElement node =
         ((SimpleToadletServer) ctx.getContainer())
             .getPushDataManager()
             .getRenderedElement(requestId, elementId);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.PushUpdateEvent;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
-import network.crypta.clients.http.updateableelements.PushDataManager;
 import network.crypta.clients.http.updateableelements.UpdaterConstants;
 import network.crypta.support.Base64;
 import network.crypta.support.api.HTTPRequest;
@@ -21,9 +21,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This {@link Toadlet} is used by the browser-side update mechanism to wait for an event and
  * then return a compact, machine-readable payload. Callers typically issue a GET request to {@link
- * #path()} with a {@code requestId} parameter; the handler consults the {@link PushDataManager}
- * from the current {@link SimpleToadletServer} and blocks until the next {@link
- * PushDataManager.UpdateEvent} becomes available for that request.
+ * #path()} with a {@code requestId} parameter; the handler consults the shared push-data manager
+ * from the current {@link SimpleToadletServer} and blocks until the next {@link PushUpdateEvent}
+ * becomes available for that request.
  *
  * <p>Notable behaviors:
  *
@@ -31,15 +31,14 @@ import org.slf4j.LoggerFactory;
  *   <li>Uses long-poll semantics: it may block until an event arrives or the request context
  *       closes.
  *   <li>Returns either a success payload containing identifiers, or a failure sentinel string.
- *   <li>Performs no state mutation itself; it delegates event sequencing to {@link
- *       PushDataManager}.
+ *   <li>Performs no state mutation itself; it delegates event sequencing to the push-data manager.
  * </ul>
  *
  * <p>Thread-safety: instances are expected to be invoked concurrently by the HTTP server; this
- * implementation performs only local computations and relies on {@link PushDataManager} for
+ * implementation performs only local computations and relies on the push-data manager for
  * synchronization and ordering.
  *
- * @see PushDataManager#getNextNotification(String)
+ * @see network.crypta.clients.http.PushDataManagerHandle#getNextNotification(String)
  * @see UpdaterConstants#NOTIFICATION_PATH
  */
 public class PushNotificationToadlet extends Toadlet {
@@ -63,10 +62,11 @@ public class PushNotificationToadlet extends Toadlet {
    * Wait for and return the next notification event for the given long-poll request.
    *
    * <p>This handler reads the {@code requestId} query parameter from {@code req} and forwards it to
-   * {@link PushDataManager#getNextNotification(String)}. When an event is available, it returns a
-   * success payload composed of the event's request identifier and element identifier; otherwise it
-   * returns a failure sentinel value. The response body is intended to be parsed by the
-   * browser-side updater logic and is not meant for direct human consumption.
+   * {@link network.crypta.clients.http.PushDataManagerHandle#getNextNotification(String)}. When an
+   * event is available, it returns a success payload composed of the event's request identifier and
+   * element identifier; otherwise it returns a failure sentinel value. The response body is
+   * intended to be parsed by the browser-side updater logic and is not meant for direct human
+   * consumption.
    *
    * <p>The method may block while waiting for an event. If the request context closes while
    * blocked, {@link ToadletContextClosedException} can be thrown by the underlying server
@@ -85,7 +85,7 @@ public class PushNotificationToadlet extends Toadlet {
   public void handleMethodGET(URI uri, HTTPRequest req, ToadletContext ctx)
       throws ToadletContextClosedException, IOException, RedirectException {
     String requestId = req.getParam("requestId");
-    PushDataManager.UpdateEvent event =
+    PushUpdateEvent event =
         ((SimpleToadletServer) ctx.getContainer())
             .getPushDataManager()
             .getNextNotification(requestId);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/bookmark/BookmarkManager.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import network.crypta.client.async.USKCallback;
 import network.crypta.client.async.USKFoundEdition;
+import network.crypta.clients.http.BookmarkManagerHandle;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.USK;
 import network.crypta.l10n.NodeL10n;
@@ -55,7 +56,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
  *   <li>Subscribe/unsubscribe to USK updates for USK-typed bookmark items.
  * </ul>
  */
-public class BookmarkManager {
+public class BookmarkManager implements BookmarkManagerHandle {
   private static final Logger LOG = LoggerFactory.getLogger(BookmarkManager.class);
 
   /**
@@ -591,6 +592,7 @@ public class BookmarkManager {
    *
    * @return an array containing the {@link FreenetURI} for each bookmark item under the main root
    */
+  @Override
   public FreenetURI[] getBookmarkURIs() {
     List<BookmarkItem> items = MAIN_CATEGORY.getAllItems();
     FreenetURI[] uris = new FreenetURI[items.size()];

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/filter/PushingTagReplacerCallback.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/filter/PushingTagReplacerCallback.java
@@ -11,9 +11,8 @@ import network.crypta.client.filter.URIProcessor;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.updateableelements.ImageElement;
+import network.crypta.clients.http.utils.ClientSideLocalizationScript;
 import network.crypta.keys.FreenetURI;
-import network.crypta.l10n.NodeL10n;
-import network.crypta.support.HTMLEncoder;
 import network.crypta.support.http.StaticResourcePaths;
 
 /**
@@ -29,8 +28,8 @@ import network.crypta.support.http.StaticResourcePaths;
  * <ul>
  *   <li>Replace eligible {@code <img>} elements with updateable image placeholders backed by the
  *       fetch tracker.
- *   <li>Inject the JavaScript, localization data, and hidden request identifier that the web
- *       pushing client expects in the final page.
+ *   <li>Inject the JavaScript, localization data, and hidden request identifier that the
+ *       web-pushing client expects in the final page.
  * </ul>
  *
  * <p>Instances are request-scoped. They hold references to the current {@link ToadletContext},
@@ -49,7 +48,7 @@ public class PushingTagReplacerCallback implements TagReplacerCallback {
    * document. The maximum size is forwarded to updateable image elements so they apply the same
    * fetch limit as the surrounding request.
    *
-   * @param tracker Fetch tracker that owns updateable elements for the current request.
+   * @param tracker The fetch tracker that owns updateable elements for the current request.
    * @param maxSize Maximum fetch size, in bytes, for rewritten updateable elements.
    * @param ctx Active toadlet context used to inspect feature flags and request metadata.
    */
@@ -62,29 +61,13 @@ public class PushingTagReplacerCallback implements TagReplacerCallback {
   /**
    * Builds the JavaScript localization object consumed by the web-pushing client.
    *
-   * <p>The method exports every localization key under the {@code fproxy.push} prefix into a small
-   * JavaScript object literal and HTML-encodes each translated value before embedding it into the
-   * page. When no matching keys are present, the method still returns a syntactically valid empty
-   * object.
+   * <p>The shared-shell seam now lives in {@link ClientSideLocalizationScript}; this delegate keeps
+   * browse-owned callers and tests source-compatible while avoiding duplication.
    *
-   * @return JavaScript source that initializes the client-side {@code l10n} object.
+   * @return JavaScript source that initializes the client-side {@code l10n} object
    */
   public static String getClientSideLocalizationScript() {
-    StringBuilder l10nBuilder = new StringBuilder("var l10n={\n");
-    boolean isNamePresentAtLeastOnce = false;
-    for (String key : NodeL10n.getBase().getAllNamesWithPrefix("fproxy.push")) {
-      l10nBuilder
-          .append(key.substring("fproxy.push".length() + 1))
-          .append(": \"")
-          .append(HTMLEncoder.encode(NodeL10n.getBase().getString(key)))
-          .append("\",\n");
-      isNamePresentAtLeastOnce = true;
-    }
-    String l10n =
-        isNamePresentAtLeastOnce
-            ? l10nBuilder.substring(0, l10nBuilder.length() - 2)
-            : l10nBuilder.toString();
-    return l10n.concat("\n};");
+    return ClientSideLocalizationScript.getClientSideLocalizationScript();
   }
 
   /**
@@ -154,7 +137,7 @@ public class PushingTagReplacerCallback implements TagReplacerCallback {
                 + "\" name=\"requestId\"/>")
         .concat(
             "<script type=\"text/javascript\" language=\"javascript\">"
-                .concat(getClientSideLocalizationScript())
+                .concat(ClientSideLocalizationScript.getClientSideLocalizationScript())
                 .concat("</script>"))
         .concat("</body>");
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/BaseUpdatableElement.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/BaseUpdatableElement.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http.updateableelements;
 
+import network.crypta.clients.http.PushUpdatableElement;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.support.HTMLNode;
@@ -29,7 +30,7 @@ import network.crypta.support.HTMLNode;
  *
  * @see SimpleToadletServer
  */
-public abstract class BaseUpdatableElement extends HTMLNode {
+public abstract class BaseUpdatableElement extends HTMLNode implements PushUpdatableElement {
 
   /**
    * Request context associated with this element's current render/update cycle.
@@ -117,53 +118,4 @@ public abstract class BaseUpdatableElement extends HTMLNode {
           .getPushDataManager()
           .elementRendered(ctx.getUniqueId(), this);
   }
-
-  /**
-   * Rebuilds this element's children to reflect the current server-side state.
-   *
-   * <p>Implementations should treat this as a full refresh of the DOM subtree rooted at this node:
-   * remove any existing children and recreate them from current state. The method is invoked during
-   * initial rendering (from {@link #init(boolean)}) and may be invoked again by the update/push
-   * pipeline when the element needs to change in place.
-   *
-   * <p>Implementations should produce a consistent subtree on every call, even if the underlying
-   * state has not changed.
-   *
-   * @param initial {@code true} when called for the first render of this instance
-   */
-  public abstract void updateState(boolean initial);
-
-  /**
-   * Returns the stable DOM id used to locate this element for client-side updates.
-   *
-   * <p>The returned value is written to the {@code id} attribute during {@link #init(boolean)} and
-   * is used as a key in internal structures for pushed elements. It may incorporate {@code
-   * requestId} to avoid collisions between concurrent renders, but it should remain stable across
-   * internal navigation (for example, redirects) where the same logical element continues to be
-   * updated.
-   *
-   * @param requestId identifier for the current HTTP request, typically from {@link ToadletContext}
-   * @return a stable and deterministic DOM id string for this element instance
-   */
-  public abstract String getUpdaterId(String requestId);
-
-  /**
-   * Returns the client-side updater type identifier for this element.
-   *
-   * <p>The returned string is used by the browser-side update framework to select an updater
-   * implementation that knows how to apply changes for this element. The exact set of supported
-   * identifiers is defined by the HTTP UI layer.
-   *
-   * @return an updater type identifier string understood by the client-side update framework
-   */
-  public abstract String getUpdaterType();
-
-  /**
-   * Releases resources associated with this element and stops further updates.
-   *
-   * <p>This is invoked when the element is no longer needed (for example, when a page is torn down
-   * or when the push framework discards it). Implementations should detach listeners, cancel
-   * scheduled work, and drop references that would otherwise keep request-scoped objects alive.
-   */
-  public abstract void dispose();
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/NotifierFetchListener.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/NotifierFetchListener.java
@@ -1,10 +1,11 @@
 package network.crypta.clients.http.updateableelements;
 
 import network.crypta.clients.http.FProxyFetchListener;
+import network.crypta.clients.http.PushDataManagerHandle;
 
 /**
- * Bridges FProxy fetch callbacks to the {@link PushDataManager} so UI-updatable elements stay in
- * sync with background downloads. A single instance is typically scoped to one {@link
+ * Bridges FProxy fetch callbacks to the {@link PushDataManagerHandle} so UI-updatable elements stay
+ * in sync with background downloads. A single instance is typically scoped to one {@link
  * BaseUpdatableElement} and passed to the HTTP client when initiating a fetch. The listener remains
  * lightweight: it delegates immediately without keeping additional state and therefore imposes
  * minimal overhead on the networking thread. Callers rely on it to propagate progress notifications
@@ -12,9 +13,9 @@ import network.crypta.clients.http.FProxyFetchListener;
  *
  * <p><strong>Lifecycle and thread safety:</strong> the listener is usually invoked from the thread
  * that processes HTTP fetch events. It does not mutate shared state on its own; correctness depends
- * on {@link PushDataManager} being safe for concurrent invocation. Instances are immutable after
- * construction, making them safe to reuse for repeated fetch attempts associated with the same
- * element.
+ * on {@link PushDataManagerHandle} being safe for concurrent invocation. Instances are immutable
+ * after construction, making them safe to reuse for repeated fetch attempts associated with the
+ * same element.
  *
  * <p><strong>Typical usage:</strong>
  *
@@ -26,7 +27,7 @@ import network.crypta.clients.http.FProxyFetchListener;
  */
 public class NotifierFetchListener implements FProxyFetchListener {
 
-  private final PushDataManager pushManager;
+  private final PushDataManagerHandle pushManager;
 
   private final BaseUpdatableElement element;
 
@@ -39,7 +40,7 @@ public class NotifierFetchListener implements FProxyFetchListener {
    * @param element updatable element whose identifier is resolved and refreshed when events are
    *     reported; must not be {@code null} for correct updater resolution.
    */
-  public NotifierFetchListener(PushDataManager pushManager, BaseUpdatableElement element) {
+  public NotifierFetchListener(PushDataManagerHandle pushManager, BaseUpdatableElement element) {
     this.pushManager = pushManager;
     this.element = element;
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/PushDataManager.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updateableelements/PushDataManager.java
@@ -5,6 +5,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Map;
+import network.crypta.clients.http.PushDataManagerHandle;
+import network.crypta.clients.http.PushUpdatableElement;
+import network.crypta.clients.http.PushUpdateEvent;
 import network.crypta.support.Ticker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,14 +15,14 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates server-side state for "push" updates in the HTTP UI.
  *
- * <p>This manager tracks which {@link BaseUpdatableElement} instances are rendered on which active
+ * <p>This manager tracks which {@link PushUpdatableElement} instances are rendered on which active
  * HTTP request (page), and it converts element changes into queued {@link UpdateEvent}s for clients
  * that poll for notifications. It is designed for UIs that render elements during normal page
  * handling and then rely on a separate long-polling (or repeated polling) request to ask, "what
- * should I refresh next?".
+ * should I refresh next?"
  *
  * <ul>
- *   <li>{@link #elementRendered(String, BaseUpdatableElement)} registers a rendered element for a
+ *   <li>{@link #elementRendered(String, PushUpdatableElement)} registers a rendered element for a
  *       request/page.
  *   <li>{@link #updateElement(String)} marks an element as changed and queues notifications for all
  *       pages currently rendering it.
@@ -40,16 +43,16 @@ import org.slf4j.LoggerFactory;
  * Cleanup also disposes elements and removes queued notifications that originated from the removed
  * request.
  */
-public class PushDataManager {
+public class PushDataManager implements PushDataManagerHandle {
   private static final Logger LOG = LoggerFactory.getLogger(PushDataManager.class);
 
   /** What notifications are waiting for the leader */
   private final Map<String, List<UpdateEvent>> awaitingNotifications = new HashMap<>();
 
   /** What elements are on the page */
-  private final Map<String, List<BaseUpdatableElement>> pages = new HashMap<>();
+  private final Map<String, List<PushUpdatableElement>> pages = new HashMap<>();
 
-  /** What pages are on the element. It is redundant with the pages map. */
+  /** What pages are on the element. It is redundant with the pages' map. */
   private final Map<String, List<String>> elements = new HashMap<>();
 
   /** Stores whether a keepalive was received for a request since the Cleaner last run */
@@ -73,7 +76,7 @@ public class PushDataManager {
    *
    * <p>The ticker is used only for scheduling the internal cleaner task; it does not execute any
    * work on the caller thread. The cleaner is scheduled lazily on the first call to {@link
-   * #elementRendered(String, BaseUpdatableElement)} and is re-scheduled while at least one active
+   * #elementRendered(String, PushUpdatableElement)} and is re-scheduled while at least one active
    * request is tracked.
    *
    * @param ticker scheduler used to queue periodic cleanup work; must not be {@code null}.
@@ -90,12 +93,13 @@ public class PushDataManager {
    * Object#notifyAll()}. If the element id is not currently registered, this method performs no
    * state changes.
    *
-   * <p>Notifications are de-duplicated per polling request: if an identical {@link UpdateEvent} is
+   * <p>Notifications are deduplicated per polling request: if an identical {@link UpdateEvent} is
    * already present in a request's queue, it is not added again. This provides a simple form of
    * coalescing when the same element changes multiple times before clients have a chance to poll.
    *
-   * @param id updater element id returned by {@link BaseUpdatableElement#getUpdaterId(String)}.
+   * @param id updater element id returned by {@link PushUpdatableElement#getUpdaterId(String)}.
    */
+  @Override
   public synchronized void updateElement(String id) {
     LOG.debug("Element updated id:{}", id);
     List<String> requestIds = elements.get(id);
@@ -151,14 +155,15 @@ public class PushDataManager {
    * <p>This method also ensures the request has an initialized notification queue. Once a request
    * is tracked, it will remain tracked until it is explicitly removed via {@link #leaving(String)}
    * or the periodic cleaner detects missing keepalives. When a request is removed, its rendered
-   * elements are disposed via {@link BaseUpdatableElement#dispose()} and any update events that
+   * elements are disposed via {@link PushUpdatableElement#dispose()} and any update events that
    * originated from that request are removed from all queues.
    *
    * @param requestUniqueId request/page identifier used for polling notifications; should be
    *     stable.
-   * @param element rendered element to track and later dispose on cleanup.
+   * @param element the rendered element to track and later dispose on cleanup.
    */
-  public synchronized void elementRendered(String requestUniqueId, BaseUpdatableElement element) {
+  @Override
+  public synchronized void elementRendered(String requestUniqueId, PushUpdatableElement element) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Element is rendered in page:{} element:{}", requestUniqueId, element);
     }
@@ -185,11 +190,11 @@ public class PushDataManager {
    * Returns the element's current state.
    *
    * <p>This looks up the element within the set previously registered via {@link
-   * #elementRendered(String, BaseUpdatableElement)} for the given request. When found, the element
-   * state is refreshed via {@link BaseUpdatableElement#updateState(boolean)} and the element is
+   * #elementRendered(String, PushUpdatableElement)} for the given request. When found, the element
+   * state is refreshed via {@link PushUpdatableElement#updateState(boolean)} and the element is
    * returned to the caller.
    *
-   * <p>This method does not register new elements and does not create placeholder state. It is
+   * <p>This method does not register new elements and does not create a placeholder state. It is
    * intended to be called by the HTTP layer when it needs to re-render a previously rendered
    * element after receiving an {@link UpdateEvent}. A missing element indicates that the request is
    * no longer tracked (for example, because it timed out and was cleaned) or that the element was
@@ -203,12 +208,13 @@ public class PushDataManager {
    * @param id element updater id previously returned for this request; used for lookup.
    * @return the tracked element with refreshed state, or {@code null} if missing.
    */
-  public synchronized BaseUpdatableElement getRenderedElement(String requestId, String id) {
+  @Override
+  public synchronized PushUpdatableElement getRenderedElement(String requestId, String id) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Getting element data for element:{} in page:{}", id, requestId);
     }
     if (pages.get(requestId) != null)
-      for (BaseUpdatableElement element : pages.get(requestId)) {
+      for (PushUpdatableElement element : pages.get(requestId)) {
         if (element.getUpdaterId(requestId).compareTo(id) == 0) {
           element.updateState(false);
           return element;
@@ -239,9 +245,10 @@ public class PushDataManager {
    * <p>If the original request id is not present, this method performs no changes.
    *
    * @param originalRequestId previous leader request id whose queue should be moved.
-   * @param newRequestId new leader request id that should receive the moved queue.
+   * @param newRequestId the new leader request id that should receive the moved queue.
    * @return {@code true} if a notification queue was migrated; {@code false} otherwise.
    */
+  @Override
   public synchronized boolean failover(String originalRequestId, String newRequestId) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Failover, original:{} new:{}", originalRequestId, newRequestId);
@@ -273,12 +280,13 @@ public class PushDataManager {
    *
    * <p>This method is intended to be called when the HTTP layer knows a page/request is finished,
    * such as when a client navigates away. It is safe to call multiple times for the same request
-   * id; subsequent calls will return {@code false} once the request has already been removed.
+   * id; later calls will return {@code false} once the request has already been removed.
    *
    * @param requestId request/page identifier to remove from internal state maps.
    * @return {@code true} if the request was present and removed; {@code false} if it was already
    *     absent.
    */
+  @Override
   public synchronized boolean leaving(String requestId) {
     return deleteRequest(requestId);
   }
@@ -291,7 +299,7 @@ public class PushDataManager {
    * avoid returning updates for a request that has not yet started polling.
    *
    * <p>This method does not create request state: the request must already have been registered via
-   * {@link #elementRendered(String, BaseUpdatableElement)}. If the request is unknown, the return
+   * {@link #elementRendered(String, PushUpdatableElement)}. If the request is unknown, the return
    * value is {@code false} and no state is created.
    *
    * <p>This call wakes blocked pollers via {@link Object#notifyAll()} so they can re-check their
@@ -300,6 +308,7 @@ public class PushDataManager {
    * @param requestId request/page identifier that is still active and polling.
    * @return {@code true} if the request is still tracked; {@code false} if it was already removed.
    */
+  @Override
   public synchronized boolean keepAliveReceived(String requestId) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Keepalive is received for page:{}", requestId);
@@ -335,7 +344,8 @@ public class PushDataManager {
    * @param requestId request/page identifier to poll; must already be registered.
    * @return the next queued update event, or {@code null} when interrupted or not tracked.
    */
-  public synchronized UpdateEvent getNextNotification(String requestId) {
+  @Override
+  public synchronized PushUpdateEvent getNextNotification(String requestId) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Polling for notification:{}", requestId);
     }
@@ -396,8 +406,8 @@ public class PushDataManager {
 
   private void removeRenderedElements(String requestId) {
     // Iterate over all the pushed elements present on the page
-    List<BaseUpdatableElement> renderedElements = pages.get(requestId);
-    for (BaseUpdatableElement element : new ArrayList<>(renderedElements)) {
+    List<PushUpdatableElement> renderedElements = pages.get(requestId);
+    for (PushUpdatableElement element : new ArrayList<>(renderedElements)) {
       renderedElements.remove(element);
       String elementId = element.getUpdaterId(requestId);
       removeRequestFromElementsIndex(requestId, elementId);
@@ -428,7 +438,7 @@ public class PushDataManager {
    * request id and element id, which allows {@link PushDataManager} to avoid enqueuing duplicates
    * for the same polling request.
    */
-  public static class UpdateEvent {
+  public static class UpdateEvent implements PushUpdateEvent {
     private final String requestId;
     private final String elementId;
 
@@ -441,7 +451,7 @@ public class PushDataManager {
      * Returns the identifier of the request/page that should apply the update.
      *
      * <p>The request id corresponds to the value used when registering rendered elements via {@link
-     * PushDataManager#elementRendered(String, BaseUpdatableElement)} and when polling for
+     * PushDataManager#elementRendered(String, PushUpdatableElement)} and when polling for
      * notifications via {@link PushDataManager#getNextNotification(String)}.
      *
      * <p>This is the target request/page identifier to refresh, not the identifier of the polling
@@ -451,6 +461,7 @@ public class PushDataManager {
      *
      * @return the request/page identifier for this update event; never {@code null}.
      */
+    @Override
     public String getRequestId() {
       return requestId;
     }
@@ -459,14 +470,15 @@ public class PushDataManager {
      * Returns the updater element id that changed and should be re-rendered.
      *
      * <p>The element id corresponds to the value returned from {@link
-     * BaseUpdatableElement#getUpdaterId(String)} for the request that rendered the element.
+     * PushUpdatableElement#getUpdaterId(String)} for the request that rendered the element.
      *
      * <p>Consumers use this id with {@link PushDataManager#getRenderedElement(String, String)} to
-     * resolve the corresponding {@link BaseUpdatableElement} for a particular request/page and then
+     * resolve the corresponding {@link PushUpdatableElement} for a particular request/page and then
      * render the refreshed state back to the client.
      *
      * @return the updater element identifier for this update event; never {@code null}.
      */
+    @Override
     public String getElementId() {
       return elementId;
     }
@@ -492,7 +504,7 @@ public class PushDataManager {
     }
   }
 
-  /** A task for the Cleaner, that periodically checks for failed requests. */
+  /** A task for the Cleaner that periodically checks for failed requests. */
   private class CleanerTimerTask implements Runnable {
     @Override
     public void run() {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/utils/ClientSideLocalizationScript.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/utils/ClientSideLocalizationScript.java
@@ -1,0 +1,51 @@
+package network.crypta.clients.http.utils;
+
+import network.crypta.l10n.NodeL10n;
+import network.crypta.support.HTMLEncoder;
+
+/**
+ * Utility for building the client-side localization payload used by legacy HTTP pages.
+ *
+ * <p>This helper centralizes the small JavaScript fragment that exposes selected localized strings
+ * to the legacy web-pushing client. Both shared-shell code and browse-owned code need the same
+ * payload, so the helper provides a neutral location that avoids duplicating string-building logic
+ * or forcing shared-shell classes to import browse-owned callback types.
+ *
+ * <p>The generated script initializes a global {@code l10n} object whose properties are derived
+ * from {@code fproxy.push.*} localization keys. Values are HTML-encoded before insertion, so the
+ * emitted JavaScript can be embedded directly into legacy pages without changing the current output
+ * shape or escaping behavior.
+ */
+public final class ClientSideLocalizationScript {
+
+  private ClientSideLocalizationScript() {}
+
+  /**
+   * Builds the JavaScript localization object consumed by the client-side web-pushing code.
+   *
+   * <p>The method walks every localization key with the {@code fproxy.push} prefix, strips that
+   * prefix down to the property name expected by the client, and appends the translated value into
+   * a JavaScript object literal. When no matching keys exist, the method still returns a valid
+   * empty object declaration, so callers can embed the result unconditionally.
+   *
+   * @return JavaScript source that initializes the client-side {@code l10n} object for legacy
+   *     web-pushing pages
+   */
+  public static String getClientSideLocalizationScript() {
+    StringBuilder l10nBuilder = new StringBuilder("var l10n={\n");
+    boolean isNamePresentAtLeastOnce = false;
+    for (String key : NodeL10n.getBase().getAllNamesWithPrefix("fproxy.push")) {
+      l10nBuilder
+          .append(key.substring("fproxy.push".length() + 1))
+          .append(": \"")
+          .append(HTMLEncoder.encode(NodeL10n.getBase().getString(key)))
+          .append("\",\n");
+      isNamePresentAtLeastOnce = true;
+    }
+    String l10n =
+        isNamePresentAtLeastOnce
+            ? l10nBuilder.substring(0, l10nBuilder.length() - 2)
+            : l10nBuilder.toString();
+    return l10n.concat("\n};");
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -31,6 +31,17 @@ class HttpLegacyAdminBoundaryTest {
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_SIMPLE_TOADLET_SERVER =
       ADAPTER_HTTP_MAIN_JAVA.resolve("SimpleToadletServer.java");
+  private static final Path ADAPTER_TOADLET_CONTEXT =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("ToadletContext.java");
+  private static final Path ADAPTER_TOADLET_CONTEXT_IMPL =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("ToadletContextImpl.java");
+  private static final Path ADAPTER_TOADLET_REQUEST_SERVICES =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("ToadletRequestServices.java");
+  private static final Path ADAPTER_HTTP_SHELL_BROWSE_BOOTSTRAP =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellBrowseBootstrap.java");
+  private static final Path ADAPTER_PAGE_MAKER = ADAPTER_HTTP_MAIN_JAVA.resolve("PageMaker.java");
+  private static final Path ADAPTER_INTERVAL_PUSHER_MANAGER =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("IntervalPusherManager.java");
   private static final Path ADAPTER_HTTP_SHELL_RUNTIME_SUPPORT =
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellRuntimeSupport.java");
   private static final Path ADAPTER_HTTP_FPROXY_BOOTSTRAP =
@@ -45,11 +56,26 @@ class HttpLegacyAdminBoundaryTest {
       ADAPTER_HTTP_MAIN_JAVA.resolve("QueueToadlet.java");
   private static final Path ADAPTER_WEB_SHELL_TOADLET =
       ADAPTER_HTTP_MAIN_JAVA.resolve("WebShellToadlet.java");
-  private static final Set<Path> CONNECTIONS_TOADLETS =
-      Set.of(
+  private static final List<Path> CONNECTIONS_TOADLETS =
+      List.of(
           ADAPTER_HTTP_MAIN_JAVA.resolve("ConnectionsToadlet.java"),
           ADAPTER_HTTP_MAIN_JAVA.resolve("DarknetConnectionsToadlet.java"),
           ADAPTER_HTTP_MAIN_JAVA.resolve("OpennetConnectionsToadlet.java"));
+  private static final List<Path> SHARED_SHELL_FILES_WITH_BROWSE_OWNED_COLLABORATORS =
+      List.of(
+          ADAPTER_SIMPLE_TOADLET_SERVER,
+          ADAPTER_TOADLET_CONTEXT,
+          ADAPTER_TOADLET_CONTEXT_IMPL,
+          ADAPTER_TOADLET_REQUEST_SERVICES,
+          ADAPTER_HTTP_SHELL_BROWSE_BOOTSTRAP,
+          ADAPTER_PAGE_MAKER,
+          ADAPTER_INTERVAL_PUSHER_MANAGER);
+  private static final List<String> FORBIDDEN_BROWSE_OWNED_COLLABORATOR_IMPORTS =
+      List.of(
+          "import network.crypta.clients.http.bookmark.BookmarkManager;",
+          "import network.crypta.clients.http.updateableelements.PushDataManager;",
+          "import network.crypta.clients.http.updateableelements.BaseUpdatableElement;",
+          "import network.crypta.clients.http.filter.PushingTagReplacerCallback;");
   private static final Path ADAPTER_HTTP_MAIN_RESOURCES =
       Path.of(MODULE_NAME, "src", "main", "resources", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_BRIDGE_MAIN_JAVA =
@@ -271,6 +297,30 @@ class HttpLegacyAdminBoundaryTest {
         source.contains("FProxyFetchInProgress.REFILTER_POLICY"),
         "SimpleToadletServer must use the HTTP-local refilter policy type instead of the nested "
             + "FProxy enum.");
+  }
+
+  @Test
+  void mainSources_whenCheckingSharedShellImports_expectBrowseOwnedCollaboratorsDetached()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile : SHARED_SHELL_FILES_WITH_BROWSE_OWNED_COLLABORATORS) {
+      Set<String> imports = readImports(repoRoot.resolve(sourceFile));
+      for (String forbiddenImport : FORBIDDEN_BROWSE_OWNED_COLLABORATOR_IMPORTS) {
+        if (imports.contains(forbiddenImport)) {
+          violations.add(sourceFile + " -> " + forbiddenImport);
+        }
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "SimpleToadletServer, ToadletContext, ToadletContextImpl, ToadletRequestServices, "
+            + "HttpShellBrowseBootstrap, PageMaker, and IntervalPusherManager must not import "
+            + "browse-owned bookmark, push, or client-script collaborators."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
   }
 
   @Test

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -11,9 +11,10 @@ and the matching `network/crypta/clients/http/**` main resources, excluding
 This PR keeps the existing adapter leaf in place but removes a few browse-specific leaks from the
 shared shell surface before the real browse split. The shared shell now uses browse-neutral
 bootstrap/context types and shared `LegacyHttpPaths` / `LegacyHttpCategories` constants instead of
-pulling those values from `FProxyToadlet` directly. The concrete browse root still lives in the
-legacy adapter leaf for now, but the seam exposed to shared-shell and bridge code is no longer
-FProxy-shaped.
+pulling those values from `FProxyToadlet` directly. It also uses neutral bookmark, push, and
+client-side script seams instead of importing the concrete browse-owned collaborator classes
+directly. The concrete browse root still lives in the legacy adapter leaf for now, but the seam
+exposed to shared-shell and bridge code is no longer FProxy-shaped.
 
 The boundary remains intentional. Production code outside `:adapter-http-legacy-admin` and
 `:bridge-http-runtime` should keep depending on runtime-owned seams, `:platform-api`, or

--- a/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
@@ -338,7 +338,8 @@ class FileInsertWizardToadletTest {
     }
 
     @Override
-    public network.crypta.clients.http.bookmark.BookmarkManager getBookmarkManager() {
+    @SuppressWarnings({"TypeParameterUnusedInFormals"})
+    public <T extends network.crypta.clients.http.BookmarkManagerHandle> T getBookmarkManager() {
       return null;
     }
 

--- a/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
+++ b/src/test/java/network/crypta/clients/http/HTTPRequestImplTest.java
@@ -289,7 +289,8 @@ class HTTPRequestImplTest {
       }
 
       @Override
-      public network.crypta.clients.http.bookmark.BookmarkManager getBookmarkManager() {
+      @SuppressWarnings({"TypeParameterUnusedInFormals"})
+      public <T extends network.crypta.clients.http.BookmarkManagerHandle> T getBookmarkManager() {
         throw new UnsupportedOperationException();
       }
 

--- a/src/test/java/network/crypta/clients/http/PageMakerTest.java
+++ b/src/test/java/network/crypta/clients/http/PageMakerTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http;
 
+import network.crypta.clients.http.utils.ClientSideLocalizationScript;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.PageChromeSnapshot;
 import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
@@ -207,6 +208,28 @@ class PageMakerTest {
     assertTrue(html.contains("progressbar-peers"));
     assertTrue(html.contains("/seclevels/"));
     assertTrue(html.contains("4 / 10"));
+  }
+
+  @Test
+  void getPageNode_whenWebPushingEnabled_injectsSharedLocalizationScriptAndRequestId() {
+    PageMaker maker = newPageMaker();
+    stubPageRenderingContext(false);
+    when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(container.isFProxyWebPushingEnabled()).thenReturn(true);
+    when(context.getUniqueId()).thenReturn("req-push");
+
+    PageNode page =
+        maker.getPageNode(
+            "Push",
+            context,
+            new PageMaker.RenderParameters().renderNavigationLinks(false).renderModeSwitch(false));
+
+    String html = page.generate();
+
+    assertTrue(html.contains("/static/freenetjs/freenetjs.nocache.js"));
+    assertTrue(html.contains("id=\"requestId\""));
+    assertTrue(html.contains("value=\"req-push\""));
+    assertTrue(html.contains(ClientSideLocalizationScript.getClientSideLocalizationScript()));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -27,6 +27,7 @@ import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -112,6 +113,15 @@ class ToadletContextImplTest {
         .thenReturn("wrong");
 
     assertFalse(context.hasFormPassword(request));
+  }
+
+  @Test
+  void getBookmarkManager_whenRequestedAsHandleOrConcrete_returnsConfiguredManager() {
+    BookmarkManagerHandle handle = context.getBookmarkManager();
+    BookmarkManager concrete = context.getBookmarkManager();
+
+    assertSame(bookmarkManager, handle);
+    assertSame(bookmarkManager, concrete);
   }
 
   @Test
@@ -209,7 +219,7 @@ class ToadletContextImplTest {
     Map<String, List<String>> map = new LinkedHashMap<>();
     List<String> lines = splitLines(raw);
     if (lines.isEmpty()) return map;
-    String statusLine = lines.get(0);
+    String statusLine = lines.getFirst();
     String[] statusParts = splitOnChar(statusLine, ' ');
     if (statusParts.length >= 2) {
       map.put("__status", List.of(statusParts[1]));
@@ -253,8 +263,8 @@ class ToadletContextImplTest {
       }
     }
     lines.add(raw.substring(start));
-    while (!lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
-      lines.remove(lines.size() - 1);
+    while (!lines.isEmpty() && lines.getLast().isEmpty()) {
+      lines.removeLast();
     }
     return lines;
   }
@@ -275,7 +285,7 @@ class ToadletContextImplTest {
         start = i + 1;
       }
     }
-    parts[partIndex] = value.substring(start, value.length());
+    parts[partIndex] = value.substring(start);
 
     int end = parts.length;
     while (end > 0 && parts[end - 1].isEmpty()) {

--- a/src/test/java/network/crypta/clients/http/filter/PushingTagReplacerCallbackTest.java
+++ b/src/test/java/network/crypta/clients/http/filter/PushingTagReplacerCallbackTest.java
@@ -10,6 +10,7 @@ import network.crypta.client.filter.HTMLFilter.ParsedTag;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.updateableelements.PushDataManager;
+import network.crypta.clients.http.utils.ClientSideLocalizationScript;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.PriorityAwareExecutor;
 import network.crypta.support.Ticker;
@@ -21,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,6 +90,7 @@ class PushingTagReplacerCallbackTest {
     String script = PushingTagReplacerCallback.getClientSideLocalizationScript();
 
     assertNotNull(script);
+    assertEquals(ClientSideLocalizationScript.getClientSideLocalizationScript(), script);
     assertTrue(script.startsWith("var l10n={"));
     assertTrue(script.endsWith("};"));
     assertTrue(script.contains("hide:"), "contains hide key");

--- a/src/test/java/network/crypta/clients/http/updateableelements/PushDataManagerTest.java
+++ b/src/test/java/network/crypta/clients/http/updateableelements/PushDataManagerTest.java
@@ -2,6 +2,8 @@ package network.crypta.clients.http.updateableelements;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import network.crypta.clients.http.PushUpdatableElement;
+import network.crypta.clients.http.PushUpdateEvent;
 import network.crypta.support.Ticker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,7 +56,7 @@ class PushDataManagerTest {
     assertEquals(expectedCleanerDelayMs(), offsetCaptor.getValue().longValue());
 
     assertTrue(manager.keepAliveReceived(requestA));
-    BaseUpdatableElement rendered = manager.getRenderedElement(requestA, "element-a");
+    PushUpdatableElement rendered = manager.getRenderedElement(requestA, "element-a");
     assertSame(elementA, rendered);
     Mockito.verify(elementA).updateState(false);
 
@@ -93,8 +95,8 @@ class PushDataManagerTest {
     assertTrue(manager.keepAliveReceived(originRequest));
 
     // Assert
-    PushDataManager.UpdateEvent eventFromOrigin = manager.getNextNotification(originRequest);
-    PushDataManager.UpdateEvent eventFromPolling = manager.getNextNotification(pollingRequest);
+    PushUpdateEvent eventFromOrigin = manager.getNextNotification(originRequest);
+    PushUpdateEvent eventFromPolling = manager.getNextNotification(pollingRequest);
     assertNotNull(eventFromOrigin);
     assertNotNull(eventFromPolling);
     assertEquals(originRequest, eventFromOrigin.getRequestId());
@@ -106,7 +108,7 @@ class PushDataManagerTest {
         eventFromOrigin.toString());
 
     CountDownLatch done = new CountDownLatch(1);
-    Holder<PushDataManager.UpdateEvent> secondPoll = new Holder<>();
+    Holder<PushUpdateEvent> secondPoll = new Holder<>();
     Thread waiter =
         new Thread(
             () -> {
@@ -134,7 +136,7 @@ class PushDataManagerTest {
     manager.elementRendered(requestId, element);
 
     // Act
-    BaseUpdatableElement rendered = manager.getRenderedElement(requestId, elementId);
+    PushUpdatableElement rendered = manager.getRenderedElement(requestId, elementId);
 
     // Assert
     assertSame(element, rendered);
@@ -190,7 +192,7 @@ class PushDataManagerTest {
     manager.elementRendered(requestId, element);
 
     CountDownLatch started = new CountDownLatch(1);
-    Holder<PushDataManager.UpdateEvent> result = new Holder<>();
+    Holder<PushUpdateEvent> result = new Holder<>();
 
     Thread thread =
         new Thread(
@@ -231,7 +233,7 @@ class PushDataManagerTest {
     assertTrue(manager.keepAliveReceived(originRequest));
 
     // Act
-    PushDataManager.UpdateEvent event = manager.getNextNotification(pollingRequest);
+    PushUpdateEvent event = manager.getNextNotification(pollingRequest);
 
     // Assert
     assertNotNull(event);
@@ -260,7 +262,7 @@ class PushDataManagerTest {
     assertTrue(manager.failover(originalRequest, newRequest));
 
     // Assert
-    PushDataManager.UpdateEvent event = manager.getNextNotification(newRequest);
+    PushUpdateEvent event = manager.getNextNotification(newRequest);
     assertNotNull(event);
     assertEquals(originalRequest, event.getRequestId());
     assertEquals(elementId, event.getElementId());


### PR DESCRIPTION
## Summary
- add neutral bookmark, push, and client-side localization seams for the shared legacy HTTP shell
- switch the shared-shell legacy HTTP classes and AJAX paths to those seams while keeping the browse-owned implementations in place
- tighten the legacy HTTP boundary test, extend focused seam coverage, and improve Javadoc/docs for the new shared-shell types

## Testing
- `./gradlew :test --tests 'network.crypta.clients.http.PageMakerTest' --tests 'network.crypta.clients.http.filter.PushingTagReplacerCallbackTest' --tests 'network.crypta.clients.http.ToadletContextImplTest' --tests 'network.crypta.clients.http.IntervalPusherManagerTest' --tests 'network.crypta.clients.http.ajaxpush.PushDataToadletTest' --tests 'network.crypta.clients.http.ajaxpush.PushNotificationToadletTest' --tests 'network.crypta.clients.http.updateableelements.PushDataManagerTest'`
- `./gradlew :adapter-http-legacy-admin:test --tests 'network.crypta.runtime.bootstrap.HttpLegacyAdminBoundaryTest'`
- `./gradlew test`
