### PR TITLE
refactor(http): Detach admin alert surface from UserAlertManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ Cryptad now uses a partial multi-project Gradle build.
   `/app/node/` through a thin legacy HTTP bridge in `:adapter-http-legacy-admin`.
 - `:runtime-alerts` owns the extracted leaf-safe alert/feed subset under
   `network.crypta.runtime.alerts`, including the full `feed` package plus the reusable alert
-  model/base types that no longer need direct daemon state.
+  model/base types that no longer need direct daemon state, along with the detached
+  consumer-facing `UserAlertSurface` used by the legacy HTTP/admin shell.
 - `:runtime-node` owns the remaining daemon runtime body across the still-cyclic
   `network.crypta.client` async/request engine and high-level client APIs, large slices of
   `network.crypta.node` after the phase-1 routing/helper move, the retained runtime-owned client
@@ -684,7 +685,8 @@ Root build also includes:
   `network.crypta.runtime.core.SSL` helper.
 - `:runtime-alerts`: extracted leaf-safe alert/feed module owning the full
   `network.crypta.runtime.alerts.feed` package plus reusable alert model/base classes that stay
-  free of direct `Node`/`NodeClientCore` coupling.
+  free of direct `Node`/`NodeClientCore` coupling, including the detached `UserAlertSurface`
+  contract for HTTP/admin consumers.
 
 ### Spotless + Dependency Verification
 
@@ -823,8 +825,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   such as `ClientEndpoints`, `NodeClientCoreInit`, and `NodeClientPersistence`; shell/password
   seams under `runtime.http`; and updater classes such as `NodeUpdateManager` and `CoreUpdater`.
   The extracted `:runtime-alerts` leaf now owns the reusable alert/feed model subset under
-  `network.crypta.runtime.alerts`, while `:runtime-node` keeps `UserAlertManager` and the
-  daemon-coupled alert producers. The root project keeps the composition class
+  `network.crypta.runtime.alerts`, plus the detached `UserAlertSurface` consumed by legacy HTTP,
+  while `:runtime-node` keeps `UserAlertManager` and the daemon-coupled alert producers. The root
+  project keeps the composition class
   `DefaultNodeRuntimeBridgeFactories`, which selects the concrete FCP and HTTP bridge
   implementations from the extracted adapter leaves.
 - Config + localization leaf (`:foundation-config`): `network.crypta.config`,
@@ -865,7 +868,7 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.node` helper slice across selected request/routing value, exception, callback,
   and request-item types; `:runtime-spi` provides `network.crypta.runtime.spi`;
   `:runtime-alerts` provides the extracted leaf-safe `network.crypta.runtime.alerts`
-  feed/model subset;
+  feed/model subset plus the detached `UserAlertSurface`;
   `:platform-api` provides the transport-neutral Platform API v1 plus the minimal AppHost
   control-plane routes; `:platform-apphost` provides the transport-neutral out-of-process AppHost
   v1 core for installed local apps;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
@@ -3,7 +3,7 @@ package network.crypta.clients.http;
 import java.io.File;
 import network.crypta.config.Config;
 import network.crypta.platform.apphost.AppHost;
-import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Ticker;
 
@@ -73,14 +73,14 @@ public interface HttpShellRuntimeSupport {
   Ticker ticker();
 
   /**
-   * Returns the alert manager surfaced through HTTP status and warning pages.
+   * Returns the detached alert surface surfaced through HTTP status and warning pages.
    *
-   * <p>The manager is shared with the rest of the daemon. Shell code should treat it as a live
+   * <p>The surface is shared with the rest of the daemon. Shell code should treat it as a live
    * runtime service whose contents may change as the node state changes.
    *
-   * @return shared user-alert manager visible to HTTP toadlets
+   * @return shared user-alert surface visible to HTTP toadlets
    */
-  UserAlertManager userAlerts();
+  UserAlertSurface userAlerts();
 
   /**
    * Returns the current hidden form password inserted into shell-generated forms.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -32,7 +32,7 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.PrioRunnable;
 import network.crypta.platform.webshell.routes.WebShellPaths;
-import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.core.SSL;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.HTMLNode;
@@ -1623,16 +1623,16 @@ public final class SimpleToadletServer
   }
 
   /**
-   * Returns the user alert manager associated with the current runtime support.
+   * Returns the detached user-alert surface associated with the current runtime support.
    *
-   * <p>The alert manager surfaces node warnings and informational banners to the UI and handles
+   * <p>The alert surface exposes node warnings and informational banners to the UI and handles
    * their dismissal state. When runtime support has not yet been assigned this method returns
    * {@code null}; callers should therefore wait until after {@link
    * #setRuntimeSupport(HttpShellRuntimeSupport)} is invoked.
    *
-   * @return active {@link UserAlertManager}, or {@code null} when unavailable.
+   * @return active {@link UserAlertSurface}, or {@code null} when unavailable.
    */
-  public UserAlertManager getUserAlertManager() {
+  public UserAlertSurface getUserAlertManager() {
     network.crypta.clients.http.HttpShellRuntimeSupport runtimeSupportRef = this.runtimeSupport;
     if (runtimeSupportRef == null) return null;
     return runtimeSupportRef.userAlerts();

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContext.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
-import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
@@ -226,11 +226,11 @@ public interface ToadletContext {
   boolean checkFullAccess(Toadlet toadlet) throws ToadletContextClosedException, IOException;
 
   /**
-   * Access the {@link UserAlertManager} that accumulates alerts for the current node.
+   * Access the detached {@link UserAlertSurface} that accumulates alerts for the current node.
    *
-   * @return Non-null alert manager tied to this context.
+   * @return non-null alert surface tied to this context.
    */
-  UserAlertManager getAlertManager();
+  UserAlertSurface getAlertManager();
 
   /**
    * Access the {@link BookmarkManagerHandle} used to read or update bookmarks within this request.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.core.SSL;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
@@ -98,7 +98,7 @@ public final class ToadletContextImpl implements ToadletContext {
   private final PageMaker pagemaker;
   private final BucketFactory bf;
   private final ToadletContainer container;
-  private final UserAlertManager userAlertManager;
+  private final UserAlertSurface userAlertManager;
   private final BookmarkManagerHandle bookmarkManager;
   private final InetAddress remoteAddr;
   private Exception firstReplySendingException;
@@ -560,10 +560,10 @@ public final class ToadletContextImpl implements ToadletContext {
    * queuing, deduplication, and localization concerns so individual toadlets can raise alerts
    * without worrying about display semantics or thread confinement.
    *
-   * @return Shared {@link UserAlertManager} instance used by the container for UI alerts.
+   * @return shared {@link UserAlertSurface} instance used by the container for UI alerts.
    */
   @Override
-  public UserAlertManager getAlertManager() {
+  public UserAlertSurface getAlertManager() {
     return userAlertManager;
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletRequestServices.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletRequestServices.java
@@ -1,6 +1,6 @@
 package network.crypta.clients.http;
 
-import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 
 /**
  * Shared services needed to build per-request {@link ToadletContextImpl} instances.
@@ -11,11 +11,11 @@ import network.crypta.runtime.alerts.UserAlertManager;
  *
  * @param container the owning toadlet container that enforces request policies
  * @param pageMaker shared page renderer used by UI toadlets
- * @param userAlertManager manager used to surface user-facing alerts
+ * @param userAlertManager alert surface used to render and mutate user-facing alerts
  * @param bookmarkManager bookmark subsystem handle for request handlers
  */
 public record ToadletRequestServices(
     ToadletContainer container,
     PageMaker pageMaker,
-    UserAlertManager userAlertManager,
+    UserAlertSurface userAlertManager,
     BookmarkManagerHandle bookmarkManager) {}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/package-info.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/package-info.java
@@ -29,9 +29,10 @@
  * implementation detail rather than as a new platform API. Runtime and bootstrap code should
  * continue to depend on runtime-owned seams and the narrow bridge/binding sites instead of growing
  * new direct dependencies on {@code network.crypta.clients.http.*}. The shared shell now uses the
- * HTTP-local route registrar seam, shared path/category helpers, and other browse-neutral helpers,
- * while {@code network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories} remains the
- * bootstrap-owned binding site for the concrete HTTP bridge implementations.
+ * HTTP-local route registrar seam, shared path/category helpers, the detached {@code
+ * network.crypta.runtime.alerts.UserAlertSurface}, and other browse-neutral helpers, while {@code
+ * network.crypta.runtime.bootstrap.DefaultNodeRuntimeBridgeFactories} remains the bootstrap-owned
+ * binding site for the concrete HTTP bridge implementations.
  *
  * <ul>
  *   <li>Implements the public web console and REST-like helper endpoints.

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -47,6 +47,8 @@ class HttpLegacyAdminBoundaryTest {
       ADAPTER_HTTP_MAIN_JAVA.resolve("IntervalPusherManager.java");
   private static final Path ADAPTER_HTTP_SHELL_RUNTIME_SUPPORT =
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellRuntimeSupport.java");
+  private static final String USER_ALERT_MANAGER_IMPORT =
+      "import network.crypta.runtime.alerts.UserAlertManager;";
   private static final Path ADAPTER_HTTP_FPROXY_BOOTSTRAP =
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellFProxyBootstrap.java");
   private static final Path ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR =
@@ -612,6 +614,33 @@ class HttpLegacyAdminBoundaryTest {
         violations.isEmpty(),
         "adapter-http-legacy-admin main sources must not import NodeStarter or the queue progress "
             + "cell helper classes removed in PR-159."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void mainSources_whenCheckingSharedShellAlertImports_expectDetachedAlertSurfaceUsed()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile :
+        List.of(
+            ADAPTER_HTTP_SHELL_RUNTIME_SUPPORT,
+            ADAPTER_TOADLET_CONTEXT,
+            ADAPTER_TOADLET_CONTEXT_IMPL,
+            ADAPTER_TOADLET_REQUEST_SERVICES,
+            ADAPTER_SIMPLE_TOADLET_SERVER)) {
+      Set<String> imports = readImports(repoRoot.resolve(sourceFile));
+      if (imports.contains(USER_ALERT_MANAGER_IMPORT)) {
+        violations.add(sourceFile + " -> " + USER_ALERT_MANAGER_IMPORT);
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Shared HTTP/admin shell sources must use the detached runtime-alerts surface instead of "
+            + "importing UserAlertManager directly."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
   }

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
@@ -12,6 +12,7 @@ import network.crypta.clients.http.bookmark.BookmarkItem;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetPeerRequiredException;
 import network.crypta.runtime.spi.UnknownPeerException;
@@ -824,7 +825,7 @@ public class BookmarkEditorToadlet extends Toadlet {
    * @param ctx execution context used for page creation, access control, redirects, and bookmark
    *     management; must not be {@code null}.
    * @throws ToadletContextClosedException if the response stream closes while emitting output,
-   *     indicating the client disconnected mid-request.
+   *     indicating the client-disconnected mid-request.
    * @throws IOException if reading form data or writing the HTML response encounters an I/O error.
    */
   public void handleMethodPOST(URI uri, HTTPRequest req, ToadletContext ctx)
@@ -990,7 +991,7 @@ public class BookmarkEditorToadlet extends Toadlet {
               req.getPartAsStringFailsafe(EXPLAIN_FIELD, MAX_EXPLANATION_LENGTH),
               hasAnActivelink,
               postCtx.bookmarkManager(),
-              postCtx.ctx().getAlertManager());
+              concreteAlertManager(postCtx.ctx()));
     } else {
       newBookmark = new BookmarkCategory(name);
     }
@@ -1010,6 +1011,10 @@ public class BookmarkEditorToadlet extends Toadlet {
             "bookmark-add-new",
             false)
         .addChild("p", NodeL10n.getBase().getString("BookmarkEditorToadlet.addedNewBookmark"));
+  }
+
+  private UserAlertManager concreteAlertManager(ToadletContext ctx) {
+    return (UserAlertManager) ctx.getAlertManager();
   }
 
   private void addInvalidKeyError(PageMaker pageMaker, HTMLNode content) {

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
@@ -980,6 +980,11 @@ public class BookmarkEditorToadlet extends Toadlet {
       throws MalformedURLException {
     Bookmark newBookmark;
     if (ACTION_ADD_ITEM.equals(action)) {
+      UserAlertManager alertManager = concreteAlertManagerOrNull(postCtx.ctx());
+      if (alertManager == null) {
+        addMissingAlertManagerError(postCtx.pageMaker(), postCtx.content());
+        return;
+      }
       FreenetURI key = new FreenetURI(req.getPartAsStringFailsafe("key", MAX_KEY_LENGTH));
       // Checkbox values are treated as true when present.
       boolean hasAnActivelink = req.isPartSet(ACTIVE_LINK_FIELD);
@@ -991,7 +996,7 @@ public class BookmarkEditorToadlet extends Toadlet {
               req.getPartAsStringFailsafe(EXPLAIN_FIELD, MAX_EXPLANATION_LENGTH),
               hasAnActivelink,
               postCtx.bookmarkManager(),
-              concreteAlertManager(postCtx.ctx()));
+              alertManager);
     } else {
       newBookmark = new BookmarkCategory(name);
     }
@@ -1013,8 +1018,22 @@ public class BookmarkEditorToadlet extends Toadlet {
         .addChild("p", NodeL10n.getBase().getString("BookmarkEditorToadlet.addedNewBookmark"));
   }
 
-  private UserAlertManager concreteAlertManager(ToadletContext ctx) {
-    return (UserAlertManager) ctx.getAlertManager();
+  private UserAlertManager concreteAlertManagerOrNull(ToadletContext ctx) {
+    if (ctx.getAlertManager() instanceof UserAlertManager alertManager) {
+      return alertManager;
+    }
+    return null;
+  }
+
+  private void addMissingAlertManagerError(PageMaker pageMaker, HTMLNode content) {
+    pageMaker
+        .getInfobox(
+            INFOBOX_ERROR,
+            NodeL10n.getBase().getString("Toadlet.internalErrorTitle"),
+            content,
+            BOOKMARK_ERROR_ID,
+            false)
+        .addChild("#", NodeL10n.getBase().getString("Toadlet.internalErrorPleaseReport"));
   }
 
   private void addInvalidKeyError(PageMaker pageMaker, HTMLNode content) {

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -42,6 +42,7 @@ import network.crypta.l10n.NodeL10n;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
 import network.crypta.node.RequestStarter;
+import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
@@ -125,12 +126,6 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
   private static final String GO_BACK_TO_PREV_KEY = "goBackToPrev";
   private static final String TOADLET_HOMEPAGE_KEY = "Toadlet.homepage";
   private static final String ABORT_TO_HOMEPAGE_KEY = "abortToHomepage";
-  static final String CATEGORY_BROWSING = LegacyHttpCategories.CATEGORY_BROWSING;
-  static final String CATEGORY_QUEUE = LegacyHttpCategories.CATEGORY_QUEUE;
-  static final String CATEGORY_FRIENDS = LegacyHttpCategories.CATEGORY_FRIENDS;
-  static final String CATEGORY_STATUS = LegacyHttpCategories.CATEGORY_STATUS;
-  static final String CATEGORY_CONFIG = LegacyHttpCategories.CATEGORY_CONFIG;
-
   static byte[] random;
   final FProxyRuntimeSupport runtimeSupport;
   final ClientContext context;
@@ -742,11 +737,15 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
     private boolean handleFeedRequest() throws ToadletContextClosedException, IOException {
       String schemeHostAndPort = getSchemeHostAndPort(ctx);
-      String atom = ctx.getAlertManager().getAtom(schemeHostAndPort);
+      String atom = concreteAlertManager(ctx).getAtom(schemeHostAndPort);
       byte[] buf = atom.getBytes(StandardCharsets.UTF_8);
       ctx.sendReplyHeadersFProxy(200, "OK", null, "application/atom+xml", buf.length);
       ctx.writeData(buf, 0, buf.length);
       return true;
+    }
+
+    private UserAlertManager concreteAlertManager(ToadletContext context) {
+      return (UserAlertManager) context.getAlertManager();
     }
 
     private boolean validateRangeHeader() throws ToadletContextClosedException, IOException {

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -736,16 +736,28 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
     }
 
     private boolean handleFeedRequest() throws ToadletContextClosedException, IOException {
+      UserAlertManager alertManager = concreteAlertManagerOrNull(ctx);
+      if (alertManager == null) {
+        LOG.warn(
+            "Cannot serve alert feed because {} exposed {} instead of UserAlertManager",
+            ToadletContext.class.getSimpleName(),
+            ctx.getAlertManager().getClass().getName());
+        ctx.sendReplyHeaders(503, "Service Unavailable", null, null, 0);
+        return true;
+      }
       String schemeHostAndPort = getSchemeHostAndPort(ctx);
-      String atom = concreteAlertManager(ctx).getAtom(schemeHostAndPort);
+      String atom = alertManager.getAtom(schemeHostAndPort);
       byte[] buf = atom.getBytes(StandardCharsets.UTF_8);
       ctx.sendReplyHeadersFProxy(200, "OK", null, "application/atom+xml", buf.length);
       ctx.writeData(buf, 0, buf.length);
       return true;
     }
 
-    private UserAlertManager concreteAlertManager(ToadletContext context) {
-      return (UserAlertManager) context.getAlertManager();
+    private UserAlertManager concreteAlertManagerOrNull(ToadletContext context) {
+      if (context.getAlertManager() instanceof UserAlertManager manager) {
+        return manager;
+      }
+      return null;
     }
 
     private boolean validateRangeHeader() throws ToadletContextClosedException, IOException {

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -654,7 +654,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
           // fall through to additional path checks below
         }
       }
-      if (ks.startsWith("/feed/") || ks.equals("/feed")) return handleFeedRequest();
+      if (ks.startsWith("/feed/") || ks.equals("/feed")) {
+        handleFeedRequest();
+        return true;
+      }
       if (ks.equals("/robots.txt") && ctx.doRobots()) {
         writeTextReply(ctx, 200, "Ok", "User-agent: *\nDisallow: /");
         return true;
@@ -735,7 +738,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
       }
     }
 
-    private boolean handleFeedRequest() throws ToadletContextClosedException, IOException {
+    private void handleFeedRequest() throws ToadletContextClosedException, IOException {
       UserAlertManager alertManager = concreteAlertManagerOrNull(ctx);
       if (alertManager == null) {
         LOG.warn(
@@ -743,14 +746,13 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
             ToadletContext.class.getSimpleName(),
             ctx.getAlertManager().getClass().getName());
         ctx.sendReplyHeaders(503, "Service Unavailable", null, null, 0);
-        return true;
+        return;
       }
       String schemeHostAndPort = getSchemeHostAndPort(ctx);
       String atom = alertManager.getAtom(schemeHostAndPort);
       byte[] buf = atom.getBytes(StandardCharsets.UTF_8);
       ctx.sendReplyHeadersFProxy(200, "OK", null, "application/atom+xml", buf.length);
       ctx.writeData(buf, 0, buf.length);
-      return true;
     }
 
     private UserAlertManager concreteAlertManagerOrNull(ToadletContext context) {

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
@@ -22,6 +22,7 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Version;
 import network.crypta.runtime.alerts.UserAlert;
+import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.WelcomePageSnapshot;
 import network.crypta.support.HTMLNode;
@@ -154,7 +155,7 @@ public class WelcomeToadlet extends Toadlet {
     if (updated) {
       HTMLNode alertCell = row.addChild("td", ATTR_STYLE, STYLE_BORDER_NONE);
       alertCell.addChild(
-          ctx.getAlertManager()
+          concreteAlertManager(ctx)
               .renderDismissButton(item.getUserAlert(), path() + "#" + BOOKMARKS_ANCHOR));
     }
   }
@@ -437,7 +438,7 @@ public class WelcomeToadlet extends Toadlet {
     if (alert.userCanDismiss() && alert.shouldUnregisterOnDismiss()) {
       alert.onDismiss();
       LOG.info("Unregistering the userAlert {}", alert.hashCode());
-      ctx.getAlertManager().unregister(alert);
+      concreteAlertManager(ctx).unregister(alert);
     } else {
       LOG.info("Disabling the userAlert {}", alert.hashCode());
       alert.isValid(false);
@@ -649,9 +650,13 @@ public class WelcomeToadlet extends Toadlet {
     String[] alertAnchors = alertsToDump.split(",");
     HashSet<String> toDump = new HashSet<>();
     Collections.addAll(toDump, alertAnchors);
-    ctx.getAlertManager().dumpEvents(toDump);
+    concreteAlertManager(ctx).dumpEvents(toDump);
     redirectToRoot(ctx);
     return true;
+  }
+
+  private UserAlertManager concreteAlertManager(ToadletContext ctx) {
+    return (UserAlertManager) ctx.getAlertManager();
   }
 
   private boolean handleUpgradeConnectionSpeed(HTTPRequest request, ToadletContext ctx)
@@ -1087,10 +1092,10 @@ public class WelcomeToadlet extends Toadlet {
    * present and readable.
    *
    * <p>The method reads up to 2,000 lines (respecting the byte cap in {@link
-   * FileUtil#getLogTailReader(File, long)}) and streams them into an infobox labeled “Current
-   * status”. It is safe to call even when the file is absent or unreadable; failures are logged at
-   * DEBUG, and the page continues rendering without interruption. No locks are taken beyond
-   * standard file reads, and the caller retains ownership of the provided {@link HTMLNode}.
+   * FileUtil#getLogTailReader}) and streams them into an infobox labeled “Current status”. It is
+   * safe to call even when the file is absent or unreadable; failures are logged at DEBUG, and the
+   * page continues rendering without interruption. No locks are taken beyond standard file reads,
+   * and the caller retains ownership of the provided {@link HTMLNode}.
    *
    * @param ctx toadlet context used to create localized infobox markup
    * @param contentNode the page node that receives the log output if available

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
@@ -86,19 +86,21 @@ public class WelcomeToadlet extends Toadlet {
   private static final String PARAM_OUTPUT_BANDWIDTH_LIMIT = "outputBandwidthLimit";
   private static final String PARAM_FILENAME = "filename";
   private static final String PARAM_RESTART = "restart";
+  private static final String PARAM_DISABLE = "disable";
   private static final String TAG_LABEL = "label";
   private static final String TEXTAREA_DESC_B = "descB";
   private static final String STYLE_BORDER_NONE = "border: none";
   private static final String TARGET_BLANK = "_blank";
-  private static final String ALERTS_PATH = "/alerts/";
 
   private final WelcomeToadletRuntimePorts runtimePorts;
+  private final String alertsPath;
 
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly.
 
   WelcomeToadlet(HighLevelSimpleClient client, WelcomeToadletRuntimePorts runtimePorts) {
     super(client);
     this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
+    alertsPath = new UserAlertsToadlet(client).path();
   }
 
   void redirectToRoot(ToadletContext ctx) throws ToadletContextClosedException, IOException {
@@ -414,7 +416,7 @@ public class WelcomeToadlet extends Toadlet {
 
   private boolean handleDisableAlert(HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    if (!request.isPartSet("disable")) {
+    if (!request.isPartSet(PARAM_DISABLE)) {
       return false;
     }
     if (!ctx.checkFormPassword(request)) {
@@ -423,27 +425,24 @@ public class WelcomeToadlet extends Toadlet {
     int validAlertsRemaining = 0;
     UserAlert[] alerts = ctx.getAlertManager().getAlerts();
     for (UserAlert alert : alerts) {
-      if (request.getIntPart("disable", -1) == alert.hashCode()) {
+      if (request.getIntPart(PARAM_DISABLE, -1) == alert.hashCode()) {
         disableMatchingAlert(ctx, alert);
       } else if (alert.isValid()) {
         validAlertsRemaining++;
       }
     }
     writePermanentRedirect(
-        ctx, l10n("disabledAlert"), (validAlertsRemaining > 0 ? "/alerts/" : "/"));
+        ctx, l10n("disabledAlert"), (validAlertsRemaining > 0 ? alertsPath : "/"));
     return true;
   }
 
   private void disableMatchingAlert(ToadletContext ctx, UserAlert alert) {
+    boolean shouldUnregister = alert.userCanDismiss() && alert.shouldUnregisterOnDismiss();
+    LOG.info(
+        "{} the userAlert {}", shouldUnregister ? "Unregistering" : "Disabling", alert.hashCode());
     if (alert.userCanDismiss()) {
-      if (alert.shouldUnregisterOnDismiss()) {
-        LOG.info("Unregistering the userAlert {}", alert.hashCode());
-      } else {
-        LOG.info("Disabling the userAlert {}", alert.hashCode());
-      }
       ctx.getAlertManager().dismissAlert(alert.hashCode());
     } else {
-      LOG.info("Disabling the userAlert {}", alert.hashCode());
       alert.isValid(false);
     }
   }
@@ -675,12 +674,12 @@ public class WelcomeToadlet extends Toadlet {
 
     HTMLNode dismissFormNode =
         result
-            .addChild("form", new String[] {"action", "method"}, new String[] {ALERTS_PATH, "post"})
+            .addChild("form", new String[] {"action", "method"}, new String[] {alertsPath, "post"})
             .addChild("div");
     dismissFormNode.addChild(
         ELEMENT_INPUT,
         new String[] {ATTR_TYPE, "name", ATTR_VALUE},
-        new String[] {INPUT_HIDDEN, "disable", String.valueOf(userAlert.hashCode())});
+        new String[] {INPUT_HIDDEN, PARAM_DISABLE, String.valueOf(userAlert.hashCode())});
     dismissFormNode.addChild(
         ELEMENT_INPUT,
         new String[] {ATTR_TYPE, "name", ATTR_VALUE},

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertBlock;
@@ -22,7 +23,6 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.Version;
 import network.crypta.runtime.alerts.UserAlert;
-import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.WelcomePageSnapshot;
 import network.crypta.support.HTMLNode;
@@ -90,6 +90,7 @@ public class WelcomeToadlet extends Toadlet {
   private static final String TEXTAREA_DESC_B = "descB";
   private static final String STYLE_BORDER_NONE = "border: none";
   private static final String TARGET_BLANK = "_blank";
+  private static final String ALERTS_PATH = "/alerts/";
 
   private final WelcomeToadletRuntimePorts runtimePorts;
 
@@ -155,8 +156,7 @@ public class WelcomeToadlet extends Toadlet {
     if (updated) {
       HTMLNode alertCell = row.addChild("td", ATTR_STYLE, STYLE_BORDER_NONE);
       alertCell.addChild(
-          concreteAlertManager(ctx)
-              .renderDismissButton(item.getUserAlert(), path() + "#" + BOOKMARKS_ANCHOR));
+          renderDismissButton(ctx, item.getUserAlert(), path() + "#" + BOOKMARKS_ANCHOR));
     }
   }
 
@@ -435,10 +435,13 @@ public class WelcomeToadlet extends Toadlet {
   }
 
   private void disableMatchingAlert(ToadletContext ctx, UserAlert alert) {
-    if (alert.userCanDismiss() && alert.shouldUnregisterOnDismiss()) {
-      alert.onDismiss();
-      LOG.info("Unregistering the userAlert {}", alert.hashCode());
-      concreteAlertManager(ctx).unregister(alert);
+    if (alert.userCanDismiss()) {
+      if (alert.shouldUnregisterOnDismiss()) {
+        LOG.info("Unregistering the userAlert {}", alert.hashCode());
+      } else {
+        LOG.info("Disabling the userAlert {}", alert.hashCode());
+      }
+      ctx.getAlertManager().dismissAlert(alert.hashCode());
     } else {
       LOG.info("Disabling the userAlert {}", alert.hashCode());
       alert.isValid(false);
@@ -650,13 +653,49 @@ public class WelcomeToadlet extends Toadlet {
     String[] alertAnchors = alertsToDump.split(",");
     HashSet<String> toDump = new HashSet<>();
     Collections.addAll(toDump, alertAnchors);
-    concreteAlertManager(ctx).dumpEvents(toDump);
+    dismissMatchingEventAlerts(ctx, toDump);
     redirectToRoot(ctx);
     return true;
   }
 
-  private UserAlertManager concreteAlertManager(ToadletContext ctx) {
-    return (UserAlertManager) ctx.getAlertManager();
+  private void dismissMatchingEventAlerts(ToadletContext ctx, Set<String> toDump) {
+    for (UserAlert alert : ctx.getAlertManager().getAlerts()) {
+      if (alert.isEventNotification() && toDump.contains(alert.anchor())) {
+        ctx.getAlertManager().dismissAlert(alert.hashCode());
+      }
+    }
+  }
+
+  private HTMLNode renderDismissButton(
+      ToadletContext ctx, UserAlert userAlert, String redirectToAfterDisable) {
+    HTMLNode result = new HTMLNode("div");
+    if (!userAlert.userCanDismiss()) {
+      return result;
+    }
+
+    HTMLNode dismissFormNode =
+        result
+            .addChild("form", new String[] {"action", "method"}, new String[] {ALERTS_PATH, "post"})
+            .addChild("div");
+    dismissFormNode.addChild(
+        ELEMENT_INPUT,
+        new String[] {ATTR_TYPE, "name", ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, "disable", String.valueOf(userAlert.hashCode())});
+    dismissFormNode.addChild(
+        ELEMENT_INPUT,
+        new String[] {ATTR_TYPE, "name", ATTR_VALUE},
+        new String[] {INPUT_HIDDEN, PARAM_FORM_PASSWORD, ctx.getFormPassword()});
+    dismissFormNode.addChild(
+        ELEMENT_INPUT,
+        new String[] {ATTR_TYPE, "name", ATTR_VALUE},
+        new String[] {INPUT_SUBMIT, "dismiss-user-alert", userAlert.dismissButtonText()});
+    if (redirectToAfterDisable != null) {
+      dismissFormNode.addChild(
+          ELEMENT_INPUT,
+          new String[] {ATTR_TYPE, "name", ATTR_VALUE},
+          new String[] {INPUT_HIDDEN, "redirectToAfterDisable", redirectToAfterDisable});
+    }
+    return result;
   }
 
   private boolean handleUpgradeConnectionSpeed(HTTPRequest request, ToadletContext ctx)

--- a/bridge-http-runtime/build.gradle.kts
+++ b/bridge-http-runtime/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation(project(":foundation-crypto-keys"))
   implementation(project(":kernel-content"))
   implementation(project(":kernel-routing"))
+  implementation(project(":runtime-alerts"))
   implementation(project(":runtime-spi"))
   implementation(project(":platform-apphost"))
   implementation(project(":runtime-node"))

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -26,7 +26,7 @@ import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostLayout;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
-import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.Ticker;
 import org.slf4j.Logger;
@@ -100,7 +100,7 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
   }
 
   @Override
-  public UserAlertManager userAlerts() {
+  public UserAlertSurface userAlerts() {
     return core.getAlerts();
   }
 

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/package-info.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/package-info.java
@@ -15,7 +15,8 @@
  * continue to treat these classes as adapter implementations rather than as part of the long-lived
  * runtime seam. This leaf also installs the admin-owned HTTP route registrar implementation into
  * the shared shell. The remaining browse/FProxy shell stays boundary-frozen in {@code
- * :adapter-http-legacy-admin}, and {@code network.crypta.clients.http.updater} also remains in that
- * adapter leaf in this PR.
+ * :adapter-http-legacy-admin}, now receives the detached {@code
+ * network.crypta.runtime.alerts.UserAlertSurface} from {@code :runtime-alerts}, and {@code
+ * network.crypta.clients.http.updater} also remains in that adapter leaf in this PR.
  */
 package network.crypta.clients.http.bridge;

--- a/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
+++ b/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
@@ -38,6 +38,7 @@ import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -130,7 +131,7 @@ class CoreHttpShellRuntimeSupportTest {
     when(core.getAlerts()).thenReturn(alerts);
     CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(core);
 
-    UserAlertManager actualAlerts = runtimeSupport.userAlerts();
+    UserAlertSurface actualAlerts = runtimeSupport.userAlerts();
 
     assertSame(alerts, actualAlerts);
   }

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -18,6 +18,13 @@ The dependency direction is one way. `:adapter-http-legacy-browse` may depend on
 must not depend on the browse leaf. `:bridge-http-runtime` depends on the browse leaf for concrete
 browse construction and still uses admin-owned seams for shell orchestration.
 
+HTTP/admin alert rendering now crosses the detached
+`network.crypta.runtime.alerts.UserAlertSurface` owned by `:runtime-alerts`. The concrete
+`UserAlertManager` remains runtime-node-owned, while `:adapter-http-legacy-admin` and
+`:bridge-http-runtime` consume the narrower alert surface instead of importing that concrete
+manager type directly. This is one focused step in the ongoing removal of
+`adapter-http-legacy-admin -> :runtime-node` coupling without widening `:runtime-spi`.
+
 The shared shell stays browse-neutral by crossing `LegacyHttpPaths` / `LegacyHttpCategories`
 constants and other small seam types instead of importing concrete browse-owned collaborator
 classes directly. Route publication, bookmark handling, push handling, and browser-side helpers

--- a/runtime-alerts/gradle/owned-output-patterns.txt
+++ b/runtime-alerts/gradle/owned-output-patterns.txt
@@ -24,5 +24,7 @@ network/crypta/runtime/alerts/TimeSkewDetectedUserAlert.class
 network/crypta/runtime/alerts/TimeSkewDetectedUserAlert$*.class
 network/crypta/runtime/alerts/UserAlert.class
 network/crypta/runtime/alerts/UserAlert$*.class
+network/crypta/runtime/alerts/UserAlertSurface.class
+network/crypta/runtime/alerts/UserAlertSurface$*.class
 network/crypta/runtime/alerts/UserEvent.class
 network/crypta/runtime/alerts/UserEvent$*.class

--- a/runtime-alerts/src/main/java/network/crypta/runtime/alerts/UserAlertSurface.java
+++ b/runtime-alerts/src/main/java/network/crypta/runtime/alerts/UserAlertSurface.java
@@ -1,0 +1,100 @@
+package network.crypta.runtime.alerts;
+
+import network.crypta.support.HTMLNode;
+
+/**
+ * Consumer-facing alert surface for legacy HTTP and other UI/admin code, owned by {@code
+ * :runtime-alerts}.
+ *
+ * <p>This interface defines the detached contract that browser-facing and administrative surfaces
+ * use to work with node alerts. It is intentionally narrower than the concrete {@code
+ * UserAlertManager}: consumers can register alerts, dismiss them by hash, take a snapshot of the
+ * current alert set, and request pre-rendered HTML fragments for the existing shared shell. That
+ * keeps the UI-side boundary small while allowing runtime-node-owned code to keep the broader
+ * lifecycle, feed, and subscriber machinery.
+ *
+ * <p>Callers should treat implementations as a live runtime service rather than as a passive data
+ * holder. The array returned by {@link #getAlerts()} is a snapshot suitable for immediate
+ * iteration, while the HTML-producing methods are convenience renderers for the legacy shell and
+ * therefore reflect the node's current alert state at call time.
+ *
+ * <ul>
+ *   <li>Registration and dismissal for user-visible alerts.
+ *   <li>Snapshot access for shell code that needs to inspect current alerts directly.
+ *   <li>HTML helpers retained for the existing legacy HTTP rendering path.
+ * </ul>
+ */
+public interface UserAlertSurface {
+
+  /**
+   * Registers a user-facing alert with the active surface.
+   *
+   * <p>Implementations typically deduplicate and order alerts according to the runtime manager's
+   * existing rules. Callers normally invoke this when a new operational condition should become
+   * visible in the shared shell or related user-facing status surfaces.
+   *
+   * @param alert alert instance to add to the active surface so current and future UI renders can
+   *     include it
+   */
+  void register(UserAlert alert);
+
+  /**
+   * Dismisses an alert identified by its hash code when that alert allows user dismissal.
+   *
+   * <p>This method mirrors the legacy HTTP behavior, where dismissal requests travel through form
+   * posts that carry an alert hash rather than a direct object reference. Implementations may
+   * ignore the request when no matching alert exists or when the matching alert is not dismissible.
+   *
+   * @param alertHashCode hash code of the alert the caller wants to dismiss from the active surface
+   */
+  void dismissAlert(int alertHashCode);
+
+  /**
+   * Returns a snapshot of the current alerts visible through this surface.
+   *
+   * <p>The returned array is intended for immediate iteration and rendering. Implementations may
+   * sort the snapshot according to the runtime manager's current ordering rules, but callers should
+   * not assume the array remains live after the method returns.
+   *
+   * @return snapshot of the active alerts currently exposed through the detached surface
+   */
+  UserAlert[] getAlerts();
+
+  /**
+   * Renders the current alert set as an HTML fragment for legacy shell pages.
+   *
+   * <p>This helper preserves the existing HTML-oriented rendering contract used by the old HTTP
+   * pages. The returned node is suitable for embedding into a larger page tree and reflects the
+   * filtering rules requested by the caller at the time of invocation.
+   *
+   * @param showOnlyErrors whether the rendered fragment should include only higher-severity alerts
+   *     instead of the full alert list
+   * @return HTML fragment containing the rendered alerts for direct inclusion in legacy page output
+   */
+  HTMLNode createAlerts(boolean showOnlyErrors);
+
+  /**
+   * Renders the default summary fragment used by legacy HTTP/admin views.
+   *
+   * <p>This overload retains the historical default summary behavior used by the existing shell,
+   * usually a compact summary of higher-severity alerts. Callers that need explicit one-line or
+   * multi-line behavior should use {@link #createSummary(boolean)} instead.
+   *
+   * @return HTML summary fragment representing the default legacy-shell alert summary view
+   */
+  HTMLNode createSummary();
+
+  /**
+   * Renders a summary fragment in either one-line or full-box mode.
+   *
+   * <p>This method supports the two summary layouts currently needed by the shared shell. Depending
+   * on implementation state and alert severity, the result may be a populated summary fragment, an
+   * intentionally empty marker node, or {@code null} when no summary should be shown at all.
+   *
+   * @param oneLine whether to render the compact single-line summary instead of the fuller box
+   *     presentation
+   * @return summary fragment for the requested mode, an empty marker node, or {@code null} when
+   *     summary rendering is suppressed
+   */
+  HTMLNode createSummary(boolean oneLine);
+}

--- a/runtime-node/src/main/java/network/crypta/runtime/alerts/UserAlertManager.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/alerts/UserAlertManager.java
@@ -61,7 +61,7 @@ import static java.util.Arrays.stream;
  * @see UserAlert
  * @see UserEvent
  */
-public class UserAlertManager implements Comparator<UserAlert> {
+public class UserAlertManager implements UserAlertSurface, Comparator<UserAlert> {
   private static final Logger LOG = LoggerFactory.getLogger(UserAlertManager.class);
   private static final char PATH_SEPARATOR = '/';
   private static final String ALERTS_PATH_SEGMENT = "alerts";
@@ -110,6 +110,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    *
    * @param alert the alert to register; must be a non-null alert instance
    */
+  @Override
   public void register(UserAlert alert) {
     if (alert instanceof UserEvent event) register(event);
     synchronized (alerts) {
@@ -216,6 +217,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    * @param alertHashCode the hash code identifying the alert to dismiss
    * @see #unregister(UserAlert)
    */
+  @Override
   public void dismissAlert(int alertHashCode) {
     UserAlert[] userAlerts = getAlerts();
     for (UserAlert userAlert : userAlerts) {
@@ -241,6 +243,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    *
    * @return a newly allocated array sorted by alert priority and recency
    */
+  @Override
   public UserAlert[] getAlerts() {
     UserAlert[] a;
     synchronized (alerts) {
@@ -321,6 +324,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    * @param showOnlyErrors whether to include only error-level alerts in the output
    * @return the root HTML node for the rendered alerts, or an empty marker node
    */
+  @Override
   public HTMLNode createAlerts(boolean showOnlyErrors) {
     HTMLNode alertsNode = new HTMLNode("div");
     int totalNumber = 0;
@@ -439,6 +443,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    *
    * @return an HTML fragment containing error-level alerts, or an empty marker node
    */
+  @Override
   public HTMLNode createSummary() {
     // This method is called by the toadlets when they want to show
     // a summary of alerts. With a status bar, we only show full errors here.
@@ -458,6 +463,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
    * @param oneLine whether to emit a compact single-line summary instead of a full infobox
    * @return the summary infobox node, an empty marker node, or {@code null} when suppressed
    */
+  @Override
   public HTMLNode createSummary(boolean oneLine) {
     SummaryStats stats = collectSummaryStats();
     if (stats.shouldHideSummary(oneLine)) {

--- a/runtime-node/src/main/java/network/crypta/runtime/alerts/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/alerts/package-info.java
@@ -2,9 +2,10 @@
  * Transitional runtime/operator-facing alerts cluster.
  *
  * <p>This package now spans the extracted {@code :runtime-alerts} leaf and the remaining
- * daemon-bound {@code :runtime-node} classes. Leaf-safe alert model and feed types live in {@code
- * :runtime-alerts}; the manager, node-backed producers, and other daemon-coupled alert
- * implementations remain adjacent to the runtime services that still own their state.
+ * daemon-bound {@code :runtime-node} classes. Leaf-safe alert model, feed types, and the detached
+ * consumer-facing {@code UserAlertSurface} live in {@code :runtime-alerts}; the concrete {@code
+ * UserAlertManager}, node-backed producers, and other daemon-coupled alert implementations remain
+ * adjacent to the runtime services that still own their state.
  *
  * <p>The ownership split is intentionally behavioral no-op only. Existing alert rendering, sorting,
  * subscription, and operator-facing semantics stay unchanged while later boundary work continues to

--- a/src/test/java/network/crypta/clients/http/BookmarkEditorToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/BookmarkEditorToadletTest.java
@@ -5,10 +5,12 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.bookmark.Bookmark;
 import network.crypta.clients.http.bookmark.BookmarkCategory;
 import network.crypta.clients.http.bookmark.BookmarkItem;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.keys.FreenetURI;
+import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -24,7 +26,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -53,6 +57,7 @@ class BookmarkEditorToadletTest {
   @Mock private PageMaker pageMaker;
   @Mock private ToadletContext context;
   @Mock private ToadletContainer container;
+  @Mock private UserAlertManager alertManager;
 
   private BookmarkEditorToadlet toadlet;
 
@@ -68,6 +73,7 @@ class BookmarkEditorToadletTest {
     when(context.getPageMaker()).thenReturn(pageMaker);
     when(context.getBookmarkManager()).thenReturn(bookmarkManager);
     when(context.getContainer()).thenReturn(container);
+    when(context.getAlertManager()).thenReturn(alertManager);
     when(context.checkFullAccess(any(Toadlet.class))).thenReturn(true);
     when(container.isFProxyJavascriptEnabled()).thenReturn(false);
     when(context.addFormChild(any(HTMLNode.class), anyString(), anyString()))
@@ -206,6 +212,39 @@ class BookmarkEditorToadletTest {
         .shareBookmark("peer-1", "KSK@shared", "shared-name", "publicDesc", true);
     verify(darknetMessagingPort, never())
         .shareBookmark(eq("peer-2"), anyString(), anyString(), anyString(), anyBoolean());
+  }
+
+  @Test
+  void handleMethodPOST_whenAddingBookmarkItem_usesContextAlertManagerForCreatedBookmark()
+      throws Exception {
+    HTTPRequest request = mock(HTTPRequest.class);
+    BookmarkCategory targetCategory = mock(BookmarkCategory.class);
+
+    when(request.isPartSet("AddDefaultBookmarks")).thenReturn(false);
+    when(request.getPartAsStringFailsafe("bookmark", 5000)).thenReturn("/target/");
+    when(request.getPartAsStringFailsafe("action", 20)).thenReturn("addItem");
+    when(request.isPartSet("confirmdelete")).thenReturn(false);
+    when(request.isPartSet("cancelCut")).thenReturn(false);
+    when(request.isPartSet("name")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("name", 500)).thenReturn("newItem");
+    when(request.getPartAsStringFailsafe("key", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("KSK@newkey");
+    when(request.getPartAsStringFailsafe("descB", QueueToadlet.MAX_KEY_LENGTH)).thenReturn("desc");
+    when(request.getPartAsStringFailsafe("explain", 1024)).thenReturn("expl");
+    when(request.getPartAsStringFailsafe("publicDescB", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("publicDesc");
+    when(bookmarkManager.getCategoryByPath("/target/")).thenReturn(targetCategory);
+    when(bookmarkManager.parentPath("/target/")).thenReturn("/target/");
+    when(bookmarkManager.getBookmarkByPath("/target/newItem")).thenReturn(null);
+
+    toadlet.handleMethodPOST(DUMMY_URI, request, context);
+
+    ArgumentCaptor<Bookmark> bookmarkCaptor = ArgumentCaptor.forClass(Bookmark.class);
+    verify(bookmarkManager).addBookmark(eq("/target/"), bookmarkCaptor.capture());
+    BookmarkItem bookmarkItem = assertInstanceOf(BookmarkItem.class, bookmarkCaptor.getValue());
+    Field alertsField = BookmarkItem.class.getDeclaredField("alerts");
+    alertsField.setAccessible(true);
+    assertSame(alertManager, alertsField.get(bookmarkItem));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
@@ -2,11 +2,17 @@ package network.crypta.clients.http;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.ClientContext;
+import network.crypta.config.Option;
+import network.crypta.config.SubConfig;
+import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -16,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,6 +39,8 @@ class FProxyToadletTest {
   @Mock private FProxyFetchTracker fetchTracker;
 
   @Mock private ClientContext clientContext;
+
+  @Mock private ToadletContainer container;
 
   @Test
   void constructor_setsMaxLengthsOnClient() {
@@ -97,6 +107,42 @@ class FProxyToadletTest {
 
     assertDoesNotThrow(
         () -> toadlet.handleMethodPOST(uri, mock(HTTPRequest.class), mock(ToadletContext.class)));
+  }
+
+  @Test
+  void handleMethodGET_whenFeedPathRequested_writesAtomFromConcreteAlertManager() throws Exception {
+    FProxyToadlet toadlet = newFProxy();
+    ToadletContext ctx = mock(ToadletContext.class);
+    HTTPRequest request = mock(HTTPRequest.class);
+    UserAlertManager alertManager = mock(UserAlertManager.class);
+    SubConfig fProxyConfig = mock(SubConfig.class);
+    @SuppressWarnings("rawtypes")
+    Option portOption = mock(Option.class);
+    @SuppressWarnings("rawtypes")
+    Option bindToOption = mock(Option.class);
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    String atom = "<feed/>";
+    byte[] atomBytes = atom.getBytes(StandardCharsets.UTF_8);
+
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(runtimeSupport.fproxyConfig()).thenReturn(fProxyConfig);
+    doReturn(portOption).when(fProxyConfig).getOption("port");
+    doReturn(bindToOption).when(fProxyConfig).getOption("bindTo");
+    when(portOption.getValueString()).thenReturn("8888");
+    when(bindToOption.getValueString()).thenReturn("example.test");
+    when(ctx.getHeaders()).thenReturn(headers);
+    when(ctx.getUri()).thenReturn(URI.create("http://example.test/feed"));
+    when(ctx.getAlertManager()).thenReturn(alertManager);
+    when(alertManager.getAtom("http://example.test")).thenReturn(atom);
+
+    toadlet.handleMethodGET(URI.create("http://example.test/feed"), request, ctx);
+
+    verify(alertManager).getAtom("http://example.test");
+    verify(ctx).sendReplyHeadersFProxy(200, "OK", null, "application/atom+xml", atomBytes.length);
+    ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(ctx).writeData(dataCaptor.capture(), eq(0), eq(atomBytes.length));
+    assertArrayEquals(atomBytes, dataCaptor.getValue());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyToadletTest.java
@@ -8,6 +8,7 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.Test;
@@ -22,9 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -143,6 +149,27 @@ class FProxyToadletTest {
     ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
     verify(ctx).writeData(dataCaptor.capture(), eq(0), eq(atomBytes.length));
     assertArrayEquals(atomBytes, dataCaptor.getValue());
+  }
+
+  @Test
+  void handleMethodGET_whenFeedPathRequestedWithoutConcreteAlertManager_returnsServiceUnavailable()
+      throws Exception {
+    FProxyToadlet toadlet = newFProxy();
+    ToadletContext ctx = mock(ToadletContext.class);
+    HTTPRequest request = mock(HTTPRequest.class);
+    UserAlertSurface alertSurface = mock(UserAlertSurface.class);
+
+    toadlet.container = container;
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(ctx.getHeaders()).thenReturn(new MultiValueTable<>());
+    when(ctx.getAlertManager()).thenReturn(alertSurface);
+
+    toadlet.handleMethodGET(URI.create("http://example.test/feed"), request, ctx);
+
+    verify(ctx).sendReplyHeaders(503, "Service Unavailable", null, null, 0);
+    verify(ctx, never())
+        .sendReplyHeadersFProxy(anyInt(), anyString(), any(), anyString(), anyLong());
+    verify(ctx, never()).writeData(any(byte[].class), anyInt(), anyInt());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -24,6 +24,7 @@ import network.crypta.node.RequestStarter;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.spi.RandomnessPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.HTMLNode;
@@ -487,6 +488,27 @@ class SimpleToadletServerTest {
     assertEquals("hidden", inputNode.getAttribute("type"));
     assertEquals("formPassword", inputNode.getAttribute("name"));
     assertEquals("secret-token", inputNode.getAttribute("value"));
+  }
+
+  @Test
+  void getUserAlertManager_whenRuntimeSupportUnavailable_returnsNull() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+
+    assertNull(server.getUserAlertManager());
+  }
+
+  @Test
+  void getUserAlertManager_whenRuntimeSupportConfigured_returnsDetachedAlertSurface()
+      throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
+    UserAlertSurface alertSurface = mock(UserAlertSurface.class);
+    when(runtimeSupport.userAlerts()).thenReturn(alertSurface);
+    server.setRuntimeSupport(runtimeSupport);
+
+    UserAlertSurface actualAlertSurface = server.getUserAlertManager();
+
+    assertSame(alertSurface, actualAlertSurface);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import network.crypta.clients.http.bookmark.BookmarkManager;
-import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.HTTPRequest;
@@ -39,7 +39,7 @@ class ToadletContextImplTest {
   @Mock private BucketFactory bucketFactory;
   @Mock private PageMaker pageMaker;
   @Mock private ToadletContainer container;
-  @Mock private UserAlertManager alertManager;
+  @Mock private UserAlertSurface alertManager;
   @Mock private BookmarkManager bookmarkManager;
   @Mock private HTTPRequest request;
 
@@ -122,6 +122,13 @@ class ToadletContextImplTest {
 
     assertSame(bookmarkManager, handle);
     assertSame(bookmarkManager, concrete);
+  }
+
+  @Test
+  void getAlertManager_whenRequested_returnsConfiguredAlertSurface() {
+    UserAlertSurface alertSurface = context.getAlertManager();
+
+    assertSame(alertManager, alertSurface);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
@@ -6,11 +6,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.clients.http.bookmark.BookmarkItem;
+import network.crypta.runtime.alerts.AbstractUserAlert;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
@@ -40,7 +40,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -85,7 +84,6 @@ class WelcomeToadletTest {
     when(container.publicGatewayMode()).thenReturn(false);
     when(container.enableActivelinks()).thenReturn(true);
     when(alertManager.createSummary()).thenReturn(new HTMLNode("div", "id", "alert-summary"));
-    when(alertManager.renderDismissButton(any(), anyString())).thenReturn(new HTMLNode("button"));
     when(request.getParam("newbookmark")).thenReturn("");
     when(request.getPartAsStringFailsafe("updateconfirm", 32)).thenReturn("");
     when(request.getPartAsStringFailsafe("update", 32)).thenReturn("");
@@ -298,16 +296,21 @@ class WelcomeToadletTest {
   }
 
   @Test
-  void handleMethodPOST_whenDismissEventsSubmitted_dumpsEventsViaConcreteAlertManager()
+  void handleMethodPOST_whenDismissEventsSubmitted_dismissesMatchingEventAlertsViaSurface()
       throws Exception {
+    UserAlert bookmarkEvent = new TestUserAlert("bookmark", true);
+    UserAlert peerEvent = new TestUserAlert("peer", true);
+    UserAlert nonEvent = new TestUserAlert("other", false);
     when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
     when(ctx.checkFormPassword(request)).thenReturn(true);
     when(request.isPartSet("dismiss-events")).thenReturn(true);
     when(request.getPartAsStringFailsafe("events", Integer.MAX_VALUE)).thenReturn("bookmark,peer");
+    when(alertManager.getAlerts()).thenReturn(new UserAlert[] {bookmarkEvent, nonEvent, peerEvent});
 
     toadlet.handleMethodPOST(URI.create("http://localhost/"), request, ctx);
 
-    verify(alertManager).dumpEvents(argThat(events -> events.equals(Set.of("bookmark", "peer"))));
+    verify(alertManager).dismissAlert(bookmarkEvent.hashCode());
+    verify(alertManager).dismissAlert(peerEvent.hashCode());
     @SuppressWarnings("unchecked")
     ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
         ArgumentCaptor.forClass(MultiValueTable.class);
@@ -355,10 +358,10 @@ class WelcomeToadletTest {
   }
 
   @Test
-  void addBookmarkItemRow_whenBookmarkUpdated_usesContextAlertManagerDismissButton()
+  void addBookmarkItemRow_whenBookmarkUpdated_rendersDismissFormUsingAlertSurfaceData()
       throws Exception {
     BookmarkItem item = mock(BookmarkItem.class);
-    UserAlert userAlert = mock(UserAlert.class);
+    UserAlert userAlert = new TestUserAlert("bookmark", false);
     HTMLNode table = new HTMLNode("table");
     when(item.hasAnActivelink()).thenReturn(false);
     when(item.hasUpdated()).thenReturn(true);
@@ -378,14 +381,19 @@ class WelcomeToadletTest {
     method.setAccessible(true);
     method.invoke(toadlet, false, table, item, ctx);
 
-    verify(alertManager).renderDismissButton(userAlert, "/#bookmarks");
+    String html = table.generate();
+    assertTrue(html.contains("action=\"/alerts/\""));
+    assertTrue(html.contains("name=\"disable\""));
+    assertTrue(html.contains("value=\"" + userAlert.hashCode() + "\""));
+    assertTrue(html.contains("name=\"formPassword\""));
+    assertTrue(html.contains("value=\"form-password\""));
+    assertTrue(html.contains("name=\"redirectToAfterDisable\""));
+    assertTrue(html.contains("value=\"/#bookmarks\""));
   }
 
   @Test
-  void disableMatchingAlert_whenAlertShouldUnregister_usesConcreteAlertManager() throws Exception {
-    UserAlert userAlert = mock(UserAlert.class);
-    when(userAlert.userCanDismiss()).thenReturn(true);
-    when(userAlert.shouldUnregisterOnDismiss()).thenReturn(true);
+  void disableMatchingAlert_whenAlertShouldUnregister_usesAlertSurfaceDismissal() throws Exception {
+    UserAlert userAlert = new TestUserAlert("dismiss", false);
 
     Method method =
         WelcomeToadlet.class.getDeclaredMethod(
@@ -393,8 +401,7 @@ class WelcomeToadletTest {
     method.setAccessible(true);
     method.invoke(toadlet, ctx, userAlert);
 
-    verify(userAlert).onDismiss();
-    verify(alertManager).unregister(userAlert);
+    verify(alertManager).dismissAlert(userAlert.hashCode());
   }
 
   @Test
@@ -507,5 +514,33 @@ class WelcomeToadletTest {
 
   private static DarknetConnectionPeerSnapshot alicePeer() {
     return new DarknetConnectionPeerSnapshot(42, "peer-1", "Alice", "", false);
+  }
+
+  private static final class TestUserAlert extends AbstractUserAlert {
+
+    private final String anchor;
+    private final boolean eventNotification;
+
+    private TestUserAlert(String anchor, boolean eventNotification) {
+      super(
+          true,
+          "Title",
+          Body.of("Text", "Short", new HTMLNode("div", "Alert")),
+          UserAlert.MINOR,
+          true,
+          new DismissOptions("Dismiss", true));
+      this.anchor = anchor;
+      this.eventNotification = eventNotification;
+    }
+
+    @Override
+    public String anchor() {
+      return anchor;
+    }
+
+    @Override
+    public boolean isEventNotification() {
+      return eventNotification;
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/WelcomeToadletTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker.RenderParameters;
@@ -39,6 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -296,6 +298,24 @@ class WelcomeToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenDismissEventsSubmitted_dumpsEventsViaConcreteAlertManager()
+      throws Exception {
+    when(ctx.checkFullAccess(any(Toadlet.class))).thenReturn(true);
+    when(ctx.checkFormPassword(request)).thenReturn(true);
+    when(request.isPartSet("dismiss-events")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("events", Integer.MAX_VALUE)).thenReturn("bookmark,peer");
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/"), request, ctx);
+
+    verify(alertManager).dumpEvents(argThat(events -> events.equals(Set.of("bookmark", "peer"))));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<MultiValueTable<String, String>> headersCaptor =
+        ArgumentCaptor.forClass(MultiValueTable.class);
+    verify(ctx).sendReplyHeaders(eq(302), eq("Found"), headersCaptor.capture(), eq(null), eq(0L));
+    assertEquals("/", headersCaptor.getValue().getFirst("Location"));
+  }
+
+  @Test
   void handleMethodGET_whenWrapperInUse_rendersRestartButtonFromLifecyclePort() throws Exception {
     WelcomeToadlet spyToadlet = createSpyToadlet();
     AtomicReference<String> html = captureHtmlReply(spyToadlet);
@@ -359,6 +379,22 @@ class WelcomeToadletTest {
     method.invoke(toadlet, false, table, item, ctx);
 
     verify(alertManager).renderDismissButton(userAlert, "/#bookmarks");
+  }
+
+  @Test
+  void disableMatchingAlert_whenAlertShouldUnregister_usesConcreteAlertManager() throws Exception {
+    UserAlert userAlert = mock(UserAlert.class);
+    when(userAlert.userCanDismiss()).thenReturn(true);
+    when(userAlert.shouldUnregisterOnDismiss()).thenReturn(true);
+
+    Method method =
+        WelcomeToadlet.class.getDeclaredMethod(
+            "disableMatchingAlert", ToadletContext.class, UserAlert.class);
+    method.setAccessible(true);
+    method.invoke(toadlet, ctx, userAlert);
+
+    verify(userAlert).onDismiss();
+    verify(alertManager).unregister(userAlert);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- introduce `UserAlertSurface` in `:runtime-alerts` as the detached consumer-facing alert contract for the legacy HTTP/admin shell
- make `UserAlertManager` implement that surface and switch the legacy admin/shared-shell and bridge HTTP seams to use it instead of the concrete manager type
- keep browse-only concrete alert-manager calls local, tighten the admin boundary guard, and add focused regression coverage for the detached seam

## How to test
- `./gradlew :runtime-alerts:test :adapter-http-legacy-admin:test :bridge-http-runtime:test`
- `./gradlew :adapter-http-legacy-browse:test`
- `./gradlew :test --tests 'network.crypta.clients.http.ToadletContextImplTest' --tests 'network.crypta.clients.http.SimpleToadletServerTest' --tests 'network.crypta.clients.http.WelcomeToadletTest' --tests 'network.crypta.clients.http.FProxyToadletTest' --tests 'network.crypta.clients.http.BookmarkEditorToadletTest'`
- `./gradlew :bridge-http-runtime:test --tests 'network.crypta.clients.http.bridge.CoreHttpShellRuntimeSupportTest'`
- `./gradlew test`