### PR TITLE
fix(http-admin): Remove runtime-node admin coupling

### DIFF
--- a/adapter-http-legacy-admin/build.gradle.kts
+++ b/adapter-http-legacy-admin/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
   implementation(project(":platform-apphost"))
   implementation(project(":platform-web-shell"))
   implementation(project(":runtime-alerts"))
-  implementation(project(":runtime-node"))
   implementation(project(":thirdparty-onion"))
 
   implementation(libs.slf4jApi)

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DarknetConnectionsToadlet.java
@@ -22,7 +22,7 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +48,8 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @see ConnectionsToadlet
- * @see network.crypta.node.DarknetPeerNode
+ * @see DarknetConnectionPeerSnapshot
+ * @see DarknetConnectionsPort
  */
 public class DarknetConnectionsToadlet extends ConnectionsToadlet {
   private static final Logger LOG = LoggerFactory.getLogger(DarknetConnectionsToadlet.class);
@@ -659,7 +660,8 @@ public class DarknetConnectionsToadlet extends ConnectionsToadlet {
     }
 
     SimpleFieldSet fs = toSimpleFieldSet(snapshot.root());
-    String filename = FileUtil.sanitizeFileNameWithExtras(peer.displayName() + FREF_SUFFIX, "\" ");
+    String filename =
+        LegacyFileSupport.sanitizeFileNameWithExtras(peer.displayName() + FREF_SUFFIX, "\" ");
     String content = fs.toString();
     MultiValueTable<String, String> extraHeaders =
         MultiValueTable.from(

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyWelcomePageSupport.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyWelcomePageSupport.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import network.crypta.clients.http.PageMaker.RenderParameters;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.support.HTMLNode;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import network.crypta.support.io.LineReadingInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * <p>The class is stateless and safe for repeated use across requests. Callers provide the current
  * {@link ToadletContext} and destination content node, and the helper fills in the same infobox and
  * meta-refresh structure that operators already expect during startup and restart transitions. It
- * deliberately fails soft when the wrapper log is unreadable, because the absence of log text
+ * deliberately fails quietly when the wrapper log is unreadable because the absence of log text
  * should not block the surrounding status page from rendering.
  *
  * <ul>
@@ -93,7 +93,7 @@ final class LegacyWelcomePageSupport {
       HTMLNode logInfoboxContent =
           ctx.getPageMaker()
               .getInfobox("infobox-info", "Current status", contentNode, "start-progress", true);
-      try (LineReadingInputStream logreader = FileUtil.getLogTailReader(logs, 2000)) {
+      try (LineReadingInputStream logreader = LegacyFileSupport.getLogTailReader(logs, 2000)) {
         String line;
         while ((line = logreader.readLine(100000, 200, true)) != null) {
           logInfoboxContent.addChild("#", line);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/QueueToadlet.java
@@ -42,7 +42,7 @@ import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.api.HTTPUploadedFile;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1688,7 +1688,7 @@ public final class QueueToadlet extends Toadlet implements LinkEnabledCallback {
               "persistenceBroken",
               new String[] {"TEMPDIR", "DBFILE"},
               new String[] {
-                FileUtil.getCanonicalFile(persistenceStatus.persistentTempDir()).toString()
+                LegacyFileSupport.getCanonicalFile(persistenceStatus.persistentTempDir()).toString()
                     + File.separator,
                 persistenceStatus.databasePath()
               }));

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SecurityLevelsToadlet.java
@@ -17,8 +17,7 @@ import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.http.ExternalLinkSupport;
-import network.crypta.support.io.FileUtil.OperatingSystem;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -975,15 +974,15 @@ public class SecurityLevelsToadlet extends Toadlet {
                   ExternalLinkSupport.escape(l10nSec("physicalThreatLevelFDELink")))
             });
     HTMLNode swapWarning = seclevelGroup.addChild("p").addChild("i");
-    OperatingSystem os = FileUtil.detectedOS;
+    String operatingSystemNameKey = LegacyFileSupport.operatingSystemNameKey();
     swapWarning.addChild(
         "#",
         NodeL10n.getBase()
             .getString(
                 "SecurityLevels.physicalThreatLevelSwapfile",
                 "operatingSystem",
-                NodeL10n.getBase().getString("OperatingSystemName." + os.name())));
-    if (os == FileUtil.OperatingSystem.WINDOWS) {
+                NodeL10n.getBase().getString("OperatingSystemName." + operatingSystemNameKey)));
+    if (LegacyFileSupport.isWindows()) {
       swapWarning.addChild("#", " " + WizardL10n.l10nSec("physicalThreatLevelSwapfileWindows"));
     }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import network.crypta.client.filter.HTMLFilter;
+import network.crypta.client.filter.HTMLFilterPolicy;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.http.PageMaker.THEME;
 import network.crypta.config.BooleanCallback;
@@ -1214,7 +1214,7 @@ public final class SimpleToadletServer
 
           @Override
           public Integer get() {
-            return HTMLFilter.getMetaRefreshSamePageMinInterval();
+            return HTMLFilterPolicy.getMetaRefreshSamePageMinInterval();
           }
 
           @Override
@@ -1222,11 +1222,11 @@ public final class SimpleToadletServer
             if (val < -1)
               throw new InvalidConfigValueException(
                   "-1 = disabled, 0+ = set a minimum interval"); // localization pending
-            HTMLFilter.setMetaRefreshSamePageMinInterval(val);
+            HTMLFilterPolicy.setMetaRefreshSamePageMinInterval(val);
           }
         },
         false);
-    HTMLFilter.setMetaRefreshSamePageMinInterval(
+    HTMLFilterPolicy.setMetaRefreshSamePageMinInterval(
         Math.max(-1, fproxyConfig.getInt("metaRefreshSamePageInterval")));
 
     fproxyConfig.register(
@@ -1242,7 +1242,7 @@ public final class SimpleToadletServer
 
           @Override
           public Integer get() {
-            return HTMLFilter.getMetaRefreshRedirectMinInterval();
+            return HTMLFilterPolicy.getMetaRefreshRedirectMinInterval();
           }
 
           @Override
@@ -1250,11 +1250,11 @@ public final class SimpleToadletServer
             if (val < -1)
               throw new InvalidConfigValueException(
                   "-1 = disabled, 0+ = set a minimum interval"); // localization pending
-            HTMLFilter.setMetaRefreshRedirectMinInterval(val);
+            HTMLFilterPolicy.setMetaRefreshRedirectMinInterval(val);
           }
         },
         false);
-    HTMLFilter.setMetaRefreshRedirectMinInterval(
+    HTMLFilterPolicy.setMetaRefreshRedirectMinInterval(
         Math.max(-1, fproxyConfig.getInt("metaRefreshRedirectInterval")));
 
     fproxyConfig.register(
@@ -1270,15 +1270,15 @@ public final class SimpleToadletServer
 
           @Override
           public Boolean get() {
-            return HTMLFilter.isEmbedM3uPlayerEnabled();
+            return HTMLFilterPolicy.isEmbedM3uPlayerEnabled();
           }
 
           @Override
           public void set(Boolean val) {
-            HTMLFilter.setEmbedM3uPlayerEnabled(val);
+            HTMLFilterPolicy.setEmbedM3uPlayerEnabled(val);
           }
         });
-    HTMLFilter.setEmbedM3uPlayerEnabled(fproxyConfig.getBoolean("embedM3uPlayerInFreesites"));
+    HTMLFilterPolicy.setEmbedM3uPlayerEnabled(fproxyConfig.getBoolean("embedM3uPlayerInFreesites"));
 
     fproxyConfig.register(
         "refilterPolicy",

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -36,7 +36,7 @@ import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.http.HttpDateParser;
 import network.crypta.support.io.BucketTools;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.IOUtils;
 import network.crypta.support.io.LineReadingInputStream;
 import network.crypta.support.io.NoFreeBucket;
 import network.crypta.support.io.TooLongException;
@@ -1033,7 +1033,7 @@ public final class ToadletContextImpl implements ToadletContext {
       return DataReadResult.success(data);
     }
 
-    FileUtil.skipFully(is, length);
+    IOUtils.skipFully(is, length);
     if ("POST".equals(method)) {
       ctx.sendMethodNotAllowed("POST", true);
     } else {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthMonthly.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/BandwidthMonthly.java
@@ -10,7 +10,6 @@ import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.URLEncoder;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.DatastoreUtil;
 
 /**
  * Renders and processes the “monthly bandwidth cap” step in the first-time configuration wizard.
@@ -41,6 +40,7 @@ import network.crypta.support.io.DatastoreUtil;
  */
 public class BandwidthMonthly extends BandwidthManipulator implements Step {
 
+  private static final long ONE_GIB = 1024L * 1024L * 1024L;
   private static final long KIB = 1024L;
   private static final String L10N_KEY_BANDWIDTH_SELECT = "bandwidthSelect";
   private static final String TAG_INPUT = "input";
@@ -186,11 +186,11 @@ public class BandwidthMonthly extends BandwidthManipulator implements Step {
    * Processes a submitted cap value and updates the node’s bandwidth configuration.
    *
    * <p>The handler reads the {@code capTo} form parameter, interprets it as a monthly cap in
-   * “GB”-labeled units, and converts it to a byte total using {@link DatastoreUtil#ONE_GIB}. The
-   * resulting value is then mapped to upload and download limits via {@link WizardBandwidthLimit}
-   * and persisted using {@link #setBandwidthLimit(String, boolean)}. If parsing fails, or if the
-   * cap is below the minimum accepted limit, this method returns a redirect target that re-displays
-   * the current step with an appropriate error indicator.
+   * “GB”-labeled units, and converts it to a byte total using a local GiB constant. The resulting
+   * value is then mapped to upload and download limits via {@link WizardBandwidthLimit} and
+   * persisted using {@link #setBandwidthLimit(String, boolean)}. If parsing fails, or if the cap is
+   * below the minimum accepted limit, this method returns a redirect target that re-displays the
+   * current step with an appropriate error indicator.
    *
    * <p>This method is intended to be called once per form submission; repeating the same submission
    * is effectively idempotent with respect to the resulting stored limit values.
@@ -210,7 +210,7 @@ public class BandwidthMonthly extends BandwidthManipulator implements Step {
             .append("&parseTarget=");
     try {
       gbPerMonth = Double.parseDouble(capTo);
-      bytesPerMonth = Math.round(gbPerMonth * DatastoreUtil.ONE_GIB);
+      bytesPerMonth = Math.round(gbPerMonth * ONE_GIB);
     } catch (NumberFormatException _) {
       target.append(URLEncoder.encode(capTo, true));
       target.append("&parseError=true");

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.http.wizardsteps;
 
 import java.util.Objects;
+import java.util.function.LongSupplier;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.DatastoreSizingSupport;
@@ -11,15 +12,14 @@ import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SizeUtil;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.DatastoreUtil;
 
 /**
  * Wizard step that renders and applies a datastore sizing choice.
  *
  * <p>This step is used by the HTTP first-time wizard to present a dropdown of sensible datastore
  * sizes based on the local environment. The UI is populated from the current {@link Config} (when
- * present) and from a best-effort auto-detection via {@link DatastoreUtil}; it also considers hard
- * limits exported through the detached first-time-wizard snapshot.
+ * present) and from detached runtime snapshot values, including the legacy datastore cap exported
+ * through the first-time-wizard port.
  *
  * <p>When the user submits the form, this step updates multiple related configuration keys under
  * {@code node.*} (datastore size and cache sizes) in a consistent way. On the first run it also
@@ -120,9 +120,9 @@ public class DatastoreSize implements Step {
    * Applies the datastore size selection submitted for this wizard step.
    *
    * <p>The selected size is read from the {@code ds} form field and passed through the same parsing
-   * and validation logic used by {@link #setDatastoreSize(String, Config)}. When this step is
-   * executed as part of the full wizard flow (i.e., not in single-step mode), it advances to the
-   * bandwidth step; otherwise it returns the completion step.
+   * and validation logic used by {@link #setDatastoreSize(String, Config, LongSupplier)}. When this
+   * step is executed as part of the full wizard flow (i.e., not in single-step mode), it advances
+   * to the bandwidth step; otherwise it returns the completion step.
    *
    * @param request HTTP request containing the submitted {@code ds} selection and optional flags
    * @return the next wizard step name, suitable for {@code FirstTimeWizardToadlet.WIZARD_STEP}
@@ -133,12 +133,13 @@ public class DatastoreSize implements Step {
     // can
     // be more
     boolean firsttime = !request.isPartSet("singlestep");
+    FirstTimeWizardSnapshot snapshot = wizardPort.snapshot();
 
     DatastoreSizingSupport.setDatastoreSize(
         request.getPartAsStringFailsafe("ds", 20),
         firsttime,
         config,
-        DatastoreUtil::maxDatastoreSize);
+        snapshot::legacyMaxStorageLimitBytes);
     if (firsttime) {
       return FirstTimeWizardToadlet.WIZARD_STEP.BANDWIDTH.name();
     } else {
@@ -157,10 +158,12 @@ public class DatastoreSize implements Step {
    *
    * @param selectedStoreSize datastore size selection string, typically including a unit suffix
    * @param config configuration instance that will be updated in-place with the derived values
+   * @param maxDatastoreSizeSupplier detached maximum datastore size bound used to validate the
+   *     selection
    */
-  public static void setDatastoreSize(String selectedStoreSize, Config config) {
-    DatastoreSizingSupport.setDatastoreSize(
-        selectedStoreSize, config, DatastoreUtil::maxDatastoreSize);
+  public static void setDatastoreSize(
+      String selectedStoreSize, Config config, LongSupplier maxDatastoreSizeSupplier) {
+    DatastoreSizingSupport.setDatastoreSize(selectedStoreSize, config, maxDatastoreSizeSupplier);
   }
 
   private static void addDatastoreSizeOptions(

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/DatastoreSize.java
@@ -120,9 +120,13 @@ public class DatastoreSize implements Step {
    * Applies the datastore size selection submitted for this wizard step.
    *
    * <p>The selected size is read from the {@code ds} form field and passed through the same parsing
-   * and validation logic used by {@link #setDatastoreSize(String, Config, LongSupplier)}. When this
-   * step is executed as part of the full wizard flow (i.e., not in single-step mode), it advances
-   * to the bandwidth step; otherwise it returns the completion step.
+   * and validation logic used by {@link #setDatastoreSize(String, Config, LongSupplier)}. The
+   * posted value is validated against {@link FirstTimeWizardSnapshot#maxStorageLimitBytes()} so the
+   * detached multipage wizard keeps the historical acceptance behavior even when its legacy
+   * dropdown thresholds are bounded more aggressively by {@link
+   * FirstTimeWizardSnapshot#legacyMaxStorageLimitBytes()}. When this step is executed as part of
+   * the full wizard flow (i.e., not in single-step mode), it advances to the bandwidth step;
+   * otherwise it returns the completion step.
    *
    * @param request HTTP request containing the submitted {@code ds} selection and optional flags
    * @return the next wizard step name, suitable for {@code FirstTimeWizardToadlet.WIZARD_STEP}
@@ -139,7 +143,7 @@ public class DatastoreSize implements Step {
         request.getPartAsStringFailsafe("ds", 20),
         firsttime,
         config,
-        snapshot::legacyMaxStorageLimitBytes);
+        snapshot::maxStorageLimitBytes);
     if (firsttime) {
       return FirstTimeWizardToadlet.WIZARD_STEP.BANDWIDTH.name();
     } else {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/SecurityPhysical.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/wizardsteps/SecurityPhysical.java
@@ -12,8 +12,7 @@ import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.HTTPRequest;
 import network.crypta.support.http.ExternalLinkSupport;
-import network.crypta.support.io.FileUtil.OperatingSystem;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,15 +123,15 @@ public class SecurityPhysical implements Step {
               HTMLNode.STRONG,
               HTMLNode.linkInNewWindow(ExternalLinkSupport.escape("http://www.truecrypt.org/"))
             });
-    OperatingSystem os = FileUtil.detectedOS;
+    String operatingSystemNameKey = LegacyFileSupport.operatingSystemNameKey();
     div.addChild(
         "p",
         NodeL10n.getBase()
             .getString(
                 "SecurityLevels.physicalThreatLevelSwapfile",
                 "operatingSystem",
-                NodeL10n.getBase().getString("OperatingSystemName." + os.name())));
-    if (os == FileUtil.OperatingSystem.WINDOWS) {
+                NodeL10n.getBase().getString("OperatingSystemName." + operatingSystemNameKey)));
+    if (LegacyFileSupport.isWindows()) {
       swapWarning.addChild("#", " " + WizardL10n.l10nSec("physicalThreatLevelSwapfileWindows"));
     }
     for (SecurityPhysicalThreatLevel level : SecurityPhysicalThreatLevel.values()) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -64,6 +64,12 @@ class HttpLegacyAdminBoundaryTest {
           "import network.crypta.client.FetchWaiter;",
           "import network.crypta.client.InsertContext;",
           "import network.crypta.client.InsertContext.CompatibilityMode;");
+  private static final Set<String> FORBIDDEN_LEAF_HELPER_IMPORTS =
+      Set.of(
+          "import network.crypta.client.filter.HTMLFilter;",
+          "import network.crypta.support.io.FileUtil;",
+          "import network.crypta.support.io.FileUtil.OperatingSystem;",
+          "import network.crypta.support.io.DatastoreUtil;");
   private static final Path ADAPTER_HTTP_FPROXY_BOOTSTRAP =
       ADAPTER_HTTP_MAIN_JAVA.resolve("HttpShellFProxyBootstrap.java");
   private static final Path ADAPTER_LEGACY_ADMIN_HTTP_ROUTE_REGISTRAR =
@@ -310,6 +316,9 @@ class HttpLegacyAdminBoundaryTest {
     assertFalse(
         adapterBuild.contains("project(\":adapter-http-legacy-browse\")"),
         ":adapter-http-legacy-admin must not depend on :adapter-http-legacy-browse");
+    assertFalse(
+        adapterBuild.contains("implementation(project(\":runtime-node\"))"),
+        ":adapter-http-legacy-admin must not depend on :runtime-node");
     assertTrue(
         Files.isRegularFile(repoRoot.resolve(BRIDGE_OWNERSHIP_METADATA)),
         ":bridge-http-runtime must declare owned-output-patterns.txt");
@@ -437,6 +446,34 @@ class HttpLegacyAdminBoundaryTest {
         violations.isEmpty(),
         "adapter-http-legacy-admin main sources must not import runtime-node client contracts "
             + "directly anymore."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void mainSources_whenScanningAdminLeafHelperImports_expectDetachedImportsAbsent()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile : findMainJavaSources(repoRoot)) {
+      Path relativePath = repoRoot.relativize(sourceFile);
+      if (!relativePath.startsWith(ADAPTER_HTTP_MAIN_JAVA)) {
+        continue;
+      }
+
+      Set<String> imports = readImports(sourceFile);
+      for (String forbiddenImport : FORBIDDEN_LEAF_HELPER_IMPORTS) {
+        if (imports.contains(forbiddenImport)) {
+          violations.add(relativePath + " -> " + forbiddenImport);
+        }
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "adapter-http-legacy-admin main sources must not import HTMLFilter, FileUtil, or "
+            + "DatastoreUtil directly anymore."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
   }

--- a/foundation-support/gradle/owned-output-patterns.txt
+++ b/foundation-support/gradle/owned-output-patterns.txt
@@ -85,6 +85,7 @@ network/crypta/support/io/Fallocate*
 network/crypta/support/io/FilenameGenerator*
 network/crypta/support/io/FilenameSanitizer*
 network/crypta/support/io/InsufficientDiskSpaceException*
+network/crypta/support/io/LegacyFileSupport*
 network/crypta/support/io/LineReader*
 network/crypta/support/io/LineReadingInputStream*
 network/crypta/support/io/InetAddressIpv6FirstComparator*

--- a/foundation-support/src/main/java/network/crypta/support/io/IOUtils.java
+++ b/foundation-support/src/main/java/network/crypta/support/io/IOUtils.java
@@ -1,6 +1,7 @@
 package network.crypta.support.io;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.zip.ZipFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,6 +110,26 @@ public class IOUtils {
       } catch (IOException e) { // Catch only IOExceptions; runtime exceptions and Errors propagate.
         LOG.error("Error during close() on ZipFile", e);
       }
+    }
+  }
+
+  /**
+   * Skips exactly {@code skip} bytes from an {@link InputStream} or throws if unable to do so.
+   *
+   * <p>Unlike {@link InputStream#skip(long)}, this method requires forward progress on each
+   * iteration and fails fast if the stream stops advancing before the requested number of bytes has
+   * been discarded.
+   *
+   * @param is input stream (not closed by this method)
+   * @param skip number of bytes to skip; must be non-negative
+   * @throws IOException if the stream cannot skip the requested number of bytes
+   */
+  public static void skipFully(InputStream is, long skip) throws IOException {
+    long skipped = 0;
+    while (skipped < skip) {
+      long x = is.skip(skip - skipped);
+      if (x <= 0) throw new IOException("Unable to skip " + (skip - skipped) + " bytes");
+      skipped += x;
     }
   }
 }

--- a/foundation-support/src/main/java/network/crypta/support/io/LegacyFileSupport.java
+++ b/foundation-support/src/main/java/network/crypta/support/io/LegacyFileSupport.java
@@ -1,0 +1,245 @@
+package network.crypta.support.io;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Locale;
+import network.crypta.fs.AppEnv;
+
+/**
+ * Provides the small legacy file-utility subset that leaf modules still need after the runtime
+ * split.
+ *
+ * <p>This class exists so code such as the legacy HTTP admin UI can keep a handful of historical
+ * behaviors without depending on the much larger runtime-owned {@code FileUtil}. The exported
+ * surface is intentionally narrow: it covers filename suggestions used in download headers,
+ * canonical-path normalization for human-readable status pages, tail reading for wrapper logs, and
+ * stable operating-system naming for localized UI copy. Callers should treat these helpers as
+ * compatibility shims rather than as a new general-purpose file API.
+ *
+ * <p>The implementation favors behavioral continuity over abstraction purity. It preserves the old
+ * filename and log-tail semantics closely enough that existing admin pages and tests do not need to
+ * change, while still moving the logic into a leaf-safe module. Platform detection starts with
+ * {@link AppEnv}, then uses limited fallbacks only where older labels such as {@code FREE_BSD} or
+ * {@code GENERIC_UNIX} still matter to visible UI text.
+ *
+ * <ul>
+ *   <li>Methods are static and process-global.
+ *   <li>Return values are compatibility-oriented suggestions, not policy decisions.
+ *   <li>Filesystem reads and canonicalization are best-effort and may still reflect concurrent
+ *       external changes.
+ * </ul>
+ */
+public final class LegacyFileSupport {
+  private enum LegacyOperatingSystem {
+    UNKNOWN(false, false, false),
+    MAC_OS(false, true, true),
+    LINUX(false, false, true),
+    FREE_BSD(false, false, true),
+    GENERIC_UNIX(false, false, true),
+    WINDOWS(true, false, false);
+
+    final boolean windowsLike;
+    final boolean macLike;
+    final boolean unixLike;
+
+    LegacyOperatingSystem(boolean windowsLike, boolean macLike, boolean unixLike) {
+      this.windowsLike = windowsLike;
+      this.macLike = macLike;
+      this.unixLike = unixLike;
+    }
+  }
+
+  private LegacyFileSupport() {
+    throw new AssertionError("No instances");
+  }
+
+  /**
+   * Produces a filename suggestion for the current platform while replacing the supplied extra
+   * characters.
+   *
+   * <p>The behavior matches the historical legacy of utility. The input is first normalized through
+   * the process filename charset, then platform-specific reserved characters and any
+   * caller-specified extra characters are replaced with a stable fallback character. This keeps
+   * generated download names predictable across Windows, macOS, Linux, and generic Unix-like
+   * environments without exposing callers to the rest of the legacy file helper surface.
+   *
+   * <p>This method does not probe the filesystem, avoid collisions, or guarantee that the result is
+   * safe in every downstream context. Callers should treat the return value as a display-friendly
+   * suggestion for a single path segment, then layer any directory, uniqueness, or policy checks on
+   * top.
+   *
+   * @param fileName input filename candidate to sanitize into a filesystem-safe suggestion for one
+   *     path segment
+   * @param extraChars additional characters to replace regardless of platform-specific reserved
+   *     character rules
+   * @return a sanitized filename suggestion derived from {@code fileName} using the current
+   *     process-wide platform view
+   */
+  public static String sanitizeFileNameWithExtras(String fileName, String extraChars) {
+    AppEnv env = new AppEnv();
+    return sanitizeFileNameWithExtras(env, fileName, extraChars);
+  }
+
+  static String sanitizeFileNameWithExtras(AppEnv env, String fileName, String extraChars) {
+    LegacyOperatingSystem operatingSystem = detectOperatingSystem(env);
+    return FilenameSanitizer.sanitizeFileName(
+        fileName,
+        fileNameCharset(),
+        operatingSystem.windowsLike,
+        operatingSystem.macLike,
+        operatingSystem.unixLike,
+        extraChars);
+  }
+
+  /**
+   * Returns the canonical form of a file while preserving the legacy path normalization quirks.
+   *
+   * <p>The implementation rebuilds the {@link File} from its path string before canonicalization so
+   * the result matches the historical handling of paths that may already contain repeated or
+   * differently cased prefixes. On Windows-style paths, the string form is normalized to lower case
+   * before canonicalization because the old helper treated a drive-letter and separator case as
+   * cosmetic. If canonicalization fails, the method falls back to the absolute path exactly as the
+   * legacy utility did.
+   *
+   * <p>Use this when the caller needs a stable, display-ready path for diagnostics or admin pages.
+   * It is not a security boundary by itself; callers still need their own path allow-listing and
+   * authorization checks when a path controls real I/O.
+   *
+   * @param file file reference whose canonical or absolute representation should be returned
+   * @return canonical or absolute file reference, never {@code null}, with legacy normalization
+   *     rules preserved
+   */
+  public static File getCanonicalFile(File file) {
+    String name = file.getPath();
+    if (File.pathSeparatorChar == '\\') {
+      name = name.toLowerCase(Locale.ROOT);
+    }
+    file = new File(name);
+    try {
+      return file.getAbsoluteFile().getCanonicalFile();
+    } catch (IOException _) {
+      return file.getAbsoluteFile();
+    }
+  }
+
+  /**
+   * Opens a line-aware stream positioned on the trailing portion of a log file.
+   *
+   * <p>The returned reader exposes at most {@code byteLimit} bytes from the end of the file. When
+   * the requested window begins in the middle of a line, the method discards that first partial
+   * line so callers only see complete lines. This matches the startup-page behavior that shows the
+   * most recent wrapper-log context without rendering half a log entry at the top of the page.
+   *
+   * <p>The method tolerates concurrent truncation and other short reads by skipping as much as is
+   * available and then dropping the potential partial line. The caller owns the returned stream and
+   * must close it. The method performs no synchronization, so concurrent writers may still change
+   * the visible tail between the size check and the actual read.
+   *
+   * @param logfile file to open and position near its trailing content
+   * @param byteLimit maximum number of bytes of trailing content to expose before dropping a
+   *     possible leading partial line
+   * @return a line-aware input stream over the tail of {@code logfile}, ready for caller-owned
+   *     reads
+   * @throws IOException if opening the file or positioning the returned stream fails
+   */
+  public static LineReadingInputStream getLogTailReader(File logfile, long byteLimit)
+      throws IOException {
+    long length = logfile.length();
+    long skip = 0;
+    if (length > byteLimit) {
+      skip = length - byteLimit;
+    }
+
+    FileInputStream fis = null;
+    LineReadingInputStream lis = null;
+    try {
+      fis = new FileInputStream(logfile);
+      lis = new LineReadingInputStream(fis);
+      if (skip > 0) {
+        long remaining = skip;
+        while (remaining > 0) {
+          long s = lis.skip(remaining);
+          if (s <= 0) break;
+          remaining -= s;
+        }
+        lis.readLine(100000, 200, true);
+      }
+      return lis;
+    } catch (IOException | RuntimeException e) {
+      IOUtils.closeQuietly(lis);
+      IOUtils.closeQuietly(fis);
+      throw e;
+    }
+  }
+
+  /**
+   * Returns the legacy localization key suffix for the current operating system.
+   *
+   * <p>The result is suitable for lookups such as {@code OperatingSystemName.<suffix>} in the
+   * legacy HTTP admin UI. Modern Windows, macOS, and Linux runtimes map directly from {@link
+   * AppEnv}. Older or less specific environments fall back to the historical labels used by the
+   * legacy file utility so that existing translations, conditional UI copy, and screenshots do not
+   * unexpectedly drift after the runtime dependency split.
+   *
+   * @return the legacy operating-system key suffix used by the HTTP admin UI and related localized
+   *     messages
+   */
+  public static String operatingSystemNameKey() {
+    return operatingSystemNameKey(new AppEnv());
+  }
+
+  static String operatingSystemNameKey(AppEnv env) {
+    return detectOperatingSystem(env).name();
+  }
+
+  /**
+   * Reports whether the current platform should be treated as Windows for UI branching.
+   *
+   * <p>This helper exists for callers that only need the historical Windows/non-Windows split used
+   * by a few admin pages. It intentionally shares the same detection path as {@link
+   * #operatingSystemNameKey()} so branching logic and localized labels stay aligned.
+   *
+   * @return {@code true} when the current runtime should follow the legacy Windows-family branch
+   *     for UI behavior
+   */
+  public static boolean isWindows() {
+    return detectOperatingSystem(new AppEnv()) == LegacyOperatingSystem.WINDOWS;
+  }
+
+  private static Charset fileNameCharset() {
+    try {
+      return Charset.forName(Charset.defaultCharset().displayName());
+    } catch (Exception _) {
+      return Charset.defaultCharset();
+    }
+  }
+
+  private static LegacyOperatingSystem detectOperatingSystem(AppEnv env) {
+    if (env.isWindows()) {
+      return LegacyOperatingSystem.WINDOWS;
+    }
+    if (env.isMac()) {
+      return LegacyOperatingSystem.MAC_OS;
+    }
+
+    String lowered = env.osNameRaw().toLowerCase(Locale.ROOT);
+    if (lowered.contains("freebsd")) {
+      return LegacyOperatingSystem.FREE_BSD;
+    }
+    if (lowered.contains("linux")) {
+      return LegacyOperatingSystem.LINUX;
+    }
+    if (lowered.contains("unix")) {
+      return LegacyOperatingSystem.GENERIC_UNIX;
+    }
+    if (File.separatorChar == '\\') {
+      return LegacyOperatingSystem.WINDOWS;
+    }
+    if (File.separatorChar == '/') {
+      return LegacyOperatingSystem.GENERIC_UNIX;
+    }
+    return LegacyOperatingSystem.UNKNOWN;
+  }
+}

--- a/foundation-support/src/test/java/network/crypta/support/io/LegacyFileSupportTest.java
+++ b/foundation-support/src/test/java/network/crypta/support/io/LegacyFileSupportTest.java
@@ -1,0 +1,78 @@
+package network.crypta.support.io;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import network.crypta.fs.AppEnv;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LegacyFileSupportTest {
+
+  @Test
+  void operatingSystemNameKey_whenEnvVaries_expectLegacyNamesPreserved() {
+    assertEquals(
+        "WINDOWS", LegacyFileSupport.operatingSystemNameKey(new AppEnv(Map.of(), "Windows 11")));
+    assertEquals("MAC_OS", LegacyFileSupport.operatingSystemNameKey(new AppEnv(Map.of(), "Mac")));
+    assertEquals("LINUX", LegacyFileSupport.operatingSystemNameKey(new AppEnv(Map.of(), "Linux")));
+    assertEquals(
+        "FREE_BSD", LegacyFileSupport.operatingSystemNameKey(new AppEnv(Map.of(), "FreeBSD")));
+    assertEquals(
+        "GENERIC_UNIX", LegacyFileSupport.operatingSystemNameKey(new AppEnv(Map.of(), "Unix")));
+  }
+
+  @Test
+  void sanitizeFileNameWithExtras_whenExtraCharsProvided_expectLegacySanitization() {
+    String sanitized =
+        LegacyFileSupport.sanitizeFileNameWithExtras(
+            new AppEnv(Map.of(), "Linux"), "Alice\" Bob.fref", "\" ");
+
+    assertEquals("Alice__Bob.fref", sanitized);
+  }
+
+  @Test
+  void sanitizeFileNameWithExtras_whenWindowsReservedBasename_expectLegacyWindowsRules() {
+    String sanitized =
+        LegacyFileSupport.sanitizeFileNameWithExtras(
+            new AppEnv(Map.of(), "Windows 11"), "con.txt", "");
+
+    assertEquals("_con.txt", sanitized);
+  }
+
+  @Test
+  void getCanonicalFile_whenDotSegmentsPresent_expectCanonicalPath(@TempDir Path tempDir)
+      throws Exception {
+    Path nested = Files.createDirectories(tempDir.resolve("nested"));
+    Path dotted = nested.resolve("..").resolve("nested");
+
+    assertEquals(nested.toRealPath().toFile(), LegacyFileSupport.getCanonicalFile(dotted.toFile()));
+  }
+
+  @Test
+  void getLogTailReader_whenTruncated_expectStartsAtNextFullLine(@TempDir Path tempDir)
+      throws Exception {
+    Path log = tempDir.resolve("wrapper.log");
+    Files.writeString(log, "line one\nline two\nline three\n");
+
+    try (LineReadingInputStream input = LegacyFileSupport.getLogTailReader(log.toFile(), 12)) {
+      assertEquals("line three", input.readLine(100000, 200, true));
+      assertNull(input.readLine(100000, 200, true));
+    }
+  }
+
+  @Test
+  void getLogTailReader_whenWithinByteLimit_expectReadsFromStart(@TempDir Path tempDir)
+      throws Exception {
+    Path log = tempDir.resolve("wrapper.log");
+    Files.writeString(log, "line one\nline two\n");
+
+    try (LineReadingInputStream input = LegacyFileSupport.getLogTailReader(log.toFile(), 2000)) {
+      assertEquals("line one", input.readLine(100000, 200, true));
+      assertEquals("line two", input.readLine(100000, 200, true));
+      assertNull(input.readLine(100000, 200, true));
+    }
+  }
+}

--- a/kernel-content/gradle/owned-output-patterns.txt
+++ b/kernel-content/gradle/owned-output-patterns.txt
@@ -95,6 +95,8 @@ network/crypta/client/filter/FilterMIMETypeDangerousFlags.class
 network/crypta/client/filter/FilterMIMETypeDangerousFlags$*.class
 network/crypta/client/filter/FilterMIMETypeNames.class
 network/crypta/client/filter/FilterMIMETypeNames$*.class
+network/crypta/client/filter/HTMLFilterPolicy.class
+network/crypta/client/filter/HTMLFilterPolicy$*.class
 network/crypta/client/filter/FilterOperation.class
 network/crypta/client/filter/FilterOperation$*.class
 network/crypta/client/filter/FlacPacket.class

--- a/kernel-content/src/main/java/network/crypta/client/filter/HTMLFilterPolicy.java
+++ b/kernel-content/src/main/java/network/crypta/client/filter/HTMLFilterPolicy.java
@@ -1,0 +1,124 @@
+package network.crypta.client.filter;
+
+/**
+ * Stores the process-wide HTML filtering policy values that must remain visible across module
+ * boundaries.
+ *
+ * <p>The legacy admin UI still needs to read and update a few HTML filtering knobs even though the
+ * full filtering engine now lives in a different module. This class provides the smallest shared
+ * state necessary for that arrangement: whether the bundled M3U helper is injected and the minimum
+ * delays enforced for same-page and redirecting {@code meta refresh} tags. Keeping those values in
+ * a detached holder lets lightweight callers participate in configuration without depending on the
+ * runtime-owned filter implementation.
+ *
+ * <p>The state is intentionally static and global because the underlying behavior has always been
+ * process-wide. Updates therefore affect later filter operations across the JVM, not only the
+ * caller that changed the value. The class performs no validation or synchronization on its own; it
+ * relies on higher-level configuration code to supply already-validated values and to coordinate
+ * when changes become visible to operators.
+ *
+ * <ul>
+ *   <li>The defaults match the historical HTML filter defaults.
+ *   <li>Negative refresh intervals mean the corresponding tag should be rejected outright.
+ *   <li>The stored values are compatibility settings, not a full per-request policy model.
+ * </ul>
+ */
+public final class HTMLFilterPolicy {
+  /** if true, embed m3u player. Enabled when fproxy javascript is enabled. */
+  private static boolean embedM3uPlayer = true;
+
+  /** -1 means don't allow it */
+  private static int metaRefreshSamePageMinInterval = 1;
+
+  /** -1 means don't allow it */
+  private static int metaRefreshRedirectMinInterval = 30;
+
+  private HTMLFilterPolicy() {}
+
+  /**
+   * Reports whether the bundled M3U player should be embedded for allowed media content.
+   *
+   * <p>When this flag is enabled, later HTML filtering passes may inline the lightweight helper
+   * needed to play eligible M3U-based media content directly in the browser. Disabling the flag
+   * leaves the rest of the filtering pipeline intact but prevents that convenience layer from being
+   * added to sanitized output.
+   *
+   * @return {@code true} when the player snippet is currently enabled for future filtering work
+   */
+  public static boolean isEmbedM3uPlayerEnabled() {
+    return embedM3uPlayer;
+  }
+
+  /**
+   * Enables or disables automatic embedding of the bundled M3U player script.
+   *
+   * <p>This value is global rather than request-scoped. Callers should update it only from
+   * configuration or bootstrap code that intends to change the node-wide HTML filtering behavior
+   * for later requests.
+   *
+   * @param enabled {@code true} to inject the helper script whenever eligible media tags are
+   *     preserved during later filtering passes
+   */
+  public static void setEmbedM3uPlayerEnabled(boolean enabled) {
+    embedM3uPlayer = enabled;
+  }
+
+  /**
+   * Returns the minimum number of seconds required between meta-refresh events that reload the same
+   * page.
+   *
+   * <p>This threshold controls refresh tags that keep the browser in the current location. Small
+   * values allow gently updating status pages, while negative values reject the behavior entirely.
+   * The number is interpreted in seconds because that is how HTML {@code meta refresh} delays are
+   * expressed in content.
+   *
+   * @return minimum same-page refresh delay in seconds, or {@code -1} when such refreshes should
+   *     always be dropped
+   */
+  public static int getMetaRefreshSamePageMinInterval() {
+    return metaRefreshSamePageMinInterval;
+  }
+
+  /**
+   * Updates the interval guarding same-page meta-refresh operations.
+   *
+   * <p>The value is stored exactly as supplied, so the policyholder stays detached from UI and
+   * validation rules. Callers are responsible for enforcing any range checks before writing the new
+   * setting.
+   *
+   * @param interval number of seconds enforced between refreshes targeting the current URI, or a
+   *     negative value to disable the behavior entirely
+   */
+  public static void setMetaRefreshSamePageMinInterval(int interval) {
+    metaRefreshSamePageMinInterval = interval;
+  }
+
+  /**
+   * Returns the minimum number of seconds required before a redirecting meta-refresh may survive
+   * filtering.
+   *
+   * <p>This setting applies to refresh tags that move the browser to a new URL. Redirecting
+   * refreshes are usually more sensitive than same-page reloads because they can be used to rush
+   * navigation or hide the final destination, so the default delay is higher.
+   *
+   * @return minimum redirect delay in seconds, or {@code -1} when redirecting refreshes are
+   *     forbidden outright
+   */
+  public static int getMetaRefreshRedirectMinInterval() {
+    return metaRefreshRedirectMinInterval;
+  }
+
+  /**
+   * Sets the minimum delay enforced for meta-refreshes that redirect the browser to a new URL.
+   *
+   * <p>Like the other policy values in this class, the assignment is immediate and process-wide for
+   * future filtering work. The method does not reject unusual values because validation belongs in
+   * the configuration layer that owns the operator-facing setting.
+   *
+   * @param interval number of seconds required before allowing a redirecting refresh to pass, or a
+   *     negative value to reject redirect refreshes completely
+   */
+  public static void setMetaRefreshRedirectMinInterval(int interval) {
+    metaRefreshRedirectMinInterval = interval;
+  }
+}

--- a/kernel-content/src/test/java/network/crypta/client/filter/HTMLFilterPolicyTest.java
+++ b/kernel-content/src/test/java/network/crypta/client/filter/HTMLFilterPolicyTest.java
@@ -1,0 +1,38 @@
+package network.crypta.client.filter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HTMLFilterPolicyTest {
+
+  @Test
+  void htmlFilterPolicy_defaults_expectDocumentedValues() {
+    assertTrue(HTMLFilterPolicy.isEmbedM3uPlayerEnabled());
+    assertEquals(1, HTMLFilterPolicy.getMetaRefreshSamePageMinInterval());
+    assertEquals(30, HTMLFilterPolicy.getMetaRefreshRedirectMinInterval());
+  }
+
+  @Test
+  void htmlFilterPolicy_whenUpdated_expectValuesStoredGlobally() {
+    boolean originalEmbed = HTMLFilterPolicy.isEmbedM3uPlayerEnabled();
+    int originalSamePage = HTMLFilterPolicy.getMetaRefreshSamePageMinInterval();
+    int originalRedirect = HTMLFilterPolicy.getMetaRefreshRedirectMinInterval();
+
+    try {
+      HTMLFilterPolicy.setEmbedM3uPlayerEnabled(false);
+      HTMLFilterPolicy.setMetaRefreshSamePageMinInterval(7);
+      HTMLFilterPolicy.setMetaRefreshRedirectMinInterval(13);
+
+      assertFalse(HTMLFilterPolicy.isEmbedM3uPlayerEnabled());
+      assertEquals(7, HTMLFilterPolicy.getMetaRefreshSamePageMinInterval());
+      assertEquals(13, HTMLFilterPolicy.getMetaRefreshRedirectMinInterval());
+    } finally {
+      HTMLFilterPolicy.setEmbedM3uPlayerEnabled(originalEmbed);
+      HTMLFilterPolicy.setMetaRefreshSamePageMinInterval(originalSamePage);
+      HTMLFilterPolicy.setMetaRefreshRedirectMinInterval(originalRedirect);
+    }
+  }
+}

--- a/runtime-node/src/main/java/network/crypta/client/filter/HTMLFilter.java
+++ b/runtime-node/src/main/java/network/crypta/client/filter/HTMLFilter.java
@@ -76,9 +76,6 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
   private static final String M3U_PLAYER_TAG_FILE =
       "network/crypta/clients/http/staticfiles/js/m3u-player.js";
 
-  /** if true, embed m3u player. Enabled when fproxy javascript is enabled. * */
-  private static boolean embedM3uPlayer = true;
-
   private static final boolean DELETE_WIERD_STUFF = true;
   private static final boolean DELETE_ERRORS = true;
 
@@ -88,14 +85,6 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * detection can be ambiguous, potentially resulting in attacks.
    */
   private static final boolean ALLOW_NO_HTML_TAG = true;
-
-  // These defaults currently apply globally across documents; future work may allow per-document
-  // overrides once the configuration flow is merged with TagReplacerCallback.
-  /** -1 means don't allow it */
-  private static int metaRefreshSamePageMinInterval = 1;
-
-  /** -1 means don't allow it */
-  private static int metaRefreshRedirectMinInterval = 30;
 
   private static final String M3U_PLAYER_SCRIPT_TAG_CONTENT = loadM3uPlayerScriptTagContent();
 
@@ -828,7 +817,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * @return {@code true} when eligible media tags cause the player snippet to be inlined
    */
   public static boolean isEmbedM3uPlayerEnabled() {
-    return embedM3uPlayer;
+    return HTMLFilterPolicy.isEmbedM3uPlayerEnabled();
   }
 
   /**
@@ -840,7 +829,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * @param enabled {@code true} to inject the helper script whenever media tags are preserved
    */
   public static void setEmbedM3uPlayerEnabled(boolean enabled) {
-    embedM3uPlayer = enabled;
+    HTMLFilterPolicy.setEmbedM3uPlayerEnabled(enabled);
   }
 
   /**
@@ -851,7 +840,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * @return minimum delay, or {@code -1} when zero-delay refreshes must always be dropped
    */
   public static int getMetaRefreshSamePageMinInterval() {
-    return metaRefreshSamePageMinInterval;
+    return HTMLFilterPolicy.getMetaRefreshSamePageMinInterval();
   }
 
   /**
@@ -862,7 +851,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * @param interval number of seconds enforced between refreshes targeting the current URI
    */
   public static void setMetaRefreshSamePageMinInterval(int interval) {
-    metaRefreshSamePageMinInterval = interval;
+    HTMLFilterPolicy.setMetaRefreshSamePageMinInterval(interval);
   }
 
   /**
@@ -874,7 +863,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * @return minimum redirect delay in seconds, or {@code -1} when redirects are forbidden outright
    */
   public static int getMetaRefreshRedirectMinInterval() {
-    return metaRefreshRedirectMinInterval;
+    return HTMLFilterPolicy.getMetaRefreshRedirectMinInterval();
   }
 
   /**
@@ -886,7 +875,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
    * @param interval number of seconds required before allowing a redirecting refresh to pass
    */
   public static void setMetaRefreshRedirectMinInterval(int interval) {
-    metaRefreshRedirectMinInterval = interval;
+    HTMLFilterPolicy.setMetaRefreshRedirectMinInterval(interval);
   }
 
   String processTag(List<String> splitTag, Writer w, HTMLParseContext pc) throws IOException {

--- a/runtime-node/src/test/java/network/crypta/client/filter/HTMLFilterPolicyTest.java
+++ b/runtime-node/src/test/java/network/crypta/client/filter/HTMLFilterPolicyTest.java
@@ -1,0 +1,39 @@
+package network.crypta.client.filter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HTMLFilterPolicyTest {
+
+  @Test
+  void htmlFilterPolicy_whenUpdatedThroughEitherFacade_expectSharedState() {
+    boolean originalEmbed = HTMLFilterPolicy.isEmbedM3uPlayerEnabled();
+    int originalSamePage = HTMLFilterPolicy.getMetaRefreshSamePageMinInterval();
+    int originalRedirect = HTMLFilterPolicy.getMetaRefreshRedirectMinInterval();
+
+    try {
+      HTMLFilterPolicy.setEmbedM3uPlayerEnabled(false);
+      HTMLFilterPolicy.setMetaRefreshSamePageMinInterval(4);
+      HTMLFilterPolicy.setMetaRefreshRedirectMinInterval(9);
+
+      assertFalse(HTMLFilter.isEmbedM3uPlayerEnabled());
+      assertEquals(4, HTMLFilter.getMetaRefreshSamePageMinInterval());
+      assertEquals(9, HTMLFilter.getMetaRefreshRedirectMinInterval());
+
+      HTMLFilter.setEmbedM3uPlayerEnabled(true);
+      HTMLFilter.setMetaRefreshSamePageMinInterval(6);
+      HTMLFilter.setMetaRefreshRedirectMinInterval(11);
+
+      assertTrue(HTMLFilterPolicy.isEmbedM3uPlayerEnabled());
+      assertEquals(6, HTMLFilterPolicy.getMetaRefreshSamePageMinInterval());
+      assertEquals(11, HTMLFilterPolicy.getMetaRefreshRedirectMinInterval());
+    } finally {
+      HTMLFilterPolicy.setEmbedM3uPlayerEnabled(originalEmbed);
+      HTMLFilterPolicy.setMetaRefreshSamePageMinInterval(originalSamePage);
+      HTMLFilterPolicy.setMetaRefreshRedirectMinInterval(originalRedirect);
+    }
+  }
+}

--- a/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthMonthlyTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/BandwidthMonthlyTest.java
@@ -13,7 +13,6 @@ import network.crypta.support.HTMLEncoder;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.URLEncoder;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.DatastoreUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +36,7 @@ import static org.mockito.Mockito.when;
 class BandwidthMonthlyTest {
 
   private static final long KIB = 1024L;
+  private static final long ONE_GIB = 1024L * 1024L * 1024L;
   private static final long MIN_BANDWIDTH_KIB = 256L;
   private static final double MIN_MONTHLY_LIMIT_GIB =
       WizardBandwidthLimit.minimumMonthlyLimitGiB(MIN_BANDWIDTH_KIB * KIB);
@@ -102,7 +102,7 @@ class BandwidthMonthlyTest {
     assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.COMPLETE.name(), next);
     assertTrue(step.wizardComplete, "Wizard must be marked complete on success");
 
-    long bytesPerMonth = Math.round(Double.parseDouble(capTo) * DatastoreUtil.ONE_GIB);
+    long bytesPerMonth = Math.round(Double.parseDouble(capTo) * ONE_GIB);
     WizardBandwidthLimit expected =
         WizardBandwidthLimit.fromMonthlyBudget(
             bytesPerMonth, DEFAULT_SNAPSHOT.minBandwidthKiB() * KIB);

--- a/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
@@ -1,25 +1,20 @@
 package network.crypta.clients.http.wizardsteps;
 
-import java.io.File;
 import java.util.List;
 import network.crypta.clients.http.FirstTimeWizardToadlet;
 import network.crypta.config.Config;
 import network.crypta.config.Option;
 import network.crypta.config.SubConfig;
-import network.crypta.node.Node;
-import network.crypta.runtime.bootstrap.NodeStarter;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.support.Fields;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.SizeUtil;
 import network.crypta.support.api.HTTPRequest;
-import network.crypta.support.io.DatastoreUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,7 +26,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,69 +49,11 @@ class DatastoreSizeTest {
   private static final String VALUE_SALT_HASH = "salt-hash";
 
   @Test
-  void maxDatastoreSize_whenMemoryLimitIsUnknown_expectOneGiB() {
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    try (MockedStatic<NodeStarter> nodeStarter = mockStatic(NodeStarter.class)) {
-      nodeStarter.when(NodeStarter::getMemoryLimitBytes).thenReturn(Long.MAX_VALUE);
-
-      long result = DatastoreUtil.maxDatastoreSize(node);
-
-      assertEquals(1024L * 1024 * 1024, result);
-    }
-  }
-
-  @Test
-  void maxDatastoreSize_whenMemoryLimitIsVerySmall_expectOneGiB() {
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    try (MockedStatic<NodeStarter> nodeStarter = mockStatic(NodeStarter.class)) {
-      nodeStarter.when(NodeStarter::getMemoryLimitBytes).thenReturn(127L * 1024 * 1024);
-
-      long result = DatastoreUtil.maxDatastoreSize(node);
-
-      assertEquals(1024L * 1024 * 1024, result);
-    }
-  }
-
-  @Test
-  void maxDatastoreSize_whenMemoryBasedExceedsDisk_expectDiskBasedMinusMargin() {
-    // Keep free-space math deterministic instead of relying on the real filesystem.
-    long freeSpace = 20L * 1024 * 1024 * 1024;
-    File storeDir = mock(File.class);
-    File fileA = mock(File.class);
-    File fileB = mock(File.class);
-    when(fileA.length()).thenReturn(1234L);
-    when(fileB.length()).thenReturn(5678L);
-    when(storeDir.getUsableSpace()).thenReturn(freeSpace);
-    when(storeDir.listFiles()).thenReturn(new File[] {fileA, fileB});
-
-    Node node = mock(Node.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
-    when(node.getStoreDir()).thenReturn(storeDir);
-
-    long expectedDiskCap = freeSpace + 1234L + 5678L;
-
-    long mockedMaxMemoryBytes = 64L * 1024 * 1024 * 1024;
-    long available = mockedMaxMemoryBytes - 100L * 1024 * 1024;
-    available = available / 2;
-    long slots = available / 4;
-    slots /= 3;
-    long expectedMemoryCap =
-        slots * network.crypta.node.subsystem.NodeStorageSubsystem.SIZE_PER_KEY;
-    long expectedCap = Math.min(expectedDiskCap, expectedMemoryCap);
-
-    try (MockedStatic<NodeStarter> nodeStarter = mockStatic(NodeStarter.class)) {
-      nodeStarter.when(NodeStarter::getMemoryLimitBytes).thenReturn(mockedMaxMemoryBytes);
-
-      long result = DatastoreUtil.maxDatastoreSize(node);
-
-      assertEquals(expectedCap - 1024L * 1024 * 1024, result);
-    }
-  }
-
-  @Test
   void setDatastoreSize_whenUnparseable_expectNumberFormatException() {
     Config config = newConfigWithNodeDefaults(10, 10, 1000L);
     assertThrows(
-        NumberFormatException.class, () -> DatastoreSize.setDatastoreSize("not-a-number", config));
+        NumberFormatException.class,
+        () -> DatastoreSize.setDatastoreSize("not-a-number", config, () -> Long.MAX_VALUE));
   }
 
   @Test
@@ -132,11 +68,7 @@ class DatastoreSizeTest {
     String defaultStoreType = node.getString(KEY_STORE_TYPE);
     String defaultClientCacheType = node.getString(KEY_CLIENT_CACHE_TYPE);
 
-    try (MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreUtil.when(DatastoreUtil::maxDatastoreSize).thenReturn(1024L);
-
-      DatastoreSize.setDatastoreSize("2KiB", config);
-    }
+    DatastoreSize.setDatastoreSize("2KiB", config, () -> 1024L);
 
     assertEquals(defaultStoreSize, Config.longOption(node, KEY_STORE_SIZE).getValue());
     assertEquals(defaultClientCacheSize, Config.longOption(node, KEY_CLIENT_CACHE_SIZE).getValue());
@@ -154,11 +86,7 @@ class DatastoreSizeTest {
 
     long selectedSize = Fields.parseLong("1GiB");
 
-    try (MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreUtil.when(DatastoreUtil::maxDatastoreSize).thenReturn(selectedSize + 1);
-
-      DatastoreSize.setDatastoreSize("1GiB", config);
-    }
+    DatastoreSize.setDatastoreSize("1GiB", config, () -> selectedSize + 1);
 
     long expectedClientCacheSize = selectedSize / 10;
     long expectedSlashdotCacheSize = 10L;
@@ -176,19 +104,17 @@ class DatastoreSizeTest {
   @Test
   void postStep_whenFirstTime_expectNextStepBandwidthAndUsesSelected() {
     Config config = newConfigWithNodeDefaults(10, 0, 1000L);
-    DatastoreSize step = new DatastoreSize(mock(FirstTimeWizardPort.class), config);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(2L * 1024 * 1024 * 1024));
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
 
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.isPartSet("singlestep")).thenReturn(false);
     when(request.getPartAsStringFailsafe("ds", 20)).thenReturn("1GiB");
 
-    try (MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreUtil.when(DatastoreUtil::maxDatastoreSize).thenReturn(2L * 1024 * 1024 * 1024);
+    String next = step.postStep(request);
 
-      String next = step.postStep(request);
-
-      assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.BANDWIDTH.name(), next);
-    }
+    assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.BANDWIDTH.name(), next);
 
     SubConfig node = config.get("node");
     assertNotNull(node);
@@ -204,19 +130,17 @@ class DatastoreSizeTest {
     assertEquals(VALUE_DEFAULT, node.getString(KEY_STORE_TYPE));
     assertEquals(VALUE_DEFAULT, node.getString(KEY_CLIENT_CACHE_TYPE));
 
-    DatastoreSize step = new DatastoreSize(mock(FirstTimeWizardPort.class), config);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(2L * 1024 * 1024 * 1024));
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
 
     HTTPRequest request = mock(HTTPRequest.class);
     when(request.isPartSet("singlestep")).thenReturn(true);
     when(request.getPartAsStringFailsafe("ds", 20)).thenReturn("1GiB");
 
-    try (MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreUtil.when(DatastoreUtil::maxDatastoreSize).thenReturn(2L * 1024 * 1024 * 1024);
+    String next = step.postStep(request);
 
-      String next = step.postStep(request);
-
-      assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.COMPLETE.name(), next);
-    }
+    assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.COMPLETE.name(), next);
 
     assertEquals(VALUE_DEFAULT, node.getString(KEY_STORE_TYPE));
     assertEquals(VALUE_DEFAULT, node.getString(KEY_CLIENT_CACHE_TYPE));
@@ -232,11 +156,7 @@ class DatastoreSizeTest {
     assertNotNull(node);
 
     long selectedSize = Fields.parseLong(selected);
-    try (MockedStatic<DatastoreUtil> datastoreUtil = mockStatic(DatastoreUtil.class)) {
-      datastoreUtil.when(DatastoreUtil::maxDatastoreSize).thenReturn(selectedSize + 1);
-
-      DatastoreSize.setDatastoreSize(selected, config);
-    }
+    DatastoreSize.setDatastoreSize(selected, config, () -> selectedSize + 1);
 
     long actualClientCacheSize = Config.longOption(node, KEY_CLIENT_CACHE_SIZE).getValue();
     assertEquals(expectedClientCacheSize, actualClientCacheSize);
@@ -407,27 +327,13 @@ class DatastoreSizeTest {
         KEY_SLASHDOT_CACHE_LIFETIME,
         slashdotLifetimeMs,
         new Option.Meta(0, false, false, "", ""),
-        (network.crypta.config.LongCallback) null,
+        null,
         false);
 
+    node.register(KEY_STORE_SIZE, 0L, new Option.Meta(0, false, false, "", ""), null, true);
+    node.register(KEY_CLIENT_CACHE_SIZE, 0L, new Option.Meta(0, false, false, "", ""), null, true);
     node.register(
-        KEY_STORE_SIZE,
-        0L,
-        new Option.Meta(0, false, false, "", ""),
-        (network.crypta.config.LongCallback) null,
-        true);
-    node.register(
-        KEY_CLIENT_CACHE_SIZE,
-        0L,
-        new Option.Meta(0, false, false, "", ""),
-        (network.crypta.config.LongCallback) null,
-        true);
-    node.register(
-        KEY_SLASHDOT_CACHE_SIZE,
-        0L,
-        new Option.Meta(0, false, false, "", ""),
-        (network.crypta.config.LongCallback) null,
-        true);
+        KEY_SLASHDOT_CACHE_SIZE, 0L, new Option.Meta(0, false, false, "", ""), null, true);
 
     node.register(
         KEY_STORE_TYPE,

--- a/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
+++ b/src/test/java/network/crypta/clients/http/wizardsteps/DatastoreSizeTest.java
@@ -123,6 +123,30 @@ class DatastoreSizeTest {
   }
 
   @Test
+  void postStep_whenLegacyDropdownCapIsLowerThanSelection_expectValidationUsesTrueMax() {
+    Config config = newConfigWithNodeDefaults(10, 0, 1000L);
+    FirstTimeWizardPort wizardPort = mock(FirstTimeWizardPort.class);
+    when(wizardPort.snapshot()).thenReturn(snapshot(512L * 1024 * 1024, -1L));
+    DatastoreSize step = new DatastoreSize(wizardPort, config);
+
+    HTTPRequest request = mock(HTTPRequest.class);
+    when(request.isPartSet("singlestep")).thenReturn(false);
+    when(request.getPartAsStringFailsafe("ds", 20)).thenReturn("1GiB");
+
+    String next = step.postStep(request);
+
+    assertEquals(FirstTimeWizardToadlet.WIZARD_STEP.BANDWIDTH.name(), next);
+
+    SubConfig node = config.get("node");
+    assertNotNull(node);
+    assertTrue(
+        Config.longOption(node, KEY_STORE_SIZE).getValue() > 0,
+        "store size should be applied even when the legacy dropdown cap is below 1 GiB");
+    assertEquals(VALUE_SALT_HASH, node.getString(KEY_STORE_TYPE));
+    assertEquals(VALUE_SALT_HASH, node.getString(KEY_CLIENT_CACHE_TYPE));
+  }
+
+  @Test
   void postStep_whenSingleStep_expectNextStepCompleteAndDoesNotSetTypes() {
     Config config = newConfigWithNodeDefaults(10, 0, 1000L);
     SubConfig node = config.get("node");

--- a/src/test/java/network/crypta/support/io/IOUtilsTest.java
+++ b/src/test/java/network/crypta/support/io/IOUtilsTest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.read.ListAppender;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.stream.Stream;
 import java.util.zip.ZipFile;
@@ -21,9 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link IOUtils}.
@@ -61,6 +65,7 @@ class IOUtilsTest {
     AutoCloseable resource = null;
 
     // Act
+    //noinspection ConstantValue
     IOUtils.closeQuietly(resource);
 
     // Assert
@@ -132,6 +137,7 @@ class IOUtilsTest {
     ZipFile zipFile = null;
 
     // Act
+    //noinspection ConstantValue
     IOUtils.closeQuietly(zipFile);
 
     // Assert
@@ -185,6 +191,37 @@ class IOUtilsTest {
     IllegalStateException ex =
         assertThrows(IllegalStateException.class, () -> IOUtils.closeQuietly(zipFile));
     assertEquals("runtime-bang", ex.getMessage());
+    assertNoErrorLogs();
+  }
+
+  // ---------------------------- skipFully ----------------------------
+
+  @Test
+  void skipFully_whenStreamAdvancesInChunks_discardsRequestedBytes() throws Exception {
+    // Arrange
+    InputStream input = mock(InputStream.class);
+    when(input.skip(anyLong())).thenReturn(2L, 3L);
+
+    // Act
+    IOUtils.skipFully(input, 5);
+
+    // Assert
+    verify(input, times(2)).skip(anyLong());
+    assertNoErrorLogs();
+  }
+
+  @Test
+  void skipFully_whenStreamStopsAdvancing_throwsIOException() throws Exception {
+    // Arrange
+    InputStream input = mock(InputStream.class);
+    when(input.skip(anyLong())).thenReturn(2L, 0L);
+
+    // Act
+    IOException exception = assertThrows(IOException.class, () -> IOUtils.skipFully(input, 5));
+
+    // Assert
+    assertEquals("Unable to skip 3 bytes", exception.getMessage());
+    verify(input, times(2)).skip(anyLong());
     assertNoErrorLogs();
   }
 


### PR DESCRIPTION
## Summary
- detach the remaining admin-side `HTMLFilter` state into `kernel-content` via `HTMLFilterPolicy`, with `runtime-node` delegating to the detached holder
- replace admin `FileUtil` and `DatastoreUtil` usage with leaf-safe helpers and detached wizard/runtime inputs, then remove `implementation(project(":runtime-node"))` from `:adapter-http-legacy-admin`
- harden `HttpLegacyAdminBoundaryTest`, add focused helper coverage for the new leaf-owned classes, and improve Javadocs on the newly added production helpers

## How to test
- `./gradlew :foundation-support:test --tests network.crypta.support.io.LegacyFileSupportTest`
- `./gradlew :test --tests network.crypta.support.io.IOUtilsTest`
- `./gradlew :kernel-content:test --tests network.crypta.client.filter.HTMLFilterPolicyTest`
- `./gradlew :runtime-node:test --tests network.crypta.client.filter.HTMLFilterPolicyTest`
- `./gradlew :adapter-http-legacy-admin:test --tests network.crypta.runtime.bootstrap.HttpLegacyAdminBoundaryTest --tests network.crypta.clients.http.LegacyWelcomePageSupportTest --tests network.crypta.clients.http.SimpleToadletServerPrimaryUiRootTest`
- `./gradlew :test --tests network.crypta.clients.http.wizardsteps.DatastoreSizeTest --tests network.crypta.clients.http.wizardsteps.BandwidthMonthlyTest --tests network.crypta.client.filter.ContentFilterTest`

## Notes
- this closes out PR-171’s remaining `:adapter-http-legacy-admin -> :runtime-node` dependency
- the branch was created from `develop`; no direct commit was made on the base branch