### PR TITLE
refactor(http): Harden admin config callback boundary

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -17,7 +17,7 @@ Use this skill when you need to:
 - Cryptad now uses a partial multi-project Gradle build.
 - The root project `:cryptad` remains the daemon/application project.
 - The root project still owns `buildJar`, `run`, `runLauncher`, distribution/jpackage tasks, the
-  strongly coupled core packages, and all tests.
+  strongly coupled core packages, and most broad tests.
 - Leaf subprojects:
   - `:foundation-support` → the current stable generic subset of `network.crypta.support`,
     `network.crypta.support.api`, `network.crypta.support.io`,
@@ -61,15 +61,24 @@ Use this skill when you need to:
   - `:platform-apphost` → `network.crypta.platform.apphost` (transport-neutral out-of-process
     AppHost core)
   - `:platform-web-shell` → `network.crypta.platform.webshell` (browser-facing Web Shell v1)
+  - `:runtime-alerts` → the extracted leaf-safe `network.crypta.runtime.alerts` feed/model subset
+    plus the detached `UserAlertSurface`
   - `:runtime-node` → extracted daemon runtime body across the remaining cyclic/high-level
     `network.crypta.client` body, the remaining peer/request/routing-engine and transport-heavy
     `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled
     transport/message execution code in `network.crypta.io*`, and the remaining daemon-coupled
     `network.crypta.support` / `network.crypta.support.io` / `network.crypta.support.api` subset
-  - `:adapter-fcp` → `network.crypta.clients.fcp`, including
+  - `:adapter-fcp` → the protocol-side `network.crypta.clients.fcp` package tree
+  - `:bridge-fcp-runtime` → the concrete runtime-binding FCP bridge package
     `network.crypta.clients.fcp.bridge`
-  - `:adapter-http-legacy-admin` → the full current legacy `network.crypta.clients.http` tree
-    plus matching `network/crypta/clients/http/**` main resources
+  - `:adapter-http-legacy-admin` → the shared legacy `network.crypta.clients.http` shell, admin
+    toadlets, `/api/v1/` and `/app/node/` bridge entrypoints, and matching
+    `network/crypta/clients/http/**` main resources
+  - `:adapter-http-legacy-browse` → the concrete legacy browse/FProxy routes, toadlets, helper
+    models, and browse-only packages under `network.crypta.clients.http`
+  - `:bridge-http-runtime` → the concrete runtime-binding HTTP bridge implementations under
+    `network.crypta.clients.http.bridge` plus the legacy HTTP GeoIP helper package
+    `network.crypta.clients.http.geoip`
   - `:thirdparty-onion` → `com.onionnetworks` plus `lib/fec.properties`
   - `:thirdparty-legacy` → `org.bitpedia`, `org.sevenzip`, `org.spaceroots`
   - `:launcher-desktop` → `network.crypta.launcher`, `com.jthemedetecor`, `oshi`, launcher
@@ -100,10 +109,13 @@ Use this skill when you need to:
   `:kernel-routing` owns the compile-neutral phase-1 routing/helper slice,
   `:platform-api` owns the transport-neutral Platform API surface, `:platform-apphost` owns the
   transport-neutral AppHost core, `:platform-web-shell` owns the browser-facing node-management
-  shell, `:runtime-node` owns the remaining runtime/node/client/support body, `:adapter-fcp`
-  owns the FCP adapter tree, `:adapter-http-legacy-admin` owns the legacy HTTP adapter tree and
-  resources, and the root project keeps tests, packaging, tool entrypoints, and remaining
-  composition glue.
+  shell, `:runtime-alerts` owns the extracted alert/feed model subset, `:runtime-node` owns the
+  remaining runtime/node/client/support body, `:adapter-fcp` owns the FCP adapter tree,
+  `:bridge-fcp-runtime` owns the concrete FCP bridge implementations,
+  `:adapter-http-legacy-admin` owns the shared legacy HTTP shell/admin layer,
+  `:adapter-http-legacy-browse` owns the concrete browse/FProxy layer,
+  `:bridge-http-runtime` owns the concrete HTTP runtime bridge, and the root project keeps tests,
+  packaging, tool entrypoints, and remaining composition glue.
 - The wire split is intentionally narrow:
   `:interop-wire` owns the message/schema nucleus, `:kernel-transport` owns the compile-neutral
   transport helper slice (`AllowedHosts`, `NetworkInterface`, `IOStatisticCollector`,
@@ -125,10 +137,11 @@ Use this skill when you need to:
 - Focused leaf-local boundary tests now freeze the extracted layout. In particular,
   `RuntimeNodeKernelSplitPrepBoundaryTest`, `KernelContentBoundaryTest`,
   `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, `PlatformApiBoundaryTest`,
-  `AdapterFcpBoundaryTest`, `AppHostBoundaryTest`, `WebShellBoundaryTest`, and
-  `HttpLegacyAdminBoundaryTest` guard leaf ownership/import rules. The runtime, kernel, platform,
-  and adapter-fcp boundary suites also require `package-info.java` in the production packages they
-  own.
+  `AdapterFcpBoundaryTest`, `BridgeFcpRuntimeBoundaryTest`, `AppHostBoundaryTest`,
+  `WebShellBoundaryTest`, `HttpLegacyAdminBoundaryTest`, `LegacyHttpBrowseBoundaryTest`, and
+  `BridgeHttpRuntimeBoundaryTest` guard leaf ownership/import rules. The runtime, kernel,
+  platform, FCP, and HTTP boundary suites also require `package-info.java` in the production
+  packages they own.
 
 ## Architecture overview (by package)
 ### Core network layer (`network.crypta.node`)
@@ -223,12 +236,18 @@ Use this skill when you need to:
     adapters, alert-feed adapters, and endpoint-handle wrappers now live under
     `network.crypta.clients.fcp.bridge`.
 - HTTP interface: `network.crypta.clients.http`
-  - This package now lives in `:adapter-http-legacy-admin` together with the matching
-    `network/crypta/clients/http/**` main resources such as `staticfiles/**` and `templates/**`.
+  - The package family is now split physically:
+    `:adapter-http-legacy-admin` owns the shared shell/admin routes and the matching
+    `network/crypta/clients/http/**` main resources such as `staticfiles/**` and `templates/**`;
+    `:adapter-http-legacy-browse` owns the concrete browse/FProxy routes, toadlets, and helper
+    models; `:bridge-http-runtime` owns the concrete runtime-binding bridge implementations under
+    `network.crypta.clients.http.bridge` plus the legacy HTTP GeoIP helper package.
   - The migrated management and shell slices no longer depend directly on live daemon peers or
     node-info exports for their core data flow.
   - `ConfigToadlet` now takes detached configuration export/update capabilities from
-    `ConfigPort` through `ConfigToadletRuntimePorts`.
+    `ConfigPort` through `ConfigToadletRuntimePorts` and classifies directory-browser fields
+    through the detached `network.crypta.config.DirectorySelectionCallback` marker instead of
+    importing `ProgramDirectory`.
   - `ConnectionsToadlet`, `DarknetConnectionsToadlet`, `OpennetConnectionsToadlet`, and
     `DarknetAddRefToadlet` use detached ports such as `ConnectionsPagePort`,
     `ConnectionsSupportPort`, `PeerPort`, and `NodeInfoPort`.
@@ -249,8 +268,11 @@ Use this skill when you need to:
   - FProxy and shell bootstrap now have local package-private seams:
     `BookmarkRuntimeSupport`, `FProxyRuntimeSupport`, `HttpShellRuntimeSupport`,
     `HttpShellFProxyBootstrap`, and `FProxyRegistrarDependencies`.
+  - HTTP/admin alert rendering now crosses the detached
+    `network.crypta.runtime.alerts.UserAlertSurface` instead of importing
+    `UserAlertManager` directly.
   - Concrete HTTP shell, bookmark, GeoIP, and security-page bridge implementations now live under
-    `network.crypta.clients.http.bridge`.
+    `network.crypta.clients.http.bridge` in `:bridge-http-runtime`.
   - `BookmarkEditorToadletRuntimePorts` and `FileInsertWizardToadletRuntimePorts` are small
     page-specific records used to keep constructor surfaces explicit during HTTP wiring.
   - `N2NTMToadlet` uses `DarknetConnectionsPort` and `DarknetMessagingPort` for selected-peer
@@ -314,6 +336,10 @@ Use this skill when you need to:
 - Main localization sources and `crypta.l10n.en.properties` also live in `:foundation-config`
   under `network.crypta.l10n`.
 - Shared setup helpers such as `DatastoreSizingSupport` also live in `:foundation-config`.
+- Narrow callback-level UI markers such as
+  `network.crypta.config.DirectorySelectionCallback` also live in `:foundation-config`, so HTTP
+  admin code can classify directory-selection fields without importing concrete runtime-owned
+  callback implementations.
 - Higher layers should prefer the narrow `RuntimePorts` sub-port that already covers the needed
   operation (`config()`, `peer()`, `nodeInfo()`, `connectionsPage()`, `connectionsSupport()`,
   `darknetConnections()`, `darknetMessaging()`, `queuePage()`, `queueDownload()`,
@@ -367,12 +393,18 @@ Use this skill when you need to:
 - `:platform-api`: `network.crypta.platform.api`
 - `:platform-apphost`: `network.crypta.platform.apphost`
 - `:platform-web-shell`: `network.crypta.platform.webshell`
+- `:runtime-alerts`: `network.crypta.runtime.alerts`, including the detached
+  `UserAlertSurface`
 - `:runtime-node`: extracted daemon runtime body across the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine
   `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled
   transport/message execution code, and the remaining daemon-coupled support helpers
 - `:adapter-fcp`: `network.crypta.clients.fcp`
-- `:adapter-http-legacy-admin`: `network.crypta.clients.http`
+- `:bridge-fcp-runtime`: `network.crypta.clients.fcp.bridge`
+- `:adapter-http-legacy-admin`: shared legacy HTTP shell/admin layer plus matching resources
+- `:adapter-http-legacy-browse`: concrete legacy browse/FProxy layer
+- `:bridge-http-runtime`: `network.crypta.clients.http.bridge` and
+  `network.crypta.clients.http.geoip`
 
 ### Vendored library leaf modules
 - `:thirdparty-onion`: `com.onionnetworks`

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -22,9 +22,10 @@ Use this skill when you need to:
   `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
   `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
   `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
-  `:platform-apphost`, `:platform-web-shell`, `:runtime-node`, `:adapter-fcp`,
-  `:adapter-http-legacy-admin`, `:thirdparty-onion`, `:thirdparty-legacy`, and
-  `:launcher-desktop`.
+  `:platform-apphost`, `:platform-web-shell`, `:runtime-alerts`, `:runtime-node`,
+  `:adapter-fcp`, `:bridge-fcp-runtime`, `:bridge-http-runtime`,
+  `:adapter-http-legacy-admin`, `:adapter-http-legacy-browse`, `:thirdparty-onion`,
+  `:thirdparty-legacy`, and `:launcher-desktop`.
 - The extracted leaf projects compile separately, but `buildJar`, `run`, `runLauncher`,
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
 - `:foundation-support` owns the current stable generic support subset under
@@ -70,9 +71,10 @@ Use this skill when you need to:
 - Focused leaf-local boundary tests now freeze the current extracted layout.
   `RuntimeNodeKernelSplitPrepBoundaryTest`, `KernelContentBoundaryTest`,
   `KernelTransportBoundaryTest`, `KernelRoutingBoundaryTest`, `PlatformApiBoundaryTest`,
-  `AdapterFcpBoundaryTest`, `AppHostBoundaryTest`, `WebShellBoundaryTest`, and
-  `HttpLegacyAdminBoundaryTest` are the focused regression checks for leaf ownership/import
-  boundaries. The runtime, kernel, platform, and adapter-fcp boundary suites also enforce
+  `AdapterFcpBoundaryTest`, `BridgeFcpRuntimeBoundaryTest`, `AppHostBoundaryTest`,
+  `WebShellBoundaryTest`, `HttpLegacyAdminBoundaryTest`, `LegacyHttpBrowseBoundaryTest`, and
+  `BridgeHttpRuntimeBoundaryTest` are the focused regression checks for leaf ownership/import
+  boundaries. The runtime, kernel, platform, FCP, and HTTP boundary suites also enforce
   `package-info.java` coverage for the production packages they own.
 - `:runtime-spi` is the JDK-only runtime/config API leaf. Its focused unit tests still live in the
   root test tree and run through the root build.
@@ -82,17 +84,27 @@ Use this skill when you need to:
   tests under `platform-apphost/src/test/java`.
 - `:platform-web-shell` owns the browser-facing Web Shell leaf and its focused leaf tests under
   `platform-web-shell/src/test/java`.
+- `:runtime-alerts` owns the extracted leaf-safe `network.crypta.runtime.alerts` feed/model
+  subset plus the detached `UserAlertSurface` used by legacy HTTP/admin code.
 - `:runtime-node` is the extracted daemon runtime leaf. It now owns the remaining cyclic/high-level
   `network.crypta.client` body, the remaining peer/request/routing-engine side of
   `network.crypta.node`, the retained node-coupled transport/message execution code in
   `network.crypta.io*`, `network.crypta.runtime.*`, and the remaining daemon-coupled support
   helpers.
-- `:adapter-fcp` owns `network.crypta.clients.fcp`, including
-  `network.crypta.clients.fcp.bridge`.
-- `:adapter-http-legacy-admin` owns the current legacy `network.crypta.clients.http` tree and the
-  matching `network/crypta/clients/http/**` main resources. On the root test/runtime classpath,
-  those resources often resolve from the leaf JAR, so tests must treat them as classpath resources
-  rather than assume a plain filesystem `Path`.
+- `:adapter-fcp` owns the protocol-side `network.crypta.clients.fcp` tree.
+- `:bridge-fcp-runtime` owns the concrete runtime-binding `network.crypta.clients.fcp.bridge`
+  implementations and its focused leaf tests under `bridge-fcp-runtime/src/test/java`.
+- `:bridge-http-runtime` owns the concrete `network.crypta.clients.http.bridge` runtime-binding
+  implementations plus the legacy HTTP `network.crypta.clients.http.geoip` helper package, with
+  focused leaf tests under `bridge-http-runtime/src/test/java`.
+- `:adapter-http-legacy-admin` owns the shared legacy `network.crypta.clients.http` shell, admin
+  toadlets, `/api/v1/` and `/app/node/` bridge entrypoints, and the matching
+  `network/crypta/clients/http/**` main resources.
+- `:adapter-http-legacy-browse` owns the concrete browse/FProxy routes, toadlets, and helper
+  models under `network.crypta.clients.http`, with focused leaf tests under
+  `adapter-http-legacy-browse/src/test/java`.
+- On the root test/runtime classpath, admin-owned HTTP resources often resolve from the leaf JAR,
+  so tests must treat them as classpath resources rather than assume a plain filesystem `Path`.
 - Most tests still live in the root project and compile against the leaf subprojects through the
   root build, but the extracted boundary suites now live with their owning leaves under each
   module's `src/test/java` tree.
@@ -131,7 +143,10 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew :kernel-routing:test`
   - `./gradlew :runtime-node:test`
   - `./gradlew :adapter-fcp:test`
+  - `./gradlew :bridge-fcp-runtime:test`
+  - `./gradlew :bridge-http-runtime:test`
   - `./gradlew :adapter-http-legacy-admin:test`
+  - `./gradlew :adapter-http-legacy-browse:test`
 - Run the remaining root-owned Platform API/bootstrap slice explicitly against the root project:
   - `./gradlew :test --tests *DefaultNodeRuntimeBridgeFactoriesTest --tests *PlatformApiRouterTest --tests *PlatformApiAppsIntegrationTest`
 
@@ -173,14 +188,23 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew :platform-apphost:compileJava`
 - Compile the Web Shell leaf when you touched `network.crypta.platform.webshell`:
   - `./gradlew :platform-web-shell:compileJava`
+- Compile the extracted runtime-alerts leaf when you touched `network.crypta.runtime.alerts`:
+  - `./gradlew :runtime-alerts:compileJava`
 - Compile the extracted runtime-node leaf when you touched daemon runtime, node, client, xfer, or
   remaining support code that now lives there:
   - `./gradlew :runtime-node:compileJava`
 - Compile the FCP adapter leaf when you touched `network.crypta.clients.fcp`:
   - `./gradlew :adapter-fcp:compileJava`
-- Compile the legacy HTTP adapter leaf when you touched `network.crypta.clients.http` sources or
-  resources:
+- Compile the concrete FCP bridge leaf when you touched `network.crypta.clients.fcp.bridge`:
+  - `./gradlew :bridge-fcp-runtime:compileJava`
+- Compile the shared legacy HTTP admin leaf when you touched shared shell/admin
+  `network.crypta.clients.http` sources or admin-owned resources:
   - `./gradlew :adapter-http-legacy-admin:compileJava :adapter-http-legacy-admin:processResources`
+- Compile the concrete legacy HTTP browse leaf when you touched browse/FProxy classes:
+  - `./gradlew :adapter-http-legacy-browse:compileJava`
+- Compile the concrete legacy HTTP runtime bridge leaf when you touched
+  `network.crypta.clients.http.bridge` or `network.crypta.clients.http.geoip`:
+  - `./gradlew :bridge-http-runtime:compileJava`
 - Compile the root project and its unchanged test tree against the leaf-module layout:
   - `./gradlew compileJava compileTestJava`
 

--- a/.agents/skills/cryptad-packaging/SKILL.md
+++ b/.agents/skills/cryptad-packaging/SKILL.md
@@ -24,9 +24,10 @@ Use this skill when working on:
   `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
   `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
   `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
-  `:platform-apphost`, `:platform-web-shell`, `:runtime-node`, `:adapter-fcp`,
-  `:adapter-http-legacy-admin`, `:thirdparty-onion`, `:thirdparty-legacy`, and
-  `:launcher-desktop`.
+  `:platform-apphost`, `:platform-web-shell`, `:runtime-alerts`, `:runtime-node`,
+  `:adapter-fcp`, `:bridge-fcp-runtime`, `:bridge-http-runtime`,
+  `:adapter-http-legacy-admin`, `:adapter-http-legacy-browse`, `:thirdparty-onion`,
+  `:thirdparty-legacy`, and `:launcher-desktop`.
 - Extracted leaf modules contribute jars and resources through the root runtime classpath.
 - `:foundation-support` and `:foundation-store-contracts` contribute shared runtime classes via
   their leaf JARs like the other extracted modules.
@@ -42,15 +43,23 @@ Use this skill when working on:
   `:platform-apphost` JAR contributes the transport-neutral local AppHost core used by that API.
 - The `:platform-web-shell` JAR contributes the browser-facing node-management shell HTML, CSS,
   JavaScript, and bootstrap resources that the legacy HTTP adapter mounts at `/app/node/`.
+- The `:runtime-alerts` JAR contributes the detached alert/feed model subset, including the
+  `UserAlertSurface` consumed by the legacy HTTP/admin shell.
 - The `:runtime-node` JAR now carries a large extracted daemon runtime/node/client/support subset
   and participates in the root runtime classpath and packaged distribution like the other leaf
   artifacts.
 - The `:adapter-fcp` JAR carries the extracted FCP adapter code.
-- The `:adapter-http-legacy-admin` JAR carries the current legacy HTTP adapter classes plus the
+- The `:bridge-fcp-runtime` JAR carries the concrete runtime-binding
+  `network.crypta.clients.fcp.bridge` implementations.
+- The `:adapter-http-legacy-admin` JAR carries the shared legacy HTTP shell/admin classes plus the
   matching `network/crypta/clients/http/**` resources. Static files and templates now ship from
   that leaf JAR on the runtime classpath, so packaged/runtime code must treat them as classpath
-  resources rather than plain files. This adapter also hosts the current `/api/v1/` bridge for
+  resources rather than plain files. This leaf also hosts the current `/api/v1/` bridge for
   `:platform-api` and the `/app/node/` bridge for `:platform-web-shell`.
+- The `:adapter-http-legacy-browse` JAR carries the concrete legacy browse/FProxy classes.
+- The `:bridge-http-runtime` JAR carries the concrete `network.crypta.clients.http.bridge`
+  runtime-binding implementations plus the legacy HTTP `network.crypta.clients.http.geoip`
+  helper package.
 - Packaging does not have separate entrypoints per leaf project; it still assembles a single daemon
   artifact and distribution layout from the root build.
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,10 @@ leaf ownership and import rules:
 ./gradlew :kernel-routing:test
 ./gradlew :runtime-node:test
 ./gradlew :adapter-fcp:test
+./gradlew :bridge-fcp-runtime:test
+./gradlew :bridge-http-runtime:test
 ./gradlew :adapter-http-legacy-admin:test
+./gradlew :adapter-http-legacy-browse:test
 ```
 
 Those boundary suites also enforce the current extracted-leaf documentation convention that the
@@ -834,7 +837,10 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.l10n`, and the main l10n properties. Its public APIs re-export
   `:foundation-support` and `:foundation-fs` where config surfaces expose `SimpleFieldSet` or
   filesystem-facing types. Shared setup helpers such as `DatastoreSizingSupport` now also live in
-  this leaf. Higher layers should still prefer `RuntimePorts#config()` and the root
+  this leaf. It also owns narrow callback-level UI markers such as
+  `DirectorySelectionCallback`, which lets legacy HTTP config code classify directory-selection
+  fields without importing concrete runtime-owned callbacks such as `ProgramDirectory`.
+  Higher layers should still prefer `RuntimePorts#config()` and the root
   `network.crypta.runtime.core.LegacyConfigPort` bridge instead of reaching through daemon
   internals.
 - Support foundation leaf (`:foundation-support`): stable generic support, support-api,

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConfigToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConfigToadlet.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigCallback;
+import network.crypta.config.DirectorySelectionCallback;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.config.NodeNeedRestartException;
@@ -12,7 +13,6 @@ import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
 import network.crypta.config.WrapperConfig;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.ProgramDirectory;
 import network.crypta.runtime.alerts.AbstractUserAlert;
 import network.crypta.runtime.alerts.UserAlert;
 import network.crypta.support.HTMLNode;
@@ -759,7 +759,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
     if (isBooleanCallback(callback)) {
       return OptionType.BOOLEAN;
     }
-    if (callback instanceof ProgramDirectory.DirectoryCallback && !callback.isReadOnly()) {
+    if (callback instanceof DirectorySelectionCallback && !callback.isReadOnly()) {
       return OptionType.DIRECTORY;
     }
     if (!callback.isReadOnly()) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -30,6 +30,8 @@ class HttpLegacyAdminBoundaryTest {
       Path.of("src", "main", "resources", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_HTTP_MAIN_JAVA =
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "http");
+  private static final Path ADAPTER_CONFIG_TOADLET =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("ConfigToadlet.java");
   private static final Path BROWSE_HTTP_MAIN_JAVA =
       Path.of(BROWSE_MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "http");
   private static final Path ADAPTER_SIMPLE_TOADLET_SERVER =
@@ -49,6 +51,8 @@ class HttpLegacyAdminBoundaryTest {
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellRuntimeSupport.java");
   private static final String USER_ALERT_MANAGER_IMPORT =
       "import network.crypta.runtime.alerts.UserAlertManager;";
+  private static final String PROGRAM_DIRECTORY_IMPORT =
+      "import network.crypta.node.ProgramDirectory;";
   private static final Path ADAPTER_HTTP_FPROXY_BOOTSTRAP =
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellFProxyBootstrap.java");
   private static final Path ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR =
@@ -643,6 +647,19 @@ class HttpLegacyAdminBoundaryTest {
             + "importing UserAlertManager directly."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void mainSources_whenCheckingConfigToadletImports_expectProgramDirectoryImportRemoved()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Set<String> imports = readImports(repoRoot.resolve(ADAPTER_CONFIG_TOADLET));
+
+    assertFalse(
+        imports.contains(PROGRAM_DIRECTORY_IMPORT),
+        repoRoot.resolve(ADAPTER_CONFIG_TOADLET)
+            + " must use the detached config directory-selection marker instead of importing "
+            + "ProgramDirectory directly.");
   }
 
   @Test

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -25,6 +25,11 @@ HTTP/admin alert rendering now crosses the detached
 manager type directly. This is one focused step in the ongoing removal of
 `adapter-http-legacy-admin -> :runtime-node` coupling without widening `:runtime-spi`.
 
+Admin config classification now also crosses a detached config-owned marker:
+`network.crypta.config.DirectorySelectionCallback` in `:foundation-config`. `ConfigToadlet`
+uses that marker to recognize directory-selection fields without importing the concrete
+runtime-owned `ProgramDirectory` callback types.
+
 The shared shell stays browse-neutral by crossing `LegacyHttpPaths` / `LegacyHttpCategories`
 constants and other small seam types instead of importing concrete browse-owned collaborator
 classes directly. Route publication, bookmark handling, push handling, and browser-side helpers

--- a/foundation-config/src/main/java/network/crypta/config/DirectorySelectionCallback.java
+++ b/foundation-config/src/main/java/network/crypta/config/DirectorySelectionCallback.java
@@ -1,0 +1,26 @@
+package network.crypta.config;
+
+/**
+ * Marks configuration callbacks whose value represents a directory path handled by the existing
+ * directory-selection UI flow.
+ *
+ * <p>This interface keeps the classification contract in {@code network.crypta.config} so admin and
+ * other configuration-facing code can recognize directory-backed options without importing a
+ * concrete runtime-owned callback implementation. Callers normally encounter the marker through a
+ * {@link ConfigCallback} instance and use it only for presentation or routing decisions, such as
+ * deciding whether to offer the legacy directory browser.
+ *
+ * <p>The marker is intentionally narrow. It identifies participation in the directory-selection
+ * flow, but it does not define path validation, normalization, or write access. Callers must still
+ * use {@link ConfigCallback#isReadOnly()} to determine mutability and rely on the surrounding
+ * callback family for get/set behavior.
+ *
+ * <ul>
+ *   <li>Use this marker to detect directory-selection options in detached UI code.
+ *   <li>Do not treat this marker as proof that the option is writable.
+ *   <li>Do not infer filesystem semantics beyond participation in the directory chooser flow.
+ * </ul>
+ *
+ * @see ConfigCallback
+ */
+public interface DirectorySelectionCallback {}

--- a/foundation-config/src/main/java/network/crypta/config/LegacyCallbackAdapters.java
+++ b/foundation-config/src/main/java/network/crypta/config/LegacyCallbackAdapters.java
@@ -213,13 +213,20 @@ final class LegacyCallbackAdapters {
     }
   }
 
-  private static final class DirectoryEnumerableStringCallbackAdapter
-      extends EnumerableStringCallbackAdapter implements DirectorySelectionCallback {
+  private static final class DirectoryEnumerableStringCallbackAdapter extends StringCallbackAdapter
+      implements EnumerableOptionCallback, DirectorySelectionCallback {
+    private final EnumerableOptionCallback enumerableCallback;
 
     private DirectoryEnumerableStringCallbackAdapter(
         network.crypta.support.api.StringCallback callback,
         EnumerableOptionCallback enumerableCallback) {
-      super(callback, enumerableCallback);
+      super(callback);
+      this.enumerableCallback = enumerableCallback;
+    }
+
+    @Override
+    public String[] getPossibleValues() {
+      return enumerableCallback.getPossibleValues();
     }
   }
 }

--- a/foundation-config/src/main/java/network/crypta/config/LegacyCallbackAdapters.java
+++ b/foundation-config/src/main/java/network/crypta/config/LegacyCallbackAdapters.java
@@ -127,8 +127,15 @@ final class LegacyCallbackAdapters {
     if (callback instanceof StringCallback adapted) {
       return adapted;
     }
+    boolean directorySelectionCallback = callback instanceof DirectorySelectionCallback;
     if (callback instanceof EnumerableOptionCallback enumerableCallback) {
+      if (directorySelectionCallback) {
+        return new DirectoryEnumerableStringCallbackAdapter(callback, enumerableCallback);
+      }
       return new EnumerableStringCallbackAdapter(callback, enumerableCallback);
+    }
+    if (directorySelectionCallback) {
+      return new DirectoryStringCallbackAdapter(callback);
     }
     return new StringCallbackAdapter(callback);
   }
@@ -181,7 +188,15 @@ final class LegacyCallbackAdapters {
     }
   }
 
-  private static final class EnumerableStringCallbackAdapter extends StringCallbackAdapter
+  private static class DirectoryStringCallbackAdapter extends StringCallbackAdapter
+      implements DirectorySelectionCallback {
+
+    private DirectoryStringCallbackAdapter(network.crypta.support.api.StringCallback callback) {
+      super(callback);
+    }
+  }
+
+  private static class EnumerableStringCallbackAdapter extends StringCallbackAdapter
       implements EnumerableOptionCallback {
     private final EnumerableOptionCallback enumerableCallback;
 
@@ -195,6 +210,16 @@ final class LegacyCallbackAdapters {
     @Override
     public String[] getPossibleValues() {
       return enumerableCallback.getPossibleValues();
+    }
+  }
+
+  private static final class DirectoryEnumerableStringCallbackAdapter
+      extends EnumerableStringCallbackAdapter implements DirectorySelectionCallback {
+
+    private DirectoryEnumerableStringCallbackAdapter(
+        network.crypta.support.api.StringCallback callback,
+        EnumerableOptionCallback enumerableCallback) {
+      super(callback, enumerableCallback);
     }
   }
 }

--- a/foundation-config/src/main/java/network/crypta/config/package-info.java
+++ b/foundation-config/src/main/java/network/crypta/config/package-info.java
@@ -16,6 +16,10 @@
  * may indicate a logical {@link network.crypta.config.Dimension} (for example, {@code SIZE} or
  * {@code DURATION}).
  *
+ * <p>Some callbacks also carry narrow UI markers such as {@link
+ * network.crypta.config.DirectorySelectionCallback} so HTTP admin code can classify special input
+ * flows without importing concrete runtime implementations.
+ *
  * <p>Persistence is environment-specific. {@link network.crypta.config.PersistentConfig} consumes
  * an initial {@link network.crypta.support.SimpleFieldSet} and exports the current state back to a
  * field set for storage. {@link network.crypta.config.WrapperConfig} provides limited support for

--- a/runtime-node/src/main/java/network/crypta/node/ProgramDirectory.java
+++ b/runtime-node/src/main/java/network/crypta/node/ProgramDirectory.java
@@ -3,6 +3,7 @@ package network.crypta.node;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import network.crypta.config.DirectorySelectionCallback;
 import network.crypta.config.InvalidConfigValueException;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.api.StringCallback;
@@ -103,7 +104,8 @@ public class ProgramDirectory {
    *
    * <p>Allows the first assignment and accepts idempotent writes; rejects changes thereafter.
    */
-  public class DirectoryCallback extends network.crypta.config.StringCallback {
+  public class DirectoryCallback extends network.crypta.config.StringCallback
+      implements DirectorySelectionCallback {
     @Override
     public String get() {
       return dir.getPath();

--- a/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
@@ -10,9 +10,11 @@ import java.util.Map;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigCallback;
+import network.crypta.config.DirectorySelectionCallback;
 import network.crypta.config.EnumerableOptionCallback;
 import network.crypta.config.NodeNeedRestartException;
 import network.crypta.config.Option;
+import network.crypta.config.StringCallback;
 import network.crypta.config.StringOption;
 import network.crypta.config.SubConfig;
 import network.crypta.config.WrapperConfig;
@@ -413,7 +415,9 @@ class ConfigToadletTest {
           }
 
           @Override
-          public void set(Boolean value) {}
+          public void set(Boolean value) {
+            ignoreCallbackMutation();
+          }
         };
     Object optionType = resolveOptionType(toadlet, callback);
 
@@ -442,17 +446,43 @@ class ConfigToadletTest {
   }
 
   @Test
+  void resolveOptionType_whenMarkerBasedWritableDirectoryCallback_expectDirectory()
+      throws Exception {
+    ConfigToadlet toadlet = createToadlet();
+    ConfigCallback<?> callback = new MarkerDirectoryStringCallback(false);
+
+    Object optionType = resolveOptionType(toadlet, callback);
+
+    assertEquals("DIRECTORY", optionType.toString());
+  }
+
+  @Test
+  void resolveOptionType_whenMarkerBasedReadOnlyDirectoryCallback_expectTextReadOnly()
+      throws Exception {
+    ConfigToadlet toadlet = createToadlet();
+    ConfigCallback<?> callback = new MarkerDirectoryStringCallback(true);
+
+    Object optionType = resolveOptionType(toadlet, callback);
+
+    assertEquals("TEXT_READ_ONLY", optionType.toString());
+  }
+
+  @Test
   @SuppressWarnings("deprecation")
   void resolveOptionType_whenLegacyEnumerableStringCallbackRegistered_expectDropDown()
       throws Exception {
     ConfigToadlet toadlet = createToadlet();
-    Config config = new Config();
-    SubConfig subConfig = config.createSubConfig("compat");
+    Config compatConfig = new Config();
+    SubConfig compatSubConfig = compatConfig.createSubConfig("compat");
     network.crypta.support.api.StringCallback callback =
         new LegacyEnumerableStringCallback("dark", new String[] {"light", "dark"});
     StringOption option =
         new StringOption(
-            subConfig, "theme", "dark", new Option.Meta(1, false, false, "sd", "ld"), callback);
+            compatSubConfig,
+            "theme",
+            "dark",
+            new Option.Meta(1, false, false, "sd", "ld"),
+            callback);
 
     Object optionType = resolveOptionType(toadlet, option.getCallback());
 
@@ -461,16 +491,75 @@ class ConfigToadletTest {
 
   @Test
   @SuppressWarnings("deprecation")
+  void resolveOptionType_whenLegacyEnumerableMarkerDirectoryCallbackRegistered_expectDropDown()
+      throws Exception {
+    ConfigToadlet toadlet = createToadlet();
+    Config compatConfig = new Config();
+    SubConfig compatSubConfig = compatConfig.createSubConfig("compat");
+    network.crypta.support.api.StringCallback callback =
+        new LegacyEnumerableDirectoryStringCallback("dark", false, new String[] {"light", "dark"});
+    StringOption option =
+        new StringOption(
+            compatSubConfig,
+            "theme",
+            "dark",
+            new Option.Meta(1, false, false, "sd", "ld"),
+            callback);
+
+    Object optionType = resolveOptionType(toadlet, option.getCallback());
+
+    assertEquals("DROP_DOWN", optionType.toString());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void resolveOptionType_whenLegacyMarkerDirectoryCallbackConstructed_expectDirectory()
+      throws Exception {
+    ConfigToadlet toadlet = createToadlet();
+    Config compatConfig = new Config();
+    SubConfig compatSubConfig = compatConfig.createSubConfig("compat");
+    network.crypta.support.api.StringCallback callback =
+        new LegacyDirectoryStringCallback("directory", false);
+    StringOption option =
+        new StringOption(
+            compatSubConfig, "dir", "path", new Option.Meta(1, false, false, "sd", "ld"), callback);
+
+    Object optionType = resolveOptionType(toadlet, option.getCallback());
+
+    assertEquals("DIRECTORY", optionType.toString());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void resolveOptionType_whenLegacyMarkerDirectoryCallbackRegisteredReadOnly_expectTextReadOnly()
+      throws Exception {
+    ConfigToadlet toadlet = createToadlet();
+    Config compatConfig = new Config();
+    SubConfig compatSubConfig = compatConfig.createSubConfig("compat");
+
+    compatSubConfig.register(
+        "dir",
+        "path",
+        new Option.Meta(1, false, false, "sd", "ld"),
+        new LegacyDirectoryStringCallback("directory", true));
+
+    Object optionType = resolveOptionType(toadlet, compatSubConfig.getOption("dir").getCallback());
+
+    assertEquals("TEXT_READ_ONLY", optionType.toString());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
   void resolveOptionType_whenLegacyProgramDirectoryCallbackRegistered_expectDirectory()
       throws Exception {
     ConfigToadlet toadlet = createToadlet();
-    Config config = new Config();
-    SubConfig subConfig = config.createSubConfig("compat");
+    Config compatConfig = new Config();
+    SubConfig compatSubConfig = compatConfig.createSubConfig("compat");
     network.crypta.support.api.StringCallback callback =
         new ProgramDirectory("move.error").getStringCallback();
     StringOption option =
         new StringOption(
-            subConfig, "dir", "path", new Option.Meta(1, false, false, "sd", "ld"), callback);
+            compatSubConfig, "dir", "path", new Option.Meta(1, false, false, "sd", "ld"), callback);
 
     Object optionType = resolveOptionType(toadlet, option.getCallback());
 
@@ -483,6 +572,93 @@ class ConfigToadletTest {
         ConfigToadlet.class.getDeclaredMethod("resolveOptionType", ConfigCallback.class);
     resolveOptionType.setAccessible(true);
     return resolveOptionType.invoke(toadlet, callback);
+  }
+
+  private static final class MarkerDirectoryStringCallback extends StringCallback
+      implements DirectorySelectionCallback {
+    private final boolean readOnly;
+
+    private MarkerDirectoryStringCallback(boolean readOnly) {
+      this.readOnly = readOnly;
+    }
+
+    @Override
+    public String get() {
+      return "directory";
+    }
+
+    @Override
+    public void set(String value) {
+      ignoreCallbackMutation();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private static final class LegacyDirectoryStringCallback
+      extends network.crypta.support.api.StringCallback implements DirectorySelectionCallback {
+    private final String value;
+    private final boolean readOnly;
+
+    private LegacyDirectoryStringCallback(String value, boolean readOnly) {
+      this.value = value;
+      this.readOnly = readOnly;
+    }
+
+    @Override
+    public String get() {
+      return value;
+    }
+
+    @Override
+    public void set(String updatedValue) {
+      ignoreCallbackMutation();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private static final class LegacyEnumerableDirectoryStringCallback
+      extends network.crypta.support.api.StringCallback
+      implements EnumerableOptionCallback, DirectorySelectionCallback {
+    private final String currentValue;
+    private final boolean readOnly;
+    private final String[] possibleValues;
+
+    private LegacyEnumerableDirectoryStringCallback(
+        String currentValue, boolean readOnly, String[] possibleValues) {
+      this.currentValue = currentValue;
+      this.readOnly = readOnly;
+      this.possibleValues = possibleValues;
+    }
+
+    @Override
+    public String get() {
+      return currentValue;
+    }
+
+    @Override
+    public void set(String value) {
+      ignoreCallbackMutation();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+
+    @Override
+    public String[] getPossibleValues() {
+      return possibleValues;
+    }
   }
 
   @SuppressWarnings("deprecation")
@@ -502,7 +678,9 @@ class ConfigToadletTest {
     }
 
     @Override
-    public void set(String value) {}
+    public void set(String value) {
+      ignoreCallbackMutation();
+    }
 
     @Override
     public String[] getPossibleValues() {
@@ -518,6 +696,10 @@ class ConfigToadletTest {
     when(request.getPartAsStringFailsafe(anyString(), anyInt()))
         .thenAnswer(invocation -> parts.getOrDefault(invocation.getArgument(0, String.class), ""));
     return request;
+  }
+
+  private static void ignoreCallbackMutation() {
+    // These helper callbacks exist only to exercise ConfigToadlet option-type resolution.
   }
 
   private void stubPageMaker() {

--- a/src/test/java/network/crypta/config/CallbackCompatibilityTest.java
+++ b/src/test/java/network/crypta/config/CallbackCompatibilityTest.java
@@ -3,7 +3,9 @@ package network.crypta.config;
 import network.crypta.node.ProgramDirectory;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -12,28 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SuppressWarnings("deprecation")
 class CallbackCompatibilityTest {
   private static final Option.Meta META = new Option.Meta(1, false, false, "sd", "ld");
-
-  @Test
-  void newCallbackTypesRemainAssignableToLegacyCallbacks() {
-    assertTrue(
-        network.crypta.support.api.BooleanCallback.class.isAssignableFrom(
-            network.crypta.config.BooleanCallback.class));
-    assertTrue(
-        network.crypta.support.api.IntCallback.class.isAssignableFrom(
-            network.crypta.config.IntCallback.class));
-    assertTrue(
-        network.crypta.support.api.LongCallback.class.isAssignableFrom(
-            network.crypta.config.LongCallback.class));
-    assertTrue(
-        network.crypta.support.api.ShortCallback.class.isAssignableFrom(
-            network.crypta.config.ShortCallback.class));
-    assertTrue(
-        network.crypta.support.api.StringCallback.class.isAssignableFrom(
-            network.crypta.config.StringCallback.class));
-    assertTrue(
-        network.crypta.support.api.StringArrCallback.class.isAssignableFrom(
-            network.crypta.config.StringArrCallback.class));
-  }
 
   @Test
   void subConfigRetainsLegacyRegisterDescriptors() {
@@ -216,9 +196,8 @@ class CallbackCompatibilityTest {
   @Test
   void legacyBooleanCallbackFactoryRemainsAvailable() {
     network.crypta.support.api.BooleanCallback callback =
-        network.crypta.support.api.BooleanCallback.from(() -> true, _ -> {});
+        network.crypta.support.api.BooleanCallback.from(() -> true, _ -> ignoreCallbackUpdate());
 
-    assertInstanceOf(network.crypta.support.api.BooleanCallback.class, callback);
     assertInstanceOf(network.crypta.config.BooleanCallback.class, callback);
   }
 
@@ -227,12 +206,6 @@ class CallbackCompatibilityTest {
     assertSame(
         network.crypta.support.api.StringCallback.class,
         ProgramDirectory.class.getMethod("getStringCallback").getReturnType());
-    assertTrue(
-        network.crypta.support.api.StringCallback.class.isAssignableFrom(
-            ProgramDirectory.DirectoryCallback.class));
-    assertTrue(
-        network.crypta.support.api.StringCallback.class.isAssignableFrom(
-            ProgramDirectory.RWDirectoryCallback.class));
   }
 
   @Test
@@ -240,26 +213,62 @@ class CallbackCompatibilityTest {
     ProgramDirectory readOnly = new ProgramDirectory();
     ProgramDirectory readWrite = new ProgramDirectory("compatibility.move.error");
 
-    assertInstanceOf(network.crypta.support.api.StringCallback.class, readOnly.getStringCallback());
     assertInstanceOf(network.crypta.config.StringCallback.class, readOnly.getStringCallback());
-    assertInstanceOf(
-        network.crypta.support.api.StringCallback.class, readWrite.getStringCallback());
+    assertInstanceOf(DirectorySelectionCallback.class, readOnly.getStringCallback());
     assertInstanceOf(network.crypta.config.StringCallback.class, readWrite.getStringCallback());
+    assertInstanceOf(DirectorySelectionCallback.class, readWrite.getStringCallback());
   }
 
   @Test
-  void nullCallbacksRemainAssignableToLegacyBridgeTypes() {
-    assertTrue(
-        network.crypta.support.api.BooleanCallback.class.isAssignableFrom(
-            NullBooleanCallback.class));
-    assertTrue(
-        network.crypta.support.api.IntCallback.class.isAssignableFrom(NullIntCallback.class));
-    assertTrue(
-        network.crypta.support.api.LongCallback.class.isAssignableFrom(NullLongCallback.class));
-    assertTrue(
-        network.crypta.support.api.ShortCallback.class.isAssignableFrom(NullShortCallback.class));
-    assertTrue(
-        network.crypta.support.api.StringCallback.class.isAssignableFrom(NullStringCallback.class));
+  void legacyStringCallbackAdaptersPreserveDirectorySelectionMarker() {
+    Config config = new Config();
+    SubConfig subConfig = config.createSubConfig("compat");
+    network.crypta.support.api.StringCallback constructorCallback =
+        new LegacyDirectorySelectionStringCallback("constructor", false);
+    StringOption constructorOption =
+        new StringOption(subConfig, "constructorPath", "constructor", META, constructorCallback);
+
+    assertBridgedRuntimeCallback(
+        constructorOption,
+        constructorCallback,
+        network.crypta.support.api.StringCallback.class,
+        network.crypta.config.StringCallback.class);
+    assertInstanceOf(DirectorySelectionCallback.class, constructorOption.getCallback());
+    assertFalse(constructorOption.getCallback().isReadOnly());
+
+    network.crypta.support.api.StringCallback registeredCallback =
+        new LegacyDirectorySelectionStringCallback("registered", true);
+    subConfig.register("registeredPath", "registered", META, registeredCallback);
+    Option<?> registeredOption = subConfig.getOption("registeredPath");
+
+    assertBridgedRuntimeCallback(
+        registeredOption,
+        registeredCallback,
+        network.crypta.support.api.StringCallback.class,
+        network.crypta.config.StringCallback.class);
+    assertInstanceOf(DirectorySelectionCallback.class, registeredOption.getCallback());
+    assertTrue(registeredOption.getCallback().isReadOnly());
+  }
+
+  @Test
+  void legacyEnumerableStringCallbackAdaptersPreserveDirectorySelectionMarker() {
+    Config config = new Config();
+    SubConfig subConfig = config.createSubConfig("compat");
+    network.crypta.support.api.StringCallback callback =
+        new LegacyEnumerableDirectorySelectionStringCallback(
+            "selected", false, new String[] {"first", "selected"});
+    StringOption option = new StringOption(subConfig, "directoryMode", "selected", META, callback);
+
+    assertBridgedRuntimeCallback(
+        option,
+        callback,
+        network.crypta.support.api.StringCallback.class,
+        network.crypta.config.StringCallback.class);
+    assertInstanceOf(DirectorySelectionCallback.class, option.getCallback());
+    EnumerableOptionCallback enumerableCallback =
+        assertInstanceOf(EnumerableOptionCallback.class, option.getCallback());
+    assertFalse(option.getCallback().isReadOnly());
+    assertArrayEquals(new String[] {"first", "selected"}, enumerableCallback.getPossibleValues());
   }
 
   @Test
@@ -274,7 +283,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Boolean value) {}
+          public void set(Boolean value) {
+            ignoreCallbackUpdate();
+          }
         };
     IntCallback intCallback =
         new IntCallback() {
@@ -284,7 +295,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Integer value) {}
+          public void set(Integer value) {
+            ignoreCallbackUpdate();
+          }
         };
     IntCallback bandwidthCallback =
         new IntCallback() {
@@ -294,7 +307,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Integer value) {}
+          public void set(Integer value) {
+            ignoreCallbackUpdate();
+          }
         };
     LongCallback longCallback =
         new LongCallback() {
@@ -304,7 +319,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Long value) {}
+          public void set(Long value) {
+            ignoreCallbackUpdate();
+          }
         };
     ShortCallback shortCallback =
         new ShortCallback() {
@@ -314,7 +331,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Short value) {}
+          public void set(Short value) {
+            ignoreCallbackUpdate();
+          }
         };
     StringCallback stringCallback =
         new StringCallback() {
@@ -324,7 +343,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(String value) {}
+          public void set(String value) {
+            ignoreCallbackUpdate();
+          }
         };
     StringArrCallback stringArrCallback =
         new StringArrCallback() {
@@ -334,7 +355,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(String[] value) {}
+          public void set(String[] value) {
+            ignoreCallbackUpdate();
+          }
         };
 
     assertLegacyRuntimeCallback(
@@ -379,7 +402,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Boolean value) {}
+          public void set(Boolean value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.IntCallback intCallback =
         new network.crypta.support.api.IntCallback() {
@@ -389,7 +414,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Integer value) {}
+          public void set(Integer value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.IntCallback bandwidthCallback =
         new network.crypta.support.api.IntCallback() {
@@ -399,7 +426,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Integer value) {}
+          public void set(Integer value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.LongCallback longCallback =
         new network.crypta.support.api.LongCallback() {
@@ -409,7 +438,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Long value) {}
+          public void set(Long value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.ShortCallback shortCallback =
         new network.crypta.support.api.ShortCallback() {
@@ -419,7 +450,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Short value) {}
+          public void set(Short value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.StringCallback stringCallback =
         new network.crypta.support.api.StringCallback() {
@@ -429,7 +462,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(String value) {}
+          public void set(String value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.StringArrCallback stringArrCallback =
         new network.crypta.support.api.StringArrCallback() {
@@ -439,7 +474,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(String[] value) {}
+          public void set(String[] value) {
+            ignoreCallbackUpdate();
+          }
         };
 
     assertBridgedRuntimeCallback(
@@ -491,7 +528,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Boolean value) {}
+          public void set(Boolean value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.IntCallback intCallback =
         new network.crypta.support.api.IntCallback() {
@@ -501,7 +540,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Integer value) {}
+          public void set(Integer value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.IntCallback bandwidthCallback =
         new network.crypta.support.api.IntCallback() {
@@ -511,7 +552,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Integer value) {}
+          public void set(Integer value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.IntCallback bandwidthStringCallback =
         new network.crypta.support.api.IntCallback() {
@@ -521,7 +564,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Integer value) {}
+          public void set(Integer value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.LongCallback longCallback =
         new network.crypta.support.api.LongCallback() {
@@ -531,7 +576,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Long value) {}
+          public void set(Long value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.LongCallback longStringCallback =
         new network.crypta.support.api.LongCallback() {
@@ -541,7 +588,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Long value) {}
+          public void set(Long value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.ShortCallback shortCallback =
         new network.crypta.support.api.ShortCallback() {
@@ -551,7 +600,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(Short value) {}
+          public void set(Short value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.StringCallback stringCallback =
         new network.crypta.support.api.StringCallback() {
@@ -561,7 +612,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(String value) {}
+          public void set(String value) {
+            ignoreCallbackUpdate();
+          }
         };
     network.crypta.support.api.StringArrCallback stringArrCallback =
         new network.crypta.support.api.StringArrCallback() {
@@ -571,7 +624,9 @@ class CallbackCompatibilityTest {
           }
 
           @Override
-          public void set(String[] value) {}
+          public void set(String[] value) {
+            ignoreCallbackUpdate();
+          }
         };
 
     subConfig.register("flag", true, META, booleanCallback);
@@ -635,6 +690,71 @@ class CallbackCompatibilityTest {
       Option<?> option, Object callback, Class<?> legacyType) {
     assertSame(callback, option.getCallback());
     assertInstanceOf(legacyType, option.getCallback());
+  }
+
+  private static void ignoreCallbackUpdate() {
+    // Compatibility tests exercise callback typing and registration, not mutation behavior.
+  }
+
+  private static final class LegacyDirectorySelectionStringCallback
+      extends network.crypta.support.api.StringCallback implements DirectorySelectionCallback {
+    private final String value;
+    private final boolean readOnly;
+
+    private LegacyDirectorySelectionStringCallback(String value, boolean readOnly) {
+      this.value = value;
+      this.readOnly = readOnly;
+    }
+
+    @Override
+    public String get() {
+      return value;
+    }
+
+    @Override
+    public void set(String updatedValue) {
+      ignoreCallbackUpdate();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+  }
+
+  private static final class LegacyEnumerableDirectorySelectionStringCallback
+      extends network.crypta.support.api.StringCallback
+      implements DirectorySelectionCallback, EnumerableOptionCallback {
+    private final String value;
+    private final boolean readOnly;
+    private final String[] possibleValues;
+
+    private LegacyEnumerableDirectorySelectionStringCallback(
+        String value, boolean readOnly, String[] possibleValues) {
+      this.value = value;
+      this.readOnly = readOnly;
+      this.possibleValues = possibleValues;
+    }
+
+    @Override
+    public String get() {
+      return value;
+    }
+
+    @Override
+    public void set(String updatedValue) {
+      ignoreCallbackUpdate();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+
+    @Override
+    public String[] getPossibleValues() {
+      return possibleValues;
+    }
   }
 
   private static void assertBridgedRuntimeCallback(


### PR DESCRIPTION
## Summary
- move the legacy HTTP config directory-selection contract to `:foundation-config` via `DirectorySelectionCallback`, keep `ProgramDirectory` runtime-owned, and switch `ConfigToadlet` away from the concrete runtime callback type
- preserve the new marker through deprecated legacy `support.api.StringCallback` adaptation paths, including the combined enumerable-plus-directory case
- refresh the legacy HTTP boundary docs, README, and local agent skills so the current extracted-leaf layout and admin/config seams match the codebase

## How to test
- `./gradlew spotlessApply`
- `./gradlew :test --tests "network.crypta.clients.http.ConfigToadletTest" --tests "network.crypta.config.CallbackCompatibilityTest"`
- `./gradlew :adapter-http-legacy-admin:test --tests "network.crypta.runtime.bootstrap.HttpLegacyAdminBoundaryTest"`
- `./gradlew test`

## Notes
- base branch: `develop`
- branch commits:
  - `refactor(http): Detach config directory marker`
  - `docs(architecture): Refresh leaf boundary guidance`