### PR TITLE
refactor(http): Harden legacy HTTP boundary seams

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ChatForumsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ChatForumsToadlet.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
@@ -31,15 +30,11 @@ public class ChatForumsToadlet extends Toadlet implements LinkEnabledCallback {
   /**
    * Creates a toadlet that can render the chat/forums landing page using the provided dependencies.
    *
-   * <p>The constructor passes the {@link HighLevelSimpleClient} to the {@link Toadlet} base class.
-   * No network operations occur here; the instance is ready for registration immediately after
+   * <p>No network operations occur here; the instance is ready for registration immediately after
    * construction and may be reused across requests because it contains no per-request state.
-   *
-   * @param client high-level client used by the superclass to perform standard toadlet duties; must
-   *     be non-null and already initialized for HTTP routing.
    */
-  protected ChatForumsToadlet(HighLevelSimpleClient client) {
-    super(client);
+  protected ChatForumsToadlet() {
+    super();
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConfigToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConfigToadlet.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigCallback;
 import network.crypta.config.DirectorySelectionCallback;
@@ -160,9 +159,9 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
   private enum OptionType {
     /** A writable option with an enumerable list of possible values. */
     DROP_DOWN("dropdown"),
-    /** A writable option which can be either true or false. */
+    /** A writable option that can be either true or false. */
     BOOLEAN("boolean"),
-    /** A writable option which is a path to a directory. */
+    /** A writable option that is a path to a directory. */
     DIRECTORY("directory"),
     /** A writable option set with a string of text. */
     TEXT("text"),
@@ -188,7 +187,6 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
    *
    * @param directoryBrowserPath path segment for directory browsing, with or without slashes; never
    *     {@code null} after normalization.
-   * @param client HTTP client used for outbound helper requests initiated by the parent toadlet.
    * @param conf configuration root used to traverse and update legacy option metadata.
    * @param subConfig logical configuration group that provides the options to render and update.
    * @param runtimePorts detached runtime services used for persistence, wrapper-state checks, and
@@ -196,11 +194,10 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
    */
   ConfigToadlet(
       String directoryBrowserPath,
-      HighLevelSimpleClient client,
       Config conf,
       SubConfig subConfig,
       ConfigToadletRuntimePorts runtimePorts) {
-    this(client, conf, subConfig, runtimePorts);
+    this(conf, subConfig, runtimePorts);
     this.directoryBrowserPath = normalizeDirectoryBrowserPath(directoryBrowserPath);
   }
 
@@ -211,18 +208,13 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
    * directory browsing endpoint. The path defaults to {@code /unset-browser-path/} until the caller
    * supplies a real location via the alternate constructor.
    *
-   * @param client HTTP client used for outbound helper requests initiated by the parent toadlet.
    * @param conf configuration root used to traverse and update legacy option metadata.
    * @param subConfig logical configuration group that provides the options to render and update.
    * @param runtimePorts detached runtime services used for persistence, wrapper-state checks, and
    *     directory-browser defaults.
    */
-  ConfigToadlet(
-      HighLevelSimpleClient client,
-      Config conf,
-      SubConfig subConfig,
-      ConfigToadletRuntimePorts runtimePorts) {
-    super(client);
+  ConfigToadlet(Config conf, SubConfig subConfig, ConfigToadletRuntimePorts runtimePorts) {
+    super();
     config = conf;
     this.runtimePorts = runtimePorts;
     this.subConfig = subConfig;

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectionsToadlet.java
@@ -7,7 +7,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringTokenizer;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.ConfigException;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.ConfigPort;
@@ -118,13 +117,11 @@ public abstract class ConnectionsToadlet extends Toadlet {
   /**
    * Creates a toadlet bound to shared node infrastructure used by connection pages.
    *
-   * @param client high-level client used to retrieve noderefs via Freenet or HTTP when users submit
-   *     URLs instead of pasted references.
    * @param runtimePorts shared detached runtime ports backing page rendering, peer changes, noderef
    *     export, config lookups, and legacy page-support helpers.
    */
-  ConnectionsToadlet(HighLevelSimpleClient client, ConnectionsToadletRuntimePorts runtimePorts) {
-    super(client);
+  ConnectionsToadlet(ConnectionsToadletRuntimePorts runtimePorts) {
+    super();
     ConnectionsToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts);
     this.connectionsPage = ports.connectionsPage();
     this.peerPort = ports.peerPort();

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ConnectivityToadlet.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.http.ConnectivityPagePaths;
 import network.crypta.runtime.spi.ConnectivityGapSnapshot;
@@ -48,13 +47,12 @@ public class ConnectivityToadlet extends Toadlet {
   private final ConnectivityPort connectivity;
 
   /**
-   * Creates a new connectivity toadlet bound to the given client and connectivity port.
+   * Creates a new connectivity toadlet bound to the given connectivity port.
    *
-   * @param client high-level HTTP client used by the superclass for rendering utilities
    * @param connectivity read-only runtime connectivity port backing this page
    */
-  protected ConnectivityToadlet(HighLevelSimpleClient client, ConnectivityPort connectivity) {
-    super(client);
+  protected ConnectivityToadlet(ConnectivityPort connectivity) {
+    super();
     this.connectivity = connectivity;
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetAddRefToadlet.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.ConnectionsInstallerSnapshot;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
@@ -63,17 +62,14 @@ public class DarknetAddRefToadlet extends Toadlet {
    *     null}
    * @param nodeInfoPort node-info port supplying the public darknet noderef export; must not be
    *     {@code null}
-   * @param client high-level HTTP client the superclass relies on for responses and redirects; may
-   *     share the lifecycle of the enclosing HTTP server.
    * @param friendsToadlet companion toadlet used to render friend lists and noderef boxes within
    *     this page; should correspond to the same node instance.
    */
   protected DarknetAddRefToadlet(
       ConnectionsSupportPort connectionsSupportPort,
       NodeInfoPort nodeInfoPort,
-      HighLevelSimpleClient client,
       DarknetConnectionsToadlet friendsToadlet) {
-    super(client);
+    super();
     this.connectionsSupportPort = Objects.requireNonNull(connectionsSupportPort);
     this.nodeInfoPort = Objects.requireNonNull(nodeInfoPort);
     this.friendsToadlet = Objects.requireNonNull(friendsToadlet);
@@ -213,8 +209,8 @@ public class DarknetAddRefToadlet extends Toadlet {
    * the immediate HTTP response, because it reflects the node’s current configuration and may
    * change when peers or keys are rotated.
    *
-   * @return field set view of the current exported darknet reference; ownership remains with the
-   *     caller for serialization but should not be mutated.
+   * @return the field set view of the current exported darknet reference; ownership remains with
+   *     the caller for serialization but should not be mutated.
    */
   protected SimpleFieldSet getNoderef() {
     return toSimpleFieldSet(

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -101,10 +100,8 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   private final PeerPort peerPort;
 
   DarknetConnectionsToadlet(
-      HighLevelSimpleClient client,
-      ConnectionsToadletRuntimePorts runtimePorts,
-      DarknetConnectionsPort darknetConnectionsPort) {
-    super(client, runtimePorts);
+      ConnectionsToadletRuntimePorts runtimePorts, DarknetConnectionsPort darknetConnectionsPort) {
+    super(runtimePorts);
     this.darknetConnectionsPort = darknetConnectionsPort;
     this.lifecyclePort = runtimePorts.lifecyclePort();
     this.peerPort = runtimePorts.peerPort();

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.DiagnosticReportSnapshot;
 import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
@@ -29,13 +28,12 @@ public class DiagnosticToadlet extends Toadlet {
   private final DiagnosticPort diagnostic;
 
   /**
-   * Builds a diagnostic toadlet bound to the provided client plumbing and diagnostic port.
+   * Builds a diagnostic toadlet bound to the provided diagnostic port.
    *
-   * @param client HTTP client facade supplied to the superclass for response handling
    * @param diagnostic read-only runtime port that supplies detached diagnostic report snapshots
    */
-  protected DiagnosticToadlet(HighLevelSimpleClient client, DiagnosticPort diagnostic) {
-    super(client);
+  protected DiagnosticToadlet(DiagnosticPort diagnostic) {
+    super();
     this.diagnostic = diagnostic;
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.http;
 
 import java.util.Arrays;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.updater.CoreActionToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.SubConfig;
@@ -53,12 +52,12 @@ final class FProxyRegistrar {
    */
   static void maybeCreateFProxyEtc(
       FProxyRegistrarDependencies dependencies, SimpleToadletServer server) {
-    HighLevelSimpleClient client = dependencies.client();
     RuntimePorts runtimePorts = dependencies.runtimePorts();
     Config config = dependencies.config();
     TransferAccessPort transferAccess = runtimePorts.transferAccess();
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar = dependencies.browseRouteRegistrar();
     LegacyHttpBrowseRouteRegistrarContext browseContext = dependencies.browseContext();
+    InsertCompatibilityModes insertCompatibilityModes = dependencies.insertCompatibilityModes();
 
     browseRouteRegistrar.registerRoutes(
         LegacyHttpBrowseRouteRegistrar.Phase.ROOT_MENU, browseContext, server);
@@ -79,7 +78,7 @@ final class FProxyRegistrar {
     browseRouteRegistrar.registerRoutes(
         LegacyHttpBrowseRouteRegistrar.Phase.INTRO_ROUTES, browseContext, server);
 
-    UserAlertsToadlet alerts = new UserAlertsToadlet(client);
+    UserAlertsToadlet alerts = new UserAlertsToadlet();
     server.register(
         alerts,
         ToadletRegistration.menuLink(
@@ -93,7 +92,6 @@ final class FProxyRegistrar {
 
     QueueToadlet downloadToadlet =
         new QueueToadlet(
-            client,
             false,
             new QueueToadletRuntimePorts(
                 runtimePorts.queuePage(),
@@ -104,7 +102,8 @@ final class FProxyRegistrar {
                 runtimePorts.queueSupport(),
                 runtimePorts.queueCompletion(),
                 runtimePorts.darknetConnections(),
-                runtimePorts.darknetMessaging()));
+                runtimePorts.darknetMessaging(),
+                insertCompatibilityModes));
     server.register(
         downloadToadlet,
         ToadletRegistration.menuLink(
@@ -116,13 +115,12 @@ final class FProxyRegistrar {
             false,
             downloadToadlet));
     LocalDownloadDirectoryToadlet localDownloadDirectoryToadlet =
-        new LocalDownloadDirectoryToadlet(transferAccess, client, QueueToadlet.PATH_DOWNLOADS);
+        new LocalDownloadDirectoryToadlet(transferAccess, QueueToadlet.PATH_DOWNLOADS);
     server.register(
         localDownloadDirectoryToadlet,
         ToadletRegistration.basic(null, localDownloadDirectoryToadlet.path(), true, false));
     QueueToadlet uploadToadlet =
         new QueueToadlet(
-            client,
             true,
             new QueueToadletRuntimePorts(
                 runtimePorts.queuePage(),
@@ -133,7 +131,8 @@ final class FProxyRegistrar {
                 runtimePorts.queueSupport(),
                 runtimePorts.queueCompletion(),
                 runtimePorts.darknetConnections(),
-                runtimePorts.darknetMessaging()));
+                runtimePorts.darknetMessaging(),
+                insertCompatibilityModes));
     server.register(
         uploadToadlet,
         ToadletRegistration.menuLink(
@@ -147,7 +146,8 @@ final class FProxyRegistrar {
 
     FileInsertWizardToadlet fiw =
         new FileInsertWizardToadlet(
-            client, new FileInsertWizardToadletRuntimePorts(runtimePorts.securityLevels()));
+            new FileInsertWizardToadletRuntimePorts(
+                runtimePorts.securityLevels(), insertCompatibilityModes));
     server.register(
         fiw,
         ToadletRegistration.menuLink(
@@ -160,8 +160,7 @@ final class FProxyRegistrar {
             fiw));
     uploadToadlet.setFIW(fiw);
 
-    LocalFileInsertToadlet localFileInsertToadlet =
-        new LocalFileInsertToadlet(transferAccess, client);
+    LocalFileInsertToadlet localFileInsertToadlet = new LocalFileInsertToadlet(transferAccess);
     server.register(
         localFileInsertToadlet,
         ToadletRegistration.basic(null, LocalFileInsertToadlet.INSERT_BROWSE_PATH, true, false));
@@ -169,13 +168,12 @@ final class FProxyRegistrar {
     browseRouteRegistrar.registerRoutes(
         LegacyHttpBrowseRouteRegistrar.Phase.QUEUE_FILTER_ROUTES, browseContext, server);
 
-    SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(client, runtimePorts.toadletSymlinks());
+    SymlinkerToadlet symlinkToadlet = new SymlinkerToadlet(runtimePorts.toadletSymlinks());
     server.register(symlinkToadlet, ToadletRegistration.basic(null, "/sl/", true, false));
 
     SecurityLevelsToadletRuntimePorts securityLevelsToadletRuntimePorts =
         new SecurityLevelsToadletRuntimePorts(runtimePorts.securityLevels(), runtimePorts.config());
-    SecurityLevelsToadlet seclevels =
-        new SecurityLevelsToadlet(client, securityLevelsToadletRuntimePorts);
+    SecurityLevelsToadlet seclevels = new SecurityLevelsToadlet(securityLevelsToadletRuntimePorts);
     server.register(
         seclevels,
         ToadletRegistration.menuLink(
@@ -197,11 +195,10 @@ final class FProxyRegistrar {
       String prefix = cfg.getPrefix();
       if (prefix.equals("security-levels")) continue;
       LocalDirectoryConfigToadlet localDirectoryConfigToadlet =
-          new LocalDirectoryConfigToadlet(
-              transferAccess, client, LegacyHttpPaths.CONFIG_PATH + prefix);
+          new LocalDirectoryConfigToadlet(transferAccess, LegacyHttpPaths.CONFIG_PATH + prefix);
       ConfigToadlet configtoadlet =
           new ConfigToadlet(
-              localDirectoryConfigToadlet.path(), client, config, cfg, configToadletRuntimePorts);
+              localDirectoryConfigToadlet.path(), config, cfg, configToadletRuntimePorts);
       server.register(
           configtoadlet,
           ToadletRegistration.menuLink(
@@ -220,8 +217,7 @@ final class FProxyRegistrar {
     browseRouteRegistrar.registerRoutes(
         LegacyHttpBrowseRouteRegistrar.Phase.POST_CONFIG_ROUTES, browseContext, server);
 
-    CoreActionToadlet coreActionToadlet =
-        new CoreActionToadlet(client, runtimePorts.coreUpdateAction());
+    CoreActionToadlet coreActionToadlet = new CoreActionToadlet(runtimePorts.coreUpdateAction());
     server.register(
         coreActionToadlet, ToadletRegistration.basic(null, CORE_UPDATE_PATH, true, false));
 
@@ -236,7 +232,7 @@ final class FProxyRegistrar {
 
     DarknetConnectionsToadlet friendsToadlet =
         new DarknetConnectionsToadlet(
-            client, connectionsToadletRuntimePorts, runtimePorts.darknetConnections());
+            connectionsToadletRuntimePorts, runtimePorts.darknetConnections());
     server.register(
         friendsToadlet,
         ToadletRegistration.menuLink(
@@ -250,7 +246,7 @@ final class FProxyRegistrar {
 
     DarknetAddRefToadlet addRefToadlet =
         new DarknetAddRefToadlet(
-            runtimePorts.connectionsSupport(), runtimePorts.nodeInfo(), client, friendsToadlet);
+            runtimePorts.connectionsSupport(), runtimePorts.nodeInfo(), friendsToadlet);
     server.register(
         addRefToadlet,
         ToadletRegistration.menuLink(
@@ -263,7 +259,7 @@ final class FProxyRegistrar {
             null));
 
     OpennetConnectionsToadlet opennetToadlet =
-        new OpennetConnectionsToadlet(client, connectionsToadletRuntimePorts);
+        new OpennetConnectionsToadlet(connectionsToadletRuntimePorts);
     server.register(
         opennetToadlet,
         ToadletRegistration.menuLink(
@@ -275,7 +271,7 @@ final class FProxyRegistrar {
             true,
             opennetToadlet));
 
-    ChatForumsToadlet chatForumsToadlet = new ChatForumsToadlet(client);
+    ChatForumsToadlet chatForumsToadlet = new ChatForumsToadlet();
     server.register(
         chatForumsToadlet,
         ToadletRegistration.menuLink(
@@ -287,8 +283,8 @@ final class FProxyRegistrar {
             true,
             chatForumsToadlet));
 
-    LocalFileN2NMToadlet localFileN2NMToadlet = new LocalFileN2NMToadlet(transferAccess, client);
-    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(runtimePorts, localFileN2NMToadlet, client);
+    LocalFileN2NMToadlet localFileN2NMToadlet = new LocalFileN2NMToadlet(transferAccess);
+    N2NTMToadlet n2ntmToadlet = new N2NTMToadlet(runtimePorts, localFileN2NMToadlet);
     server.register(n2ntmToadlet, ToadletRegistration.basic(null, "/send_n2ntm/", true, true));
     server.register(
         localFileN2NMToadlet,
@@ -297,7 +293,7 @@ final class FProxyRegistrar {
     browseRouteRegistrar.registerRoutes(
         LegacyHttpBrowseRouteRegistrar.Phase.POST_MESSAGING_ROUTES, browseContext, server);
 
-    WebShellToadlet webShellToadlet = new WebShellToadlet(client);
+    WebShellToadlet webShellToadlet = new WebShellToadlet();
     server.register(
         webShellToadlet,
         ToadletRegistration.menuLink(
@@ -310,7 +306,7 @@ final class FProxyRegistrar {
             ignored -> WebShellPaths.SHELL_ROOT.equals(server.primaryUiRoot())));
 
     PlatformApiToadlet platformApiToadlet =
-        new PlatformApiToadlet(client, runtimePorts, dependencies.appHost());
+        new PlatformApiToadlet(runtimePorts, dependencies.appHost());
     server.register(
         platformApiToadlet,
         ToadletRegistration.basic(null, PlatformApiToadlet.MOUNT_PATH, true, true));
@@ -318,7 +314,7 @@ final class FProxyRegistrar {
     browseRouteRegistrar.registerRoutes(
         LegacyHttpBrowseRouteRegistrar.Phase.POST_PLATFORM_API_ROUTES, browseContext, server);
 
-    StatisticsToadlet statisticsToadlet = new StatisticsToadlet(client, runtimePorts.statistics());
+    StatisticsToadlet statisticsToadlet = new StatisticsToadlet(runtimePorts.statistics());
     server.register(
         statisticsToadlet,
         ToadletRegistration.menuLink(
@@ -330,7 +326,7 @@ final class FProxyRegistrar {
             true,
             null));
 
-    DiagnosticToadlet diagnosticToadlet = new DiagnosticToadlet(client, runtimePorts.diagnostic());
+    DiagnosticToadlet diagnosticToadlet = new DiagnosticToadlet(runtimePorts.diagnostic());
     server.register(
         diagnosticToadlet,
         ToadletRegistration.menuLink(
@@ -342,8 +338,7 @@ final class FProxyRegistrar {
             true,
             null));
 
-    ConnectivityToadlet connectivityToadlet =
-        new ConnectivityToadlet(client, runtimePorts.connectivity());
+    ConnectivityToadlet connectivityToadlet = new ConnectivityToadlet(runtimePorts.connectivity());
     server.register(
         connectivityToadlet,
         ToadletRegistration.menuLink(
@@ -355,7 +350,7 @@ final class FProxyRegistrar {
             true,
             null));
 
-    TranslationToadlet translationToadlet = new TranslationToadlet(client);
+    TranslationToadlet translationToadlet = new TranslationToadlet();
     server.register(
         translationToadlet,
         ToadletRegistration.menuLink(
@@ -369,18 +364,18 @@ final class FProxyRegistrar {
 
     FirstTimeWizardToadlet firstTimeWizardToadlet =
         new FirstTimeWizardToadlet(
-            client, config, new FirstTimeWizardToadletRuntimePorts(runtimePorts.firstTimeWizard()));
+            config, new FirstTimeWizardToadletRuntimePorts(runtimePorts.firstTimeWizard()));
     server.register(
         firstTimeWizardToadlet,
         ToadletRegistration.basic(null, FirstTimeWizardToadlet.TOADLET_URL, true, false));
 
     FirstTimeWizardNewToadlet firstTimeWizardNewToadlet =
-        new FirstTimeWizardNewToadlet(client, runtimePorts.firstTimeWizard());
+        new FirstTimeWizardNewToadlet(runtimePorts.firstTimeWizard());
     server.register(
         firstTimeWizardNewToadlet,
         ToadletRegistration.basic(null, FirstTimeWizardNewToadlet.TOADLET_URL, true, false));
 
-    SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet(client);
+    SimpleHelpToadlet simpleHelpToadlet = new SimpleHelpToadlet();
     server.register(simpleHelpToadlet, ToadletRegistration.basic(null, "/help/", true, false));
 
     browseRouteRegistrar.registerRoutes(

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.http;
 
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -20,20 +19,21 @@ import network.crypta.runtime.spi.RuntimePorts;
  * actually consumes so startup composition remains in one place while HTTP registration remains
  * deterministic and easy to test.
  *
- * @param client shared interactive client used by registered HTTP toadlets
  * @param runtimePorts detached runtime ports exposed to the HTTP shell
  * @param appHost shared AppHost instance exposed through the Platform API bridge
  * @param config node configuration used to list sub-config toadlets
  * @param browseRoot prebuilt root browse toadlet handed to the registrar for root-path registration
  * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route publication
+ * @param insertCompatibilityModes detached compatibility-mode choices used by queue and insert
+ *     forms
  */
 record FProxyRegistrarDependencies(
-    HighLevelSimpleClient client,
     RuntimePorts runtimePorts,
     AppHost appHost,
     Config config,
     Toadlet browseRoot,
-    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
+    InsertCompatibilityModes insertCompatibilityModes) {
   /**
    * Creates a validated dependency bundle for {@link FProxyRegistrar}.
    *
@@ -41,25 +41,26 @@ record FProxyRegistrarDependencies(
    * constructor rejects the partially assembled state early, so the caller fails to close to the
    * HTTP shell composition site rather than later during menu or toadlet registration.
    *
-   * @param client shared interactive client used by registered HTTP toadlets during registration
    * @param runtimePorts runtime-spi ports exposed to HTTP-layer toadlets and helper pages
    * @param appHost shared AppHost instance exposed through the Platform API bridge
    * @param config node configuration used to list and filter sub-config toadlets
    * @param browseRoot prebuilt root browse toadlet that is registered at the HTTP root path
    * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route
    *     publication
+   * @param insertCompatibilityModes detached compatibility-mode choices used by queue and insert
+   *     forms
    * @throws NullPointerException if any required collaborator is absent at construction time
    */
   FProxyRegistrarDependencies {
-    Objects.requireNonNull(client);
     Objects.requireNonNull(runtimePorts);
     Objects.requireNonNull(appHost);
     Objects.requireNonNull(config);
     Objects.requireNonNull(browseRoot);
     Objects.requireNonNull(browseRouteRegistrar);
+    Objects.requireNonNull(insertCompatibilityModes);
   }
 
   LegacyHttpBrowseRouteRegistrarContext browseContext() {
-    return new LegacyHttpBrowseRouteRegistrarContext(client, runtimePorts, browseRoot);
+    return new LegacyHttpBrowseRouteRegistrarContext(runtimePorts, browseRoot);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FileInsertWizardToadlet.java
@@ -3,9 +3,6 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.client.InsertContext.CompatibilityMode;
-import network.crypta.client.InsertContext;
 import network.crypta.client.filter.FilterOperation;
 import network.crypta.clients.http.LegacyContentFilterSupport.ResultHandling;
 import network.crypta.l10n.NodeL10n;
@@ -43,21 +40,18 @@ import static network.crypta.clients.http.LegacyContentFilterSupport.CONTENT_FIL
 public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallback {
 
   /**
-   * Creates the toadlet that renders the file-insert wizard for the given client and detached
-   * runtime ports. The instance keeps only lightweight preferences and is intended to be
-   * short-lived; callers typically construct one per incoming HTTP request or per handler
-   * registration. The constructor does not perform I/O, and all dependencies are assumed to remain
-   * valid for the lifetime of the toadlet. State stored in the instance is not synchronized and
-   * should not be shared across threads without external coordination.
+   * Creates the toadlet that renders the file-insert wizard for the detached runtime ports. The
+   * instance keeps only lightweight preferences and is intended to be short-lived; callers
+   * typically construct one per incoming HTTP request or per handler registration. The constructor
+   * does not perform I/O, and all dependencies are assumed to remain valid for the lifetime of the
+   * toadlet. State stored in the instance is not synchronized and should not be shared across
+   * threads without external coordination.
    *
-   * @param client high-level client used to bind uploads to the current session; never {@code
-   *     null}.
    * @param runtimePorts detached runtime collaborators used to read the current network threat
    *     level; never {@code null}.
    */
-  FileInsertWizardToadlet(
-      HighLevelSimpleClient client, FileInsertWizardToadletRuntimePorts runtimePorts) {
-    super(client);
+  FileInsertWizardToadlet(FileInsertWizardToadletRuntimePorts runtimePorts) {
+    super();
     this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
   }
 
@@ -218,17 +212,15 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
     insertForm.addChild("br");
     insertForm.addChild("#", NodeL10n.getBase().getString("QueueToadlet.compatModeLabel") + ": ");
     HTMLNode select = insertForm.addChild("select", "name", "compatibilityMode");
-    for (CompatibilityMode mode : InsertContext.CompatibilityMode.values()) {
-      if (mode == CompatibilityMode.COMPAT_UNKNOWN) {
-        continue;
-      }
+    InsertCompatibilityModes insertCompatibilityModes = runtimePorts.insertCompatibilityModes();
+    for (String modeName : insertCompatibilityModes.supportedModeNames()) {
       HTMLNode option =
           select.addChild(
               "option",
               ATTR_VALUE,
-              mode.name(),
-              NodeL10n.getBase().getString("InsertContext.CompatibilityMode." + mode.name()));
-      if (mode == CompatibilityMode.COMPAT_DEFAULT) {
+              modeName,
+              NodeL10n.getBase().getString("InsertContext.CompatibilityMode." + modeName));
+      if (modeName.equals(insertCompatibilityModes.defaultModeName())) {
         option.addAttribute("selected", "");
       }
     }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FileInsertWizardToadletRuntimePorts.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FileInsertWizardToadletRuntimePorts.java
@@ -19,8 +19,11 @@ import network.crypta.runtime.spi.SecurityLevelsPort;
  *
  * @param securityLevelsPort detached runtime view that supplies the current network threat level
  *     used when the wizard chooses its default key type
+ * @param insertCompatibilityModes detached HTTP-local compatibility-mode names used by the wizard
+ *     insert form
  */
-record FileInsertWizardToadletRuntimePorts(SecurityLevelsPort securityLevelsPort) {
+record FileInsertWizardToadletRuntimePorts(
+    SecurityLevelsPort securityLevelsPort, InsertCompatibilityModes insertCompatibilityModes) {
   /**
    * Creates the runtime bundle for the file-insert wizard.
    *
@@ -32,5 +35,6 @@ record FileInsertWizardToadletRuntimePorts(SecurityLevelsPort securityLevelsPort
    */
   FileInsertWizardToadletRuntimePorts {
     Objects.requireNonNull(securityLevelsPort);
+    Objects.requireNonNull(insertCompatibilityModes);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FirstTimeWizardNewToadlet.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
@@ -62,8 +61,8 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
 
   private static final String CHECKED_VALUE = "checked";
 
-  FirstTimeWizardNewToadlet(HighLevelSimpleClient client, FirstTimeWizardPort wizardPort) {
-    super(client);
+  FirstTimeWizardNewToadlet(FirstTimeWizardPort wizardPort) {
+    super();
     this.wizardPort = Objects.requireNonNull(wizardPort, "wizardPort");
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FirstTimeWizardToadlet.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.EnumMap;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.wizardsteps.Bandwidth;
 import network.crypta.clients.http.wizardsteps.BandwidthMonthly;
 import network.crypta.clients.http.wizardsteps.BandwidthRate;
@@ -150,12 +149,9 @@ public class FirstTimeWizardToadlet extends Toadlet {
     HIGH
   }
 
-  FirstTimeWizardToadlet(
-      HighLevelSimpleClient client,
-      Config config,
-      FirstTimeWizardToadletRuntimePorts runtimePorts) {
+  FirstTimeWizardToadlet(Config config, FirstTimeWizardToadletRuntimePorts runtimePorts) {
     // Generic Toadlet-related initialization.
-    super(client);
+    super();
     FirstTimeWizardToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts, "runtimePorts");
     wizardPort = ports.firstTimeWizardPort();
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellBrowseBootstrap.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellBrowseBootstrap.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.util.Objects;
 import java.util.function.Consumer;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
@@ -23,8 +22,6 @@ import network.crypta.runtime.spi.RuntimePorts;
  *
  * @param bookmarkManager bookmark handle wired against the daemon-backed bookmark runtime support
  *     for the surrounding shell lifecycle
- * @param client interactive client shared by HTTP toadlets created during shell startup and route
- *     registration
  * @param appHost shared AppHost instance used by the Platform API control plane and exposed through
  *     legacy HTTP routes
  * @param browseRoot browse-root toadlet constructed during bootstrap and handed to the registrar
@@ -36,7 +33,6 @@ import network.crypta.runtime.spi.RuntimePorts;
  */
 public record HttpShellBrowseBootstrap(
     BookmarkManagerHandle bookmarkManager,
-    HighLevelSimpleClient client,
     AppHost appHost,
     Toadlet browseRoot,
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
@@ -51,7 +47,6 @@ public record HttpShellBrowseBootstrap(
    *
    * @param bookmarkManager bookmark handle used by the surrounding shell bootstrap to populate
    *     bookmark-backed routes
-   * @param client interactive client shared by shell toadlets that are registered during startup
    * @param appHost shared AppHost instance used by the platform control plane and related routes
    * @param browseRoot browse-root toadlet used by route registration at the legacy browsing root
    * @param browseRouteRegistrar browse-neutral registrar seam for the browse-owned routes
@@ -59,11 +54,10 @@ public record HttpShellBrowseBootstrap(
    */
   public static HttpShellBrowseBootstrap create(
       BookmarkManagerHandle bookmarkManager,
-      HighLevelSimpleClient client,
       AppHost appHost,
       Toadlet browseRoot,
       LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
-    return create(bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar, _ -> {});
+    return create(bookmarkManager, appHost, browseRoot, browseRouteRegistrar, _ -> {});
   }
 
   /**
@@ -76,7 +70,6 @@ public record HttpShellBrowseBootstrap(
    *
    * @param bookmarkManager bookmark handle used by the surrounding shell bootstrap to populate
    *     bookmark-backed routes
-   * @param client interactive client shared by shell toadlets that are registered during startup
    * @param appHost shared AppHost instance used by the platform control plane and related routes
    * @param browseRoot browse-root toadlet used by route registration at the legacy browsing root
    * @param browseRouteRegistrar browse-neutral registrar seam for the browse-owned routes
@@ -86,13 +79,12 @@ public record HttpShellBrowseBootstrap(
    */
   public static HttpShellBrowseBootstrap create(
       BookmarkManagerHandle bookmarkManager,
-      HighLevelSimpleClient client,
       AppHost appHost,
       Toadlet browseRoot,
       LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
       Consumer<RuntimePorts> sharedShellInitializer) {
     return new HttpShellBrowseBootstrap(
-        bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar, sharedShellInitializer);
+        bookmarkManager, appHost, browseRoot, browseRouteRegistrar, sharedShellInitializer);
   }
 
   /**
@@ -123,7 +115,6 @@ public record HttpShellBrowseBootstrap(
    */
   public HttpShellBrowseBootstrap {
     Objects.requireNonNull(bookmarkManager);
-    Objects.requireNonNull(client);
     Objects.requireNonNull(appHost);
     Objects.requireNonNull(browseRoot);
     Objects.requireNonNull(browseRouteRegistrar);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
@@ -122,6 +122,17 @@ public interface HttpShellRuntimeSupport {
   boolean canRedirectToWizard();
 
   /**
+   * Returns the detached insert compatibility modes used by legacy HTTP forms.
+   *
+   * <p>The returned value object keeps the admin shell independent of the runtime-node insert enum
+   * while preserving the current ordering, labels, and default selection used by the legacy upload
+   * forms.
+   *
+   * @return HTTP-local compatibility-mode names and their default selection
+   */
+  InsertCompatibilityModes insertCompatibilityModes();
+
+  /**
    * Registers a listener for network threat-level changes using HTTP-local enum values.
    *
    * <p>The callback receives detached values so {@link SimpleToadletServer} does not have to depend
@@ -150,7 +161,7 @@ public interface HttpShellRuntimeSupport {
    * bootstrap snapshot for the current shell instance.
    *
    * @param publicGatewayMode whether the shell should bootstrap public-gateway bookmark behavior
-   * @return bootstrap bundle containing the bookmark manager, interactive client, and browse root
+   * @return bootstrap bundle containing the bookmark manager and browse-owned startup collaborators
    */
   HttpShellBrowseBootstrap createBrowseBootstrap(boolean publicGatewayMode);
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/InsertCompatibilityModes.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/InsertCompatibilityModes.java
@@ -1,0 +1,46 @@
+package network.crypta.clients.http;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detached HTTP-local compatibility-mode names used by the legacy insert forms.
+ *
+ * <p>This record is the shell-facing representation of the compatibility-mode choices that appear
+ * in legacy upload and queue forms. The admin-owned HTTP code only needs stable display names, the
+ * ordering of those names, and the default selection to preselect in generated HTML. It does not
+ * need the runtime-node enum itself, nor the broader insert-context behavior behind that enum.
+ *
+ * <p>Keeping those values in a small HTTP-local record narrows the remaining bridge seam. Runtime
+ * wiring can translate from the live daemon-side compatibility enum into this record once during
+ * bootstrap, while admin toadlets stay coupled only to plain strings and ordering rules. The record
+ * does not attempt to interpret or normalize the supplied names. Callers are expected to provide
+ * already-normalized values in user-visible order and to supply a default name that is meaningful
+ * for the same rendered choice set.
+ *
+ * @param supportedModeNames ordered compatibility-mode names presented to users in legacy HTTP
+ *     forms; the record preserves this order exactly
+ * @param defaultModeName compatibility-mode name selected by default when the shell renders a new
+ *     form
+ */
+public record InsertCompatibilityModes(List<String> supportedModeNames, String defaultModeName) {
+  /**
+   * Creates a validated detached compatibility-mode bundle.
+   *
+   * <p>The constructor performs only structural validation and defensive copying. It ensures the
+   * record never stores {@code null} references and that later mutations to the caller-provided
+   * list cannot change the HTTP shell's view of the compatibility choices. It intentionally does
+   * not enforce that {@code defaultModeName} appears in {@code supportedModeNames}; callers are
+   * responsible for supplying a coherent set of values.
+   *
+   * @param supportedModeNames ordered compatibility-mode names to present to the user; copied into
+   *     an unmodifiable list for stable later reads
+   * @param defaultModeName compatibility-mode name selected by default in the form; stored exactly
+   *     as supplied
+   * @throws NullPointerException if either argument is {@code null}
+   */
+  public InsertCompatibilityModes(List<String> supportedModeNames, String defaultModeName) {
+    this.supportedModeNames = List.copyOf(Objects.requireNonNull(supportedModeNames));
+    this.defaultModeName = Objects.requireNonNull(defaultModeName);
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
@@ -29,10 +29,11 @@ public final class LegacyAdminHttpRouteRegistrar implements LegacyHttpRouteRegis
   /**
    * Registers the concrete legacy HTTP routes for the supplied shell instance.
    *
-   * <p>The provided context already contains the interactive client, runtime ports, configuration,
-   * AppHost bridge, browse-root toadlet, and browse registrar seam prepared by the shared shell
-   * bootstrap path. Repackaging those collaborators here keeps the public seam small while letting
-   * the existing admin-owned registrar continue to own the overall registration order.
+   * <p>The provided context already contains the runtime ports, configuration, AppHost bridge,
+   * browse-root toadlet, browse registrar seam, and detached insert compatibility choices prepared
+   * by the shared shell bootstrap path. Repackaging those collaborators here keeps the public seam
+   * small while letting the existing admin-owned registrar continue to own the overall registration
+   * order.
    *
    * @param context prepared bootstrap collaborators that the admin-owned registrar requires
    * @param server shell instance that receives the registered menus and toadlets
@@ -41,12 +42,12 @@ public final class LegacyAdminHttpRouteRegistrar implements LegacyHttpRouteRegis
   public void registerRoutes(LegacyHttpRouteRegistrarContext context, SimpleToadletServer server) {
     FProxyRegistrar.maybeCreateFProxyEtc(
         new FProxyRegistrarDependencies(
-            context.client(),
             context.runtimePorts(),
             context.appHost(),
             context.config(),
             context.browseRoot(),
-            context.browseRouteRegistrar()),
+            context.browseRouteRegistrar(),
+            context.insertCompatibilityModes()),
         server);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpBrowseRouteRegistrarContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpBrowseRouteRegistrarContext.java
@@ -1,18 +1,16 @@
 package network.crypta.clients.http;
 
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
  * Immutable startup context for browse-owned legacy HTTP route registration.
  *
  * <p>This record keeps the browse-owned registrar seam narrow. It still exposes the collaborators
- * that the current browse route publication requires: the shared interactive client, the detached
- * runtime ports used by welcome, bookmark, and filter routes, and the prebuilt browse root toadlet.
- * The type is public because bridge-owned production code installs concrete browse registrars
- * across module boundaries. The carried state remains intentionally limited to the browse-owned
- * registration concern.
+ * that the current browse route publication requires: the detached runtime ports used by welcome,
+ * bookmark, and filter routes, and the prebuilt browse root toadlet. The type is public because
+ * bridge-owned production code installs concrete browse registrars across module boundaries. The
+ * carried state remains intentionally limited to the browse-owned registration concern.
  *
  * <p>Callers should treat the record as a startup snapshot, not as a long-lived service locator. It
  * exists so the admin-owned shell can hand the browse registrar exactly the collaborators that
@@ -20,12 +18,10 @@ import network.crypta.runtime.spi.RuntimePorts;
  * the record small also makes later extraction easier: if a browse route needs a new collaborator,
  * that dependency change becomes visible at the seam instead of leaking back into the shared shell.
  *
- * @param client shared interactive client used by browse-owned HTTP toadlets
  * @param runtimePorts detached runtime ports exposed to browse-owned HTTP routes
  * @param browseRoot prebuilt browse-root toadlet registered at the legacy browsing root
  */
-public record LegacyHttpBrowseRouteRegistrarContext(
-    HighLevelSimpleClient client, RuntimePorts runtimePorts, Toadlet browseRoot) {
+public record LegacyHttpBrowseRouteRegistrarContext(RuntimePorts runtimePorts, Toadlet browseRoot) {
 
   /**
    * Creates a validated browse-route registration context.
@@ -35,13 +31,11 @@ public record LegacyHttpBrowseRouteRegistrarContext(
    * later phase and tries to instantiate a route. The record stores the exact references prepared
    * by the shared bootstrap path and does not wrap or copy them.
    *
-   * @param client shared interactive client used by browse-owned HTTP toadlets
    * @param runtimePorts detached runtime ports exposed to browse-owned HTTP routes
    * @param browseRoot prebuilt browse-root toadlet registered at the legacy browsing root
    * @throws NullPointerException if any required collaborator is absent
    */
   public LegacyHttpBrowseRouteRegistrarContext {
-    Objects.requireNonNull(client);
     Objects.requireNonNull(runtimePorts);
     Objects.requireNonNull(browseRoot);
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.http;
 
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -17,12 +16,10 @@ import network.crypta.runtime.spi.RuntimePorts;
  * on route registration rather than broader daemon lifecycle control.
  *
  * <p>The context is intentionally narrow and immutable. It carries only the collaborators needed to
- * publish legacy HTTP routes today: the interactive client, detached runtime ports, AppHost bridge,
- * node configuration, and the already-created browse root. Registrars should treat the record as a
- * startup snapshot and avoid mutating or retaining it beyond registration.
+ * publish legacy HTTP routes today: detached runtime ports, AppHost bridge, node configuration, and
+ * the already-created browse root. Registrars should treat the record as a startup snapshot and
+ * avoid mutating or retaining it beyond registration.
  *
- * @param client shared interactive client that registered toadlets use for request-adjacent
- *     operations
  * @param runtimePorts detached runtime-spi ports surfaced to HTTP routes and helper pages
  * @param appHost shared AppHost bridge that exposes the current Platform API runtime surface
  * @param config node configuration view used when listing or filtering sub-config toadlets
@@ -30,14 +27,16 @@ import network.crypta.runtime.spi.RuntimePorts;
  *     browsing root
  * @param browseRouteRegistrar browse-neutral registrar seam used for concrete browse-owned route
  *     publication
+ * @param insertCompatibilityModes detached compatibility-mode choices used by queue and insert
+ *     forms
  */
 public record LegacyHttpRouteRegistrarContext(
-    HighLevelSimpleClient client,
     RuntimePorts runtimePorts,
     AppHost appHost,
     Config config,
     Toadlet browseRoot,
-    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
+    LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
+    InsertCompatibilityModes insertCompatibilityModes) {
 
   /**
    * Creates a validated route-registration context.
@@ -47,21 +46,22 @@ public record LegacyHttpRouteRegistrarContext(
    * toadlets. The stored references are the same objects prepared by the shell bootstrap path; the
    * constructor does not wrap, copy, or otherwise transform them.
    *
-   * @param client shared interactive client that registered toadlets may call into during startup
    * @param runtimePorts detached runtime-spi ports exposed to the HTTP registrar
    * @param appHost shared AppHost bridge made visible through HTTP-owned routes
    * @param config node configuration view that registration may inspect for sub-config pages
    * @param browseRoot prebuilt root browse toadlet registered at the browsing root
    * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route
    *     publication
+   * @param insertCompatibilityModes detached compatibility-mode choices used by queue and insert
+   *     forms
    * @throws NullPointerException if any required collaborator is absent when the context is built
    */
   public LegacyHttpRouteRegistrarContext {
-    Objects.requireNonNull(client);
     Objects.requireNonNull(runtimePorts);
     Objects.requireNonNull(appHost);
     Objects.requireNonNull(config);
     Objects.requireNonNull(browseRoot);
     Objects.requireNonNull(browseRouteRegistrar);
+    Objects.requireNonNull(insertCompatibilityModes);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalDirectoryConfigToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalDirectoryConfigToadlet.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.io.File;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -43,17 +42,12 @@ public class LocalDirectoryConfigToadlet extends LocalDirectoryToadlet {
    *
    * @param transferAccess initialized transfer-access runtime port carried by the shared local
    *     browser base; must be non-null and remain reachable for the lifetime of the instance.
-   * @param highLevelSimpleClient HTTP client helper passed to the parent {@link Toadlet}; must be
-   *     non-null and thread-safe for concurrent request handling.
    * @param postTo relative URL segment (beginning with a slash) that identifies the handler to
    *     receive selected directories; the value is concatenated with {@link #path()} and reused for
    *     redirects.
    */
-  public LocalDirectoryConfigToadlet(
-      TransferAccessPort transferAccess,
-      HighLevelSimpleClient highLevelSimpleClient,
-      String postTo) {
-    super(transferAccess, highLevelSimpleClient, postTo);
+  public LocalDirectoryConfigToadlet(TransferAccessPort transferAccess, String postTo) {
+    super(transferAccess, postTo);
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalDirectoryToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalDirectoryToadlet.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.http;
 
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 
@@ -50,16 +49,11 @@ public abstract class LocalDirectoryToadlet extends LocalFileBrowserToadlet {
    *
    * @param transferAccess transfer-access runtime port providing access to validation and default
    *     directory resolution; must be initialized and non-null.
-   * @param highLevelSimpleClient client helper used for higher-level operations triggered by user
-   *     actions; expected to be thread-safe and non-null.
    * @param postTo relative URL suffix appended to {@link #BASE_PATH} when building form actions;
    *     must not be null and should start with a leading slash for correct concatenation.
    */
-  protected LocalDirectoryToadlet(
-      TransferAccessPort transferAccess,
-      HighLevelSimpleClient highLevelSimpleClient,
-      String postTo) {
-    super(transferAccess, highLevelSimpleClient);
+  protected LocalDirectoryToadlet(TransferAccessPort transferAccess, String postTo) {
+    super(transferAccess);
     this.postToPath = postTo;
   }
 
@@ -73,7 +67,7 @@ public abstract class LocalDirectoryToadlet extends LocalFileBrowserToadlet {
    * string concatenation, callers should perform any necessary URL encoding for user-supplied
    * segments that might be appended later.
    *
-   * @return full path, starting with a slash, that uniquely identifies this directory browsing
+   * @return full path, starting with a slash that uniquely identifies this directory browsing
    *     endpoint within the local HTTP UI; never null.
    */
   @Override

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalDownloadDirectoryToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalDownloadDirectoryToadlet.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -32,9 +31,8 @@ public class LocalDownloadDirectoryToadlet extends LocalDirectoryToadlet {
   private static final String BULK_DOWNLOADS = "bulkDownloads";
   private static final String FILTER_DATA = "filterData";
 
-  LocalDownloadDirectoryToadlet(
-      TransferAccessPort transferAccess, HighLevelSimpleClient highLevelSimpleClient, String post) {
-    super(transferAccess, highLevelSimpleClient, post);
+  LocalDownloadDirectoryToadlet(TransferAccessPort transferAccess, String post) {
+    super(transferAccess, post);
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalFileBrowserToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalFileBrowserToadlet.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -69,12 +68,8 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
    *
    * @param transferAccess transfer-access runtime port that exposes allowed directories and
    *     download defaults; must not be {@code null}.
-   * @param highLevelSimpleClient HTTP client passed to the {@link Toadlet} base for responding to
-   *     user requests; must not be {@code null}.
    */
-  protected LocalFileBrowserToadlet(
-      TransferAccessPort transferAccess, HighLevelSimpleClient highLevelSimpleClient) {
-    super(highLevelSimpleClient);
+  protected LocalFileBrowserToadlet(TransferAccessPort transferAccess) {
     this.transferAccess = transferAccess;
   }
 
@@ -378,7 +373,7 @@ public abstract class LocalFileBrowserToadlet extends Toadlet {
    * Presents a file selection screen, or a something has been selected notes its directory and
    * redirects to the POST target.
    *
-   * @param fieldPairs fields which are to be persisted between views
+   * @param fieldPairs fields that are to be persisted between views
    * @param path current path to display
    * @param ctx context used for rendering
    * @param filename a filename if a file or directory is selected, NULL if not.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalFileInsertToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalFileInsertToadlet.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.keys.FreenetURI;
 import network.crypta.runtime.spi.TransferAccessPort;
 
@@ -76,12 +75,9 @@ public class LocalFileInsertToadlet extends LocalFileBrowserToadlet {
    *
    * @param transferAccess transfer-access runtime port used for permission checks and default
    *     directory resolution; must not be {@code null}.
-   * @param highLevelSimpleClient client wrapper that binds uploads to the current user session;
-   *     must not be {@code null}.
    */
-  public LocalFileInsertToadlet(
-      TransferAccessPort transferAccess, HighLevelSimpleClient highLevelSimpleClient) {
-    super(transferAccess, highLevelSimpleClient);
+  public LocalFileInsertToadlet(TransferAccessPort transferAccess) {
+    super(transferAccess);
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalFileN2NMToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LocalFileN2NMToadlet.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 
@@ -59,12 +58,9 @@ public class LocalFileN2NMToadlet extends LocalFileBrowserToadlet {
    *
    * @param transferAccess transfer-access runtime port that supplies configuration and upload
    *     permission checks; must not be {@code null}.
-   * @param highLevelSimpleClient helper used to build client requests and responses for this
-   *     toadlet; expected to be initialized by the surrounding HTTP layer.
    */
-  public LocalFileN2NMToadlet(
-      TransferAccessPort transferAccess, HighLevelSimpleClient highLevelSimpleClient) {
-    super(transferAccess, highLevelSimpleClient);
+  public LocalFileN2NMToadlet(TransferAccessPort transferAccess) {
+    super(transferAccess);
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/N2NTMToadlet.java
@@ -9,7 +9,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -78,17 +77,14 @@ public class N2NTMToadlet extends Toadlet {
    *
    * <p>The instance keeps references to the detached runtime ports and its browser toadlet so it
    * can resolve peers, send messages, open the local file browser, and emit localized responses.
-   * Callers should provide the same {@link HighLevelSimpleClient} used by other toadlets to keep
-   * configuration and permissions consistent. The constructor performs no I/O and does not register
-   * itself; registration is managed elsewhere by the HTTP subsystem.
+   * The constructor performs no I/O and does not register itself; registration is managed elsewhere
+   * by the HTTP subsystem.
    *
    * @param runtimePorts runtime aggregate that exposes detached peer lookup and messaging ports.
    * @param browser browser toadlet used for local file selection.
-   * @param client HTTP client wrapper used by the base {@link Toadlet}.
    */
-  protected N2NTMToadlet(
-      RuntimePorts runtimePorts, LocalFileN2NMToadlet browser, HighLevelSimpleClient client) {
-    super(client);
+  protected N2NTMToadlet(RuntimePorts runtimePorts, LocalFileN2NMToadlet browser) {
+    super();
     RuntimePorts ports = Objects.requireNonNull(runtimePorts, "runtimePorts");
     this.darknetConnections = Objects.requireNonNull(ports.darknetConnections());
     this.darknetMessaging = Objects.requireNonNull(ports.darknetMessaging());

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/OpennetConnectionsToadlet.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.http;
 
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.support.HTMLNode;
@@ -32,14 +31,11 @@ public class OpennetConnectionsToadlet extends ConnectionsToadlet implements Lin
    * state. The instance can be created eagerly during UI wiring because it defers all data
    * retrieval to per-request handlers, avoiding heavy startup costs.
    *
-   * @param client high-level client for UI links and redirects; expected to be configured for
-   *     opennet-safe operations.
    * @param runtimePorts shared detached runtime ports backing page rendering, noderef export, and
    *     legacy support helpers.
    */
-  OpennetConnectionsToadlet(
-      HighLevelSimpleClient client, ConnectionsToadletRuntimePorts runtimePorts) {
-    super(client, runtimePorts);
+  OpennetConnectionsToadlet(ConnectionsToadletRuntimePorts runtimePorts) {
+    super(runtimePorts);
     this.connectionsSupportPort = runtimePorts.connectionsSupportPort();
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.platform.api.PlatformApiPaths;
 import network.crypta.platform.api.PlatformApiRequest;
 import network.crypta.platform.api.PlatformApiResponse;
@@ -56,23 +55,20 @@ public final class PlatformApiToadlet extends Toadlet {
   /**
    * Creates a platform API toadlet backed by the supplied runtime ports.
    *
-   * @param client high-level client helper retained by the toadlet base type
    * @param runtimePorts detached runtime ports exposed to the platform API leaf
    */
-  public PlatformApiToadlet(HighLevelSimpleClient client, RuntimePorts runtimePorts) {
-    this(client, new PlatformApiRouter(runtimePorts));
+  public PlatformApiToadlet(RuntimePorts runtimePorts) {
+    this(new PlatformApiRouter(runtimePorts));
   }
 
   /**
    * Creates a platform API toadlet backed by runtime ports and AppHost.
    *
-   * @param client high-level client helper retained by the toadlet base type
    * @param runtimePorts detached runtime ports exposed to the platform API leaf
    * @param appHost detached AppHost exposed through the app-management control surface
    */
-  public PlatformApiToadlet(
-      HighLevelSimpleClient client, RuntimePorts runtimePorts, AppHost appHost) {
-    this(client, new PlatformApiRouter(runtimePorts, appHost));
+  public PlatformApiToadlet(RuntimePorts runtimePorts, AppHost appHost) {
+    this(new PlatformApiRouter(runtimePorts, appHost));
   }
 
   /**
@@ -80,14 +76,12 @@ public final class PlatformApiToadlet extends Toadlet {
    *
    * <p>This constructor exists for tests and narrow composition sites that need to inject a router
    * with controlled behavior. Production wiring normally uses {@link
-   * #PlatformApiToadlet(HighLevelSimpleClient, RuntimePorts, AppHost)} so the bridge owns router
-   * creation.
+   * #PlatformApiToadlet(RuntimePorts, AppHost)} so the bridge owns router creation.
    *
-   * @param client high-level client helper retained by the toadlet base type
    * @param router transport-neutral router that handles request validation and response generation
    */
-  PlatformApiToadlet(HighLevelSimpleClient client, PlatformApiRouter router) {
-    super(client);
+  PlatformApiToadlet(PlatformApiRouter router) {
+    super();
     this.router = Objects.requireNonNull(router, "router");
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -1138,6 +1138,9 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
       if (compatibilityMode.isEmpty()) {
         return insertCompatibilityModes.defaultModeName();
       }
+      if ("COMPAT_CURRENT".equals(compatibilityMode)) {
+        return insertCompatibilityModes.defaultModeName();
+      }
       if (insertCompatibilityModes.supportedModeNames().contains(compatibilityMode)) {
         return compatibilityMode;
       }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -10,8 +10,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
@@ -113,6 +111,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
   private final QueueSupportPort queueSupportPort;
   private final DarknetConnectionsPort darknetConnectionsPort;
   private final DarknetMessagingPort darknetMessagingPort;
+  private final InsertCompatibilityModes insertCompatibilityModes;
   private FileInsertWizardToadlet fiw;
   private final QueuePostHandler postHandler;
 
@@ -164,13 +163,11 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
    * this instance renders and which operations it allows; callers should create one instance per
    * queue side.
    *
-   * @param client HTTP client used by {@link Toadlet} for replies and navigation.
    * @param uploads {@code true} for upload queues, {@code false} for download queues.
    * @param runtimePorts queue-specific runtime-port bundle used by the legacy HTTP handlers
    */
-  public QueueToadlet(
-      HighLevelSimpleClient client, boolean uploads, QueueToadletRuntimePorts runtimePorts) {
-    super(client);
+  public QueueToadlet(boolean uploads, QueueToadletRuntimePorts runtimePorts) {
+    super();
     QueueToadletRuntimePorts ports = Objects.requireNonNull(runtimePorts);
     this.queuePagePort = ports.queuePagePort();
     this.transferAccessPort = ports.transferAccessPort();
@@ -180,6 +177,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     this.queueSupportPort = ports.queueSupportPort();
     this.darknetConnectionsPort = ports.darknetConnectionsPort();
     this.darknetMessagingPort = ports.darknetMessagingPort();
+    this.insertCompatibilityModes = ports.insertCompatibilityModes();
     this.uploads = uploads;
     this.postHandler = new QueuePostHandler();
     ports.queueCompletionPort().ensureTrackingStarted(uploads);
@@ -1138,9 +1136,12 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
     private String parseCompatibilityMode(HTTPRequest request) {
       String compatibilityMode = request.getPartAsStringFailsafe(COMPATIBILITY_MODE_FIELD, 100);
       if (compatibilityMode.isEmpty()) {
-        return CompatibilityMode.COMPAT_DEFAULT.intern().name();
+        return insertCompatibilityModes.defaultModeName();
       }
-      return CompatibilityMode.valueOf(compatibilityMode).intern().name();
+      if (insertCompatibilityModes.supportedModeNames().contains(compatibilityMode)) {
+        return compatibilityMode;
+      }
+      throw new IllegalArgumentException(compatibilityMode);
     }
 
     private QueueUploadedFile toQueueUploadedFile(HTTPUploadedFile file) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadletRuntimePorts.java
@@ -39,7 +39,9 @@ import network.crypta.runtime.spi.TransferAccessPort;
  *     startup
  * @param darknetConnectionsPort detached darknet friends-page companion port used by queue
  *     recommendation rendering
- * @param darknetMessagingPort detached darknet messaging port used by queue recommendation sends
+ * @param darknetMessagingPort detached darknet messaging port used by queue recommendation sending
+ * @param insertCompatibilityModes detached HTTP-local compatibility-mode names used by queue insert
+ *     parsing and form rendering
  */
 public record QueueToadletRuntimePorts(
     QueuePagePort queuePagePort,
@@ -50,7 +52,8 @@ public record QueueToadletRuntimePorts(
     QueueSupportPort queueSupportPort,
     QueueCompletionPort queueCompletionPort,
     DarknetConnectionsPort darknetConnectionsPort,
-    DarknetMessagingPort darknetMessagingPort) {
+    DarknetMessagingPort darknetMessagingPort,
+    InsertCompatibilityModes insertCompatibilityModes) {
   /**
    * Creates one validated queue-toadlet port bundle.
    *
@@ -70,6 +73,8 @@ public record QueueToadletRuntimePorts(
    *     download and upload toadlets for queue recommendation rendering
    * @param darknetMessagingPort detached darknet messaging port shared by the download and upload
    *     toadlets for queue recommendation sends
+   * @param insertCompatibilityModes detached HTTP-local compatibility-mode bundle shared by the
+   *     download and upload toadlets
    * @throws NullPointerException if any port is {@code null}
    */
   public QueueToadletRuntimePorts {
@@ -82,5 +87,6 @@ public record QueueToadletRuntimePorts(
     Objects.requireNonNull(queueCompletionPort);
     Objects.requireNonNull(darknetConnectionsPort);
     Objects.requireNonNull(darknetMessagingPort);
+    Objects.requireNonNull(insertCompatibilityModes);
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
@@ -5,7 +5,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.wizardsteps.PageHelper;
 import network.crypta.clients.http.wizardsteps.WizardL10n;
 import network.crypta.l10n.NodeL10n;
@@ -108,9 +107,8 @@ public class SecurityLevelsToadlet extends Toadlet {
 
   // Legacy Logger threshold callbacks removed; use LOG.isDebugEnabled() directly.
 
-  SecurityLevelsToadlet(
-      HighLevelSimpleClient client, SecurityLevelsToadletRuntimePorts runtimePorts) {
-    super(client);
+  SecurityLevelsToadlet(SecurityLevelsToadletRuntimePorts runtimePorts) {
+    super();
     this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleHelpToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleHelpToadlet.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.net.URI;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
@@ -39,8 +38,8 @@ import network.crypta.support.api.HTTPRequest;
 public class SimpleHelpToadlet extends Toadlet {
   private static final String INFOBOX_CONTENT = "infobox-content";
 
-  SimpleHelpToadlet(HighLevelSimpleClient client) {
-    super(client);
+  SimpleHelpToadlet() {
+    super();
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -486,12 +486,12 @@ public final class SimpleToadletServer
 
     routeRegistrarRef.registerRoutes(
         new LegacyHttpRouteRegistrarContext(
-            bootstrap.client(),
             runtimePorts,
             runtimeSupportRef.appHost(),
             runtimeSupportRef.config(),
             bootstrap.browseRoot(),
-            bootstrap.browseRouteRegistrar()),
+            bootstrap.browseRouteRegistrar(),
+            runtimeSupportRef.insertCompatibilityModes()),
         this);
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/StartupToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/StartupToadlet.java
@@ -47,7 +47,7 @@ public class StartupToadlet extends Toadlet {
    *     is not needed during startup.
    */
   public StartupToadlet(StaticToadlet staticToadlet) {
-    super(null);
+    super();
     this.staticToadlet = staticToadlet;
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/StaticToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/StaticToadlet.java
@@ -43,7 +43,7 @@ import network.crypta.support.io.FileBucket;
  */
 public class StaticToadlet extends Toadlet {
   StaticToadlet() {
-    super(null);
+    super();
   }
 
   private static final String KEY_PATH_NOT_FOUND_TITLE = "pathNotFoundTitle";
@@ -150,7 +150,7 @@ public class StaticToadlet extends Toadlet {
 
       long lastModified = connection.getLastModified();
       return lastModified == 0 ? null : Instant.ofEpochMilli(lastModified);
-    } catch (IOException e) {
+    } catch (IOException _) {
       return null;
     }
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/StatisticsToadlet.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.StatisticsPageSnapshot;
 import network.crypta.runtime.spi.StatisticsPort;
@@ -38,12 +37,12 @@ public class StatisticsToadlet extends Toadlet {
   private final String path;
   private final StatisticsPort statistics;
 
-  protected StatisticsToadlet(HighLevelSimpleClient client, StatisticsPort statistics) {
-    this(client, statistics, TOADLET_URL);
+  protected StatisticsToadlet(StatisticsPort statistics) {
+    this(statistics, TOADLET_URL);
   }
 
-  StatisticsToadlet(HighLevelSimpleClient client, StatisticsPort statistics, String path) {
-    super(client);
+  StatisticsToadlet(StatisticsPort statistics, String path) {
+    super();
     this.path = Objects.requireNonNull(path);
     this.statistics = statistics;
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SymlinkerToadlet.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.ToadletSymlinkEntry;
 import network.crypta.runtime.spi.ToadletSymlinkPort;
@@ -51,11 +50,10 @@ public class SymlinkerToadlet extends Toadlet {
    * port and populates the in-memory map. Construction is not thread-safe, but further alias access
    * is synchronized on the internal map.
    *
-   * @param client high-level HTTP client used to write responses and redirects for requests.
    * @param symlinkPort runtime port supplying a configuration-backed alias load and persistence.
    */
-  public SymlinkerToadlet(HighLevelSimpleClient client, ToadletSymlinkPort symlinkPort) {
-    super(client);
+  public SymlinkerToadlet(ToadletSymlinkPort symlinkPort) {
+    super();
     this.symlinkPort = Objects.requireNonNull(symlinkPort, "symlinkPort");
     for (ToadletSymlinkEntry entry : symlinkPort.loadConfiguredSymlinks()) {
       addLink(entry.alias(), entry.target(), false);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/Toadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/Toadlet.java
@@ -8,18 +8,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-import network.crypta.client.FetchContext;
-import network.crypta.client.FetchException;
-import network.crypta.client.FetchResult;
-import network.crypta.client.FetchWaiter;
-import network.crypta.client.HighLevelSimpleClient;
-import network.crypta.client.InsertBlock;
-import network.crypta.client.InsertException;
-import network.crypta.client.InsertUriChecks;
-import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
-import network.crypta.node.RequestClient;
 import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
@@ -33,8 +22,8 @@ import org.slf4j.LoggerFactory;
  * Abstract base for HTTP "toadlets" served by Crypta's browser interface. Each subclass maps to a
  * controller that renders pages or performs actions over FProxy-style endpoints without relying on
  * a servlet container. The type orchestrates reflection-based dispatch to {@code handleMethod*}
- * handlers, keeps the node-specific client helper available, and exposes helpers for common reply
- * and error patterns so subclasses stay focused on domain logic.
+ * handlers and exposes helpers for common reply and error patterns so subclasses stay focused on
+ * domain logic.
  *
  * <p>Typical usage creates a concrete toadlet, registers it with a {@link ToadletContainer}, and
  * lets the container invoke {@link #handleMethodGET(URI, HTTPRequest, ToadletContext)} or the
@@ -70,21 +59,8 @@ public abstract class Toadlet {
    */
   public static final String HANDLE_METHOD_PREFIX = "handleMethod";
 
-  final HighLevelSimpleClient client;
   ToadletContainer container;
   private String supportedMethodsCache;
-
-  /**
-   * Creates a toadlet bound to the high-level client helper used for fetch and insert operations.
-   * The client is typically shared across multiple toadlets, so connection pooling, throttling, and
-   * authentication remain consistent. Implementations should store configuration on the client
-   * rather than subclass fields so that instances stay lightweight and easy to construct.
-   *
-   * @param client Non-null helper that performs network requests on behalf of this toadlet.
-   */
-  protected Toadlet(HighLevelSimpleClient client) {
-    this.client = client;
-  }
 
   private static String l10nWithReason(String key, String value) {
     return NodeL10n.getBase()
@@ -297,46 +273,6 @@ public abstract class Toadlet {
       supportedMethodsCache = sb.toString();
     }
     return supportedMethodsCache;
-  }
-
-  /**
-   * Client calls from the above messages to run a Freenet request. This method may block (or
-   * suspend).
-   *
-   * @param maxSize Maximum length of returned content.
-   * @param clientContext Client context object. This should be the same for any group of related
-   *     requests, but different for any two unrelated requests. Request selection round-robin's
-   *     over these, within any priority and retry count class, and above the level of individual
-   *     block fetches.
-   */
-  FetchResult fetch(FreenetURI uri, long maxSize, RequestClient clientContext, FetchContext fctx)
-      throws FetchException {
-    // Honor the provided maxSize for this request.
-    if (maxSize > 0) {
-      fctx.setMaxOutputLength(maxSize);
-      fctx.setMaxTempLength(maxSize);
-    }
-    FetchWaiter fw = new FetchWaiter(clientContext);
-    getClientImpl().fetch(uri, fw, fctx);
-    return fw.waitForCompletion();
-  }
-
-  /**
-   * Returns a default FetchContext
-   *
-   * @param maxSize The maximum allowable size of the fetch's result
-   * @return A default FetchContext
-   */
-  FetchContext getFetchContext(long maxSize, String schemeHostAndPort) {
-    // We want to retrieve a FetchContext we may override
-    return getClientImpl().getFetchContext(maxSize, schemeHostAndPort);
-  }
-
-  FreenetURI insert(InsertBlock insert, String filenameHint) throws InsertException {
-    // For now, just run it blocking.
-    FreenetURI desiredURI = Objects.requireNonNull(insert.desiredURI, "InsertBlock.desiredURI");
-    InsertUriChecks.checkInsertURI(desiredURI);
-    return getClientImpl().insert(insert, false, filenameHint);
   }
 
   /**
@@ -581,7 +517,7 @@ public abstract class Toadlet {
    * @param ctx The context object for this request.
    * @param desc The title of the error page
    * @param message The message to be sent to the user. The stack trace will follow.
-   * @param t The Throwable which caused the error.
+   * @param t The Throwable that caused the error.
    * @throws IOException If there is an error writing the reply.
    * @throws ToadletContextClosedException If the context has already been closed.
    */
@@ -650,16 +586,5 @@ public abstract class Toadlet {
     pw.flush();
     msg = msg + sw + "</pre></body></html>";
     writeHTMLReply(ctx, 500, "Internal Error", msg);
-  }
-
-  /**
-   * Exposes the underlying high-level client used for network operations. Callers may tweak shared
-   * settings or initiate fetch/insert requests, but should respect the container's threading model
-   * and avoid blocking calls on UI threads.
-   *
-   * @return The reusable {@link HighLevelSimpleClient} instance backing this toadlet.
-   */
-  protected HighLevelSimpleClient getClientImpl() {
-    return client;
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/TranslationToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/TranslationToadlet.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.l10n.TranslationPaths;
@@ -36,10 +35,9 @@ import network.crypta.support.io.BucketTools;
  *   <li>After changes, the user can download the override file for persistence.
  * </ul>
  *
- * The toadlet relies on {@link HighLevelSimpleClient} for application glue, but it keeps
- * request-level parsing and HTML generation self-contained to minimize coupling. Callers should
- * treat it as a long-lived endpoint registered once during node initialization and reused for
- * multiple sessions.
+ * The toadlet keeps request-level parsing and HTML generation self-contained to minimize coupling.
+ * Callers should treat it as a long-lived endpoint registered once during node initialization and
+ * reused for multiple sessions.
  *
  * @author Florent Daigni&egrave;re &lt;nextgens@freenetproject.org&gt;
  * @author Artefact2
@@ -82,8 +80,8 @@ public class TranslationToadlet extends Toadlet {
   private BaseL10n base;
   private String translatingFor;
 
-  TranslationToadlet(HighLevelSimpleClient client) {
-    super(client);
+  TranslationToadlet() {
+    super();
     this.base = NodeL10n.getBase();
     this.translatingFor = "Node";
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/UserAlertsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/UserAlertsToadlet.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import javax.naming.SizeLimitExceededException;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.alerts.AbstractNodeToNodeFileOfferUserAlert;
 import network.crypta.runtime.alerts.NodeToNodeMessageUserAlert;
@@ -20,7 +19,7 @@ import network.crypta.support.api.HTTPRequest;
  * <p>This toadlet renders a dedicated alerts page for browser clients. The page shows the current
  * queue of {@link UserAlert} instances produced by the running node, optionally providing bulk
  * controls to dismiss every dismissible alert or to permanently delete node-to-node messages after
- * explicit confirmation. When no alerts exist it renders a localized infobox explaining that the
+ * explicit confirmation. When no alerts exist, it renders a localized infobox explaining that the
  * inbox is empty. The class is stateless apart from its injected client, so each invocation uses
  * the request-scoped {@link ToadletContext} and the alert manager it exposes.
  *
@@ -32,7 +31,7 @@ import network.crypta.support.api.HTTPRequest;
  * markup consistent with the surrounding UI.
  *
  * <ul>
- *   <li>Responsibilities: render alert list, expose bulk dismiss/delete controls, perform safe
+ *   <li>Responsibilities: render the alert list, expose bulk dismiss/delete controls, perform safe
  *       redirects after mutation.
  *   <li>Thread safety: relies on request-scoped context; no mutable state stored on the instance.
  * </ul>
@@ -48,18 +47,18 @@ public class UserAlertsToadlet extends Toadlet {
   private static final String TITLE = "title";
   private static final String INPUT_TAG = "input";
 
-  UserAlertsToadlet(HighLevelSimpleClient client) {
-    super(client);
+  UserAlertsToadlet() {
+    super();
   }
 
   /**
-   * Handles GET requests to render the alerts page and present available bulk actions.
+   * Handles GET requests to render the Alerts page and present available bulk actions.
    *
    * <p>The method first enforces full-access requirements for the current user, then constructs a
-   * page using the {@link PageMaker} provided by the context. When alerts exist it attaches
+   * page using the {@link PageMaker} provided by the context. When alerts exist, it attaches
    * localized buttons to dismiss every dismissible alert or delete eligible node-to-node messages;
    * otherwise it renders a friendly infobox explaining that no messages are pending. The resulting
-   * HTML is written with a 200 OK status and without modifying alert state.
+   * HTML is written with a 200 OK status and without modifying the alert state.
    *
    * @param uri absolute request URI that should point to the "alerts" endpoint.
    * @param request HTTP request carrying any query parameters; body content is ignored.
@@ -132,10 +131,10 @@ public class UserAlertsToadlet extends Toadlet {
    * <p>The handler inspects submitted form parts to determine which action to execute. It supports
    * dismissing a single alert by hash code, bulk dismissing every user-dismissible alert, and
    * deleting all node-to-node message alerts after the caller affirms a dedicated confirmation
-   * checkbox. After mutating state it redirects to a constrained, validated location to avoid
+   * checkbox. After mutating the state, it redirects to a constrained, validated location to avoid
    * untrusted redirects.
    *
-   * @param uri absolute request URI for the alerts endpoint; not directly mutated.
+   * @param uri absolute request URI for the Alerts endpoint; not directly mutated.
    * @param request HTTP request containing form parts that indicate the desired alert action.
    * @param ctx toadlet context providing alert management facilities and redirect helpers.
    * @throws ToadletContextClosedException if the client disconnects before the redirect headers are

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.fs.readiness.LauncherReadinessInfo;
 import network.crypta.platform.webshell.WebShellPageRenderer;
 import network.crypta.platform.webshell.WebShellResources;
@@ -46,13 +45,9 @@ public final class WebShellToadlet extends Toadlet {
   /** Adapter-owned bootstrap payload injected into the rendered shell document. */
   private final WebShellBootstrap bootstrap;
 
-  /**
-   * Creates a Web Shell bridge backed by the shared interactive HTTP client.
-   *
-   * @param client high-level client retained by the toadlet base type
-   */
-  public WebShellToadlet(HighLevelSimpleClient client) {
-    this(client, createNodeManagementBootstrap(defaultLegacyLinks()));
+  /** Creates a Web Shell bridge backed by the default node-management bootstrap payload. */
+  public WebShellToadlet() {
+    this(createNodeManagementBootstrap(defaultLegacyLinks()));
   }
 
   /**
@@ -61,11 +56,10 @@ public final class WebShellToadlet extends Toadlet {
    * <p>This package-local constructor exists for focused adapter tests that need to verify
    * bootstrap injection without relying on the default legacy-link set.
    *
-   * @param client high-level client retained by the toadlet base type
    * @param bootstrap shell bootstrap payload to embed in the rendered page
    */
-  WebShellToadlet(HighLevelSimpleClient client, WebShellBootstrap bootstrap) {
-    super(client);
+  WebShellToadlet(WebShellBootstrap bootstrap) {
+    super();
     this.bootstrap = Objects.requireNonNull(bootstrap, "bootstrap");
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebTemplateToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebTemplateToadlet.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.utils.PebbleUtils;
 import network.crypta.support.HTMLNode;
 
@@ -13,9 +12,8 @@ import network.crypta.support.HTMLNode;
  * are already being composed in memory rather than streamed directly to the client. It keeps the
  * templating concerns narrowly focused on delegating to {@link PebbleUtils}, while leaving request
  * routing, validation, and error handling to concrete toadlets. The class is stateless apart from
- * the shared {@link HighLevelSimpleClient} reference, so instances can be reused across requests as
- * long as callers supply thread-safe model data and do not share mutable {@link HTMLNode} trees
- * unsafely.
+ * the shared HTTP shell, so instances can be reused across requests as long as callers supply
+ * thread-safe model data and do not share mutable {@link HTMLNode} trees unsafely.
  *
  * <p>Typical usage is to build an {@code HTMLNode} hierarchy with structural elements, then call
  * {@link #addChild(HTMLNode, String, Map, String)} for each section that should be rendered from a
@@ -32,19 +30,9 @@ import network.crypta.support.HTMLNode;
  */
 abstract class WebTemplateToadlet extends Toadlet {
 
-  /**
-   * Creates a template-aware toadlet wrapper bound to the provided client.
-   *
-   * <p>The client reference is retained for use by subclasses; it is neither copied nor closed by
-   * this base class. Callers should ensure the client remains valid for the lifetime of the
-   * toadlet. The constructor performs no I/O and is safe to invoke during application startup or
-   * lazy initialization.
-   *
-   * @param client client used by subclasses to perform higher-level HTTP interactions; must remain
-   *     usable for the lifespan of this toadlet instance.
-   */
-  WebTemplateToadlet(HighLevelSimpleClient client) {
-    super(client);
+  /** Creates a template-aware toadlet wrapper. */
+  WebTemplateToadlet() {
+    super();
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updater/CoreActionToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/updater/CoreActionToadlet.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker;
 import network.crypta.clients.http.PageNode;
 import network.crypta.clients.http.ReplyHeaders;
@@ -102,13 +101,11 @@ public class CoreActionToadlet extends Toadlet {
    * installer path validation while the toadlet keeps runtime environment and response rendering
    * behavior in the HTTP layer.
    *
-   * @param client high-level client used by the toadlet base class for HTTP operations
    * @param coreUpdateActionPort runtime port that exposes the remaining daemon-backed updater
    *     actions needed by this toadlet
    */
-  public CoreActionToadlet(
-      HighLevelSimpleClient client, CoreUpdateActionPort coreUpdateActionPort) {
-    super(client);
+  public CoreActionToadlet(CoreUpdateActionPort coreUpdateActionPort) {
+    super();
     this.coreUpdateActionPort =
         Objects.requireNonNull(coreUpdateActionPort, "coreUpdateActionPort");
   }

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/HttpShellBrowseBootstrapTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/HttpShellBrowseBootstrapTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.http;
 
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 import org.junit.jupiter.api.Test;
@@ -17,18 +16,15 @@ class HttpShellBrowseBootstrapTest {
   @Test
   void create_whenGivenBrowseRoot_returnsBootstrapWithSameCollaborators() {
     BookmarkManagerHandle bookmarkManager = mock(BookmarkManagerHandle.class);
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
         mock(LegacyHttpBrowseRouteRegistrar.class);
 
     HttpShellBrowseBootstrap bootstrap =
-        HttpShellBrowseBootstrap.create(
-            bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar);
+        HttpShellBrowseBootstrap.create(bookmarkManager, appHost, browseRoot, browseRouteRegistrar);
 
     assertSame(bookmarkManager, bootstrap.bookmarkManager());
-    assertSame(client, bootstrap.client());
     assertSame(appHost, bootstrap.appHost());
     assertSame(browseRoot, bootstrap.browseRoot());
     assertSame(browseRouteRegistrar, bootstrap.browseRouteRegistrar());
@@ -37,7 +33,6 @@ class HttpShellBrowseBootstrapTest {
   @Test
   void create_whenGivenInitializationHook_returnsBootstrapWithSameCollaborators() {
     BookmarkManagerHandle bookmarkManager = mock(BookmarkManagerHandle.class);
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
@@ -46,15 +41,9 @@ class HttpShellBrowseBootstrapTest {
 
     HttpShellBrowseBootstrap bootstrap =
         HttpShellBrowseBootstrap.create(
-            bookmarkManager,
-            client,
-            appHost,
-            browseRoot,
-            browseRouteRegistrar,
-            runtimePortsSeen::set);
+            bookmarkManager, appHost, browseRoot, browseRouteRegistrar, runtimePortsSeen::set);
 
     assertSame(bookmarkManager, bootstrap.bookmarkManager());
-    assertSame(client, bootstrap.client());
     assertSame(appHost, bootstrap.appHost());
     assertSame(browseRoot, bootstrap.browseRoot());
     assertSame(browseRouteRegistrar, bootstrap.browseRouteRegistrar());
@@ -68,7 +57,6 @@ class HttpShellBrowseBootstrapTest {
   @Test
   void create_whenInitializationHookNull_throwsNullPointerException() {
     BookmarkManagerHandle bookmarkManager = mock(BookmarkManagerHandle.class);
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
@@ -78,32 +66,30 @@ class HttpShellBrowseBootstrapTest {
         NullPointerException.class,
         () ->
             HttpShellBrowseBootstrap.create(
-                bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar, null));
+                bookmarkManager, appHost, browseRoot, browseRouteRegistrar, null));
   }
 
   @Test
   void create_whenBrowseRouteRegistrarNull_throwsNullPointerException() {
     BookmarkManagerHandle bookmarkManager = mock(BookmarkManagerHandle.class);
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
 
     assertThrows(
         NullPointerException.class,
-        () -> HttpShellBrowseBootstrap.create(bookmarkManager, client, appHost, browseRoot, null));
+        () -> HttpShellBrowseBootstrap.create(bookmarkManager, appHost, browseRoot, null));
   }
 
   @Test
   void initializeSharedShellState_whenUsingDefaultHook_skipsInitialization() {
     BookmarkManagerHandle bookmarkManager = mock(BookmarkManagerHandle.class);
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
         mock(LegacyHttpBrowseRouteRegistrar.class);
     HttpShellBrowseBootstrap bootstrap =
         HttpShellBrowseBootstrap.create(
-            bookmarkManager, client, appHost, mock(Toadlet.class), browseRouteRegistrar);
+            bookmarkManager, appHost, mock(Toadlet.class), browseRouteRegistrar);
 
     bootstrap.initializeSharedShellState(runtimePorts);
 
@@ -113,14 +99,12 @@ class HttpShellBrowseBootstrapTest {
   @Test
   void initializeSharedShellState_whenRuntimePortsNull_throwsNullPointerException() {
     BookmarkManagerHandle bookmarkManager = mock(BookmarkManagerHandle.class);
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     AppHost appHost = mock(AppHost.class);
     Toadlet browseRoot = mock(Toadlet.class);
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar =
         mock(LegacyHttpBrowseRouteRegistrar.class);
     HttpShellBrowseBootstrap bootstrap =
-        HttpShellBrowseBootstrap.create(
-            bookmarkManager, client, appHost, browseRoot, browseRouteRegistrar);
+        HttpShellBrowseBootstrap.create(bookmarkManager, appHost, browseRoot, browseRouteRegistrar);
 
     assertThrows(NullPointerException.class, () -> bootstrap.initializeSharedShellState(null));
   }

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -49,10 +49,21 @@ class HttpLegacyAdminBoundaryTest {
       ADAPTER_HTTP_MAIN_JAVA.resolve("IntervalPusherManager.java");
   private static final Path ADAPTER_HTTP_SHELL_RUNTIME_SUPPORT =
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellRuntimeSupport.java");
+  private static final Path ADAPTER_LEGACY_HTTP_BROWSE_ROUTE_REGISTRAR_CONTEXT =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("LegacyHttpBrowseRouteRegistrarContext.java");
+  private static final Path ADAPTER_FPROXY_REGISTRAR_DEPENDENCIES =
+      ADAPTER_HTTP_MAIN_JAVA.resolve("FProxyRegistrarDependencies.java");
   private static final String USER_ALERT_MANAGER_IMPORT =
       "import network.crypta.runtime.alerts.UserAlertManager;";
   private static final String PROGRAM_DIRECTORY_IMPORT =
       "import network.crypta.node.ProgramDirectory;";
+  private static final Set<String> FORBIDDEN_RUNTIME_NODE_CLIENT_IMPORTS =
+      Set.of(
+          "import network.crypta.client.HighLevelSimpleClient;",
+          "import network.crypta.client.FetchContext;",
+          "import network.crypta.client.FetchWaiter;",
+          "import network.crypta.client.InsertContext;",
+          "import network.crypta.client.InsertContext.CompatibilityMode;");
   private static final Path ADAPTER_HTTP_FPROXY_BOOTSTRAP =
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellFProxyBootstrap.java");
   private static final Path ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR =
@@ -277,6 +288,7 @@ class HttpLegacyAdminBoundaryTest {
     String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
     String adapterBuild = Files.readString(repoRoot.resolve(ADAPTER_BUILD_FILE));
     String browseBuild = Files.readString(repoRoot.resolve(BROWSE_BUILD_FILE));
+    String browseMetadata = Files.readString(repoRoot.resolve(BROWSE_OWNERSHIP_METADATA));
     String bridgeMetadata = Files.readString(repoRoot.resolve(BRIDGE_OWNERSHIP_METADATA));
     String adapterMetadata = Files.readString(repoRoot.resolve(OWNERSHIP_METADATA));
 
@@ -289,6 +301,9 @@ class HttpLegacyAdminBoundaryTest {
     assertTrue(
         Files.isRegularFile(repoRoot.resolve(BROWSE_OWNERSHIP_METADATA)),
         ":adapter-http-legacy-browse must declare owned-output-patterns.txt");
+    assertTrue(
+        browseMetadata.contains("network/crypta/clients/http/ContentToadlet*.class"),
+        ":adapter-http-legacy-browse must own network/crypta/clients/http/ContentToadlet*.class");
     assertTrue(
         browseBuild.contains("project(\":adapter-http-legacy-admin\")"),
         ":adapter-http-legacy-browse must depend on :adapter-http-legacy-admin");
@@ -306,6 +321,9 @@ class HttpLegacyAdminBoundaryTest {
     assertFalse(
         adapterMetadata.contains("network/crypta/clients/http/geoip/**"),
         ":adapter-http-legacy-admin must not claim network/crypta/clients/http/geoip/**");
+    assertFalse(
+        adapterMetadata.contains("network/crypta/clients/http/ContentToadlet*.class"),
+        ":adapter-http-legacy-admin must not claim ContentToadlet*.class");
   }
 
   @Test
@@ -391,6 +409,64 @@ class HttpLegacyAdminBoundaryTest {
         "SimpleToadletServer, ToadletContext, ToadletContextImpl, ToadletRequestServices, "
             + "HttpShellBrowseBootstrap, PageMaker, and IntervalPusherManager must not import "
             + "browse-owned bookmark, push, or client-script collaborators."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void mainSources_whenCheckingAdminHttpImports_expectRuntimeNodeClientContractsRemoved()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile : findMainJavaSources(repoRoot)) {
+      Path relativePath = repoRoot.relativize(sourceFile);
+      if (!relativePath.startsWith(ADAPTER_HTTP_MAIN_JAVA)) {
+        continue;
+      }
+
+      Set<String> imports = readImports(sourceFile);
+      for (String forbiddenImport : FORBIDDEN_RUNTIME_NODE_CLIENT_IMPORTS) {
+        if (imports.contains(forbiddenImport)) {
+          violations.add(relativePath + " -> " + forbiddenImport);
+        }
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "adapter-http-legacy-admin main sources must not import runtime-node client contracts "
+            + "directly anymore."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void mainSources_whenCheckingAdminBrowseSeam_expectRegistrarContextsDetached()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile :
+        List.of(
+            ADAPTER_HTTP_SHELL_BROWSE_BOOTSTRAP,
+            ADAPTER_LEGACY_HTTP_BROWSE_ROUTE_REGISTRAR_CONTEXT,
+            ADAPTER_FPROXY_REGISTRAR_DEPENDENCIES,
+            ADAPTER_HTTP_SHELL_RUNTIME_SUPPORT,
+            ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR,
+            ADAPTER_FPROXY_REGISTRAR,
+            ADAPTER_LEGACY_HTTP_ROUTE_REGISTRAR_CONTEXT,
+            ADAPTER_QUEUE_TOADLET,
+            ADAPTER_HTTP_MAIN_JAVA.resolve("FileInsertWizardToadlet.java"))) {
+      String source = Files.readString(repoRoot.resolve(sourceFile));
+      if (source.contains("HighLevelSimpleClient")) {
+        violations.add(sourceFile + " -> HighLevelSimpleClient");
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Admin-owned legacy HTTP seam classes should no longer mention HighLevelSimpleClient."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
   }

--- a/adapter-http-legacy-browse/gradle/owned-output-patterns.txt
+++ b/adapter-http-legacy-browse/gradle/owned-output-patterns.txt
@@ -4,6 +4,7 @@
 network/crypta/clients/http/BookmarkEditorToadlet*.class
 network/crypta/clients/http/BookmarkEditorToadletRuntimePorts*.class
 network/crypta/clients/http/BrowserTestToadlet*.class
+network/crypta/clients/http/ContentToadlet*.class
 network/crypta/clients/http/ContentFilterToadlet*.class
 network/crypta/clients/http/DecodeToadlet*.class
 network/crypta/clients/http/ExternalLinkToadlet*.class

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BookmarkEditorToadlet.java
@@ -52,7 +52,7 @@ import static network.crypta.clients.http.QueueToadlet.MAX_KEY_LENGTH;
  * to track clipboard state, so callers should ensure per-request isolation. All other operations
  * are delegated to thread-safe components owned by the surrounding node.
  */
-public class BookmarkEditorToadlet extends Toadlet {
+public class BookmarkEditorToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(BookmarkEditorToadlet.class);
   private static final int MAX_ACTION_LENGTH = 20;
   private static final String ATTRIBUTE_CLASS = "class";

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BrowserTestToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/BrowserTestToadlet.java
@@ -33,7 +33,7 @@ import network.crypta.support.api.HTTPRequest;
  *
  * @see Toadlet
  */
-public class BrowserTestToadlet extends Toadlet {
+public class BrowserTestToadlet extends ContentToadlet {
 
   BrowserTestToadlet(HighLevelSimpleClient client) {
     super(client);
@@ -206,7 +206,7 @@ public class BrowserTestToadlet extends Toadlet {
    * summaries sourced from the context's alert manager.
    *
    * @param uri URI identifying the resource path within the test toadlet.
-   * @param request HTTPRequest containing query parameters and browser capability hints sent by
+   * @param request HTTPRequest containing query parameters and browser capability hints sent by the
    *     client.
    * @param ctx Context that renders HTML, manages permissions, and writes response safely.
    * @throws ToadletContextClosedException if the connection closes before the response is written.
@@ -215,7 +215,7 @@ public class BrowserTestToadlet extends Toadlet {
   @Override
   public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
-    // Yes, we need that in order to test the browser (number of connections per server)
+    // Yes, we need that to test the browser (number of connections per server)
     if (request.isParameterSet("wontload")) return;
 
     PageNode page = ctx.getPageMaker().getPageNode("Crypta browser testing tool", ctx);
@@ -224,7 +224,7 @@ public class BrowserTestToadlet extends Toadlet {
     if (ctx.isAllowedFullAccess()) contentNode.addChild(ctx.getAlertManager().createSummary());
 
     // #### Test MIME inline
-    /* for test (for allow <img src="data:...) add "; img-src 'self' data:"
+    /* for test (for allowing <img src="data:...) add "; img-src 'self' data:"
      * to freenet.clients.http.ToadletContextImpl#generateCSP return statement */
     ctx.getPageMaker()
         .getInfobox(INFOBOX_WARNING_CLASS, "MIME Inline", contentNode, "mime-inline-test", true)

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ContentFilterToadlet.java
@@ -28,8 +28,6 @@ import network.crypta.support.io.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static network.crypta.clients.http.LegacyContentFilterSupport.l10n;
-
 /**
  * Exposes a small HTTP UI that lets advanced users run the content filter against uploaded or local
  * files and inspect the sanitized output.
@@ -56,7 +54,7 @@ import static network.crypta.clients.http.LegacyContentFilterSupport.l10n;
  * @see LocalFileFilterToadlet
  * @see ContentFilter
  */
-public class ContentFilterToadlet extends Toadlet implements LinkEnabledCallback {
+public class ContentFilterToadlet extends ContentToadlet implements LinkEnabledCallback {
   private static final Logger LOG = LoggerFactory.getLogger(ContentFilterToadlet.class);
 
   /**

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ContentToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ContentToadlet.java
@@ -1,0 +1,135 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchResult;
+import network.crypta.client.FetchWaiter;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.InsertBlock;
+import network.crypta.client.InsertException;
+import network.crypta.client.InsertUriChecks;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+
+/**
+ * Browse-owned HTTP toadlet base that retains the shared high-level client helper.
+ *
+ * <p>This class is the browse-side counterpart to the now content-neutral admin-owned {@link
+ * Toadlet} base. The shared shell still owns route dispatch, reply helpers, and general HTTP
+ * presentation logic, while browse-owned routes continue to need direct access to the legacy
+ * high-level client for content fetches, insert requests, and fetch-context creation. Keeping those
+ * operations here lets the boundary stay explicit: admin code no longer imports the client
+ * contracts, and browse code keeps the remaining runtime-node coupling in one local place.
+ *
+ * <p>Subclasses typically use this base when they render or mutate network-backed content during a
+ * request. The helper methods intentionally keep the historic blocking behavior of legacy browse
+ * toadlets. Callers should therefore continue to use them only in request paths that already expect
+ * synchronous fetch or insert work, and should prefer detached runtime ports elsewhere when a
+ * narrower seam is available.
+ *
+ * <ul>
+ *   <li>Owns the shared {@link HighLevelSimpleClient} for browse-only toadlets.
+ *   <li>Preserves the legacy-blocking fetch and insert helper shape.
+ *   <li>Keeps runtime-node content-client contracts out of admin-owned shell classes.
+ * </ul>
+ *
+ * @see Toadlet
+ * @see HighLevelSimpleClient
+ */
+public abstract class ContentToadlet extends Toadlet {
+  final HighLevelSimpleClient client;
+
+  /**
+   * Creates a browse-owned toadlet bound to the shared high-level client.
+   *
+   * <p>The supplied client is typically created once during browse bootstrap and then reused across
+   * multiple browse-owned toadlets so they share fetch defaults, request attribution, and insert
+   * behavior. The base stores only the client reference; it does not perform I/O during
+   * construction and does not create derived contexts eagerly.
+   *
+   * @param client shared browse-side high-level client used for fetch-context creation, blocking
+   *     fetches, and inserts
+   * @throws NullPointerException if {@code client} is {@code null}
+   */
+  protected ContentToadlet(HighLevelSimpleClient client) {
+    this.client = Objects.requireNonNull(client, "client");
+  }
+
+  /**
+   * Performs a blocking fetch using the shared browse-side client.
+   *
+   * <p>The helper preserves the historical legacy HTTP behavior: if {@code maxSize} is positive, it
+   * applies that value to both output and temporary-length limits on the supplied fetch context,
+   * starts an asynchronous fetch, then blocks on a {@link FetchWaiter} until completion. The
+   * caller-provided {@link RequestClient} is reused for request attribution and scheduler grouping.
+   *
+   * @param uri content URI to fetch for the current request
+   * @param maxSize maximum number of bytes to allow for the fetched output and temporary data;
+   *     non-positive values leave the existing context limits unchanged
+   * @param clientContext request identity used by the waiter and scheduler for this fetch
+   * @param fctx mutable fetch context to use for the request
+   * @return completed fetch result returned by the shared client after the waiter observes success
+   * @throws FetchException if the fetch fails, is canceled, or the waiter reports an error
+   */
+  FetchResult fetch(FreenetURI uri, long maxSize, RequestClient clientContext, FetchContext fctx)
+      throws FetchException {
+    if (maxSize > 0) {
+      fctx.setMaxOutputLength(maxSize);
+      fctx.setMaxTempLength(maxSize);
+    }
+    FetchWaiter fw = new FetchWaiter(clientContext);
+    client.fetch(uri, fw, fctx);
+    return fw.waitForCompletion();
+  }
+
+  /**
+   * Returns a fresh fetch context derived from the shared browse-side client.
+   *
+   * <p>Browse-owned toadlets use this to get the same baseline fetch policy the shared client would
+   * use elsewhere, while still allowing per-request size limits and scheme/host hints to be applied
+   * by callers. The returned context remains mutable and caller-owned after creation.
+   *
+   * @param maxSize requested maximum output size for the derived context
+   * @param schemeHostAndPort scheme, host, and port string used when the client derives request
+   *     context defaults for the current origin
+   * @return fetch context created by the shared high-level client for one request
+   */
+  FetchContext getFetchContext(long maxSize, String schemeHostAndPort) {
+    return client.getFetchContext(maxSize, schemeHostAndPort);
+  }
+
+  /**
+   * Performs a blocking insert using the shared browse-side client.
+   *
+   * <p>The helper validates that the supplied {@link InsertBlock} carries a non-null desired URI
+   * and that the URI is acceptable for legacy insert handling before delegating to the shared
+   * client. It preserves the historic single-file insert behavior by requesting a normal insert
+   * rather than a CHK-only computation.
+   *
+   * @param insert insert payload, metadata, and desired target URI for the operation
+   * @param filenameHint optional filename hint used by the client when it derives manifest details
+   * @return final URI returned by the shared high-level client after the insert completes
+   * @throws InsertException if URI validation fails or the insert does not complete successfully
+   * @throws NullPointerException if {@code insert.desiredURI} is {@code null}
+   */
+  FreenetURI insert(InsertBlock insert, String filenameHint) throws InsertException {
+    FreenetURI desiredURI = Objects.requireNonNull(insert.desiredURI, "InsertBlock.desiredURI");
+    InsertUriChecks.checkInsertURI(desiredURI);
+    return client.insert(insert, false, filenameHint);
+  }
+
+  /**
+   * Exposes the underlying high-level client for browse-owned subclasses that still need it.
+   *
+   * <p>Most subclasses should prefer the narrower helper methods on this base, but some legacy
+   * browse-owned code still needs direct access to client operations or client-level configuration.
+   * The returned instance is the same shared client that the constructor received.
+   *
+   * @return shared browse-side high-level client backing this toadlet
+   */
+  @SuppressWarnings("unused")
+  protected HighLevelSimpleClient getClientImpl() {
+    return client;
+  }
+}

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/DecodeToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/DecodeToadlet.java
@@ -29,7 +29,7 @@ import network.crypta.support.api.HTTPRequest;
  * @see Toadlet
  * @see ToadletContext
  */
-public class DecodeToadlet extends Toadlet {
+public class DecodeToadlet extends ContentToadlet {
   DecodeToadlet(HighLevelSimpleClient client) {
     super(client);
   }

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ExternalLinkToadlet.java
@@ -34,7 +34,7 @@ import network.crypta.support.http.ExternalLinkSupport;
  * relies on upstream components for network access and policy. Because it operates on user-supplied
  * URLs, callers should ensure the surrounding flow already escaped or encoded values appropriately.
  */
-public class ExternalLinkToadlet extends Toadlet {
+public class ExternalLinkToadlet extends ContentToadlet {
 
   private static final int MAX_URL_LENGTH = 1024 * 1024;
 

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/FProxyToadlet.java
@@ -94,7 +94,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @see QueueToadlet
  * @see FProxyFetchTracker
  */
-public final class FProxyToadlet extends Toadlet implements RequestClient {
+public final class FProxyToadlet extends ContentToadlet implements RequestClient {
   private static final Logger LOG = LoggerFactory.getLogger(FProxyToadlet.class);
 
   private static final String L10N_PREFIX = "FProxyToadlet.";

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ImageCreatorToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ImageCreatorToadlet.java
@@ -25,11 +25,11 @@ import network.crypta.support.api.HTTPRequest;
  * parameter and may optionally influence the canvas size through {@code width} and {@code height}
  * query parameters. When either dimension is omitted, sensible defaults keep the output compact
  * enough for inline display. Oversized inputs are rejected to avoid unbounded memory growth and to
- * keep latency predictable even under concurrent load.
+ * keep latency predictable even under a concurrent load.
  *
  * <p>Responses include a strong {@code Last-Modified} header keyed to the class timestamp so
  * browsers can reuse cached images without regenerating them on every request. The implementation
- * is effectively stateless; each request builds its own buffer and disposes it immediately after
+ * is effectively stateless; each request builds its own buffer and disposes of it immediately after
  * the PNG is streamed to the client-side bucket. No shared mutable state is retained, so instances
  * are safe to serve multiple requests concurrently when registered with the toadlet server.
  *
@@ -41,7 +41,7 @@ import network.crypta.support.api.HTTPRequest;
  *
  * @see network.crypta.clients.http.Toadlet
  */
-public class ImageCreatorToadlet extends Toadlet {
+public class ImageCreatorToadlet extends ContentToadlet {
 
   private static final String ROOT_URL = "/imagecreator/";
 
@@ -84,7 +84,7 @@ public class ImageCreatorToadlet extends Toadlet {
    * and response writing. Instances created through this constructor are stateless; multiple
    * toadlets may coexist and serve concurrent requests as long as the client manages shared
    * resources safely. Callers typically register the instance with the toadlet server immediately
-   * after construction so HTTP requests under the configured path are dispatched here.
+   * after construction, so HTTP requests under the configured path are dispatched here.
    *
    * @param client non-null high-level client used for bucket creation and other inherited helpers
    */

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/InsertFreesiteToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/InsertFreesiteToadlet.java
@@ -30,7 +30,7 @@ import network.crypta.support.http.ExternalLinkSupport;
  * localization and link content are fixed at compile time, which avoids runtime variability and
  * keeps the rendered HTML deterministic for testing.
  */
-public class InsertFreesiteToadlet extends Toadlet {
+public class InsertFreesiteToadlet extends ContentToadlet {
 
   /**
    * Create a new freesite help toadlet bound to the shared high-level client.

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrar.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrar.java
@@ -15,26 +15,25 @@ import network.crypta.runtime.spi.TransferAccessPort;
  * classes out of the admin-owned startup path while preserving the exact historical insertion
  * points that the legacy shell already exposed.
  *
- * <p>The registrar is stateless and safe to reuse across startup attempts as long as callers still
- * treat registration as a one-shot action for a single {@link SimpleToadletServer}. It does not
- * create menus or routes eagerly. Instead, it reacts to the requested {@link Phase}, publishes only
- * the browse-owned routes assigned to that phase, and leaves the surrounding admin registrar
- * responsible for the overall route order. The AJAX-push route family is delegated to {@link
+ * <p>The registrar captures the browse-side client during bridge/runtime construction, so the
+ * admin-owned shell records no longer need to carry it through the registration seam. It is safe to
+ * reuse across startup attempts as long as callers still treat registration as a one-shot action
+ * for a single {@link SimpleToadletServer}. The AJAX-push route family is delegated to {@link
  * LegacyFProxyAjaxPushRouteRegistrar} so this class can focus on the larger browse ownership seam.
  */
 public final class LegacyFProxyBrowseRouteRegistrar implements LegacyHttpBrowseRouteRegistrar {
   private static final LegacyFProxyAjaxPushRouteRegistrar AJAX_PUSH_ROUTE_REGISTRAR =
       new LegacyFProxyAjaxPushRouteRegistrar();
 
+  private final HighLevelSimpleClient client;
+
   /**
-   * Creates a stateless browse-route registrar for the current FProxy-backed legacy HTTP shell.
+   * Creates a browse-route registrar bound to the shared interactive client.
    *
-   * <p>Construction performs no route instantiation and does not capture runtime-specific state.
-   * All browse-owned collaborators still arrive later through the registration context prepared by
-   * the shared shell bootstrap path.
+   * @param client shared interactive client used by browse-owned HTTP toadlets
    */
-  public LegacyFProxyBrowseRouteRegistrar() {
-    // This registrar is intentionally stateless.
+  public LegacyFProxyBrowseRouteRegistrar(HighLevelSimpleClient client) {
+    this.client = client;
   }
 
   /**
@@ -59,8 +58,8 @@ public final class LegacyFProxyBrowseRouteRegistrar implements LegacyHttpBrowseR
       case QUEUE_FILTER_ROUTES -> registerQueueFilterRoutes(context, server);
       case POST_CONFIG_ROUTES -> registerPostConfigRoutes(context, server);
       case POST_MESSAGING_ROUTES -> registerPostMessagingRoutes(context, server);
-      case POST_PLATFORM_API_ROUTES -> registerPostPlatformApiRoutes(context, server);
-      case TAIL_ROUTES -> registerTailRoutes(context.client(), server);
+      case POST_PLATFORM_API_ROUTES -> registerPostPlatformApiRoutes(server);
+      case TAIL_ROUTES -> registerTailRoutes(server);
     }
   }
 
@@ -69,10 +68,8 @@ public final class LegacyFProxyBrowseRouteRegistrar implements LegacyHttpBrowseR
         "/", LegacyHttpCategories.CATEGORY_BROWSING, "FProxyToadlet.categoryTitleBrowsing");
   }
 
-  private static void registerIntroRoutes(
+  private void registerIntroRoutes(
       LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
-    HighLevelSimpleClient client = context.client();
-
     server.register(
         context.browseRoot(),
         ToadletRegistration.menuLink(
@@ -100,9 +97,8 @@ public final class LegacyFProxyBrowseRouteRegistrar implements LegacyHttpBrowseR
             null));
   }
 
-  private static void registerQueueFilterRoutes(
+  private void registerQueueFilterRoutes(
       LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
-    HighLevelSimpleClient client = context.client();
     TransferAccessPort transferAccess = context.runtimePorts().transferAccess();
 
     ContentFilterToadlet contentFilterToadlet = new ContentFilterToadlet(client);
@@ -117,16 +113,14 @@ public final class LegacyFProxyBrowseRouteRegistrar implements LegacyHttpBrowseR
             false,
             contentFilterToadlet));
 
-    LocalFileFilterToadlet localFileFilterToadlet =
-        new LocalFileFilterToadlet(transferAccess, client);
+    LocalFileFilterToadlet localFileFilterToadlet = new LocalFileFilterToadlet(transferAccess);
     server.register(
         localFileFilterToadlet,
         ToadletRegistration.basic(null, LocalFileFilterToadlet.BROWSE_PATH, true, false));
   }
 
-  private static void registerPostConfigRoutes(
+  private void registerPostConfigRoutes(
       LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
-    HighLevelSimpleClient client = context.client();
     RuntimePorts runtimePorts = context.runtimePorts();
 
     WelcomeToadletRuntimePorts welcomeToadletRuntimePorts =
@@ -145,25 +139,24 @@ public final class LegacyFProxyBrowseRouteRegistrar implements LegacyHttpBrowseR
         ToadletRegistration.basic(null, ExternalLinkToadlet.EXTERNAL_LINK_PATH, true, false));
   }
 
-  private static void registerPostMessagingRoutes(
+  private void registerPostMessagingRoutes(
       LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
     RuntimePorts runtimePorts = context.runtimePorts();
     BookmarkEditorToadlet bookmarkEditorToadlet =
         new BookmarkEditorToadlet(
-            context.client(),
+            client,
             new BookmarkEditorToadletRuntimePorts(
                 runtimePorts.darknetConnections(), runtimePorts.darknetMessaging()));
     server.register(
         bookmarkEditorToadlet, ToadletRegistration.basic(null, "/bookmarkEditor/", true, false));
   }
 
-  private static void registerPostPlatformApiRoutes(
-      LegacyHttpBrowseRouteRegistrarContext context, SimpleToadletServer server) {
-    BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(context.client());
+  private void registerPostPlatformApiRoutes(SimpleToadletServer server) {
+    BrowserTestToadlet browserTestToadlet = new BrowserTestToadlet(client);
     server.register(browserTestToadlet, ToadletRegistration.basic(null, "/test/", true, false));
   }
 
-  private static void registerTailRoutes(HighLevelSimpleClient client, SimpleToadletServer server) {
+  private void registerTailRoutes(SimpleToadletServer server) {
     AJAX_PUSH_ROUTE_REGISTRAR.registerRoutes(client, server);
 
     ImageCreatorToadlet imageCreatorToadlet = new ImageCreatorToadlet(client);

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/LocalFileFilterToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/LocalFileFilterToadlet.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 
@@ -64,12 +63,9 @@ public class LocalFileFilterToadlet extends LocalFileBrowserToadlet {
    *
    * @param transferAccess transfer-access runtime port used for upload permission checks; must not
    *     be {@code null} and should stay alive for as long as requests may be served.
-   * @param highLevelSimpleClient HTTP client abstraction used by the superclass to render and link
-   *     HTML responses; must not be {@code null}.
    */
-  public LocalFileFilterToadlet(
-      TransferAccessPort transferAccess, HighLevelSimpleClient highLevelSimpleClient) {
-    super(transferAccess, highLevelSimpleClient);
+  public LocalFileFilterToadlet(TransferAccessPort transferAccess) {
+    super(transferAccess);
   }
 
   /**

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/WelcomeToadlet.java
@@ -57,7 +57,7 @@ import org.tanukisoftware.wrapper.WrapperManager;
  * @see network.crypta.clients.http.Toadlet
  * @see network.crypta.clients.http.PageMaker
  */
-public class WelcomeToadlet extends Toadlet {
+public class WelcomeToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(WelcomeToadlet.class);
 
   /** Suffix {@link #path()} with "#" + BOOKMARKS_ANCHOR to deep link to the bookmark list */
@@ -100,7 +100,7 @@ public class WelcomeToadlet extends Toadlet {
   WelcomeToadlet(HighLevelSimpleClient client, WelcomeToadletRuntimePorts runtimePorts) {
     super(client);
     this.runtimePorts = Objects.requireNonNull(runtimePorts, "runtimePorts");
-    alertsPath = new UserAlertsToadlet(client).path();
+    alertsPath = new UserAlertsToadlet().path();
   }
 
   void redirectToRoot(ToadletContext ctx) throws ToadletContextClosedException, IOException {

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/DismissAlertToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/DismissAlertToadlet.java
@@ -3,8 +3,8 @@ package network.crypta.clients.http.ajaxpush;
 import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.RedirectException;
-import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
 import network.crypta.clients.http.updateableelements.UpdaterConstants;
@@ -39,15 +39,15 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Registration is performed by the HTTP container setup for the node.
  */
-public class DismissAlertToadlet extends Toadlet {
+public class DismissAlertToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(DismissAlertToadlet.class);
 
   /**
    * Creates a new dismiss-alert toadlet bound to the node's high-level client helper.
    *
-   * <p>The client is passed through to {@link Toadlet}'s constructor for consistency with other
-   * HTTP toadlets, even though this endpoint does not currently perform network operations itself.
-   * The instance is expected to be registered once with a {@link
+   * <p>The client is passed through to {@link ContentToadlet}'s constructor for consistency with
+   * other HTTP toadlets, even though this endpoint does not currently perform network operations
+   * itself. The instance is expected to be registered once with a {@link
    * network.crypta.clients.http.ToadletContainer} and then reused for incoming requests.
    *
    * @param client High-level client associated with the node; must be non-null.
@@ -73,7 +73,7 @@ public class DismissAlertToadlet extends Toadlet {
    * @param req Parsed HTTP request providing access to query parameters and headers.
    * @param ctx Active toadlet context used to write the HTTP response.
    * @throws ToadletContextClosedException If the client disconnects before the reply is written.
-   * @throws IOException If writing the response fails due to I/O problems.
+   * @throws IOException If writing, the response fails due to I/O problems.
    * @throws RedirectException Never thrown by this implementation, but declared by contract.
    */
   @Override

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/LogWritebackToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/LogWritebackToadlet.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http.ajaxpush;
 import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
@@ -38,18 +39,18 @@ import org.slf4j.LoggerFactory;
  * <p>Thread-safety: instances are stateless and safe to reuse concurrently as long as the
  * surrounding {@link Toadlet} infrastructure is used as intended.
  */
-public class LogWritebackToadlet extends Toadlet {
+public class LogWritebackToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(LogWritebackToadlet.class);
 
   /**
    * Creates a new instance bound to the provided high-level client helper.
    *
-   * <p>The client is required by the {@link Toadlet} base type even though this particular endpoint
-   * does not perform network fetches or inserts. Callers typically construct this once and register
-   * it with the HTTP container that routes requests based on {@link #path()}.
+   * <p>The client is required by the {@link ContentToadlet} base type even though this particular
+   * endpoint does not perform network fetches or inserts. Callers typically construct this once and
+   * register it with the HTTP container that routes requests based on {@link #path()}.
    *
-   * @param client non-null client helper retained by the base {@link Toadlet}; unused by this
-   *     implementation but required for consistent wiring and future compatibility
+   * @param client non-null client helper retained by the base {@link ContentToadlet}; unused by
+   *     this implementation but required for consistent wiring and future compatibility
    */
   public LogWritebackToadlet(HighLevelSimpleClient client) {
     super(client);
@@ -65,7 +66,7 @@ public class LogWritebackToadlet extends Toadlet {
    *
    * <p>Regardless of logging outcome, the handler sends an HTML response with status {@code 200},
    * reason phrase {@code "OK"}, and body {@link UpdaterConstants#SUCCESS}. The method is intended
-   * to be idempotent: repeated calls with the same input do not change server state beyond
+   * to be idempotent: repeated calls with the same input do not change the server state beyond
    * producing log output.
    *
    * @param uri request URI passed by the container; not used by this handler but provided for
@@ -74,8 +75,8 @@ public class LogWritebackToadlet extends Toadlet {
    *     HTTPRequest#getParam(String)} and defaults to an empty string when missing
    * @param ctx response context used to write the {@code 200 OK} success reply; must be open when
    *     called or a close exception is thrown by the context implementation
-   * @throws ToadletContextClosedException if the client disconnects before the success reply can be
-   *     written to the {@link ToadletContext}
+   * @throws ToadletContextClosedException if the client disconnects before the success, reply can
+   *     be written to the {@link ToadletContext}
    * @throws IOException if writing the response fails due to an underlying I/O error
    * @throws RedirectException declared for the base dispatch contract; this implementation does not
    *     initiate redirects

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushDataToadlet.java
@@ -4,10 +4,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.PushUpdatableElement;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
-import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
 import network.crypta.clients.http.updateableelements.UpdaterConstants;
@@ -44,15 +44,15 @@ import org.slf4j.LoggerFactory;
  * @see network.crypta.clients.http.PushUpdatableElement
  * @see network.crypta.clients.http.updateableelements.UpdaterConstants
  */
-public class PushDataToadlet extends Toadlet {
+public class PushDataToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushDataToadlet.class);
 
   /**
    * Creates a new toadlet instance bound to the supplied high-level client helper.
    *
-   * <p>The client is stored by the {@link network.crypta.clients.http.Toadlet} base class and is
-   * available for toadlets that need to perform networked operations. This specific endpoint only
-   * reads request parameters and queries the {@link
+   * <p>The client is stored by the {@link network.crypta.clients.http.ContentToadlet} base class
+   * and is available for toadlets that need to perform networked operations. This specific endpoint
+   * only reads request parameters and queries the {@link
    * network.crypta.clients.http.updateableelements.PushDataManager}, but it follows the same
    * construction pattern as other toadlets and is typically registered with the toadlet container
    * during HTTP server initialization.
@@ -87,7 +87,7 @@ public class PushDataToadlet extends Toadlet {
    * @param req Parsed HTTP request providing query parameters for the lookup operation.
    * @param ctx Request context used to resolve the server container and write the reply.
    * @throws ToadletContextClosedException If the connection is closed while writing the response.
-   * @throws IOException If writing the response fails due to an I/O error.
+   * @throws IOException If writing, the response fails due to an I/O error.
    * @throws RedirectException If the container requests a redirect while processing this request.
    */
   @Override
@@ -97,7 +97,7 @@ public class PushDataToadlet extends Toadlet {
     String elementId = req.getParam("elementId");
     elementId =
         elementId.replace(
-            " ", "+"); // This is needed, because BASE64 has '+', but it is an HTML escape for ' '
+            " ", "+"); // This is needed because BASE64 has '+', but it is an HTML escape for ' '
     if (LOG.isDebugEnabled()) LOG.debug("Fetching push data for elementId={}", elementId);
     PushUpdatableElement node =
         ((SimpleToadletServer) ctx.getContainer())

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushFailoverToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushFailoverToadlet.java
@@ -3,9 +3,9 @@ package network.crypta.clients.http.ajaxpush;
 import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
-import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
 import network.crypta.clients.http.updateableelements.UpdaterConstants;
@@ -17,9 +17,9 @@ import org.slf4j.LoggerFactory;
  * Handles push-leader failover for the AJAX push subsystem.
  *
  * <p>This toadlet implements a small HTTP endpoint used by the browser-side “AJAX push” code when
- * leadership for a page/session changes. In that situation, outstanding update notifications that
- * were waiting on the previous leader request may need to be reassigned to the new leader request
- * so polling continues without losing queued updates.
+ * leadership for a page/session changes. In that situation, outstanding update notifications
+ * waiting on the previous leader request may need to be reassigned to the new leader request so
+ * polling continues without losing queued updates.
  *
  * <p>The handler reads two query parameters from the incoming request: {@code originalRequestId}
  * (the request id that previously acted as leader) and {@code requestId} (the request id that is
@@ -41,18 +41,18 @@ import org.slf4j.LoggerFactory;
  * @see network.crypta.clients.http.ajaxpush.PushDataToadlet
  * @see network.crypta.clients.http.ajaxpush.PushNotificationToadlet
  */
-public class PushFailoverToadlet extends Toadlet {
+public class PushFailoverToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushFailoverToadlet.class);
 
   /**
    * Creates a new toadlet instance bound to the supplied high-level client helper.
    *
-   * <p>The {@link network.crypta.clients.http.Toadlet} base class stores the client reference for
-   * use by endpoints that need to perform node-backed operations. This specific toadlet delegates
-   * to the {@link network.crypta.clients.http.updateableelements.PushDataManager} attached to the
-   * active {@link network.crypta.clients.http.SimpleToadletServer}, but it follows the same
-   * construction pattern as the rest of the HTTP toadlets and is typically registered during HTTP
-   * server startup.
+   * <p>The {@link network.crypta.clients.http.ContentToadlet} base class stores the client
+   * reference for use by endpoints that need to perform node-backed operations. This specific
+   * toadlet delegates to the {@link network.crypta.clients.http.updateableelements.PushDataManager}
+   * attached to the active {@link network.crypta.clients.http.SimpleToadletServer}, but it follows
+   * the same construction pattern as the rest of the HTTP toadlets and is typically registered
+   * during HTTP server startup.
    *
    * @param client Non-null client helper provided by the node for toadlet operations.
    */
@@ -61,7 +61,7 @@ public class PushFailoverToadlet extends Toadlet {
   }
 
   /**
-   * Performs a push failover by moving queued notifications from one request id to another.
+   * Performs push failover by moving queued notifications from one request id to another.
    *
    * <p>The request must provide the {@code originalRequestId} query parameter identifying the
    * request/session that previously acted as the leader and the {@code requestId} query parameter
@@ -84,7 +84,7 @@ public class PushFailoverToadlet extends Toadlet {
    * @param req Parsed HTTP request providing the failover query parameters.
    * @param ctx Request context used to resolve the server container and write the reply.
    * @throws ToadletContextClosedException If the connection is closed while writing the response.
-   * @throws IOException If writing the response fails due to an I/O error.
+   * @throws IOException If writing, the response fails due to an I/O error.
    * @throws RedirectException If the container requests a redirect while processing this request.
    */
   @Override

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushKeepaliveToadlet.java
@@ -3,9 +3,9 @@ package network.crypta.clients.http.ajaxpush;
 import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
-import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
 import network.crypta.clients.http.updateableelements.UpdaterConstants;
@@ -38,18 +38,18 @@ import org.slf4j.LoggerFactory;
  * @see network.crypta.clients.http.updateableelements.PushDataManager#keepAliveReceived(String)
  * @see network.crypta.clients.http.updateableelements.UpdaterConstants#KEEPALIVE_PATH
  */
-public class PushKeepaliveToadlet extends Toadlet {
+public class PushKeepaliveToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushKeepaliveToadlet.class);
 
   /**
    * Creates a keepalive endpoint bound to the given client context.
    *
-   * <p>The {@code HighLevelSimpleClient} is passed through to the {@link Toadlet} base class and is
-   * used by shared toadlet infrastructure (for example, reply helpers and common request wiring).
-   * This toadlet itself does not retain additional mutable state beyond what the superclass
-   * maintains.
+   * <p>The {@code HighLevelSimpleClient} is passed through to the {@link ContentToadlet} base class
+   * and is used by shared toadlet infrastructure (for example, reply helpers and common request
+   * wiring). This toadlet itself does not retain an additional mutable state beyond what the
+   * superclass maintains.
    *
-   * @param client client context used by the {@link Toadlet} superclass; must be non-null
+   * @param client client context used by the {@link ContentToadlet} superclass; must be non-null
    */
   public PushKeepaliveToadlet(HighLevelSimpleClient client) {
     super(client);

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushLeavingToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushLeavingToadlet.java
@@ -3,9 +3,9 @@ package network.crypta.clients.http.ajaxpush;
 import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
-import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.ToadletContext;
 import network.crypta.clients.http.ToadletContextClosedException;
 import network.crypta.clients.http.updateableelements.UpdaterConstants;
@@ -23,8 +23,8 @@ import org.slf4j.LoggerFactory;
  * or other per-page resources after the client is no longer present.
  *
  * <p><strong>Thread-safety:</strong> Instances are used by the toadlet server and may be invoked
- * concurrently for different connections. This class is effectively stateless; all mutable state is
- * owned by the container and its push-data manager.
+ * concurrently for different connections. This class is effectively stateless; all mutable states
+ * are owned by the container and its push-data manager.
  *
  * <p>Responsibilities include:
  *
@@ -36,15 +36,15 @@ import org.slf4j.LoggerFactory;
  *
  * @see UpdaterConstants#LEAVING_PATH
  */
-public class PushLeavingToadlet extends Toadlet {
+public class PushLeavingToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushLeavingToadlet.class);
 
   /**
    * Creates a toadlet instance that can be registered on a {@link SimpleToadletServer}.
    *
-   * <p>The provided client is forwarded to the {@link Toadlet} base type and is used for common
-   * toadlet functionality. This implementation does not store additional mutable state; request
-   * handling delegates to the container's push-data manager obtained from the {@link
+   * <p>The provided client is forwarded to the {@link ContentToadlet} base type and is used for
+   * common toadlet functionality. This implementation does not store additional mutable state;
+   * request handling delegates to the container's push-data manager obtained from the {@link
    * ToadletContext} provided at request time.
    *
    * @param client the node client backing this toadlet, passed to the superclass for shared

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushNotificationToadlet.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.PushUpdateEvent;
 import network.crypta.clients.http.RedirectException;
 import network.crypta.clients.http.SimpleToadletServer;
@@ -30,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>Uses long-poll semantics: it may block until an event arrives or the request context
  *       closes.
- *   <li>Returns either a success payload containing identifiers, or a failure sentinel string.
+ *   <li>Returns either a success payload containing identifiers or a failure sentinel string.
  *   <li>Performs no state mutation itself; it delegates event sequencing to the push-data manager.
  * </ul>
  *
@@ -41,15 +42,15 @@ import org.slf4j.LoggerFactory;
  * @see network.crypta.clients.http.PushDataManagerHandle#getNextNotification(String)
  * @see UpdaterConstants#NOTIFICATION_PATH
  */
-public class PushNotificationToadlet extends Toadlet {
+public class PushNotificationToadlet extends ContentToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(PushNotificationToadlet.class);
 
   /**
    * Create a toadlet bound to a client context.
    *
-   * <p>The provided client is passed to the parent {@link Toadlet} and is used for shared
-   * HTTP/toadlet infrastructure. This class does not retain additional mutable state, so a single
-   * instance can serve multiple requests over its lifetime as managed by the server.
+   * <p>The provided client is passed to the parent {@link ContentToadlet} and is used for shared
+   * HTTP/toadlet infrastructure. This class does not retain an additional mutable state, so a
+   * single instance can serve multiple requests over its lifetime as managed by the server.
    *
    * @param client client context used by the toadlet framework; must be non-null for normal
    *     operation

--- a/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushTesterToadlet.java
+++ b/adapter-http-legacy-browse/src/main/java/network/crypta/clients/http/ajaxpush/PushTesterToadlet.java
@@ -3,6 +3,7 @@ package network.crypta.clients.http.ajaxpush;
 import java.io.IOException;
 import java.net.URI;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.clients.http.PageNode;
 import network.crypta.clients.http.RedirectException;
@@ -35,18 +36,18 @@ import network.crypta.support.api.HTTPRequest;
  *
  * @see TesterElement
  */
-public class PushTesterToadlet extends Toadlet {
+public class PushTesterToadlet extends ContentToadlet {
 
   /**
    * Creates a new instance that serves the push-test page.
    *
-   * <p>The provided {@link HighLevelSimpleClient} is forwarded to the {@link Toadlet} superclass.
-   * This class does not retain additional mutable state, so instances are safe to reuse across
-   * requests as long as the surrounding toadlet container provides the usual per-request {@link
-   * ToadletContext}.
+   * <p>The provided {@link HighLevelSimpleClient} is forwarded to the {@link ContentToadlet}
+   * superclass. This class does not retain additional mutable state, so instances are safe to reuse
+   * across requests as long as the surrounding toadlet container provides the usual per-request
+   * {@link ToadletContext}.
    *
-   * @param client client instance passed to the {@link Toadlet} superclass; must be non-null and
-   *     configured
+   * @param client client instance passed to the {@link ContentToadlet} superclass; must be non-null
+   *     and configured
    */
   public PushTesterToadlet(HighLevelSimpleClient client) {
     super(client);

--- a/adapter-http-legacy-browse/src/test/java/network/crypta/clients/http/ContentToadletTest.java
+++ b/adapter-http-legacy-browse/src/test/java/network/crypta/clients/http/ContentToadletTest.java
@@ -1,0 +1,107 @@
+package network.crypta.clients.http;
+
+import java.net.URI;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchResult;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.InsertBlock;
+import network.crypta.client.async.ClientGetCallback;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+@ExtendWith(MockitoExtension.class)
+class ContentToadletTest {
+
+  @Test
+  void constructor_whenClientNull_throwsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new TestContentToadlet(null));
+  }
+
+  @Test
+  void getFetchContext_whenInvoked_delegatesToClient() {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    FetchContext expectedContext = mock(FetchContext.class);
+    when(client.getFetchContext(2048L, "http://127.0.0.1:8888")).thenReturn(expectedContext);
+    TestContentToadlet toadlet = new TestContentToadlet(client);
+
+    FetchContext actualContext = toadlet.fetchContext();
+
+    assertSame(expectedContext, actualContext);
+  }
+
+  @Test
+  void fetch_whenMaxSizePositive_updatesContextAndReturnsCompletedResult() throws Exception {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    RequestClient requestClient = mock(RequestClient.class);
+    FreenetURI uri = new FreenetURI("KSK", "content-toadlet-fetch");
+    FetchResult expectedResult =
+        FetchResult.create(mock(ClientMetadata.class), mock(RandomAccessBucket.class));
+    when(client.fetch(eq(uri), any(ClientGetCallback.class), same(fetchContext)))
+        .thenAnswer(
+            invocation -> {
+              ClientGetCallback callback = invocation.getArgument(1);
+              callback.onSuccess(expectedResult, mock(ClientGetter.class));
+              return mock(ClientGetter.class);
+            });
+    TestContentToadlet toadlet = new TestContentToadlet(client);
+
+    FetchResult actualResult = toadlet.fetch(uri, 2048L, requestClient, fetchContext);
+
+    assertSame(expectedResult, actualResult);
+    verify(fetchContext).setMaxOutputLength(2048L);
+    verify(fetchContext).setMaxTempLength(2048L);
+  }
+
+  @Test
+  void insert_whenDesiredUriPresent_delegatesToClient() throws Exception {
+    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
+    TestContentToadlet toadlet = new TestContentToadlet(client);
+    InsertBlock insertBlock =
+        new InsertBlock(mock(RandomAccessBucket.class), null, new FreenetURI("KSK", "insert-src"));
+    FreenetURI insertedUri = new FreenetURI("KSK", "insert-result");
+    when(client.insert(insertBlock, false, "result.txt")).thenReturn(insertedUri);
+
+    FreenetURI actualUri = toadlet.insert(insertBlock, "result.txt");
+
+    assertSame(insertedUri, actualUri);
+    verify(client).insert(insertBlock, false, "result.txt");
+  }
+
+  private static final class TestContentToadlet extends ContentToadlet {
+    private TestContentToadlet(HighLevelSimpleClient client) {
+      super(client);
+    }
+
+    @Override
+    public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String path() {
+      return "/content-toadlet-test/";
+    }
+
+    private FetchContext fetchContext() {
+      return getFetchContext(2048L, "http://127.0.0.1:8888");
+    }
+  }
+}

--- a/adapter-http-legacy-browse/src/test/java/network/crypta/clients/http/LegacyFProxyAjaxPushRouteRegistrarTest.java
+++ b/adapter-http-legacy-browse/src/test/java/network/crypta/clients/http/LegacyFProxyAjaxPushRouteRegistrarTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -41,8 +42,16 @@ class LegacyFProxyAjaxPushRouteRegistrarTest {
             PushTesterToadlet.class,
             PushLeavingToadlet.class),
         toadlets.stream().map(Object::getClass).toList());
+    toadlets.forEach(LegacyFProxyAjaxPushRouteRegistrarTest::assertContentToadlet);
     assertEquals(
         toadlets.stream().map(Toadlet::path).toList(),
         registrationCaptor.getAllValues().stream().map(ToadletRegistration::urlPrefix).toList());
+  }
+
+  private static void assertContentToadlet(Toadlet toadlet) {
+    assertInstanceOf(
+        ContentToadlet.class,
+        toadlet,
+        toadlet.getClass().getName() + " must extend ContentToadlet");
   }
 }

--- a/adapter-http-legacy-browse/src/test/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrarTest.java
+++ b/adapter-http-legacy-browse/src/test/java/network/crypta/clients/http/LegacyFProxyBrowseRouteRegistrarTest.java
@@ -54,8 +54,8 @@ class LegacyFProxyBrowseRouteRegistrarTest {
 
   @BeforeEach
   void setUp() {
-    context = new LegacyHttpBrowseRouteRegistrarContext(client, runtimePorts, browseRoot);
-    registrar = new LegacyFProxyBrowseRouteRegistrar();
+    context = new LegacyHttpBrowseRouteRegistrarContext(runtimePorts, browseRoot);
+    registrar = new LegacyFProxyBrowseRouteRegistrar(client);
   }
 
   @Test
@@ -76,6 +76,8 @@ class LegacyFProxyBrowseRouteRegistrarTest {
     assertSame(browseRoot, registrations.get(0).toadlet());
     assertInstanceOf(DecodeToadlet.class, registrations.get(1).toadlet());
     assertInstanceOf(InsertFreesiteToadlet.class, registrations.get(2).toadlet());
+    assertContentToadlet(registrations.get(1).toadlet());
+    assertContentToadlet(registrations.get(2).toadlet());
     assertEquals(List.of("/", "/decode/", "/insertsite/"), registrationPrefixes(registrations));
   }
 
@@ -89,6 +91,7 @@ class LegacyFProxyBrowseRouteRegistrarTest {
     List<RegisteredToadlet> registrations = capturedRegistrations(2);
     assertInstanceOf(ContentFilterToadlet.class, registrations.get(0).toadlet());
     assertInstanceOf(LocalFileFilterToadlet.class, registrations.get(1).toadlet());
+    assertContentToadlet(registrations.get(0).toadlet());
     assertEquals(
         List.of(ContentFilterToadlet.CONTENT_FILTER_PATH, LocalFileFilterToadlet.BROWSE_PATH),
         registrationPrefixes(registrations));
@@ -109,6 +112,8 @@ class LegacyFProxyBrowseRouteRegistrarTest {
     List<RegisteredToadlet> registrations = capturedRegistrations(2);
     assertInstanceOf(WelcomeToadlet.class, registrations.get(0).toadlet());
     assertInstanceOf(ExternalLinkToadlet.class, registrations.get(1).toadlet());
+    assertContentToadlet(registrations.get(0).toadlet());
+    assertContentToadlet(registrations.get(1).toadlet());
     assertEquals(
         List.of(LegacyHttpPaths.WELCOME_PATH, ExternalLinkToadlet.EXTERNAL_LINK_PATH),
         registrationPrefixes(registrations));
@@ -131,6 +136,7 @@ class LegacyFProxyBrowseRouteRegistrarTest {
 
     List<RegisteredToadlet> registrations = capturedRegistrations(1);
     assertInstanceOf(BookmarkEditorToadlet.class, registrations.getFirst().toadlet());
+    assertContentToadlet(registrations.getFirst().toadlet());
     assertEquals(List.of("/bookmarkEditor/"), registrationPrefixes(registrations));
 
     BookmarkEditorToadletRuntimePorts bookmarkRuntimePorts =
@@ -147,6 +153,7 @@ class LegacyFProxyBrowseRouteRegistrarTest {
 
     List<RegisteredToadlet> registrations = capturedRegistrations(1);
     assertInstanceOf(BrowserTestToadlet.class, registrations.getFirst().toadlet());
+    assertContentToadlet(registrations.getFirst().toadlet());
     assertEquals(List.of("/test/"), registrationPrefixes(registrations));
   }
 
@@ -167,6 +174,9 @@ class LegacyFProxyBrowseRouteRegistrarTest {
             LogWritebackToadlet.class,
             DismissAlertToadlet.class),
         registrations.stream().map(RegisteredToadlet::toadlet).map(Object::getClass).toList());
+    assertContentToadlet(registrations.get(6).toadlet());
+    assertContentToadlet(registrations.get(7).toadlet());
+    assertContentToadlet(registrations.get(8).toadlet());
     assertEquals(
         registrations.stream().map(RegisteredToadlet::toadlet).map(Toadlet::path).toList(),
         registrationPrefixes(registrations));
@@ -191,6 +201,13 @@ class LegacyFProxyBrowseRouteRegistrarTest {
         .map(RegisteredToadlet::registration)
         .map(ToadletRegistration::urlPrefix)
         .toList();
+  }
+
+  private static void assertContentToadlet(Toadlet toadlet) {
+    assertInstanceOf(
+        ContentToadlet.class,
+        toadlet,
+        toadlet.getClass().getName() + " must extend ContentToadlet");
   }
 
   private static Object readField(Object target, String fieldName) {

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -2,13 +2,16 @@ package network.crypta.clients.http.bridge;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyRuntimeSupport;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.HttpShellBrowseBootstrap;
 import network.crypta.clients.http.HttpShellRuntimeSupport;
+import network.crypta.clients.http.InsertCompatibilityModes;
 import network.crypta.clients.http.LegacyFProxyBrowseRouteRegistrar;
 import network.crypta.clients.http.PushDataManagerHandle;
 import network.crypta.clients.http.SimpleToadletServer;
@@ -120,6 +123,18 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
   }
 
   @Override
+  public InsertCompatibilityModes insertCompatibilityModes() {
+    return new InsertCompatibilityModes(
+        Arrays.stream(CompatibilityMode.values())
+            .map(CompatibilityMode::intern)
+            .filter(mode -> mode != CompatibilityMode.COMPAT_UNKNOWN)
+            .map(CompatibilityMode::name)
+            .distinct()
+            .toList(),
+        CompatibilityMode.COMPAT_DEFAULT.intern().name());
+  }
+
+  @Override
   public boolean canRedirectToWizard() {
     return true;
   }
@@ -163,10 +178,9 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
     FProxyRuntimeSupport fproxyRuntimeSupport = new CoreFProxyRuntimeSupport(core);
     return HttpShellBrowseBootstrap.create(
         bookmarkManager,
-        client,
         appHost,
         FProxyToadlet.create(client, fproxyRuntimeSupport, fetchTracker),
-        new LegacyFProxyBrowseRouteRegistrar(),
+        new LegacyFProxyBrowseRouteRegistrar(client),
         CoreHttpShellRuntimeSupport::initializeFProxySharedState);
   }
 

--- a/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
+++ b/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
@@ -5,18 +5,23 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import network.crypta.client.FetchContext;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.async.ClientContext;
+import network.crypta.clients.http.ContentToadlet;
 import network.crypta.clients.http.FProxyFetchTracker;
 import network.crypta.clients.http.FProxyToadlet;
 import network.crypta.clients.http.HttpShellBrowseBootstrap;
 import network.crypta.clients.http.HttpShellRuntimeSupport;
+import network.crypta.clients.http.InsertCompatibilityModes;
 import network.crypta.clients.http.LegacyFProxyBrowseRouteRegistrar;
 import network.crypta.clients.http.PushDataManagerHandle;
+import network.crypta.clients.http.Toadlet;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.clients.http.bridge.bookmark.CoreBookmarkRuntimeSupport;
 import network.crypta.clients.http.updateableelements.PushDataManager;
@@ -145,6 +150,23 @@ class CoreHttpShellRuntimeSupportTest {
     String formPassword = runtimeSupport.formPassword();
 
     assertEquals("secret-token", formPassword);
+  }
+
+  @Test
+  void insertCompatibilityModes_whenInvoked_returnsDetachedOrderedModeNames() {
+    CoreHttpShellRuntimeSupport runtimeSupport = runtimeSupport(mock(NodeClientCore.class));
+
+    InsertCompatibilityModes actualModes = runtimeSupport.insertCompatibilityModes();
+
+    List<String> expectedModeNames =
+        Arrays.stream(CompatibilityMode.values())
+            .map(CompatibilityMode::intern)
+            .filter(mode -> mode != CompatibilityMode.COMPAT_UNKNOWN)
+            .map(CompatibilityMode::name)
+            .distinct()
+            .toList();
+    assertEquals(expectedModeNames, actualModes.supportedModeNames());
+    assertEquals(CompatibilityMode.COMPAT_DEFAULT.intern().name(), actualModes.defaultModeName());
   }
 
   @ParameterizedTest
@@ -333,10 +355,13 @@ class CoreHttpShellRuntimeSupportTest {
       assertInstanceOf(CoreFProxyRuntimeSupport.class, browseRootArguments.get().get(1));
       assertSame(fetchTrackers.constructed().getFirst(), browseRootArguments.get().get(2));
       assertSame(bookmarkManagers.constructed().getFirst(), bootstrap.bookmarkManager());
-      assertSame(client, bootstrap.client());
       assertSame(runtimeSupport.appHost(), bootstrap.appHost());
       assertSame(fproxies.constructed().getFirst(), bootstrap.browseRoot());
-      assertInstanceOf(LegacyFProxyBrowseRouteRegistrar.class, bootstrap.browseRouteRegistrar());
+      assertContentToadlet(fproxies.constructed().getFirst());
+      LegacyFProxyBrowseRouteRegistrar browseRouteRegistrar =
+          assertInstanceOf(
+              LegacyFProxyBrowseRouteRegistrar.class, bootstrap.browseRouteRegistrar());
+      assertSame(client, readRegistrarClient(browseRouteRegistrar));
       verify(core, never()).getRuntimePorts();
       verifyNoInteractions(bootstrapRuntimePorts);
       verify(core, never()).getEndpoints();
@@ -503,6 +528,17 @@ class CoreHttpShellRuntimeSupportTest {
     return new CoreHttpShellRuntimeSupport(core, mock(AppHost.class));
   }
 
+  private static HighLevelSimpleClient readRegistrarClient(
+      LegacyFProxyBrowseRouteRegistrar registrar) {
+    try {
+      Field field = registrar.getClass().getDeclaredField("client");
+      field.setAccessible(true);
+      return (HighLevelSimpleClient) field.get(registrar);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed reading field 'client'", e);
+    }
+  }
+
   private static AppHostLayout readLayout(LocalProcessAppHost appHost) {
     try {
       Field field = appHost.getClass().getDeclaredField("layout");
@@ -534,6 +570,13 @@ class CoreHttpShellRuntimeSupportTest {
             Path.of("build", "test-runtime", "apphost", "run", appId).toAbsolutePath());
     return new RunningAppSnapshot(
         manifest, paths, "token-" + appId, 4242L, Instant.parse("2024-01-02T03:04:05Z"));
+  }
+
+  private static void assertContentToadlet(Toadlet toadlet) {
+    assertInstanceOf(
+        ContentToadlet.class,
+        toadlet,
+        toadlet.getClass().getName() + " must extend ContentToadlet");
   }
 
   private record NetworkListenerContext(

--- a/src/test/java/network/crypta/clients/http/ChatForumsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ChatForumsToadletTest.java
@@ -127,7 +127,7 @@ class ChatForumsToadletTest {
     private String lastReplyBody;
 
     TestableChatForumsToadlet(HighLevelSimpleClient client) {
-      super(client);
+      super();
     }
 
     @Override

--- a/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ConfigToadletTest.java
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.config.Config;
 import network.crypta.config.ConfigCallback;
 import network.crypta.config.DirectorySelectionCallback;
@@ -62,7 +61,6 @@ class ConfigToadletTest {
 
   @Mock private SubConfig subConfig;
   @Mock private Config config;
-  @Mock private HighLevelSimpleClient client;
   @Mock private ConfigPort configPort;
   @Mock private TransferAccessPort transferAccessPort;
   @Mock private LifecyclePort lifecyclePort;
@@ -77,7 +75,6 @@ class ConfigToadletTest {
 
   private ConfigToadlet createToadlet() {
     return new ConfigToadlet(
-        client,
         config,
         subConfig,
         new ConfigToadletRuntimePorts(configPort, transferAccessPort, lifecyclePort));
@@ -261,7 +258,6 @@ class ConfigToadletTest {
     ConfigToadlet toadlet =
         new ConfigToadlet(
             "directory-browser",
-            client,
             config,
             subConfig,
             new ConfigToadletRuntimePorts(configPort, transferAccessPort, lifecyclePort));

--- a/src/test/java/network/crypta/clients/http/ConnectivityToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ConnectivityToadletTest.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.ConnectivityGapSnapshot;
@@ -41,7 +40,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ConnectivityToadletTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private ConnectivityPort connectivity;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
@@ -50,7 +48,7 @@ class ConnectivityToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new ConnectivityToadlet(client, connectivity);
+    toadlet = new ConnectivityToadlet(connectivity);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetAddRefToadletTest.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.NodeFile;
@@ -52,7 +51,6 @@ class DarknetAddRefToadletTest {
 
   @Mock private ConnectionsSupportPort connectionsSupportPort;
   @Mock private NodeInfoPort nodeInfoPort;
-  @Mock private HighLevelSimpleClient client;
   @Mock private DarknetConnectionsToadlet friendsToadlet;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
@@ -75,8 +73,7 @@ class DarknetAddRefToadletTest {
         .when(nodeInfoPort.exportReference(NodeReferenceView.DARKNET_PUBLIC, false))
         .thenReturn(sampleNoderefSnapshot());
     toadlet =
-        new TestableDarknetAddRefToadlet(
-            connectionsSupportPort, nodeInfoPort, client, friendsToadlet);
+        new TestableDarknetAddRefToadlet(connectionsSupportPort, nodeInfoPort, friendsToadlet);
   }
 
   @Test
@@ -253,9 +250,8 @@ class DarknetAddRefToadletTest {
     TestableDarknetAddRefToadlet(
         ConnectionsSupportPort connectionsSupportPort,
         NodeInfoPort nodeInfoPort,
-        HighLevelSimpleClient client,
         DarknetConnectionsToadlet friendsToadlet) {
-      super(connectionsSupportPort, nodeInfoPort, client, friendsToadlet);
+      super(connectionsSupportPort, nodeInfoPort, friendsToadlet);
     }
 
     @Override

--- a/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DarknetConnectionsToadletTest.java
@@ -10,7 +10,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
@@ -76,7 +75,6 @@ class DarknetConnectionsToadletTest {
   private static final String OWN_NODE_PHYSICAL_UDP = "127.0.0.1:1234";
   private static final String TEST_NODE_IDENTIFIER = "peer-1";
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private ConnectionsPagePort connectionsPage;
   @Mock private ConnectionsSupportPort connectionsSupportPort;
   @Mock private DarknetConnectionsPort darknetConnectionsPort;
@@ -99,7 +97,7 @@ class DarknetConnectionsToadletTest {
             configPort,
             connectionsSupportPort,
             lifecyclePort);
-    toadlet = new DarknetConnectionsToadlet(client, runtimePorts, darknetConnectionsPort);
+    toadlet = new DarknetConnectionsToadlet(runtimePorts, darknetConnectionsPort);
     Mockito.lenient().when(request.isPartSet(anyString())).thenReturn(false);
   }
 
@@ -114,8 +112,7 @@ class DarknetConnectionsToadletTest {
             connectionsSupportPort,
             lifecyclePort);
 
-    assertDoesNotThrow(
-        () -> new DarknetConnectionsToadlet(client, runtimePorts, darknetConnectionsPort));
+    assertDoesNotThrow(() -> new DarknetConnectionsToadlet(runtimePorts, darknetConnectionsPort));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/DiagnosticToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DiagnosticToadletTest.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.DiagnosticReportSnapshot;
 import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
@@ -32,7 +31,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class DiagnosticToadletTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private DiagnosticPort diagnostic;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
@@ -41,7 +39,7 @@ class DiagnosticToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new DiagnosticToadlet(client, diagnostic);
+    toadlet = new DiagnosticToadlet(diagnostic);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -117,7 +117,7 @@ class FProxyRegistrarTest {
   @Test
   void maybeCreateFProxyEtc_whenInvoked_registersMenusSetsFProxyAndStartsQueueCompletion() {
     FProxyRegistrar.maybeCreateFProxyEtc(
-        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
+        dependencies(new LegacyFProxyBrowseRouteRegistrar(client)), server);
 
     verify(server)
         .registerMenu(
@@ -228,7 +228,7 @@ class FProxyRegistrarTest {
   @Test
   void maybeCreateFProxyEtc_whenSecurityLevelsSubconfigPresent_skipsSecurityLevelsConfigToadlet() {
     FProxyRegistrar.maybeCreateFProxyEtc(
-        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
+        dependencies(new LegacyFProxyBrowseRouteRegistrar(client)), server);
 
     Set<String> configToadletPrefixes =
         capturedRegistrations().stream()
@@ -248,7 +248,7 @@ class FProxyRegistrarTest {
         .thenReturn(LauncherReadinessInfo.DEFAULT_UI_ROOT, WebShellPaths.SHELL_ROOT);
 
     FProxyRegistrar.maybeCreateFProxyEtc(
-        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
+        dependencies(new LegacyFProxyBrowseRouteRegistrar(client)), server);
 
     ToadletRegistration webShellRegistration =
         capturedRegistrations().stream()
@@ -267,7 +267,7 @@ class FProxyRegistrarTest {
   @Test
   void maybeCreateFProxyEtc_whenUsingConcreteBrowseRegistrar_preservesTailBrowseRouteOrder() {
     FProxyRegistrar.maybeCreateFProxyEtc(
-        dependencies(new LegacyFProxyBrowseRouteRegistrar()), server);
+        dependencies(new LegacyFProxyBrowseRouteRegistrar(client)), server);
 
     List<Class<?>> tailRouteTypes = new ArrayList<>();
     for (RegisteredToadlet registration : capturedRegistrations()) {
@@ -312,7 +312,6 @@ class FProxyRegistrarTest {
             LegacyHttpBrowseRouteRegistrar.Phase.TAIL_ROUTES),
         phaseCaptor.getAllValues());
     for (LegacyHttpBrowseRouteRegistrarContext browseContext : browseContextCaptor.getAllValues()) {
-      assertSame(client, browseContext.client());
       assertSame(runtimePorts, browseContext.runtimePorts());
       assertSame(browseRoot, browseContext.browseRoot());
     }
@@ -388,7 +387,12 @@ class FProxyRegistrarTest {
   void registerRoutes_whenInvokedViaLegacyAdminRegistrar_forwardsEquivalentDependencies() {
     LegacyHttpRouteRegistrarContext context =
         new LegacyHttpRouteRegistrarContext(
-            client, runtimePorts, appHost, config, browseRoot, browseRouteRegistrar);
+            runtimePorts,
+            appHost,
+            config,
+            browseRoot,
+            browseRouteRegistrar,
+            new InsertCompatibilityModes(List.of("COMPAT_DEFAULT"), "COMPAT_DEFAULT"));
 
     try (MockedStatic<FProxyRegistrar> registrar = mockStatic(FProxyRegistrar.class)) {
       new LegacyAdminHttpRouteRegistrar().registerRoutes(context, server);
@@ -397,7 +401,12 @@ class FProxyRegistrarTest {
           () ->
               FProxyRegistrar.maybeCreateFProxyEtc(
                   new FProxyRegistrarDependencies(
-                      client, runtimePorts, appHost, config, browseRoot, browseRouteRegistrar),
+                      runtimePorts,
+                      appHost,
+                      config,
+                      browseRoot,
+                      browseRouteRegistrar,
+                      new InsertCompatibilityModes(List.of("COMPAT_DEFAULT"), "COMPAT_DEFAULT")),
                   server));
     }
   }
@@ -405,7 +414,12 @@ class FProxyRegistrarTest {
   private FProxyRegistrarDependencies dependencies(
       LegacyHttpBrowseRouteRegistrar browseRouteRegistrar) {
     return new FProxyRegistrarDependencies(
-        client, runtimePorts, appHost, config, browseRoot, browseRouteRegistrar);
+        runtimePorts,
+        appHost,
+        config,
+        browseRoot,
+        browseRouteRegistrar,
+        new InsertCompatibilityModes(List.of("COMPAT_DEFAULT"), "COMPAT_DEFAULT"));
   }
 
   private static void registerBandwidthOption(

--- a/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FileInsertWizardToadletTest.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.time.Instant;
-import network.crypta.client.HighLevelSimpleClient;
+import java.util.List;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.SecurityLevelsSnapshot;
@@ -41,8 +41,6 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class FileInsertWizardToadletTest {
 
-  @Mock HighLevelSimpleClient client;
-
   @Mock SecurityLevelsPort securityLevelsPort;
 
   @Mock ToadletContainer container;
@@ -52,9 +50,7 @@ class FileInsertWizardToadletTest {
   @BeforeEach
   void setUp() throws Exception {
     toadlet =
-        new FileInsertWizardToadlet(
-            client, new FileInsertWizardToadletRuntimePorts(securityLevelsPort));
-    setContainer(toadlet, container);
+        createToadlet(new InsertCompatibilityModes(List.of("COMPAT_DEFAULT"), "COMPAT_DEFAULT"));
   }
 
   @Test
@@ -66,7 +62,7 @@ class FileInsertWizardToadletTest {
   void constructor_whenRuntimePortsProvided_noLongerNeedsNodeClientCore() {
     assertEquals(1, FileInsertWizardToadlet.class.getDeclaredConstructors().length);
     assertArrayEquals(
-        new Class<?>[] {HighLevelSimpleClient.class, FileInsertWizardToadletRuntimePorts.class},
+        new Class<?>[] {FileInsertWizardToadletRuntimePorts.class},
         FileInsertWizardToadlet.class.getDeclaredConstructors()[0].getParameterTypes());
   }
 
@@ -157,6 +153,33 @@ class FileInsertWizardToadletTest {
   }
 
   @Test
+  void handleMethodGET_whenAdvancedModeEnabled_rendersDetachedCompatibilityOptionsInOrder()
+      throws Exception {
+    toadlet =
+        createToadlet(
+            new InsertCompatibilityModes(List.of("COMPAT_DEFAULT", "COMPAT_1468"), "COMPAT_1468"));
+    when(container.publicGatewayMode()).thenReturn(false);
+    when(securityLevelsPort.snapshot())
+        .thenReturn(securitySnapshot(SecurityNetworkThreatLevel.LOW));
+
+    PageHolder holder = new PageHolder();
+    PageMaker pageMaker = buildPageMaker(holder);
+    CapturingContext ctx = new CapturingContext(pageMaker, true, true);
+
+    toadlet.handleMethodGET(new URI("http://localhost/insertfile/"), mock(HTTPRequest.class), ctx);
+
+    HTMLNode select =
+        findByNameAndAttribute(holder.page.getContentNode(), "select", "name", "compatibilityMode");
+    assertNotNull(select);
+    List<HTMLNode> options = select.getChildren();
+    assertEquals(
+        List.of("COMPAT_DEFAULT", "COMPAT_1468"),
+        options.stream().map(option -> option.getAttribute("value")).toList());
+    assertNull(options.getFirst().getAttribute("selected"));
+    assertEquals("", options.get(1).getAttribute("selected"));
+  }
+
+  @Test
   void handleMethodGET_whenPublicGatewayAndNoFullAccess_sendsUnauthorized() throws Exception {
     when(container.publicGatewayMode()).thenReturn(true);
 
@@ -167,6 +190,15 @@ class FileInsertWizardToadletTest {
     toadlet.handleMethodGET(new URI("http://localhost/insertfile/"), mock(HTTPRequest.class), ctx);
 
     assertEquals(403, ctx.getStatusCode());
+  }
+
+  private FileInsertWizardToadlet createToadlet(InsertCompatibilityModes compatibilityModes)
+      throws Exception {
+    FileInsertWizardToadlet created =
+        new FileInsertWizardToadlet(
+            new FileInsertWizardToadletRuntimePorts(securityLevelsPort, compatibilityModes));
+    setContainer(created, container);
+    return created;
   }
 
   private static void setContainer(FileInsertWizardToadlet toadlet, ToadletContainer container)
@@ -182,6 +214,20 @@ class FileInsertWizardToadletTest {
     }
     for (HTMLNode child : root.getChildren()) {
       HTMLNode found = findById(child, id);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private static HTMLNode findByNameAndAttribute(
+      HTMLNode root, String name, String attributeName, String attributeValue) {
+    if (name.equals(root.getName()) && attributeValue.equals(root.getAttribute(attributeName))) {
+      return root;
+    }
+    for (HTMLNode child : root.getChildren()) {
+      HTMLNode found = findByNameAndAttribute(child, name, attributeName, attributeValue);
       if (found != null) {
         return found;
       }

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardNewToadletTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
@@ -55,7 +54,6 @@ class FirstTimeWizardNewToadletTest {
           "",
           -1L);
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private FirstTimeWizardPort wizardPort;
   @Mock private ToadletContext ctx;
   @Mock private PageMaker pageMaker;
@@ -77,15 +75,14 @@ class FirstTimeWizardNewToadletTest {
 
   @Test
   void path_returnsWizardUrl() {
-    FirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    FirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
 
     assertEquals(FirstTimeWizardNewToadlet.TOADLET_URL, toadlet.path());
   }
 
   @Test
   void handleMethodGET_whenAccessDenied_returnsEarly() throws Exception {
-    TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(false);
 
     toadlet.handleMethodGET(
@@ -100,8 +97,7 @@ class FirstTimeWizardNewToadletTest {
   @Test
   void handleMethodGET_whenSnapshotHasSuggestedValues_populatesModelFromSnapshot()
       throws Exception {
-    TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     when(wizardPort.snapshot())
         .thenReturn(
@@ -140,8 +136,7 @@ class FirstTimeWizardNewToadletTest {
 
   @Test
   void handleMethodPOST_whenValidInput_appliesDetachedSubmissionAndRedirects() throws Exception {
-    TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
     Map<String, String> parts = new HashMap<>();
@@ -178,8 +173,7 @@ class FirstTimeWizardNewToadletTest {
 
   @Test
   void handleMethodPOST_whenDownloadBelowMinimum_rendersErrorsInsteadOfRedirect() throws Exception {
-    TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
     Map<String, String> parts = new HashMap<>();
@@ -208,8 +202,7 @@ class FirstTimeWizardNewToadletTest {
 
   @Test
   void handleMethodPOST_whenDownloadExceedsIntBackedConfigRange_rendersErrors() throws Exception {
-    TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
     Map<String, String> parts = new HashMap<>();
@@ -238,8 +231,7 @@ class FirstTimeWizardNewToadletTest {
 
   @Test
   void handleMethodPOST_whenStorageExceedsExactRoundedCap_rendersErrors() throws Exception {
-    TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     when(wizardPort.snapshot())
         .thenReturn(
@@ -284,8 +276,7 @@ class FirstTimeWizardNewToadletTest {
   @Test
   void handleMethodPOST_whenMonthlyLimitUsesUnsupportedExponentFormat_rendersErrors()
       throws Exception {
-    TestableFirstTimeWizardNewToadlet toadlet =
-        new TestableFirstTimeWizardNewToadlet(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet toadlet = new TestableFirstTimeWizardNewToadlet(wizardPort);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
     Map<String, String> parts = new HashMap<>();
@@ -350,9 +341,8 @@ class FirstTimeWizardNewToadletTest {
     Map<String, Object> lastModel;
     boolean htmlWritten;
 
-    TestableFirstTimeWizardNewToadlet(
-        HighLevelSimpleClient client, FirstTimeWizardPort wizardPort) {
-      super(client, wizardPort);
+    TestableFirstTimeWizardNewToadlet(FirstTimeWizardPort wizardPort) {
+      super(wizardPort);
     }
 
     @Override

--- a/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/FirstTimeWizardToadletTest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.EnumMap;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.FirstTimeWizardToadlet.WIZARD_PRESET;
 import network.crypta.clients.http.FirstTimeWizardToadlet.WIZARD_STEP;
 import network.crypta.clients.http.wizardsteps.Misc;
@@ -43,8 +42,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 class FirstTimeWizardToadletTest {
 
-  @Mock private HighLevelSimpleClient client;
-
   @Mock private FirstTimeWizardPort firstTimeWizardPort;
   @Mock private ToadletContext ctx;
 
@@ -70,7 +67,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
+                config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -98,7 +95,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
+                config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -126,7 +123,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
+                config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(true);
     when(request.getParam("step", FirstTimeWizardToadlet.WIZARD_STEP.WELCOME.toString()))
@@ -151,7 +148,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
+                config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe("step", 20)).thenReturn("WELCOME");
@@ -193,7 +190,7 @@ class FirstTimeWizardToadletTest {
     FirstTimeWizardToadlet toadlet =
         spy(
             new FirstTimeWizardToadlet(
-                client, config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
+                config, new FirstTimeWizardToadletRuntimePorts(firstTimeWizardPort)));
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.hasParameters()).thenReturn(false);
     when(request.getPartAsStringFailsafe("step", 20)).thenReturn("MISC");

--- a/src/test/java/network/crypta/clients/http/ImageCreatorToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/ImageCreatorToadletTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,7 +54,7 @@ class ImageCreatorToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new ImageCreatorToadlet(null);
+    toadlet = new ImageCreatorToadlet(mock(network.crypta.client.HighLevelSimpleClient.class));
   }
 
   @Test
@@ -262,7 +263,7 @@ class ImageCreatorToadletTest {
     boolean htmlReplyCalled = false;
 
     ShortCircuitToadlet() {
-      super(null);
+      super(mock(network.crypta.client.HighLevelSimpleClient.class));
     }
 
     @Override

--- a/src/test/java/network/crypta/clients/http/LocalDirectoryConfigToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/LocalDirectoryConfigToadletTest.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -23,12 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LocalDirectoryConfigToadletTest {
 
   @Mock private TransferAccessPort transferAccess;
-  @Mock private HighLevelSimpleClient highLevelSimpleClient;
 
   private static final String POST_TO = "/config";
 
   private LocalDirectoryConfigToadlet createToadlet() {
-    return new LocalDirectoryConfigToadlet(transferAccess, highLevelSimpleClient, POST_TO);
+    return new LocalDirectoryConfigToadlet(transferAccess, POST_TO);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/LocalDownloadDirectoryToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/LocalDownloadDirectoryToadletTest.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
@@ -30,14 +29,13 @@ import static org.mockito.Mockito.when;
 class LocalDownloadDirectoryToadletTest {
 
   @Mock TransferAccessPort transferAccess;
-  @Mock HighLevelSimpleClient client;
 
   private LocalDownloadDirectoryToadlet toadlet;
 
   @BeforeEach
   void setUp() {
     lenient().doCallRealMethod().when(transferAccess).defaultDownloadDir();
-    toadlet = new LocalDownloadDirectoryToadlet(transferAccess, client, "/post");
+    toadlet = new LocalDownloadDirectoryToadlet(transferAccess, "/post");
   }
 
   @ParameterizedTest

--- a/src/test/java/network/crypta/clients/http/LocalFileFilterToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/LocalFileFilterToadletTest.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.HTMLNode;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,14 +26,13 @@ import static org.mockito.Mockito.when;
 class LocalFileFilterToadletTest {
 
   @Mock private TransferAccessPort transferAccess;
-  @Mock private HighLevelSimpleClient client;
 
   private LocalFileFilterToadlet toadlet;
 
   @BeforeEach
   void setUp() {
     lenient().doCallRealMethod().when(transferAccess).defaultUploadDir();
-    toadlet = new LocalFileFilterToadlet(transferAccess, client);
+    toadlet = new LocalFileFilterToadlet(transferAccess);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/LocalFileInsertToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/LocalFileInsertToadletTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,14 +25,12 @@ class LocalFileInsertToadletTest {
 
   @Mock private TransferAccessPort transferAccess;
 
-  @Mock private HighLevelSimpleClient highLevelSimpleClient;
-
   private LocalFileInsertToadlet toadlet;
 
   @BeforeEach
   void setUp() {
     lenient().doCallRealMethod().when(transferAccess).defaultUploadDir();
-    toadlet = new LocalFileInsertToadlet(transferAccess, highLevelSimpleClient);
+    toadlet = new LocalFileInsertToadlet(transferAccess);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/LocalFileN2NMToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/LocalFileN2NMToadletTest.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,14 +26,12 @@ class LocalFileN2NMToadletTest {
 
   @Mock private TransferAccessPort transferAccess;
 
-  @Mock private HighLevelSimpleClient highLevelSimpleClient;
-
   private LocalFileN2NMToadlet toadlet;
 
   @BeforeEach
   void setUp() {
     lenient().doCallRealMethod().when(transferAccess).defaultUploadDir();
-    toadlet = new LocalFileN2NMToadlet(transferAccess, highLevelSimpleClient);
+    toadlet = new LocalFileN2NMToadlet(transferAccess);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/N2NTMToadletTest.java
@@ -10,7 +10,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -61,7 +60,6 @@ class N2NTMToadletTest {
   @Mock private DarknetMessagingPort darknetMessagingPort;
   @Mock private LifecyclePort lifecyclePort;
   @Mock private LocalFileN2NMToadlet browser;
-  @Mock private HighLevelSimpleClient client;
   @Mock private HTTPRequest request;
   @Mock private ToadletContext ctx;
 
@@ -81,7 +79,7 @@ class N2NTMToadletTest {
         .when(runtimePorts.darknetMessaging())
         .thenReturn(darknetMessagingPort);
     org.mockito.Mockito.lenient().when(runtimePorts.lifecycle()).thenReturn(lifecyclePort);
-    toadlet = new N2NTMToadlet(runtimePorts, browser, client);
+    toadlet = new N2NTMToadlet(runtimePorts, browser);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/OpennetConnectionsToadletTest.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPageKind;
 import network.crypta.runtime.spi.ConnectionsPagePort;
@@ -53,7 +52,6 @@ class OpennetConnectionsToadletTest {
   private static final String OWN_NODE_IDENTITY = "peer-1";
   private static final String OWN_NODE_LAST_GOOD_VERSION = "1";
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private ConnectionsPagePort connectionsPage;
   @Mock private ConnectionsSupportPort connectionsSupportPort;
   @Mock private LifecyclePort lifecyclePort;
@@ -75,7 +73,7 @@ class OpennetConnectionsToadletTest {
             configPort,
             connectionsSupportPort,
             lifecyclePort);
-    toadlet = new OpennetConnectionsToadlet(client, runtimePorts);
+    toadlet = new OpennetConnectionsToadlet(runtimePorts);
   }
 
   @Test
@@ -89,7 +87,7 @@ class OpennetConnectionsToadletTest {
             connectionsSupportPort,
             lifecyclePort);
 
-    assertDoesNotThrow(() -> new OpennetConnectionsToadlet(client, runtimePorts));
+    assertDoesNotThrow(() -> new OpennetConnectionsToadlet(runtimePorts));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.platform.api.PlatformApiRequest;
 import network.crypta.platform.api.PlatformApiResponse;
 import network.crypta.platform.api.PlatformApiRouter;
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PlatformApiToadletTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private PlatformApiRouter router;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
@@ -39,7 +37,7 @@ class PlatformApiToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new PlatformApiToadlet(client, router);
+    toadlet = new PlatformApiToadlet(router);
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostDownloadTest.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Random;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientContextDefaults;
@@ -98,7 +97,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletPostDownloadTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
@@ -370,7 +368,6 @@ class QueueToadletPostDownloadTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            client,
             false,
             new QueueToadletRuntimePorts(
                 queuePagePort,
@@ -381,7 +378,11 @@ class QueueToadletPostDownloadTest {
                 queueSupportPort,
                 queueCompletionPort,
                 darknetConnectionsPort,
-                darknetMessagingPort));
+                darknetMessagingPort,
+                new InsertCompatibilityModes(
+                    java.util.List.of(
+                        InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name()),
+                    InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name())));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
@@ -5,11 +5,11 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientContextDefaults;
@@ -98,7 +98,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletPostInsertTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
@@ -162,6 +161,35 @@ class QueueToadletPostInsertTest {
     try (var inputStream = request.upload().openStream()) {
       assertArrayEquals("payload".getBytes(StandardCharsets.UTF_8), inputStream.readAllBytes());
     }
+  }
+
+  @Test
+  void handleMethodPOST_whenSupportedCompatibilityProvided_passesDetachedModeThrough()
+      throws Exception {
+    String customCompatibilityMode = InsertContext.CompatibilityMode.COMPAT_1468.name();
+    QueueToadlet toadlet =
+        createQueueToadlet(
+            new InsertCompatibilityModes(
+                List.of(defaultCompatibilityMode(), customCompatibilityMode),
+                defaultCompatibilityMode()));
+    HTTPUploadedFile uploadedFile = uploadedFile();
+    when(queueInsertPort.enqueueBrowserUploadInsert(any()))
+        .thenReturn(QueueInsertOutcome.METADATA_UNRESOLVED);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(
+            Map.of(
+                "insert", "yes",
+                "keytype", "CHK",
+                "compatibilityMode", customCompatibilityMode),
+            uploadedFile),
+        ctx);
+
+    ArgumentCaptor<QueueBrowserUploadInsertRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueBrowserUploadInsertRequest.class);
+    verify(queueInsertPort).enqueueBrowserUploadInsert(requestCaptor.capture());
+    assertEquals(customCompatibilityMode, requestCaptor.getValue().compatibilityMode());
   }
 
   @Test
@@ -319,6 +347,14 @@ class QueueToadletPostInsertTest {
   }
 
   private QueueToadlet createQueueToadlet() throws Exception {
+    return createQueueToadlet(
+        new InsertCompatibilityModes(
+            List.of(InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name()),
+            InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name()));
+  }
+
+  private QueueToadlet createQueueToadlet(InsertCompatibilityModes compatibilityModes)
+      throws Exception {
     ProgramDirectory userDir = new ProgramDirectory();
     userDir.move(tempDir.toString());
 
@@ -375,7 +411,6 @@ class QueueToadletPostInsertTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            client,
             true,
             new QueueToadletRuntimePorts(
                 queuePagePort,
@@ -386,7 +421,8 @@ class QueueToadletPostInsertTest {
                 queueSupportPort,
                 queueCompletionPort,
                 darknetConnectionsPort,
-                darknetMessagingPort));
+                darknetMessagingPort,
+                compatibilityModes));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostInsertTest.java
@@ -193,6 +193,29 @@ class QueueToadletPostInsertTest {
   }
 
   @Test
+  void handleMethodPOST_whenCompatCurrentProvided_normalizesToDetachedDefault() throws Exception {
+    QueueToadlet toadlet = createQueueToadlet();
+    HTTPUploadedFile uploadedFile = uploadedFile();
+    when(queueInsertPort.enqueueBrowserUploadInsert(any()))
+        .thenReturn(QueueInsertOutcome.METADATA_UNRESOLVED);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/uploads/"),
+        createRequest(
+            Map.of(
+                "insert", "yes",
+                "keytype", "CHK",
+                "compatibilityMode", InsertContext.CompatibilityMode.COMPAT_CURRENT.name()),
+            uploadedFile),
+        ctx);
+
+    ArgumentCaptor<QueueBrowserUploadInsertRequest> requestCaptor =
+        ArgumentCaptor.forClass(QueueBrowserUploadInsertRequest.class);
+    verify(queueInsertPort).enqueueBrowserUploadInsert(requestCaptor.capture());
+    assertEquals(defaultCompatibilityMode(), requestCaptor.getValue().compatibilityMode());
+  }
+
+  @Test
   void handleMethodPOST_whenBrowserUploadRejected_returnsInsertErrorPage() throws Exception {
     QueueToadlet toadlet = createQueueToadlet();
     HTTPUploadedFile uploadedFile = uploadedFile();

--- a/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletPostMutationTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Random;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientContextDefaults;
@@ -91,7 +90,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletPostMutationTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
@@ -345,7 +343,6 @@ class QueueToadletPostMutationTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            client,
             uploads,
             new QueueToadletRuntimePorts(
                 queuePagePort,
@@ -356,7 +353,11 @@ class QueueToadletPostMutationTest {
                 queueSupportPort,
                 queueCompletionPort,
                 darknetConnectionsPort,
-                darknetMessagingPort));
+                darknetMessagingPort,
+                new InsertCompatibilityModes(
+                    java.util.List.of(
+                        InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name()),
+                    InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name())));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletRecommendTest.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Random;
 import network.crypta.client.ArchiveManager;
 import network.crypta.client.FetchContext;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientContextDefaults;
@@ -96,7 +95,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings({"java:S100", "MockNotUsedInProduction"})
 class QueueToadletRecommendTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private FCPServer fcp;
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
@@ -321,7 +319,6 @@ class QueueToadletRecommendTest {
 
     QueueToadlet toadlet =
         new QueueToadlet(
-            client,
             false,
             new QueueToadletRuntimePorts(
                 queuePagePort,
@@ -332,7 +329,11 @@ class QueueToadletRecommendTest {
                 queueSupportPort,
                 queueCompletionPort,
                 darknetConnectionsPort,
-                darknetMessagingPort));
+                darknetMessagingPort,
+                new InsertCompatibilityModes(
+                    java.util.List.of(
+                        InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name()),
+                    InsertContext.CompatibilityMode.COMPAT_DEFAULT.intern().name())));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/QueueToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/QueueToadletTest.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -54,7 +53,6 @@ class QueueToadletTest {
 
   private static final String TEST_FORM_PASSWORD = "queue-form-password";
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private QueuePagePort queuePagePort;
   @Mock private TransferAccessPort transferAccessPort;
   @Mock private QueueDownloadPort queueDownloadPort;
@@ -333,7 +331,6 @@ class QueueToadletTest {
   private QueueToadlet createQueueToadlet(boolean uploads) {
     QueueToadlet toadlet =
         new QueueToadlet(
-            client,
             uploads,
             new QueueToadletRuntimePorts(
                 queuePagePort,
@@ -344,7 +341,15 @@ class QueueToadletTest {
                 queueSupportPort,
                 queueCompletionPort,
                 darknetConnectionsPort,
-                darknetMessagingPort));
+                darknetMessagingPort,
+                new InsertCompatibilityModes(
+                    java.util.List.of(
+                        network.crypta.client.InsertContext.CompatibilityMode.COMPAT_DEFAULT
+                            .intern()
+                            .name()),
+                    network.crypta.client.InsertContext.CompatibilityMode.COMPAT_DEFAULT
+                        .intern()
+                        .name())));
     toadlet.container = container;
     return toadlet;
   }

--- a/src/test/java/network/crypta/clients/http/SecurityLevelsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SecurityLevelsToadletTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.SecurityLevelsSnapshot;
@@ -37,7 +36,6 @@ class SecurityLevelsToadletTest {
     ConfigPort configPort = mock(ConfigPort.class);
     SecurityLevelsToadlet toadlet =
         new SecurityLevelsToadlet(
-            mock(HighLevelSimpleClient.class),
             new SecurityLevelsToadletRuntimePorts(securityLevelsPort, configPort));
 
     String result = toadlet.path();
@@ -51,7 +49,6 @@ class SecurityLevelsToadletTest {
     ConfigPort configPort = mock(ConfigPort.class);
     SecurityLevelsToadlet toadlet =
         new SecurityLevelsToadlet(
-            mock(HighLevelSimpleClient.class),
             new SecurityLevelsToadletRuntimePorts(securityLevelsPort, configPort));
     HTTPRequest request = mock(HTTPRequest.class);
     ToadletContext ctx = mock(ToadletContext.class);

--- a/src/test/java/network/crypta/clients/http/SimpleHelpToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleHelpToadletTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.support.HTMLNode;
@@ -31,8 +30,7 @@ class SimpleHelpToadletTest {
 
   @Test
   void handleMethodGET_whenFullAccess_addsSummaryAndWritesHtml() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet(client));
+    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet());
 
     ToadletContext ctx = mock(ToadletContext.class);
     PageMaker pageMaker = mock(PageMaker.class);
@@ -78,8 +76,7 @@ class SimpleHelpToadletTest {
 
   @Test
   void handleMethodGET_whenRestricted_doesNotAddSummary() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
-    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet(client));
+    SimpleHelpToadlet toadlet = spy(new SimpleHelpToadlet());
 
     ToadletContext ctx = mock(ToadletContext.class);
     PageMaker pageMaker = mock(PageMaker.class);
@@ -109,13 +106,13 @@ class SimpleHelpToadletTest {
   void constructor_withoutCoreDependency_acceptsClientOnly() {
     assertEquals(1, SimpleHelpToadlet.class.getDeclaredConstructors().length);
     assertArrayEquals(
-        new Class<?>[] {HighLevelSimpleClient.class},
+        new Class<?>[] {},
         SimpleHelpToadlet.class.getDeclaredConstructors()[0].getParameterTypes());
   }
 
   @Test
   void path_whenCalled_returnsHelpPath() {
-    SimpleHelpToadlet toadlet = new SimpleHelpToadlet(mock(HighLevelSimpleClient.class));
+    SimpleHelpToadlet toadlet = new SimpleHelpToadlet();
     assertEquals("/help/", toadlet.path());
   }
 }

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -284,7 +284,6 @@ class SimpleToadletServerTest {
     verify(core, never()).getRandom();
     verify(routeRegistrar, times(1))
         .registerRoutes(any(LegacyHttpRouteRegistrarContext.class), same(server));
-    assertSame(client, routeRegistrarContextRef.get().client());
     assertSame(runtimePorts, routeRegistrarContextRef.get().runtimePorts());
     assertSame(appHost, routeRegistrarContextRef.get().appHost());
     assertSame(nodeConfig, routeRegistrarContextRef.get().config());
@@ -330,6 +329,8 @@ class SimpleToadletServerTest {
     when(runtimeSupport.appHost()).thenReturn(appHost);
     when(runtimeSupport.config()).thenReturn(config);
     when(runtimeSupport.ticker()).thenReturn(ticker);
+    when(runtimeSupport.insertCompatibilityModes())
+        .thenReturn(new InsertCompatibilityModes(List.of("COMPAT_DEFAULT"), "COMPAT_DEFAULT"));
     when(runtimeSupport.createPushDataManagerHandle(ticker)).thenReturn(pushDataManagerHandle);
     when(fproxyRuntimeSupport.clientContext()).thenReturn(clientContext);
     server.setRuntimeSupport(runtimeSupport);
@@ -340,7 +341,6 @@ class SimpleToadletServerTest {
         .thenReturn(
             HttpShellBrowseBootstrap.create(
                 bookmarkManager,
-                client,
                 appHost,
                 browseRoot,
                 browseRouteRegistrar,
@@ -599,7 +599,7 @@ class SimpleToadletServerTest {
     private final String path;
 
     DummyToadlet(String path) {
-      super(null);
+      super();
       this.path = path;
     }
 

--- a/src/test/java/network/crypta/clients/http/StatisticsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/StatisticsToadletTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.http;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.StatisticsPageSnapshot;
 import network.crypta.runtime.spi.StatisticsPort;
@@ -35,7 +34,6 @@ class StatisticsToadletTest {
 
   private static final String TEST_FORM_PASSWORD = "test-form-password";
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private StatisticsPort statistics;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
@@ -44,7 +42,7 @@ class StatisticsToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new StatisticsToadlet(client, statistics);
+    toadlet = new StatisticsToadlet(statistics);
   }
 
   @Test
@@ -54,8 +52,7 @@ class StatisticsToadletTest {
 
   @Test
   void path_whenCustomPathConfigured_returnsConfiguredPath() {
-    StatisticsToadlet customPathToadlet =
-        new StatisticsToadlet(client, statistics, "/custom-stats/");
+    StatisticsToadlet customPathToadlet = new StatisticsToadlet(statistics, "/custom-stats/");
 
     assertEquals("/custom-stats/", customPathToadlet.path());
   }

--- a/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/SymlinkerToadletTest.java
@@ -8,7 +8,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.spi.ToadletSymlinkEntry;
 import network.crypta.runtime.spi.ToadletSymlinkPort;
 import network.crypta.support.api.HTTPRequest;
@@ -34,7 +33,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class SymlinkerToadletTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private ToadletSymlinkPort symlinkPort;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
@@ -43,7 +41,7 @@ class SymlinkerToadletTest {
   void handleMethodGET_whenAliasMatches_redirectsWithOriginalQueryAndFragment() throws Exception {
     when(symlinkPort.loadConfiguredSymlinks())
         .thenReturn(List.of(new ToadletSymlinkEntry("/cfg/", "/target/")));
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(symlinkPort);
 
     URI incoming = new URI("http://localhost/cfg/path?foo=bar#frag");
 
@@ -59,7 +57,7 @@ class SymlinkerToadletTest {
   @Test
   void addLink_whenStoreTrue_persistsAndRedirects() {
     when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(symlinkPort);
 
     boolean added = toadlet.addLink("/alias/", "/dest/", true);
 
@@ -78,7 +76,7 @@ class SymlinkerToadletTest {
   @Test
   void addLink_whenConcurrentStoredUpdates_persistsSnapshotsInMutationOrder() throws Exception {
     BlockingToadletSymlinkPort blockingPort = new BlockingToadletSymlinkPort();
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, blockingPort);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(blockingPort);
     CountDownLatch secondStarted = new CountDownLatch(1);
     Thread firstUpdate = new Thread(() -> toadlet.addLink("/a/", "/dest-a/", true));
     Thread secondUpdate =
@@ -114,7 +112,7 @@ class SymlinkerToadletTest {
   @Test
   void removeLink_whenExistingAlias_returnsTrueAndPreventsRedirect() throws Exception {
     when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(symlinkPort);
 
     toadlet.addLink("/remove/", "/kept/", false);
 
@@ -140,7 +138,7 @@ class SymlinkerToadletTest {
   @Test
   void handleMethodGET_whenNoMatchingAlias_sends404Response() throws Exception {
     when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(symlinkPort);
 
     assertDoesNotThrow(
         () -> toadlet.handleMethodGET(new URI("http://localhost/unknown"), request, ctx));
@@ -159,7 +157,7 @@ class SymlinkerToadletTest {
   @Test
   void handleMethodGET_whenTargetContainsSpaces_redirectsWithEncodedPath() {
     when(symlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
-    SymlinkerToadlet toadlet = new SymlinkerToadlet(client, symlinkPort);
+    SymlinkerToadlet toadlet = new SymlinkerToadlet(symlinkPort);
     toadlet.addLink("/bad/", "/target with space/", false);
 
     RedirectException redirect =

--- a/src/test/java/network/crypta/clients/http/TranslationToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/TranslationToadletTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.lang.reflect.Field;
 import java.net.URI;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.l10n.TranslationPaths;
@@ -36,7 +35,6 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class TranslationToadletTest {
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
 
@@ -56,7 +54,7 @@ class TranslationToadletTest {
     when(baseL10n.getString(anyString(), any(String[].class), any(String[].class)))
         .thenAnswer(invocation -> invocation.getArgument(0, String.class));
 
-    toadlet = new TranslationToadlet(client);
+    toadlet = new TranslationToadlet();
   }
 
   @AfterEach

--- a/src/test/java/network/crypta/clients/http/UserAlertsToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/UserAlertsToadletTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.http;
 
 import java.net.URI;
 import javax.naming.SizeLimitExceededException;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.runtime.alerts.AbstractNodeToNodeFileOfferUserAlert;
 import network.crypta.runtime.alerts.NodeToNodeMessageUserAlert;
 import network.crypta.runtime.alerts.UserAlert;
@@ -43,7 +42,6 @@ class UserAlertsToadletTest {
 
   private static final URI ALERTS_URI = URI.create("http://localhost/alerts/");
 
-  @Mock private HighLevelSimpleClient client;
   @Mock private ToadletContext context;
   @Mock private PageMaker pageMaker;
   @Mock private UserAlertManager alertManager;
@@ -52,7 +50,7 @@ class UserAlertsToadletTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    toadlet = new UserAlertsToadlet(client);
+    toadlet = new UserAlertsToadlet();
 
     when(context.getAlertManager()).thenReturn(alertManager);
     when(context.getPageMaker()).thenReturn(pageMaker);

--- a/src/test/java/network/crypta/clients/http/WebShellToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/WebShellToadletTest.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.fs.readiness.LauncherReadinessInfo;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.support.HTMLNode;
@@ -35,7 +34,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class WebShellToadletTest {
-  @Mock private HighLevelSimpleClient client;
   @Mock private ToadletContext ctx;
   @Mock private ToadletContainer container;
   @Mock private HTTPRequest request;
@@ -44,7 +42,7 @@ class WebShellToadletTest {
 
   @BeforeEach
   void setUp() {
-    toadlet = new WebShellToadlet(client);
+    toadlet = new WebShellToadlet();
   }
 
   @Test
@@ -117,7 +115,7 @@ class WebShellToadletTest {
 
   @Test
   void handleMethodGET_whenRouteUnknown_expectNotFound() throws Exception {
-    WebShellToadlet spyToadlet = spy(new WebShellToadlet(client));
+    WebShellToadlet spyToadlet = spy(new WebShellToadlet());
     PageMaker pageMaker = mock(PageMaker.class);
     PageNode pageNode = mock(PageNode.class);
     HTMLNode contentNode = new HTMLNode("div");

--- a/src/test/java/network/crypta/clients/http/updater/CoreActionToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/updater/CoreActionToadletTest.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Optional;
-import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.clients.http.PageMaker;
 import network.crypta.clients.http.PageNode;
 import network.crypta.clients.http.ToadletContext;
@@ -44,8 +43,7 @@ class CoreActionToadletTest {
 
   @Test
   void path_whenCalled_expectCoreUpdatePath() {
-    CoreActionToadlet toadlet =
-        new CoreActionToadlet(mock(HighLevelSimpleClient.class), mock(CoreUpdateActionPort.class));
+    CoreActionToadlet toadlet = new CoreActionToadlet(mock(CoreUpdateActionPort.class));
 
     assertEquals(UpdaterPaths.CORE_UPDATE_PATH, toadlet.path());
   }
@@ -54,8 +52,7 @@ class CoreActionToadletTest {
   void handleMethodGET_whenCalled_expectRedirectToAlerts() throws Exception {
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet =
-        new CoreActionToadlet(mock(HighLevelSimpleClient.class), mock(CoreUpdateActionPort.class));
+    CoreActionToadlet toadlet = new CoreActionToadlet(mock(CoreUpdateActionPort.class));
 
     doNothing().when(ctx).sendReplyHeaders(eq(302), eq("Found"), any(), isNull(), eq(0L));
 
@@ -70,11 +67,10 @@ class CoreActionToadletTest {
 
   @Test
   void handleMethodPOST_whenFormPasswordInvalid_expectNoRedirect() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(false);
 
@@ -86,11 +82,10 @@ class CoreActionToadletTest {
 
   @Test
   void handleMethodPOST_whenCoreUpdaterMissing_expectRedirect() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
     when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(false);
@@ -108,11 +103,10 @@ class CoreActionToadletTest {
   @Test
   void handleMethodPOST_whenActionUnknownAndCoreUpdaterAvailable_expectRedirect() throws Exception {
     // Arrange
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
     when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
@@ -132,11 +126,10 @@ class CoreActionToadletTest {
 
   @Test
   void handleMethodPOST_whenDownloadAction_expectStartDownloadAndRedirect() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
     when(request.getPartAsStringFailsafe(eq("action"), anyInt())).thenReturn("download");
@@ -155,11 +148,10 @@ class CoreActionToadletTest {
 
   @Test
   void handleMethodPOST_whenInstallPathInvalid_expectFailurePage() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     String invalidPath = tempDir.resolve("outside/installer.deb").toFile().getAbsolutePath();
 
@@ -180,11 +172,10 @@ class CoreActionToadletTest {
 
   @Test
   void handleMethodPOST_whenInstallPathValidInServiceMode_expectFailurePage() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     File baseDir = tempDir.resolve("node").toFile();
     File updatesDir = new File(baseDir, "updates/core");
@@ -216,11 +207,10 @@ class CoreActionToadletTest {
 
   @Test
   void handleMethodPOST_whenOpenStoreUnknown_expectFailurePage() throws Exception {
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
     when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
@@ -241,11 +231,10 @@ class CoreActionToadletTest {
   @Test
   void handleMethodPOST_whenInstallSnapInsideSnapSandbox_expectGuidancePage() throws Exception {
     // Arrange
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     File baseDir = tempDir.resolve("node").toFile();
     File updatesDir = new File(baseDir, "updates/core");
@@ -287,11 +276,10 @@ class CoreActionToadletTest {
   void handleMethodPOST_whenOpenStoreSnapInsideSnapSandbox_expectManualCommandPage()
       throws Exception {
     // Arrange
-    HighLevelSimpleClient client = mock(HighLevelSimpleClient.class);
     CoreUpdateActionPort coreUpdateActionPort = mock(CoreUpdateActionPort.class);
     ToadletContext ctx = mock(ToadletContext.class);
     HTTPRequest request = mock(HTTPRequest.class);
-    CoreActionToadlet toadlet = new CoreActionToadlet(client, coreUpdateActionPort);
+    CoreActionToadlet toadlet = new CoreActionToadlet(coreUpdateActionPort);
 
     when(ctx.checkFormPassword(request)).thenReturn(true);
     when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);


### PR DESCRIPTION
## Summary
- split the legacy HTTP base so `adapter-http-legacy-admin` owns a content-neutral `Toadlet` and browse-owned code carries the remaining client-backed helpers in `ContentToadlet`
- replace admin-side `InsertContext.CompatibilityMode` usage with detached `InsertCompatibilityModes` supplied by `HttpShellRuntimeSupport` / `CoreHttpShellRuntimeSupport`
- slim the legacy HTTP registration seam by removing admin/shared-shell `HighLevelSimpleClient` carriage, then update boundary coverage, ownership metadata, and root HTTP tests to lock the new boundary in place

## How to test
- `./gradlew test`

## Notes
- base branch: `develop`
- branch: `feature/legacy-http-boundary-hardening`