### PR TITLE
refactor(connections): Route noderef loading through runtime SPI

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -1,20 +1,15 @@
 package network.crypta.clients.http;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringTokenizer;
-import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.ConfigException;
-import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
@@ -376,51 +371,27 @@ public abstract class ConnectionsToadlet extends Toadlet {
   private StringBuilder fetchReference(AddPeerRequestData data, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
     if (!data.urltext().isEmpty()) {
-      return fetchReferenceFromUrl(data.urltext(), ctx);
+      try {
+        return connectionsSupportPort.readPeerReferenceText(data.urltext());
+      } catch (IOException _) {
+        this.sendErrorPage(
+            ctx,
+            200,
+            l10n("failedToAddNodeTitle"),
+            NodeL10n.getBase()
+                .getString(
+                    "DarknetConnectionsToadlet.cantFetchNoderefURL",
+                    new String[] {"url"},
+                    new String[] {data.urltext()}),
+            !isOpennet());
+        return null;
+      }
     }
     if (!data.reftext().isEmpty()) {
       return new StringBuilder(cleanReferenceText(data.reftext()));
     }
     this.sendErrorPage(ctx, 200, l10n("failedToAddNodeTitle"), l10n("noRefOrURL"), !isOpennet());
     return null;
-  }
-
-  private StringBuilder fetchReferenceFromUrl(String urltext, ToadletContext ctx)
-      throws ToadletContextClosedException, IOException {
-    try {
-      return fetchReferenceViaUrl(urltext);
-    } catch (IOException _) {
-      this.sendErrorPage(
-          ctx,
-          200,
-          l10n("failedToAddNodeTitle"),
-          NodeL10n.getBase()
-              .getString(
-                  "DarknetConnectionsToadlet.cantFetchNoderefURL",
-                  new String[] {"url"},
-                  new String[] {urltext}),
-          !isOpennet());
-      return null;
-    }
-  }
-
-  private StringBuilder fetchReferenceViaUrl(String urltext) throws IOException {
-    try {
-      FreenetURI refUri = new FreenetURI(urltext);
-      return PeerReferenceTextLoader.readFromFreenetUri(refUri, client);
-    } catch (MalformedURLException | FetchException _) {
-      LOG.warn("Url cannot be used as Crypta URI, trying to fetch as URL: {}", urltext);
-      URL url = buildUrl(urltext);
-      return PeerReferenceTextLoader.readFromUrl(url);
-    }
-  }
-
-  private URL buildUrl(String urltext) throws MalformedURLException {
-    try {
-      return URI.create(urltext).toURL();
-    } catch (IllegalArgumentException uriException) {
-      throw new MalformedURLException(uriException.getMessage());
-    }
   }
 
   private void processReferences(AddPeerRequestData data, StringBuilder ref, ToadletContext ctx)

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -216,6 +216,7 @@ class HttpLegacyAdminBoundaryTest {
           "import network.crypta.node.DarknetPeerNode.FRIEND_TRUST;",
           "import network.crypta.node.DarknetPeerNode.FRIEND_VISIBILITY;",
           "import network.crypta.node.Version;",
+          "import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;",
           "import network.crypta.runtime.peers.html.PeerTrustInputForAddPeerBoxNode;",
           "import network.crypta.runtime.peers.html.PeerVisibilityInputForAddPeerBoxNode;");
   private static final Set<String> EXPECTED_DEFAULT_BRIDGE_FACTORIES_HTTP_IMPORTS =

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -1,7 +1,10 @@
 package network.crypta.runtime.admin;
 
+import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.support.http.HttpFetchSizeLimits;
 
 /**
  * Creates the legacy admin and page-oriented runtime SPI adapters as one package-owned bundle.
@@ -37,9 +40,14 @@ public final class AdminRuntimePortsFactory {
    */
   public static AdminRuntimePortsBundle create(
       Node node, NodeClientCore core, AdminRuntimeBridgeInputs bridgeInputs) {
+    long maxLengthNoProgress = HttpFetchSizeLimits.getMaxLengthNoProgress();
+    HighLevelSimpleClient peerReferenceClient =
+        core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+    peerReferenceClient.setMaxLength(maxLengthNoProgress);
+    peerReferenceClient.setMaxIntermediateLength(maxLengthNoProgress);
     return new AdminRuntimePortsBundle(
         new LegacyConnectionsPagePort(node, bridgeInputs.geoIpCountryLookup()),
-        new LegacyConnectionsSupportPort(node),
+        new LegacyConnectionsSupportPort(node, peerReferenceClient),
         new LegacyDarknetConnectionsPort(node),
         new LegacyDarknetMessagingPort(node),
         new LegacyDiagnosticPort(node, core, bridgeInputs.queueAdminBackend()),

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyConnectionsSupportPort.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyConnectionsSupportPort.java
@@ -2,9 +2,16 @@ package network.crypta.runtime.admin;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 import java.util.Objects;
+import network.crypta.client.FetchException;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.NodeFile;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.spi.ConnectionsInstallerSnapshot;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.updater.NodeUpdateManager;
@@ -14,14 +21,16 @@ import network.crypta.support.io.FileUtil;
  * Adapts the remaining connections-page support helpers behind the runtime SPI.
  *
  * <p>This bridge is intentionally narrow and transitional. It keeps the legacy add-friend installer
- * lookups, opennet-enabled check, and peer-offer file traversal inside the daemon root module while
- * exposing only JDK-only values to the HTTP connections-family toadlets.
+ * lookups, opennet-enabled check, peer-offer file traversal, and noderef text loading inside the
+ * daemon root module while exposing only JDK-only values to the HTTP connections-family toadlets.
  */
 final class LegacyConnectionsSupportPort implements ConnectionsSupportPort {
   private final Node node;
+  private final HighLevelSimpleClient peerReferenceClient;
 
-  LegacyConnectionsSupportPort(Node node) {
+  LegacyConnectionsSupportPort(Node node, HighLevelSimpleClient peerReferenceClient) {
     this.node = Objects.requireNonNull(node);
+    this.peerReferenceClient = Objects.requireNonNull(peerReferenceClient);
   }
 
   @Override
@@ -61,5 +70,38 @@ final class LegacyConnectionsSupportPort implements ConnectionsSupportPort {
       }
     }
     return peerOfferReferencesText.toString();
+  }
+
+  @Override
+  public StringBuilder readPeerReferenceText(String locationText) throws IOException {
+    try {
+      FreenetURI freenetURI = new FreenetURI(locationText);
+      return readFromFreenetUriOrUrl(freenetURI, locationText);
+    } catch (MalformedURLException _) {
+      return readFromUrl(locationText);
+    }
+  }
+
+  private StringBuilder readFromFreenetUriOrUrl(FreenetURI freenetURI, String locationText)
+      throws IOException {
+    try {
+      return PeerReferenceTextLoader.readFromFreenetUri(freenetURI, peerReferenceClient);
+    } catch (FetchException _) {
+      return readFromUrl(locationText);
+    }
+  }
+
+  private static StringBuilder readFromUrl(String locationText) throws IOException {
+    return PeerReferenceTextLoader.readFromUrl(buildUrl(locationText));
+  }
+
+  private static URL buildUrl(String locationText) throws MalformedURLException {
+    try {
+      return URI.create(locationText).toURL();
+    } catch (IllegalArgumentException e) {
+      MalformedURLException malformedURLException = new MalformedURLException(e.getMessage());
+      malformedURLException.initCause(e);
+      throw malformedURLException;
+    }
   }
 }

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsSupportPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ConnectionsSupportPort.java
@@ -8,9 +8,9 @@ import java.io.IOException;
  * <p>This port is intentionally transitional and page-oriented. The legacy friends and strangers
  * pages still need a small set of support helpers that do not justify widening broader runtime SPI
  * surfaces such as {@link ConnectionsPagePort} or {@link NodeInfoPort}: installer download metadata
- * for the add-friend page, one feature-flag check, and one file-backed noderef import source.
- * Implementations may delegate to live daemon state internally while exposing only JDK-only types
- * here.
+ * for the add-friend page, one feature-flag check, one file-backed noderef import source, and one
+ * URL/Freenet-URI noderef loading helper. Implementations may delegate to live daemon state
+ * internally while exposing only JDK-only types here.
  *
  * <p>The port is not a general node API. It exists only to finish removing direct daemon-root
  * dependencies from the legacy connections-family HTTP toadlets.
@@ -59,4 +59,17 @@ public interface ConnectionsSupportPort {
    * @throws IOException on I/O failure while reading the peer-offer reference files
    */
   String readPeerOfferReferencesText() throws IOException;
+
+  /**
+   * Reads peer-reference text from a URL or Freenet URI source for legacy add-peer import.
+   *
+   * <p>The supplied location text may be a Freenet URI or a regular URL. Implementations should
+   * preserve the historical URI-first then URL-fallback loading behavior while keeping the exposed
+   * API JDK-only.
+   *
+   * @param locationText source text naming the peer-reference document to load
+   * @return fetched peer-reference text with the legacy newline-preserving shape
+   * @throws IOException if the text cannot be parsed as a usable location or if loading fails
+   */
+  StringBuilder readPeerReferenceText(String locationText) throws IOException;
 }

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.http;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -55,6 +56,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -428,6 +430,63 @@ class DarknetConnectionsToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenAddPeerFormUsesUrl_delegatesReferenceLoadingThroughSupportPort()
+      throws Exception {
+    String locationText = "https://example.invalid/noderef";
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isPartSet("add")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("url", 200)).thenReturn(locationText);
+    when(request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("peerPrivateNote", 250)).thenReturn("");
+    when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("false");
+    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn(PeerTrust.NORMAL.name());
+    when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn(PeerVisibility.NO.name());
+    when(connectionsSupportPort.readPeerReferenceText(locationText))
+        .thenReturn(new StringBuilder(VALID_PEER_REFERENCE));
+    when(peerPort.add(any(), any(), any())).thenReturn(peerSnapshot("peer-added"));
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    captureBody(ctx);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/friends/"), request, ctx);
+
+    verify(connectionsSupportPort).readPeerReferenceText(locationText);
+    ArgumentCaptor<PeerFieldSet> fieldSetCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
+    verify(peerPort).add(fieldSetCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.NO));
+    assertEquals("peer-identity", fieldSetCaptor.getValue().directValues().get("identity"));
+    assertEquals("1", fieldSetCaptor.getValue().directValues().get("lastGoodVersion"));
+  }
+
+  @Test
+  void handleMethodPOST_whenUrlReferenceLoadingFails_rendersErrorPageAndSkipsPeerAdd()
+      throws Exception {
+    String locationText = "https://example.invalid/noderef";
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(request.isPartSet("add")).thenReturn(true);
+    when(request.getPartAsStringFailsafe("url", 200)).thenReturn(locationText);
+    when(request.getPartAsStringFailsafe("ref", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("reffile", Integer.MAX_VALUE)).thenReturn("");
+    when(request.getPartAsStringFailsafe("peerPrivateNote", 250)).thenReturn("");
+    when(request.getPartAsStringFailsafe("peers-offers-files", 5)).thenReturn("false");
+    when(request.getPartAsStringFailsafe("trust", 10)).thenReturn(PeerTrust.NORMAL.name());
+    when(request.getPartAsStringFailsafe("visibility", 10)).thenReturn(PeerVisibility.NO.name());
+    when(connectionsSupportPort.readPeerReferenceText(locationText))
+        .thenThrow(new IOException("boom"));
+    PageMaker pageMaker = stubPageMaker(new HTMLNode("div"));
+    when(ctx.getPageMaker()).thenReturn(pageMaker);
+    ByteArrayOutputStream body = captureBody(ctx);
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/friends/"), request, ctx);
+
+    verify(connectionsSupportPort).readPeerReferenceText(locationText);
+    verifyNoInteractions(peerPort);
+    String html = body.toString(StandardCharsets.UTF_8);
+    assertTrue(html.contains(locationText));
+    assertTrue(html.contains("/addfriend/"));
+  }
+
+  @Test
   void handleMethodPOST_whenAddPeerFormContainsDarknetReference_addsPeerAndWritesPrivateNote()
       throws Exception {
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
@@ -564,7 +623,11 @@ class DarknetConnectionsToadletTest {
     Mockito.lenient()
         .when(
             pageMaker.getInfobox(
-                anyString(), anyString(), any(HTMLNode.class), anyString(), anyBoolean()))
+                anyString(),
+                anyString(),
+                any(HTMLNode.class),
+                nullable(String.class),
+                anyBoolean()))
         .thenAnswer(
             invocation -> {
               HTMLNode parentNode = invocation.getArgument(2);

--- a/src/test/java/network/crypta/runtime/admin/AdminRuntimePortsFactoryTest.java
+++ b/src/test/java/network/crypta/runtime/admin/AdminRuntimePortsFactoryTest.java
@@ -1,0 +1,64 @@
+package network.crypta.runtime.admin;
+
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.node.Node;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestStarter;
+import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
+import network.crypta.runtime.admin.queue.QueueAdminBackend;
+import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueInsertPort;
+import network.crypta.support.http.HttpFetchSizeLimits;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminRuntimePortsFactoryTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Node node;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private NodeClientCore core;
+
+  @Mock private HighLevelSimpleClient peerReferenceClient;
+  @Mock private QueueAdminBackend queueAdminBackend;
+  @Mock private QueuePageBackend queuePageBackend;
+  @Mock private QueueCompletionPort queueCompletionPort;
+  @Mock private QueueDownloadPort queueDownloadPort;
+  @Mock private QueueInsertPort queueInsertPort;
+  @Mock private GeoIpCountryLookup geoIpCountryLookup;
+
+  @Test
+  void create_whenBuildingBundle_usesRealtimeSizeCappedClientForPeerReferenceLoading() {
+    AdminRuntimeBridgeInputs bridgeInputs =
+        new AdminRuntimeBridgeInputs(
+            queueAdminBackend,
+            queuePageBackend,
+            queueCompletionPort,
+            queueDownloadPort,
+            queueInsertPort,
+            geoIpCountryLookup);
+    when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true))
+        .thenReturn(peerReferenceClient);
+
+    AdminRuntimePortsBundle bundle = AdminRuntimePortsFactory.create(node, core, bridgeInputs);
+
+    assertNotNull(bundle.connectionsSupport());
+    verify(core).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
+    verify(peerReferenceClient).setMaxLength(HttpFetchSizeLimits.getMaxLengthNoProgress());
+    verify(peerReferenceClient)
+        .setMaxIntermediateLength(HttpFetchSizeLimits.getMaxLengthNoProgress());
+    verify(core, never()).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, false);
+  }
+}

--- a/src/test/java/network/crypta/runtime/admin/LegacyConnectionsSupportPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyConnectionsSupportPortTest.java
@@ -1,14 +1,21 @@
 package network.crypta.runtime.admin;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
+import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.NodeFile;
 import network.crypta.node.ProgramDirectory;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.runtime.peers.reference.PeerReferenceTextLoader;
 import network.crypta.runtime.services.NodeServicesSubsystem;
 import network.crypta.runtime.spi.ConnectionsInstallerSnapshot;
 import network.crypta.runtime.updater.NodeUpdateManager;
@@ -17,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,8 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +45,7 @@ class LegacyConnectionsSupportPortTest {
   @Mock private Node node;
   @Mock private NodeServicesSubsystem services;
   @Mock private NodeUpdateManager nodeUpdater;
+  @Mock private HighLevelSimpleClient peerReferenceClient;
 
   @TempDir private Path tempDir;
 
@@ -44,7 +55,7 @@ class LegacyConnectionsSupportPortTest {
   void setUp() {
     lenient().when(node.services()).thenReturn(services);
     lenient().when(services.nodeUpdater()).thenReturn(nodeUpdater);
-    port = new LegacyConnectionsSupportPort(node);
+    port = new LegacyConnectionsSupportPort(node, peerReferenceClient);
   }
 
   @Test
@@ -129,6 +140,83 @@ class LegacyConnectionsSupportPortTest {
 
     assertEquals(expected.toString(), actual);
     assertFalse(actual.contains("ignored"));
+  }
+
+  @Test
+  void readPeerReferenceText_whenFreenetUriLoadSucceeds_returnsFreenetText() throws Exception {
+    FreenetURI uri = new FreenetURI("KSK@peer-reference");
+    StringBuilder expected = new StringBuilder();
+    expected.append("freenet-line-1\n").append("freenet-line-2\n");
+
+    try (MockedStatic<PeerReferenceTextLoader> mocked = mockStatic(PeerReferenceTextLoader.class)) {
+      mocked
+          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, peerReferenceClient))
+          .thenReturn(expected);
+
+      StringBuilder actual = port.readPeerReferenceText(uri.toString());
+
+      assertSame(expected, actual);
+      mocked.verify(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, peerReferenceClient));
+      mocked.verifyNoMoreInteractions();
+    }
+  }
+
+  @Test
+  void readPeerReferenceText_whenFreenetFetchFails_fallsBackToUrlLoader() throws Exception {
+    String locationText = "https://example.invalid/KSK@peer-reference";
+    FreenetURI uri = new FreenetURI(locationText);
+    URL url = URI.create(locationText).toURL();
+    StringBuilder expected = new StringBuilder();
+    expected.append("url-line-1\n").append("url-line-2\n");
+
+    try (MockedStatic<PeerReferenceTextLoader> mocked = mockStatic(PeerReferenceTextLoader.class)) {
+      mocked
+          .when(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, peerReferenceClient))
+          .thenThrow(new FetchException(FetchExceptionMode.DATA_NOT_FOUND));
+      mocked.when(() -> PeerReferenceTextLoader.readFromUrl(url)).thenReturn(expected);
+
+      StringBuilder actual = port.readPeerReferenceText(locationText);
+
+      assertSame(expected, actual);
+      mocked.verify(() -> PeerReferenceTextLoader.readFromFreenetUri(uri, peerReferenceClient));
+      mocked.verify(() -> PeerReferenceTextLoader.readFromUrl(url));
+      mocked.verifyNoMoreInteractions();
+    }
+  }
+
+  @Test
+  void readPeerReferenceText_whenFreenetUriParsingFails_fallsBackToUrlLoader() throws Exception {
+    URL url = tempDir.resolve("peer-reference.txt").toUri().toURL();
+    StringBuilder expected = new StringBuilder();
+    expected.append("url-line-1\n").append("url-line-2\n");
+
+    try (MockedStatic<PeerReferenceTextLoader> mocked = mockStatic(PeerReferenceTextLoader.class)) {
+      mocked.when(() -> PeerReferenceTextLoader.readFromUrl(url)).thenReturn(expected);
+
+      StringBuilder actual = port.readPeerReferenceText(url.toExternalForm());
+
+      assertSame(expected, actual);
+      mocked.verify(() -> PeerReferenceTextLoader.readFromUrl(url));
+      mocked.verifyNoMoreInteractions();
+    }
+  }
+
+  @Test
+  void readPeerReferenceText_whenUrlReadFails_propagatesIOException() throws Exception {
+    URL url = tempDir.resolve("peer-reference.txt").toUri().toURL();
+
+    try (MockedStatic<PeerReferenceTextLoader> mocked = mockStatic(PeerReferenceTextLoader.class)) {
+      mocked
+          .when(() -> PeerReferenceTextLoader.readFromUrl(url))
+          .thenThrow(new IOException("boom"));
+
+      IOException exception =
+          assertThrows(IOException.class, () -> port.readPeerReferenceText(url.toExternalForm()));
+
+      assertEquals("boom", exception.getMessage());
+      mocked.verify(() -> PeerReferenceTextLoader.readFromUrl(url));
+      mocked.verifyNoMoreInteractions();
+    }
   }
 
   private void stubRunDir() throws Exception {


### PR DESCRIPTION
## Summary
- add `ConnectionsSupportPort.readPeerReferenceText(String)` so legacy add-peer URL and Freenet-URI noderef loading goes through the existing JDK-only runtime SPI
- move the concrete noderef loading logic into `LegacyConnectionsSupportPort` and remove `ConnectionsToadlet`'s direct dependency on `PeerReferenceTextLoader`
- preserve the old HTTP client behavior for Freenet noderef fetches by keeping realtime scheduling and the no-progress size limits on the runtime-owned client, and add focused regression coverage

## How to test
- `./gradlew :test --tests "network.crypta.runtime.admin.AdminRuntimePortsFactoryTest" --tests "network.crypta.runtime.admin.LegacyConnectionsSupportPortTest" --tests "network.crypta.clients.http.DarknetConnectionsToadletTest"`
- `./gradlew :adapter-http-legacy-admin:test --tests "network.crypta.runtime.bootstrap.HttpLegacyAdminBoundaryTest"`
- `./gradlew test`

## Notes
- `PeerReferenceTextLoader` remains in `:runtime-node`
- FCP and text-mode code are unchanged
- `ConnectionsToadlet` now delegates URL/Freenet-URI noderef loading through `ConnectionsSupportPort`