### PR TITLE
refactor(http): Split legacy browse route registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ Cryptad now uses a partial multi-project Gradle build.
   the matching `network/crypta/clients/http/**` main resources such as `staticfiles/**` and
   `templates/**`, excluding `network.crypta.clients.http.bridge` and
   `network.crypta.clients.http.geoip`. The remaining legacy
-  browse/FProxy shell inside this leaf is boundary-frozen until a later PR refines it further.
+  browse/FProxy shell inside this leaf is still not physically split yet, but route-registration
+  ownership is now separated behind a neutral browse registrar seam so the later browse extraction
+  can stay mechanical.
   That shell also hosts the temporary `/api/v1/` mount for `:platform-api` plus the first
   `/app/node/` Web Shell bridge for `:platform-web-shell`; future AppHost UI and remote
   update-channel work remain separate. The concrete HTTP bridge implementations plus the legacy
@@ -665,9 +667,9 @@ Root build also includes:
 - `:adapter-http-legacy-admin`: extracted legacy `network.crypta.clients.http` adapter code plus
   `network/crypta/clients/http/**` main resources. The root project no longer owns that main
   HTTP source/resource tree, and the remaining browse/FProxy shell in this adapter is
-  boundary-frozen for now. The shared shell now crosses neutral bookmark, push, and client-side
-  localization seams instead of importing the concrete browse-owned collaborators directly. It
-  currently hosts both the temporary `/api/v1/` bridge for
+  boundary-frozen for now. The shared shell now crosses neutral bookmark, push, client-side
+  localization, and browse-route-registration seams instead of importing or instantiating the
+  concrete browse-owned collaborators directly. It currently hosts both the temporary `/api/v1/` bridge for
   `:platform-api` and the initial `/app/node/` bridge for `:platform-web-shell`. See
   [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
   boundary.
@@ -800,10 +802,11 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.runtime.http` and `network.crypta.runtime.http.security`, and client-local
   helpers such as `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellBrowseBootstrap`,
   and the shared HTTP route registrar seam. The shared legacy shell now also uses neutral bookmark,
-  push, and client-side script seams instead of importing browse-owned collaborator classes
-  directly. Concrete browse-root and push-manager construction now lives in the
-  bridge/runtime-owned HTTP bootstrap path, keeping the shared shell browse-neutral ahead of the
-  later `:adapter-http-legacy-browse` split. Concrete HTTP shell, bookmark, GeoIP, and
+  push, client-side script, and browse-route-registration seams instead of importing or
+  instantiating browse-owned collaborator classes directly. Concrete browse-root, browse-route
+  registrar, and push-manager construction now lives in the bridge/runtime-owned HTTP bootstrap
+  path, keeping the shared shell browse-neutral ahead of the later
+  `:adapter-http-legacy-browse` split. Concrete HTTP shell, bookmark, GeoIP, and
   security-page adapters now live under
   `network.crypta.clients.http.bridge` in
   `:bridge-http-runtime`, and that leaf also owns the legacy HTTP GeoIP helper package

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -2,14 +2,6 @@ package network.crypta.clients.http;
 
 import java.util.Arrays;
 import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.clients.http.ajaxpush.DismissAlertToadlet;
-import network.crypta.clients.http.ajaxpush.LogWritebackToadlet;
-import network.crypta.clients.http.ajaxpush.PushDataToadlet;
-import network.crypta.clients.http.ajaxpush.PushFailoverToadlet;
-import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
-import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
-import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
-import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
 import network.crypta.clients.http.updater.CoreActionToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
@@ -20,22 +12,23 @@ import network.crypta.runtime.spi.TransferAccessPort;
 import static network.crypta.runtime.updater.UpdaterPaths.CORE_UPDATE_PATH;
 
 /**
- * Registers every FProxy-facing toadlet and menu entry exposed by the Crypta node.
+ * Registers the legacy HTTP route set while delegating browse-owned publication through a seam.
  *
- * <p>This helper centralizes the wiring of the HTTP user interface after daemon-only composition
- * has already happened elsewhere. It assigns menu categories, instantiates secondary toadlets,
- * connects them to prebuilt collaborators, and publishes them on the {@link SimpleToadletServer}.
- * Callers invoke it once during node startup to ensure all public endpoints for browsing, queue
- * management, configuration, alerts, and update actions are available before handling requests. The
- * registrar is intentionally package-private and stateless; it relies only on the narrow
- * dependencies bundle assembled by the admin-owned registrar adapter.
+ * <p>This helper centralizes the remaining admin-owned wiring of the legacy HTTP user interface
+ * after daemon-only composition has already happened elsewhere. It preserves the historical route
+ * and menu order while delegating concrete browse/FProxy route publication to the neutral {@link
+ * LegacyHttpBrowseRouteRegistrar} seam at the exact points where those browse-owned routes used to
+ * be instantiated inline. Callers invoke it once during node startup to ensure all public endpoints
+ * for queue management, configuration, alerts, maintenance flows, and browse-owned insertions are
+ * available before handling requests.
  *
  * <p>Responsibilities include:
  *
  * <ul>
- *   <li>Registering navigation menus under canonical categories for consistent UI grouping.
+ *   <li>Registering the admin-owned navigation menus under canonical categories.
  *   <li>Instantiating functional toadlets for downloads, uploads, security, chat, stats,
  *       connectivity, first-time wizard flows, and core updates.
+ *   <li>Delegating browse-owned registration phases to the browse registrar without changing order.
  * </ul>
  *
  * <p>Thread-safety: registration is expected to run on a single startup thread; no internal state
@@ -49,11 +42,11 @@ final class FProxyRegistrar {
    * Builds and registers the full FProxy toadlet set if the environment supports it.
    *
    * <p>The method assumes the root browse toadlet, interactive client, and runtime ports have
-   * already been assembled by the caller and then registers every relevant toadlet with the
-   * provided server. Registration order aligns with menu placement: browsing first, followed by
-   * queue handlers, configuration, status/alerts, chat, and maintenance endpoints. This method must
-   * be called exactly once during startup; it performs no deduplication and assumes the server is
-   * empty.
+   * already been assembled by the caller and then registers every relevant route with the provided
+   * server. Registration order aligns with the existing legacy shell behavior: browse-owned phases
+   * are delegated through the browse registrar, with admin-owned routes published in between. This
+   * method must be called exactly once during startup; it performs no deduplication and assumes the
+   * server is empty.
    *
    * @param dependencies prebuilt shell dependencies required to register the FProxy HTTP surface
    * @param server toadlet server that exposes HTTP endpoints; expected to be in registration phase.
@@ -63,56 +56,34 @@ final class FProxyRegistrar {
     HighLevelSimpleClient client = dependencies.client();
     RuntimePorts runtimePorts = dependencies.runtimePorts();
     Config config = dependencies.config();
-    Toadlet browseRoot = dependencies.browseRoot();
     TransferAccessPort transferAccess = runtimePorts.transferAccess();
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar = dependencies.browseRouteRegistrar();
+    LegacyHttpBrowseRouteRegistrarContext browseContext = dependencies.browseContext();
 
+    browseRouteRegistrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.ROOT_MENU, browseContext, server);
     server.registerMenu(
-        "/", FProxyToadlet.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");
-    server.registerMenu(
-        FProxyToadlet.DOWNLOADS_PATH,
-        FProxyToadlet.CATEGORY_QUEUE,
+        LegacyHttpPaths.DOWNLOADS_PATH,
+        LegacyHttpCategories.CATEGORY_QUEUE,
         "FProxyToadlet.categoryTitleQueue");
     server.registerMenu(
-        FProxyToadlet.FRIENDS_PATH,
-        FProxyToadlet.CATEGORY_FRIENDS,
+        LegacyHttpPaths.FRIENDS_PATH,
+        LegacyHttpCategories.CATEGORY_FRIENDS,
         "FProxyToadlet.categoryTitleFriends");
     server.registerMenu("/chat/", "FProxyToadlet.categoryChat", "FProxyToadlet.categoryTitleChat");
     server.registerMenu(
-        "/alerts/", FProxyToadlet.CATEGORY_STATUS, "FProxyToadlet.categoryTitleStatus");
+        "/alerts/", LegacyHttpCategories.CATEGORY_STATUS, "FProxyToadlet.categoryTitleStatus");
     server.registerMenu(
-        "/seclevels/", FProxyToadlet.CATEGORY_CONFIG, "FProxyToadlet.categoryTitleConfig");
+        "/seclevels/", LegacyHttpCategories.CATEGORY_CONFIG, "FProxyToadlet.categoryTitleConfig");
 
-    server.register(
-        browseRoot,
-        ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_BROWSING,
-            "/",
-            false,
-            "FProxyToadlet.welcomeTitle",
-            "FProxyToadlet.welcome",
-            false,
-            null));
-
-    DecodeToadlet decodeKeywordURL = new DecodeToadlet(client);
-    server.register(decodeKeywordURL, ToadletRegistration.basic(null, "/decode/", true, false));
-
-    InsertFreesiteToadlet siteinsert = new InsertFreesiteToadlet(client);
-    server.register(
-        siteinsert,
-        ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_BROWSING,
-            "/insertsite/",
-            true,
-            "FProxyToadlet.insertFreesiteTitle",
-            "FProxyToadlet.insertFreesite",
-            false,
-            null));
+    browseRouteRegistrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.INTRO_ROUTES, browseContext, server);
 
     UserAlertsToadlet alerts = new UserAlertsToadlet(client);
     server.register(
         alerts,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_STATUS,
+            LegacyHttpCategories.CATEGORY_STATUS,
             "/alerts/",
             true,
             "FProxyToadlet.alertsTitle",
@@ -137,7 +108,7 @@ final class FProxyRegistrar {
     server.register(
         downloadToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_QUEUE,
+            LegacyHttpCategories.CATEGORY_QUEUE,
             QueueToadlet.PATH_DOWNLOADS,
             true,
             "FProxyToadlet.downloadsTitle",
@@ -166,7 +137,7 @@ final class FProxyRegistrar {
     server.register(
         uploadToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_QUEUE,
+            LegacyHttpCategories.CATEGORY_QUEUE,
             QueueToadlet.PATH_UPLOADS,
             true,
             "FProxyToadlet.uploadsTitle",
@@ -180,7 +151,7 @@ final class FProxyRegistrar {
     server.register(
         fiw,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_QUEUE,
+            LegacyHttpCategories.CATEGORY_QUEUE,
             FileInsertWizardToadlet.PATH,
             true,
             "FProxyToadlet.uploadFileWizardTitle",
@@ -195,23 +166,8 @@ final class FProxyRegistrar {
         localFileInsertToadlet,
         ToadletRegistration.basic(null, LocalFileInsertToadlet.INSERT_BROWSE_PATH, true, false));
 
-    ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client);
-    server.register(
-        contentFilterToadlet,
-        ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_QUEUE,
-            ContentFilterToadlet.CONTENT_FILTER_PATH,
-            true,
-            "FProxyToadlet.filterFileTitle",
-            "FProxyToadlet.filterFile",
-            false,
-            contentFilterToadlet));
-
-    LocalFileFilterToadlet localFileFilterToadlet =
-        new LocalFileFilterToadlet(transferAccess, client);
-    server.register(
-        localFileFilterToadlet,
-        ToadletRegistration.basic(null, LocalFileFilterToadlet.BROWSE_PATH, true, false));
+    browseRouteRegistrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.QUEUE_FILTER_ROUTES, browseContext, server);
 
     SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, runtimePorts.toadletSymlinks());
     server.register(symlinkToadlet, ToadletRegistration.basic(null, "/sl/", true, false));
@@ -223,7 +179,7 @@ final class FProxyRegistrar {
     server.register(
         seclevels,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_CONFIG,
+            LegacyHttpCategories.CATEGORY_CONFIG,
             "/seclevels/",
             true,
             "FProxyToadlet.seclevelsTitle",
@@ -242,15 +198,15 @@ final class FProxyRegistrar {
       if (prefix.equals("security-levels")) continue;
       LocalDirectoryConfigToadlet localDirectoryConfigToadlet =
           new LocalDirectoryConfigToadlet(
-              transferAccess, client, FProxyToadlet.CONFIG_PATH + prefix);
+              transferAccess, client, LegacyHttpPaths.CONFIG_PATH + prefix);
       ConfigToadlet configtoadlet =
           new ConfigToadlet(
               localDirectoryConfigToadlet.path(), client, config, cfg, configToadletRuntimePorts);
       server.register(
           configtoadlet,
           ToadletRegistration.menuLink(
-              FProxyToadlet.CATEGORY_CONFIG,
-              FProxyToadlet.CONFIG_PATH + prefix,
+              LegacyHttpCategories.CATEGORY_CONFIG,
+              LegacyHttpPaths.CONFIG_PATH + prefix,
               true,
               "ConfigToadlet." + prefix,
               "ConfigToadlet.title." + prefix,
@@ -261,20 +217,8 @@ final class FProxyRegistrar {
           ToadletRegistration.basic(null, localDirectoryConfigToadlet.path(), true, false));
     }
 
-    WelcomeToadletRuntimePorts welcomeToadletRuntimePorts =
-        new WelcomeToadletRuntimePorts(
-            runtimePorts.welcomePage(),
-            runtimePorts.darknetConnections(),
-            runtimePorts.lifecycle(),
-            runtimePorts.welcomeAction());
-    WelcomeToadlet welcometoadlet = new WelcomeToadlet(client, welcomeToadletRuntimePorts);
-    server.register(
-        welcometoadlet, ToadletRegistration.basic(null, FProxyToadlet.WELCOME_PATH, true, false));
-
-    ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client);
-    server.register(
-        externalLinkToadlet,
-        ToadletRegistration.basic(null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false));
+    browseRouteRegistrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.POST_CONFIG_ROUTES, browseContext, server);
 
     CoreActionToadlet coreActionToadlet =
         new CoreActionToadlet(client, runtimePorts.coreUpdateAction());
@@ -296,8 +240,8 @@ final class FProxyRegistrar {
     server.register(
         friendsToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_FRIENDS,
-            FProxyToadlet.FRIENDS_PATH,
+            LegacyHttpCategories.CATEGORY_FRIENDS,
+            LegacyHttpPaths.FRIENDS_PATH,
             true,
             "FProxyToadlet.friendsTitle",
             "FProxyToadlet.friends",
@@ -310,7 +254,7 @@ final class FProxyRegistrar {
     server.register(
         addRefToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_FRIENDS,
+            LegacyHttpCategories.CATEGORY_FRIENDS,
             "/addfriend/",
             true,
             "FProxyToadlet.addFriendTitle",
@@ -323,7 +267,7 @@ final class FProxyRegistrar {
     server.register(
         opennetToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_STATUS,
+            LegacyHttpCategories.CATEGORY_STATUS,
             "/strangers/",
             true,
             "FProxyToadlet.opennetTitle",
@@ -350,19 +294,14 @@ final class FProxyRegistrar {
         localFileN2NMToadlet,
         ToadletRegistration.basic(null, LocalFileN2NMToadlet.BROWSE_PATH, true, false));
 
-    BookmarkEditorToadlet bookmarkEditorToadlet =
-        new BookmarkEditorToadlet(
-            client,
-            new BookmarkEditorToadletRuntimePorts(
-                runtimePorts.darknetConnections(), runtimePorts.darknetMessaging()));
-    server.register(
-        bookmarkEditorToadlet, ToadletRegistration.basic(null, "/bookmarkEditor/", true, false));
+    browseRouteRegistrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.POST_MESSAGING_ROUTES, browseContext, server);
 
     WebShellToadlet webShellToadlet = new WebShellToadlet(client);
     server.register(
         webShellToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_STATUS,
+            LegacyHttpCategories.CATEGORY_STATUS,
             WebShellPaths.SHELL_ROOT,
             true,
             "FProxyToadlet.webShellTitle",
@@ -376,14 +315,14 @@ final class FProxyRegistrar {
         platformApiToadlet,
         ToadletRegistration.basic(null, PlatformApiToadlet.MOUNT_PATH, true, true));
 
-    BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(client);
-    server.register(browserTestToadlet, ToadletRegistration.basic(null, "/test/", true, false));
+    browseRouteRegistrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.POST_PLATFORM_API_ROUTES, browseContext, server);
 
     StatisticsToadlet statisticsToadlet = new StatisticsToadlet(client, runtimePorts.statistics());
     server.register(
         statisticsToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_STATUS,
+            LegacyHttpCategories.CATEGORY_STATUS,
             "/stats/",
             true,
             "FProxyToadlet.statsTitle",
@@ -395,7 +334,7 @@ final class FProxyRegistrar {
     server.register(
         diagnosticToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_STATUS,
+            LegacyHttpCategories.CATEGORY_STATUS,
             "/diagnostic/",
             true,
             "FProxyToadlet.diagnosticTitle",
@@ -408,7 +347,7 @@ final class FProxyRegistrar {
     server.register(
         connectivityToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_STATUS,
+            LegacyHttpCategories.CATEGORY_STATUS,
             "/connectivity/",
             true,
             "ConnectivityToadlet.connectivityTitle",
@@ -420,7 +359,7 @@ final class FProxyRegistrar {
     server.register(
         translationToadlet,
         ToadletRegistration.menuLink(
-            FProxyToadlet.CATEGORY_CONFIG,
+            LegacyHttpCategories.CATEGORY_CONFIG,
             TranslationToadlet.TOADLET_URL,
             true,
             "TranslationToadlet.title",
@@ -444,47 +383,7 @@ final class FProxyRegistrar {
     SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet(client);
     server.register(simpleHelpToadlet, ToadletRegistration.basic(null, "/help/", true, false));
 
-    PushDataToadlet pushDataToadlet = new PushDataToadlet(client);
-    server.register(
-        pushDataToadlet, ToadletRegistration.basic(null, pushDataToadlet.path(), true, false));
-
-    PushNotificationToadlet pushNotificationToadlet = new PushNotificationToadlet(client);
-    server.register(
-        pushNotificationToadlet,
-        ToadletRegistration.basic(null, pushNotificationToadlet.path(), true, false));
-
-    PushKeepaliveToadlet pushKeepaliveToadlet = new PushKeepaliveToadlet(client);
-    server.register(
-        pushKeepaliveToadlet,
-        ToadletRegistration.basic(null, pushKeepaliveToadlet.path(), true, false));
-
-    PushFailoverToadlet pushFailoverToadlet = new PushFailoverToadlet(client);
-    server.register(
-        pushFailoverToadlet,
-        ToadletRegistration.basic(null, pushFailoverToadlet.path(), true, false));
-
-    PushTesterToadlet pushTesterToadlet = new PushTesterToadlet(client);
-    server.register(
-        pushTesterToadlet, ToadletRegistration.basic(null, pushTesterToadlet.path(), true, false));
-
-    PushLeavingToadlet pushLeavingToadlet = new PushLeavingToadlet(client);
-    server.register(
-        pushLeavingToadlet,
-        ToadletRegistration.basic(null, pushLeavingToadlet.path(), true, false));
-
-    ImageCreatorToadlet imageCreatorToadlet = new ImageCreatorToadlet(client);
-    server.register(
-        imageCreatorToadlet,
-        ToadletRegistration.basic(null, imageCreatorToadlet.path(), true, false));
-
-    LogWritebackToadlet logWritebackToadlet = new LogWritebackToadlet(client);
-    server.register(
-        logWritebackToadlet,
-        ToadletRegistration.basic(null, logWritebackToadlet.path(), true, false));
-
-    DismissAlertToadlet dismissAlertToadlet = new DismissAlertToadlet(client);
-    server.register(
-        dismissAlertToadlet,
-        ToadletRegistration.basic(null, dismissAlertToadlet.path(), true, false));
+    browseRouteRegistrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.TAIL_ROUTES, browseContext, server);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
@@ -25,13 +25,15 @@ import network.crypta.runtime.spi.RuntimePorts;
  * @param appHost shared AppHost instance exposed through the Platform API bridge
  * @param config node configuration used to list sub-config toadlets
  * @param browseRoot prebuilt root browse toadlet handed to the registrar for root-path registration
+ * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route publication
  */
 record FProxyRegistrarDependencies(
     HighLevelSimpleClient client,
     RuntimePorts runtimePorts,
     AppHost appHost,
     Config config,
-    Toadlet browseRoot) {
+    Toadlet browseRoot,
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
   /**
    * Creates a validated dependency bundle for {@link FProxyRegistrar}.
    *
@@ -44,6 +46,8 @@ record FProxyRegistrarDependencies(
    * @param appHost shared AppHost instance exposed through the Platform API bridge
    * @param config node configuration used to list and filter sub-config toadlets
    * @param browseRoot prebuilt root browse toadlet that is registered at the HTTP root path
+   * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route
+   *     publication
    * @throws NullPointerException if any required collaborator is absent at construction time
    */
   FProxyRegistrarDependencies {
@@ -52,5 +56,10 @@ record FProxyRegistrarDependencies(
     Objects.requireNonNull(appHost);
     Objects.requireNonNull(config);
     Objects.requireNonNull(browseRoot);
+    Objects.requireNonNull(browseRouteRegistrar);
+  }
+
+  LegacyHttpBrowseRouteRegistrarContext browseContext() {
+    return new LegacyHttpBrowseRouteRegistrarContext(client, runtimePorts, browseRoot);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellBrowseBootstrap.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellBrowseBootstrap.java
@@ -29,6 +29,8 @@ import network.crypta.runtime.spi.RuntimePorts;
  *     legacy HTTP routes
  * @param browseRoot browse-root toadlet constructed during bootstrap and handed to the registrar
  *     for root-path registration
+ * @param browseRouteRegistrar browse-neutral registrar seam that publishes browse-owned routes at
+ *     the historical insertion points
  * @param sharedShellInitializer browse-neutral hook for any shell-local initialization that must
  *     run before route registration
  */
@@ -37,6 +39,7 @@ public record HttpShellBrowseBootstrap(
     HighLevelSimpleClient client,
     AppHost appHost,
     Toadlet browseRoot,
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
     Consumer<RuntimePorts> sharedShellInitializer) {
   /**
    * Creates the bundle while keeping the browse-root toadlet constructor package-local.
@@ -51,14 +54,16 @@ public record HttpShellBrowseBootstrap(
    * @param client interactive client shared by shell toadlets that are registered during startup
    * @param appHost shared AppHost instance used by the platform control plane and related routes
    * @param browseRoot browse-root toadlet used by route registration at the legacy browsing root
+   * @param browseRouteRegistrar browse-neutral registrar seam for the browse-owned routes
    * @return browse-neutral bootstrap bundle containing the supplied collaborators and browse root
    */
   public static HttpShellBrowseBootstrap create(
       BookmarkManagerHandle bookmarkManager,
       HighLevelSimpleClient client,
       AppHost appHost,
-      Toadlet browseRoot) {
-    return create(bookmarkManager, client, appHost, browseRoot, _ -> {});
+      Toadlet browseRoot,
+      LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
+    return create(bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar, _ -> {});
   }
 
   /**
@@ -74,6 +79,7 @@ public record HttpShellBrowseBootstrap(
    * @param client interactive client shared by shell toadlets that are registered during startup
    * @param appHost shared AppHost instance used by the platform control plane and related routes
    * @param browseRoot browse-root toadlet used by route registration at the legacy browsing root
+   * @param browseRouteRegistrar browse-neutral registrar seam for the browse-owned routes
    * @param sharedShellInitializer browse-neutral hook invoked before route registration starts
    * @return browse-neutral bootstrap bundle containing the supplied collaborators and
    *     initialization hook
@@ -83,9 +89,10 @@ public record HttpShellBrowseBootstrap(
       HighLevelSimpleClient client,
       AppHost appHost,
       Toadlet browseRoot,
+      LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
       Consumer<RuntimePorts> sharedShellInitializer) {
     return new HttpShellBrowseBootstrap(
-        bookmarkManager, client, appHost, browseRoot, sharedShellInitializer);
+        bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar, sharedShellInitializer);
   }
 
   /**
@@ -119,6 +126,7 @@ public record HttpShellBrowseBootstrap(
     Objects.requireNonNull(client);
     Objects.requireNonNull(appHost);
     Objects.requireNonNull(browseRoot);
+    Objects.requireNonNull(browseRouteRegistrar);
     Objects.requireNonNull(sharedShellInitializer);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
@@ -30,10 +30,9 @@ public final class LegacyAdminHttpRouteRegistrar implements LegacyHttpRouteRegis
    * Registers the concrete legacy HTTP routes for the supplied shell instance.
    *
    * <p>The provided context already contains the interactive client, runtime ports, configuration,
-   * AppHost bridge, and browse-root toadlet prepared by the shared shell bootstrap path.
-   * Repackaging those collaborators here keeps the public seam small while letting the existing
-   * admin-owned registrar continue to own menu creation, toadlet instantiation, and registration
-   * order.
+   * AppHost bridge, browse-root toadlet, and browse registrar seam prepared by the shared shell
+   * bootstrap path. Repackaging those collaborators here keeps the public seam small while letting
+   * the existing admin-owned registrar continue to own the overall registration order.
    *
    * @param context prepared bootstrap collaborators that the admin-owned registrar requires
    * @param server shell instance that receives the registered menus and toadlets
@@ -46,7 +45,8 @@ public final class LegacyAdminHttpRouteRegistrar implements LegacyHttpRouteRegis
             context.runtimePorts(),
             context.appHost(),
             context.config(),
-            context.browseRoot()),
+            context.browseRoot(),
+            context.browseRouteRegistrar()),
         server);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyFProxyAjaxPushRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyFProxyAjaxPushRouteRegistrar.java
@@ -1,0 +1,80 @@
+package network.crypta.clients.http;
+
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ajaxpush.PushDataToadlet;
+import network.crypta.clients.http.ajaxpush.PushFailoverToadlet;
+import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
+import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
+import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
+import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
+
+/**
+ * Registers the AJAX-push browse routes owned by the current legacy FProxy shell.
+ *
+ * <p>This helper keeps the tightly related push toadlets together and out of {@link
+ * LegacyFProxyBrowseRouteRegistrar} so the top-level browse registrar can stay focused on the phase
+ * boundaries that matter for the future physical browse split. The class remains in the legacy
+ * admin module for now because this PR only introduces the registrar seam. It does not move the
+ * browse-owned code yet.
+ *
+ * <p>Callers use this helper only during one-shot HTTP startup. It instantiates the concrete
+ * AJAX-push toadlets, registers them in the historical order already exposed by the legacy shell,
+ * and leaves menu publication to the surrounding browse registrar. The helper is intentionally
+ * stateless and does not retain the supplied client or server after registration completes.
+ */
+final class LegacyFProxyAjaxPushRouteRegistrar {
+
+  /**
+   * Creates a stateless helper for AJAX-push route publication.
+   *
+   * <p>The constructor exists only to make the helper's startup role explicit in generated API
+   * documentation. Instances carry no mutable state and can be reused across startup attempts as
+   * long as callers still treat registration as a one-shot shell-initialization step.
+   */
+  LegacyFProxyAjaxPushRouteRegistrar() {
+    // This helper is intentionally stateless.
+  }
+
+  /**
+   * Registers the AJAX-push routes that occupy the tail of the legacy browse surface.
+   *
+   * <p>The method publishes only the push toadlets that belong to the AJAX-update subfamily. It
+   * preserves the current startup order, so the caller can still insert later browse-tail
+   * registrations such as image creation and alert dismissal immediately afterward. The method does
+   * not add menu links, perform deduplication, or mutate global shell state beyond adding routes to
+   * the provided server.
+   *
+   * @param client a shared interactive client passed into each push toadlet constructor during
+   *     startup
+   * @param server legacy HTTP shell that receives the registered push routes in their fixed order
+   */
+  void registerRoutes(HighLevelSimpleClient client, SimpleToadletServer server) {
+    PushDataToadlet pushDataToadlet = new PushDataToadlet(client);
+    server.register(
+        pushDataToadlet, ToadletRegistration.basic(null, pushDataToadlet.path(), true, false));
+
+    PushNotificationToadlet pushNotificationToadlet = new PushNotificationToadlet(client);
+    server.register(
+        pushNotificationToadlet,
+        ToadletRegistration.basic(null, pushNotificationToadlet.path(), true, false));
+
+    PushKeepaliveToadlet pushKeepaliveToadlet = new PushKeepaliveToadlet(client);
+    server.register(
+        pushKeepaliveToadlet,
+        ToadletRegistration.basic(null, pushKeepaliveToadlet.path(), true, false));
+
+    PushFailoverToadlet pushFailoverToadlet = new PushFailoverToadlet(client);
+    server.register(
+        pushFailoverToadlet,
+        ToadletRegistration.basic(null, pushFailoverToadlet.path(), true, false));
+
+    PushTesterToadlet pushTesterToadlet = new PushTesterToadlet(client);
+    server.register(
+        pushTesterToadlet, ToadletRegistration.basic(null, pushTesterToadlet.path(), true, false));
+
+    PushLeavingToadlet pushLeavingToadlet = new PushLeavingToadlet(client);
+    server.register(
+        pushLeavingToadlet,
+        ToadletRegistration.basic(null, pushLeavingToadlet.path(), true, false));
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrar.java
@@ -1,0 +1,185 @@
+package network.crypta.clients.http;
+
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ajaxpush.DismissAlertToadlet;
+import network.crypta.clients.http.ajaxpush.LogWritebackToadlet;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
+
+/**
+ * Concrete browse-owned legacy HTTP route registrar used by the current FProxy-backed shell.
+ *
+ * <p>This implementation stays in {@code :adapter-http-legacy-admin} for now so the physical
+ * browse-module move can remain a later mechanical PR. Its job is deliberately small: instantiate
+ * the browse/FProxy-owned routes that still live in this package tree today and publish them only
+ * when the admin-owned orchestrator asks for the matching registration phase. That keeps concrete
+ * browse classes out of the admin-owned startup path while preserving the exact historical
+ * insertion points that the legacy shell already exposed.
+ *
+ * <p>The registrar is stateless and safe to reuse across startup attempts as long as callers still
+ * treat registration as a one-shot action for a single {@link SimpleToadletServer}. It does not
+ * create menus or routes eagerly. Instead, it reacts to the requested {@link Phase}, publishes only
+ * the browse-owned routes assigned to that phase, and leaves the surrounding admin registrar
+ * responsible for the overall route order. The AJAX-push route family is delegated to {@link
+ * LegacyFProxyAjaxPushRouteRegistrar} so this class can focus on the larger browse ownership seam.
+ */
+public final class LegacyFProxyBrowseRouteRegistrar implements LegacyHttpBrowseRouteRegistrar {
+  private static final LegacyFProxyAjaxPushRouteRegistrar AJAX_PUSH_ROUTE_REGISTRAR =
+      new LegacyFProxyAjaxPushRouteRegistrar();
+
+  /**
+   * Creates a stateless browse-route registrar for the current FProxy-backed legacy HTTP shell.
+   *
+   * <p>Construction performs no route instantiation and does not capture runtime-specific state.
+   * All browse-owned collaborators still arrive later through the registration context prepared by
+   * the shared shell bootstrap path.
+   */
+  public LegacyFProxyBrowseRouteRegistrar() {
+    // This registrar is intentionally stateless.
+  }
+
+  /**
+   * Publishes the browse-owned routes assigned to one historical legacy registration phase.
+   *
+   * <p>Each phase corresponds to a fixed insertion point in the old monolithic FProxy registrar.
+   * Callers are expected to invoke the phases in the established order while registering the
+   * remaining admin-owned routes in between. This method performs no deduplication and assumes it
+   * is running during startup against a server that is still being assembled.
+   *
+   * @param phase browse-owned insertion point whose routes should be published during this call
+   * @param context browse-local collaborators required to instantiate the phase-owned routes
+   * @param server shell instance that receives the published browse routes and any browse menu
+   *     entries
+   */
+  @Override
+  public void registerRoutes(
+      Phase phase, LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
+    switch (phase) {
+      case ROOT_MENU -> registerRootMenu(server);
+      case INTRO_ROUTES -> registerIntroRoutes(context, server);
+      case QUEUE_FILTER_ROUTES -> registerQueueFilterRoutes(context, server);
+      case POST_CONFIG_ROUTES -> registerPostConfigRoutes(context, server);
+      case POST_MESSAGING_ROUTES -> registerPostMessagingRoutes(context, server);
+      case POST_PLATFORM_API_ROUTES -> registerPostPlatformApiRoutes(context, server);
+      case TAIL_ROUTES -> registerTailRoutes(context.client(), server);
+    }
+  }
+
+  private static void registerRootMenu(SimpleToadletServer server) {
+    server.registerMenu(
+        "/", LegacyHttpCategories.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");
+  }
+
+  private static void registerIntroRoutes(
+      LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
+    HighLevelSimpleClient client = context.client();
+
+    server.register(
+        context.browseRoot(),
+        ToadletRegistration.menuLink(
+            LegacyHttpCategories.CATEGORY_BROWSING,
+            "/",
+            false,
+            "FProxyToadlet.welcomeTitle",
+            "FProxyToadlet.welcome",
+            false,
+            null));
+
+    DecodeToadlet decodeKeywordURL = new DecodeToadlet(client);
+    server.register(decodeKeywordURL, ToadletRegistration.basic(null, "/decode/", true, false));
+
+    InsertFreesiteToadlet siteinsert = new InsertFreesiteToadlet(client);
+    server.register(
+        siteinsert,
+        ToadletRegistration.menuLink(
+            LegacyHttpCategories.CATEGORY_BROWSING,
+            "/insertsite/",
+            true,
+            "FProxyToadlet.insertFreesiteTitle",
+            "FProxyToadlet.insertFreesite",
+            false,
+            null));
+  }
+
+  private static void registerQueueFilterRoutes(
+      LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
+    HighLevelSimpleClient client = context.client();
+    TransferAccessPort transferAccess = context.runtimePorts().transferAccess();
+
+    ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client);
+    server.register(
+        contentFilterToadlet,
+        ToadletRegistration.menuLink(
+            LegacyHttpCategories.CATEGORY_QUEUE,
+            ContentFilterToadlet.CONTENT_FILTER_PATH,
+            true,
+            "FProxyToadlet.filterFileTitle",
+            "FProxyToadlet.filterFile",
+            false,
+            contentFilterToadlet));
+
+    LocalFileFilterToadlet localFileFilterToadlet =
+        new LocalFileFilterToadlet(transferAccess, client);
+    server.register(
+        localFileFilterToadlet,
+        ToadletRegistration.basic(null, LocalFileFilterToadlet.BROWSE_PATH, true, false));
+  }
+
+  private static void registerPostConfigRoutes(
+      LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
+    HighLevelSimpleClient client = context.client();
+    RuntimePorts runtimePorts = context.runtimePorts();
+
+    WelcomeToadletRuntimePorts welcomeToadletRuntimePorts =
+        new WelcomeToadletRuntimePorts(
+            runtimePorts.welcomePage(),
+            runtimePorts.darknetConnections(),
+            runtimePorts.lifecycle(),
+            runtimePorts.welcomeAction());
+    WelcomeToadlet welcomeToadlet = new WelcomeToadlet(client, welcomeToadletRuntimePorts);
+    server.register(
+        welcomeToadlet, ToadletRegistration.basic(null, LegacyHttpPaths.WELCOME_PATH, true, false));
+
+    ExternalLinkToadlet externalLinkToadlet = new ExternalLinkToadlet(client);
+    server.register(
+        externalLinkToadlet,
+        ToadletRegistration.basic(null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false));
+  }
+
+  private static void registerPostMessagingRoutes(
+      LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
+    RuntimePorts runtimePorts = context.runtimePorts();
+    BookmarkEditorToadlet bookmarkEditorToadlet =
+        new BookmarkEditorToadlet(
+            context.client(),
+            new BookmarkEditorToadletRuntimePorts(
+                runtimePorts.darknetConnections(), runtimePorts.darknetMessaging()));
+    server.register(
+        bookmarkEditorToadlet, ToadletRegistration.basic(null, "/bookmarkEditor/", true, false));
+  }
+
+  private static void registerPostPlatformApiRoutes(
+      LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
+    BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(context.client());
+    server.register(browserTestToadlet, ToadletRegistration.basic(null, "/test/", true, false));
+  }
+
+  private static void registerTailRoutes(HighLevelSimpleClient client, SimpleToadletServer server) {
+    AJAX_PUSH_ROUTE_REGISTRAR.registerRoutes(client, server);
+
+    ImageCreatorToadlet imageCreatorToadlet = new ImageCreatorToadlet(client);
+    server.register(
+        imageCreatorToadlet,
+        ToadletRegistration.basic(null, imageCreatorToadlet.path(), true, false));
+
+    LogWritebackToadlet logWritebackToadlet = new LogWritebackToadlet(client);
+    server.register(
+        logWritebackToadlet,
+        ToadletRegistration.basic(null, logWritebackToadlet.path(), true, false));
+
+    DismissAlertToadlet dismissAlertToadlet = new DismissAlertToadlet(client);
+    server.register(
+        dismissAlertToadlet,
+        ToadletRegistration.basic(null, dismissAlertToadlet.path(), true, false));
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpBrowseRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpBrowseRouteRegistrar.java
@@ -1,0 +1,74 @@
+package network.crypta.clients.http;
+
+/**
+ * Browse-neutral seam for publishing browse-owned legacy HTTP routes.
+ *
+ * <p>The admin-owned legacy HTTP registrar still owns the overall startup orchestration and must
+ * preserve the historical registration order. It should not directly instantiate the concrete
+ * browse/FProxy route families that will move out during the future physical browse split. This
+ * seam lets the admin-owned orchestration invoke browse-owned publication at the exact existing
+ * insertion points. It also keeps shared-shell and admin bootstrap code free from concrete
+ * browse-route classes, which makes the eventual module extraction mostly mechanical instead of a
+ * second behavior-changing refactor.
+ *
+ * <p>Implementations are expected to treat registration as a one-shot startup action for a single
+ * {@link SimpleToadletServer}. They should publish only the browse-owned routes assigned to the
+ * requested {@link Phase}, avoid retaining the provided context after startup, and preserve the
+ * current route and menu ordering established by the admin-owned orchestrator. The seam is narrow
+ * by design: it is not a general plugin system for arbitrary HTTP features. It exists only to
+ * separate browse-owned route construction from the still-admin-owned legacy startup flow.
+ */
+public interface LegacyHttpBrowseRouteRegistrar {
+
+  /**
+   * Fixed browse-owned insertion points in the historical legacy HTTP registration order.
+   *
+   * <p>The admin-owned registrar invokes these phases in order while registering the remaining
+   * admin-owned routes in between. Concrete browse registrars must publish only the routes assigned
+   * to the requested phase so behavior, route order, and menu visibility remain unchanged.
+   */
+  enum Phase {
+    /** Registers the browsing menu bucket itself before any browse-owned toadlets are published. */
+    ROOT_MENU,
+
+    /**
+     * Registers the initial browse surface near the root, including the browse root and early
+     * helper routes.
+     */
+    INTRO_ROUTES,
+
+    /**
+     * Registers browse-adjacent queue filter routes after the admin-owned queue routes have been
+     * published.
+     */
+    QUEUE_FILTER_ROUTES,
+
+    /** Registers browse-owned routes that historically appeared after the config toadlet block. */
+    POST_CONFIG_ROUTES,
+
+    /**
+     * Registers browse-owned messaging and bookmark routes after the admin-owned messaging pages.
+     */
+    POST_MESSAGING_ROUTES,
+
+    /** Registers browse-owned browser-test routes after the platform API and Web Shell entries. */
+    POST_PLATFORM_API_ROUTES,
+
+    /** Registers the remaining browse-owned tail routes at the end of legacy HTTP startup. */
+    TAIL_ROUTES
+  }
+
+  /**
+   * Publishes the browse-owned routes assigned to one insertion point.
+   *
+   * <p>Callers should invoke this only during startup and only in the historical phase order.
+   * Implementations should assume the surrounding admin registrar remains responsible for all
+   * admin-owned routes, menu categories, and any interleaving between browse-owned phases.
+   *
+   * @param phase historical registration point whose browse-owned routes should be published
+   * @param context browse-local startup collaborators needed to build browse-owned routes
+   * @param server shell instance that receives the published browse routes and menu entries
+   */
+  void registerRoutes(
+      Phase phase, LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server);
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpBrowseRouteRegistrarContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpBrowseRouteRegistrarContext.java
@@ -1,0 +1,48 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.runtime.spi.RuntimePorts;
+
+/**
+ * Immutable startup context for browse-owned legacy HTTP route registration.
+ *
+ * <p>This record keeps the browse-owned registrar seam narrow. It still exposes the collaborators
+ * that the current browse route publication requires: the shared interactive client, the detached
+ * runtime ports used by welcome, bookmark, and filter routes, and the prebuilt browse root toadlet.
+ * The type is public because bridge-owned production code installs concrete browse registrars
+ * across module boundaries. The carried state remains intentionally limited to the browse-owned
+ * registration concern.
+ *
+ * <p>Callers should treat the record as a startup snapshot, not as a long-lived service locator. It
+ * exists so the admin-owned shell can hand the browse registrar exactly the collaborators that
+ * browse-owned routes still need today while the broader physical split remains deferred. Keeping
+ * the record small also makes later extraction easier: if a browse route needs a new collaborator,
+ * that dependency change becomes visible at the seam instead of leaking back into the shared shell.
+ *
+ * @param client shared interactive client used by browse-owned HTTP toadlets
+ * @param runtimePorts detached runtime ports exposed to browse-owned HTTP routes
+ * @param browseRoot prebuilt browse-root toadlet registered at the legacy browsing root
+ */
+public record LegacyHttpBrowseRouteRegistrarContext(
+    HighLevelSimpleClient client, RuntimePorts runtimePorts, Toadlet browseRoot) {
+
+  /**
+   * Creates a validated browse-route registration context.
+   *
+   * <p>Construction fails fast because browse-route publication is still a startup-only step. A
+   * partially populated context would otherwise defer wiring mistakes until the registrar reaches a
+   * later phase and tries to instantiate a route. The record stores the exact references prepared
+   * by the shared bootstrap path and does not wrap or copy them.
+   *
+   * @param client shared interactive client used by browse-owned HTTP toadlets
+   * @param runtimePorts detached runtime ports exposed to browse-owned HTTP routes
+   * @param browseRoot prebuilt browse-root toadlet registered at the legacy browsing root
+   * @throws NullPointerException if any required collaborator is absent
+   */
+  public LegacyHttpBrowseRouteRegistrarContext {
+    Objects.requireNonNull(client);
+    Objects.requireNonNull(runtimePorts);
+    Objects.requireNonNull(browseRoot);
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
@@ -28,13 +28,16 @@ import network.crypta.runtime.spi.RuntimePorts;
  * @param config node configuration view used when listing or filtering sub-config toadlets
  * @param browseRoot prebuilt root browse toadlet that anchors the registration pass at the legacy
  *     browsing root
+ * @param browseRouteRegistrar browse-neutral registrar seam used for concrete browse-owned route
+ *     publication
  */
 public record LegacyHttpRouteRegistrarContext(
     HighLevelSimpleClient client,
     RuntimePorts runtimePorts,
     AppHost appHost,
     Config config,
-    Toadlet browseRoot) {
+    Toadlet browseRoot,
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
 
   /**
    * Creates a validated route-registration context.
@@ -49,6 +52,8 @@ public record LegacyHttpRouteRegistrarContext(
    * @param appHost shared AppHost bridge made visible through HTTP-owned routes
    * @param config node configuration view that registration may inspect for sub-config pages
    * @param browseRoot prebuilt root browse toadlet registered at the browsing root
+   * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route
+   *     publication
    * @throws NullPointerException if any required collaborator is absent when the context is built
    */
   public LegacyHttpRouteRegistrarContext {
@@ -57,5 +62,6 @@ public record LegacyHttpRouteRegistrarContext(
     Objects.requireNonNull(appHost);
     Objects.requireNonNull(config);
     Objects.requireNonNull(browseRoot);
+    Objects.requireNonNull(browseRouteRegistrar);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -490,7 +490,8 @@ public final class SimpleToadletServer
             runtimePorts,
             runtimeSupportRef.appHost(),
             runtimeSupportRef.config(),
-            bootstrap.browseRoot()),
+            bootstrap.browseRoot(),
+            bootstrap.browseRouteRegistrar()),
         this);
   }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/HttpShellBrowseBootstrapTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/HttpShellBrowseBootstrapTest.java
@@ -21,14 +21,18 @@ class HttpShellBrowseBootstrapTest {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
+        mock(LegacyHttpBrowseRouteRegistrar.class);
 
     HttpShellBrowseBootstrap bootstrap =
-        HttpShellBrowseBootstrap.create(bookmarkManager, client, appHost, browseRoot);
+        HttpShellBrowseBootstrap.create(
+            bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar);
 
     assertSame(bookmarkManager, bootstrap.bookmarkManager());
     assertSame(client, bootstrap.client());
     assertSame(appHost, bootstrap.appHost());
     assertSame(browseRoot, bootstrap.browseRoot());
+    assertSame(browseRouteRegistrar, bootstrap.browseRouteRegistrar());
   }
 
   @Test
@@ -37,16 +41,24 @@ class HttpShellBrowseBootstrapTest {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
+        mock(LegacyHttpBrowseRouteRegistrar.class);
     AtomicReference<RuntimePorts> runtimePortsSeen = new AtomicReference<>();
 
     HttpShellBrowseBootstrap bootstrap =
         HttpShellBrowseBootstrap.create(
-            bookmarkManager, client, appHost, browseRoot, runtimePortsSeen::set);
+            bookmarkManager,
+            client,
+            appHost,
+            browseRoot,
+            browseRouteRegistrar,
+            runtimePortsSeen::set);
 
     assertSame(bookmarkManager, bootstrap.bookmarkManager());
     assertSame(client, bootstrap.client());
     assertSame(appHost, bootstrap.appHost());
     assertSame(browseRoot, bootstrap.browseRoot());
+    assertSame(browseRouteRegistrar, bootstrap.browseRouteRegistrar());
 
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     bootstrap.initializeSharedShellState(runtimePorts);
@@ -56,6 +68,22 @@ class HttpShellBrowseBootstrapTest {
 
   @Test
   void create_whenInitializationHookNull_throwsNullPointerException() {
+    BookmarkManager bookmarkManager = mock(BookmarkManager.class);
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    AppHost appHost = mock(AppHost.class);
+    Toadlet browseRoot = mock(Toadlet.class);
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
+        mock(LegacyHttpBrowseRouteRegistrar.class);
+
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            HttpShellBrowseBootstrap.create(
+                bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar, null));
+  }
+
+  @Test
+  void create_whenBrowseRouteRegistrarNull_throwsNullPointerException() {
     BookmarkManager bookmarkManager = mock(BookmarkManager.class);
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
@@ -72,8 +100,11 @@ class HttpShellBrowseBootstrapTest {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
+        mock(LegacyHttpBrowseRouteRegistrar.class);
     HttpShellBrowseBootstrap bootstrap =
-        HttpShellBrowseBootstrap.create(bookmarkManager, client, appHost, mock(Toadlet.class));
+        HttpShellBrowseBootstrap.create(
+            bookmarkManager, client, appHost, mock(Toadlet.class), browseRouteRegistrar);
 
     bootstrap.initializeSharedShellState(runtimePorts);
 
@@ -86,8 +117,11 @@ class HttpShellBrowseBootstrapTest {
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
+        mock(LegacyHttpBrowseRouteRegistrar.class);
     HttpShellBrowseBootstrap bootstrap =
-        HttpShellBrowseBootstrap.create(bookmarkManager, client, appHost, browseRoot);
+        HttpShellBrowseBootstrap.create(
+            bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar);
 
     assertThrows(NullPointerException.class, () -> bootstrap.initializeSharedShellState(null));
   }

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyFProxyAjaxPushRouteRegistrarTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyFProxyAjaxPushRouteRegistrarTest.java
@@ -1,0 +1,48 @@
+package network.crypta.clients.http;
+
+import java.util.List;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ajaxpush.PushDataToadlet;
+import network.crypta.clients.http.ajaxpush.PushFailoverToadlet;
+import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
+import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
+import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
+import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("java:S100")
+class LegacyFProxyAjaxPushRouteRegistrarTest {
+
+  @Test
+  void registerRoutes_whenInvoked_registersAjaxPushRoutesInHistoricalOrder() {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    SimpleToadletServer server = mock(SimpleToadletServer.class);
+
+    new LegacyFProxyAjaxPushRouteRegistrar().registerRoutes(client, server);
+
+    ArgumentCaptor<Toadlet> toadletCaptor = ArgumentCaptor.forClass(Toadlet.class);
+    ArgumentCaptor<ToadletRegistration> registrationCaptor =
+        ArgumentCaptor.forClass(ToadletRegistration.class);
+    verify(server, times(6)).register(toadletCaptor.capture(), registrationCaptor.capture());
+
+    List<Toadlet> toadlets = toadletCaptor.getAllValues();
+    assertEquals(
+        List.of(
+            PushDataToadlet.class,
+            PushNotificationToadlet.class,
+            PushKeepaliveToadlet.class,
+            PushFailoverToadlet.class,
+            PushTesterToadlet.class,
+            PushLeavingToadlet.class),
+        toadlets.stream().map(Object::getClass).toList());
+    assertEquals(
+        toadlets.stream().map(Toadlet::path).toList(),
+        registrationCaptor.getAllValues().stream().map(ToadletRegistration::urlPrefix).toList());
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrarTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrarTest.java
@@ -1,0 +1,214 @@
+package network.crypta.clients.http;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.IntStream;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ajaxpush.DismissAlertToadlet;
+import network.crypta.clients.http.ajaxpush.LogWritebackToadlet;
+import network.crypta.clients.http.ajaxpush.PushDataToadlet;
+import network.crypta.clients.http.ajaxpush.PushFailoverToadlet;
+import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
+import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
+import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
+import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetMessagingPort;
+import network.crypta.runtime.spi.LifecyclePort;
+import network.crypta.runtime.spi.RuntimePorts;
+import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.runtime.spi.WelcomeActionPort;
+import network.crypta.runtime.spi.WelcomePagePort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyFProxyBrowseRouteRegistrarTest {
+
+  @Mock private HighLevelSimpleClient client;
+  @Mock private RuntimePorts runtimePorts;
+  @Mock private WelcomePagePort welcomePagePort;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
+  @Mock private LifecyclePort lifecyclePort;
+  @Mock private WelcomeActionPort welcomeActionPort;
+  @Mock private DarknetMessagingPort darknetMessagingPort;
+  @Mock private TransferAccessPort transferAccess;
+  @Mock private Toadlet browseRoot;
+  @Mock private SimpleToadletServer server;
+
+  private LegacyHttpBrowseRouteRegistrarContext context;
+  private LegacyFProxyBrowseRouteRegistrar registrar;
+
+  @BeforeEach
+  void setUp() {
+    context = new LegacyHttpBrowseRouteRegistrarContext(client, runtimePorts, browseRoot);
+    registrar = new LegacyFProxyBrowseRouteRegistrar();
+  }
+
+  @Test
+  void registerRoutes_whenPhaseRootMenu_registersBrowsingMenu() {
+    registrar.registerRoutes(LegacyHttpBrowseRouteRegistrar.Phase.ROOT_MENU, context, server);
+
+    verify(server)
+        .registerMenu(
+            "/", LegacyHttpCategories.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");
+    verifyNoMoreInteractions(server);
+  }
+
+  @Test
+  void registerRoutes_whenPhaseIntroRoutes_registersBrowseRootDecodeAndInsertInOrder() {
+    registrar.registerRoutes(LegacyHttpBrowseRouteRegistrar.Phase.INTRO_ROUTES, context, server);
+
+    List<RegisteredToadlet> registrations = capturedRegistrations(3);
+    assertSame(browseRoot, registrations.get(0).toadlet());
+    assertInstanceOf(DecodeToadlet.class, registrations.get(1).toadlet());
+    assertInstanceOf(InsertFreesiteToadlet.class, registrations.get(2).toadlet());
+    assertEquals(List.of("/", "/decode/", "/insertsite/"), registrationPrefixes(registrations));
+  }
+
+  @Test
+  void registerRoutes_whenPhaseQueueFilterRoutes_registersFilterRoutesAndTransferAccess() {
+    when(runtimePorts.transferAccess()).thenReturn(transferAccess);
+
+    registrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.QUEUE_FILTER_ROUTES, context, server);
+
+    List<RegisteredToadlet> registrations = capturedRegistrations(2);
+    assertInstanceOf(ContentFilterToadlet.class, registrations.get(0).toadlet());
+    assertInstanceOf(LocalFileFilterToadlet.class, registrations.get(1).toadlet());
+    assertEquals(
+        List.of(ContentFilterToadlet.CONTENT_FILTER_PATH, LocalFileFilterToadlet.BROWSE_PATH),
+        registrationPrefixes(registrations));
+    assertSame(registrations.get(0).toadlet(), registrations.get(0).registration().callback());
+    assertSame(transferAccess, readField(registrations.get(1).toadlet(), "transferAccess"));
+  }
+
+  @Test
+  void registerRoutes_whenPhasePostConfigRoutes_registersWelcomeAndExternalLinkWithPorts() {
+    when(runtimePorts.welcomePage()).thenReturn(welcomePagePort);
+    when(runtimePorts.darknetConnections()).thenReturn(darknetConnectionsPort);
+    when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
+    when(runtimePorts.welcomeAction()).thenReturn(welcomeActionPort);
+
+    registrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.POST_CONFIG_ROUTES, context, server);
+
+    List<RegisteredToadlet> registrations = capturedRegistrations(2);
+    assertInstanceOf(WelcomeToadlet.class, registrations.get(0).toadlet());
+    assertInstanceOf(ExternalLinkToadlet.class, registrations.get(1).toadlet());
+    assertEquals(
+        List.of(LegacyHttpPaths.WELCOME_PATH, ExternalLinkToadlet.EXTERNAL_LINK_PATH),
+        registrationPrefixes(registrations));
+
+    WelcomeToadletRuntimePorts welcomeRuntimePorts =
+        (WelcomeToadletRuntimePorts) readField(registrations.get(0).toadlet(), "runtimePorts");
+    assertSame(welcomePagePort, welcomeRuntimePorts.welcomePagePort());
+    assertSame(darknetConnectionsPort, welcomeRuntimePorts.darknetConnectionsPort());
+    assertSame(lifecyclePort, welcomeRuntimePorts.lifecyclePort());
+    assertSame(welcomeActionPort, welcomeRuntimePorts.welcomeActionPort());
+  }
+
+  @Test
+  void registerRoutes_whenPhasePostMessagingRoutes_registersBookmarkEditorWithPorts() {
+    when(runtimePorts.darknetConnections()).thenReturn(darknetConnectionsPort);
+    when(runtimePorts.darknetMessaging()).thenReturn(darknetMessagingPort);
+
+    registrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.POST_MESSAGING_ROUTES, context, server);
+
+    List<RegisteredToadlet> registrations = capturedRegistrations(1);
+    assertInstanceOf(BookmarkEditorToadlet.class, registrations.getFirst().toadlet());
+    assertEquals(List.of("/bookmarkEditor/"), registrationPrefixes(registrations));
+
+    BookmarkEditorToadletRuntimePorts bookmarkRuntimePorts =
+        (BookmarkEditorToadletRuntimePorts)
+            readField(registrations.getFirst().toadlet(), "runtimePorts");
+    assertSame(darknetConnectionsPort, bookmarkRuntimePorts.darknetConnectionsPort());
+    assertSame(darknetMessagingPort, bookmarkRuntimePorts.darknetMessagingPort());
+  }
+
+  @Test
+  void registerRoutes_whenPhasePostPlatformApiRoutes_registersBrowserTest() {
+    registrar.registerRoutes(
+        LegacyHttpBrowseRouteRegistrar.Phase.POST_PLATFORM_API_ROUTES, context, server);
+
+    List<RegisteredToadlet> registrations = capturedRegistrations(1);
+    assertInstanceOf(BrowserTestToadlet.class, registrations.getFirst().toadlet());
+    assertEquals(List.of("/test/"), registrationPrefixes(registrations));
+  }
+
+  @Test
+  void registerRoutes_whenPhaseTailRoutes_registersAjaxPushThenRemainingTailRoutes() {
+    registrar.registerRoutes(LegacyHttpBrowseRouteRegistrar.Phase.TAIL_ROUTES, context, server);
+
+    List<RegisteredToadlet> registrations = capturedRegistrations(9);
+    assertEquals(
+        List.of(
+            PushDataToadlet.class,
+            PushNotificationToadlet.class,
+            PushKeepaliveToadlet.class,
+            PushFailoverToadlet.class,
+            PushTesterToadlet.class,
+            PushLeavingToadlet.class,
+            ImageCreatorToadlet.class,
+            LogWritebackToadlet.class,
+            DismissAlertToadlet.class),
+        registrations.stream().map(RegisteredToadlet::toadlet).map(Object::getClass).toList());
+    assertEquals(
+        registrations.stream().map(RegisteredToadlet::toadlet).map(Toadlet::path).toList(),
+        registrationPrefixes(registrations));
+  }
+
+  private List<RegisteredToadlet> capturedRegistrations(int expectedCount) {
+    ArgumentCaptor<Toadlet> toadletCaptor = ArgumentCaptor.forClass(Toadlet.class);
+    ArgumentCaptor<ToadletRegistration> registrationCaptor =
+        ArgumentCaptor.forClass(ToadletRegistration.class);
+    verify(server, times(expectedCount))
+        .register(toadletCaptor.capture(), registrationCaptor.capture());
+
+    List<Toadlet> toadlets = toadletCaptor.getAllValues();
+    List<ToadletRegistration> registrations = registrationCaptor.getAllValues();
+    return IntStream.range(0, expectedCount)
+        .mapToObj(index -> new RegisteredToadlet(toadlets.get(index), registrations.get(index)))
+        .toList();
+  }
+
+  private static List<String> registrationPrefixes(List<RegisteredToadlet> registrations) {
+    return registrations.stream()
+        .map(RegisteredToadlet::registration)
+        .map(ToadletRegistration::urlPrefix)
+        .toList();
+  }
+
+  private static Object readField(Object target, String fieldName) {
+    try {
+      for (Class<?> type = target.getClass(); type != null; type = type.getSuperclass()) {
+        try {
+          Field field = type.getDeclaredField(fieldName);
+          field.setAccessible(true);
+          return field.get(target);
+        } catch (NoSuchFieldException _) {
+          // Search the next superclass.
+        }
+      }
+      throw new NoSuchFieldException(fieldName);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Unable to read field " + fieldName + " from " + target.getClass(), e);
+    }
+  }
+
+  private record RegisteredToadlet(Toadlet toadlet, ToadletRegistration registration) {}
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -48,6 +48,8 @@ class HttpLegacyAdminBoundaryTest {
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellFProxyBootstrap.java");
   private static final Path ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR =
       ADAPTER_HTTP_MAIN_JAVA.resolve("LegacyAdminHttpRouteRegistrar.java");
+  private static final Path ADAPTER_FPROXY_REGISTRAR =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("FProxyRegistrar.java");
   private static final Path ADAPTER_LEGACY_HTTP_ROUTE_REGISTRAR_CONTEXT =
       ADAPTER_HTTP_MAIN_JAVA.resolve("LegacyHttpRouteRegistrarContext.java");
   private static final Path ADAPTER_N2NTM_TOADLET =
@@ -410,6 +412,66 @@ class HttpLegacyAdminBoundaryTest {
             "PushDataManagerHandles",
             "PushDataManagerHandles.create(",
             "network.crypta.clients.http.updateableelements.PushDataManager"));
+  }
+
+  @Test
+  void
+      mainSources_whenCheckingAdminOwnedRouteRegistration_expectBrowseConstructionDelegatedThroughSeam()
+          throws IOException {
+    Path repoRoot = repoRoot();
+    String legacyAdminRouteRegistrarSource =
+        Files.readString(repoRoot.resolve(ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR));
+    String fproxyRegistrarSource = Files.readString(repoRoot.resolve(ADAPTER_FPROXY_REGISTRAR));
+
+    assertTrue(
+        legacyAdminRouteRegistrarSource.contains("context.browseRouteRegistrar()"),
+        repoRoot.resolve(ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR)
+            + " must forward the browse-route registrar seam.");
+    assertTrue(
+        fproxyRegistrarSource.contains("browseRouteRegistrar.registerRoutes("),
+        repoRoot.resolve(ADAPTER_FPROXY_REGISTRAR)
+            + " must delegate browse-owned route publication through the neutral seam.");
+    assertSourceDoesNotContainAny(
+        repoRoot.resolve(ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR),
+        List.of(
+            "new DecodeToadlet(",
+            "new InsertFreesiteToadlet(",
+            "new ContentFilterToadlet(",
+            "new LocalFileFilterToadlet(",
+            "new WelcomeToadlet(",
+            "new ExternalLinkToadlet(",
+            "new BookmarkEditorToadlet(",
+            "new BrowserTestToadlet(",
+            "new ImageCreatorToadlet(",
+            "new PushDataToadlet(",
+            "new PushNotificationToadlet(",
+            "new PushKeepaliveToadlet(",
+            "new PushFailoverToadlet(",
+            "new PushTesterToadlet(",
+            "new PushLeavingToadlet(",
+            "new LogWritebackToadlet(",
+            "new DismissAlertToadlet(",
+            "new LegacyFProxyBrowseRouteRegistrar("));
+    assertSourceDoesNotContainAny(
+        repoRoot.resolve(ADAPTER_FPROXY_REGISTRAR),
+        List.of(
+            "new DecodeToadlet(",
+            "new InsertFreesiteToadlet(",
+            "new ContentFilterToadlet(",
+            "new LocalFileFilterToadlet(",
+            "new WelcomeToadlet(",
+            "new ExternalLinkToadlet(",
+            "new BookmarkEditorToadlet(",
+            "new BrowserTestToadlet(",
+            "new ImageCreatorToadlet(",
+            "new PushDataToadlet(",
+            "new PushNotificationToadlet(",
+            "new PushKeepaliveToadlet(",
+            "new PushFailoverToadlet(",
+            "new PushTesterToadlet(",
+            "new PushLeavingToadlet(",
+            "new LogWritebackToadlet(",
+            "new DismissAlertToadlet("));
   }
 
   @Test

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -9,6 +9,7 @@ import network.crypta.clients.http.FProxyRuntimeSupport;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.HttpShellBrowseBootstrap;
 import network.crypta.clients.http.HttpShellRuntimeSupport;
+import network.crypta.clients.http.LegacyFProxyBrowseRouteRegistrar;
 import network.crypta.clients.http.PushDataManagerHandle;
 import network.crypta.clients.http.SimpleToadletServer;
 import network.crypta.clients.http.bookmark.BookmarkManager;
@@ -165,6 +166,7 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
         client,
         appHost,
         FProxyToadlet.create(client, fproxyRuntimeSupport, fetchTracker),
+        new LegacyFProxyBrowseRouteRegistrar(),
         CoreHttpShellRuntimeSupport::initializeFProxySharedState);
   }
 

--- a/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
+++ b/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
@@ -15,6 +15,7 @@ import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.HttpShellBrowseBootstrap;
 import network.crypta.clients.http.HttpShellRuntimeSupport;
+import network.crypta.clients.http.LegacyFProxyBrowseRouteRegistrar;
 import network.crypta.clients.http.PushDataManagerHandle;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.clients.http.bridge.bookmark.CoreBookmarkRuntimeSupport;
@@ -334,6 +335,7 @@ class CoreHttpShellRuntimeSupportTest {
       assertSame(client, bootstrap.client());
       assertSame(runtimeSupport.appHost(), bootstrap.appHost());
       assertSame(fproxies.constructed().getFirst(), bootstrap.browseRoot());
+      assertInstanceOf(LegacyFProxyBrowseRouteRegistrar.class, bootstrap.browseRouteRegistrar());
       verify(core, never()).getRuntimePorts();
       verifyNoInteractions(bootstrapRuntimePorts);
       verify(core, never()).getEndpoints();

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -8,14 +8,19 @@ and the matching `network/crypta/clients/http/**` main resources, excluding
 `network.crypta.clients.http.bridge` plus the legacy HTTP GeoIP helper package under
 `network.crypta.clients.http.geoip`.
 
-This PR keeps the existing adapter leaf in place but removes a few browse-specific leaks from the
-shared shell surface before the real browse split. The shared shell now uses browse-neutral
-bootstrap/context types and shared `LegacyHttpPaths` / `LegacyHttpCategories` constants instead of
-pulling those values from `FProxyToadlet` directly. It also uses neutral bookmark, push, and
-client-side script seams instead of importing the concrete browse-owned collaborator classes
-directly. The shared shell no longer constructs the concrete browse root or concrete push manager
-itself; those concrete constructions now live in the bridge/runtime-owned HTTP bootstrap path so
-the shared shell stays browse-neutral ahead of the future `:adapter-http-legacy-browse` split.
+This PR keeps the existing adapter leaf in place and still does not create
+`:adapter-http-legacy-browse`, but it removes the last major route-registration blocker for that
+future split. The shared shell already crosses browse-neutral bootstrap/context types and shared
+`LegacyHttpPaths` / `LegacyHttpCategories` constants instead of pulling those values from
+`FProxyToadlet` directly. It also uses neutral bookmark, push, and client-side script seams
+instead of importing concrete browse-owned collaborator classes directly.
+
+The new change in this PR is route-registration ownership. Admin-owned startup code now preserves
+the historical registration order while delegating browse-owned route publication through a neutral
+`LegacyHttpBrowseRouteRegistrar` seam installed by the bridge/runtime-owned HTTP bootstrap path.
+That keeps the shared shell browse-neutral, keeps the admin-owned registrar from instantiating the
+concrete browse routes directly, and makes the future browse-module move mechanical instead of
+another logic refactor.
 
 The boundary remains intentional. Production code outside `:adapter-http-legacy-admin` and
 `:bridge-http-runtime` should keep depending on runtime-owned seams, `:platform-api`, or
@@ -25,5 +30,5 @@ The boundary remains intentional. Production code outside `:adapter-http-legacy-
 updater-action adapters remain in `:adapter-http-legacy-admin` in this PR.
 
 Future browse/FProxy decomposition or replacement is still deferred. This PR only prepares the
-shared shell for a later `:adapter-http-legacy-browse` split by neutralizing the route/path
-constants and the bootstrap/context seam.
+later `:adapter-http-legacy-browse` extraction by neutralizing the shared shell seams and splitting
+admin-owned versus browse-owned route registration behind that neutral registrar boundary.

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -5,6 +5,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ajaxpush.DismissAlertToadlet;
+import network.crypta.clients.http.ajaxpush.LogWritebackToadlet;
+import network.crypta.clients.http.ajaxpush.PushDataToadlet;
+import network.crypta.clients.http.ajaxpush.PushFailoverToadlet;
+import network.crypta.clients.http.ajaxpush.PushKeepaliveToadlet;
+import network.crypta.clients.http.ajaxpush.PushLeavingToadlet;
+import network.crypta.clients.http.ajaxpush.PushNotificationToadlet;
+import network.crypta.clients.http.ajaxpush.PushTesterToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.IntCallback;
 import network.crypta.config.Option;
@@ -36,13 +44,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import static network.crypta.runtime.updater.UpdaterPaths.CORE_UPDATE_PATH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,6 +83,7 @@ class FProxyRegistrarTest {
   @Mock private ToadletSymlinkPort toadletSymlinkPort;
   @Mock private TransferAccessPort transferAccess;
   @Mock private SimpleToadletServer server;
+  @Mock private LegacyHttpBrowseRouteRegistrar browseRouteRegistrar;
 
   private Config config;
 
@@ -102,7 +117,7 @@ class FProxyRegistrarTest {
   @Test
   void maybeCreateFProxyEtc_whenInvoked_registersMenusSetsFProxyAndStartsQueueCompletion() {
     FProxyRegistrar.maybeCreateFProxyEtc(
-        new FProxyRegistrarDependencies(client, runtimePorts, appHost, config, browseRoot), server);
+        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
 
     verify(server)
         .registerMenu(
@@ -213,7 +228,7 @@ class FProxyRegistrarTest {
   @Test
   void maybeCreateFProxyEtc_whenSecurityLevelsSubconfigPresent_skipsSecurityLevelsConfigToadlet() {
     FProxyRegistrar.maybeCreateFProxyEtc(
-        new FProxyRegistrarDependencies(client, runtimePorts, appHost, config, browseRoot), server);
+        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
 
     Set<String> configToadletPrefixes =
         capturedRegistrations().stream()
@@ -233,7 +248,7 @@ class FProxyRegistrarTest {
         .thenReturn(LauncherReadinessInfo.DEFAULT_UI_ROOT, WebShellPaths.SHELL_ROOT);
 
     FProxyRegistrar.maybeCreateFProxyEtc(
-        new FProxyRegistrarDependencies(client, runtimePorts, appHost, config, browseRoot), server);
+        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
 
     ToadletRegistration webShellRegistration =
         capturedRegistrations().stream()
@@ -250,9 +265,130 @@ class FProxyRegistrarTest {
   }
 
   @Test
+  void maybeCreateFProxyEtc_whenUsingConcreteBrowseRegistrar_preservesTailBrowseRouteOrder() {
+    FProxyRegistrar.maybeCreateFProxyEtc(
+        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
+
+    List<Class<?>> tailRouteTypes = new ArrayList<>();
+    for (RegisteredToadlet registration : capturedRegistrations()) {
+      Class<?> toadletType = registration.toadlet().getClass();
+      if (isTailRouteType(toadletType)) {
+        tailRouteTypes.add(toadletType);
+      }
+    }
+
+    assertEquals(
+        List.of(
+            PushDataToadlet.class,
+            PushNotificationToadlet.class,
+            PushKeepaliveToadlet.class,
+            PushFailoverToadlet.class,
+            PushTesterToadlet.class,
+            PushLeavingToadlet.class,
+            ImageCreatorToadlet.class,
+            LogWritebackToadlet.class,
+            DismissAlertToadlet.class),
+        tailRouteTypes);
+  }
+
+  @Test
+  void maybeCreateFProxyEtc_whenUsingBrowseSeam_preservesHistoricalInsertionPoints() {
+    FProxyRegistrar.maybeCreateFProxyEtc(dependencies(browseRouteRegistrar), server);
+
+    ArgumentCaptor<LegacyHttpBrowseRouteRegistrar.Phase> phaseCaptor =
+        ArgumentCaptor.forClass(LegacyHttpBrowseRouteRegistrar.Phase.class);
+    ArgumentCaptor<LegacyHttpBrowseRouteRegistrarContext> browseContextCaptor =
+        ArgumentCaptor.forClass(LegacyHttpBrowseRouteRegistrarContext.class);
+    verify(browseRouteRegistrar, times(7))
+        .registerRoutes(phaseCaptor.capture(), browseContextCaptor.capture(), same(server));
+    assertEquals(
+        List.of(
+            LegacyHttpBrowseRouteRegistrar.Phase.ROOT_MENU,
+            LegacyHttpBrowseRouteRegistrar.Phase.INTRO_ROUTES,
+            LegacyHttpBrowseRouteRegistrar.Phase.QUEUE_FILTER_ROUTES,
+            LegacyHttpBrowseRouteRegistrar.Phase.POST_CONFIG_ROUTES,
+            LegacyHttpBrowseRouteRegistrar.Phase.POST_MESSAGING_ROUTES,
+            LegacyHttpBrowseRouteRegistrar.Phase.POST_PLATFORM_API_ROUTES,
+            LegacyHttpBrowseRouteRegistrar.Phase.TAIL_ROUTES),
+        phaseCaptor.getAllValues());
+    for (LegacyHttpBrowseRouteRegistrarContext browseContext : browseContextCaptor.getAllValues()) {
+      assertSame(client, browseContext.client());
+      assertSame(runtimePorts, browseContext.runtimePorts());
+      assertSame(browseRoot, browseContext.browseRoot());
+    }
+
+    InOrder inOrder = inOrder(server, browseRouteRegistrar);
+    inOrder
+        .verify(browseRouteRegistrar)
+        .registerRoutes(
+            eq(LegacyHttpBrowseRouteRegistrar.Phase.ROOT_MENU),
+            any(LegacyHttpBrowseRouteRegistrarContext.class),
+            same(server));
+    inOrder
+        .verify(server)
+        .registerMenu(
+            LegacyHttpPaths.DOWNLOADS_PATH,
+            LegacyHttpCategories.CATEGORY_QUEUE,
+            "FProxyToadlet.categoryTitleQueue");
+    inOrder
+        .verify(browseRouteRegistrar)
+        .registerRoutes(
+            eq(LegacyHttpBrowseRouteRegistrar.Phase.INTRO_ROUTES),
+            any(LegacyHttpBrowseRouteRegistrarContext.class),
+            same(server));
+    verifyRegistrationInOrder(inOrder, server, UserAlertsToadlet.class, "/alerts/");
+    verifyRegistrationInOrder(
+        inOrder, server, LocalFileInsertToadlet.class, LocalFileInsertToadlet.INSERT_BROWSE_PATH);
+    inOrder
+        .verify(browseRouteRegistrar)
+        .registerRoutes(
+            eq(LegacyHttpBrowseRouteRegistrar.Phase.QUEUE_FILTER_ROUTES),
+            any(LegacyHttpBrowseRouteRegistrarContext.class),
+            same(server));
+    verifyRegistrationInOrder(inOrder, server, SymlinkerToadlet.class, "/sl/");
+    inOrder
+        .verify(browseRouteRegistrar)
+        .registerRoutes(
+            eq(LegacyHttpBrowseRouteRegistrar.Phase.POST_CONFIG_ROUTES),
+            any(LegacyHttpBrowseRouteRegistrarContext.class),
+            same(server));
+    verifyRegistrationInOrder(
+        inOrder,
+        server,
+        network.crypta.clients.http.updater.CoreActionToadlet.class,
+        CORE_UPDATE_PATH);
+    verifyRegistrationInOrder(
+        inOrder, server, LocalFileN2NMToadlet.class, LocalFileN2NMToadlet.BROWSE_PATH);
+    inOrder
+        .verify(browseRouteRegistrar)
+        .registerRoutes(
+            eq(LegacyHttpBrowseRouteRegistrar.Phase.POST_MESSAGING_ROUTES),
+            any(LegacyHttpBrowseRouteRegistrarContext.class),
+            same(server));
+    verifyRegistrationInOrder(inOrder, server, WebShellToadlet.class, WebShellPaths.SHELL_ROOT);
+    verifyRegistrationInOrder(
+        inOrder, server, PlatformApiToadlet.class, PlatformApiToadlet.MOUNT_PATH);
+    inOrder
+        .verify(browseRouteRegistrar)
+        .registerRoutes(
+            eq(LegacyHttpBrowseRouteRegistrar.Phase.POST_PLATFORM_API_ROUTES),
+            any(LegacyHttpBrowseRouteRegistrarContext.class),
+            same(server));
+    verifyRegistrationInOrder(inOrder, server, StatisticsToadlet.class, "/stats/");
+    verifyRegistrationInOrder(inOrder, server, SimpleHelpToadlet.class, "/help/");
+    inOrder
+        .verify(browseRouteRegistrar)
+        .registerRoutes(
+            eq(LegacyHttpBrowseRouteRegistrar.Phase.TAIL_ROUTES),
+            any(LegacyHttpBrowseRouteRegistrarContext.class),
+            same(server));
+  }
+
+  @Test
   void registerRoutes_whenInvokedViaLegacyAdminRegistrar_forwardsEquivalentDependencies() {
     LegacyHttpRouteRegistrarContext context =
-        new LegacyHttpRouteRegistrarContext(client, runtimePorts, appHost, config, browseRoot);
+        new LegacyHttpRouteRegistrarContext(
+            client, runtimePorts, appHost, config, browseRoot, browseRouteRegistrar);
 
     try (MockedStatic<FProxyRegistrar> registrar = mockStatic(FProxyRegistrar.class)) {
       new LegacyAdminHttpRouteRegistrar().registerRoutes(context, server);
@@ -261,9 +397,15 @@ class FProxyRegistrarTest {
           () ->
               FProxyRegistrar.maybeCreateFProxyEtc(
                   new FProxyRegistrarDependencies(
-                      client, runtimePorts, appHost, config, browseRoot),
+                      client, runtimePorts, appHost, config, browseRoot, browseRouteRegistrar),
                   server));
     }
+  }
+
+  private FProxyRegistrarDependencies dependencies(
+      LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
+    return new FProxyRegistrarDependencies(
+        client, runtimePorts, appHost, config, browseRoot, browseRouteRegistrar);
   }
 
   private static void registerBandwidthOption(
@@ -292,6 +434,29 @@ class FProxyRegistrarTest {
 
   private static FirstTimeWizardPort readWizardPortField(Object target) {
     return (FirstTimeWizardPort) readField(target, "wizardPort");
+  }
+
+  private static void verifyRegistrationInOrder(
+      InOrder inOrder,
+      SimpleToadletServer server,
+      Class<? extends Toadlet> toadletType,
+      String urlPrefix) {
+    inOrder
+        .verify(server)
+        .register(
+            argThat(toadletType::isInstance), argThat(reg -> urlPrefix.equals(reg.urlPrefix())));
+  }
+
+  private static boolean isTailRouteType(Class<?> toadletType) {
+    return toadletType == PushDataToadlet.class
+        || toadletType == PushNotificationToadlet.class
+        || toadletType == PushKeepaliveToadlet.class
+        || toadletType == PushFailoverToadlet.class
+        || toadletType == PushTesterToadlet.class
+        || toadletType == PushLeavingToadlet.class
+        || toadletType == ImageCreatorToadlet.class
+        || toadletType == LogWritebackToadlet.class
+        || toadletType == DismissAlertToadlet.class;
   }
 
   private static Object readField(Object target, String fieldName) {

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -288,6 +288,9 @@ class SimpleToadletServerTest {
     assertSame(appHost, routeRegistrarContextRef.get().appHost());
     assertSame(nodeConfig, routeRegistrarContextRef.get().config());
     assertInstanceOf(FProxyToadlet.class, routeRegistrarContextRef.get().browseRoot());
+    assertInstanceOf(
+        LegacyFProxyBrowseRouteRegistrar.class,
+        routeRegistrarContextRef.get().browseRouteRegistrar());
   }
 
   @Test
@@ -313,6 +316,8 @@ class SimpleToadletServerTest {
     BookmarkManager bookmarkManager = mock(BookmarkManager.class);
     HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
+        mock(LegacyHttpBrowseRouteRegistrar.class);
     Config config = new Config();
     FProxyRuntimeSupport fproxyRuntimeSupport = mock(FProxyRuntimeSupport.class);
     FProxyFetchTracker fetchTracker = mock(FProxyFetchTracker.class);
@@ -337,6 +342,7 @@ class SimpleToadletServerTest {
                 client,
                 appHost,
                 browseRoot,
+                browseRouteRegistrar,
                 ports -> FProxyToadlet.initializeSharedRandom(ports.randomness())));
     AtomicReference<LegacyHttpRouteRegistrarContext> routeRegistrarContextRef =
         new AtomicReference<>();
@@ -366,6 +372,7 @@ class SimpleToadletServerTest {
     verify(runtimeSupport).ticker();
     verify(runtimeSupport).createPushDataManagerHandle(same(ticker));
     assertSame(browseRoot, routeRegistrarContextRef.get().browseRoot());
+    assertSame(browseRouteRegistrar, routeRegistrarContextRef.get().browseRouteRegistrar());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- introduce a neutral `LegacyHttpBrowseRouteRegistrar` seam and browse-local context so admin-owned startup no longer constructs browse-owned routes directly
- split the monolithic `FProxyRegistrar` flow so the admin path remains the order-preserving orchestrator while concrete browse-owned registration moves into dedicated browse registrars
- thread the browse registrar through `HttpShellBrowseBootstrap`, `SimpleToadletServer`, the legacy route-registrar contexts, and bridge-owned runtime wiring
- add focused tests for seam usage, preserved route order, bootstrap wiring, browse-phase registration, and boundary expectations
- update `README.md` and `docs/legacy-http-boundary.md` to document that this prepares the future browse-module extraction without performing it yet

## How to test

- `./gradlew spotlessApply`
- `./gradlew :adapter-http-legacy-admin:test --tests "network.crypta.clients.http.LegacyFProxyBrowseRouteRegistrarTest"`
- `./gradlew :adapter-http-legacy-admin:test --tests "network.crypta.clients.http.LegacyFProxyBrowseRouteRegistrarTest" --tests "network.crypta.clients.http.LegacyFProxyAjaxPushRouteRegistrarTest"`
- `./gradlew :test --tests "network.crypta.clients.http.FProxyRegistrarTest" --tests "network.crypta.clients.http.SimpleToadletServerTest"`
- `./gradlew test`

## Notes

- This PR does not create `:adapter-http-legacy-browse`.
- Route paths, menu visibility, and historical registration order are preserved.
