### PR TITLE
refactor(fcp): Detach GET runtime handoff

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -6,13 +6,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext.CompatibilityMode;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.ChecksumChecker;
@@ -26,9 +23,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates a single FCP GET request over the asynchronous client interface.
  *
- * <p>This request owns its {@link FetchContext}, {@link ClientGetter}, progress caches, and
- * persistence metadata so it can migrate cleanly between a connection queue, the global queue, and
- * durable storage across node restarts. It translates client-side events into higher-level FCP
+ * <p>This request owns its detached fetch configuration, opaque execution handle, progress caches,
+ * and persistence metadata so it can migrate cleanly between a connection queue, the global queue,
+ * and durable storage across node restarts. It translates client-side events into higher-level FCP
  * messages, tracks retry and restart policy, and resolves the selected delivery strategy (direct
  * bucket, disk file, chunked stream, or acknowledgement only). The class therefore acts as the
  * boundary between long-lived persistent jobs and transient FCP sessions.
@@ -39,9 +36,10 @@ import org.slf4j.LoggerFactory;
  * returned objects or assuming immediate cross-thread visibility without synchronization.
  *
  * <p>Typical usage is to construct the request from a {@link ClientGetMessage}, register it with
- * the owning client queue, and then invoke {@link #start(ClientContext)}. The request may persist
- * across reconnections, and callers should treat it as a long-lived state machine whose outputs are
- * FCP messages rather than synchronous return values.
+ * the owning client queue, and then invoke {@link
+ * #start(network.crypta.client.async.ClientContext)}. The request may persist across reconnections,
+ * and callers should treat it as a long-lived state machine whose outputs are FCP messages rather
+ * than synchronous return values.
  *
  * <ul>
  *   <li><strong>Queueing and persistence</strong>: registers against either the connection-scoped
@@ -53,7 +51,6 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @see ClientRequest
- * @see ClientGetter
  * @see network.crypta.client.async.ClientGetCallback
  */
 public final class ClientGet extends ClientRequest {
@@ -61,14 +58,11 @@ public final class ClientGet extends ClientRequest {
 
   @Serial private static final long serialVersionUID = 1L;
 
-  /**
-   * Fetch context. Never passed in: always created new by the ClientGet. Therefore, we can safely
-   * delete it in requestWasRemoved().
-   */
-  private final FetchContext fctx;
+  /** Detached fetch configuration owned by the request. */
+  private final ClientGetFetchConfig fetchConfig;
 
-  /** Underlying asynchronous fetcher responsible for talking to the node core. */
-  private final ClientGetter getter;
+  /** Opaque live execution responsible for talking to the node core. */
+  private final transient ClientGetExecution execution;
 
   /** Selected return strategy describing how result data should be surfaced to the caller. */
   private final ReturnType returnType;
@@ -88,9 +82,12 @@ public final class ClientGet extends ClientRequest {
   /** Optional client-provided filename extension used to validate post-filtering output. */
   private final String extensionCheck;
 
-  /** Metadata bucket supplied at creation time, relayed untouched to the {@link ClientGetter}. */
+  /** Metadata bucket supplied at creation time, relayed untouched to the live execution. */
   @SuppressWarnings("java:S1948")
   private final Bucket initialMetadata;
+
+  /** Runtime bridge used to encode fetch configuration and create live execution on demand. */
+  private final transient FcpFetchRuntimeSupport runtimeFetchSupport;
 
   private transient ClientGetHelpers helpers;
 
@@ -254,24 +251,24 @@ public final class ClientGet extends ClientRequest {
    * Creates a new request that has already been validated and configured by {@link
    * ClientGetFactory}.
    *
-   * <p>Callers are expected to supply an initialized {@link FetchContext}, return routing data, and
-   * any initial metadata buckets. The constructor wires up request state, event listeners, and the
-   * underlying {@link ClientGetter} but performs no validation on the inputs.
+   * <p>Callers are expected to supply detached fetch configuration, return routing data, and any
+   * initial metadata buckets. The constructor wires up the request state and the underlying runtime
+   * execution but performs no validation on the inputs.
    */
   ClientGet(ClientRequestParams params, PersistentRequestClient globalClient, ClientGetSetup setup)
       throws IOException {
     super(prepareConstructorInit(params, null, globalClient));
     state = new ClientGetState(this);
-    fctx = setup.fetchContext();
-    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
+    fetchConfig = setup.fetchConfig();
     this.returnType = setup.returnType();
     this.binaryBlob = setup.binaryBlob();
     ClientGetReturnPlanner.ReturnSetup returnSetup = setup.returnSetup();
     this.targetFile = returnSetup.targetFile();
     this.extensionCheck = returnSetup.extension();
     this.initialMetadata = setup.initialMetadata();
-    getter = makeGetter(setup.fetchRuntimeSupport(), returnSetup.bucket());
-    applyDiagnosticIdentifier(getter);
+    this.runtimeFetchSupport = setup.fetchRuntimeSupport();
+    execution = makeExecution(setup.fetchRuntimeSupport(), returnSetup.bucket());
+    applyDiagnosticIdentifier(execution.requester());
     initHelpers();
   }
 
@@ -283,52 +280,51 @@ public final class ClientGet extends ClientRequest {
       throws IOException {
     super(prepareConstructorInit(params, handler));
     state = new ClientGetState(this);
-    fctx = setup.fetchContext();
-    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(this));
+    fetchConfig = setup.fetchConfig();
     this.returnType = setup.returnType();
     this.binaryBlob = setup.binaryBlob();
     ClientGetReturnPlanner.ReturnSetup returnSetup = setup.returnSetup();
     this.targetFile = returnSetup.targetFile();
     this.extensionCheck = returnSetup.extension();
     this.initialMetadata = setup.initialMetadata();
-    getter = makeGetter(setup.fetchRuntimeSupport(), returnSetup.bucket());
-    applyDiagnosticIdentifier(getter);
+    this.runtimeFetchSupport = setup.fetchRuntimeSupport();
+    execution = makeExecution(setup.fetchRuntimeSupport(), returnSetup.bucket());
+    applyDiagnosticIdentifier(execution.requester());
     initHelpers();
   }
 
-  private ClientGetter makeGetter(Bucket ret) throws IOException {
-    return makeGetter(null, ret);
-  }
-
-  private ClientGetter makeGetter(FcpFetchRuntimeSupport fetchRuntimeSupport, Bucket ret)
+  private ClientGetExecution makeExecution(FcpFetchRuntimeSupport fetchRuntimeSupport, Bucket ret)
       throws IOException {
-    return ClientGetGetterFactory.createGetterForRequest(this, ret, fetchRuntimeSupport);
+    return ClientGetExecutionFactory.create(this, fetchRuntimeSupport, ret);
   }
 
-  ClientGetter makeGetterForPersistence(Bucket ret) throws IOException {
-    return makeGetter(ret);
+  ClientGetExecution makeExecutionForPersistence(
+      FcpFetchRuntimeSupport fetchRuntimeSupport, Bucket ret) throws IOException {
+    return ClientGetExecutionFactory.create(this, fetchRuntimeSupport, ret);
   }
 
   /**
    * Serialization-only constructor used when reconstructing requests from persistent storage.
    *
    * <p>All fields are intentionally left {@code null} (or primitive defaults) so that the
-   * deserialization helpers can populate them explicitly via {@link #innerResume(ClientContext)}
-   * and related restoration methods. Production code should never invoke this constructor directly;
-   * always use one of the fully parameterized alternatives that configure a {@link FetchContext}
-   * and {@link ClientGetter}. This constructor exists solely to satisfy the Java serialization
-   * framework and keep field initialization centralized in the resume path.
+   * deserialization helpers can populate them explicitly via {@link
+   * #innerResume(network.crypta.client.async.ClientContext)} and related restoration methods.
+   * Production code should never invoke this constructor directly; always use one of the fully
+   * parameterized alternatives that configure detached fetch settings and a live execution handle.
+   * This constructor exists solely to satisfy the Java serialization framework and keep field
+   * initialization centralized in the resume path.
    */
   ClientGet() {
     // For serialization.
     state = new ClientGetState(this);
-    fctx = null;
-    getter = null;
+    fetchConfig = null;
+    execution = null;
     returnType = null;
     targetFile = null;
     binaryBlob = false;
     extensionCheck = null;
     initialMetadata = null;
+    runtimeFetchSupport = null;
   }
 
   private void initHelpers() {
@@ -395,28 +391,29 @@ public final class ClientGet extends ClientRequest {
    * Starts the asynchronous fetch if it has not yet reached a terminal state.
    *
    * <p>This method synchronizes briefly to avoid racing with completion logic, kicks off the
-   * underlying {@link ClientGetter}, and emits a persistent tag when the request is tracked beyond
-   * the connection scope. It updates {@link RequestStatusCache} listeners so UIs can reflect the
-   * {@code started} flag even if the fetch fails before any progress callbacks are produced. The
-   * call is idempotent with respect to terminal state: if the request is already finished, it
-   * returns immediately without side effects. Exceptions raised by the getter are translated into
-   * {@link FetchException} instances and routed through {@link #onFailure(FetchException)} to
-   * ensure consistent cleanup.
+   * underlying live execution, and emits a persistent tag when the request is tracked beyond the
+   * connection scope. It updates {@link RequestStatusCache} listeners so UIs can reflect the {@code
+   * started} flag even if the fetch fails before any progress callbacks are produced. The call is
+   * idempotent with respect to terminal state: if the request is already finished, it returns
+   * immediately without side effects. Exceptions raised by the execution are translated into {@link
+   * FetchException} instances and routed through {@link #onFailure(FetchException)} to ensure
+   * consistent cleanup.
    *
    * <p>On success, this call merely schedules work; it does not block for results. If a failure is
    * raised before progress events fire, the request is still marked as started so external status
    * caches remain consistent. Callers may invoke this multiple times safely; only the first call
    * before completion has any effect.
    *
-   * @param context client context providing schedulers, bucket factories, and execution lanes.
+   * @param context client context provided by the legacy request API; the live execution keeps its
+   *     own runtime binding.
    */
   @Override
-  public void start(ClientContext context) {
+  public void start(network.crypta.client.async.ClientContext context) {
     try {
       synchronized (persistenceLock) {
         if (finished) return;
       }
-      getter.start(context);
+      execution.start();
       if (shouldSendPersistentTag()) {
         FCPMessage msg = persistentTagMessage();
         client.queueClientRequestMessage(msg, 0);
@@ -465,7 +462,7 @@ public final class ClientGet extends ClientRequest {
    * @param context client context owning the request and its scheduler association.
    */
   @Override
-  public void onLostConnection(ClientContext context) {
+  public void onLostConnection(network.crypta.client.async.ClientContext context) {
     if (persistence == Persistence.CONNECTION) cancel(context);
     // Otherwise ignore
   }
@@ -474,7 +471,7 @@ public final class ClientGet extends ClientRequest {
    * Processes a successful fetch completion and notifies all interested parties.
    *
    * <p>The method snapshots final MIME type, payload length, completion timestamp, and the bucket
-   * or blob handle returned by {@link ClientGetter}. Depending on {@link ReturnType}, it either
+   * or blob handle returned by the live execution. Depending on {@link ReturnType}, it either
    * retains the bucket for {@link AllDataMessage} delivery or leaves the bytes on disk. It then
    * emits {@link DataFoundMessage} and {@link AllDataMessage} as appropriate, updates status
    * caches, and informs the owning {@link FCPConnectionHandler} or {@link PersistentRequestClient}.
@@ -485,9 +482,9 @@ public final class ClientGet extends ClientRequest {
    * completion time before any outbound messages so that emitted timestamps remain consistent.
    *
    * @param result result wrapper providing MIME metadata and the decoded data bucket.
-   * @param state client getter instance used to access BinaryBlob payload buckets.
+   * @param state execution handle used to access Binary Blob payload buckets.
    */
-  public void onSuccess(FetchResult result, ClientGetter state) {
+  public void onSuccess(FetchResult result, ClientGetExecution state) {
     helpers().lifecycle().onSuccess(result, state);
   }
 
@@ -505,15 +502,14 @@ public final class ClientGet extends ClientRequest {
    * cached fields so that later status queries and persistence writes reflect the migrated success
    * state.
    *
-   * @param context client context performing migration validation and bucket operations.
    * @param completionTime epoch milliseconds for the recorded completion instant.
    * @param data bucket containing the downloaded payload for direct delivery.
    * @throws ResumeFailedException when stored output does not match recorded metadata.
    */
   @SuppressWarnings("unused")
-  public void setSuccessForMigration(ClientContext context, long completionTime, Bucket data)
+  public void setSuccessForMigration(long completionTime, Bucket data)
       throws ResumeFailedException {
-    helpers().lifecycle().setSuccessForMigration(context, completionTime, data);
+    helpers().lifecycle().setSuccessForMigration(completionTime, data);
   }
 
   void trySendDataFoundOrGetFailed(
@@ -576,7 +572,7 @@ public final class ClientGet extends ClientRequest {
   }
 
   /**
-   * Handles failure notifications from the {@link ClientGetter} and propagates them to clients.
+   * Handles failure notifications from the live GET execution and propagates them to clients.
    *
    * <p>The failure path caches any expected size or MIME hints exposed by the exception, builds a
    * {@link GetFailedMessage}, records completion timestamps, and marks the request as finished so
@@ -603,12 +599,12 @@ public final class ClientGet extends ClientRequest {
    * safe to invoke once per removal event.
    *
    * <p>The removal path does not attempt to stop network activity directly; it assumes the owning
-   * scheduler has already detached the underlying {@link ClientGetter}.
+   * scheduler has already detached the underlying live GET execution.
    *
    * @param context client context invoking the removal for lifecycle bookkeeping.
    */
   @Override
-  public void requestWasRemoved(ClientContext context) {
+  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
     helpers().lifecycle().requestWasRemoved();
     super.requestWasRemoved(context);
   }
@@ -626,14 +622,14 @@ public final class ClientGet extends ClientRequest {
    *
    * <p>The base {@link ClientRequest} infrastructure uses this accessor to determine which
    * requester instance owns the in-flight operation for persistence, cancellation, and stats
-   * tracking. The returned object is the request's active {@link ClientGetter} and should be
-   * treated as read-only by callers outside the request lifecycle.
+   * tracking. The returned object is the request's active requester and should be treated as
+   * read-only by callers outside the request lifecycle.
    *
    * @return client requester instance used to run this request.
    */
   @Override
   protected ClientRequester getClientRequest() {
-    return getter;
+    return execution == null ? null : execution.requester();
   }
 
   /**
@@ -662,8 +658,8 @@ public final class ClientGet extends ClientRequest {
    *
    * <p>The value remains {@code true} even after {@link #freeData()} releases buckets so that
    * clients can distinguish between cleanly finished requests and those canceled during restart. It
-   * is set when {@link #onSuccess(FetchResult, ClientGetter)} records the terminal state and never
-   * reset unless a restart is initiated.
+   * is set when {@link #onSuccess(FetchResult, ClientGetExecution)} records the terminal state and
+   * never reset unless a restart is initiated.
    *
    * <p>This flag is a snapshot of the most recent attempt; it does not imply that payload data is
    * still available in memory. Callers should consult {@link #getBucket()} or {@link
@@ -689,7 +685,7 @@ public final class ClientGet extends ClientRequest {
    * @return {@code true} when AllData messages should be emitted upon completion.
    */
   public boolean isDirect() {
-    return this.returnType == ReturnType.DIRECT;
+    return helpers().payloadAccess().isDirect();
   }
 
   /**
@@ -704,7 +700,7 @@ public final class ClientGet extends ClientRequest {
    * @return {@code true} when this request writes into a caller-specified file.
    */
   public boolean isToDisk() {
-    return this.returnType == ReturnType.DISK;
+    return helpers().payloadAccess().isToDisk();
   }
 
   /**
@@ -724,12 +720,20 @@ public final class ClientGet extends ClientRequest {
   }
 
   /**
-   * Exposes the fetch context for package-local helpers.
+   * Exposes the detached fetch configuration for package-local helpers.
    *
-   * @return live {@link FetchContext} backing this request for internal helper access.
+   * @return detached fetch configuration backing this request for helper access.
    */
-  FetchContext fetchContextForGetter() {
-    return fctx;
+  ClientGetFetchConfig fetchConfig() {
+    return fetchConfig;
+  }
+
+  ClientGetExecution execution() {
+    return execution;
+  }
+
+  FcpFetchRuntimeSupport runtimeFetchSupport() {
+    return runtimeFetchSupport;
   }
 
   /**
@@ -782,8 +786,7 @@ public final class ClientGet extends ClientRequest {
    * @return recorded payload length in bytes, or {@code -1} when unknown.
    */
   public long getDataSize() {
-    if (state.getFoundDataLength() > 0) return state.getFoundDataLength();
-    return -1;
+    return helpers().payloadAccess().getDataSize();
   }
 
   /**
@@ -800,8 +803,7 @@ public final class ClientGet extends ClientRequest {
    * @return MIME type reported for the payload, or {@code null} if undetermined.
    */
   public String getMIMEType() {
-    if (state.getFoundDataMimeType() != null) return state.getFoundDataMimeType();
-    return null;
+    return helpers().payloadAccess().getMimeType();
   }
 
   /**
@@ -1017,19 +1019,11 @@ public final class ClientGet extends ClientRequest {
    * @return bucket containing the payload, or {@code null} when no bucket form exists.
    */
   public Bucket getBucket() {
-    return makeBucket(true);
+    return helpers().payloadAccess().getBucket();
   }
 
-  Bucket makeBucket(boolean readOnly) {
-    return switch (returnType) {
-      case DIRECT -> {
-        synchronized (persistenceLock) {
-          yield state.getReturnBucketDirect();
-        }
-      }
-      case DISK -> ClientGetGetterFactory.diskBucket(targetFile, readOnly);
-      default -> null;
-    };
+  Bucket makePersistenceBucket() {
+    return helpers().payloadAccess().makePersistenceBucket();
   }
 
   /**
@@ -1038,7 +1032,8 @@ public final class ClientGet extends ClientRequest {
    * <p>The getter must support restart semantics, the request must have finished, and it must not
    * have succeeded yet. Success cases require manual deletion or explicit reset before another
    * attempt. This method performs the minimal checks needed to decide if {@link
-   * #restart(ClientContext, boolean)} is likely to proceed without immediate failure.
+   * #restart(network.crypta.client.async.ClientContext, boolean)} is likely to proceed without
+   * immediate failure.
    *
    * <p>This method does not modify the state; it is intended for UI or scheduler decisions before
    * initiating a restart.
@@ -1054,21 +1049,22 @@ public final class ClientGet extends ClientRequest {
    * Attempts to restart the request after a failure or redirect.
    *
    * <p>The method clears cached errors, resets compatibility tracking, optionally disables
-   * filtering, and hands the restart request to the underlying {@link ClientGetter}. Cache
-   * observers are updated so that frontends show the new redirect or restarted state immediately.
-   * If the underlying getter fails to restart, the failure is routed through {@link
-   * #onFailure(FetchException)} and the method returns {@code false}.
+   * filtering, and hands the restart request to the live execution. Cache observers are updated so
+   * that frontends show the new redirect or restarted state immediately. If the underlying
+   * execution fails to restart, the failure is routed through {@link #onFailure(FetchException)}
+   * and the method returns {@code false}.
    *
    * <p>Restarting does not guarantee success; it merely schedules a new attempt with the updated
-   * parameters. The method returns quickly once the getter acknowledges the restart request.
+   * parameters. The method returns quickly once the execution acknowledges the restart request.
    *
-   * @param context client context providing schedulers and bucket factories for restart logic.
+   * @param context client context provided by the legacy request API.
    * @param disableFilterData {@code true} to disable filtering for the next attempt.
    * @return {@code true} when the restart is accepted and scheduled by the getter.
    */
   @Override
-  public boolean restart(ClientContext context, final boolean disableFilterData) {
-    return helpers().restartCoordinator().restart(context, disableFilterData);
+  public boolean restart(
+      network.crypta.client.async.ClientContext context, final boolean disableFilterData) {
+    return helpers().restartCoordinator().restart(disableFilterData);
   }
 
   /**
@@ -1090,20 +1086,20 @@ public final class ClientGet extends ClientRequest {
   }
 
   /**
-   * Returns whether filterData is currently enabled on the {@link FetchContext}.
+   * Returns whether filterData is currently enabled on the detached fetch configuration.
    *
    * <p>The flag controls whether content filtering is applied before delivery. It can be toggled
    * during restart flows to temporarily disable filtering for a retry. This method simply reads the
-   * current {@link FetchContext} setting and does not alter any state. Because restarts can change
-   * the flag between attempts, callers should treat the value as a point-in-time snapshot rather
-   * than a promise about future retries.
+   * current configuration setting and does not alter any state. Because restarts can change the
+   * flag between attempts, callers should treat the value as a point-in-time snapshot rather than a
+   * promise about future retries.
    *
    * <p>Use this to reflect the current filtering state in status reporting.
    *
    * @return {@code true} when payloads should be filtered before delivery.
    */
   public boolean filterData() {
-    return fctx.getFilterData();
+    return fetchConfig.getFilterData();
   }
 
   @Override
@@ -1117,10 +1113,10 @@ public final class ClientGet extends ClientRequest {
    * Serializes the request state for persistence so that it can be resumed later.
    *
    * <p>Only {@link Persistence#FOREVER} requests write detail entries. The method records URIs,
-   * return types, binary-blob preferences, fetch contexts, metadata buckets, and—when finished—
-   * either the success bucket or the failure descriptor. It also streams recent progress snapshots
-   * so restarts can resume without re-downloading already verified blocks. Callers should provide a
-   * stream already framed by the persistence layer.
+   * return types, binary-blob preferences, detached fetch configuration, metadata buckets, and—when
+   * finished— either the success bucket or the failure descriptor. It also streams recent progress
+   * snapshots so restarts can resume without re-downloading already verified blocks. Callers should
+   * provide a stream already framed by the persistence layer.
    *
    * <p>The serialization format is versioned; if it changes, the version constants in {@link
    * ClientGetPersistenceCodec} must be updated in lockstep with the restore logic.
@@ -1137,27 +1133,32 @@ public final class ClientGet extends ClientRequest {
   }
 
   ClientGet(
-      DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
+      DataInputStream dis,
+      RequestIdentifier reqID,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
+      network.crypta.client.async.ClientContext context,
+      ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
     super(dis, reqID, context);
     state = new ClientGetState(this);
     ClientGetPersistenceCodec.BasicRestoreData restoreData =
-        ClientGetPersistenceCodec.readBasicRestoreData(this, dis, context, checker);
+        ClientGetPersistenceCodec.readBasicRestoreData(dis, fetchRuntimeSupport, checker);
     uri = restoreData.uri();
     returnType = restoreData.returnType();
     targetFile = restoreData.targetFile();
     binaryBlob = restoreData.binaryBlob();
-    fctx = restoreData.fetchContext();
+    fetchConfig = restoreData.fetchConfig();
     extensionCheck = restoreData.extensionCheck();
     initialMetadata = restoreData.initialMetadata();
-    ClientGetter restoredGetter =
-        ClientGetPersistenceCodec.restoreState(this, dis, reqID, context, checker);
+    runtimeFetchSupport = fetchRuntimeSupport;
+    ClientGetExecution restoredExecution =
+        ClientGetPersistenceCodec.restoreState(this, dis, reqID, fetchRuntimeSupport, checker);
     state.ensureCompatibilityMode();
-    if (restoredGetter == null) {
-      restoredGetter = makeGetterForPersistence(makeBucket(false));
+    if (restoredExecution == null) {
+      restoredExecution = makeExecutionForPersistence(fetchRuntimeSupport, makePersistenceBucket());
     }
-    getter = restoredGetter;
-    applyDiagnosticIdentifier(getter);
+    execution = restoredExecution;
+    applyDiagnosticIdentifier(execution.requester());
     initHelpers();
   }
 
@@ -1165,9 +1166,9 @@ public final class ClientGet extends ClientRequest {
    * Rehydrates transient state after a persistent resuming has restored core fields.
    *
    * <p>This hook is invoked by the base resume flow once serialization has recreated the request
-   * and the {@link ClientGetter}. It forwards the resume signal to any retained buckets and then
-   * repopulates size and MIME hints from the getter if they were not stored explicitly. The method
-   * does not trigger network activity; it only rebinds state so later status queries are
+   * and the live execution. It forwards the resume signal to any retained buckets and then
+   * repopulates size and MIME hints from the execution if they were not stored explicitly. The
+   * method does not trigger network activity; it only rebinds state so later status queries are
    * consistent.
    *
    * <p>Callers should invoke this only during resume flows and not during normal execution.
@@ -1176,12 +1177,13 @@ public final class ClientGet extends ClientRequest {
    * @throws ResumeFailedException if bucket resume logic reports unrecoverable failure.
    */
   @Override
-  protected void innerResume(ClientContext context) throws ResumeFailedException {
+  protected void innerResume(network.crypta.client.async.ClientContext context)
+      throws ResumeFailedException {
     if (state.getReturnBucketDirect() != null) state.getReturnBucketDirect().onResume(context);
     if (initialMetadata != null) initialMetadata.onResume(context);
     // We might already have these if we've just restored.
-    if (state.getFoundDataLength() <= 0) state.setFoundDataLength(getter.expectedSize());
-    if (state.getFoundDataMimeType() == null) state.setFoundDataMimeType(getter.expectedMIME());
+    if (state.getFoundDataLength() <= 0) state.setFoundDataLength(execution.expectedSize());
+    if (state.getFoundDataMimeType() == null) state.setFoundDataMimeType(execution.expectedMime());
   }
 
   @Override
@@ -1193,17 +1195,17 @@ public final class ClientGet extends ClientRequest {
    * Indicates whether every component of the request has been restored successfully after resume.
    *
    * <p>This is a lightweight health check used by persistence logic to decide whether the request
-   * can continue without restarting. It delegates to {@link ClientGetter#resumedFetcher()} and also
-   * ensures the getter itself is present. A {@code false} return indicates that the request should
-   * be restarted or rebuilt.
+   * can continue without restarting. It delegates to the opaque execution handle and also ensures
+   * the execution itself is present. A {@code false} return indicates that the request should be
+   * restarted or rebuilt.
    *
    * <p>The method has no side effects and should be safe to call repeatedly.
    *
-   * @return {@code true} when the getter reports a valid, fully resumed fetcher.
+   * @return {@code true} when the execution reports a valid, fully resumed fetcher.
    */
   @Override
   public boolean fullyResumed() {
-    return getter != null && getter.resumedFetcher();
+    return execution != null && execution.resumedFetcher();
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -64,7 +64,7 @@ public final class ClientGet extends ClientRequest {
   private final ClientGetFetchConfig fetchConfig;
 
   /** Opaque live execution responsible for talking to the node core. */
-  private final transient ClientGetExecution execution;
+  private ClientGetExecution execution;
 
   /** Selected return strategy describing how result data should be surfaced to the caller. */
   private final ReturnType returnType;
@@ -745,7 +745,19 @@ public final class ClientGet extends ClientRequest {
   }
 
   FcpFetchRuntimeSupport runtimeFetchSupport() {
-    return runtimeFetchSupport;
+    if (runtimeFetchSupport != null) {
+      return runtimeFetchSupport;
+    }
+    PersistentRequestClient persistentClient = client;
+    if (persistentClient == null) {
+      return null;
+    }
+    FCPConnectionHandler connection = persistentClient.getConnection();
+    if (connection != null) {
+      return connection.getServer().fetchRuntimeSupport();
+    }
+    PersistentRequestRoot persistentRoot = persistentClient.root;
+    return persistentRoot == null ? null : persistentRoot.fetchRuntimeSupport();
   }
 
   byte[] persistedFetchConfigEncoding() {
@@ -1200,11 +1212,25 @@ public final class ClientGet extends ClientRequest {
   @Override
   protected void innerResume(network.crypta.client.async.ClientContext context)
       throws ResumeFailedException {
+    if (execution != null) {
+      execution.onResume(context);
+    } else if (!finished) {
+      execution = recreateExecutionForResume();
+      try {
+        execution.start();
+      } catch (FetchException e) {
+        throw new ResumeFailedException(e);
+      }
+    }
     if (state.getReturnBucketDirect() != null) state.getReturnBucketDirect().onResume(context);
     if (initialMetadata != null) initialMetadata.onResume(context);
     // We might already have these if we've just restored.
-    if (state.getFoundDataLength() <= 0) state.setFoundDataLength(execution.expectedSize());
-    if (state.getFoundDataMimeType() == null) state.setFoundDataMimeType(execution.expectedMime());
+    if (execution != null && state.getFoundDataLength() <= 0) {
+      state.setFoundDataLength(execution.expectedSize());
+    }
+    if (execution != null && state.getFoundDataMimeType() == null) {
+      state.setFoundDataMimeType(execution.expectedMime());
+    }
   }
 
   @Override
@@ -1236,15 +1262,31 @@ public final class ClientGet extends ClientRequest {
   }
 
   private void refreshPersistedFetchConfigEncoding() {
-    if (runtimeFetchSupport == null || fetchConfig == null) {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = runtimeFetchSupport();
+    if (fetchRuntimeSupport == null || fetchConfig == null) {
       return;
     }
     try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         DataOutputStream encoded = new DataOutputStream(buffer)) {
-      runtimeFetchSupport.encodeFetchConfig(fetchConfig, encoded);
+      fetchRuntimeSupport.encodeFetchConfig(fetchConfig, encoded);
       persistedFetchConfigEncoding = buffer.toByteArray();
     } catch (IOException e) {
       LOG.warn("Unable to refresh cached fetch configuration encoding for {}", identifier, e);
+    }
+  }
+
+  private ClientGetExecution recreateExecutionForResume() throws ResumeFailedException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = runtimeFetchSupport();
+    if (fetchRuntimeSupport == null) {
+      throw new ResumeFailedException("Missing fetch runtime support for GET resume");
+    }
+    try {
+      ClientGetExecution resumedExecution =
+          makeExecutionForPersistence(fetchRuntimeSupport, makePersistenceBucket());
+      applyDiagnosticIdentifier(resumedExecution.requester());
+      return resumedExecution;
+    } catch (IOException e) {
+      throw new ResumeFailedException(e);
     }
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -1,9 +1,11 @@
 package network.crypta.clients.fcp;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import network.crypta.client.FetchException.FetchExceptionMode;
@@ -88,6 +90,15 @@ public final class ClientGet extends ClientRequest {
 
   /** Runtime bridge used to encode fetch configuration and create live execution on demand. */
   private final transient FcpFetchRuntimeSupport runtimeFetchSupport;
+
+  /**
+   * Last canonical fetch-configuration encoding written into a serialized request snapshot.
+   *
+   * <p>This allows recovery-data checkpoints to preserve the existing binary fetch-context format
+   * even when a request was reloaded through Java serialization and therefore no longer carries a
+   * live {@link FcpFetchRuntimeSupport} reference.
+   */
+  private byte[] persistedFetchConfigEncoding;
 
   private transient ClientGetHelpers helpers;
 
@@ -325,6 +336,7 @@ public final class ClientGet extends ClientRequest {
     extensionCheck = null;
     initialMetadata = null;
     runtimeFetchSupport = null;
+    persistedFetchConfigEncoding = null;
   }
 
   private void initHelpers() {
@@ -734,6 +746,15 @@ public final class ClientGet extends ClientRequest {
 
   FcpFetchRuntimeSupport runtimeFetchSupport() {
     return runtimeFetchSupport;
+  }
+
+  byte[] persistedFetchConfigEncoding() {
+    return persistedFetchConfigEncoding == null ? null : persistedFetchConfigEncoding.clone();
+  }
+
+  void setPersistedFetchConfigEncoding(byte[] persistedFetchConfigEncoding) {
+    this.persistedFetchConfigEncoding =
+        persistedFetchConfigEncoding == null ? null : persistedFetchConfigEncoding.clone();
   }
 
   /**
@@ -1206,6 +1227,25 @@ public final class ClientGet extends ClientRequest {
   @Override
   public boolean fullyResumed() {
     return execution != null && execution.resumedFetcher();
+  }
+
+  @Serial
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    refreshPersistedFetchConfigEncoding();
+    out.defaultWriteObject();
+  }
+
+  private void refreshPersistedFetchConfigEncoding() {
+    if (runtimeFetchSupport == null || fetchConfig == null) {
+      return;
+    }
+    try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        DataOutputStream encoded = new DataOutputStream(buffer)) {
+      runtimeFetchSupport.encodeFetchConfig(fetchConfig, encoded);
+      persistedFetchConfigEncoding = buffer.toByteArray();
+    } catch (IOException e) {
+      LOG.warn("Unable to refresh cached fetch configuration encoding for {}", identifier, e);
+    }
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecution.java
@@ -3,8 +3,10 @@ package network.crypta.clients.fcp;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import network.crypta.client.FetchException;
 import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 
@@ -33,7 +35,19 @@ import network.crypta.support.api.Bucket;
  *       #resumeFromTrivialProgress(DataInputStream)}.
  * </ul>
  */
-public interface ClientGetExecution {
+public interface ClientGetExecution extends Serializable {
+
+  /**
+   * Rebinds transient runtime collaborators after Java deserialization.
+   *
+   * <p>Execution handles may preserve serializable requester state across durable snapshots while
+   * still needing a fresh runtime context when the daemon comes back up. Implementations should use
+   * this callback to reconnect any transient context providers needed for later restart or trivial
+   * resume operations. The callback must not itself start network activity.
+   *
+   * @param context runtime resume token supplied by the persistent-request owner.
+   */
+  void onResume(PersistentRequestRuntimeContext context);
 
   /**
    * Returns the low-level requester currently backing this execution.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecution.java
@@ -1,0 +1,166 @@
+package network.crypta.clients.fcp;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import network.crypta.client.FetchException;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Opaque adapter-owned handle for one live FCP GET execution.
+ *
+ * <p>This interface is the adapter-side control surface for a fetch that is actually implemented by
+ * the runtime bridge. {@link ClientGet} and its helper classes use it to start work, inspect the
+ * best-known result metadata, and persist just enough transient state to support the existing
+ * restart and replay flows. The concrete runtime fetcher remains hidden behind this boundary, which
+ * keeps {@code :adapter-fcp} independent of daemon-owned execution classes while preserving the
+ * long-lived request behavior expected by the FCP protocol.
+ *
+ * <p>Implementations are expected to represent a single execution attempt for a single request.
+ * They may observe mutable runtime state, but callers treat them as request-scoped handles rather
+ * than reusable services. Methods that expose expected MIME type, size, or Binary Blob state return
+ * the current best-known view from the underlying fetcher and may therefore change as the fetch
+ * progresses.
+ *
+ * <ul>
+ *   <li>Lifecycle control: {@link #start()}, {@link #canRestart()}, and {@link #restart(FreenetURI,
+ *       boolean)}.
+ *   <li>Observation: {@link #requester()}, {@link #expectedMime()}, {@link #expectedSize()}, and
+ *       {@link #blobBucket()}.
+ *   <li>Minimal resume support: {@link #writeTrivialProgress(DataOutputStream)} and {@link
+ *       #resumeFromTrivialProgress(DataInputStream)}.
+ * </ul>
+ */
+public interface ClientGetExecution {
+
+  /**
+   * Returns the low-level requester currently backing this execution.
+   *
+   * <p>The request lifecycle uses this value for diagnostics, persistent tagging, and other legacy
+   * integration points that still operate on the common requester abstraction. The returned object
+   * belongs to the live runtime execution and should be treated as an observational handle rather
+   * than as an ownership transfer.
+   *
+   * @return runtime-backed requester associated with this fetch attempt.
+   */
+  ClientRequester requester();
+
+  /**
+   * Starts the live fetch using the runtime-bound execution context.
+   *
+   * <p>Callers use this exactly when a configured request moves from setup into active execution.
+   * The method is expected to delegate to the runtime fetch engine that owns scheduling, network
+   * I/O, and callback delivery. It does not describe completion; success and failure are still
+   * reported asynchronously through the owning {@link ClientGet}.
+   *
+   * @throws FetchException if the runtime rejects the start request before asynchronous execution
+   *     begins.
+   */
+  void start() throws FetchException;
+
+  /**
+   * Returns whether the current live execution can be restarted.
+   *
+   * <p>This is primarily used by redirect and retry logic to decide whether the existing runtime
+   * fetcher can be reused. A return value of {@code false} means the caller must treat the current
+   * attempt as non-restartable and rely on the existing failure handling path instead of issuing a
+   * restart.
+   *
+   * @return {@code true} when the underlying runtime fetcher supports restart for the current
+   *     state.
+   */
+  boolean canRestart();
+
+  /**
+   * Restarts the live execution with a new redirect target and filtering choice.
+   *
+   * <p>The redirect URI is normally supplied by fetch failure handling after the runtime reports a
+   * restartable redirect. The {@code filterData} flag preserves the FCP-visible decision about
+   * whether the restarted attempt should run the content filter. Implementations may reject the
+   * restart when the runtime fetcher is no longer in a restartable state.
+   *
+   * @param redirect redirect target that should replace the previous fetch URI.
+   * @param filterData whether the restarted fetch should apply content filtering.
+   * @return {@code true} when the runtime accepted the restart request.
+   * @throws FetchException if restart setup fails before the restarted attempt is handed back to
+   *     the runtime engine.
+   */
+  boolean restart(FreenetURI redirect, boolean filterData) throws FetchException;
+
+  /**
+   * Returns the best-known expected MIME type, if any.
+   *
+   * <p>This value is advisory status information from the underlying fetcher. It may be unavailable
+   * early in the request lifecycle and may become more specific as metadata is discovered.
+   *
+   * @return expected MIME type, or {@code null} when the runtime has not determined one.
+   */
+  String expectedMime();
+
+  /**
+   * Returns the best-known expected payload size.
+   *
+   * <p>The size is a best-effort estimate reported by the live fetcher. Callers use it for status
+   * reporting and planning decisions only; it is not a guarantee that the final payload will match
+   * exactly.
+   *
+   * @return expected payload size in bytes, or {@code 0} when the runtime cannot currently predict
+   *     one.
+   */
+  long expectedSize();
+
+  /**
+   * Returns the Binary Blob bucket associated with this execution.
+   *
+   * <p>This is only meaningful when the request was configured for Binary Blob recording. For
+   * ordinary GET requests, implementations may return {@code null}. Callers should treat the
+   * returned bucket as runtime-owned storage that exists to preserve current FCP Binary Blob
+   * behavior rather than as a general output channel.
+   *
+   * @return Binary Blob bucket for this execution, or {@code null} when Binary Blob recording is
+   *     not active.
+   */
+  Bucket blobBucket();
+
+  /**
+   * Writes the minimal transient state needed for trivial resume.
+   *
+   * <p>This is the lightest-weight persistence hook used by the existing GET replay path. It is
+   * intentionally narrower than full request serialization and should only emit the extra runtime
+   * state that cannot be reconstructed from the persisted adapter-owned request fields alone.
+   *
+   * @param dos stream that receives the compact transient progress payload.
+   * @return {@code true} when trivial progress data was written for the current execution state.
+   * @throws IOException if the progress payload cannot be serialized to {@code dos}.
+   */
+  boolean writeTrivialProgress(DataOutputStream dos) throws IOException;
+
+  /**
+   * Attempts to restore the minimal transient state previously written by {@link
+   * #writeTrivialProgress(DataOutputStream)}.
+   *
+   * <p>Implementations use this during request replay to rebuild the live fetcher as cheaply as
+   * possible. A return value of {@code false} indicates that the trivial resume payload was not
+   * enough and the caller should continue with the heavier recovery path already defined by the
+   * request lifecycle.
+   *
+   * @param dis stream positioned at a previously written trivial-progress payload.
+   * @return {@code true} when the runtime fetcher was rebuilt from the trivial payload.
+   * @throws IOException if the payload cannot be read or is structurally invalid for trivial
+   *     resume.
+   */
+  boolean resumeFromTrivialProgress(DataInputStream dis) throws IOException;
+
+  /**
+   * Returns whether trivial resume rebuilt the underlying fetcher successfully.
+   *
+   * <p>This is a post-resume status check used by the legacy replay flow. It allows the request to
+   * distinguish between merely reading the trivial payload and actually ending up with a live
+   * runtime fetcher that can continue execution.
+   *
+   * @return {@code true} when the runtime fetcher is available after trivial resume handling.
+   */
+  boolean resumedFetcher();
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecutionFactory.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecutionFactory.java
@@ -1,0 +1,65 @@
+package network.crypta.clients.fcp;
+
+import java.io.IOException;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Builds request-scoped {@link ClientGetExecution} handles from adapter-owned GET state.
+ *
+ * <p>This helper exists to keep {@link ClientGet} focused on request lifecycle orchestration
+ * instead of also owning the boilerplate that converts detached request data into a {@link
+ * ClientGetExecutionSpec}. The adapter still decides which fetch configuration, return bucket, and
+ * request flags should apply to the current attempt, but the actual bundling of those values into
+ * the bridge-facing execution descriptor is centralized here. That keeps the runtime handoff easy
+ * to audit and avoids scattering execution-assembly rules across constructors, persistence code,
+ * and restart paths.
+ *
+ * <p>The class is intentionally stateless. Every call creates a fresh execution descriptor, passes
+ * through the current request-owned values, and delegates construction of the live runtime fetcher
+ * to {@link FcpFetchRuntimeSupport}. No caching occurs here, so callers always get a descriptor
+ * that reflects the request's current detached state.
+ */
+final class ClientGetExecutionFactory {
+  /** Prevents instantiation because this class only exposes static assembly helpers. */
+  private ClientGetExecutionFactory() {}
+
+  /**
+   * Creates a live execution for one GET request attempt.
+   *
+   * <p>The method snapshots the request-owned values that matter for runtime execution and
+   * persistence: target URI, scheduler priority, detached fetch configuration, optional return
+   * bucket, Binary Blob mode, persistence class, initial metadata, and extension hint used by the
+   * filtering path. It also creates a fresh {@link ClientGetEventHandling} bridge so the runtime
+   * execution can continue reporting progress and terminal callbacks back into the owning request.
+   *
+   * <p>The returned execution is ready to be started or resumed by the surrounding request
+   * lifecycle. This method does not itself start network activity; it only performs the
+   * deterministic assembly step before control passes to the runtime support implementation.
+   *
+   * @param request owning request whose detached state drives execution assembly.
+   * @param fetchRuntimeSupport runtime seam that turns the detached execution descriptor into a
+   *     live runtime fetcher.
+   * @param returnBucket return bucket selected for this attempt, or {@code null} when the request
+   *     discards payload data or lets the runtime allocate Binary Blob storage.
+   * @return the configured live execution handle for the current request attempt.
+   * @throws IOException if the runtime support cannot allocate or initialize the execution handle.
+   */
+  static ClientGetExecution create(
+      ClientGet request, FcpFetchRuntimeSupport fetchRuntimeSupport, Bucket returnBucket)
+      throws IOException {
+    ClientGetExecutionSpec executionSpec =
+        new ClientGetExecutionSpec(
+            request,
+            request.getURI(),
+            request.getPriority(),
+            request.fetchConfig(),
+            returnBucket,
+            request.returnTypeForGetter() == ClientGet.ReturnType.NONE,
+            request.binaryBlobRequested(),
+            request.persistence == ClientRequest.Persistence.FOREVER,
+            request.initialMetadataBucket(),
+            request.extensionCheckForGetter(),
+            new ClientGetEventHandling(request));
+    return fetchRuntimeSupport.createExecution(executionSpec);
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecutionSpec.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecutionSpec.java
@@ -1,0 +1,53 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.events.ClientEventListener;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Detached execution descriptor used to create a live GET fetcher behind the adapter-owned seam.
+ *
+ * <p>This record is the last adapter-owned representation before control passes into {@link
+ * FcpFetchRuntimeSupport}. It collects the request-scoped values that the bridge needs to build a
+ * concrete runtime fetcher while keeping the adapter independent of daemon-owned execution classes.
+ * The descriptor is intentionally immutable, so persistence, restart, and constructor code can hand
+ * the same logical state to the runtime bridge without worrying about concurrent mutation while the
+ * live execution is being assembled.
+ *
+ * <p>Several fields are related and should be read together. {@code returnBucket} is the caller's
+ * chosen payload bucket when ordinary return data is expected. {@code discardData} signals the
+ * special FCP mode where ordinary payload bytes should be thrown away. {@code binaryBlob} indicates
+ * that Binary Blob recording is active, in which case the runtime may use {@code returnBucket} for
+ * blob output or allocate equivalent storage itself. {@code persistenceForever} carries the bucket
+ * allocation policy that must remain compatible with the existing persistent GET behavior.
+ *
+ * @param request owning request that receives fetch callbacks and lifecycle updates from the live
+ *     execution.
+ * @param uri target key that the runtime fetcher should request.
+ * @param priorityClass scheduler priority class that should be applied to the runtime fetcher.
+ * @param fetchConfig detached fetch configuration snapshot for this request attempt.
+ * @param returnBucket caller-selected bucket for returned data, or {@code null} when no ordinary
+ *     payload bucket is needed yet.
+ * @param discardData whether ordinary payload data should be discarded instead of being returned to
+ *     the caller.
+ * @param binaryBlob whether Binary Blob recording is enabled for this execution attempt.
+ * @param persistenceForever whether runtime bucket allocation should use the forever-persistent
+ *     policy instead of transient or reboot-only storage.
+ * @param initialMetadata optional initial metadata bucket that should be presented to the runtime
+ *     fetcher before network activity begins.
+ * @param extensionCheck optional extension hint used by filtered disk-return handling.
+ * @param eventListener listener that should receive fetch-context events emitted by the runtime
+ *     fetcher.
+ */
+public record ClientGetExecutionSpec(
+    ClientGet request,
+    FreenetURI uri,
+    short priorityClass,
+    ClientGetFetchConfig fetchConfig,
+    Bucket returnBucket,
+    boolean discardData,
+    boolean binaryBlob,
+    boolean persistenceForever,
+    Bucket initialMetadata,
+    String extensionCheck,
+    ClientEventListener eventListener) {}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetFactory.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import java.io.IOException;
-import network.crypta.client.FetchContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
@@ -11,10 +10,11 @@ import org.slf4j.LoggerFactory;
  * Builds fully configured {@link ClientGet} instances from FCP inputs.
  *
  * <p>The factory performs the deterministic wiring for GET requests: it validates identifiers,
- * assembles an appropriate {@link FetchContext}, plans return handling, and packages everything
- * into a {@link ClientGetSetup}. Callers use the resulting request object for registration and
- * execution; the factory does not start or enqueue the request itself. Because it is stateless and
- * uses only local variables, the class is thread-safe and can be called concurrently.
+ * assembles an appropriate detached fetch configuration, plans return handling, and packages
+ * everything into a {@link ClientGetSetup}. Callers use the resulting request object for
+ * registration and execution; the factory does not start or enqueue the request itself. Because it
+ * is stateless and uses only local variables, the class is thread-safe and can be called
+ * concurrently.
  *
  * <p>The factory is intentionally conservative about side effects: it only logs ignored parameters
  * (such as a legacy charset hint) and throws explicit exceptions for identifier collisions or
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li><strong>Validation</strong>: checks identifier uniqueness in the appropriate scope.
- *   <li><strong>Context setup</strong>: clones and adjusts a persistent {@link FetchContext}.
+ *   <li><strong>Context setup</strong>: clones and adjusts a persistent fetch configuration.
  *   <li><strong>Return planning</strong>: resolves disk/bucket targets and metadata buckets.
  * </ul>
  *
@@ -41,7 +41,7 @@ final class ClientGetFactory {
   /**
    * Creates a persistent, global-queue {@link ClientGet} from a validated configuration.
    *
-   * <p>The method derives a persistent {@link FetchContext} from the node core, applies the
+   * <p>The method derives persistent fetch defaults from the runtime bridge, applies the
    * configuration's limits and flags, and plans the return path according to {@link
    * ClientGet.ReturnType}. It then constructs a {@link ClientGet} instance without starting it. The
    * returned request is ready to be registered with a persistent client and subsequently started.
@@ -92,7 +92,8 @@ final class ClientGetFactory {
       FcpFetchRuntimeSupport fetchRuntimeSupport)
       throws IdentifierCollisionException, NotAllowedException, IOException {
     ensureGlobalIdentifierAvailable(globalClient, requestConfig.identifier());
-    FetchContext fctx = buildFetchContextForGlobal(fetchRuntimeSupport, requestConfig);
+    ClientGetFetchConfig fetchConfig =
+        buildFetchConfigForGlobal(fetchRuntimeSupport, requestConfig);
     if (requestConfig.charset() != null && LOG.isDebugEnabled()) {
       LOG.debug(
           "Charset parameter is ignored for ClientGet global queue requests: {}",
@@ -101,7 +102,7 @@ final class ClientGetFactory {
     ClientGetReturnPlanner.ReturnSetup returnSetup =
         ClientGetGetterFactory.planReturnForGlobal(
             requestConfig.identifier(),
-            fctx,
+            fetchConfig,
             requestConfig.returnType(),
             requestConfig.returnFilename(),
             requestConfig.filterData(),
@@ -120,7 +121,7 @@ final class ClientGetFactory {
             true);
     ClientGetSetup requestSetup =
         new ClientGetSetup(
-            fctx,
+            fetchConfig,
             returnSetup,
             requestConfig.returnType(),
             requestConfig.binaryBlob(),
@@ -165,12 +166,12 @@ final class ClientGetFactory {
     if (message.persistence == ClientRequest.Persistence.CONNECTION) {
       ensureConnectionIdentifierAvailable(handler, message.identifier);
     }
-    FetchContext fctx = buildFetchContextForMessage(fetchRuntimeSupport, message);
+    ClientGetFetchConfig fetchConfig = buildFetchConfigForMessage(fetchRuntimeSupport, message);
     ClientGetReturnPlanner.ReturnSetup returnSetup =
         ClientGetGetterFactory.planReturnForMessage(
             message.identifier,
             message.global,
-            fctx,
+            fetchConfig,
             message,
             fetchRuntimeSupport.transferAccess(),
             handler);
@@ -178,7 +179,7 @@ final class ClientGetFactory {
     try {
       ClientGetSetup requestSetup =
           new ClientGetSetup(
-              fctx,
+              fetchConfig,
               returnSetup,
               message.returnType,
               message.binaryBlob,
@@ -227,7 +228,7 @@ final class ClientGetFactory {
   }
 
   /**
-   * Builds a {@link FetchContext} for global-queue requests using default persistent settings.
+   * Builds detached fetch configuration for global-queue requests using persistent defaults.
    *
    * <p>The context is cloned from the node core's persistent template and then adjusted with the
    * configuration's limits, datastore flags, and filtering preferences. The returned context is
@@ -236,24 +237,24 @@ final class ClientGetFactory {
    * @param fetchRuntimeSupport fetch runtime support providing the default persistent fetch
    *     context.
    * @param requestConfig configuration containing datastore flags and retry limits.
-   * @return configured fetch context instance tailored for this request.
+   * @return configured detached fetch configuration tailored for this request.
    */
-  private static FetchContext buildFetchContextForGlobal(
+  private static ClientGetFetchConfig buildFetchConfigForGlobal(
       FcpFetchRuntimeSupport fetchRuntimeSupport, ClientGetGlobalRequestConfig requestConfig) {
-    FetchContext fctx = fetchRuntimeSupport.defaultPersistentFetchContext();
-    fctx.setLocalRequestOnly(requestConfig.dsOnly());
-    fctx.setIgnoreStore(requestConfig.ignoreDS());
-    fctx.setMaxNonSplitfileRetries(requestConfig.maxNonSplitfileRetries());
-    fctx.setMaxSplitfileBlockRetries(requestConfig.maxSplitfileRetries());
-    fctx.setFilterData(requestConfig.filterData());
-    fctx.setMaxOutputLength(requestConfig.maxOutputLength());
-    fctx.setMaxTempLength(requestConfig.maxOutputLength());
-    fctx.setCanWriteClientCache(requestConfig.writeToClientCache());
-    return fctx;
+    ClientGetFetchConfig fetchConfig = fetchRuntimeSupport.defaultPersistentFetchConfig();
+    fetchConfig.setLocalRequestOnly(requestConfig.dsOnly());
+    fetchConfig.setIgnoreStore(requestConfig.ignoreDS());
+    fetchConfig.setMaxNonSplitfileRetries(requestConfig.maxNonSplitfileRetries());
+    fetchConfig.setMaxSplitfileBlockRetries(requestConfig.maxSplitfileRetries());
+    fetchConfig.setFilterData(requestConfig.filterData());
+    fetchConfig.setMaxOutputLength(requestConfig.maxOutputLength());
+    fetchConfig.setMaxTempLength(requestConfig.maxOutputLength());
+    fetchConfig.setCanWriteClientCache(requestConfig.writeToClientCache());
+    return fetchConfig;
   }
 
   /**
-   * Builds a {@link FetchContext} for message-driven requests with per-message overrides.
+   * Builds detached fetch configuration for message-driven requests with per-message overrides.
    *
    * <p>The context starts from the persistent defaults and is then updated with message-specific
    * retry limits, size limits, allowed MIME types, and USK date hint behavior. The returned context
@@ -262,22 +263,22 @@ final class ClientGetFactory {
    * @param fetchRuntimeSupport fetch runtime support providing the default persistent fetch
    *     context.
    * @param message the parsed message supplying overrides and allowed MIME type hints.
-   * @return configured fetch context instance tailored for the message.
+   * @return configured detached fetch configuration tailored for the message.
    */
-  private static FetchContext buildFetchContextForMessage(
+  private static ClientGetFetchConfig buildFetchConfigForMessage(
       FcpFetchRuntimeSupport fetchRuntimeSupport, ClientGetMessage message) {
-    FetchContext fctx = fetchRuntimeSupport.defaultPersistentFetchContext();
-    fctx.setLocalRequestOnly(message.dsOnly);
-    fctx.setIgnoreStore(message.ignoreDS);
-    fctx.setMaxNonSplitfileRetries(message.maxRetries);
-    fctx.setMaxSplitfileBlockRetries(message.maxRetries);
-    fctx.setMaxOutputLength(message.maxSize);
-    fctx.setMaxTempLength(message.maxTempSize);
-    fctx.setCanWriteClientCache(message.shouldWriteToClientCache());
-    fctx.setFilterData(message.filterData);
-    fctx.setIgnoreUSKDatehints(message.ignoreUSKDatehints);
-    ClientGetGetterFactory.applyAllowedMimeTypes(fctx, message.allowedMIMETypes);
-    return fctx;
+    ClientGetFetchConfig fetchConfig = fetchRuntimeSupport.defaultPersistentFetchConfig();
+    fetchConfig.setLocalRequestOnly(message.dsOnly);
+    fetchConfig.setIgnoreStore(message.ignoreDS);
+    fetchConfig.setMaxNonSplitfileRetries(message.maxRetries);
+    fetchConfig.setMaxSplitfileBlockRetries(message.maxRetries);
+    fetchConfig.setMaxOutputLength(message.maxSize);
+    fetchConfig.setMaxTempLength(message.maxTempSize);
+    fetchConfig.setCanWriteClientCache(message.shouldWriteToClientCache());
+    fetchConfig.setFilterData(message.filterData);
+    fetchConfig.setIgnoreUSKDatehints(message.ignoreUSKDatehints);
+    ClientGetGetterFactory.applyAllowedMimeTypes(fetchConfig, message.allowedMIMETypes);
+    return fetchConfig;
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetFetchConfig.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetFetchConfig.java
@@ -1,0 +1,791 @@
+package network.crypta.clients.fcp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Detached fetch configuration for one GET request.
+ *
+ * <p>This value object mirrors the subset of runtime fetch-context state that the FCP adapter needs
+ * to persist, restore, inspect, and adjust for GET requests. It deliberately stays adapter-owned so
+ * request parsing, replay, and status code can work with a stable representation instead of holding
+ * onto live daemon fetch-context instances. The bridge layer is responsible for translating this
+ * detached state back into a concrete runtime fetch context when a request is started or resumed.
+ *
+ * <p>The class is mutable because FCP request construction still follows the existing pattern of
+ * cloning defaults and then applying per-request overrides. Callers should therefore treat each
+ * instance as a request-scoped state rather than as a reusable shared template. The only collection
+ * member, {@code allowedMimeTypes}, uses defensive copying on input and output so mutations outside
+ * the object do not leak into persisted request state.
+ */
+@SuppressWarnings({"java:S6206"})
+public final class ClientGetFetchConfig implements Serializable {
+  /** Serialization version for the detached fetch configuration representation. */
+  @Serial private static final long serialVersionUID = 1L;
+
+  /** Maximum final payload length, in bytes, that the request is willing to return. */
+  private long maxOutputLength;
+
+  /** Maximum temporary storage length, in bytes, allowed while fetching or filtering. */
+  private long maxTempLength;
+
+  /** Maximum recursion depth when traversing nested metadata and archive structures. */
+  private int maxRecursionLevel;
+
+  /** Maximum number of archive restart attempts allowed during traversal. */
+  private int maxArchiveRestarts;
+
+  /** Maximum number of archive layers that may be entered during fetch processing. */
+  private int maxArchiveLevels;
+
+  /** Whether implicit archives should be skipped unless explicitly requested. */
+  private boolean dontEnterImplicitArchives;
+
+  /** Retry limit for splitfile block fetches. */
+  private int maxSplitfileBlockRetries;
+
+  /** Retry limit for non-splitfile fetches. */
+  private int maxNonSplitfileRetries;
+
+  /** Retry limit for USK lookups. */
+  private int maxUSKRetries;
+
+  /** Whether splitfiles may be fetched at all. */
+  private boolean allowSplitfiles;
+
+  /** Whether permanent or temporary, redirects should be followed automatically. */
+  private boolean followRedirects;
+
+  /** Whether the request should be restricted to datastore-only or otherwise local handling. */
+  private boolean localRequestOnly;
+
+  /** Whether the datastore should be bypassed when servicing the fetch. */
+  private boolean ignoreStore;
+
+  /** Maximum metadata size, in bytes, that the fetch should accept. */
+  private int maxMetadataSize;
+
+  /** Maximum data blocks per splitfile segment. */
+  private int maxDataBlocksPerSegment;
+
+  /** Maximum check blocks per splitfile segment. */
+  private int maxCheckBlocksPerSegment;
+
+  /** Whether ZIP manifests should be returned instead of being expanded automatically. */
+  private boolean returnZIPManifests;
+
+  /** Whether the fetched payload should be passed through the content filter. */
+  private boolean filterData;
+
+  /** Whether path components beyond the configured threshold should be tolerated. */
+  private boolean ignoreTooManyPathComponents;
+
+  /** Optional allowlist of MIME types that the request will accept. */
+  private Set<String> allowedMimeTypes;
+
+  /** Optional charset override supplied to the content filter. */
+  private String charset;
+
+  /** Whether the client cache may be written as part of this fetch. */
+  private boolean canWriteClientCache;
+
+  /** Optional MIME override supplied to the content filter. */
+  private String overrideMime;
+
+  /** Number of cooldown retries before the runtime should give up. */
+  private int cooldownRetries;
+
+  /** Cooldown duration, in milliseconds, between retry attempts. */
+  private long cooldownTime;
+
+  /** Whether USK date hints should be ignored while resolving editions. */
+  private boolean ignoreUSKDatehints;
+
+  /** Optional scheme, host, and port override used by filtering or URI rewriting logic. */
+  private String schemeHostAndPort;
+
+  /** Creates an empty detached fetch configuration. */
+  public ClientGetFetchConfig() {}
+
+  /**
+   * Creates a deep copy of another detached fetch configuration.
+   *
+   * <p>Primitive and string members are copied directly, while mutable collection state is cloned
+   * so later changes to either instance remain isolated.
+   *
+   * @param other source configuration to copy.
+   */
+  public ClientGetFetchConfig(ClientGetFetchConfig other) {
+    maxOutputLength = other.maxOutputLength;
+    maxTempLength = other.maxTempLength;
+    maxRecursionLevel = other.maxRecursionLevel;
+    maxArchiveRestarts = other.maxArchiveRestarts;
+    maxArchiveLevels = other.maxArchiveLevels;
+    dontEnterImplicitArchives = other.dontEnterImplicitArchives;
+    maxSplitfileBlockRetries = other.maxSplitfileBlockRetries;
+    maxNonSplitfileRetries = other.maxNonSplitfileRetries;
+    maxUSKRetries = other.maxUSKRetries;
+    allowSplitfiles = other.allowSplitfiles;
+    followRedirects = other.followRedirects;
+    localRequestOnly = other.localRequestOnly;
+    ignoreStore = other.ignoreStore;
+    maxMetadataSize = other.maxMetadataSize;
+    maxDataBlocksPerSegment = other.maxDataBlocksPerSegment;
+    maxCheckBlocksPerSegment = other.maxCheckBlocksPerSegment;
+    returnZIPManifests = other.returnZIPManifests;
+    filterData = other.filterData;
+    ignoreTooManyPathComponents = other.ignoreTooManyPathComponents;
+    allowedMimeTypes = copyAllowedMimeTypes(other.allowedMimeTypes);
+    charset = other.charset;
+    canWriteClientCache = other.canWriteClientCache;
+    overrideMime = other.overrideMime;
+    cooldownRetries = other.cooldownRetries;
+    cooldownTime = other.cooldownTime;
+    ignoreUSKDatehints = other.ignoreUSKDatehints;
+    schemeHostAndPort = other.schemeHostAndPort;
+  }
+
+  /**
+   * Returns a detached copy of this configuration.
+   *
+   * <p>Callers typically use this when they need to start from an existing baseline and apply
+   * request-specific overrides without mutating the original instance.
+   *
+   * @return independent copy of this configuration.
+   */
+  public ClientGetFetchConfig copy() {
+    return new ClientGetFetchConfig(this);
+  }
+
+  /**
+   * Returns the configured maximum final payload length in bytes.
+   *
+   * @return maximum returned payload length, in bytes.
+   */
+  public long getMaxOutputLength() {
+    return maxOutputLength;
+  }
+
+  /**
+   * Sets the maximum final payload length in bytes.
+   *
+   * @param maxOutputLength maximum returned payload length, in bytes.
+   */
+  public void setMaxOutputLength(long maxOutputLength) {
+    this.maxOutputLength = maxOutputLength;
+  }
+
+  /**
+   * Returns the configured maximum temporary storage length in bytes.
+   *
+   * @return temporary storage limit, in bytes.
+   */
+  public long getMaxTempLength() {
+    return maxTempLength;
+  }
+
+  /**
+   * Sets the maximum temporary storage length in bytes.
+   *
+   * @param maxTempLength temporary storage limit, in bytes.
+   */
+  public void setMaxTempLength(long maxTempLength) {
+    this.maxTempLength = maxTempLength;
+  }
+
+  /**
+   * Returns the maximum metadata and archive recursion depth.
+   *
+   * @return recursion depth limit for metadata and archives.
+   */
+  public int getMaxRecursionLevel() {
+    return maxRecursionLevel;
+  }
+
+  /**
+   * Sets the maximum metadata and archive recursion depth.
+   *
+   * @param maxRecursionLevel recursion depth limit for metadata and archives.
+   */
+  public void setMaxRecursionLevel(int maxRecursionLevel) {
+    this.maxRecursionLevel = maxRecursionLevel;
+  }
+
+  /**
+   * Returns the maximum number of archive restart attempts.
+   *
+   * @return archive restart limit.
+   */
+  public int getMaxArchiveRestarts() {
+    return maxArchiveRestarts;
+  }
+
+  /**
+   * Sets the maximum number of archive restart attempts.
+   *
+   * @param maxArchiveRestarts archive restart limit.
+   */
+  public void setMaxArchiveRestarts(int maxArchiveRestarts) {
+    this.maxArchiveRestarts = maxArchiveRestarts;
+  }
+
+  /**
+   * Returns the maximum number of archive layers that may be traversed.
+   *
+   * @return archive depth limit.
+   */
+  public int getMaxArchiveLevels() {
+    return maxArchiveLevels;
+  }
+
+  /**
+   * Sets the maximum number of archive layers that may be traversed.
+   *
+   * @param maxArchiveLevels archive depth limit.
+   */
+  public void setMaxArchiveLevels(int maxArchiveLevels) {
+    this.maxArchiveLevels = maxArchiveLevels;
+  }
+
+  /**
+   * Returns whether implicit archives are skipped unless explicitly requested.
+   *
+   * @return {@code true} when implicit archives should not be entered automatically.
+   */
+  public boolean getDontEnterImplicitArchives() {
+    return dontEnterImplicitArchives;
+  }
+
+  /**
+   * Sets whether implicit archives are skipped unless explicitly requested.
+   *
+   * @param dontEnterImplicitArchives {@code true} to avoid entering implicit archives
+   *     automatically.
+   */
+  public void setDontEnterImplicitArchives(boolean dontEnterImplicitArchives) {
+    this.dontEnterImplicitArchives = dontEnterImplicitArchives;
+  }
+
+  /**
+   * Returns the retry limit for splitfile block fetches.
+   *
+   * @return splitfile block retry limit.
+   */
+  public int getMaxSplitfileBlockRetries() {
+    return maxSplitfileBlockRetries;
+  }
+
+  /**
+   * Sets the retry limit for splitfile block fetches.
+   *
+   * @param maxSplitfileBlockRetries splitfile block retry limit.
+   */
+  public void setMaxSplitfileBlockRetries(int maxSplitfileBlockRetries) {
+    this.maxSplitfileBlockRetries = maxSplitfileBlockRetries;
+  }
+
+  /**
+   * Returns the retry limit for non-splitfile fetches.
+   *
+   * @return non-splitfile retry limit.
+   */
+  public int getMaxNonSplitfileRetries() {
+    return maxNonSplitfileRetries;
+  }
+
+  /**
+   * Sets the retry limit for non-splitfile fetches.
+   *
+   * @param maxNonSplitfileRetries non-splitfile retry limit.
+   */
+  public void setMaxNonSplitfileRetries(int maxNonSplitfileRetries) {
+    this.maxNonSplitfileRetries = maxNonSplitfileRetries;
+  }
+
+  /**
+   * Returns the retry limit for USK lookups.
+   *
+   * @return USK retry limit.
+   */
+  public int getMaxUSKRetries() {
+    return maxUSKRetries;
+  }
+
+  /**
+   * Sets the retry limit for USK lookups.
+   *
+   * @param maxUSKRetries USK retry limit.
+   */
+  public void setMaxUSKRetries(int maxUSKRetries) {
+    this.maxUSKRetries = maxUSKRetries;
+  }
+
+  /**
+   * Returns whether splitfiles may be fetched.
+   *
+   * @return {@code true} when splitfile handling is enabled.
+   */
+  public boolean getAllowSplitfiles() {
+    return allowSplitfiles;
+  }
+
+  /**
+   * Sets whether splitfiles may be fetched.
+   *
+   * @param allowSplitfiles {@code true} to permit splitfile handling.
+   */
+  public void setAllowSplitfiles(boolean allowSplitfiles) {
+    this.allowSplitfiles = allowSplitfiles;
+  }
+
+  /**
+   * Returns whether redirects should be followed automatically.
+   *
+   * @return {@code true} when redirect following is enabled.
+   */
+  public boolean getFollowRedirects() {
+    return followRedirects;
+  }
+
+  /**
+   * Sets whether redirects should be followed automatically.
+   *
+   * @param followRedirects {@code true} to follow redirects automatically.
+   */
+  public void setFollowRedirects(boolean followRedirects) {
+    this.followRedirects = followRedirects;
+  }
+
+  /**
+   * Returns whether the request should be handled locally only.
+   *
+   * @return {@code true} when the fetch should stay local to the node.
+   */
+  public boolean getLocalRequestOnly() {
+    return localRequestOnly;
+  }
+
+  /**
+   * Sets whether the request should be handled locally only.
+   *
+   * @param localRequestOnly {@code true} to keep the fetch local to the node.
+   */
+  public void setLocalRequestOnly(boolean localRequestOnly) {
+    this.localRequestOnly = localRequestOnly;
+  }
+
+  /**
+   * Returns whether the datastore should be bypassed.
+   *
+   * @return {@code true} when datastore lookups should be skipped.
+   */
+  public boolean getIgnoreStore() {
+    return ignoreStore;
+  }
+
+  /**
+   * Sets whether the datastore should be bypassed.
+   *
+   * @param ignoreStore {@code true} to skip datastore lookups.
+   */
+  public void setIgnoreStore(boolean ignoreStore) {
+    this.ignoreStore = ignoreStore;
+  }
+
+  /**
+   * Returns the maximum metadata size in bytes.
+   *
+   * @return metadata size limit, in bytes.
+   */
+  public int getMaxMetadataSize() {
+    return maxMetadataSize;
+  }
+
+  /**
+   * Sets the maximum metadata size in bytes.
+   *
+   * @param maxMetadataSize metadata size limit, in bytes.
+   */
+  public void setMaxMetadataSize(int maxMetadataSize) {
+    this.maxMetadataSize = maxMetadataSize;
+  }
+
+  /**
+   * Returns the maximum number of data blocks per splitfile segment.
+   *
+   * @return data-block limit per segment.
+   */
+  public int getMaxDataBlocksPerSegment() {
+    return maxDataBlocksPerSegment;
+  }
+
+  /**
+   * Sets the maximum number of data blocks per splitfile segment.
+   *
+   * @param maxDataBlocksPerSegment data-block limit per segment.
+   */
+  public void setMaxDataBlocksPerSegment(int maxDataBlocksPerSegment) {
+    this.maxDataBlocksPerSegment = maxDataBlocksPerSegment;
+  }
+
+  /**
+   * Returns the maximum number of check blocks per splitfile segment.
+   *
+   * @return check-block limit per segment.
+   */
+  public int getMaxCheckBlocksPerSegment() {
+    return maxCheckBlocksPerSegment;
+  }
+
+  /**
+   * Sets the maximum number of check blocks per splitfile segment.
+   *
+   * @param maxCheckBlocksPerSegment check-block limit per segment.
+   */
+  public void setMaxCheckBlocksPerSegment(int maxCheckBlocksPerSegment) {
+    this.maxCheckBlocksPerSegment = maxCheckBlocksPerSegment;
+  }
+
+  /**
+   * Returns whether ZIP manifests should be returned as ZIP data.
+   *
+   * @return {@code true} when ZIP manifests should not be expanded automatically.
+   */
+  public boolean getReturnZIPManifests() {
+    return returnZIPManifests;
+  }
+
+  /**
+   * Sets whether ZIP manifests should be returned as ZIP data.
+   *
+   * @param returnZIPManifests {@code true} to return ZIP manifests directly.
+   */
+  public void setReturnZIPManifests(boolean returnZIPManifests) {
+    this.returnZIPManifests = returnZIPManifests;
+  }
+
+  /**
+   * Returns whether the fetched payload should be filtered.
+   *
+   * @return {@code true} when content filtering is enabled.
+   */
+  public boolean getFilterData() {
+    return filterData;
+  }
+
+  /**
+   * Sets whether the fetched payload should be filtered.
+   *
+   * @param filterData {@code true} to enable content filtering.
+   */
+  public void setFilterData(boolean filterData) {
+    this.filterData = filterData;
+  }
+
+  /**
+   * Returns whether extra path components should be tolerated.
+   *
+   * @return {@code true} when excess path components should not fail the fetch.
+   */
+  public boolean getIgnoreTooManyPathComponents() {
+    return ignoreTooManyPathComponents;
+  }
+
+  /**
+   * Sets whether extra path components should be tolerated.
+   *
+   * @param ignoreTooManyPathComponents {@code true} to tolerate excess path components.
+   */
+  public void setIgnoreTooManyPathComponents(boolean ignoreTooManyPathComponents) {
+    this.ignoreTooManyPathComponents = ignoreTooManyPathComponents;
+  }
+
+  /**
+   * Returns the allowed MIME-type set as a defensive copy.
+   *
+   * <p>The caller may modify the returned set without affecting this configuration.
+   *
+   * @return copied allowlist of MIME types, or {@code null} when no allowlist is configured.
+   */
+  public Set<String> getAllowedMimeTypes() {
+    return copyAllowedMimeTypes(allowedMimeTypes);
+  }
+
+  /**
+   * Stores the allowed MIME-type set as a defensive copy.
+   *
+   * @param allowedMimeTypes allowlist to copy into this configuration, or {@code null} to clear the
+   *     restriction.
+   */
+  public void setAllowedMimeTypes(Set<String> allowedMimeTypes) {
+    this.allowedMimeTypes = copyAllowedMimeTypes(allowedMimeTypes);
+  }
+
+  /**
+   * Returns the optional charset override used by filtering.
+   *
+   * @return charset override, or {@code null} when none is configured.
+   */
+  public String getCharset() {
+    return charset;
+  }
+
+  /**
+   * Sets the optional charset override used by filtering.
+   *
+   * @param charset charset override, or {@code null} to clear it.
+   */
+  public void setCharset(String charset) {
+    this.charset = charset;
+  }
+
+  /**
+   * Returns whether the client cache may be written during this fetch.
+   *
+   * @return {@code true} when client-cache writes are allowed.
+   */
+  public boolean getCanWriteClientCache() {
+    return canWriteClientCache;
+  }
+
+  /**
+   * Sets whether the client cache may be written during this fetch.
+   *
+   * @param canWriteClientCache {@code true} to allow client-cache writes.
+   */
+  public void setCanWriteClientCache(boolean canWriteClientCache) {
+    this.canWriteClientCache = canWriteClientCache;
+  }
+
+  /**
+   * Returns the optional MIME override used by filtering.
+   *
+   * @return MIME override, or {@code null} when none is configured.
+   */
+  public String getOverrideMime() {
+    return overrideMime;
+  }
+
+  /**
+   * Sets the optional MIME override used by filtering.
+   *
+   * @param overrideMime MIME override, or {@code null} to clear it.
+   */
+  public void setOverrideMime(String overrideMime) {
+    this.overrideMime = overrideMime;
+  }
+
+  /**
+   * Returns the configured number of cooldown retries.
+   *
+   * @return cooldown retry count.
+   */
+  public int getCooldownRetries() {
+    return cooldownRetries;
+  }
+
+  /**
+   * Sets the configured number of cooldown retries.
+   *
+   * @param cooldownRetries cooldown retry count.
+   */
+  public void setCooldownRetries(int cooldownRetries) {
+    this.cooldownRetries = cooldownRetries;
+  }
+
+  /**
+   * Returns the cooldown interval in milliseconds.
+   *
+   * @return cooldown interval, in milliseconds.
+   */
+  public long getCooldownTime() {
+    return cooldownTime;
+  }
+
+  /**
+   * Sets the cooldown interval in milliseconds.
+   *
+   * @param cooldownTime cooldown interval, in milliseconds.
+   */
+  public void setCooldownTime(long cooldownTime) {
+    this.cooldownTime = cooldownTime;
+  }
+
+  /**
+   * Returns whether USK date hints should be ignored.
+   *
+   * @return {@code true} when USK date hints are ignored.
+   */
+  public boolean getIgnoreUSKDatehints() {
+    return ignoreUSKDatehints;
+  }
+
+  /**
+   * Sets whether USK date hints should be ignored.
+   *
+   * @param ignoreUSKDatehints {@code true} to ignore USK date hints.
+   */
+  public void setIgnoreUSKDatehints(boolean ignoreUSKDatehints) {
+    this.ignoreUSKDatehints = ignoreUSKDatehints;
+  }
+
+  /**
+   * Returns the optional scheme, host, and port override used by filtering logic.
+   *
+   * @return scheme, host, and port override, or {@code null} when unset.
+   */
+  public String getSchemeHostAndPort() {
+    return schemeHostAndPort;
+  }
+
+  /**
+   * Sets the optional scheme, host, and port override used by filtering logic.
+   *
+   * @param schemeHostAndPort scheme, host, and port override, or {@code null} to clear it.
+   */
+  public void setSchemeHostAndPort(String schemeHostAndPort) {
+    this.schemeHostAndPort = schemeHostAndPort;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof ClientGetFetchConfig that)) {
+      return false;
+    }
+    return maxOutputLength == that.maxOutputLength
+        && maxTempLength == that.maxTempLength
+        && maxRecursionLevel == that.maxRecursionLevel
+        && maxArchiveRestarts == that.maxArchiveRestarts
+        && maxArchiveLevels == that.maxArchiveLevels
+        && dontEnterImplicitArchives == that.dontEnterImplicitArchives
+        && maxSplitfileBlockRetries == that.maxSplitfileBlockRetries
+        && maxNonSplitfileRetries == that.maxNonSplitfileRetries
+        && maxUSKRetries == that.maxUSKRetries
+        && allowSplitfiles == that.allowSplitfiles
+        && followRedirects == that.followRedirects
+        && localRequestOnly == that.localRequestOnly
+        && ignoreStore == that.ignoreStore
+        && maxMetadataSize == that.maxMetadataSize
+        && maxDataBlocksPerSegment == that.maxDataBlocksPerSegment
+        && maxCheckBlocksPerSegment == that.maxCheckBlocksPerSegment
+        && returnZIPManifests == that.returnZIPManifests
+        && filterData == that.filterData
+        && ignoreTooManyPathComponents == that.ignoreTooManyPathComponents
+        && canWriteClientCache == that.canWriteClientCache
+        && cooldownRetries == that.cooldownRetries
+        && cooldownTime == that.cooldownTime
+        && ignoreUSKDatehints == that.ignoreUSKDatehints
+        && Objects.equals(allowedMimeTypes, that.allowedMimeTypes)
+        && Objects.equals(charset, that.charset)
+        && Objects.equals(overrideMime, that.overrideMime)
+        && Objects.equals(schemeHostAndPort, that.schemeHostAndPort);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        maxOutputLength,
+        maxTempLength,
+        maxRecursionLevel,
+        maxArchiveRestarts,
+        maxArchiveLevels,
+        dontEnterImplicitArchives,
+        maxSplitfileBlockRetries,
+        maxNonSplitfileRetries,
+        maxUSKRetries,
+        allowSplitfiles,
+        followRedirects,
+        localRequestOnly,
+        ignoreStore,
+        maxMetadataSize,
+        maxDataBlocksPerSegment,
+        maxCheckBlocksPerSegment,
+        returnZIPManifests,
+        filterData,
+        ignoreTooManyPathComponents,
+        allowedMimeTypes,
+        charset,
+        canWriteClientCache,
+        overrideMime,
+        cooldownRetries,
+        cooldownTime,
+        ignoreUSKDatehints,
+        schemeHostAndPort);
+  }
+
+  @Override
+  public String toString() {
+    return "ClientGetFetchConfig["
+        + "maxOutputLength="
+        + maxOutputLength
+        + ", maxTempLength="
+        + maxTempLength
+        + ", maxRecursionLevel="
+        + maxRecursionLevel
+        + ", maxArchiveRestarts="
+        + maxArchiveRestarts
+        + ", maxArchiveLevels="
+        + maxArchiveLevels
+        + ", dontEnterImplicitArchives="
+        + dontEnterImplicitArchives
+        + ", maxSplitfileBlockRetries="
+        + maxSplitfileBlockRetries
+        + ", maxNonSplitfileRetries="
+        + maxNonSplitfileRetries
+        + ", maxUSKRetries="
+        + maxUSKRetries
+        + ", allowSplitfiles="
+        + allowSplitfiles
+        + ", followRedirects="
+        + followRedirects
+        + ", localRequestOnly="
+        + localRequestOnly
+        + ", ignoreStore="
+        + ignoreStore
+        + ", maxMetadataSize="
+        + maxMetadataSize
+        + ", maxDataBlocksPerSegment="
+        + maxDataBlocksPerSegment
+        + ", maxCheckBlocksPerSegment="
+        + maxCheckBlocksPerSegment
+        + ", returnZIPManifests="
+        + returnZIPManifests
+        + ", filterData="
+        + filterData
+        + ", ignoreTooManyPathComponents="
+        + ignoreTooManyPathComponents
+        + ", allowedMimeTypes="
+        + allowedMimeTypes
+        + ", charset="
+        + charset
+        + ", canWriteClientCache="
+        + canWriteClientCache
+        + ", overrideMime="
+        + overrideMime
+        + ", cooldownRetries="
+        + cooldownRetries
+        + ", cooldownTime="
+        + cooldownTime
+        + ", ignoreUSKDatehints="
+        + ignoreUSKDatehints
+        + ", schemeHostAndPort="
+        + schemeHostAndPort
+        + ']';
+  }
+
+  /**
+   * Copies the allowlist set defensively.
+   *
+   * @param input source set to clone.
+   * @return cloned set, or {@code null} when {@code input} is {@code null}.
+   */
+  private static Set<String> copyAllowedMimeTypes(Set<String> input) {
+    return input == null ? null : new HashSet<>(input);
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetGetterFactory.java
@@ -4,75 +4,39 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.Serial;
-import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
-import network.crypta.client.FetchException;
-import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.BinaryBlob;
-import network.crypta.client.async.BinaryBlobWriter;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetCallback;
-import network.crypta.client.async.ClientGetter;
-import network.crypta.client.async.ClientGetterOptions;
-import network.crypta.client.async.ClientGetterRequest;
-import network.crypta.client.async.PersistentClientCallback;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ArrayBucketFactory;
 import network.crypta.support.io.FileBucket;
-import network.crypta.support.io.NullBucket;
-import network.crypta.support.io.ResumeFailedException;
-import network.crypta.support.io.StorageFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Creates {@link ClientGetter} instances for {@link ClientGet} requests, including Binary Blob
- * support.
+ * Houses detached GET helpers that remain adapter-owned after the runtime handoff.
  *
- * <p>This utility centralizes the wiring required to build a {@link ClientGetter} with the correct
- * callback adapter, bucket choices, and optional {@link BinaryBlobWriter} so the request class can
- * focus on persistence and lifecycle duties. Callers typically invoke it during request creation or
- * resume paths to get a fully configured fetcher while keeping Binary Blob concerns out of {@link
- * ClientGet} and under the Sonar coupling limit (rule {@code java:S6539}).
+ * <p>The bridge now owns live fetch execution, but the adapter still owns stable helpers for
+ * detached fetch configuration, return planning, bucket wrappers, and status projection.
  *
- * <p>There is no mutable-shared state beyond a reusable {@link NullBucket} instance, so the class
- * is effectively stateless. Thread-safety is therefore determined by the collaborators passed in,
- * not by this factory. The method contracts favor explicit inputs (for example, whether to discard
- * data or enable Binary Blob recording) and will fail fast when required dependencies such as
- * {@link FcpFetchRuntimeSupport} are missing.
+ * <p>The class is effectively stateless. Thread-safety is therefore determined by the collaborators
+ * passed in, not by this factory. The method contracts favor explicit inputs and will fail fast
+ * when required dependencies such as {@link FcpFetchRuntimeSupport} are missing.
  *
  * <ul>
- *   <li>Wires request callbacks via an adapter that implements persistence interfaces.
- *   <li>Selects output buckets and Binary Blob writers based on caller intent.
+ *   <li>Applies request-visible fetch configuration overrides.
+ *   <li>Plans output buckets and disk-return behavior.
  *   <li>Creates disk-backed buckets and hash envelopes for persistence helpers.
  * </ul>
- *
- * @see ClientGetter
- * @see ClientGet
- * @see BinaryBlobWriter
  */
 final class ClientGetGetterFactory {
   private static final Logger LOG = LoggerFactory.getLogger(ClientGetGetterFactory.class);
-
-  /**
-   * Reusable {@link NullBucket} to discard output without allocating per call.
-   *
-   * <p>The instance holds no external resources and has no state changes, so it is safe to share
-   * across factory invocations. It is returned where a caller asks to discard data or when Binary
-   * Blob fetching should ignore the ordinary return bucket.
-   */
-  @SuppressWarnings("java:S2095")
-  private static final Bucket NULL_BUCKET = new NullBucket();
 
   /** Prevents instantiation because this class is a static factory. */
   private ClientGetGetterFactory() {}
@@ -87,57 +51,6 @@ final class ClientGetGetterFactory {
    */
   static String binaryBlobMimeType() {
     return BinaryBlob.MIME_TYPE;
-  }
-
-  /**
-   * Adapter that forwards fetch callbacks back to the owning {@link ClientGet}.
-   *
-   * <p>The adapter implements both {@link ClientGetCallback} and {@link PersistentClientCallback}
-   * so persistent requests can resume and serialize details through a single delegate. The only
-   * state retained is the request instance provided at construction time.
-   */
-  @SuppressWarnings("ClassCanBeRecord")
-  private static final class CallbackAdapter
-      implements ClientGetCallback, PersistentClientCallback, Serializable {
-    /** Serialization identifier for the adapter; no evolving state is persisted. */
-    @Serial private static final long serialVersionUID = 1L;
-
-    /** Request to receive all callback signals from the fetcher. */
-    private final ClientGet request;
-
-    /**
-     * Creates an adapter that forwards callbacks to the supplied request.
-     *
-     * @param request owning request that implements the callback logic; must not be {@code null}.
-     */
-    private CallbackAdapter(ClientGet request) {
-      this.request = request;
-    }
-
-    @Override
-    public void onSuccess(FetchResult result, ClientGetter state) {
-      request.onSuccess(result, state);
-    }
-
-    @Override
-    public void onFailure(FetchException e) {
-      request.onFailure(e);
-    }
-
-    @Override
-    public void onResume(ClientContext context) throws ResumeFailedException {
-      request.onResume(context);
-    }
-
-    @Override
-    public RequestClient getRequestClient() {
-      return request.getRequestClient();
-    }
-
-    @Override
-    public void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException {
-      request.getClientDetail(dos, checker);
-    }
   }
 
   /**
@@ -159,22 +72,21 @@ final class ClientGetGetterFactory {
   }
 
   /**
-   * Applies allowed MIME types to a fetch context.
+   * Applies allowed MIME types to detached fetch configuration.
    *
    * <p>The method initializes the allowed MIME type set when configured in the request message.
-   * Passing {@code null} leaves the fetch context unchanged.
+   * Passing {@code null} leaves the configuration unchanged.
    *
-   * @param fetchContext fetch context to update with allowed MIME types.
+   * @param fetchConfig detached fetch configuration to update with allowed MIME types.
    * @param allowedMimeTypes optional list of allowed MIME type strings.
    */
-  static void applyAllowedMimeTypes(FetchContext fetchContext, String[] allowedMimeTypes) {
+  static void applyAllowedMimeTypes(ClientGetFetchConfig fetchConfig, String[] allowedMimeTypes) {
     if (allowedMimeTypes == null) {
       return;
     }
-    fetchContext.setAllowedMIMETypes(new HashSet<>());
-    for (String mime : allowedMimeTypes) {
-      fetchContext.getAllowedMIMETypes().add(mime);
-    }
+    HashSet<String> updated = new HashSet<>();
+    Collections.addAll(updated, allowedMimeTypes);
+    fetchConfig.setAllowedMimeTypes(updated);
   }
 
   /**
@@ -196,7 +108,7 @@ final class ClientGetGetterFactory {
     long foundDataLength = snapshot.foundDataLength();
     File destinationFile = snapshot.destinationFile();
     Bucket dataBucket = snapshot.dataBucket();
-    FetchContext fetchContext = snapshot.fetchContext();
+    ClientGetFetchConfig fetchConfig = snapshot.fetchConfig();
     InsertContext.CompatibilityMode[] compatModes = snapshot.compatModes();
     byte[] splitfileKey = snapshot.splitfileKey();
     FreenetURI uri = snapshot.uri();
@@ -226,9 +138,9 @@ final class ClientGetGetterFactory {
       }
     }
 
-    boolean filterData = fetchContext.getFilterData();
+    boolean filterData = fetchConfig.getFilterData();
     boolean overriddenDataType =
-        fetchContext.getOverrideMIME() != null || fetchContext.getCharset() != null;
+        fetchConfig.getOverrideMime() != null || fetchConfig.getCharset() != null;
 
     DownloadOutcomeInfo outcome =
         new DownloadOutcomeInfo(
@@ -253,7 +165,7 @@ final class ClientGetGetterFactory {
    * order.
    *
    * @param identifier request identifier used for policy checks.
-   * @param fetchContext fetch context for return planning.
+   * @param fetchConfig detached fetch configuration for return planning.
    * @param returnType configured return type.
    * @param returnFilename target file for disk returns.
    * @param filterData whether to derive an extension hint when filtering.
@@ -264,14 +176,14 @@ final class ClientGetGetterFactory {
    */
   static ClientGetReturnPlanner.ReturnSetup planReturnForGlobal(
       String identifier,
-      FetchContext fetchContext,
+      ClientGetFetchConfig fetchConfig,
       ClientGet.ReturnType returnType,
       File returnFilename,
       boolean filterData,
       TransferAccessPort transferAccess)
       throws NotAllowedException, IOException {
     ClientGetReturnPlanner returnPlanner =
-        new ClientGetReturnPlanner(identifier, true, fetchContext);
+        new ClientGetReturnPlanner(identifier, true, fetchConfig);
     return returnPlanner.forGlobalRequest(returnType, returnFilename, filterData, transferAccess);
   }
 
@@ -283,7 +195,7 @@ final class ClientGetGetterFactory {
    *
    * @param identifier request identifier used for policy checks.
    * @param global whether the request uses the global identifier namespace.
-   * @param fetchContext fetch context for return planning.
+   * @param fetchConfig detached fetch configuration for return planning.
    * @param message message containing return settings.
    * @param transferAccess transfer policy used for policy checks.
    * @param handler connection handler providing DDA validation.
@@ -293,101 +205,14 @@ final class ClientGetGetterFactory {
   static ClientGetReturnPlanner.ReturnSetup planReturnForMessage(
       String identifier,
       boolean global,
-      FetchContext fetchContext,
+      ClientGetFetchConfig fetchConfig,
       ClientGetMessage message,
       TransferAccessPort transferAccess,
       FCPConnectionHandler handler)
       throws MessageInvalidException {
     ClientGetReturnPlanner returnPlanner =
-        new ClientGetReturnPlanner(identifier, global, fetchContext);
+        new ClientGetReturnPlanner(identifier, global, fetchConfig);
     return returnPlanner.forMessage(message, transferAccess, handler);
-  }
-
-  /**
-   * Restores a {@link FetchContext} or defaults when recovery fails.
-   *
-   * @param dis input stream positioned at the fetch context data.
-   * @param context client context providing default fetch settings.
-   * @param checker checksum helper used to verify the serialized block.
-   * @return restored {@link FetchContext} or the default when recovery fails.
-   */
-  static FetchContext readFetchContextOrDefault(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker) {
-    return ClientGetPersistenceIO.readFetchContextOrDefault(dis, context, checker);
-  }
-
-  /**
-   * Restores an initial metadata bucket for the request, if present.
-   *
-   * @param dis input stream positioned at the metadata bucket marker.
-   * @param context client context owning persistent bucket services.
-   * @param checker checksum helper used to verify the bucket metadata.
-   * @return restored bucket or {@code null} when no metadata marker was set.
-   * @throws IOException if the underlying stream cannot be read.
-   * @throws StorageFormatException if metadata integrity checks fail.
-   * @throws ResumeFailedException if bucket restoration fails.
-   */
-  static Bucket readInitialMetadata(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
-      throws IOException, StorageFormatException, ResumeFailedException {
-    return ClientGetPersistenceIO.readInitialMetadata(dis, context, checker);
-  }
-
-  /**
-   * Restores a completed direct bucket from persistent storage.
-   *
-   * @param dis input stream positioned at the bucket payload.
-   * @param context client context owning persistent bucket services.
-   * @param checker checksum helper used to verify the bucket metadata.
-   * @return restored bucket, or {@code null} when restoration failed.
-   * @throws ResumeFailedException if bucket restoration fails.
-   */
-  static Bucket restoreCompletedDirectBucketOrNull(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
-      throws ResumeFailedException {
-    return ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(dis, context, checker);
-  }
-
-  /**
-   * Restores the failure message for a finished request.
-   *
-   * @param dis input stream positioned at the failure message payload.
-   * @param reqID request identifier used to populate the failure message.
-   * @param foundDataLength recorded data length for the request.
-   * @param foundDataMimeType recorded MIME type for the request.
-   * @param context client context providing checksum helpers.
-   * @param checker checksum helper used to verify the payload.
-   * @return restored {@link GetFailedMessage} or {@code null} when recovery fails.
-   */
-  static GetFailedMessage restoreFailureMessageOrNull(
-      DataInputStream dis,
-      RequestIdentifier reqID,
-      long foundDataLength,
-      String foundDataMimeType,
-      ClientContext context,
-      ChecksumChecker checker) {
-    return ClientGetPersistenceIO.restoreFailureMessageOrNull(
-        dis, reqID, foundDataLength, foundDataMimeType, context, checker);
-  }
-
-  /**
-   * Restores in-progress getter state along with transient progress fields.
-   *
-   * @param dis input stream positioned at the progress data block.
-   * @param context client context used to resume the getter.
-   * @param checker checksum helper used to validate the block.
-   * @param inProgressGetter getter instance to resume.
-   * @param request request instance for restoring transient fields.
-   * @throws StorageFormatException if the serialized state is invalid.
-   */
-  static void restoreInProgressState(
-      DataInputStream dis,
-      ClientContext context,
-      ChecksumChecker checker,
-      ClientGetter inProgressGetter,
-      ClientGet request)
-      throws StorageFormatException {
-    ClientGetPersistenceIO.restoreInProgressState(dis, context, checker, inProgressGetter, request);
   }
 
   /**
@@ -453,112 +278,5 @@ final class ClientGetGetterFactory {
   static void writeExpectedHashes(DataOutputStream dos, ExpectedHashes expectedHashes)
       throws IOException {
     HashResult.write(expectedHashes == null ? null : expectedHashes.hashes, dos);
-  }
-
-  /**
-   * Builds the {@link ClientGetterRequest} used to start a {@link ClientGet} fetch.
-   *
-   * <p>The request wires a {@link CallbackAdapter} so persistence operations and result delivery
-   * are delegated to the owning {@link ClientGet} instance.
-   *
-   * @param request owning request to receive callbacks and resume signals; must not be {@code
-   *     null}.
-   * @param uri target {@link FreenetURI} to fetch; must not be {@code null}.
-   * @param fetchContext fetch configuration that defines size limits and filters; must not be
-   *     {@code null}.
-   * @param priorityClass scheduler priority class for the request.
-   * @return a {@link ClientGetterRequest} configured for the provided request context.
-   */
-  static ClientGetterRequest createGetterRequest(
-      ClientGet request, FreenetURI uri, FetchContext fetchContext, short priorityClass) {
-    ClientGetCallback callback = new CallbackAdapter(request);
-    return new ClientGetterRequest(callback, uri, fetchContext, priorityClass);
-  }
-
-  /**
-   * Builds a {@link ClientGetter} for the supplied request settings.
-   *
-   * <p>This convenience wrapper keeps the request class free from option and flag types while still
-   * delegating to {@link #createGetter} for the actual fetcher creation.
-   *
-   * @param request owning request that receives fetch callbacks.
-   * @param returnBucket bucket holding returned data when not discarded.
-   * @param fetchRuntimeSupport fetch runtime support used to allocate buckets when required.
-   * @return a configured {@link ClientGetter} ready to run.
-   * @throws IOException if bucket allocation fails.
-   */
-  static ClientGetter createGetterForRequest(
-      ClientGet request, Bucket returnBucket, FcpFetchRuntimeSupport fetchRuntimeSupport)
-      throws IOException {
-    ClientGetterRequest getterRequest =
-        createGetterRequest(
-            request, request.getURI(), request.fetchContextForGetter(), request.getPriority());
-    ClientGetterOptions options =
-        new ClientGetterOptions(
-            returnBucket,
-            null,
-            false,
-            request.initialMetadataBucket(),
-            request.extensionCheckForGetter());
-    ClientGet.ReturnType returnType = request.returnTypeForGetter();
-    ClientGetGetterFlags flags =
-        new ClientGetGetterFlags(
-            returnType == ClientGet.ReturnType.NONE,
-            request.binaryBlobRequested(),
-            request.persistence == ClientRequest.Persistence.FOREVER);
-    return createGetter(getterRequest, options, flags, fetchRuntimeSupport);
-  }
-
-  /**
-   * Creates a configured {@link ClientGetter} for a {@link ClientGet} request.
-   *
-   * <p>The factory chooses the correct return bucket strategy and optionally sets up a {@link
-   * BinaryBlobWriter} when Binary Blob recording is requested. If Binary Blob recording is enabled
-   * and the options do not specify a return bucket, the method uses {@code fetchRuntimeSupport} to
-   * allocate a bucket sized to {@link FetchContext#getMaxOutputLength()}. When {@link
-   * ClientGetGetterFlags#discardData()} is true and Binary Blob is disabled, the returned fetcher
-   * writes into a shared {@link NullBucket} instead of the provided bucket.
-   *
-   * @param request request parameters including the callback, URI, and fetch context.
-   * @param options return bucket, metadata, and extension options for the fetcher.
-   * @param flags behavior flags for Binary Blob recording and discard handling.
-   * @param fetchRuntimeSupport fetch runtime support used to allocate buckets when needed; required
-   *     if Binary Blob recording is enabled and no return bucket is supplied.
-   * @return a fully constructed {@link ClientGetter} ready to start.
-   * @throws IOException if bucket allocation fails or underlying stream setup fails.
-   * @throws NullPointerException if {@code fetchRuntimeSupport} is required but not provided.
-   */
-  static ClientGetter createGetter(
-      ClientGetterRequest request,
-      ClientGetterOptions options,
-      ClientGetGetterFlags flags,
-      FcpFetchRuntimeSupport fetchRuntimeSupport)
-      throws IOException {
-    Bucket returnBucket = options.returnBucket();
-    Bucket initialMetadata = options.initialMetadata();
-    String extensionCheck = options.forceCompatibleExtension();
-    Bucket blobBucket = returnBucket;
-    if (flags.binaryBlob()) {
-      if (blobBucket == null) {
-        Objects.requireNonNull(fetchRuntimeSupport, "fetchRuntimeSupport");
-        blobBucket =
-            fetchRuntimeSupport.allocateBinaryBlobBucket(
-                request.ctx().getMaxOutputLength(), flags.persistenceForever());
-      }
-      return new ClientGetter(
-          request,
-          new ClientGetterOptions(
-              NULL_BUCKET,
-              new BinaryBlobWriter(blobBucket),
-              false,
-              initialMetadata,
-              extensionCheck));
-    }
-    if (flags.discardData()) {
-      returnBucket = NULL_BUCKET;
-    }
-    return new ClientGetter(
-        request,
-        new ClientGetterOptions(returnBucket, null, false, initialMetadata, extensionCheck));
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetHelpers.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetHelpers.java
@@ -20,6 +20,9 @@ final class ClientGetHelpers {
   /** Helper that applies success, failure, and cleanup transitions to the request. */
   private final ClientGetLifecycle lifecycle;
 
+  /** Helper that exposes payload-oriented accessors without bloating the request class. */
+  private final ClientGetPayloadAccess payloadAccess;
+
   /** Helper that captures the request state used to build status snapshots. */
   private final ClientGetStatusSnapshotBuilder statusSnapshotBuilder;
 
@@ -41,6 +44,7 @@ final class ClientGetHelpers {
   ClientGetHelpers(ClientGet request) {
     messageReplay = new ClientGetMessageReplay(request);
     lifecycle = new ClientGetLifecycle(request);
+    payloadAccess = new ClientGetPayloadAccess(request);
     statusSnapshotBuilder = new ClientGetStatusSnapshotBuilder(request);
     restartCoordinator = new ClientGetRestartCoordinator(request);
     statusReporter = new ClientGetStatusReporter(request);
@@ -62,6 +66,15 @@ final class ClientGetHelpers {
    */
   ClientGetLifecycle lifecycle() {
     return lifecycle;
+  }
+
+  /**
+   * Returns the helper that exposes payload data and delivery-mode views.
+   *
+   * @return payload helper used for bucket, size, MIME, and return-type access
+   */
+  ClientGetPayloadAccess payloadAccess() {
+    return payloadAccess;
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
@@ -3,8 +3,6 @@ package network.crypta.clients.fcp;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ResumeFailedException;
 import org.slf4j.Logger;
@@ -61,11 +59,11 @@ final class ClientGetLifecycle {
    * requests, the payload length and MIME type are derived from the blob bucket.
    *
    * @param result result wrapper providing MIME metadata and the decoded data bucket.
-   * @param state client getter instance used to access BinaryBlob buckets when required.
+   * @param state execution handle used to access Binary Blob buckets when required.
    */
-  void onSuccess(FetchResult result, ClientGetter state) {
+  void onSuccess(FetchResult result, ClientGetExecution state) {
     LOG.debug("Succeeded: {}", request.identifier);
-    Bucket data = request.binaryBlobRequested() ? state.getBlobBucket() : result.asBucket();
+    Bucket data = request.binaryBlobRequested() ? state.blobBucket() : result.asBucket();
     ClientGetState requestState = request.state();
     synchronized (request.persistenceLock()) {
       if (requestState.hasSucceeded()) {
@@ -108,17 +106,11 @@ final class ClientGetLifecycle {
    * ResumeFailedException} to signal that the request should restart instead of trusting corrupted
    * state.
    *
-   * @param context client context used for migration validation callbacks.
    * @param completionTime epoch milliseconds to record as the completion timestamp.
    * @param data bucket holding the payload when {@link ClientGet.ReturnType#DIRECT} applies.
    * @throws ResumeFailedException when stored output does not match the recorded metadata.
-   * @throws NullPointerException when {@code context} is {@code null}.
    */
-  void setSuccessForMigration(ClientContext context, long completionTime, Bucket data)
-      throws ResumeFailedException {
-    if (context == null) {
-      throw new NullPointerException("context");
-    }
+  void setSuccessForMigration(long completionTime, Bucket data) throws ResumeFailedException {
     ClientGetState requestState = request.state();
     synchronized (request.persistenceLock()) {
       requestState.setSucceeded(true);
@@ -126,15 +118,19 @@ final class ClientGetLifecycle {
       request.finished = true;
       request.completionTime = completionTime;
       ClientGet.ReturnType returnType = request.returnTypeForReplay();
+      if (returnType == null) {
+        throw new ResumeFailedException("Success but return type is missing");
+      }
+      java.io.File targetFile = request.targetFileForLifecycle();
       switch (returnType) {
         case ClientGet.ReturnType type when type == ClientGet.ReturnType.NONE -> {
           // Nothing to validate.
         }
         case ClientGet.ReturnType type
             when type == ClientGet.ReturnType.DISK
-                && (!request.targetFileForLifecycle().exists()
-                    || request.targetFileForLifecycle().length()
-                        != requestState.getFoundDataLength()) ->
+                && (targetFile == null
+                    || !targetFile.exists()
+                    || targetFile.length() != requestState.getFoundDataLength()) ->
             throw new ResumeFailedException("Success but target file doesn't exist or isn't valid");
         case ClientGet.ReturnType type when type == ClientGet.ReturnType.DISK -> {
           // Validation already passed.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPayloadAccess.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPayloadAccess.java
@@ -1,0 +1,136 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Read-only payload view and bucket adapter for {@link ClientGet}.
+ *
+ * <p>This helper pulls the small amount of payload-oriented logic out of {@link ClientGet} so the
+ * request class does not need to know how direct-return buckets, disk-return wrappers, and simple
+ * payload metadata are exposed to callers. It does not own any durable state beyond a reference to
+ * the request. Instead, it interprets the request's current return mode and the state snapshot each
+ * time a caller asks for bucket or metadata information.
+ *
+ * <p>The class also preserves an important distinction in the GET flow: client-facing disk buckets
+ * are opened read-only, while persistence and resume code may need a writable wrapper around the
+ * same destination path. Serialization-only request instances can have a {@code null} return type,
+ * so the bucket-building methods treat that state as "no bucket available" rather than throwing.
+ */
+final class ClientGetPayloadAccess {
+  /** Request whose current return mode and payload state are being exposed. */
+  private final ClientGet request;
+
+  /**
+   * Creates a payload view for one request.
+   *
+   * @param request request whose payload-oriented state should be exposed.
+   */
+  ClientGetPayloadAccess(ClientGet request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  /**
+   * Returns whether the request is configured for direct return delivery.
+   *
+   * @return {@code true} when payload bytes are returned through the direct bucket path.
+   */
+  boolean isDirect() {
+    return request.returnTypeForGetter() == ClientGet.ReturnType.DIRECT;
+  }
+
+  /**
+   * Returns whether the request is configured for disk return delivery.
+   *
+   * @return {@code true} when payload bytes are returned to a disk file.
+   */
+  boolean isToDisk() {
+    return request.returnTypeForGetter() == ClientGet.ReturnType.DISK;
+  }
+
+  /**
+   * Returns the best-known payload size.
+   *
+   * <p>The request state records the found data length once the runtime has learned it. Until then,
+   * this method returns {@code -1} to preserve the existing unknown-size contract.
+   *
+   * @return payload size in bytes, or {@code -1} when the size is still unknown.
+   */
+  long getDataSize() {
+    if (request.state().getFoundDataLength() > 0) {
+      return request.state().getFoundDataLength();
+    }
+    return -1;
+  }
+
+  /**
+   * Returns the best-known MIME type recorded on the request state.
+   *
+   * @return MIME type string, or {@code null} when none is known yet.
+   */
+  String getMimeType() {
+    return request.state().getFoundDataMimeType();
+  }
+
+  /**
+   * Returns the bucket that should be exposed to ordinary callers.
+   *
+   * @return direct-return bucket, read-only disk bucket, or {@code null} when the request has no
+   *     caller-visible bucket.
+   */
+  Bucket getBucket() {
+    return makeClientBucket();
+  }
+
+  /**
+   * Builds the caller-facing bucket view for the current request state.
+   *
+   * <p>Direct-return requests reuse the runtime-populated in-memory bucket under the request lock.
+   * Disk-return requests wrap the destination path in a read-only file bucket so callers can
+   * inspect the result without gaining write access through this accessor. Requests in
+   * serialization-only state or with {@link ClientGet.ReturnType#NONE} simply return {@code null}.
+   *
+   * @return caller-facing bucket view, or {@code null} when no such bucket exists.
+   */
+  Bucket makeClientBucket() {
+    ClientGet.ReturnType returnType = request.returnTypeForGetter();
+    if (returnType == null) {
+      return null;
+    }
+    return switch (returnType) {
+      case DIRECT -> {
+        synchronized (request.persistenceLock()) {
+          yield request.state().getReturnBucketDirect();
+        }
+      }
+      case DISK -> ClientGetGetterFactory.diskBucket(request.getDestFilename(), true);
+      default -> null;
+    };
+  }
+
+  /**
+   * Builds the bucket view used by persistence and resume code.
+   *
+   * <p>This differs from {@link #makeClientBucket()} only for disk-return requests. Persistence
+   * must be able to reopen the destination file in writable mode when reconstructing the request
+   * state, so the disk wrapper here is not forced to read-only.
+   *
+   * @return persistence bucket view, or {@code null} when the request has no persisted payload
+   *     bucket.
+   */
+  Bucket makePersistenceBucket() {
+    ClientGet.ReturnType returnType = request.returnTypeForGetter();
+    if (returnType == null) {
+      return null;
+    }
+    return switch (returnType) {
+      case DIRECT -> {
+        synchronized (request.persistenceLock()) {
+          yield request.state().getReturnBucketDirect();
+        }
+      }
+      case DISK -> ClientGetGetterFactory.diskBucket(request.getDestFilename(), false);
+      default -> null;
+    };
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
@@ -4,9 +4,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
-import network.crypta.client.FetchContext;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
@@ -68,7 +65,7 @@ final class ClientGetPersistenceCodec {
    *
    * @param dis input stream positioned at the serialized client-detail payload.
    * @param reqID identifier tuple describing the request owner and scope.
-   * @param context client context providing factories for restoration.
+   * @param fetchRuntimeSupport fetch runtime support providing factories for restoration.
    * @param checker checksum helper verifying embedded bucket sections.
    * @return reconstructed {@link ClientGet} instance ready for registration.
    * @throws StorageFormatException when magic or version checks fail.
@@ -76,9 +73,13 @@ final class ClientGetPersistenceCodec {
    * @throws ResumeFailedException when state cannot be safely resumed.
    */
   static ClientGet restartFrom(
-      DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
+      DataInputStream dis,
+      RequestIdentifier reqID,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
+      network.crypta.client.async.ClientContext context,
+      ChecksumChecker checker)
       throws StorageFormatException, IOException, ResumeFailedException {
-    return new ClientGet(dis, reqID, context, checker);
+    return new ClientGet(dis, reqID, fetchRuntimeSupport, context, checker);
   }
 
   /**
@@ -106,7 +107,7 @@ final class ClientGetPersistenceCodec {
     }
     dos.writeBoolean(request.binaryBlobRequested());
     try (DataOutputStream ctxStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-      request.fetchContextForGetter().writeTo(ctxStream);
+      request.runtimeFetchSupport().encodeFetchConfig(request.fetchConfig(), ctxStream);
     }
     String extensionCheck = request.extensionCheckForGetter();
     if (extensionCheck != null) {
@@ -149,7 +150,7 @@ final class ClientGetPersistenceCodec {
       }
     }
     try (DataOutputStream progressStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-      if (((ClientGetter) request.getClientRequest()).writeTrivialProgress(progressStream)) {
+      if (request.execution().writeTrivialProgress(progressStream)) {
         synchronized (request.persistenceLock()) {
           writeTransientProgressFields(request, progressStream);
         }
@@ -160,14 +161,13 @@ final class ClientGetPersistenceCodec {
   /**
    * Reads core configuration and metadata needed to reconstruct a {@link ClientGet}.
    *
-   * <p>This method validates the header, parses the return type, fetch context, optional extension
-   * check, and initial metadata bucket. It does not restore progress or final success/failure
-   * state; that work happens in {@link #restoreState(ClientGet, DataInputStream, RequestIdentifier,
-   * ClientContext, ChecksumChecker)}.
+   * <p>This method validates the header, parses the return type, detached fetch configuration,
+   * optional extension check, and initial metadata bucket. It does not restore progress or final
+   * success/failure state; that work happens in {@link #restoreState(ClientGet, DataInputStream,
+   * RequestIdentifier, FcpFetchRuntimeSupport, ChecksumChecker)}.
    *
-   * @param request the request instance that will own the reconstructed state.
    * @param dis input stream positioned at the client-detail payload.
-   * @param context client context providing bucket factories and event handlers.
+   * @param fetchRuntimeSupport fetch runtime support providing bucket factories and event handlers.
    * @param checker checksum helper used to read embedded bucket data.
    * @return basic restore data bundle with configuration and metadata buckets.
    * @throws IOException when reading from the stream fails.
@@ -175,53 +175,56 @@ final class ClientGetPersistenceCodec {
    * @throws ResumeFailedException when metadata buckets fail to resume.
    */
   static BasicRestoreData readBasicRestoreData(
-      ClientGet request, DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      DataInputStream dis, FcpFetchRuntimeSupport fetchRuntimeSupport, ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
     validateClientDetailHeader(dis);
     FreenetURI uri = parseUri(dis.readUTF());
     ClientGet.ReturnType returnType = parseReturnType(dis.readShort());
     File targetFile = returnType == ClientGet.ReturnType.DISK ? new File(dis.readUTF()) : null;
     boolean binaryBlob = dis.readBoolean();
-    FetchContext fctx = ClientGetGetterFactory.readFetchContextOrDefault(dis, context, checker);
-    fctx.getEventProducer().addEventListener(new ClientGetEventHandling(request));
+    ClientGetFetchConfig fetchConfig =
+        ClientGetPersistenceIO.readFetchConfigOrDefault(dis, fetchRuntimeSupport, checker);
     String extensionCheck = dis.readBoolean() ? dis.readUTF() : null;
-    Bucket initialMetadata = ClientGetGetterFactory.readInitialMetadata(dis, context, checker);
+    Bucket initialMetadata =
+        ClientGetPersistenceIO.readInitialMetadata(dis, fetchRuntimeSupport, checker);
     return new BasicRestoreData(
-        uri, returnType, targetFile, binaryBlob, fctx, extensionCheck, initialMetadata);
+        uri, returnType, targetFile, binaryBlob, fetchConfig, extensionCheck, initialMetadata);
   }
 
   /**
    * Restores progress or terminal state for a {@link ClientGet} from the stream.
    *
    * <p>If the request is already marked as finished, this method reads the final success or failure
-   * payload and updates the request state accordingly. Otherwise, it creates a getter suitable for
-   * resuming and delegates to the lower-level progress restoration helpers. The returned getter is
-   * owned by the caller and should be installed on the request.
+   * payload and updates the request state accordingly. Otherwise, it creates an execution suitable
+   * for resuming and delegates to the lower-level progress restoration helpers. The returned
+   * execution is owned by the caller and should be installed on the request.
    *
    * @param request request whose mutable state is updated from persistence.
    * @param dis input stream positioned at the progress or terminal section.
    * @param reqID identifier tuple describing the request owner and scope.
-   * @param context client context used to rehydrate buckets and caches.
+   * @param fetchRuntimeSupport fetch runtime support used to rehydrate buckets and caches.
    * @param checker checksum helper for embedded bucket segments.
-   * @return restored {@link ClientGetter}, or {@code null} when already finished.
+   * @return restored execution handle, or {@code null} when already finished.
    * @throws IOException when stream I/O fails during restoration.
    * @throws StorageFormatException when encoded values are invalid.
    * @throws ResumeFailedException when the request must restart instead of resuming.
    */
-  static ClientGetter restoreState(
+  static ClientGetExecution restoreState(
       ClientGet request,
       DataInputStream dis,
       RequestIdentifier reqID,
-      ClientContext context,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
       ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
     if (request.finished) {
-      restoreFinishedState(request, dis, reqID, context, checker);
+      restoreFinishedState(request, dis, reqID, fetchRuntimeSupport, checker);
       return null;
     }
-    ClientGetter inProgressGetter = request.makeGetterForPersistence(request.makeBucket(false));
-    ClientGetGetterFactory.restoreInProgressState(dis, context, checker, inProgressGetter, request);
-    return inProgressGetter;
+    ClientGetExecution inProgressExecution =
+        request.makeExecutionForPersistence(fetchRuntimeSupport, request.makePersistenceBucket());
+    ClientGetPersistenceIO.restoreInProgressState(
+        dis, fetchRuntimeSupport, checker, inProgressExecution, request);
+    return inProgressExecution;
   }
 
   /**
@@ -294,7 +297,7 @@ final class ClientGetPersistenceCodec {
    * @param request request whose terminal state is being reconstructed.
    * @param dis input stream positioned at the finished-state payload.
    * @param reqID identifier tuple used for failure message decoding.
-   * @param context client context used to restore buckets and metadata.
+   * @param fetchRuntimeSupport fetch runtime support used to restore buckets and metadata.
    * @param checker checksum helper verifying embedded bucket sections.
    * @throws IOException when stream I/O fails while reading data.
    * @throws StorageFormatException when encoded, data is invalid or incompatible.
@@ -304,7 +307,7 @@ final class ClientGetPersistenceCodec {
       ClientGet request,
       DataInputStream dis,
       RequestIdentifier reqID,
-      ClientContext context,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
       ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
     ClientGetState state = request.state();
@@ -313,7 +316,8 @@ final class ClientGetPersistenceCodec {
     if (state.hasSucceeded()) {
       if (request.returnTypeForGetter() == ClientGet.ReturnType.DIRECT) {
         Bucket restoredBucket =
-            ClientGetGetterFactory.restoreCompletedDirectBucketOrNull(dis, context, checker);
+            ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(
+                dis, fetchRuntimeSupport, checker);
         if (restoredBucket != null) {
           state.setReturnBucketDirect(restoredBucket);
         } else {
@@ -324,12 +328,12 @@ final class ClientGetPersistenceCodec {
       }
     } else {
       GetFailedMessage restoredMessage =
-          ClientGetGetterFactory.restoreFailureMessageOrNull(
+          ClientGetPersistenceIO.restoreFailureMessageOrNull(
               dis,
               reqID,
               state.getFoundDataLength(),
               state.getFoundDataMimeType(),
-              context,
+              fetchRuntimeSupport,
               checker);
       if (restoredMessage != null) {
         state.setFailedMessage(restoredMessage);
@@ -413,9 +417,9 @@ final class ClientGetPersistenceCodec {
    * Bundles the minimal configuration needed to reconstruct a {@link ClientGet}.
    *
    * <p>The container holds immutable values parsed from persistence, such as the target URI, return
-   * type, output destination, and fetch context. It does not carry transient progress or terminal
-   * success/failure state. Callers use these values to populate the request before restoring
-   * progress and completion metadata.
+   * type, output destination, and detached fetch configuration. It does not carry transient
+   * progress or terminal success/failure state. Callers use these values to populate the request
+   * before restoring progress and completion metadata.
    */
   static final class BasicRestoreData {
     /** The target URI parsed from the persistence stream. */
@@ -430,8 +434,10 @@ final class ClientGetPersistenceCodec {
     /** True when the request is configured for BinaryBlob output instead of raw buckets. */
     private final boolean binaryBlob;
 
-    /** Fetch context reconstructed from the persistence stream and ready for reuse. */
-    private final FetchContext fetchContext;
+    /**
+     * Detached fetch configuration reconstructed from the persistence stream and ready for reuse.
+     */
+    private final ClientGetFetchConfig fetchConfig;
 
     /** Optional filename extension hint used to validate filtering output. */
     private final String extensionCheck;
@@ -446,7 +452,7 @@ final class ClientGetPersistenceCodec {
      * @param returnType return type describing delivery semantics; must be non-null.
      * @param targetFile disk target when return type is disk; otherwise {@code null}.
      * @param binaryBlob true when BinaryBlob output is enabled for the request.
-     * @param fetchContext reconstructed fetch context for the request.
+     * @param fetchConfig reconstructed detached fetch configuration for the request.
      * @param extensionCheck optional extension hint used for validation, or {@code null}.
      * @param initialMetadata optional metadata bucket, or {@code null} when absent.
      */
@@ -455,14 +461,14 @@ final class ClientGetPersistenceCodec {
         ClientGet.ReturnType returnType,
         File targetFile,
         boolean binaryBlob,
-        FetchContext fetchContext,
+        ClientGetFetchConfig fetchConfig,
         String extensionCheck,
         Bucket initialMetadata) {
       this.uri = uri;
       this.returnType = returnType;
       this.targetFile = targetFile;
       this.binaryBlob = binaryBlob;
-      this.fetchContext = fetchContext;
+      this.fetchConfig = fetchConfig;
       this.extensionCheck = extensionCheck;
       this.initialMetadata = initialMetadata;
     }
@@ -504,12 +510,12 @@ final class ClientGetPersistenceCodec {
     }
 
     /**
-     * Returns the fetch context reconstructed from persistence.
+     * Returns the detached fetch configuration reconstructed from persistence.
      *
-     * @return fetch context ready to be used by the restored request.
+     * @return detached fetch configuration ready to be used by the restored request.
      */
-    FetchContext fetchContext() {
-      return fetchContext;
+    ClientGetFetchConfig fetchConfig() {
+      return fetchConfig;
     }
 
     /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -106,8 +107,9 @@ final class ClientGetPersistenceCodec {
       dos.writeUTF(request.targetFileForLifecycle().toString());
     }
     dos.writeBoolean(request.binaryBlobRequested());
+    byte[] encodedFetchConfig = encodedFetchConfigForPersistence(request);
     try (DataOutputStream ctxStream = ClientGetGetterFactory.checksummedWriter(dos, checker)) {
-      request.runtimeFetchSupport().encodeFetchConfig(request.fetchConfig(), ctxStream);
+      ctxStream.write(encodedFetchConfig);
     }
     String extensionCheck = request.extensionCheckForGetter();
     if (extensionCheck != null) {
@@ -284,6 +286,40 @@ final class ClientGetPersistenceCodec {
     } catch (IllegalArgumentException _) {
       throw new StorageFormatException("Bad return type " + code);
     }
+  }
+
+  private static byte[] encodedFetchConfigForPersistence(ClientGet request) throws IOException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = runtimeFetchSupportForPersistence(request);
+    if (fetchRuntimeSupport != null) {
+      try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+          DataOutputStream encoded = new DataOutputStream(buffer)) {
+        fetchRuntimeSupport.encodeFetchConfig(request.fetchConfig(), encoded);
+        byte[] encodedFetchConfig = buffer.toByteArray();
+        request.setPersistedFetchConfigEncoding(encodedFetchConfig);
+        return encodedFetchConfig;
+      }
+    }
+    byte[] cachedEncoding = request.persistedFetchConfigEncoding();
+    if (cachedEncoding != null) {
+      return cachedEncoding;
+    }
+    throw new IOException("No runtime fetch support or cached fetch configuration encoding");
+  }
+
+  private static FcpFetchRuntimeSupport runtimeFetchSupportForPersistence(ClientGet request) {
+    FcpFetchRuntimeSupport runtimeFetchSupport = request.runtimeFetchSupport();
+    if (runtimeFetchSupport != null) {
+      return runtimeFetchSupport;
+    }
+    PersistentRequestClient client = request.client;
+    if (client == null) {
+      return null;
+    }
+    FCPConnectionHandler connection = client.getConnection();
+    if (connection == null) {
+      return null;
+    }
+    return connection.getServer().fetchRuntimeSupport();
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
@@ -2,13 +2,9 @@ package network.crypta.clients.fcp;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import network.crypta.client.FetchContext;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
 import network.crypta.support.api.Bucket;
-import network.crypta.support.io.BucketTools;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
 import org.slf4j.Logger;
@@ -35,7 +31,7 @@ final class ClientGetPersistenceIO {
    * Creates a checksummed reader that wraps the supplied stream.
    *
    * @param dis input stream positioned at the checksummed payload.
-   * @param context client context providing a temporary bucket factory.
+   * @param fetchRuntimeSupport fetch runtime support providing temporary bucket services.
    * @param checker checksum helper used to verify the payload.
    * @param maxLength maximum length accepted for the checksummed payload.
    * @return a {@link DataInputStream} that validates checksums on close.
@@ -43,16 +39,12 @@ final class ClientGetPersistenceIO {
    * @throws StorageFormatException if checksum verification fails.
    */
   static DataInputStream openChecksummed(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker, long maxLength)
+      DataInputStream dis,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
+      ChecksumChecker checker,
+      long maxLength)
       throws IOException, StorageFormatException {
-    try {
-      return new DataInputStream(
-          checker.checksumReaderWithLength(dis, context.tempBucketFactory, maxLength));
-    } catch (ChecksumFailedException e) {
-      StorageFormatException storageFormatException = new StorageFormatException("Checksum failed");
-      storageFormatException.initCause(e);
-      throw storageFormatException;
-    }
+    return fetchRuntimeSupport.openChecksummed(dis, checker, maxLength);
   }
 
   private static boolean isChecksumFailure(StorageFormatException exception) {
@@ -60,18 +52,18 @@ final class ClientGetPersistenceIO {
   }
 
   /**
-   * Restores the {@link FetchContext}, or returns defaults when recovery fails.
+   * Restores detached fetch configuration or returns defaults when recovery fails.
    *
    * @param dis input stream positioned at the fetch context data.
-   * @param context client context providing default fetch settings.
+   * @param fetchRuntimeSupport fetch runtime support providing default fetch settings.
    * @param checker checksum helper used to verify the serialized block.
-   * @return restored {@link FetchContext} or the default when recovery fails.
+   * @return restored detached fetch configuration or the default when recovery fails.
    */
-  static FetchContext readFetchContextOrDefault(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker) {
+  static ClientGetFetchConfig readFetchConfigOrDefault(
+      DataInputStream dis, FcpFetchRuntimeSupport fetchRuntimeSupport, ChecksumChecker checker) {
     try (DataInputStream inner =
-        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
-      return new FetchContext(inner);
+        openChecksummed(dis, fetchRuntimeSupport, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
+      return fetchRuntimeSupport.decodeFetchConfig(inner);
     } catch (IOException e) {
       LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE, e);
     } catch (StorageFormatException e) {
@@ -81,14 +73,14 @@ final class ClientGetPersistenceIO {
         LOG.error(FETCH_SETTINGS_FALLBACK_MESSAGE, e);
       }
     }
-    return context.getDefaultPersistentFetchContext();
+    return fetchRuntimeSupport.defaultPersistentFetchConfig();
   }
 
   /**
    * Restores a bucket from a checksummed payload.
    *
    * @param dis input stream positioned at the bucket payload.
-   * @param context client context owning persistent bucket services.
+   * @param fetchRuntimeSupport fetch runtime support owning persistent bucket services.
    * @param checker checksum helper used to verify the bucket metadata.
    * @return restored bucket from the checksummed payload.
    * @throws IOException if the underlying stream cannot be read.
@@ -96,15 +88,11 @@ final class ClientGetPersistenceIO {
    * @throws ResumeFailedException if bucket restoration fails.
    */
   static Bucket restoreBucketFromChecksummedBlock(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      DataInputStream dis, FcpFetchRuntimeSupport fetchRuntimeSupport, ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
     try (DataInputStream inner =
-        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
-      return BucketTools.restoreFrom(
-          inner,
-          context.persistentFG,
-          context.getPersistentFileTracker(),
-          context.getPersistentMasterSecret());
+        openChecksummed(dis, fetchRuntimeSupport, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
+      return fetchRuntimeSupport.restorePersistentBucket(inner);
     }
   }
 
@@ -112,7 +100,7 @@ final class ClientGetPersistenceIO {
    * Restores an initial metadata bucket for the request, if present.
    *
    * @param dis input stream positioned at the metadata bucket marker.
-   * @param context client context owning persistent bucket services.
+   * @param fetchRuntimeSupport fetch runtime support owning persistent bucket services.
    * @param checker checksum helper used to verify the bucket metadata.
    * @return restored bucket or {@code null} when no metadata marker was set.
    * @throws IOException if the underlying stream cannot be read.
@@ -120,13 +108,13 @@ final class ClientGetPersistenceIO {
    * @throws ResumeFailedException if bucket restoration fails.
    */
   static Bucket readInitialMetadata(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      DataInputStream dis, FcpFetchRuntimeSupport fetchRuntimeSupport, ChecksumChecker checker)
       throws IOException, StorageFormatException, ResumeFailedException {
     if (!dis.readBoolean()) {
       return null;
     }
     try {
-      return restoreBucketFromChecksummedBlock(dis, context, checker);
+      return restoreBucketFromChecksummedBlock(dis, fetchRuntimeSupport, checker);
     } catch (StorageFormatException e) {
       if (isChecksumFailure(e)) {
         StorageFormatException storageFormatException =
@@ -143,16 +131,16 @@ final class ClientGetPersistenceIO {
    * Restores a completed direct bucket from persistent storage.
    *
    * @param dis input stream positioned at the bucket payload.
-   * @param context client context owning persistent bucket services.
+   * @param fetchRuntimeSupport fetch runtime support owning persistent bucket services.
    * @param checker checksum helper used to verify the bucket metadata.
    * @return restored bucket, or {@code null} when restoration failed.
    * @throws ResumeFailedException if bucket restoration fails.
    */
   static Bucket restoreCompletedDirectBucketOrNull(
-      DataInputStream dis, ClientContext context, ChecksumChecker checker)
+      DataInputStream dis, FcpFetchRuntimeSupport fetchRuntimeSupport, ChecksumChecker checker)
       throws ResumeFailedException {
     try {
-      return restoreBucketFromChecksummedBlock(dis, context, checker);
+      return restoreBucketFromChecksummedBlock(dis, fetchRuntimeSupport, checker);
     } catch (IOException | StorageFormatException e) {
       LOG.error(COMPLETED_DOWNLOAD_RESTORE_FAILURE, e);
       return null;
@@ -166,7 +154,7 @@ final class ClientGetPersistenceIO {
    * @param reqID request identifier used to populate the failure message.
    * @param foundDataLength recorded data length for the request.
    * @param foundDataMimeType recorded MIME type for the request.
-   * @param context client context providing checksum helpers.
+   * @param fetchRuntimeSupport fetch runtime support providing checksum helpers.
    * @param checker checksum helper used to verify the payload.
    * @return restored {@link GetFailedMessage} or {@code null} when recovery fails.
    */
@@ -175,10 +163,10 @@ final class ClientGetPersistenceIO {
       RequestIdentifier reqID,
       long foundDataLength,
       String foundDataMimeType,
-      ClientContext context,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
       ChecksumChecker checker) {
     try (DataInputStream inner =
-        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
+        openChecksummed(dis, fetchRuntimeSupport, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
       return new GetFailedMessage(inner, reqID, foundDataLength, foundDataMimeType);
     } catch (IOException | StorageFormatException e) {
       LOG.error("Unable to restore reason for failure, restarting request", e);
@@ -190,22 +178,22 @@ final class ClientGetPersistenceIO {
    * Restores in-progress getter state along with transient progress fields.
    *
    * @param dis input stream positioned at the progress data block.
-   * @param context client context used to resume the getter.
+   * @param fetchRuntimeSupport fetch runtime support used to resume the execution.
    * @param checker checksum helper used to validate the block.
-   * @param inProgressGetter getter instance to resume.
-   * @param request request instance for restoring transient fields.
+   * @param execution execution handle to resume.
+   * @param request the request instance for restoring transient fields.
    * @throws StorageFormatException if the serialized state is invalid.
    */
   static void restoreInProgressState(
       DataInputStream dis,
-      ClientContext context,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
       ChecksumChecker checker,
-      ClientGetter inProgressGetter,
+      ClientGetExecution execution,
       ClientGet request)
       throws StorageFormatException {
     try (DataInputStream inner =
-        openChecksummed(dis, context, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
-      if (inProgressGetter.resumeFromTrivialProgress(inner, context)) {
+        openChecksummed(dis, fetchRuntimeSupport, checker, CHECKSUMMED_BLOCK_MAX_LENGTH)) {
+      if (execution.resumeFromTrivialProgress(inner)) {
         ClientGetPersistenceCodec.readTransientProgressFields(request, inner);
       }
     } catch (IOException e) {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetRestartCoordinator.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetRestartCoordinator.java
@@ -1,10 +1,7 @@
 package network.crypta.clients.fcp;
 
 import java.util.Objects;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.keys.FreenetURI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,21 +11,21 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The coordinator encapsulates the restart state machine for GET requests: it checks restart
  * eligibility, clears failure metadata, applies redirect updates, and notifies cache listeners. It
- * does not start or stop the underlying {@link ClientGetter} directly; instead it delegates to the
- * getter and then updates the request's bookkeeping fields to reflect the new attempt.
+ * does not start or stop the underlying live execution directly; instead, it delegates to the
+ * execution handle and then updates the request's bookkeeping fields to reflect the new attempt.
  *
  * <p>The class is intentionally thin and relies on the {@link ClientGet} request lock to guard
  * state changes. Callers should treat the coordinator as request-scoped and not reuse it across
  * different requests.
  *
  * <ul>
- *   <li><strong>Eligibility</strong>: validates finished state and getter restart capability.
+ *   <li><strong>Eligibility</strong>: validates finished state and execution restart capability.
  *   <li><strong>State reset</strong>: clears cached failures, progress, and compatibility hints.
  *   <li><strong>Redirects</strong>: applies permanent redirect URIs when available.
  * </ul>
  *
  * @see ClientGet
- * @see ClientGetter
+ * @see ClientGetExecution
  */
 final class ClientGetRestartCoordinator {
   /** Logger for restart eligibility and flow diagnostics. */
@@ -54,8 +51,8 @@ final class ClientGetRestartCoordinator {
    * Determines whether the request can be restarted at this time.
    *
    * <p>A request is restartable only after it has finished, has not succeeded, and the underlying
-   * {@link ClientGetter} reports that it supports restart semantics. The method is side-effect-free
-   * and logs the reason for non-restartability at debug level.
+   * execution reports that it supports restart semantics. The method is side-effect-free and logs
+   * the reason for non-restartability at debug level.
    *
    * @return {@code true} when the request is finished, failed, and restartable.
    */
@@ -68,33 +65,32 @@ final class ClientGetRestartCoordinator {
       LOG.debug("Cannot restart because succeeded for {}", request.identifier);
       return false;
     }
-    return getter().canRestart();
+    return request.execution().canRestart();
   }
 
   /**
    * Attempts to restart the request and update cached state for a new attempt.
    *
    * <p>The method clears failure metadata, optionally disables filtering for the next run, and
-   * delegates the restart to the underlying {@link ClientGetter}. If a permanent redirect is stored
-   * in the failure message, it is applied before restart, so the new attempt uses the redirected
-   * URI. Any restart failure is routed through {@link ClientGet#onFailure(FetchException)} to keep
-   * error handling consistent with normal fetch errors.
+   * delegates the restart to the underlying live execution. If a permanent redirect is stored in
+   * the failure message, it is applied before restart, so the new attempt uses the redirected URI.
+   * Any restart failure is routed through {@link ClientGet#onFailure(FetchException)} to keep error
+   * handling consistent with normal fetch errors.
    *
-   * @param context client context providing schedulers and bucket factories.
    * @param disableFilterData true to disable filtering for the next attempt.
-   * @return {@code true} when the restart is accepted and scheduled by the getter.
+   * @return {@code true} when the restart is accepted and scheduled by the execution.
    */
-  boolean restart(ClientContext context, boolean disableFilterData) {
+  boolean restart(boolean disableFilterData) {
     if (!canRestart()) return false;
-    FetchContext fetchContext = request.fetchContextForGetter();
-    if (fetchContext == null) {
+    ClientGetFetchConfig fetchConfig = request.fetchConfig();
+    if (fetchConfig == null) {
       LOG.warn("Cannot restart because fetch context is missing for {}", request.identifier);
       return false;
     }
-    FreenetURI redirect = resetStateForRestart(disableFilterData, fetchContext);
+    FreenetURI redirect = resetStateForRestart(disableFilterData, fetchConfig);
     notifyCacheAboutRedirect(redirect);
     try {
-      if (getter().restart(redirect, fetchContext.getFilterData(), context)) {
+      if (request.execution().restart(redirect, fetchConfig.getFilterData())) {
         markRestarted(redirect);
       }
       notifyCacheStartedFlag();
@@ -125,13 +121,15 @@ final class ClientGetRestartCoordinator {
    *
    * <p>The method clears cached failures, progress snapshots, compatibility metadata, and expected
    * hashes. It also marks the request as not started/finished and optionally disables filtering in
-   * the fetch context. The returned redirect, if present, should be applied before restarting.
+   * the detached fetch configuration. The returned redirect, if present, should be applied before
+   * restarting.
    *
    * @param disableFilterData true to disable filtering for the next attempt.
-   * @param fetchContext fetch context bound to the request.
+   * @param fetchConfig detached fetch configuration bound to the request.
    * @return redirect URI to apply, or {@code null} if none was stored.
    */
-  private FreenetURI resetStateForRestart(boolean disableFilterData, FetchContext fetchContext) {
+  private FreenetURI resetStateForRestart(
+      boolean disableFilterData, ClientGetFetchConfig fetchConfig) {
     synchronized (request.persistenceLock()) {
       request.finished = false;
       GetFailedMessage failure = request.state().getFailedMessage();
@@ -142,7 +140,7 @@ final class ClientGetRestartCoordinator {
       request.state().clearExpectedHashes();
       request.started = false;
       if (disableFilterData) {
-        fetchContext.setFilterData(false);
+        fetchConfig.setFilterData(false);
       }
       return redirect;
     }
@@ -197,14 +195,5 @@ final class ClientGetRestartCoordinator {
     if (cache != null) {
       cache.updateStarted(request.identifier, true);
     }
-  }
-
-  /**
-   * Returns the underlying {@link ClientGetter} associated with the request.
-   *
-   * @return the request's {@link ClientGetter}, cast from the base requester.
-   */
-  private ClientGetter getter() {
-    return (ClientGetter) request.getClientRequest();
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetReturnPlanner.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetReturnPlanner.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Objects;
-import network.crypta.client.FetchContext;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
@@ -15,8 +14,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This helper isolates DDA checks, existing file handling, and extension validation so the core
  * request flow can focus on scheduling and status coordination. It is intentionally stateful to
- * carry the request identifier and {@link FetchContext} needed for error reporting and per-request
- * validation.
+ * carry the request identifier and detached fetch configuration needed for error reporting and
+ * per-request validation.
  *
  * <p>Typical usage is to construct one planner per request and call either {@link
  * #forGlobalRequest(ClientGet.ReturnType, File, boolean, TransferAccessPort)} for global requests
@@ -47,7 +46,7 @@ final class ClientGetReturnPlanner {
   private final boolean global;
 
   /** Fetch settings supplying filter decisions for disk return setups. */
-  private final FetchContext fetchContext;
+  private final ClientGetFetchConfig fetchConfig;
 
   /**
    * Creates a planner for a single request using the supplied identifier and fetch settings.
@@ -59,13 +58,13 @@ final class ClientGetReturnPlanner {
    *
    * @param identifier request identifier to associate with protocol errors; must be non-null.
    * @param global whether generated errors should be flagged as connection-global.
-   * @param fetchContext fetch settings used for filter decisions; must be non-null.
-   * @throws NullPointerException if {@code identifier} or {@code fetchContext} is null.
+   * @param fetchConfig fetch settings used for filter decisions; must be non-null.
+   * @throws NullPointerException if {@code identifier} or {@code fetchConfig} is null.
    */
-  ClientGetReturnPlanner(String identifier, boolean global, FetchContext fetchContext) {
+  ClientGetReturnPlanner(String identifier, boolean global, ClientGetFetchConfig fetchConfig) {
     this.identifier = Objects.requireNonNull(identifier, "identifier");
     this.global = global;
-    this.fetchContext = Objects.requireNonNull(fetchContext, "fetchContext");
+    this.fetchConfig = Objects.requireNonNull(fetchConfig, "fetchConfig");
   }
 
   /**
@@ -173,7 +172,7 @@ final class ClientGetReturnPlanner {
       mie.initCause(e);
       throw mie;
     }
-    return createDiskReturnSetup(diskFile, fetchContext.getFilterData());
+    return createDiskReturnSetup(diskFile, fetchConfig.getFilterData());
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetSetup.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetSetup.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.FetchContext;
 import network.crypta.support.api.Bucket;
 
 /**
@@ -16,7 +15,7 @@ import network.crypta.support.api.Bucket;
  * mutate or enrich the record later, so a {@link ClientGet} can treat each component as the
  * authoritative setup decided by the factory stage.
  *
- * @param fetchContext fully prepared fetch context that should be used by the request
+ * @param fetchConfig fully prepared detached fetch configuration for the request
  * @param returnSetup resolved return-handling plan, including any bucket or target file
  * @param returnType requested return mode that controls how fetched data is exposed
  * @param binaryBlob whether the request should produce Binary Blob output
@@ -24,7 +23,7 @@ import network.crypta.support.api.Bucket;
  * @param fetchRuntimeSupport runtime support seam used for getter creation and request start
  */
 record ClientGetSetup(
-    FetchContext fetchContext,
+    ClientGetFetchConfig fetchConfig,
     ClientGetReturnPlanner.ReturnSetup returnSetup,
     ClientGet.ReturnType returnType,
     boolean binaryBlob,

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetStatusReporter.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetStatusReporter.java
@@ -61,7 +61,7 @@ final class ClientGetStatusReporter {
   }
 
   /**
-   * Returns the failure classification associated with the last recorded failure.
+   * Returns the failure classification associated with the last-recorded failure.
    *
    * <p>The classification is derived from the cached {@link GetFailedMessage}. It returns {@code
    * null} when no failure is recorded yet.
@@ -198,7 +198,7 @@ final class ClientGetStatusReporter {
             request.getBucket());
     DownloadContextSnapshot contextSnapshot =
         new DownloadContextSnapshot(
-            request.fetchContextForGetter(),
+            request.fetchConfig(),
             request.getCompatibilityMode(),
             request.getOverriddenSplitfileCryptoKey(),
             request.getURI(),

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshot.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.File;
 import java.time.Instant;
 import java.util.Arrays;
-import network.crypta.client.FetchContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
@@ -273,17 +272,17 @@ public final class ClientGetStatusSnapshot {
   }
 
   /**
-   * Returns the fetch context used for the request.
+   * Returns the detached fetch configuration used for the request.
    *
-   * <p>The context can include MIME overrides, filter settings, and other request-scoped options.
-   * The snapshot stores the reference as provided and does not copy or validate it. A {@code null}
-   * value is permitted when a context is not available, and consumers should handle that case by
-   * falling back to their own defaults.
+   * <p>The configuration can include MIME overrides, filter settings, and other request-scoped
+   * options. The snapshot stores a defensive copy and returns a defensive copy. A {@code null}
+   * value is permitted when configuration is not available, and consumers should handle that case
+   * by falling back to their own defaults.
    *
-   * @return the fetch context, or {@code null} when no context is available
+   * @return detached fetch configuration, or {@code null} when unavailable
    */
-  public FetchContext fetchContext() {
-    return contextSnapshot.fetchContext();
+  public ClientGetFetchConfig fetchConfig() {
+    return contextSnapshot.fetchConfig();
   }
 
   /**
@@ -390,7 +389,7 @@ public final class ClientGetStatusSnapshot {
         && java.util.Objects.equals(foundDataMimeType(), otherSnapshot.foundDataMimeType())
         && java.util.Objects.equals(destinationFile(), otherSnapshot.destinationFile())
         && java.util.Objects.equals(dataBucket(), otherSnapshot.dataBucket())
-        && java.util.Objects.equals(fetchContext(), otherSnapshot.fetchContext())
+        && java.util.Objects.equals(fetchConfig(), otherSnapshot.fetchConfig())
         && Arrays.equals(compatModes(), otherSnapshot.compatModes())
         && Arrays.equals(splitfileKey(), otherSnapshot.splitfileKey())
         && java.util.Objects.equals(uri(), otherSnapshot.uri());
@@ -421,7 +420,7 @@ public final class ClientGetStatusSnapshot {
             foundDataLength(),
             destinationFile(),
             dataBucket(),
-            fetchContext(),
+            fetchConfig(),
             priorityClass(),
             uri(),
             dontCompress());
@@ -466,8 +465,8 @@ public final class ClientGetStatusSnapshot {
         + destinationFile()
         + ", dataBucket="
         + dataBucket()
-        + ", fetchContext="
-        + (fetchContext() == null ? "null" : java.util.Objects.toIdentityString(fetchContext()))
+        + ", fetchConfig="
+        + fetchConfig()
         + ", priorityClass="
         + priorityClass()
         + ", compatModes="

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilder.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilder.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import java.util.Objects;
-import network.crypta.client.FetchContext;
 
 /**
  * Builds persistent tag and status snapshot messages for {@link ClientGet}.
@@ -62,15 +61,15 @@ final class ClientGetStatusSnapshotBuilder {
             request.isRealTime(),
             request.clientToken,
             request.client.isGlobalQueue);
-    FetchContext fetchContext = request.fetchContextForGetter();
+    ClientGetFetchConfig fetchConfig = Objects.requireNonNull(request.fetchConfig(), "fetchConfig");
     PersistentGetDescriptor descriptor =
         new PersistentGetDescriptor(
             request.returnTypeForReplay(),
             request.targetFileForLifecycle(),
             request.started,
-            fetchContext.getMaxNonSplitfileRetries(),
+            fetchConfig.getMaxNonSplitfileRetries(),
             request.binaryBlobRequested(),
-            fetchContext.getMaxOutputLength());
+            fetchConfig.getMaxOutputLength());
     return new PersistentGet(requestParams, descriptor);
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -1150,6 +1150,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    *
    * @param dis input stream positioned at the start of a client-detail record
    * @param reqID identifier describing the request type and queue used during serialization
+   * @param fetchRuntimeSupport fetch runtime support used to rebuild detached GET execution state
    * @param context client context used to create any dependent objects during restart
    * @param checker checksum helper responsible for validating the integrity of the serialized data
    * @return reconstructed request instance, or {@code null} when the type is not supported here
@@ -1159,10 +1160,14 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * @throws ResumeFailedException if the request cannot be reattached to the runtime environment
    */
   public static ClientRequest restartFrom(
-      DataInputStream dis, RequestIdentifier reqID, ClientContext context, ChecksumChecker checker)
+      DataInputStream dis,
+      RequestIdentifier reqID,
+      FcpFetchRuntimeSupport fetchRuntimeSupport,
+      ClientContext context,
+      ChecksumChecker checker)
       throws StorageFormatException, IOException, ResumeFailedException {
     return reqID.type == GET
-        ? ClientGetPersistenceCodec.restartFrom(dis, reqID, context, checker)
+        ? ClientGetPersistenceCodec.restartFrom(dis, reqID, fetchRuntimeSupport, context, checker)
         : null;
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/DownloadContextSnapshot.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/DownloadContextSnapshot.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.FetchContext;
 import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.keys.FreenetURI;
 
@@ -13,23 +12,23 @@ import network.crypta.keys.FreenetURI;
  * an FCP reply. The snapshot stores object references as provided and does not perform validation
  * or normalization; mutable array inputs are defensively copied.
  *
- * <p>The instance is immutable. Referenced objects such as {@link FetchContext} may still be
- * mutable and shared, while array fields are defensively copied at construction and access time.
- * The snapshot intentionally does not interpret compatibility mode ordering or URI normalization,
- * leaving those concerns to downstream consumers.
+ * <p>The instance is immutable. The detached fetch configuration remains mutable by type but is
+ * copied at construction and access time, while array fields are defensively copied at construction
+ * and access time. The snapshot intentionally does not interpret compatibility mode ordering or URI
+ * normalization, leaving those concerns to downstream consumers.
  *
  * <ul>
- *   <li>Preserves fetch-context settings that influence status output and filtering.
+ *   <li>Preserves detached fetch settings that influence status output and filtering.
  *   <li>Captures compatibility modes and splitfile key overrides, if any.
  *   <li>Holds request URI and compression policy for reporting purposes.
  * </ul>
  *
- * @see FetchContext
+ * @see ClientGetFetchConfig
  * @see DownloadRequestStatusDetails
  */
 @SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
 public final class DownloadContextSnapshot {
-  private final FetchContext fetchContext;
+  private final ClientGetFetchConfig fetchConfig;
   private final CompatibilityMode[] compatModes;
   private final byte[] splitfileKey;
   private final FreenetURI uri;
@@ -47,22 +46,23 @@ public final class DownloadContextSnapshot {
    *
    * <pre>{@code
    * DownloadContextSnapshot context =
-   *     new DownloadContextSnapshot(fetchContext, compatModes, splitfileKey, uri, dontCompress);
+   *     new DownloadContextSnapshot(fetchConfig, compatModes, splitfileKey, uri, dontCompress);
    * }</pre>
    *
-   * @param fetchContext fetch context providing filter and MIME overrides, or {@code null}
+   * @param fetchConfig detached fetch configuration providing filter and MIME overrides, or {@code
+   *     null}
    * @param compatModes compatibility modes observed for the request, possibly empty or {@code null}
    * @param splitfileKey splitfile crypto key override bytes, or {@code null} if not applicable
    * @param uri request URI to report, or {@code null} when not yet resolved
    * @param dontCompress whether reinsertion should skip compression when producing output
    */
   public DownloadContextSnapshot(
-      FetchContext fetchContext,
+      ClientGetFetchConfig fetchConfig,
       CompatibilityMode[] compatModes,
       byte[] splitfileKey,
       FreenetURI uri,
       boolean dontCompress) {
-    this.fetchContext = fetchContext;
+    this.fetchConfig = copyFetchConfig(fetchConfig);
     this.compatModes = copyCompatModes(compatModes);
     this.splitfileKey = copySplitfileKey(splitfileKey);
     this.uri = uri;
@@ -70,17 +70,17 @@ public final class DownloadContextSnapshot {
   }
 
   /**
-   * Returns the fetch context captured in this snapshot.
+   * Returns the detached fetch configuration captured in this snapshot.
    *
-   * <p>The context can include filtering settings, MIME overrides, and other request-scoped
-   * options. The returned reference is the original object supplied at construction time and is not
-   * copied. It may be {@code null} when no context was available, and callers should handle that
-   * case by applying their own defaults or by omitting context-derived fields in status output.
+   * <p>The configuration can include filtering settings, MIME overrides, and other request-scoped
+   * options. The returned value is a defensive copy. It may be {@code null} when no configuration
+   * was available, and callers should handle that case by applying their own defaults or by
+   * omitting context-derived fields in status output.
    *
-   * @return the fetch context reference, or {@code null} when not available
+   * @return detached fetch configuration, or {@code null} when not available
    */
-  public FetchContext fetchContext() {
-    return fetchContext;
+  public ClientGetFetchConfig fetchConfig() {
+    return copyFetchConfig(fetchConfig);
   }
 
   /**
@@ -134,6 +134,10 @@ public final class DownloadContextSnapshot {
 
   private static CompatibilityMode[] copyCompatModes(CompatibilityMode[] input) {
     return input == null ? null : input.clone();
+  }
+
+  private static ClientGetFetchConfig copyFetchConfig(ClientGetFetchConfig input) {
+    return input == null ? null : input.copy();
   }
 
   private static byte[] copySplitfileKey(byte[] input) {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -482,7 +482,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(server.fetchRuntimeSupport().clientContext());
+    request.start(serverClientContext());
   }
 
   private void startRebootClientGet(ClientGetMessage message) {
@@ -493,7 +493,7 @@ public class FCPConnectionHandler implements Closeable {
     if (!registerPersistentRequest(request, message.identifier, message.global)) {
       return;
     }
-    request.start(server.fetchRuntimeSupport().clientContext());
+    request.start(serverClientContext());
   }
 
   private void startForeverClientGet(ClientGetMessage message) {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -113,6 +113,7 @@ public class FCPServer implements Runnable, DownloadCache {
     this.fetchRuntimeSupport = dependencies.fetchRuntimeSupport();
     this.messageFetchRuntimeSupport = dependencies.messageFetchRuntimeSupport();
     this.insertRuntimeSupport = dependencies.insertRuntimeSupport();
+    dependencies.persistentRoot().setFetchRuntimeSupport(this.fetchRuntimeSupport);
     this.assumeDownloadDDAIsAllowed = config.assumeDownloadDDAAllowed();
     this.assumeUploadDDAIsAllowed = config.assumeUploadDDAAllowed();
     this.neverDropAMessage = config.neverDropAMessage();

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpFetchRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpFetchRuntimeSupport.java
@@ -1,75 +1,43 @@
 package network.crypta.clients.fcp;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
-import network.crypta.client.FetchContext;
-import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.ChecksumChecker;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
 
 /**
  * Narrow runtime support seam for the FCP GET/fetch path.
  *
- * <p>This adapter keeps the GET request creation and getter wiring independent of direct {@code
- * NodeClientCore} access while preserving the current runtime behavior. It exposes only the
- * fetch-specific services needed by {@link ClientGet}, {@link ClientGetFactory}, and {@link
- * ClientGetGetterFactory}: the live {@link ClientContext}, the default persistent {@link
- * FetchContext}, transfer-policy checks, and binary-blob bucket allocation.
- *
- * <p>The interface remains owned by {@code clients.fcp} even though core-backed implementations now
- * live under runtime bootstrap wiring. It is public only so those runtime-owned adapters can
- * implement it from outside the package. It is not a general FCP runtime facade and does not widen
- * {@code runtime-spi}; callers should add new methods only when a later refactoring needs a
- * demonstrably GET-specific seam. Typical call flow starts with {@link ClientGetFactory} reading
- * the default context and transfer policy during request construction, then {@link ClientGet} and
- * {@link ClientGetGetterFactory} using the same support object again when the request starts or
- * allocates Binary Blob output.
+ * <p>The adapter owns the detached fetch configuration and opaque execution handle types. Bridge
+ * implementations translate those adapter-owned values to the live daemon fetch runtime.
  */
 public interface FcpFetchRuntimeSupport {
 
-  /**
-   * Returns the live client context used to start or resume fetch requests.
-   *
-   * <p>The returned context is the same runtime object that request code should pass into start or
-   * resume operations. Callers should treat it as a live daemon state rather than a detached
-   * snapshot.
-   *
-   * @return current client context backing FCP fetch operations
-   */
-  ClientContext clientContext();
+  /** Returns detached defaults for a new persistent GET request. */
+  ClientGetFetchConfig defaultPersistentFetchConfig();
 
-  /**
-   * Returns the default persistent fetch context template for new GET requests.
-   *
-   * <p>Factories typically clone or adjust the returned context immediately for one request. The
-   * value acts as the persistent-fetch baseline from which request-specific flags and limits are
-   * derived.
-   *
-   * @return persistent fetch context defaults supplied by the daemon runtime
-   */
-  FetchContext defaultPersistentFetchContext();
+  /** Encodes detached fetch configuration using the runtime's canonical fetch-context format. */
+  void encodeFetchConfig(ClientGetFetchConfig fetchConfig, DataOutputStream dos) throws IOException;
 
-  /**
-   * Returns the transfer-access policy used for disk-return planning.
-   *
-   * <p>This policy must stay aligned with the owning FCP server runtime, so default download
-   * directories and DDA decisions match the rest of the server's request handling.
-   *
-   * @return transfer policy for download path validation and defaults
-   */
+  /** Decodes detached fetch configuration from the runtime's canonical fetch-context format. */
+  ClientGetFetchConfig decodeFetchConfig(DataInputStream dis)
+      throws IOException, StorageFormatException;
+
+  /** Opens a checksummed persistence block using the runtime-backed temporary bucket services. */
+  DataInputStream openChecksummed(DataInputStream dis, ChecksumChecker checker, long maxLength)
+      throws IOException, StorageFormatException;
+
+  /** Restores a persistent bucket from an already opened checksummed block. */
+  Bucket restorePersistentBucket(DataInputStream dis)
+      throws IOException, StorageFormatException, ResumeFailedException;
+
+  /** Returns the transfer-access policy used for disk-return planning. */
   TransferAccessPort transferAccess();
 
-  /**
-   * Allocates a bucket for binary-blob output when a request has no caller-provided return bucket.
-   *
-   * <p>The request path uses this only for Binary Blob fetches that still need a storage target.
-   * The caller handles ordinary return planning earlier.
-   *
-   * @param maxOutputLength maximum expected payload size for the fetch
-   * @param persistentForever whether the request persists forever and therefore needs the forever
-   *     bucket factory
-   * @return newly allocated bucket for binary-blob output
-   * @throws IOException if bucket allocation fails
-   */
-  Bucket allocateBinaryBlobBucket(long maxOutputLength, boolean persistentForever)
-      throws IOException;
+  /** Creates the live GET execution hidden behind the adapter-owned execution handle. */
+  ClientGetExecution createExecution(ClientGetExecutionSpec executionSpec) throws IOException;
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -11,7 +11,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchResult;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
@@ -610,11 +609,11 @@ final class FcpServerPersistentOps implements DownloadCache {
   private void innerMakePersistentGlobalRequest(PersistentGlobalRequestSpec spec)
       throws IdentifierCollisionException, NotAllowedException, IOException {
     FcpFetchRuntimeSupport fetchRuntimeSupport = server.fetchRuntimeSupport();
-    FetchContext defaultFetchContext = fetchRuntimeSupport.defaultPersistentFetchContext();
+    ClientGetFetchConfig defaultFetchConfig = fetchRuntimeSupport.defaultPersistentFetchConfig();
     ClientGetGlobalRequestConfig requestConfig =
         new ClientGetGlobalRequestConfig(
-            defaultFetchContext.getLocalRequestOnly(),
-            defaultFetchContext.getIgnoreStore(),
+            defaultFetchConfig.getLocalRequestOnly(),
+            defaultFetchConfig.getIgnoreStore(),
             spec.filterData(),
             FCPServer.QUEUE_MAX_RETRIES,
             FCPServer.QUEUE_MAX_RETRIES,
@@ -636,7 +635,7 @@ final class FcpServerPersistentOps implements DownloadCache {
             requestConfig,
             fetchRuntimeSupport);
     cg.register(false);
-    cg.start(fetchRuntimeSupport.clientContext());
+    cg.start(clientContext());
   }
 
   PersistentRequestClient getGlobalForeverClient() {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestRoot.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestRoot.java
@@ -45,6 +45,7 @@ public class PersistentRequestRoot implements PersistentRequestCoordinator {
 
   final PersistentRequestClient globalForeverClient;
   private final Map<String, PersistentRequestClient> clients;
+  private transient FcpFetchRuntimeSupport fetchRuntimeSupport;
 
   // Legacy threshold callback removed.
 
@@ -214,6 +215,14 @@ public class PersistentRequestRoot implements PersistentRequestCoordinator {
    */
   public PersistentRequestClient getGlobalForeverClient() {
     return globalForeverClient;
+  }
+
+  void setFetchRuntimeSupport(FcpFetchRuntimeSupport fetchRuntimeSupport) {
+    this.fetchRuntimeSupport = fetchRuntimeSupport;
+  }
+
+  FcpFetchRuntimeSupport fetchRuntimeSupport() {
+    return fetchRuntimeSupport;
   }
 
   private static ClientRequest requireClientRequest(PersistentRequestHandle request) {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -29,8 +29,35 @@ class AdapterFcpBoundaryTest {
   private static final Path ADAPTER_FCP_MAIN_JAVA =
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "fcp");
   private static final Path ADD_PEER_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("AddPeer.java");
+  private static final Path CLIENT_GET_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("ClientGet.java");
+  private static final Path CLIENT_GET_FACTORY_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetFactory.java");
+  private static final Path CLIENT_GET_GETTER_FACTORY_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetGetterFactory.java");
+  private static final Path CLIENT_GET_LIFECYCLE_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetLifecycle.java");
+  private static final Path CLIENT_GET_PERSISTENCE_CODEC_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetPersistenceCodec.java");
+  private static final Path CLIENT_GET_PERSISTENCE_IO_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetPersistenceIO.java");
+  private static final Path CLIENT_GET_RESTART_COORDINATOR_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetRestartCoordinator.java");
+  private static final Path CLIENT_GET_RETURN_PLANNER_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetReturnPlanner.java");
+  private static final Path CLIENT_GET_SETUP_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetSetup.java");
+  private static final Path CLIENT_GET_STATUS_BUILDER_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetStatusSnapshotBuilder.java");
+  private static final Path DOWNLOAD_CONTEXT_SNAPSHOT_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("DownloadContextSnapshot.java");
+  private static final Path FCP_CONNECTION_HANDLER_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FCPConnectionHandler.java");
+  private static final Path FCP_FETCH_RUNTIME_SUPPORT_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FcpFetchRuntimeSupport.java");
   private static final Path FCP_MESSAGE_RUNTIME_SUPPORT_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpMessageRuntimeSupport.java");
+  private static final Path FCP_SERVER_PERSISTENT_OPS_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FcpServerPersistentOps.java");
   private static final Path BRIDGE_FCP_RUNTIME_MAIN_JAVA =
       Path.of(
           "bridge-fcp-runtime",
@@ -64,6 +91,26 @@ class AdapterFcpBoundaryTest {
       Pattern.compile(
           "^import\\s+(network\\.crypta\\.node\\.(?:PeerNode|DarknetPeerNode)|"
               + "network\\.crypta\\.node\\.probe\\.[^;]+);$");
+  private static final Set<String> FORBIDDEN_GET_RUNTIME_IMPORTS =
+      Set.of(
+          "network.crypta.client.FetchContext",
+          "network.crypta.client.async.ClientContext",
+          "network.crypta.client.async.ClientGetter",
+          "network.crypta.client.async.ClientGetterRequest");
+  private static final Set<Path> GET_RUNTIME_SEAM_SOURCES =
+      Set.of(
+          FCP_FETCH_RUNTIME_SUPPORT_SOURCE,
+          CLIENT_GET_SOURCE,
+          CLIENT_GET_FACTORY_SOURCE,
+          CLIENT_GET_GETTER_FACTORY_SOURCE,
+          CLIENT_GET_PERSISTENCE_CODEC_SOURCE,
+          CLIENT_GET_PERSISTENCE_IO_SOURCE,
+          CLIENT_GET_RESTART_COORDINATOR_SOURCE,
+          CLIENT_GET_LIFECYCLE_SOURCE,
+          CLIENT_GET_RETURN_PLANNER_SOURCE,
+          CLIENT_GET_SETUP_SOURCE,
+          CLIENT_GET_STATUS_BUILDER_SOURCE,
+          DOWNLOAD_CONTEXT_SNAPSHOT_SOURCE);
   private static final Set<String> EXPECTED_DEFAULT_BRIDGE_FACTORIES_IMPORTS =
       Set.of(
           "network.crypta.clients.fcp.bridge.FcpPersistentRequestServices",
@@ -238,6 +285,53 @@ class AdapterFcpBoundaryTest {
         "FcpMessageRuntimeSupport must not expose raw makeClient(...) anymore");
   }
 
+  @Test
+  void adapterFcpMain_whenCheckingGetRuntimeSeam_expectNoLiveFetchTypeImports() throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path source : GET_RUNTIME_SEAM_SOURCES) {
+      Set<String> imports = readImports(repoRoot.resolve(source));
+      Set<String> forbiddenImports = new TreeSet<>(imports);
+      forbiddenImports.retainAll(FORBIDDEN_GET_RUNTIME_IMPORTS);
+      if (!forbiddenImports.isEmpty()) {
+        violations.add(source + " -> " + String.join(", ", forbiddenImports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "GET-path adapter sources must not import live runtime fetch types."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void fetchRuntimeSupport_whenCheckingPublicSurface_expectNoLegacyLiveFetchAccessors()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    String source = Files.readString(repoRoot.resolve(FCP_FETCH_RUNTIME_SUPPORT_SOURCE));
+
+    assertFalse(source.contains("clientContext("));
+    assertFalse(source.contains("defaultPersistentFetchContext("));
+    assertFalse(source.contains("FetchContext"));
+    assertFalse(source.contains("ClientContext"));
+  }
+
+  @Test
+  void getCallSites_whenCheckingMixedFiles_expectNoLegacyFetchRuntimeReachThrough()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    String connectionHandler = Files.readString(repoRoot.resolve(FCP_CONNECTION_HANDLER_SOURCE));
+    String persistentOps = Files.readString(repoRoot.resolve(FCP_SERVER_PERSISTENT_OPS_SOURCE));
+
+    assertFalse(connectionHandler.contains("fetchRuntimeSupport().clientContext()"));
+    assertFalse(connectionHandler.contains("messageFetchRuntimeSupport().clientContext()"));
+    assertFalse(connectionHandler.contains("defaultPersistentFetchContext("));
+    assertFalse(persistentOps.contains("fetchRuntimeSupport.clientContext()"));
+    assertFalse(persistentOps.contains("defaultPersistentFetchContext("));
+  }
+
   private static List<Path> findJavaSources(Path root) throws IOException {
     try (Stream<Path> walk = Files.walk(root)) {
       return walk.filter(Files::isRegularFile)
@@ -280,6 +374,16 @@ class AdapterFcpBoundaryTest {
           .map(FCP_IMPORT_PATTERN::matcher)
           .filter(Matcher::matches)
           .map(matcher -> matcher.group(1))
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static Set<String> readImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .filter(line -> line.startsWith("import "))
+          .map(line -> line.substring("import ".length(), line.length() - 1))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
   }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
@@ -1,111 +1,421 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchResult;
+import network.crypta.client.async.BinaryBlobWriter;
 import network.crypta.client.async.ClientContext;
-import network.crypta.clients.fcp.FCPServer;
+import network.crypta.client.async.ClientGetCallback;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.client.async.ClientGetterOptions;
+import network.crypta.client.async.ClientGetterRequest;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.PersistentClientCallback;
+import network.crypta.client.events.ClientEventListener;
+import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.clients.fcp.ClientGet;
+import network.crypta.clients.fcp.ClientGetExecution;
+import network.crypta.clients.fcp.ClientGetExecutionSpec;
+import network.crypta.clients.fcp.ClientGetFetchConfig;
 import network.crypta.clients.fcp.FcpFetchRuntimeSupport;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.ChecksumFailedException;
+import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
+import network.crypta.support.io.BucketTools;
+import network.crypta.support.io.NullBucket;
+import network.crypta.support.io.ResumeFailedException;
+import network.crypta.support.io.StorageFormatException;
 
 /**
  * Core-backed implementation of {@link FcpFetchRuntimeSupport}.
  *
- * <p>This adapter is the GET-path assembly seam between {@code clients.fcp} and the broader daemon
- * runtime. It keeps the fetch-specific wiring local to runtime-owned bootstrap code by translating
- * the small set of GET dependencies into direct delegations on the wrapped {@link NodeClientCore}
- * plus the owning server's transfer-access policy supplier. The adapter is immutable after
- * construction and observes the live daemon state on each call.
- *
- * <p>The split between {@code core} and {@code transferAccessSupplier} is intentional. Fetch
- * creation still needs the live client context and bucket factories from the daemon core, while DDA
- * checks and default download locations must remain aligned with the {@link FCPServer} runtime that
- * owns the request flow. Keeping both collaborators here preserves that behavior without letting
- * the GET classes depend on {@code NodeClientCore} directly.
- *
- * @param core live daemon core used for fetch contexts, client starts, and bucket allocation
- * @param transferAccessSupplier live transfer-policy lookup from the owning runtime, used for DDA
- *     checks and download-path defaults
+ * <p>This adapter owns the concrete translation between the adapter-owned detached GET seam and the
+ * live daemon fetch runtime.
  */
 record CoreFcpFetchRuntimeSupport(
-    NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier)
+    Supplier<ClientContext> clientContextSupplier,
+    Supplier<TransferAccessPort> transferAccessSupplier)
     implements FcpFetchRuntimeSupport {
 
-  /**
-   * Creates a fetch runtime adapter for the supplied node core.
-   *
-   * <p>The adapter is a thin wrapper and does not snapshot mutable daemon state. Later method calls
-   * continue to observe the live client context and bucket factories exposed by {@code core}, while
-   * transfer checks continue to read the current port from the supplied runtime lookup.
-   *
-   * @param core live daemon core providing fetch contexts and bucket allocation
-   * @param transferAccessSupplier live transfer-policy lookup from the owning runtime, used for DDA
-   *     checks and default download locations
-   */
+  @SuppressWarnings("java:S2095")
+  private static final Bucket NULL_BUCKET = new NullBucket();
+
   CoreFcpFetchRuntimeSupport(
-      NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier) {
-    this.core = Objects.requireNonNull(core);
+      Supplier<ClientContext> clientContextSupplier,
+      Supplier<TransferAccessPort> transferAccessSupplier) {
+    this.clientContextSupplier = Objects.requireNonNull(clientContextSupplier);
     this.transferAccessSupplier = Objects.requireNonNull(transferAccessSupplier);
   }
 
-  /**
-   * Returns the live client context from the wrapped daemon core.
-   *
-   * <p>GET requests use this context when they start or resume execution. The adapter does not
-   * cache or clone the value, so callers observe the same live context the core currently exposes.
-   *
-   * @return current client context used for FCP fetch execution
-   */
-  @Override
-  public ClientContext clientContext() {
-    return core.getClientContext();
+  CoreFcpFetchRuntimeSupport(
+      NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier) {
+    NodeClientCore nonNullCore = Objects.requireNonNull(core);
+    this(nonNullCore::getClientContext, transferAccessSupplier);
   }
 
-  /**
-   * Returns the default persistent fetch context supplied by the wrapped daemon core.
-   *
-   * <p>Factories typically adjust the returned context immediately for one request, but the
-   * baseline always comes from the live core, so persistent GET defaults remain unchanged.
-   *
-   * @return default persistent fetch context template from the daemon core
-   */
-  @Override
-  public FetchContext defaultPersistentFetchContext() {
-    return core.getClientContext().getDefaultPersistentFetchContext();
+  CoreFcpFetchRuntimeSupport(
+      ClientContext clientContext, Supplier<TransferAccessPort> transferAccessSupplier) {
+    ClientContext nonNullClientContext = Objects.requireNonNull(clientContext);
+    this(() -> nonNullClientContext, transferAccessSupplier);
   }
 
-  /**
-   * Returns the transfer-access policy owned by the surrounding FCP server runtime.
-   *
-   * <p>This intentionally resolves the transfer policy on each call instead of caching a
-   * constructor-time reference. Persistent global GET request planning must stay aligned with the
-   * runtime that supplied the current download policy and default directories.
-   *
-   * @return transfer policy used for DDA checks and default download resolution
-   */
+  @Override
+  public ClientGetFetchConfig defaultPersistentFetchConfig() {
+    return toFetchConfig(clientContext().getDefaultPersistentFetchContext());
+  }
+
+  @Override
+  public void encodeFetchConfig(ClientGetFetchConfig fetchConfig, DataOutputStream dos)
+      throws IOException {
+    materializeFetchContext(fetchConfig, null).writeTo(dos);
+  }
+
+  @Override
+  public ClientGetFetchConfig decodeFetchConfig(DataInputStream dis)
+      throws IOException, StorageFormatException {
+    return toFetchConfig(new FetchContext(dis));
+  }
+
+  @Override
+  public DataInputStream openChecksummed(
+      DataInputStream dis, ChecksumChecker checker, long maxLength)
+      throws IOException, StorageFormatException {
+    try {
+      return new DataInputStream(
+          checker.checksumReaderWithLength(dis, clientContext().tempBucketFactory, maxLength));
+    } catch (ChecksumFailedException e) {
+      StorageFormatException storageFormatException = new StorageFormatException("Checksum failed");
+      storageFormatException.initCause(e);
+      throw storageFormatException;
+    }
+  }
+
+  @Override
+  public Bucket restorePersistentBucket(DataInputStream dis)
+      throws IOException, StorageFormatException, ResumeFailedException {
+    ClientContext context = clientContext();
+    return BucketTools.restoreFrom(
+        dis,
+        context.persistentFG,
+        context.getPersistentFileTracker(),
+        context.getPersistentMasterSecret());
+  }
+
   @Override
   public TransferAccessPort transferAccess() {
     return Objects.requireNonNull(transferAccessSupplier.get());
   }
 
-  /**
-   * Allocates a Binary Blob bucket through the wrapped daemon core.
-   *
-   * <p>The bucket comes from the core's bucket factory for the requested persistence class. This
-   * keeps Binary Blob storage behavior identical to the pre-refactor GET path while exposing only a
-   * narrow runtime-support seam to callers.
-   *
-   * @param maxOutputLength maximum number of bytes the bucket should be prepared to hold
-   * @param persistentForever whether the forever-persistent bucket factory should be used
-   * @return newly allocated bucket suitable for Binary Blob output
-   * @throws IOException if the underlying bucket factory cannot create the bucket
-   */
   @Override
-  public Bucket allocateBinaryBlobBucket(long maxOutputLength, boolean persistentForever)
+  public ClientGetExecution createExecution(ClientGetExecutionSpec executionSpec)
       throws IOException {
-    return core.getClientContext().getBucketFactory(persistentForever).makeBucket(maxOutputLength);
+    return new CoreClientGetExecution(clientContextSupplier, executionSpec);
+  }
+
+  private ClientContext clientContext() {
+    return Objects.requireNonNull(clientContextSupplier.get());
+  }
+
+  private static FetchContext materializeFetchContext(
+      ClientGetFetchConfig fetchConfig, ClientEventListener eventListener) {
+    FetchContextOptions options =
+        FetchContextOptions.builder()
+            .limits(
+                fetchConfig.getMaxOutputLength(),
+                fetchConfig.getMaxTempLength(),
+                fetchConfig.getMaxMetadataSize())
+            .archiveLimits(
+                fetchConfig.getMaxRecursionLevel(),
+                fetchConfig.getMaxArchiveRestarts(),
+                fetchConfig.getMaxArchiveLevels(),
+                fetchConfig.getDontEnterImplicitArchives())
+            .retryLimits(
+                fetchConfig.getMaxSplitfileBlockRetries(),
+                fetchConfig.getMaxNonSplitfileRetries(),
+                fetchConfig.getMaxUSKRetries())
+            .splitfileLimits(
+                fetchConfig.getAllowSplitfiles(),
+                fetchConfig.getMaxDataBlocksPerSegment(),
+                fetchConfig.getMaxCheckBlocksPerSegment())
+            .behavior(
+                fetchConfig.getFollowRedirects(),
+                fetchConfig.getLocalRequestOnly(),
+                fetchConfig.getFilterData())
+            .clientOptions(
+                new SimpleEventProducer(),
+                fetchConfig.getIgnoreTooManyPathComponents(),
+                fetchConfig.getCanWriteClientCache())
+            .filterOverrides(
+                fetchConfig.getCharset(),
+                fetchConfig.getOverrideMime(),
+                fetchConfig.getSchemeHostAndPort())
+            .build();
+    return createFetchContext(fetchConfig, eventListener, options);
+  }
+
+  private static FetchContext createFetchContext(
+      ClientGetFetchConfig fetchConfig,
+      ClientEventListener eventListener,
+      FetchContextOptions options) {
+    FetchContext fetchContext = new FetchContext(options);
+    fetchContext.setIgnoreStore(fetchConfig.getIgnoreStore());
+    fetchContext.setReturnZIPManifests(fetchConfig.getReturnZIPManifests());
+    fetchContext.setAllowedMIMETypes(copyAllowedMimeTypes(fetchConfig.getAllowedMimeTypes()));
+    fetchContext.setCooldownRetries(fetchConfig.getCooldownRetries());
+    fetchContext.setCooldownTime(fetchConfig.getCooldownTime(), true);
+    fetchContext.setIgnoreUSKDatehints(fetchConfig.getIgnoreUSKDatehints());
+    if (eventListener != null) {
+      fetchContext.getEventProducer().addEventListener(eventListener);
+    }
+    return fetchContext;
+  }
+
+  private static ClientGetFetchConfig toFetchConfig(FetchContext fetchContext) {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setMaxOutputLength(fetchContext.getMaxOutputLength());
+    fetchConfig.setMaxTempLength(fetchContext.getMaxTempLength());
+    fetchConfig.setMaxRecursionLevel(fetchContext.getMaxRecursionLevel());
+    fetchConfig.setMaxArchiveRestarts(fetchContext.getMaxArchiveRestarts());
+    fetchConfig.setMaxArchiveLevels(fetchContext.getMaxArchiveLevels());
+    fetchConfig.setDontEnterImplicitArchives(fetchContext.getDontEnterImplicitArchives());
+    fetchConfig.setMaxSplitfileBlockRetries(fetchContext.getMaxSplitfileBlockRetries());
+    fetchConfig.setMaxNonSplitfileRetries(fetchContext.getMaxNonSplitfileRetries());
+    fetchConfig.setMaxUSKRetries(fetchContext.getMaxUSKRetries());
+    fetchConfig.setAllowSplitfiles(fetchContext.getAllowSplitfiles());
+    fetchConfig.setFollowRedirects(fetchContext.getFollowRedirects());
+    fetchConfig.setLocalRequestOnly(fetchContext.getLocalRequestOnly());
+    fetchConfig.setIgnoreStore(fetchContext.getIgnoreStore());
+    fetchConfig.setMaxMetadataSize(fetchContext.getMaxMetadataSize());
+    fetchConfig.setMaxDataBlocksPerSegment(fetchContext.getMaxDataBlocksPerSegment());
+    fetchConfig.setMaxCheckBlocksPerSegment(fetchContext.getMaxCheckBlocksPerSegment());
+    fetchConfig.setReturnZIPManifests(fetchContext.getReturnZIPManifests());
+    fetchConfig.setFilterData(fetchContext.getFilterData());
+    fetchConfig.setIgnoreTooManyPathComponents(fetchContext.getIgnoreTooManyPathComponents());
+    fetchConfig.setAllowedMimeTypes(copyAllowedMimeTypes(fetchContext.getAllowedMIMETypes()));
+    fetchConfig.setCharset(fetchContext.getCharset());
+    fetchConfig.setCanWriteClientCache(fetchContext.getCanWriteClientCache());
+    fetchConfig.setOverrideMime(fetchContext.getOverrideMIME());
+    fetchConfig.setCooldownRetries(fetchContext.getCooldownRetries());
+    fetchConfig.setCooldownTime(fetchContext.getCooldownTime());
+    fetchConfig.setIgnoreUSKDatehints(fetchContext.getIgnoreUSKDatehints());
+    fetchConfig.setSchemeHostAndPort(fetchContext.getSchemeHostAndPort());
+    return fetchConfig;
+  }
+
+  private static Set<String> copyAllowedMimeTypes(Set<String> allowedMimeTypes) {
+    return allowedMimeTypes == null ? null : new HashSet<>(allowedMimeTypes);
+  }
+
+  private static final class CoreClientGetExecution implements ClientGetExecution {
+    private final Supplier<ClientContext> clientContextSupplier;
+    private final ClientGetter getter;
+
+    private CoreClientGetExecution(
+        Supplier<ClientContext> clientContextSupplier, ClientGetExecutionSpec executionSpec)
+        throws IOException {
+      this.clientContextSupplier = Objects.requireNonNull(clientContextSupplier);
+      CoreCallbackAdapter callback = new CoreCallbackAdapter(executionSpec.request());
+      FetchContext fetchContext =
+          materializeFetchContext(executionSpec.fetchConfig(), executionSpec.eventListener());
+      ClientGetterRequest getterRequest =
+          new ClientGetterRequest(
+              callback, executionSpec.uri(), fetchContext, executionSpec.priorityClass());
+      ClientGetterOptions options = createOptions(executionSpec, fetchContext);
+      this.getter = new ClientGetter(getterRequest, options);
+    }
+
+    @Override
+    public ClientRequester requester() {
+      return getter;
+    }
+
+    @Override
+    public void start() throws FetchException {
+      getter.start(clientContext());
+    }
+
+    @Override
+    public boolean canRestart() {
+      return getter.canRestart();
+    }
+
+    @Override
+    public boolean restart(FreenetURI redirect, boolean filterData) throws FetchException {
+      return getter.restart(redirect, filterData, clientContext());
+    }
+
+    @Override
+    public String expectedMime() {
+      return getter.expectedMIME();
+    }
+
+    @Override
+    public long expectedSize() {
+      return getter.expectedSize();
+    }
+
+    @Override
+    public Bucket blobBucket() {
+      return getter.getBlobBucket();
+    }
+
+    @Override
+    public boolean writeTrivialProgress(DataOutputStream dos) throws IOException {
+      return getter.writeTrivialProgress(dos);
+    }
+
+    @Override
+    public boolean resumeFromTrivialProgress(DataInputStream dis) throws IOException {
+      return getter.resumeFromTrivialProgress(dis, clientContext());
+    }
+
+    @Override
+    public boolean resumedFetcher() {
+      return getter.resumedFetcher();
+    }
+
+    private ClientContext clientContext() {
+      return Objects.requireNonNull(clientContextSupplier.get());
+    }
+
+    private ClientGetterOptions createOptions(
+        ClientGetExecutionSpec executionSpec, FetchContext fetchContext) throws IOException {
+      Bucket returnBucket = executionSpec.returnBucket();
+      if (executionSpec.binaryBlob()) {
+        Bucket blobBucket = returnBucket;
+        if (blobBucket == null) {
+          blobBucket =
+              clientContext()
+                  .getBucketFactory(executionSpec.persistenceForever())
+                  .makeBucket(fetchContext.getMaxOutputLength());
+        }
+        return new ClientGetterOptions(
+            NULL_BUCKET,
+            new BinaryBlobWriter(blobBucket),
+            false,
+            executionSpec.initialMetadata(),
+            executionSpec.extensionCheck());
+      }
+      if (executionSpec.discardData()) {
+        returnBucket = NULL_BUCKET;
+      }
+      return new ClientGetterOptions(
+          returnBucket,
+          null,
+          false,
+          executionSpec.initialMetadata(),
+          executionSpec.extensionCheck());
+    }
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class CoreCallbackAdapter
+      implements ClientGetCallback, PersistentClientCallback, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final ClientGet request;
+
+    private CoreCallbackAdapter(ClientGet request) {
+      this.request = request;
+    }
+
+    @Override
+    public void onSuccess(FetchResult result, ClientGetter state) {
+      request.onSuccess(result, new CallbackSuccessExecution(state));
+    }
+
+    @Override
+    public void onFailure(FetchException e) {
+      request.onFailure(e);
+    }
+
+    @Override
+    public void onResume(ClientContext context) throws ResumeFailedException {
+      request.onResume(context);
+    }
+
+    @Override
+    public RequestClient getRequestClient() {
+      return request.getRequestClient();
+    }
+
+    @Override
+    public void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException {
+      request.getClientDetail(dos, checker);
+    }
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class CallbackSuccessExecution implements ClientGetExecution {
+    private final ClientGetter getter;
+
+    private CallbackSuccessExecution(ClientGetter getter) {
+      this.getter = Objects.requireNonNull(getter);
+    }
+
+    @Override
+    public ClientRequester requester() {
+      return getter;
+    }
+
+    @Override
+    public void start() {
+      throw new UnsupportedOperationException("Success callback execution cannot be started");
+    }
+
+    @Override
+    public boolean canRestart() {
+      return getter.canRestart();
+    }
+
+    @Override
+    public boolean restart(FreenetURI redirect, boolean filterData) {
+      throw new UnsupportedOperationException("Success callback execution cannot be restarted");
+    }
+
+    @Override
+    public String expectedMime() {
+      return getter.expectedMIME();
+    }
+
+    @Override
+    public long expectedSize() {
+      return getter.expectedSize();
+    }
+
+    @Override
+    public Bucket blobBucket() {
+      return getter.getBlobBucket();
+    }
+
+    @Override
+    public boolean writeTrivialProgress(DataOutputStream dos) throws IOException {
+      return getter.writeTrivialProgress(dos);
+    }
+
+    @Override
+    public boolean resumeFromTrivialProgress(DataInputStream dis) {
+      throw new UnsupportedOperationException(
+          "Success callback execution cannot resume trivial progress");
+    }
+
+    @Override
+    public boolean resumedFetcher() {
+      return getter.resumedFetcher();
+    }
   }
 }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
@@ -3,6 +3,7 @@ package network.crypta.clients.fcp.bridge;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.HashSet;
@@ -21,6 +22,7 @@ import network.crypta.client.async.ClientGetterOptions;
 import network.crypta.client.async.ClientGetterRequest;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.PersistentClientCallback;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.client.events.ClientEventListener;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.clients.fcp.ClientGet;
@@ -221,7 +223,9 @@ record CoreFcpFetchRuntimeSupport(
   }
 
   private static final class CoreClientGetExecution implements ClientGetExecution {
-    private final Supplier<ClientContext> clientContextSupplier;
+    @Serial private static final long serialVersionUID = 1L;
+
+    private transient Supplier<ClientContext> clientContextSupplier;
     private final ClientGetter getter;
 
     private CoreClientGetExecution(
@@ -241,6 +245,11 @@ record CoreFcpFetchRuntimeSupport(
     @Override
     public ClientRequester requester() {
       return getter;
+    }
+
+    @Override
+    public void onResume(PersistentRequestRuntimeContext context) {
+      clientContextSupplier = () -> requireClientContext(context);
     }
 
     @Override
@@ -290,6 +299,12 @@ record CoreFcpFetchRuntimeSupport(
 
     private ClientContext clientContext() {
       return Objects.requireNonNull(clientContextSupplier.get());
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      clientContextSupplier = null;
     }
 
     private ClientGetterOptions createOptions(
@@ -361,6 +376,8 @@ record CoreFcpFetchRuntimeSupport(
 
   @SuppressWarnings("ClassCanBeRecord")
   private static final class CallbackSuccessExecution implements ClientGetExecution {
+    @Serial private static final long serialVersionUID = 1L;
+
     private final ClientGetter getter;
 
     private CallbackSuccessExecution(ClientGetter getter) {
@@ -370,6 +387,11 @@ record CoreFcpFetchRuntimeSupport(
     @Override
     public ClientRequester requester() {
       return getter;
+    }
+
+    @Override
+    public void onResume(PersistentRequestRuntimeContext context) {
+      // Success callback executions are ephemeral wrappers and do not hold resume-only state.
     }
 
     @Override
@@ -417,5 +439,14 @@ record CoreFcpFetchRuntimeSupport(
     public boolean resumedFetcher() {
       return getter.resumedFetcher();
     }
+  }
+
+  private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {
+    if (context instanceof ClientContext clientContext) {
+      return clientContext;
+    }
+    String contextType = context == null ? "null" : context.getClass().getName();
+    throw new IllegalArgumentException(
+        "FCP GET execution resume requires ClientContext but got " + contextType);
   }
 }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/FcpPersistentRequestRecoveryCodec.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/FcpPersistentRequestRecoveryCodec.java
@@ -20,8 +20,9 @@ import network.crypta.support.io.StorageFormatException;
  * It converts the client-owned durable identifier into the legacy FCP identifier type, narrows the
  * runtime-context seam back to {@link ClientContext} at the bridge boundary, and then delegates
  * reconstruction to {@link ClientRequest#restartFrom(DataInputStream, RequestIdentifier,
- * ClientContext, ChecksumChecker)}. The adapter stays stateless, so startup wiring can reuse a
- * single instance without coordinating additional caches or configuration.
+ * network.crypta.clients.fcp.FcpFetchRuntimeSupport, ClientContext, ChecksumChecker)}. The adapter
+ * stays stateless, so startup wiring can reuse a single instance without coordinating additional
+ * caches or configuration.
  */
 public final class FcpPersistentRequestRecoveryCodec implements PersistentRequestRecoveryCodec {
 
@@ -45,8 +46,18 @@ public final class FcpPersistentRequestRecoveryCodec implements PersistentReques
       throws StorageFormatException, IOException, ResumeFailedException {
     RequestIdentifier requestIdentifier =
         RequestIdentifier.fromPersistentRequestIdentifier(identifier);
+    ClientContext clientContext = requireClientContext(context);
     return ClientRequest.restartFrom(
-        dis, requestIdentifier, requireClientContext(context), checker);
+        dis,
+        requestIdentifier,
+        new CoreFcpFetchRuntimeSupport(
+            clientContext,
+            () -> {
+              throw new UnsupportedOperationException(
+                  "transferAccess is unavailable during persistent request recovery");
+            }),
+        clientContext,
+        checker);
   }
 
   private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupportTest.java
@@ -1,9 +1,21 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.util.function.Supplier;
 import network.crypta.client.FetchContext;
+import network.crypta.client.FetchContextOptions;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.events.ClientEventListener;
+import network.crypta.clients.fcp.ClientGet;
+import network.crypta.clients.fcp.ClientGetExecution;
+import network.crypta.clients.fcp.ClientGetExecutionSpec;
+import network.crypta.clients.fcp.ClientGetFetchConfig;
+import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
@@ -13,8 +25,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,125 +42,190 @@ class CoreFcpFetchRuntimeSupportTest {
 
   @Mock private NodeClientCore core;
   @Mock private ClientContext clientContext;
-  @Mock private FetchContext fetchContext;
   @Mock private TransferAccessPort firstTransferAccess;
   @Mock private TransferAccessPort secondTransferAccess;
-  @Mock private BucketFactory persistentBucketFactory;
   @Mock private BucketFactory transientBucketFactory;
   @Mock private RandomAccessBucket bucket;
+  @Mock private ClientGet request;
+  @Mock private RequestClient requestClient;
+  @Mock private ClientEventListener eventListener;
 
   @Test
   void constructor_whenCoreNull_throwsNullPointerException() {
-    // Arrange
     Supplier<TransferAccessPort> transferAccessSupplier = () -> firstTransferAccess;
 
-    // Act + Assert
     assertThrows(
         NullPointerException.class,
-        () -> new CoreFcpFetchRuntimeSupport(null, transferAccessSupplier));
+        () -> new CoreFcpFetchRuntimeSupport((NodeClientCore) null, transferAccessSupplier));
   }
 
   @Test
   void constructor_whenTransferAccessSupplierNull_throwsNullPointerException() {
-    // Act + Assert
     assertThrows(NullPointerException.class, () -> new CoreFcpFetchRuntimeSupport(core, null));
   }
 
   @Test
-  void clientContext_whenCalled_returnsLiveClientContext() {
-    // Arrange
-    when(core.getClientContext()).thenReturn(clientContext);
-    CoreFcpFetchRuntimeSupport support =
-        new CoreFcpFetchRuntimeSupport(core, () -> firstTransferAccess);
-
-    // Act
-    ClientContext actual = support.clientContext();
-
-    // Assert
-    assertSame(clientContext, actual);
-    verify(core).getClientContext();
-  }
-
-  @Test
-  void defaultPersistentFetchContext_whenCalled_returnsCoreDefaultFetchContext() {
-    // Arrange
+  void defaultPersistentFetchConfig_whenCalled_returnsDetachedCopy() {
+    FetchContext fetchContext = baseFetchContext();
+    fetchContext.setIgnoreStore(true);
+    fetchContext.setFilterData(true);
+    fetchContext.setMaxOutputLength(4096L);
     when(core.getClientContext()).thenReturn(clientContext);
     when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
     CoreFcpFetchRuntimeSupport support =
         new CoreFcpFetchRuntimeSupport(core, () -> firstTransferAccess);
 
-    // Act
-    FetchContext actual = support.defaultPersistentFetchContext();
+    ClientGetFetchConfig actual = support.defaultPersistentFetchConfig();
 
-    // Assert
-    assertSame(fetchContext, actual);
-    verify(core).getClientContext();
-    verify(clientContext).getDefaultPersistentFetchContext();
+    assertTrue(actual.getIgnoreStore());
+    assertTrue(actual.getFilterData());
+    assertEquals(4096L, actual.getMaxOutputLength());
+  }
+
+  @Test
+  void
+      defaultPersistentFetchConfig_whenCallerMutatesDetachedCopy_leavesSourceFetchContextUntouched() {
+    FetchContext fetchContext = baseFetchContext();
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(clientContext.getDefaultPersistentFetchContext()).thenReturn(fetchContext);
+    CoreFcpFetchRuntimeSupport support =
+        new CoreFcpFetchRuntimeSupport(core, () -> firstTransferAccess);
+
+    ClientGetFetchConfig actual = support.defaultPersistentFetchConfig();
+    actual.setFilterData(true);
+    actual.setMaxOutputLength(8192L);
+
+    assertFalse(fetchContext.getFilterData());
+    assertEquals(1024L, fetchContext.getMaxOutputLength());
+  }
+
+  @Test
+  void encodeAndDecodeFetchConfig_whenRoundTripped_preservesFields() throws Exception {
+    CoreFcpFetchRuntimeSupport support =
+        new CoreFcpFetchRuntimeSupport(clientContext, () -> firstTransferAccess);
+    ClientGetFetchConfig fetchConfig = sampleFetchConfig();
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(output)) {
+      support.encodeFetchConfig(fetchConfig, dos);
+    }
+
+    ClientGetFetchConfig restored =
+        support.decodeFetchConfig(
+            new DataInputStream(new ByteArrayInputStream(output.toByteArray())));
+
+    assertEquals(fetchConfig, restored);
   }
 
   @Test
   void transferAccess_whenSupplierChanges_returnsLatestPortOnEachCall() {
-    // Arrange
     @SuppressWarnings("unchecked")
     Supplier<TransferAccessPort> transferAccessSupplier = org.mockito.Mockito.mock(Supplier.class);
     when(transferAccessSupplier.get()).thenReturn(firstTransferAccess, secondTransferAccess);
     CoreFcpFetchRuntimeSupport support =
         new CoreFcpFetchRuntimeSupport(core, transferAccessSupplier);
 
-    // Act
     TransferAccessPort firstActual = support.transferAccess();
     TransferAccessPort secondActual = support.transferAccess();
 
-    // Assert
     assertSame(firstTransferAccess, firstActual);
     assertSame(secondTransferAccess, secondActual);
     verify(transferAccessSupplier, times(2)).get();
   }
 
   @Test
-  void transferAccess_whenSupplierReturnsNull_throwsNullPointerException() {
-    // Arrange
-    CoreFcpFetchRuntimeSupport support = new CoreFcpFetchRuntimeSupport(core, () -> null);
-
-    // Act + Assert
-    assertThrows(NullPointerException.class, support::transferAccess);
-  }
-
-  @Test
-  void allocateBinaryBlobBucket_whenTransientRequested_usesTransientBucketFactory()
-      throws Exception {
-    // Arrange
-    when(core.getClientContext()).thenReturn(clientContext);
+  void createExecution_whenBinaryBlobNeedsBucket_usesRuntimeBucketFactory() throws Exception {
+    when(request.getRequestClient()).thenReturn(requestClient);
     when(clientContext.getBucketFactory(false)).thenReturn(transientBucketFactory);
     when(transientBucketFactory.makeBucket(128L)).thenReturn(bucket);
     CoreFcpFetchRuntimeSupport support =
-        new CoreFcpFetchRuntimeSupport(core, () -> firstTransferAccess);
+        new CoreFcpFetchRuntimeSupport(clientContext, () -> firstTransferAccess);
+    ClientGetExecution execution = createBinaryBlobExecution(support);
 
-    // Act
-    Bucket actual = support.allocateBinaryBlobBucket(128L, false);
-
-    // Assert
-    assertSame(bucket, actual);
+    assertNotNull(execution);
+    assertNotNull(execution.requester());
     verify(clientContext).getBucketFactory(false);
+    //noinspection resource
     verify(transientBucketFactory).makeBucket(128L);
   }
 
   @Test
-  void allocateBinaryBlobBucket_whenPersistentRequested_usesPersistentBucketFactory()
+  void createExecution_whenBinaryBlobBucketProvided_skipsRuntimeBucketAllocation()
       throws Exception {
-    // Arrange
-    when(core.getClientContext()).thenReturn(clientContext);
-    when(clientContext.getBucketFactory(true)).thenReturn(persistentBucketFactory);
-    when(persistentBucketFactory.makeBucket(256L)).thenReturn(bucket);
+    when(request.getRequestClient()).thenReturn(requestClient);
+    Bucket providedBucket = org.mockito.Mockito.mock(Bucket.class);
     CoreFcpFetchRuntimeSupport support =
-        new CoreFcpFetchRuntimeSupport(core, () -> firstTransferAccess);
+        new CoreFcpFetchRuntimeSupport(clientContext, () -> firstTransferAccess);
 
-    // Act
-    Bucket actual = support.allocateBinaryBlobBucket(256L, true);
+    ClientGetExecution execution =
+        support.createExecution(
+            new ClientGetExecutionSpec(
+                request,
+                FreenetURI.EMPTY_CHK_URI,
+                (short) 2,
+                binaryBlobFetchConfig(),
+                providedBucket,
+                false,
+                true,
+                false,
+                null,
+                null,
+                eventListener));
 
-    // Assert
-    assertSame(bucket, actual);
-    verify(clientContext).getBucketFactory(true);
-    verify(persistentBucketFactory).makeBucket(256L);
+    assertNotNull(execution.requester());
+    verify(clientContext, never()).getBucketFactory(false);
+  }
+
+  private ClientGetExecution createBinaryBlobExecution(CoreFcpFetchRuntimeSupport support)
+      throws Exception {
+    return support.createExecution(
+        new ClientGetExecutionSpec(
+            request,
+            FreenetURI.EMPTY_CHK_URI,
+            (short) 2,
+            binaryBlobFetchConfig(),
+            null,
+            false,
+            true,
+            false,
+            null,
+            null,
+            eventListener));
+  }
+
+  private static ClientGetFetchConfig sampleFetchConfig() {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setMaxOutputLength(4096L);
+    fetchConfig.setMaxTempLength(1024L);
+    fetchConfig.setMaxNonSplitfileRetries(7);
+    fetchConfig.setMaxSplitfileBlockRetries(8);
+    fetchConfig.setIgnoreStore(true);
+    fetchConfig.setFilterData(true);
+    fetchConfig.setIgnoreUSKDatehints(true);
+    fetchConfig.setCharset("UTF-8");
+    fetchConfig.setOverrideMime("text/plain");
+    fetchConfig.setSchemeHostAndPort("https://localhost:1234");
+    return fetchConfig;
+  }
+
+  private static ClientGetFetchConfig binaryBlobFetchConfig() {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setMaxOutputLength(128L);
+    fetchConfig.setMaxTempLength(128L);
+    return fetchConfig;
+  }
+
+  private static FetchContext baseFetchContext() {
+    FetchContextOptions options =
+        FetchContextOptions.builder()
+            .limits(1024L, 1024L, 1024)
+            .archiveLimits(3, 2, 4, false)
+            .retryLimits(1, 2, 3)
+            .splitfileLimits(true, 10, 5)
+            .behavior(true, false, false)
+            .clientOptions(new network.crypta.client.events.SimpleEventProducer(), false, true)
+            .filterOverrides(null, null, null)
+            .build();
+    return new FetchContext(options);
   }
 }

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/FcpPersistentRequestRecoveryCodecTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/FcpPersistentRequestRecoveryCodecTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockedStatic;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -44,7 +45,11 @@ class FcpPersistentRequestRecoveryCodecTest {
           .when(
               () ->
                   ClientRequest.restartFrom(
-                      same(dis), eq(requestIdentifier), same(context), same(checker)))
+                      same(dis),
+                      eq(requestIdentifier),
+                      any(network.crypta.clients.fcp.FcpFetchRuntimeSupport.class),
+                      same(context),
+                      same(checker)))
           .thenReturn(expectedRequest);
 
       PersistentRequestHandle restored =
@@ -55,7 +60,11 @@ class FcpPersistentRequestRecoveryCodecTest {
       clientRequestMock.verify(
           () ->
               ClientRequest.restartFrom(
-                  same(dis), eq(requestIdentifier), same(context), same(checker)));
+                  same(dis),
+                  eq(requestIdentifier),
+                  any(network.crypta.clients.fcp.FcpFetchRuntimeSupport.class),
+                  same(context),
+                  same(checker)));
     }
   }
 

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -1585,15 +1585,14 @@ public final class LocalProcessAppHost implements AppHost {
 
   private RunningProcess trackRunningProcessForStop(String appId, RunningProcess runningProcess) {
     List<ProcessHandle> processTree = runningProcess.processTree();
-    try {
-      RunningProcess trackedRunningProcess = runningProcess.withProcessTree(processTree);
-      runningApps.replace(appId, runningProcess, trackedRunningProcess);
-      return trackedRunningProcess;
-    } catch (IllegalArgumentException _) {
+    RunningProcess trackedRunningProcess = runningProcess.tryWithProcessTree(processTree);
+    if (trackedRunningProcess == null) {
       runningProcess.exitCleanup().join();
       runningApps.remove(appId, runningProcess);
       return null;
     }
+    runningApps.replace(appId, runningProcess, trackedRunningProcess);
+    return trackedRunningProcess;
   }
 
   private RunningProcess refreshTrackedRunningProcess(String appId, RunningProcess runningProcess) {
@@ -1638,7 +1637,7 @@ public final class LocalProcessAppHost implements AppHost {
     if (recoveredHandles.isEmpty()) {
       return null;
     }
-    return runningProcess.withProcessTree(recoveredHandles);
+    return runningProcess.tryWithProcessTree(recoveredHandles);
   }
 
   private List<ProcessHandle> recoverTrackedProcesses(
@@ -2096,13 +2095,13 @@ public final class LocalProcessAppHost implements AppHost {
       if (currentProcessTree.isEmpty()) {
         return null;
       }
-      return withProcessTree(currentProcessTree);
+      return tryWithProcessTree(currentProcessTree);
     }
 
-    private RunningProcess withProcessTree(List<ProcessHandle> newProcessTree) {
+    private RunningProcess tryWithProcessTree(List<ProcessHandle> newProcessTree) {
       List<ProcessHandle> aliveProcessTree = aliveHandles(newProcessTree);
       if (aliveProcessTree.isEmpty()) {
-        throw new IllegalArgumentException("newProcessTree must contain a live process");
+        return null;
       }
       long updatedPid = representativePid(aliveProcessTree, snapshot.pid(), false);
       RunningAppSnapshot updatedSnapshot =

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -1821,6 +1821,21 @@ class LocalProcessAppHostTest {
     assertTrue(host.listRunning().isEmpty());
   }
 
+  @Test
+  void preserveRunningState_whenTrackedProcessExitsDuringRefresh_expectEntryRemovedWithoutFailure()
+      throws ReflectiveOperationException {
+    LocalProcessAppHost host = host();
+    RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
+    injectRunningProcess(host, RUNNER_APP_ID, snapshot, new FadingProcess(snapshot.pid(), 1));
+
+    Object runningProcess = runnerProcessEntry(host);
+    boolean preserved = invokePreserveRunnerState(host, runningProcess);
+
+    assertFalse(preserved);
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    assertTrue(host.listRunning().isEmpty());
+  }
+
   private LocalProcessAppHost host() {
     return host(Duration.ofSeconds(1));
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -5,10 +5,8 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Path;
 import java.util.Arrays;
-import network.crypta.client.FetchContext;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
-import network.crypta.client.events.ClientEventProducer;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -22,17 +20,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,8 +43,8 @@ import static org.mockito.Mockito.when;
 class ClientGetFactoryTest {
 
   @Mock private FcpFetchRuntimeSupport fetchRuntimeSupport;
-  @Mock private FetchContext fetchContext;
-  @Mock private ClientEventProducer eventProducer;
+  @Mock private ClientGetExecution execution;
+  @Mock private ClientRequester requester;
   @Mock private TransferAccessPort transferAccess;
 
   @Test
@@ -80,9 +81,9 @@ class ClientGetFactoryTest {
 
   @ParameterizedTest
   @CsvSource({"true,false", "false,true"})
-  void fromGlobal_whenValidConfig_buildsRequestAndAppliesFetchContext(
+  void fromGlobal_whenValidConfig_buildsRequestAndAppliesFetchConfig(
       boolean persistRebootOnly, boolean expectedForever) throws Exception {
-    configureFetchRuntimeSupportWithFetchContext();
+    configureFetchRuntimeSupportDefaults();
     PersistentRequestClient client =
         newPersistentClient(persistRebootOnly ? Persistence.REBOOT : Persistence.FOREVER);
     FreenetURI uri = new FreenetURI("KSK@global-ok-" + persistRebootOnly);
@@ -107,35 +108,22 @@ class ClientGetFactoryTest {
 
     ClientGet request = ClientGetFactory.fromGlobal(client, uri, config, fetchRuntimeSupport);
 
-    assertNotNull(request);
-    assertEquals(config.identifier(), request.getIdentifier());
-    assertSame(uri, request.getURI());
-    assertEquals(config.prioClass(), request.getPriority());
-    assertTrue(request.isPersistent());
-    assertEquals(expectedForever, request.isPersistentForever());
-    assertTrue(request.isDirect());
-    assertFalse(request.isToDisk());
-
-    RequestClient lowLevelClient = request.getRequestClient();
-    assertEquals(expectedForever, lowLevelClient.persistent());
-    assertTrue(lowLevelClient.realTimeFlag());
-
-    verify(fetchContext).setLocalRequestOnly(config.dsOnly());
-    verify(fetchContext).setIgnoreStore(config.ignoreDS());
-    verify(fetchContext).setMaxNonSplitfileRetries(config.maxNonSplitfileRetries());
-    verify(fetchContext).setMaxSplitfileBlockRetries(config.maxSplitfileRetries());
-    verify(fetchContext).setFilterData(config.filterData());
-    verify(fetchContext).setMaxOutputLength(config.maxOutputLength());
-    verify(fetchContext).setMaxTempLength(config.maxOutputLength());
-    verify(fetchContext).setCanWriteClientCache(config.writeToClientCache());
-    verify(fetchRuntimeSupport).defaultPersistentFetchContext();
-    verify(fetchRuntimeSupport).transferAccess();
-    verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
+    checkGlobalRequestState(request, config, uri, expectedForever);
+    ClientGetFetchConfig fetchConfig = fetchConfigFrom(request);
+    checkGlobalFetchConfig(fetchConfig, config);
+    checkFetchRuntimeSupportInteractions();
+    checkExecutionSpecShape(
+        executionSpecFromRuntimeSupport(),
+        request,
+        uri,
+        config.prioClass(),
+        fetchConfig,
+        expectedForever);
   }
 
   @Test
   void fromGlobal_whenUsingLegacyPublicConfigAlias_buildsRequest() throws Exception {
-    configureFetchRuntimeSupportWithFetchContext();
+    configureFetchRuntimeSupportDefaults();
     PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
     FreenetURI uri = new FreenetURI("KSK@legacy-global-config");
     ClientGet.GlobalRequestConfig config =
@@ -162,12 +150,13 @@ class ClientGetFactoryTest {
     assertNotNull(request);
     assertEquals(config.identifier(), request.getIdentifier());
     assertSame(uri, request.getURI());
-    verify(fetchRuntimeSupport).defaultPersistentFetchContext();
+    verify(fetchRuntimeSupport).defaultPersistentFetchConfig();
     verify(fetchRuntimeSupport).transferAccess();
   }
 
   @Test
-  void fromGlobal_whenDiskReturnDenied_throwsNotAllowedException(@TempDir Path tempDir) {
+  void fromGlobal_whenDiskReturnDenied_throwsNotAllowedException(@TempDir Path tempDir)
+      throws IOException {
     configureFetchRuntimeSupportDefaults();
     PersistentRequestClient client = newPersistentClient(Persistence.REBOOT);
     File target = tempDir.resolve("target.bin").toFile();
@@ -214,9 +203,9 @@ class ClientGetFactoryTest {
   }
 
   @Test
-  void fromMessage_whenValidConnectionMessage_buildsRequestAndAppliesFetchContext()
+  void fromMessage_whenValidConnectionMessage_buildsRequestAndAppliesFetchConfig()
       throws Exception {
-    configureFetchRuntimeSupportWithFetchContext();
+    configureFetchRuntimeSupportDefaults();
     SimpleFieldSet fs = baseMessageFieldSet("message-ok");
     fs.putOverwrite("DSOnly", "true");
     fs.putOverwrite("IgnoreDS", "true");
@@ -232,37 +221,47 @@ class ClientGetFactoryTest {
 
     ClientGet request = ClientGetFactory.fromMessage(null, message, fetchRuntimeSupport);
 
-    assertNotNull(request);
-    assertEquals("message-ok", request.getIdentifier());
-    assertEquals((short) 3, request.getPriority());
-    assertTrue(request.isDirect());
-    assertFalse(request.isToDisk());
-    assertFalse(request.isPersistent());
-    assertFalse(request.isPersistentForever());
-    assertFalse(request.getRequestClient().persistent());
-    assertTrue(request.getRequestClient().realTimeFlag());
+    checkMessageRequestState(request);
+    ClientGetFetchConfig fetchConfig = fetchConfigFrom(request);
+    checkMessageFetchConfig(fetchConfig);
+    checkFetchRuntimeSupportInteractions();
+    checkExecutionSpecShape(
+        executionSpecFromRuntimeSupport(),
+        request,
+        request.getURI(),
+        (short) 3,
+        fetchConfig,
+        false);
+  }
 
-    verify(fetchContext).setLocalRequestOnly(true);
-    verify(fetchContext).setIgnoreStore(true);
-    verify(fetchContext).setMaxNonSplitfileRetries(9);
-    verify(fetchContext).setMaxSplitfileBlockRetries(9);
-    verify(fetchContext).setMaxOutputLength(2048);
-    verify(fetchContext).setMaxTempLength(1024);
-    verify(fetchContext).setCanWriteClientCache(false);
-    verify(fetchContext).setFilterData(true);
-    verify(fetchContext).setIgnoreUSKDatehints(true);
-    verify(fetchRuntimeSupport).defaultPersistentFetchContext();
-    verify(fetchRuntimeSupport).transferAccess();
-    verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
+  @Test
+  void fromMessage_whenReturnTypeNone_marksExecutionSpecDiscardData() throws Exception {
+    configureFetchRuntimeSupportDefaults();
+    SimpleFieldSet fs = baseMessageFieldSet("message-none");
+    fs.putOverwrite("ReturnType", ReturnType.NONE.name());
+    ClientGetMessage message = new ClientGetMessage(fs);
+
+    ClientGet request = ClientGetFactory.fromMessage(null, message, fetchRuntimeSupport);
+
+    assertNotNull(request);
+    assertFalse(request.isDirect());
+    assertFalse(request.isToDisk());
+    ArgumentCaptor<ClientGetExecutionSpec> executionSpecCaptor =
+        ArgumentCaptor.forClass(ClientGetExecutionSpec.class);
+    verify(fetchRuntimeSupport).createExecution(executionSpecCaptor.capture());
+    ClientGetExecutionSpec executionSpec = executionSpecCaptor.getValue();
+    assertTrue(executionSpec.discardData());
+    assertNull(executionSpec.returnBucket());
+    assertFalse(executionSpec.binaryBlob());
   }
 
   @Test
   void fromMessage_whenBinaryBlobBucketCreationFails_wrapsIntoMessageInvalidException()
       throws Exception {
-    configureFetchRuntimeSupportWithFetchContext();
+    configureFetchRuntimeSupportDefaults();
     IOException ioFailure = new IOException("disk-full");
-    when(fetchContext.getMaxOutputLength()).thenReturn(333L);
-    when(fetchRuntimeSupport.allocateBinaryBlobBucket(333L, false)).thenThrow(ioFailure);
+    when(fetchRuntimeSupport.createExecution(any(ClientGetExecutionSpec.class)))
+        .thenThrow(ioFailure);
 
     SimpleFieldSet fs = baseMessageFieldSet("blob-io");
     fs.putOverwrite("BinaryBlob", "true");
@@ -278,18 +277,17 @@ class ClientGetFactoryTest {
     assertFalse(exception.global);
     assertSame(ioFailure, exception.getCause());
     assertTrue(exception.getMessage().contains("Cannot create bucket for temporary storage"));
-    //noinspection resource
-    verify(fetchRuntimeSupport).allocateBinaryBlobBucket(333L, false);
+    verify(fetchRuntimeSupport).createExecution(any(ClientGetExecutionSpec.class));
   }
 
-  private void configureFetchRuntimeSupportWithFetchContext() {
-    configureFetchRuntimeSupportDefaults();
-    when(fetchContext.getEventProducer()).thenReturn(eventProducer);
-  }
-
-  private void configureFetchRuntimeSupportDefaults() {
-    when(fetchRuntimeSupport.defaultPersistentFetchContext()).thenReturn(fetchContext);
+  private void configureFetchRuntimeSupportDefaults() throws IOException {
+    when(fetchRuntimeSupport.defaultPersistentFetchConfig()).thenReturn(new ClientGetFetchConfig());
     when(fetchRuntimeSupport.transferAccess()).thenReturn(transferAccess);
+    lenient()
+        .doReturn(execution)
+        .when(fetchRuntimeSupport)
+        .createExecution(any(ClientGetExecutionSpec.class));
+    lenient().when(execution.requester()).thenReturn(requester);
   }
 
   private FCPConnectionHandler newConnectionHandler() {
@@ -312,6 +310,101 @@ class ClientGetFactoryTest {
         .when(randomnessPort)
         .fillSecureRandom(any(byte[].class));
     return new FCPConnectionHandler(socket, server);
+  }
+
+  private void checkFetchRuntimeSupportInteractions() {
+    verify(fetchRuntimeSupport).defaultPersistentFetchConfig();
+    verify(fetchRuntimeSupport).transferAccess();
+  }
+
+  private ClientGetExecutionSpec executionSpecFromRuntimeSupport() throws IOException {
+    ArgumentCaptor<ClientGetExecutionSpec> executionSpecCaptor =
+        ArgumentCaptor.forClass(ClientGetExecutionSpec.class);
+    verify(fetchRuntimeSupport).createExecution(executionSpecCaptor.capture());
+    return executionSpecCaptor.getValue();
+  }
+
+  private static void checkGlobalRequestState(
+      ClientGet request,
+      ClientGetGlobalRequestConfig config,
+      FreenetURI uri,
+      boolean expectedForever) {
+    assertNotNull(request);
+    assertEquals(config.identifier(), request.getIdentifier());
+    assertSame(uri, request.getURI());
+    assertEquals(config.prioClass(), request.getPriority());
+    assertTrue(request.isPersistent());
+    assertEquals(expectedForever, request.isPersistentForever());
+    assertTrue(request.isDirect());
+    assertFalse(request.isToDisk());
+
+    RequestClient lowLevelClient = request.getRequestClient();
+    assertEquals(expectedForever, lowLevelClient.persistent());
+    assertTrue(lowLevelClient.realTimeFlag());
+  }
+
+  private static void checkMessageRequestState(ClientGet request) {
+    assertNotNull(request);
+    assertEquals("message-ok", request.getIdentifier());
+    assertEquals((short) 3, request.getPriority());
+    assertTrue(request.isDirect());
+    assertFalse(request.isToDisk());
+    assertFalse(request.isPersistent());
+    assertFalse(request.isPersistentForever());
+
+    RequestClient lowLevelClient = request.getRequestClient();
+    assertFalse(lowLevelClient.persistent());
+    assertTrue(lowLevelClient.realTimeFlag());
+  }
+
+  private static ClientGetFetchConfig fetchConfigFrom(ClientGet request) {
+    ClientGetFetchConfig fetchConfig = request.fetchConfig();
+    assertNotNull(fetchConfig);
+    return fetchConfig;
+  }
+
+  private static void checkGlobalFetchConfig(
+      ClientGetFetchConfig fetchConfig, ClientGetGlobalRequestConfig config) {
+    assertTrue(fetchConfig.getLocalRequestOnly());
+    assertTrue(fetchConfig.getIgnoreStore());
+    assertEquals(config.maxNonSplitfileRetries(), fetchConfig.getMaxNonSplitfileRetries());
+    assertEquals(config.maxSplitfileRetries(), fetchConfig.getMaxSplitfileBlockRetries());
+    assertTrue(fetchConfig.getFilterData());
+    assertEquals(config.maxOutputLength(), fetchConfig.getMaxOutputLength());
+    assertEquals(config.maxOutputLength(), fetchConfig.getMaxTempLength());
+    assertFalse(fetchConfig.getCanWriteClientCache());
+  }
+
+  private static void checkMessageFetchConfig(ClientGetFetchConfig fetchConfig) {
+    assertTrue(fetchConfig.getLocalRequestOnly());
+    assertTrue(fetchConfig.getIgnoreStore());
+    assertEquals(9, fetchConfig.getMaxNonSplitfileRetries());
+    assertEquals(9, fetchConfig.getMaxSplitfileBlockRetries());
+    assertEquals(2048L, fetchConfig.getMaxOutputLength());
+    assertEquals(1024L, fetchConfig.getMaxTempLength());
+    assertFalse(fetchConfig.getCanWriteClientCache());
+    assertTrue(fetchConfig.getFilterData());
+    assertTrue(fetchConfig.getIgnoreUSKDatehints());
+  }
+
+  private static void checkExecutionSpecShape(
+      ClientGetExecutionSpec executionSpec,
+      ClientGet request,
+      FreenetURI uri,
+      short priority,
+      ClientGetFetchConfig fetchConfig,
+      boolean persistenceForever) {
+    assertSame(request, executionSpec.request());
+    assertSame(uri, executionSpec.uri());
+    assertEquals(priority, executionSpec.priorityClass());
+    assertSame(fetchConfig, executionSpec.fetchConfig());
+    assertNull(executionSpec.returnBucket());
+    assertFalse(executionSpec.discardData());
+    assertFalse(executionSpec.binaryBlob());
+    assertEquals(persistenceForever, executionSpec.persistenceForever());
+    assertNull(executionSpec.initialMetadata());
+    assertNull(executionSpec.extensionCheck());
+    assertNotNull(executionSpec.eventListener());
   }
 
   private static PersistentRequestClient newPersistentClient(Persistence persistence) {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFetchConfigTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFetchConfigTest.java
@@ -1,0 +1,53 @@
+package network.crypta.clients.fcp;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class ClientGetFetchConfigTest {
+
+  @Test
+  void setAllowedMimeTypes_whenSourceSetMutates_keepsDetachedStoredCopy() {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    Set<String> sourceMimeTypes = new HashSet<>(Set.of("text/plain"));
+
+    fetchConfig.setAllowedMimeTypes(sourceMimeTypes);
+    sourceMimeTypes.add("image/png");
+
+    assertEquals(Set.of("text/plain"), fetchConfig.getAllowedMimeTypes());
+  }
+
+  @Test
+  void getAllowedMimeTypes_whenReturnedSetMutates_keepsStoredSetUnchanged() {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setAllowedMimeTypes(new HashSet<>(Set.of("text/plain")));
+
+    Set<String> returnedMimeTypes = fetchConfig.getAllowedMimeTypes();
+    returnedMimeTypes.add("image/png");
+
+    assertEquals(Set.of("text/plain"), fetchConfig.getAllowedMimeTypes());
+  }
+
+  @Test
+  void copy_whenOriginalMutates_keepsIndependentState() {
+    ClientGetFetchConfig original = new ClientGetFetchConfig();
+    original.setAllowedMimeTypes(new HashSet<>(Set.of("text/plain")));
+    original.setFilterData(true);
+    original.setMaxOutputLength(4096L);
+
+    ClientGetFetchConfig copy = original.copy();
+    original.setAllowedMimeTypes(new HashSet<>(Set.of("image/png")));
+    original.setFilterData(false);
+    original.setMaxOutputLength(2048L);
+
+    assertEquals(Set.of("text/plain"), copy.getAllowedMimeTypes());
+    assertTrue(copy.getFilterData());
+    assertEquals(4096L, copy.getMaxOutputLength());
+    assertNotEquals(original, copy);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetGetterFactoryTest.java
@@ -2,82 +2,68 @@ package network.crypta.clients.fcp;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.reflect.Field;
-import network.crypta.client.FetchContext;
-import network.crypta.client.FetchException;
-import network.crypta.client.FetchResult;
+import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.async.BinaryBlob;
-import network.crypta.client.async.BinaryBlobWriter;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetCallback;
-import network.crypta.client.async.ClientGetter;
-import network.crypta.client.async.ClientGetterOptions;
-import network.crypta.client.async.ClientGetterRequest;
-import network.crypta.client.async.PersistentClientCallback;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
 import network.crypta.crypt.HashType;
 import network.crypta.keys.FreenetURI;
-import network.crypta.node.RequestClient;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.FileBucket;
-import network.crypta.support.io.NullBucket;
+import network.crypta.support.io.PrependLengthOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockingDetails;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class ClientGetGetterFactoryTest {
   @TempDir File tempDir;
-  @Mock private FcpFetchRuntimeSupport fetchRuntimeSupport;
 
   @Test
   void binaryBlobMimeType_whenCalled_returnsBinaryBlobMimeType() {
-    String mimeType = ClientGetGetterFactory.binaryBlobMimeType();
-
-    assertEquals(BinaryBlob.MIME_TYPE, mimeType);
+    assertEquals(BinaryBlob.MIME_TYPE, ClientGetGetterFactory.binaryBlobMimeType());
   }
 
   @Test
   void checksummedWriter_whenCalled_usesChecksumWriterWithLength() throws IOException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     DataOutputStream target = new DataOutputStream(output);
-    RecordingChecksumChecker checker = new RecordingChecksumChecker();
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    PrependLengthOutputStream prependLengthOutputStream = mock(PrependLengthOutputStream.class);
+    when(checker.checksumWriterWithLength(org.mockito.ArgumentMatchers.eq(target), any()))
+        .thenReturn(prependLengthOutputStream);
 
     DataOutputStream writer = ClientGetGetterFactory.checksummedWriter(target, checker);
-    writer.writeInt(1234);
-    writer.close();
 
     assertNotNull(writer);
-    assertEquals(8, checker.lastSkipPrefix);
-    assertSame(target, checker.lastTarget);
+  }
+
+  @Test
+  void applyAllowedMimeTypes_whenConfigured_updatesDetachedFetchConfig() {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+
+    ClientGetGetterFactory.applyAllowedMimeTypes(
+        fetchConfig, new String[] {"text/plain", "image/png"});
+
+    assertNotNull(fetchConfig.getAllowedMimeTypes());
+    assertTrue(fetchConfig.getAllowedMimeTypes().contains("text/plain"));
+    assertTrue(fetchConfig.getAllowedMimeTypes().contains("image/png"));
   }
 
   @Test
@@ -95,67 +81,22 @@ class ClientGetGetterFactoryTest {
     }
   }
 
-  @ParameterizedTest
-  @CsvSource({"true", "false"})
-  void diskBucket_whenCreated_appliesReadOnlyFlag(boolean readOnly) {
+  @Test
+  void diskBucket_whenCreated_appliesReadOnlyFlag() {
     File file = new File(tempDir, "bucket.bin");
 
-    try (Bucket bucket = ClientGetGetterFactory.diskBucket(file, readOnly)) {
+    try (Bucket bucket = ClientGetGetterFactory.diskBucket(file, true)) {
       assertInstanceOf(FileBucket.class, bucket);
       FileBucket fileBucket = (FileBucket) bucket;
       assertEquals(file.getAbsoluteFile(), fileBucket.getFile());
-      assertEquals(readOnly, fileBucket.isReadOnly());
+      assertTrue(fileBucket.isReadOnly());
       assertFalse(readBooleanField(fileBucket, "createFileOnlyFlag"));
     }
   }
 
   @Test
-  void readExpectedHashes_whenNoHashes_returnsNull() throws IOException {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(output);
-    dos.writeInt(0);
-    dos.flush();
-
-    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(output.toByteArray()));
-    ExpectedHashes result = ClientGetGetterFactory.readExpectedHashes(dis, "identifier", true);
-
-    assertNull(result);
-  }
-
-  @Test
-  void readExpectedHashes_whenHashesPresent_returnsExpectedHashes() throws IOException {
-    HashResult[] hashes = new HashResult[] {hashFor(HashType.SHA256, (byte) 7)};
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(output);
-    HashResult.write(hashes, dos);
-    dos.flush();
-
-    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(output.toByteArray()));
-    ExpectedHashes result = ClientGetGetterFactory.readExpectedHashes(dis, "id", false);
-
-    assertNotNull(result);
-    assertEquals("id", result.messageIdentifier);
-    assertFalse(result.global);
-    assertNotNull(result.hashes);
-    assertEquals(1, result.hashes.length);
-    assertEquals(hashes[0], result.hashes[0]);
-  }
-
-  @Test
-  void writeExpectedHashes_whenNull_writesEmptyHashes() throws IOException {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    DataOutputStream dos = new DataOutputStream(output);
-
-    ClientGetGetterFactory.writeExpectedHashes(dos, null);
-
-    DataInputStream dis = new DataInputStream(new ByteArrayInputStream(output.toByteArray()));
-    ExpectedHashes result = ClientGetGetterFactory.readExpectedHashes(dis, "ignored", false);
-    assertNull(result);
-  }
-
-  @Test
-  void writeExpectedHashes_whenPresent_roundTripsThroughRead() throws IOException {
-    HashResult[] hashes = new HashResult[] {hashFor(HashType.SHA1, (byte) 3)};
+  void readAndWriteExpectedHashes_whenHashesPresent_roundTrip() throws IOException {
+    HashResult[] hashes = new HashResult[] {sampleSha256Hash()};
     ExpectedHashes expected = new ExpectedHashes(hashes, "abc", true);
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(output);
@@ -173,261 +114,58 @@ class ClientGetGetterFactoryTest {
   }
 
   @Test
-  void createGetter_whenBinaryBlobTrueAndReturnBucketProvided_usesBucketWriter() throws Exception {
-    ClientGet request = mockRequestWithClient();
-    FetchContext fetchContext = mock(FetchContext.class);
-    Bucket returnBucket = mock(Bucket.class);
-
-    ClientGetter getter =
-        createGetter(
-            request,
-            mock(FreenetURI.class),
-            fetchContext,
-            returnBucket,
-            false,
+  void buildStatus_whenDetachedFetchConfigCarriesOverrides_usesThemInStatus() {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setFilterData(true);
+    fetchConfig.setOverrideMime("text/html");
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            "req",
+            ClientRequest.Persistence.REBOOT,
             true,
-            false,
-            fetchRuntimeSupport);
-
-    Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
-    BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
-
-    assertInstanceOf(NullBucket.class, storedReturnBucket);
-    assertNotNull(writer);
-    assertSame(returnBucket, readField(writer, "out"));
-    verifyNoInteractions(fetchRuntimeSupport);
-  }
-
-  @Test
-  void createGetter_whenBinaryBlobTrueAndReturnBucketNull_requiresRuntimeSupport() {
-    ClientGet request = mock(ClientGet.class);
-    FetchContext fetchContext = mock(FetchContext.class);
-
-    assertThrows(
-        NullPointerException.class,
-        () ->
-            createGetter(
-                request, mock(FreenetURI.class), fetchContext, null, false, true, false, null));
-  }
-
-  @Test
-  void createGetter_whenBinaryBlobTrueAndReturnBucketNull_allocatesBucket() throws Exception {
-    ClientGet request = mockRequestWithClient();
-    FetchContext fetchContext = mock(FetchContext.class);
-
-    try (Bucket createdBucket = new NullBucket()) {
-      when(fetchContext.getMaxOutputLength()).thenReturn(128L);
-      when(fetchRuntimeSupport.allocateBinaryBlobBucket(128L, true)).thenReturn(createdBucket);
-
-      ClientGetter getter =
-          createGetter(
-              request,
-              mock(FreenetURI.class),
-              fetchContext,
-              null,
-              false,
-              true,
-              true,
-              fetchRuntimeSupport);
-
-      BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
-      assertNotNull(writer);
-      assertSame(createdBucket, readField(writer, "out"));
-      assertEquals(
-          1,
-          mockingDetails(fetchRuntimeSupport).getInvocations().stream()
-              .filter(
-                  invocation -> invocation.getMethod().getName().equals("allocateBinaryBlobBucket"))
-              .filter(invocation -> invocation.getArguments()[0].equals(128L))
-              .filter(invocation -> invocation.getArguments()[1].equals(true))
-              .count());
-    }
-  }
-
-  @Test
-  void createGetter_whenDiscardDataTrue_usesNullBucket() throws Exception {
-    ClientGet request = mockRequestWithClient();
-    FetchContext fetchContext = mock(FetchContext.class);
-    Bucket returnBucket = mock(Bucket.class);
-
-    ClientGetter getter =
-        createGetter(
-            request,
-            mock(FreenetURI.class),
-            fetchContext,
-            returnBucket,
             true,
-            false,
-            false,
-            fetchRuntimeSupport);
-
-    Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
-
-    assertInstanceOf(NullBucket.class, storedReturnBucket);
-    verifyNoInteractions(fetchRuntimeSupport);
-  }
-
-  @Test
-  void createGetter_whenDiscardDataFalse_preservesReturnBucket() throws Exception {
-    ClientGet request = mockRequestWithClient();
-    FetchContext fetchContext = mock(FetchContext.class);
-    Bucket returnBucket = mock(Bucket.class);
-
-    ClientGetter getter =
-        createGetter(
-            request,
-            mock(FreenetURI.class),
-            fetchContext,
-            returnBucket,
-            false,
-            false,
-            false,
-            fetchRuntimeSupport);
-
-    Bucket storedReturnBucket = (Bucket) readField(getter, "returnBucket");
-    BinaryBlobWriter writer = (BinaryBlobWriter) readField(getter, "binaryBlobWriter");
-
-    assertSame(returnBucket, storedReturnBucket);
-    assertNull(writer);
-    verifyNoInteractions(fetchRuntimeSupport);
-  }
-
-  @Test
-  void createGetter_whenBinaryBlobFalse_callbackDelegatesToRequest() throws Exception {
-    ClientGet request = mock(ClientGet.class);
-    FetchContext fetchContext = mock(FetchContext.class);
-    RequestClient requestClient = mock(RequestClient.class);
-    ChecksumChecker checker = mock(ChecksumChecker.class);
-    DataOutputStream dos = new DataOutputStream(new ByteArrayOutputStream());
-    ClientContext context = mock(ClientContext.class);
-    FetchResult fetchResult = mock(FetchResult.class);
-    FetchException fetchException = mock(FetchException.class);
-
-    when(request.getRequestClient()).thenReturn(requestClient);
-    doNothing().when(request).getClientDetail(dos, checker);
-
-    ClientGetter getter =
-        createGetter(
-            request,
-            mock(FreenetURI.class),
-            fetchContext,
+            true,
+            1,
+            1,
+            1,
+            java.time.Instant.now(),
+            0,
+            0,
             null,
-            false,
-            false,
-            false,
-            fetchRuntimeSupport);
+            true,
+            (short) 1);
+    DownloadProgressSnapshot progressSnapshot = new DownloadProgressSnapshot(null, null);
+    DownloadDataSnapshot dataSnapshot =
+        new DownloadDataSnapshot("text/plain", 9L, new File("target.bin"), mock(Bucket.class));
+    DownloadContextSnapshot contextSnapshot =
+        new DownloadContextSnapshot(
+            fetchConfig,
+            new CompatibilityMode[] {CompatibilityMode.COMPAT_1250},
+            new byte[] {1, 2, 3},
+            FreenetURI.EMPTY_CHK_URI,
+            false);
 
-    ClientGetCallback callback = getter.getClientCallback();
+    RequestStatus status =
+        ClientGetGetterFactory.buildStatus(
+            new ClientGetStatusSnapshot(
+                statusSnapshot, progressSnapshot, dataSnapshot, contextSnapshot));
 
-    assertInstanceOf(PersistentClientCallback.class, callback);
-
-    callback.onSuccess(fetchResult, getter);
-    callback.onFailure(fetchException);
-    callback.onResume(context);
-    RequestClient resolvedClient = callback.getRequestClient();
-    ((PersistentClientCallback) callback).getClientDetail(dos, checker);
-
-    assertSame(requestClient, resolvedClient);
-    verify(request).onSuccess(fetchResult, getter);
-    verify(request).onFailure(fetchException);
-    verify(request).onResume(context);
-    verify(request).getClientDetail(dos, checker);
-    verifyNoInteractions(fetchRuntimeSupport);
+    assertInstanceOf(DownloadRequestStatus.class, status);
   }
 
-  private static ClientGetter createGetter(
-      ClientGet request,
-      FreenetURI uri,
-      FetchContext fetchContext,
-      Bucket returnBucket,
-      boolean discardData,
-      boolean binaryBlob,
-      boolean persistenceForever,
-      FcpFetchRuntimeSupport fetchRuntimeSupport)
-      throws IOException {
-    ClientGetterRequest getterRequest =
-        ClientGetGetterFactory.createGetterRequest(request, uri, fetchContext, (short) 1);
-    ClientGetterOptions options = new ClientGetterOptions(returnBucket, null, false, null, null);
-    ClientGetGetterFlags flags =
-        new ClientGetGetterFlags(discardData, binaryBlob, persistenceForever);
-    return ClientGetGetterFactory.createGetter(getterRequest, options, flags, fetchRuntimeSupport);
-  }
-
-  private static HashResult hashFor(HashType type, byte seed) {
-    byte[] bytes = new byte[type.hashLength];
-    for (int i = 0; i < bytes.length; i++) {
-      bytes[i] = (byte) (seed + i);
-    }
-    return new HashResult(type, bytes);
-  }
-
-  private static ClientGet mockRequestWithClient() {
-    ClientGet request = mock(ClientGet.class);
-    RequestClient requestClient = mock(RequestClient.class);
-    when(request.getRequestClient()).thenReturn(requestClient);
-    return request;
-  }
-
-  private static Object readField(Object target, String name) throws Exception {
-    Field field = target.getClass().getDeclaredField(name);
-    field.setAccessible(true);
-    return field.get(target);
-  }
-
-  private static boolean readBooleanField(Object target, String name) {
+  private static boolean readBooleanField(FileBucket bucket, String fieldName) {
     try {
-      Field field = target.getClass().getDeclaredField(name);
+      Field field = FileBucket.class.getDeclaredField(fieldName);
       field.setAccessible(true);
-      return field.getBoolean(target);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new IllegalStateException(e);
+      return field.getBoolean(bucket);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError(e);
     }
   }
 
-  private static final class RecordingChecksumChecker extends ChecksumChecker {
-    private int lastSkipPrefix = -1;
-    private OutputStream lastTarget;
-
-    @Override
-    public int checksumLength() {
-      return 0;
-    }
-
-    @Override
-    public OutputStream checksumWriter(OutputStream os, int skipPrefix) {
-      lastSkipPrefix = skipPrefix;
-      lastTarget = os;
-      return os;
-    }
-
-    @Override
-    public byte[] appendChecksum(byte[] data) {
-      return data;
-    }
-
-    @Override
-    public boolean checkChecksum(byte[] data, int offset, int length, byte[] checksum) {
-      return true;
-    }
-
-    @Override
-    public byte[] generateChecksum(byte[] bufToChecksum, int offset, int length) {
-      return new byte[0];
-    }
-
-    @Override
-    public int getChecksumTypeID() {
-      return 0;
-    }
-
-    @Override
-    public void copyAndStripChecksum(InputStream is, OutputStream os, long length) {
-      throw new UnsupportedOperationException("Not used in tests");
-    }
-
-    @Override
-    public void readAndChecksum(DataInput is, byte[] buf, int offset, int length) {
-      throw new UnsupportedOperationException("Not used in tests");
-    }
+  private static HashResult sampleSha256Hash() {
+    byte[] digest = new byte[HashType.SHA256.hashLength];
+    java.util.Arrays.fill(digest, (byte) 7);
+    return new HashResult(HashType.SHA256, digest);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
@@ -6,8 +6,6 @@ import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.support.api.Bucket;
@@ -38,7 +36,7 @@ class ClientGetLifecycleTest {
     Bucket bucket = Mockito.mock(Bucket.class);
     when(bucket.size()).thenReturn(123L);
     FetchResult result = FetchResult.create(new ClientMetadata("text/plain"), bucket);
-    ClientGetter getter = Mockito.mock(ClientGetter.class);
+    ClientGetExecution execution = Mockito.mock(ClientGetExecution.class);
     PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
     setField(request, "client", client);
     doNothing().when(request).trySendDataFoundOrGetFailed(null, null);
@@ -47,7 +45,7 @@ class ClientGetLifecycleTest {
     ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
 
     // Act
-    lifecycle.onSuccess(result, getter);
+    lifecycle.onSuccess(result, execution);
 
     // Assert
     assertTrue(getBooleanField(request, "started"));
@@ -70,33 +68,20 @@ class ClientGetLifecycleTest {
     Bucket blobBucket = Mockito.mock(Bucket.class);
     when(blobBucket.size()).thenReturn(50L);
     FetchResult result = FetchResult.create(new ClientMetadata("text/plain"), resultBucket);
-    ClientGetter getter = Mockito.mock(ClientGetter.class);
-    when(getter.getBlobBucket()).thenReturn(blobBucket);
+    ClientGetExecution execution = Mockito.mock(ClientGetExecution.class);
+    when(execution.blobBucket()).thenReturn(blobBucket);
     doNothing().when(request).trySendDataFoundOrGetFailed(null, null);
     doNothing().when(request).trySendAllDataMessage(null, null);
     doNothing().when(request).finish();
     ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
 
     // Act
-    lifecycle.onSuccess(result, getter);
+    lifecycle.onSuccess(result, execution);
 
     // Assert
     assertEquals(50L, request.state().getFoundDataLength());
     assertEquals(
         ClientGetGetterFactory.binaryBlobMimeType(), request.state().getFoundDataMimeType());
-  }
-
-  @Test
-  void setSuccessForMigration_whenContextNull_expectNullPointerException() {
-    // Arrange
-    ClientGet request = new ClientGet();
-    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
-    //noinspection resource
-    Bucket bucket = Mockito.mock(Bucket.class);
-
-    // Act + Assert
-    assertThrows(
-        NullPointerException.class, () -> lifecycle.setSuccessForMigration(null, 1L, bucket));
   }
 
   @Test
@@ -108,12 +93,10 @@ class ClientGetLifecycleTest {
     when(bucket.size()).thenReturn(7L);
     setField(request, "returnType", ReturnType.DIRECT);
     request.state().setFoundDataLength(5L);
-    ClientContext context = Mockito.mock(ClientContext.class);
     ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
 
     // Act + Assert
-    assertThrows(
-        ResumeFailedException.class, () -> lifecycle.setSuccessForMigration(context, 10L, bucket));
+    assertThrows(ResumeFailedException.class, () -> lifecycle.setSuccessForMigration(10L, bucket));
     assertEquals(bucket, request.state().getReturnBucketDirect());
   }
 
@@ -124,12 +107,10 @@ class ClientGetLifecycleTest {
     //noinspection resource
     Bucket bucket = Mockito.mock(Bucket.class);
     setField(request, "returnType", ReturnType.CHUNKED);
-    ClientContext context = Mockito.mock(ClientContext.class);
     ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
 
     // Act + Assert
-    assertThrows(
-        ResumeFailedException.class, () -> lifecycle.setSuccessForMigration(context, 10L, bucket));
+    assertThrows(ResumeFailedException.class, () -> lifecycle.setSuccessForMigration(10L, bucket));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetMessageReplayTest.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import java.util.List;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.async.CompatibilityAnalyser;
@@ -40,9 +39,9 @@ class ClientGetMessageReplayTest {
   void sendPendingMessages_whenOnlyDataFalse_expectTagProgressAndMetadataMessages()
       throws Exception {
     // Arrange
-    FetchContext fetchContext = Mockito.mock(FetchContext.class);
-    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(3);
-    when(fetchContext.getMaxOutputLength()).thenReturn(1_000L);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setMaxNonSplitfileRetries(3);
+    fetchConfig.setMaxOutputLength(1_000L);
     RequestClient requestClient = Mockito.mock(RequestClient.class);
     when(requestClient.realTimeFlag()).thenReturn(false);
     PersistentRequestRoot root = new PersistentRequestRoot();
@@ -61,7 +60,7 @@ class ClientGetMessageReplayTest {
             true,
             Persistence.FOREVER,
             client,
-            fetchContext,
+            fetchConfig,
             requestClient,
             ReturnType.DIRECT);
     request.state().setProgressPending(progressMessage);
@@ -99,7 +98,7 @@ class ClientGetMessageReplayTest {
   @Test
   void sendPendingMessages_whenOnlyDataTrueAndNonDirect_expectProtocolErrorOnly() throws Exception {
     // Arrange
-    FetchContext fetchContext = Mockito.mock(FetchContext.class);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
     RequestClient requestClient = Mockito.mock(RequestClient.class);
     PersistentRequestClient client =
         new PersistentRequestClient("client", null, false, null, Persistence.REBOOT, null);
@@ -110,7 +109,7 @@ class ClientGetMessageReplayTest {
             false,
             Persistence.REBOOT,
             client,
-            fetchContext,
+            fetchConfig,
             requestClient,
             ReturnType.NONE);
     ClientGetMessageReplay replay = new ClientGetMessageReplay(request);
@@ -254,7 +253,7 @@ class ClientGetMessageReplayTest {
       boolean global,
       Persistence persistence,
       PersistentRequestClient client,
-      FetchContext fetchContext,
+      ClientGetFetchConfig fetchConfig,
       RequestClient requestClient,
       ReturnType returnType)
       throws Exception {
@@ -270,7 +269,7 @@ class ClientGetMessageReplayTest {
     setField(request, "returnType", returnType);
     setField(request, "targetFile", new File("target.bin"));
     setField(request, "binaryBlob", false);
-    setField(request, "fctx", fetchContext);
+    setField(request, "fetchConfig", fetchConfig);
     setField(request, "lowLevelClient", requestClient);
     setField(request, "global", global);
     return request;

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
@@ -5,10 +5,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
 import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
+import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.StorageFormatException;
 import org.junit.jupiter.api.Test;
@@ -17,6 +21,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -179,6 +184,62 @@ class ClientGetPersistenceCodecTest {
     }
   }
 
+  @Test
+  void serializedRequest_whenRuntimeFetchSupportPresent_cachesFetchConfigEncoding()
+      throws Exception {
+    ClientGet request = persistenceReadyRequest();
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
+    byte[] encodedFetchConfig = new byte[] {4, 5, 6};
+    Mockito.doAnswer(
+            invocation -> {
+              DataOutputStream encoded = invocation.getArgument(1);
+              encoded.write(encodedFetchConfig);
+              return null;
+            })
+        .when(fetchRuntimeSupport)
+        .encodeFetchConfig(eq(request.fetchConfig()), any(DataOutputStream.class));
+    setField(request, ClientGet.class, "runtimeFetchSupport", fetchRuntimeSupport);
+
+    ClientGet restored = serializeAndDeserialize(request);
+
+    assertArrayEquals(encodedFetchConfig, restored.persistedFetchConfigEncoding());
+  }
+
+  @Test
+  void writeClientDetail_whenRuntimeFetchSupportMissing_usesCachedFetchConfigEncoding()
+      throws Exception {
+    ClientGet request = persistenceReadyRequest();
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    byte[] cachedEncoding = new byte[] {1, 2, 3};
+    setField(request, ClientGet.class, "execution", execution);
+    request.setPersistedFetchConfigEncoding(cachedEncoding);
+    Mockito.when(execution.writeTrivialProgress(any(DataOutputStream.class))).thenReturn(false);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ByteArrayOutputStream encodedFetchConfig = new ByteArrayOutputStream();
+    AtomicInteger checksummedWriterCalls = new AtomicInteger();
+
+    try (MockedStatic<ClientGetGetterFactory> mocked =
+        Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      mocked
+          .when(
+              () ->
+                  ClientGetGetterFactory.checksummedWriter(
+                      any(DataOutputStream.class), eq(checker)))
+          .thenAnswer(
+              invocation ->
+                  new DataOutputStream(
+                      checksummedWriterCalls.getAndIncrement() == 0
+                          ? encodedFetchConfig
+                          : new ByteArrayOutputStream()));
+
+      ClientGetPersistenceCodec.writeClientDetail(
+          request, new DataOutputStream(new ByteArrayOutputStream()), checker);
+    }
+
+    assertArrayEquals(cachedEncoding, encodedFetchConfig.toByteArray());
+    Mockito.verify(execution).writeTrivialProgress(any(DataOutputStream.class));
+  }
+
   private static ClientGet finishedDirectRequest() throws Exception {
     ClientGet request = new ClientGet();
     setField(request, ClientRequest.class, "identifier", "req-finished-direct");
@@ -187,6 +248,27 @@ class ClientGetPersistenceCodecTest {
     setField(request, ClientGet.class, "returnType", ClientGet.ReturnType.DIRECT);
     request.state().setSucceeded(true);
     return request;
+  }
+
+  private static ClientGet persistenceReadyRequest() throws Exception {
+    ClientGet request = new ClientGet();
+    setField(request, ClientRequest.class, "identifier", "req-persist");
+    setField(request, ClientRequest.class, "global", false);
+    setField(request, ClientRequest.class, "uri", new FreenetURI("KSK@persist"));
+    setField(request, ClientGet.class, "fetchConfig", new ClientGetFetchConfig());
+    setField(request, ClientGet.class, "returnType", ClientGet.ReturnType.DIRECT);
+    return request;
+  }
+
+  private static ClientGet serializeAndDeserialize(ClientGet request) throws Exception {
+    ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(serialized)) {
+      out.writeObject(request);
+    }
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(serialized.toByteArray()))) {
+      return (ClientGet) in.readObject();
+    }
   }
 
   private static DataInputStream input(byte[] payload) {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
@@ -240,6 +240,54 @@ class ClientGetPersistenceCodecTest {
     Mockito.verify(execution).writeTrivialProgress(any(DataOutputStream.class));
   }
 
+  @Test
+  void writeClientDetail_whenClientRootProvidesRuntimeSupport_encodesFetchConfig()
+      throws Exception {
+    ClientGet request = persistenceReadyRequest();
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
+    byte[] encodedFetchConfig = new byte[] {9, 8, 7};
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    root.setFetchRuntimeSupport(fetchRuntimeSupport);
+    PersistentRequestClient client = root.registerForeverClient("persist-client", null);
+    setField(request, ClientRequest.class, "client", client);
+    setField(request, ClientGet.class, "execution", execution);
+    Mockito.doAnswer(
+            invocation -> {
+              DataOutputStream encoded = invocation.getArgument(1);
+              encoded.write(encodedFetchConfig);
+              return null;
+            })
+        .when(fetchRuntimeSupport)
+        .encodeFetchConfig(eq(request.fetchConfig()), any(DataOutputStream.class));
+    Mockito.when(execution.writeTrivialProgress(any(DataOutputStream.class))).thenReturn(false);
+    ChecksumChecker checker = mock(ChecksumChecker.class);
+    ByteArrayOutputStream capturedFetchConfig = new ByteArrayOutputStream();
+    AtomicInteger checksummedWriterCalls = new AtomicInteger();
+
+    try (MockedStatic<ClientGetGetterFactory> mocked =
+        Mockito.mockStatic(ClientGetGetterFactory.class)) {
+      mocked
+          .when(
+              () ->
+                  ClientGetGetterFactory.checksummedWriter(
+                      any(DataOutputStream.class), eq(checker)))
+          .thenAnswer(
+              invocation ->
+                  new DataOutputStream(
+                      checksummedWriterCalls.getAndIncrement() == 0
+                          ? capturedFetchConfig
+                          : new ByteArrayOutputStream()));
+
+      ClientGetPersistenceCodec.writeClientDetail(
+          request, new DataOutputStream(new ByteArrayOutputStream()), checker);
+    }
+
+    assertArrayEquals(encodedFetchConfig, capturedFetchConfig.toByteArray());
+    assertArrayEquals(encodedFetchConfig, request.persistedFetchConfigEncoding());
+    Mockito.verify(fetchRuntimeSupport).encodeFetchConfig(eq(request.fetchConfig()), any());
+  }
+
   private static ClientGet finishedDirectRequest() throws Exception {
     ClientGet request = new ClientGet();
     setField(request, ClientRequest.class, "identifier", "req-finished-direct");

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
@@ -6,16 +6,10 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import network.crypta.client.FetchContext;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.client.async.CompatibilityAnalyser;
-import network.crypta.client.events.ClientEventProducer;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.HashResult;
-import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
-import network.crypta.support.io.NonClosingOutputStream;
 import network.crypta.support.io.StorageFormatException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,12 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
@@ -47,42 +38,41 @@ class ClientGetPersistenceCodecTest {
   private static final int CLIENT_DETAIL_VERSION = 1;
 
   @Test
-  void readBasicRestoreData_whenValidDiskData_returnsParsedBundleAndRegistersListener()
-      throws Exception {
-    ClientGet request = new ClientGet();
-    ClientContext context = mock(ClientContext.class);
+  void readBasicRestoreData_whenValidDiskData_returnsParsedBundle() throws Exception {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
-    FetchContext fetchContext = mock(FetchContext.class);
-    ClientEventProducer eventProducer = mock(ClientEventProducer.class);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setFilterData(true);
     Bucket initialMetadata = mock(Bucket.class);
-    when(fetchContext.getEventProducer()).thenReturn(eventProducer);
     try (DataInputStream input = input(basicRestoreHeaderPayload());
-        MockedStatic<ClientGetGetterFactory> mocked =
-            Mockito.mockStatic(ClientGetGetterFactory.class)) {
+        MockedStatic<ClientGetPersistenceIO> mocked =
+            Mockito.mockStatic(ClientGetPersistenceIO.class)) {
       mocked
-          .when(() -> ClientGetGetterFactory.readFetchContextOrDefault(input, context, checker))
-          .thenReturn(fetchContext);
+          .when(
+              () ->
+                  ClientGetPersistenceIO.readFetchConfigOrDefault(
+                      input, fetchRuntimeSupport, checker))
+          .thenReturn(fetchConfig);
       mocked
-          .when(() -> ClientGetGetterFactory.readInitialMetadata(input, context, checker))
+          .when(
+              () -> ClientGetPersistenceIO.readInitialMetadata(input, fetchRuntimeSupport, checker))
           .thenReturn(initialMetadata);
 
       ClientGetPersistenceCodec.BasicRestoreData restored =
-          ClientGetPersistenceCodec.readBasicRestoreData(request, input, context, checker);
+          ClientGetPersistenceCodec.readBasicRestoreData(input, fetchRuntimeSupport, checker);
 
       assertEquals("KSK@codec-restore", restored.uri().toString());
       assertEquals(ClientGet.ReturnType.DISK, restored.returnType());
       assertEquals("target.bin", restored.targetFile().getPath());
       assertTrue(restored.binaryBlob());
-      assertSame(fetchContext, restored.fetchContext());
+      assertEquals(fetchConfig, restored.fetchConfig());
       assertEquals("txt", restored.extensionCheck());
       assertSame(initialMetadata, restored.initialMetadata());
-      verify(eventProducer).addEventListener(any(ClientGetEventHandling.class));
     }
   }
 
   @Test
   void readBasicRestoreData_whenMagicIsInvalid_throwsStorageFormatException() throws IOException {
-    ClientGet request = new ClientGet();
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     try (DataOutputStream out = new DataOutputStream(buffer)) {
       out.writeLong(123L);
@@ -94,73 +84,9 @@ class ClientGetPersistenceCodecTest {
               StorageFormatException.class,
               () ->
                   ClientGetPersistenceCodec.readBasicRestoreData(
-                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
+                      input, mock(FcpFetchRuntimeSupport.class), mock(ChecksumChecker.class)));
 
       assertEquals("Bad magic for request", error.getMessage());
-    }
-  }
-
-  @Test
-  void readBasicRestoreData_whenVersionIsInvalid_throwsStorageFormatException() throws IOException {
-    ClientGet request = new ClientGet();
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeLong(CLIENT_DETAIL_MAGIC);
-      out.writeInt(CLIENT_DETAIL_VERSION + 1);
-    }
-    try (DataInputStream input = input(buffer.toByteArray())) {
-      StorageFormatException error =
-          assertThrows(
-              StorageFormatException.class,
-              () ->
-                  ClientGetPersistenceCodec.readBasicRestoreData(
-                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
-
-      assertEquals("Bad version 2", error.getMessage());
-    }
-  }
-
-  @Test
-  void readBasicRestoreData_whenUriIsInvalid_throwsStorageFormatException() throws IOException {
-    ClientGet request = new ClientGet();
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeLong(CLIENT_DETAIL_MAGIC);
-      out.writeInt(CLIENT_DETAIL_VERSION);
-      out.writeUTF("not-a-freenet-uri");
-    }
-    try (DataInputStream input = input(buffer.toByteArray())) {
-      StorageFormatException error =
-          assertThrows(
-              StorageFormatException.class,
-              () ->
-                  ClientGetPersistenceCodec.readBasicRestoreData(
-                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
-
-      assertEquals("Bad URI", error.getMessage());
-    }
-  }
-
-  @Test
-  void readBasicRestoreData_whenReturnTypeIsInvalid_throwsStorageFormatException()
-      throws IOException {
-    ClientGet request = new ClientGet();
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeLong(CLIENT_DETAIL_MAGIC);
-      out.writeInt(CLIENT_DETAIL_VERSION);
-      out.writeUTF("KSK@codec-invalid-type");
-      out.writeShort(99);
-    }
-    try (DataInputStream input = input(buffer.toByteArray())) {
-      StorageFormatException error =
-          assertThrows(
-              StorageFormatException.class,
-              () ->
-                  ClientGetPersistenceCodec.readBasicRestoreData(
-                      request, input, mock(ClientContext.class), mock(ChecksumChecker.class)));
-
-      assertEquals("Bad return type 99", error.getMessage());
     }
   }
 
@@ -186,253 +112,85 @@ class ClientGetPersistenceCodecTest {
   }
 
   @Test
-  void readTransientProgressFields_whenUsingRequestIdentifier_usesRequestScope() throws Exception {
-    ClientGet request = new ClientGet();
-    setField(request, ClientRequest.class, "identifier", "req-overload");
-    setField(request, ClientRequest.class, "global", true);
-    try (DataInputStream input = input(transientPayload(7L, null));
-        MockedStatic<ClientGetGetterFactory> mocked =
-            Mockito.mockStatic(ClientGetGetterFactory.class)) {
-      mocked
-          .when(() -> ClientGetGetterFactory.readExpectedHashes(input, "req-overload", true))
-          .thenReturn(null);
-
-      ClientGetPersistenceCodec.readTransientProgressFields(request, input);
-
-      assertEquals(7L, request.state().getFoundDataLength());
-      assertNull(request.state().getFoundDataMimeType());
-      mocked.verify(
-          () -> ClientGetGetterFactory.readExpectedHashes(input, "req-overload", true), times(1));
-    }
-  }
-
-  @Test
-  void restoreState_whenInProgress_returnsGetterAndDelegatesRestore() throws Exception {
+  void restoreState_whenInProgress_returnsExecutionAndDelegatesRestore() throws Exception {
     ClientGet request = Mockito.spy(new ClientGet());
-    ClientContext context = mock(ClientContext.class);
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
     RequestIdentifier reqID =
         new RequestIdentifier(false, "client", "req-restore", RequestIdentifier.RequestType.GET);
     Bucket bucket = mock(Bucket.class);
-    ClientGetter getter = mock(ClientGetter.class);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
     //noinspection resource
-    doReturn(bucket).when(request).makeBucket(false);
-    doReturn(getter).when(request).makeGetterForPersistence(bucket);
+    doReturn(bucket).when(request).makePersistenceBucket();
+    doReturn(execution).when(request).makeExecutionForPersistence(fetchRuntimeSupport, bucket);
 
     try (DataInputStream input = input(new byte[0]);
-        MockedStatic<ClientGetGetterFactory> mocked =
-            Mockito.mockStatic(ClientGetGetterFactory.class)) {
-      ClientGetter restored =
-          ClientGetPersistenceCodec.restoreState(request, input, reqID, context, checker);
+        MockedStatic<ClientGetPersistenceIO> mocked =
+            Mockito.mockStatic(ClientGetPersistenceIO.class)) {
+      ClientGetExecution restored =
+          ClientGetPersistenceCodec.restoreState(
+              request, input, reqID, fetchRuntimeSupport, checker);
 
-      assertSame(getter, restored);
+      assertSame(execution, restored);
       mocked.verify(
           () ->
-              ClientGetGetterFactory.restoreInProgressState(
-                  any(DataInputStream.class), eq(context), eq(checker), eq(getter), eq(request)),
+              ClientGetPersistenceIO.restoreInProgressState(
+                  any(DataInputStream.class),
+                  eq(fetchRuntimeSupport),
+                  eq(checker),
+                  eq(execution),
+                  eq(request)),
           times(1));
     }
   }
 
   @Test
   void restoreState_whenFinishedDirectAndBucketMissing_marksRequestUnfinished() throws Exception {
-    ClientGet request = bareRequest("req-finished-direct");
-    setField(request, ClientRequest.class, "finished", true);
-    ClientContext context = mock(ClientContext.class);
+    ClientGet request = finishedDirectRequest();
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
     RequestIdentifier reqID =
         new RequestIdentifier(
             false, "client", "req-finished-direct", RequestIdentifier.RequestType.GET);
 
-    try (DataInputStream input = input(finishedPayload(true, transientPayload(55L, null)));
-        MockedStatic<ClientGetGetterFactory> mocked =
-            Mockito.mockStatic(ClientGetGetterFactory.class)) {
-      mocked
+    try (DataInputStream input = input(finishedPayload(transientPayload(55L, null)));
+        MockedStatic<ClientGetGetterFactory> mockedGetterFactory =
+            Mockito.mockStatic(ClientGetGetterFactory.class);
+        MockedStatic<ClientGetPersistenceIO> mockedPersistenceIO =
+            Mockito.mockStatic(ClientGetPersistenceIO.class)) {
+      mockedGetterFactory
           .when(() -> ClientGetGetterFactory.readExpectedHashes(any(), any(), anyBoolean()))
           .thenReturn(null);
-      mocked
+      mockedPersistenceIO
           .when(
               () ->
-                  ClientGetGetterFactory.restoreCompletedDirectBucketOrNull(
-                      any(DataInputStream.class), eq(context), eq(checker)))
+                  ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(
+                      any(DataInputStream.class), eq(fetchRuntimeSupport), eq(checker)))
           .thenReturn(null);
 
-      ClientGetter restored =
-          ClientGetPersistenceCodec.restoreState(request, input, reqID, context, checker);
+      ClientGetExecution restored =
+          ClientGetPersistenceCodec.restoreState(
+              request, input, reqID, fetchRuntimeSupport, checker);
 
       assertNull(restored);
+      assertFalse(isFinished(request));
       assertFalse(request.state().hasSucceeded());
-      assertFalse(getClientRequestBooleanField(request, "finished"));
       assertNull(request.state().getReturnBucketDirect());
     }
   }
 
-  @Test
-  void restoreState_whenFinishedFailureWithMessage_setsFailedMessageAndStarted() throws Exception {
-    ClientGet request = bareRequest("req-finished-failure");
-    setField(request, ClientRequest.class, "finished", true);
-    ClientContext context = mock(ClientContext.class);
-    ChecksumChecker checker = mock(ChecksumChecker.class);
-    RequestIdentifier reqID =
-        new RequestIdentifier(
-            false, "client", "req-finished-failure", RequestIdentifier.RequestType.GET);
-    GetFailedMessage failure = mock(GetFailedMessage.class);
-
-    try (DataInputStream input =
-            input(finishedPayload(false, transientPayload(91L, "application/json")));
-        MockedStatic<ClientGetGetterFactory> mocked =
-            Mockito.mockStatic(ClientGetGetterFactory.class)) {
-      mocked
-          .when(() -> ClientGetGetterFactory.readExpectedHashes(any(), any(), anyBoolean()))
-          .thenReturn(null);
-      mocked
-          .when(
-              () ->
-                  ClientGetGetterFactory.restoreFailureMessageOrNull(
-                      any(DataInputStream.class),
-                      eq(reqID),
-                      eq(91L),
-                      eq("application/json"),
-                      eq(context),
-                      eq(checker)))
-          .thenReturn(failure);
-
-      ClientGetter restored =
-          ClientGetPersistenceCodec.restoreState(request, input, reqID, context, checker);
-
-      assertNull(restored);
-      assertSame(failure, request.state().getFailedMessage());
-      assertTrue(getClientRequestBooleanField(request, "started"));
-    }
-  }
-
-  @Test
-  void writeClientDetail_whenInProgressAndTrivialProgressTrue_writesCoreFieldsAndTransientState()
-      throws Exception {
-    ClientGet request = bareRequest("req-write");
-    setField(request, ClientRequest.class, "uri", new FreenetURI("KSK@req-write"));
-    setField(request, ClientGet.class, "binaryBlob", false);
-    setField(request, ClientGet.class, "extensionCheck", "txt");
-    setField(request, ClientGet.class, "initialMetadata", null);
-    setField(request, ClientRequest.class, "finished", false);
-    FetchContext fetchContext = mock(FetchContext.class);
-    setField(request, ClientGet.class, "fctx", fetchContext);
-    ClientGetter getter = mock(ClientGetter.class);
-    when(getter.writeTrivialProgress(any(DataOutputStream.class))).thenReturn(true);
-    setField(request, ClientGet.class, "getter", getter);
-    request.state().setFoundDataLength(321L);
-    request.state().setFoundDataMimeType("text/plain");
-    request.state().setCompatibilityAnalyser(new CompatibilityAnalyser());
-    request.state().setExpectedHashes(null);
-    ChecksumChecker checker = mock(ChecksumChecker.class);
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    DataOutputStream out = new DataOutputStream(buffer);
-
-    try (MockedStatic<ClientGetGetterFactory> mocked =
-        Mockito.mockStatic(ClientGetGetterFactory.class, Mockito.CALLS_REAL_METHODS)) {
-      mocked
-          .when(
-              () ->
-                  ClientGetGetterFactory.checksummedWriter(
-                      any(DataOutputStream.class), any(ChecksumChecker.class)))
-          .thenAnswer(
-              invocation -> {
-                DataOutputStream target = invocation.getArgument(0);
-                return new DataOutputStream(new NonClosingOutputStream(target));
-              });
-
-      ClientGetPersistenceCodec.writeClientDetail(request, out, checker);
-    }
-
-    try (DataInputStream in = input(buffer.toByteArray())) {
-      assertEquals(CLIENT_DETAIL_MAGIC, in.readLong());
-      assertEquals(CLIENT_DETAIL_VERSION, in.readInt());
-      assertEquals("KSK@req-write", in.readUTF());
-      assertEquals(ClientGet.ReturnType.DIRECT.code, in.readShort());
-      assertFalse(in.readBoolean());
-      assertTrue(in.readBoolean());
-      assertEquals("txt", in.readUTF());
-      assertFalse(in.readBoolean());
-      assertEquals(321L, in.readLong());
-      assertTrue(in.readBoolean());
-      assertEquals("text/plain", in.readUTF());
-      //noinspection ObviousNullCheck
-      assertNotNull(new CompatibilityAnalyser(in));
-      assertEquals(0, in.readInt());
-    }
-
-    verify(fetchContext).writeTo(any(DataOutputStream.class));
-    verify(getter).writeTrivialProgress(any(DataOutputStream.class));
-  }
-
-  @Test
-  void writeClientDetail_whenFinishedDirectSuccess_writesStoredBucket() throws Exception {
-    ClientGet request = bareRequest("req-finished-write");
-    setField(request, ClientRequest.class, "uri", new FreenetURI("KSK@req-finished-write"));
-    setField(request, ClientGet.class, "binaryBlob", true);
-    setField(request, ClientGet.class, "extensionCheck", null);
-    setField(request, ClientGet.class, "initialMetadata", null);
-    setField(request, ClientRequest.class, "finished", true);
-    FetchContext fetchContext = mock(FetchContext.class);
-    setField(request, ClientGet.class, "fctx", fetchContext);
-    request.state().setSucceeded(true);
-    request.state().setFoundDataLength(999L);
-    request.state().setFoundDataMimeType(null);
-    request.state().setExpectedHashes(null);
-    Bucket directBucket = mock(Bucket.class);
-    doAnswer(
-            invocation -> {
-              DataOutputStream stream = invocation.getArgument(0);
-              stream.writeInt(777);
-              return null;
-            })
-        .when(directBucket)
-        .storeTo(any(DataOutputStream.class));
-    request.state().setReturnBucketDirect(directBucket);
-    ChecksumChecker checker = mock(ChecksumChecker.class);
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    DataOutputStream out = new DataOutputStream(buffer);
-
-    try (MockedStatic<ClientGetGetterFactory> mocked =
-        Mockito.mockStatic(ClientGetGetterFactory.class, Mockito.CALLS_REAL_METHODS)) {
-      mocked
-          .when(
-              () ->
-                  ClientGetGetterFactory.checksummedWriter(
-                      any(DataOutputStream.class), any(ChecksumChecker.class)))
-          .thenAnswer(
-              invocation -> {
-                DataOutputStream target = invocation.getArgument(0);
-                return new DataOutputStream(new NonClosingOutputStream(target));
-              });
-
-      ClientGetPersistenceCodec.writeClientDetail(request, out, checker);
-    }
-
-    try (DataInputStream in = input(buffer.toByteArray())) {
-      assertEquals(CLIENT_DETAIL_MAGIC, in.readLong());
-      assertEquals(CLIENT_DETAIL_VERSION, in.readInt());
-      assertEquals("KSK@req-finished-write", in.readUTF());
-      assertEquals(ClientGet.ReturnType.DIRECT.code, in.readShort());
-      assertTrue(in.readBoolean());
-      assertFalse(in.readBoolean());
-      assertFalse(in.readBoolean());
-      assertTrue(in.readBoolean());
-      assertEquals(999L, in.readLong());
-      assertFalse(in.readBoolean());
-      //noinspection ObviousNullCheck
-      assertNotNull(new CompatibilityAnalyser(in));
-      assertEquals(0, in.readInt());
-      assertEquals(777, in.readInt());
-    }
-  }
-
-  private static ClientGet bareRequest(String identifier) throws Exception {
+  private static ClientGet finishedDirectRequest() throws Exception {
     ClientGet request = new ClientGet();
-    setField(request, ClientRequest.class, "identifier", identifier);
+    setField(request, ClientRequest.class, "identifier", "req-finished-direct");
     setField(request, ClientRequest.class, "global", false);
+    setField(request, ClientRequest.class, "finished", true);
     setField(request, ClientGet.class, "returnType", ClientGet.ReturnType.DIRECT);
+    request.state().setSucceeded(true);
     return request;
+  }
+
+  private static DataInputStream input(byte[] payload) {
+    return new DataInputStream(new ByteArrayInputStream(payload));
   }
 
   private static byte[] basicRestoreHeaderPayload() throws IOException {
@@ -446,52 +204,44 @@ class ClientGetPersistenceCodecTest {
       out.writeBoolean(true);
       out.writeBoolean(true);
       out.writeUTF("txt");
+      out.writeBoolean(false);
     }
     return buffer.toByteArray();
   }
 
-  private static byte[] transientPayload(long foundDataLength, String mimeType) throws IOException {
+  private static byte[] transientPayload(long dataLength, String mimeType) throws IOException {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeLong(foundDataLength);
+      out.writeLong(dataLength);
+      out.writeBoolean(mimeType != null);
       if (mimeType != null) {
-        out.writeBoolean(true);
         out.writeUTF(mimeType);
-      } else {
-        out.writeBoolean(false);
       }
       new CompatibilityAnalyser().writeTo(out);
+      out.writeInt(0);
     }
     return buffer.toByteArray();
   }
 
-  private static byte[] finishedPayload(boolean succeeded, byte[] transientPayload)
-      throws IOException {
+  private static byte[] finishedPayload(byte[] transientPayload) throws IOException {
     ByteArrayOutputStream buffer = new ByteArrayOutputStream();
     try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeBoolean(succeeded);
+      out.writeBoolean(true);
       out.write(transientPayload);
     }
     return buffer.toByteArray();
   }
 
-  private static DataInputStream input(byte[] bytes) {
-    return new DataInputStream(new ByteArrayInputStream(bytes));
-  }
-
-  @SuppressWarnings({"java:S3011"})
   private static void setField(Object target, Class<?> owner, String fieldName, Object value)
-      throws ReflectiveOperationException {
+      throws Exception {
     Field field = owner.getDeclaredField(fieldName);
     field.setAccessible(true);
     field.set(target, value);
   }
 
-  @SuppressWarnings({"java:S3011"})
-  private static boolean getClientRequestBooleanField(Object target, String fieldName)
-      throws ReflectiveOperationException {
-    Field field = ClientRequest.class.getDeclaredField(fieldName);
+  private static boolean isFinished(ClientGet request) throws Exception {
+    Field field = ClientRequest.class.getDeclaredField("finished");
     field.setAccessible(true);
-    return field.getBoolean(target);
+    return field.getBoolean(request);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
@@ -5,64 +5,22 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.security.SecureRandom;
-import network.crypta.client.ArchiveManager;
-import network.crypta.client.FetchContext;
-import network.crypta.client.FetchContextOptions;
 import network.crypta.client.FetchException;
-import network.crypta.client.InsertContext;
-import network.crypta.client.InsertContextOptions;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientContextDefaults;
-import network.crypta.client.async.ClientContextRafFactories;
-import network.crypta.client.async.ClientContextResources;
-import network.crypta.client.async.ClientContextRuntime;
-import network.crypta.client.async.ClientContextServices;
-import network.crypta.client.async.ClientContextStorageFactories;
-import network.crypta.client.async.ClientGetter;
-import network.crypta.client.async.ClientLayerPersister;
 import network.crypta.client.async.CompatibilityAnalyser;
-import network.crypta.client.async.DatastoreChecker;
-import network.crypta.client.async.HealingQueue;
-import network.crypta.client.async.USKManager;
-import network.crypta.client.events.SimpleEventProducer;
-import network.crypta.client.filter.LinkFilterExceptionProvider;
-import network.crypta.config.Config;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
-import network.crypta.crypt.MasterSecret;
-import network.crypta.crypt.RandomSource;
-import network.crypta.support.MemoryLimitedJobRunner;
-import network.crypta.support.PriorityAwareExecutor;
-import network.crypta.support.Ticker;
 import network.crypta.support.api.Bucket;
-import network.crypta.support.api.LockableRandomAccessBufferFactory;
-import network.crypta.support.compress.RealCompressor;
-import network.crypta.support.io.BucketTools;
-import network.crypta.support.io.FileRandomAccessBufferFactory;
-import network.crypta.support.io.FilenameGenerator;
-import network.crypta.support.io.PersistentFileTracker;
-import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
-import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -72,9 +30,9 @@ import static org.mockito.Mockito.when;
 class ClientGetPersistenceIOTest {
 
   @Test
-  void openChecksummed_whenChecksumReturnsStream_readsPayload()
-      throws IOException, ChecksumFailedException, StorageFormatException {
-    ClientContext context = newClientContext();
+  void openChecksummed_whenRuntimeSupportProvidesStream_readsPayload()
+      throws IOException, StorageFormatException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
     ByteArrayOutputStream payloadBuffer = new ByteArrayOutputStream();
     try (DataOutputStream payloadOut = new DataOutputStream(payloadBuffer)) {
@@ -82,55 +40,58 @@ class ClientGetPersistenceIOTest {
     }
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
 
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(payloadBuffer.toByteArray()));
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L))
+        .thenReturn(new DataInputStream(new ByteArrayInputStream(payloadBuffer.toByteArray())));
 
     DataInputStream result =
-        ClientGetPersistenceIO.openChecksummed(input, context, checker, 65536L);
+        ClientGetPersistenceIO.openChecksummed(input, fetchRuntimeSupport, checker, 65536L);
 
     assertEquals(42, result.readInt());
-    verify(checker).checksumReaderWithLength(input, context.tempBucketFactory, 65536);
+    verify(fetchRuntimeSupport).openChecksummed(input, checker, 65536L);
   }
 
   @Test
-  void readFetchContextOrDefault_whenValidData_returnsRestoredContext()
-      throws IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
-    FetchContext expected = buildFetchContext();
-    byte[] payload = serializeFetchContext(expected);
+  void readFetchConfigOrDefault_whenValidData_returnsRestoredConfig()
+      throws IOException, StorageFormatException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
+    ClientGetFetchConfig expected = new ClientGetFetchConfig();
+    expected.setFilterData(true);
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+    DataInputStream inner = new DataInputStream(new ByteArrayInputStream(new byte[0]));
 
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(payload));
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L)).thenReturn(inner);
+    when(fetchRuntimeSupport.decodeFetchConfig(inner)).thenReturn(expected);
 
-    FetchContext restored =
-        ClientGetPersistenceIO.readFetchContextOrDefault(input, context, checker);
+    ClientGetFetchConfig restored =
+        ClientGetPersistenceIO.readFetchConfigOrDefault(input, fetchRuntimeSupport, checker);
 
-    assertArrayEquals(payload, serializeFetchContext(restored));
+    assertEquals(expected, restored);
   }
 
   @Test
-  void readFetchContextOrDefault_whenChecksumFails_returnsDefault()
-      throws IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
-    FetchContext fallback = context.getDefaultPersistentFetchContext();
+  void readFetchConfigOrDefault_whenChecksumFails_returnsDefault()
+      throws IOException, StorageFormatException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
+    ClientGetFetchConfig fallback = new ClientGetFetchConfig();
+    fallback.setIgnoreStore(true);
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
 
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenThrow(new ChecksumFailedException());
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L))
+        .thenThrow(storageFormatExceptionWithChecksumFailure());
+    when(fetchRuntimeSupport.defaultPersistentFetchConfig()).thenReturn(fallback);
 
-    FetchContext restored =
-        ClientGetPersistenceIO.readFetchContextOrDefault(input, context, checker);
+    ClientGetFetchConfig restored =
+        ClientGetPersistenceIO.readFetchConfigOrDefault(input, fetchRuntimeSupport, checker);
 
-    assertArrayEquals(serializeFetchContext(fallback), serializeFetchContext(restored));
+    assertEquals(fallback, restored);
   }
 
   @Test
   void readInitialMetadata_whenMarkerFalse_returnsNull()
       throws IOException, StorageFormatException, ResumeFailedException {
-    ClientContext context = newClientContext();
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
     ByteArrayOutputStream data = new ByteArrayOutputStream();
     try (DataOutputStream out = new DataOutputStream(data)) {
@@ -138,359 +99,148 @@ class ClientGetPersistenceIOTest {
     }
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(data.toByteArray()));
 
-    Bucket result = ClientGetPersistenceIO.readInitialMetadata(input, context, checker);
+    Bucket result = ClientGetPersistenceIO.readInitialMetadata(input, fetchRuntimeSupport, checker);
 
     assertNull(result);
-    verifyNoInteractions(checker);
+    verifyNoInteractions(fetchRuntimeSupport, checker);
   }
 
   @Test
-  void readInitialMetadata_whenChecksumFails_throwsStorageFormatException()
-      throws IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
+  void readInitialMetadata_whenRestoreSucceeds_returnsBucket()
+      throws IOException, StorageFormatException, ResumeFailedException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
+    Bucket expected = mock(Bucket.class);
     ByteArrayOutputStream data = new ByteArrayOutputStream();
     try (DataOutputStream out = new DataOutputStream(data)) {
       out.writeBoolean(true);
     }
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(data.toByteArray()));
+    DataInputStream inner = new DataInputStream(new ByteArrayInputStream(new byte[0]));
 
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenThrow(new ChecksumFailedException());
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L)).thenReturn(inner);
+    when(fetchRuntimeSupport.restorePersistentBucket(inner)).thenReturn(expected);
 
-    StorageFormatException error =
-        assertThrows(
-            StorageFormatException.class,
-            () -> ClientGetPersistenceIO.readInitialMetadata(input, context, checker));
+    Bucket restored =
+        ClientGetPersistenceIO.readInitialMetadata(input, fetchRuntimeSupport, checker);
 
-    assertEquals(ChecksumFailedException.class, error.getCause().getClass());
-  }
-
-  @Test
-  void restoreCompletedDirectBucketOrNull_whenRestoreSucceeds_returnsBucket()
-      throws ResumeFailedException, IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
-    ChecksumChecker checker = mock(ChecksumChecker.class);
-    Bucket expectedBucket = mock(Bucket.class);
-    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(new byte[0]));
-
-    try (MockedStatic<BucketTools> bucketTools = mockStatic(BucketTools.class)) {
-      bucketTools
-          .when(
-              () ->
-                  BucketTools.restoreFrom(
-                      any(DataInputStream.class),
-                      eq(context.persistentFG),
-                      eq(context.getPersistentFileTracker()),
-                      eq(context.getPersistentMasterSecret())))
-          .thenReturn(expectedBucket);
-
-      Bucket restored =
-          ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(input, context, checker);
-
-      assertEquals(expectedBucket, restored);
-    }
+    assertEquals(expected, restored);
   }
 
   @Test
   void restoreCompletedDirectBucketOrNull_whenChecksumFails_returnsNull()
-      throws ResumeFailedException, IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
+      throws ResumeFailedException, IOException, StorageFormatException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
 
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenThrow(new ChecksumFailedException());
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L))
+        .thenThrow(storageFormatExceptionWithChecksumFailure());
 
     Bucket restored =
-        ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(input, context, checker);
+        ClientGetPersistenceIO.restoreCompletedDirectBucketOrNull(
+            input, fetchRuntimeSupport, checker);
 
     assertNull(restored);
   }
 
   @Test
   void restoreFailureMessageOrNull_whenValidMessage_returnsMessage()
-      throws IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
+      throws IOException, StorageFormatException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
     RequestIdentifier reqID =
         new RequestIdentifier(true, null, "req-1", RequestIdentifier.RequestType.GET);
-    long expectedLength = 123L;
-    String expectedType = "text/plain";
     byte[] payload =
         serializeFailureMessage(
-            FetchException.FetchExceptionMode.DATA_NOT_FOUND, "missing", false, null);
+            new GetFailedMessage(
+                new FetchException(FetchException.FetchExceptionMode.DATA_NOT_FOUND, "missing"),
+                reqID.identifier,
+                reqID.globalQueue));
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+    DataInputStream inner = new DataInputStream(new ByteArrayInputStream(payload));
 
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(payload));
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L)).thenReturn(inner);
 
     GetFailedMessage restored =
         ClientGetPersistenceIO.restoreFailureMessageOrNull(
-            input, reqID, expectedLength, expectedType, context, checker);
+            input, reqID, 123L, "text/plain", fetchRuntimeSupport, checker);
 
     assertNotNull(restored);
     assertEquals(FetchException.FetchExceptionMode.DATA_NOT_FOUND, restored.failureMode);
     assertEquals(reqID.identifier, restored.requestIdentifier);
     assertEquals(reqID.globalQueue, restored.global);
-    assertEquals(expectedLength, restored.expectedDataLength);
-    assertEquals(expectedType, restored.expectedMimeType);
-  }
-
-  @Test
-  void restoreFailureMessageOrNull_whenRedirectProvided_readsRedirect()
-      throws IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
-    ChecksumChecker checker = mock(ChecksumChecker.class);
-    RequestIdentifier reqID =
-        new RequestIdentifier(true, null, "req-redirect", RequestIdentifier.RequestType.GET);
-    String redirectUri =
-        "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
-    byte[] payload =
-        serializeFailureMessage(
-            FetchException.FetchExceptionMode.INTERNAL_ERROR, "boom", true, redirectUri);
-    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(payload));
-
-    GetFailedMessage restored =
-        ClientGetPersistenceIO.restoreFailureMessageOrNull(
-            input, reqID, -1L, null, context, checker);
-
-    assertNotNull(restored);
-    assertEquals("boom", restored.extraDescription);
-    assertTrue(restored.finalizedExpected);
-    assertNotNull(restored.redirectURI);
-    assertEquals(redirectUri, restored.redirectURI.toString());
-  }
-
-  @Test
-  void restoreFailureMessageOrNull_whenInvalidPayload_returnsNull()
-      throws IOException, ChecksumFailedException {
-    ClientContext context = newClientContext();
-    ChecksumChecker checker = mock(ChecksumChecker.class);
-    RequestIdentifier reqID =
-        new RequestIdentifier(false, "client", "req-2", RequestIdentifier.RequestType.GET);
-    DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-    byte[] payload = serializeInvalidFailureMessage();
-
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(payload));
-
-    GetFailedMessage restored =
-        ClientGetPersistenceIO.restoreFailureMessageOrNull(
-            input, reqID, -1L, null, context, checker);
-
-    assertNull(restored);
   }
 
   @Test
   void restoreInProgressState_whenResumeReturnsTrue_readsTransientFields()
-      throws IOException, ChecksumFailedException, StorageFormatException {
-    ClientContext context = newClientContext();
+      throws IOException, StorageFormatException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
-    ClientGetter getter = mock(ClientGetter.class);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
     ClientGet request = newRequestWithState();
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-
     byte[] payload = serializeTransientProgress();
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenReturn(new ByteArrayInputStream(payload));
-    when(getter.resumeFromTrivialProgress(any(DataInputStream.class), eq(context)))
-        .thenReturn(true);
+    DataInputStream inner = new DataInputStream(new ByteArrayInputStream(payload));
 
-    ClientGetPersistenceIO.restoreInProgressState(input, context, checker, getter, request);
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L)).thenReturn(inner);
+    when(execution.resumeFromTrivialProgress(any(DataInputStream.class))).thenReturn(true);
 
-    verify(getter).resumeFromTrivialProgress(any(DataInputStream.class), eq(context));
+    ClientGetPersistenceIO.restoreInProgressState(
+        input, fetchRuntimeSupport, checker, execution, request);
+
+    verify(execution).resumeFromTrivialProgress(any(DataInputStream.class));
     assertEquals(42L, request.state().getFoundDataLength());
     assertEquals("text/plain", request.state().getFoundDataMimeType());
   }
 
   @Test
   void restoreInProgressState_whenChecksumFails_skipsResume()
-      throws IOException, ChecksumFailedException, StorageFormatException {
-    ClientContext context = newClientContext();
+      throws IOException, StorageFormatException {
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     ChecksumChecker checker = mock(ChecksumChecker.class);
-    ClientGetter getter = mock(ClientGetter.class);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
     ClientGet request = mock(ClientGet.class);
     DataInputStream input = new DataInputStream(new ByteArrayInputStream(new byte[0]));
 
-    when(checker.checksumReaderWithLength(input, context.tempBucketFactory, 65536))
-        .thenThrow(new ChecksumFailedException());
+    when(fetchRuntimeSupport.openChecksummed(input, checker, 65536L))
+        .thenThrow(storageFormatExceptionWithChecksumFailure());
 
-    ClientGetPersistenceIO.restoreInProgressState(input, context, checker, getter, request);
+    ClientGetPersistenceIO.restoreInProgressState(
+        input, fetchRuntimeSupport, checker, execution, request);
 
-    verifyNoInteractions(getter, request);
+    verifyNoInteractions(execution, request);
   }
 
-  private static ClientContext newClientContext() {
-    ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
-    PriorityAwareExecutor mainExecutor = mock(PriorityAwareExecutor.class);
-    MemoryLimitedJobRunner memoryLimitedJobRunner = mock(MemoryLimitedJobRunner.class);
-    Ticker ticker = mock(Ticker.class);
-    RandomSource strongRandom = mock(RandomSource.class);
-    SecureRandom fastWeakRandom = new SecureRandom();
-    MasterSecret transientSecret = mock(MasterSecret.class);
-    MasterSecret persistentSecret = mock(MasterSecret.class);
-    PersistentTempBucketFactory persistentBucketFactory = mock(PersistentTempBucketFactory.class);
-    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
-    PersistentFileTracker persistentFileTracker = mock(PersistentFileTracker.class);
-    FilenameGenerator fg = mock(FilenameGenerator.class);
-    FilenameGenerator persistentFG = mock(FilenameGenerator.class);
-    FileRandomAccessBufferFactory fileRAFTransient = mock(FileRandomAccessBufferFactory.class);
-    FileRandomAccessBufferFactory fileRAFPersistent = mock(FileRandomAccessBufferFactory.class);
-    LockableRandomAccessBufferFactory tempRAF = mock(LockableRandomAccessBufferFactory.class);
-    LockableRandomAccessBufferFactory persistentRAF = mock(LockableRandomAccessBufferFactory.class);
-    ArchiveManager archiveManager = mock(ArchiveManager.class);
-    HealingQueue healingQueue = mock(HealingQueue.class);
-    USKManager uskManager = mock(USKManager.class);
-    RealCompressor compressor = mock(RealCompressor.class);
-    DatastoreChecker datastoreChecker = mock(DatastoreChecker.class);
-    PersistentRequestRoot persistentRoot = mock(PersistentRequestRoot.class);
-    LinkFilterExceptionProvider linkFilterExceptionProvider =
-        mock(LinkFilterExceptionProvider.class);
-
-    FetchContext defaultFetchContext = buildFetchContext();
-    InsertContext defaultInsertContext = buildInsertContext();
-
-    ClientContext context =
-        new ClientContext(
-            1L,
-            new ClientContextRuntime(
-                jobRunner,
-                mainExecutor,
-                memoryLimitedJobRunner,
-                ticker,
-                strongRandom,
-                fastWeakRandom,
-                transientSecret),
-            new ClientContextStorageFactories(
-                persistentBucketFactory,
-                tempBucketFactory,
-                persistentFileTracker,
-                fg,
-                persistentFG,
-                fileRAFTransient,
-                fileRAFPersistent),
-            new ClientContextRafFactories(tempRAF, persistentRAF),
-            new ClientContextServices(
-                new ClientContextResources(archiveManager, healingQueue),
-                uskManager,
-                compressor,
-                datastoreChecker,
-                persistentRoot,
-                linkFilterExceptionProvider),
-            new ClientContextDefaults(defaultFetchContext, defaultInsertContext, new Config()));
-
-    context.setPersistentMasterSecret(persistentSecret);
-    return context;
-  }
-
-  private static FetchContext buildFetchContext() {
-    return new FetchContext(
-        FetchContextOptions.builder()
-            .limits(1024L, 2048L, 4096)
-            .archiveLimits(2, 3, 1, false)
-            .retryLimits(1, 1, 0)
-            .splitfileLimits(true, 16, 16)
-            .behavior(true, false, true)
-            .clientOptions(new SimpleEventProducer(), false, true)
-            .filterOverrides(null, null, null)
-            .build());
-  }
-
-  private static InsertContext buildInsertContext() {
-    return new InsertContext(
-        InsertContextOptions.builder()
-            .retryLimits(1, 0)
-            .splitfileSegmentLimits(16, 16)
-            .clientOptions(new SimpleEventProducer(), true, false, false)
-            .compressorDescriptor(null)
-            .redundancy(0, 0)
-            .compatibility(InsertContext.CompatibilityMode.COMPAT_CURRENT)
-            .build());
+  private static StorageFormatException storageFormatExceptionWithChecksumFailure() {
+    StorageFormatException exception = new StorageFormatException("Checksum failed");
+    exception.initCause(new ChecksumFailedException());
+    return exception;
   }
 
   private static ClientGet newRequestWithState() {
-    ClientGet request =
-        mock(ClientGet.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-    setField(request, ClientRequest.class, "identifier", "req-1");
-    setField(request, ClientRequest.class, "global", false);
-    setField(request, ClientGet.class, "state", new ClientGetState(request));
-    setField(request, ClientGet.class, "persistenceLock", new ClientGet().persistenceLock());
+    ClientGet request = new ClientGet();
+    request.state().setCompatibilityAnalyser(new CompatibilityAnalyser());
     return request;
   }
 
+  private static byte[] serializeFailureMessage(GetFailedMessage message) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(output)) {
+      message.writeTo(dos);
+    }
+    return output.toByteArray();
+  }
+
   private static byte[] serializeTransientProgress() throws IOException {
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeLong(42L);
-      out.writeBoolean(true);
-      out.writeUTF("text/plain");
-      new CompatibilityAnalyser().writeTo(out);
-      ClientGetGetterFactory.writeExpectedHashes(out, null);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(output)) {
+      dos.writeLong(42L);
+      dos.writeBoolean(true);
+      dos.writeUTF("text/plain");
+      new CompatibilityAnalyser().writeTo(dos);
+      dos.writeInt(0);
     }
-    return buffer.toByteArray();
-  }
-
-  @SuppressWarnings("java:S3011")
-  private static void setField(Object target, Class<?> owner, String fieldName, Object value) {
-    try {
-      Field field = owner.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      field.set(target, value);
-    } catch (ReflectiveOperationException e) {
-      throw new LinkageError("Failed to set field: " + fieldName, e);
-    }
-  }
-
-  private static byte[] serializeFetchContext(FetchContext context) throws IOException {
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (DataOutputStream out = new DataOutputStream(buffer)) {
-      context.writeTo(out);
-    }
-    return buffer.toByteArray();
-  }
-
-  private static byte[] serializeFailureMessage(
-      FetchException.FetchExceptionMode mode,
-      String description,
-      boolean finalizedExpected,
-      String redirectUri)
-      throws IOException {
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeInt(GetFailedMessage.VERSION);
-      out.writeInt(mode.code);
-      writePossiblyNull(out, description);
-      out.writeBoolean(finalizedExpected);
-      writePossiblyNull(out, redirectUri);
-    }
-    return buffer.toByteArray();
-  }
-
-  private static byte[] serializeInvalidFailureMessage() throws IOException {
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    try (DataOutputStream out = new DataOutputStream(buffer)) {
-      out.writeInt(GetFailedMessage.VERSION + 1);
-      out.writeInt(FetchException.FetchExceptionMode.DATA_NOT_FOUND.code);
-      writePossiblyNull(out, "bad");
-      out.writeBoolean(false);
-      writePossiblyNull(out, null);
-    }
-    return buffer.toByteArray();
-  }
-
-  private static void writePossiblyNull(DataOutputStream out, String value) throws IOException {
-    if (value == null) {
-      out.writeBoolean(false);
-    } else {
-      out.writeBoolean(true);
-      out.writeUTF(value);
-    }
+    return output.toByteArray();
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetRestartCoordinatorTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetRestartCoordinatorTest.java
@@ -1,12 +1,8 @@
 package network.crypta.clients.fcp;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.atomic.AtomicBoolean;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientGetter;
 import network.crypta.crypt.HashResult;
 import network.crypta.keys.FreenetURI;
 import org.junit.jupiter.api.Test;
@@ -24,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -45,43 +40,43 @@ class ClientGetRestartCoordinatorTest {
   @Test
   void canRestart_whenRequestNotFinished_returnsFalseWithoutConsultingGetter() throws Exception {
     ClientGet request = new ClientGet();
-    ClientGetter getter = mock(ClientGetter.class);
-    setClientGetField(request, "getter", getter);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    setClientGetField(request, "execution", execution);
 
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
     assertFalse(coordinator.canRestart());
-    verifyNoInteractions(getter);
+    verifyNoInteractions(execution);
   }
 
   @Test
   void canRestart_whenRequestAlreadySucceeded_returnsFalseWithoutConsultingGetter()
       throws Exception {
     ClientGet request = new ClientGet();
-    ClientGetter getter = mock(ClientGetter.class);
-    setClientGetField(request, "getter", getter);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    setClientGetField(request, "execution", execution);
     setClientRequestField(request, "finished", true);
     request.state().setSucceeded(true);
 
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
     assertFalse(coordinator.canRestart());
-    verifyNoInteractions(getter);
+    verifyNoInteractions(execution);
   }
 
   @Test
   void canRestart_whenFinishedAndGetterCanRestart_returnsTrue() throws Exception {
     ClientGet request = new ClientGet();
-    ClientGetter getter = mock(ClientGetter.class);
-    when(getter.canRestart()).thenReturn(true);
-    setClientGetField(request, "getter", getter);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    when(execution.canRestart()).thenReturn(true);
+    setClientGetField(request, "execution", execution);
     setClientRequestField(request, "finished", true);
     request.state().setSucceeded(false);
 
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
     assertTrue(coordinator.canRestart());
-    verify(getter).canRestart();
+    verify(execution).canRestart();
   }
 
   @Test
@@ -112,59 +107,50 @@ class ClientGetRestartCoordinatorTest {
     ClientGet request = new ClientGet();
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
-    assertFalse(coordinator.restart(mock(ClientContext.class), false));
+    assertFalse(coordinator.restart(false));
   }
 
   @Test
   void restart_whenFetchContextMissing_returnsFalseWithoutRestartingGetter() throws Exception {
     ClientGet request = new ClientGet();
-    ClientGetter getter = mock(ClientGetter.class);
-    when(getter.canRestart()).thenReturn(true);
-    setClientGetField(request, "getter", getter);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    when(execution.canRestart()).thenReturn(true);
+    setClientGetField(request, "execution", execution);
     setClientRequestField(request, "finished", true);
     request.state().setSucceeded(false);
 
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
-    assertFalse(coordinator.restart(mock(ClientContext.class), false));
-    verify(getter).canRestart();
-    verify(getter, never()).restart(any(), anyBoolean(), any(ClientContext.class));
+    assertFalse(coordinator.restart(false));
+    verify(execution).canRestart();
+    verify(execution, never()).restart(any(), anyBoolean());
   }
 
   @Test
   void restart_whenGetterRestartsWithRedirect_resetsStateAndNotifiesCache() throws Exception {
     ClientGet request = new ClientGet();
-    ClientGetter getter = mock(ClientGetter.class);
-    FetchContext fetchContext = mock(FetchContext.class);
-    ClientContext context = mock(ClientContext.class);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     RequestStatusCache cache = mock(RequestStatusCache.class);
     when(client.getRequestStatusCache()).thenReturn(cache);
-    AtomicBoolean filterData = new AtomicBoolean(true);
-    when(fetchContext.getFilterData()).thenAnswer(_ -> filterData.get());
-    doAnswer(
-            invocation -> {
-              filterData.set(invocation.getArgument(0));
-              return null;
-            })
-        .when(fetchContext)
-        .setFilterData(anyBoolean());
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setFilterData(true);
 
     FreenetURI original = new FreenetURI("KSK@original");
     FreenetURI redirect = new FreenetURI("KSK@redirect");
     FetchException failure =
         new FetchException(FetchExceptionMode.PERMANENT_REDIRECT, "redirecting", redirect);
 
-    when(getter.canRestart()).thenReturn(true);
-    when(getter.restart(redirect, false, context)).thenReturn(true);
+    when(execution.canRestart()).thenReturn(true);
+    when(execution.restart(redirect, false)).thenReturn(true);
 
     setClientRequestField(request, "identifier", "req-redirect");
     setClientRequestField(request, "uri", original);
     setClientRequestField(request, "client", client);
     setClientRequestField(request, "finished", true);
     setClientRequestField(request, "started", true);
-    setClientGetField(request, "getter", getter);
-    setClientGetField(request, "fctx", fetchContext);
+    setClientGetField(request, "execution", execution);
+    setClientGetField(request, "fetchConfig", fetchConfig);
 
     request.state().setSucceeded(false);
     request.state().setFailedMessage(new GetFailedMessage(failure, "req-redirect", false));
@@ -174,10 +160,10 @@ class ClientGetRestartCoordinatorTest {
 
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
-    assertTrue(coordinator.restart(context, true));
+    assertTrue(coordinator.restart(true));
 
-    verify(fetchContext).setFilterData(false);
-    verify(getter).restart(redirect, false, context);
+    assertFalse(fetchConfig.getFilterData());
+    verify(execution).restart(redirect, false);
     verify(cache).updateStarted("req-redirect", redirect);
     verify(cache).updateStarted("req-redirect", true);
     assertFalse(getClientRequestBooleanField(request, "finished"));
@@ -193,27 +179,25 @@ class ClientGetRestartCoordinatorTest {
   @Test
   void restart_whenGetterDeclinesRestart_returnsTrueAndKeepsStartedFalse() throws Exception {
     ClientGet request = new ClientGet();
-    ClientGetter getter = mock(ClientGetter.class);
-    FetchContext fetchContext = mock(FetchContext.class);
-    ClientContext context = mock(ClientContext.class);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
     FreenetURI original = new FreenetURI("KSK@original-no-restart");
 
-    when(getter.canRestart()).thenReturn(true);
-    when(getter.restart(null, true, context)).thenReturn(false);
-    when(fetchContext.getFilterData()).thenReturn(true);
+    when(execution.canRestart()).thenReturn(true);
+    when(execution.restart(null, true)).thenReturn(false);
+    fetchConfig.setFilterData(true);
 
     setClientRequestField(request, "uri", original);
     setClientRequestField(request, "finished", true);
     setClientRequestField(request, "started", true);
-    setClientGetField(request, "getter", getter);
-    setClientGetField(request, "fctx", fetchContext);
+    setClientGetField(request, "execution", execution);
+    setClientGetField(request, "fetchConfig", fetchConfig);
 
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
-    assertTrue(coordinator.restart(context, false));
+    assertTrue(coordinator.restart(false));
 
-    verify(fetchContext, never()).setFilterData(anyBoolean());
-    verify(getter).restart(null, true, context);
+    verify(execution).restart(null, true);
     assertFalse(getClientRequestBooleanField(request, "finished"));
     assertFalse(getClientRequestBooleanField(request, "started"));
     assertSame(original, request.getURI());
@@ -222,28 +206,27 @@ class ClientGetRestartCoordinatorTest {
   @Test
   void restart_whenGetterThrowsFetchException_invokesOnFailureAndReturnsFalse() throws Exception {
     ClientGet request = spy(new ClientGet());
-    ClientGetter getter = mock(ClientGetter.class);
-    FetchContext fetchContext = mock(FetchContext.class);
-    ClientContext context = mock(ClientContext.class);
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     RequestStatusCache cache = mock(RequestStatusCache.class);
     when(client.getRequestStatusCache()).thenReturn(cache);
 
     FetchException failure = new FetchException(FetchExceptionMode.INTERNAL_ERROR, "boom");
-    when(getter.canRestart()).thenReturn(true);
-    when(getter.restart(null, false, context)).thenThrow(failure);
-    when(fetchContext.getFilterData()).thenReturn(false);
+    when(execution.canRestart()).thenReturn(true);
+    when(execution.restart(null, false)).thenThrow(failure);
+    fetchConfig.setFilterData(false);
     doNothing().when(request).onFailure(any(FetchException.class));
 
     setClientRequestField(request, "identifier", "req-failure");
     setClientRequestField(request, "client", client);
     setClientRequestField(request, "finished", true);
-    setClientGetField(request, "getter", getter);
-    setClientGetField(request, "fctx", fetchContext);
+    setClientGetField(request, "execution", execution);
+    setClientGetField(request, "fetchConfig", fetchConfig);
 
     ClientGetRestartCoordinator coordinator = new ClientGetRestartCoordinator(request);
 
-    assertFalse(coordinator.restart(context, false));
+    assertFalse(coordinator.restart(false));
 
     verify(request).onFailure(failure);
     verify(cache).updateStarted(eq("req-failure"), isNull(FreenetURI.class));

--- a/src/test/java/network/crypta/clients/fcp/ClientGetReturnPlannerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetReturnPlannerTest.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import network.crypta.client.FetchContext;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
@@ -36,7 +35,6 @@ class ClientGetReturnPlannerTest {
   private static final String PAYLOAD_BIN = "payload.bin";
   private static final String REQUEST_ID = "id";
 
-  @Mock private FetchContext fetchContext;
   @Mock private TransferAccessPort transferAccess;
   @Mock private FCPConnectionHandler handler;
   @Mock private DdaAccessController ddaAccessController;
@@ -45,8 +43,10 @@ class ClientGetReturnPlannerTest {
 
   @Test
   void constructor_whenIdentifierNull_throwsNullPointerException() {
+    ClientGetFetchConfig fetchConfig = newFetchConfig(false);
+
     assertThrows(
-        NullPointerException.class, () -> new ClientGetReturnPlanner(null, false, fetchContext));
+        NullPointerException.class, () -> new ClientGetReturnPlanner(null, false, fetchConfig));
   }
 
   @Test
@@ -57,7 +57,8 @@ class ClientGetReturnPlannerTest {
 
   @Test
   void forGlobalRequest_whenReturnTypeNotDisk_returnsEmptySetup() throws Exception {
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(false));
 
     ClientGetReturnPlanner.ReturnSetup setup =
         planner.forGlobalRequest(ReturnType.DIRECT, null, false, transferAccess);
@@ -71,7 +72,8 @@ class ClientGetReturnPlannerTest {
 
   @Test
   void forGlobalRequest_whenDiskNotAllowed_throwsNotAllowedException() {
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(false));
     File target = tempDir.resolve(PAYLOAD_BIN).toFile();
     when(transferAccess.allowDownloadTo(target)).thenReturn(false);
 
@@ -84,7 +86,8 @@ class ClientGetReturnPlannerTest {
 
   @Test
   void forGlobalRequest_whenDiskAndZeroLengthFile_deletesAndReturnsSetup() throws Exception {
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(false));
     File target = tempDir.resolve(PAYLOAD_BIN).toFile();
     assertTrue(target.createNewFile());
     when(transferAccess.allowDownloadTo(target)).thenReturn(true);
@@ -101,7 +104,8 @@ class ClientGetReturnPlannerTest {
 
   @Test
   void forGlobalRequest_whenDiskAndExistingNonZeroFile_throwsIOException() throws Exception {
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(false));
     Path targetPath = tempDir.resolve(PAYLOAD_BIN);
     Files.writeString(targetPath, "data");
     File target = targetPath.toFile();
@@ -119,7 +123,8 @@ class ClientGetReturnPlannerTest {
   @Test
   void forMessage_whenReturnTypeNotDisk_returnsEmptySetup() throws Exception {
     ClientGetMessage message = buildMessage(ReturnType.NONE, null);
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(false));
 
     ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, transferAccess, handler);
 
@@ -134,7 +139,8 @@ class ClientGetReturnPlannerTest {
   void forMessage_whenDownloadNotAllowed_throwsMessageInvalidException() throws Exception {
     Path targetPath = tempDir.resolve(PAYLOAD_BIN);
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, true, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, true, newFetchConfig(false));
     when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(false);
 
     MessageInvalidException thrown =
@@ -152,7 +158,8 @@ class ClientGetReturnPlannerTest {
   void forMessage_whenDdaDenied_throwsMessageInvalidException() throws Exception {
     Path targetPath = tempDir.resolve(PAYLOAD_BIN);
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(false));
     when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaAccessController);
     when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(false);
@@ -171,7 +178,8 @@ class ClientGetReturnPlannerTest {
     Path targetPath = tempDir.resolve(PAYLOAD_BIN);
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
     Files.writeString(targetPath, "data");
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(false));
     when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaAccessController);
     when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(true);
@@ -191,11 +199,11 @@ class ClientGetReturnPlannerTest {
   void forMessage_whenAllowedAndFilterDataTrue_returnsSetupWithExtension() throws Exception {
     Path targetPath = tempDir.resolve("payload.txt");
     ClientGetMessage message = buildMessage(ReturnType.DISK, targetPath.toFile());
-    ClientGetReturnPlanner planner = new ClientGetReturnPlanner(REQUEST_ID, false, fetchContext);
+    ClientGetReturnPlanner planner =
+        new ClientGetReturnPlanner(REQUEST_ID, false, newFetchConfig(true));
     when(transferAccess.allowDownloadTo(targetPath.toFile())).thenReturn(true);
     when(handler.ddaAccessController()).thenReturn(ddaAccessController);
     when(ddaAccessController.allowDDAFrom(targetPath.toFile(), true)).thenReturn(true);
-    when(fetchContext.getFilterData()).thenReturn(true);
 
     ClientGetReturnPlanner.ReturnSetup setup = planner.forMessage(message, transferAccess, handler);
 
@@ -203,6 +211,12 @@ class ClientGetReturnPlannerTest {
         () -> assertInstanceOf(FileBucket.class, setup.bucket()),
         () -> assertEquals(targetPath.toFile(), setup.targetFile()),
         () -> assertEquals("txt", setup.extension()));
+  }
+
+  private static ClientGetFetchConfig newFetchConfig(boolean filterData) {
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setFilterData(filterData);
+    return fetchConfig;
   }
 
   private ClientGetMessage buildMessage(ReturnType type, File diskFile)

--- a/src/test/java/network/crypta/clients/fcp/ClientGetStatusReporterTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetStatusReporterTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.time.Instant;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.InsertContext;
@@ -166,8 +165,8 @@ class ClientGetStatusReporterTest {
     setClientRequestField(request, "uri", new FreenetURI("KSK@status"));
     setClientGetField(request, "returnType", ClientGet.ReturnType.DIRECT);
     setClientGetField(request, "targetFile", new File("download.bin"));
-    FetchContext fetchContext = mock(FetchContext.class);
-    setClientGetField(request, "fctx", fetchContext);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    setClientGetField(request, "fetchConfig", fetchConfig);
 
     Bucket bucket = mock(Bucket.class);
     request.state().setReturnBucketDirect(bucket);
@@ -226,7 +225,7 @@ class ClientGetStatusReporterTest {
       assertEquals(123L, snapshot.foundDataLength());
       assertEquals("download.bin", snapshot.destinationFile().getPath());
       assertSame(bucket, snapshot.dataBucket());
-      assertSame(fetchContext, snapshot.fetchContext());
+      assertEquals(fetchConfig, snapshot.fetchConfig());
       assertArrayEquals(
           new InsertContext.CompatibilityMode[] {
             InsertContext.CompatibilityMode.COMPAT_1250, InsertContext.CompatibilityMode.COMPAT_1468
@@ -253,7 +252,7 @@ class ClientGetStatusReporterTest {
     setClientRequestField(request, "finished", true);
     setClientRequestField(request, "started", true);
     setClientGetField(request, "returnType", ClientGet.ReturnType.NONE);
-    setClientGetField(request, "fctx", mock(FetchContext.class));
+    setClientGetField(request, "fetchConfig", new ClientGetFetchConfig());
     request.state().setSucceeded(true);
     SimpleProgressMessage progress = mock(SimpleProgressMessage.class);
     when(progress.isTotalFinalized()).thenReturn(false);

--- a/src/test/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilderTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetStatusSnapshotBuilderTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import network.crypta.client.FetchContext;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -28,9 +27,9 @@ class ClientGetStatusSnapshotBuilderTest {
   void persistentTagMessage_whenDiskReturnType_expectFieldSetContainsDiskFilenameAndValues()
       throws Exception {
     // Arrange
-    FetchContext fetchContext = Mockito.mock(FetchContext.class);
-    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(7);
-    when(fetchContext.getMaxOutputLength()).thenReturn(12_345L);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setMaxNonSplitfileRetries(7);
+    fetchConfig.setMaxOutputLength(12_345L);
     RequestClient requestClient = Mockito.mock(RequestClient.class);
     when(requestClient.realTimeFlag()).thenReturn(true);
     File targetFile = new File("target.bin");
@@ -49,7 +48,7 @@ class ClientGetStatusSnapshotBuilderTest {
             ReturnType.DISK,
             targetFile,
             true,
-            fetchContext,
+            fetchConfig,
             requestClient);
     ClientGetStatusSnapshotBuilder builder = new ClientGetStatusSnapshotBuilder(request);
 
@@ -78,9 +77,9 @@ class ClientGetStatusSnapshotBuilderTest {
   void persistentTagMessage_whenClientTokenNull_expectFieldSetOmitsClientTokenAndFilename()
       throws Exception {
     // Arrange
-    FetchContext fetchContext = Mockito.mock(FetchContext.class);
-    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(1);
-    when(fetchContext.getMaxOutputLength()).thenReturn(42L);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setMaxNonSplitfileRetries(1);
+    fetchConfig.setMaxOutputLength(42L);
     RequestClient requestClient = Mockito.mock(RequestClient.class);
     when(requestClient.realTimeFlag()).thenReturn(false);
     PersistentRequestClient client =
@@ -98,7 +97,7 @@ class ClientGetStatusSnapshotBuilderTest {
             ReturnType.DIRECT,
             null,
             false,
-            fetchContext,
+            fetchConfig,
             requestClient);
     ClientGetStatusSnapshotBuilder builder = new ClientGetStatusSnapshotBuilder(request);
 
@@ -121,9 +120,9 @@ class ClientGetStatusSnapshotBuilderTest {
   @Test
   void persistentTagMessage_whenUriNull_expectThrowsNullPointerException() throws Exception {
     // Arrange
-    FetchContext fetchContext = Mockito.mock(FetchContext.class);
-    when(fetchContext.getMaxNonSplitfileRetries()).thenReturn(1);
-    when(fetchContext.getMaxOutputLength()).thenReturn(1L);
+    ClientGetFetchConfig fetchConfig = new ClientGetFetchConfig();
+    fetchConfig.setMaxNonSplitfileRetries(1);
+    fetchConfig.setMaxOutputLength(1L);
     RequestClient requestClient = Mockito.mock(RequestClient.class);
     when(requestClient.realTimeFlag()).thenReturn(false);
     PersistentRequestClient client =
@@ -141,7 +140,7 @@ class ClientGetStatusSnapshotBuilderTest {
             ReturnType.NONE,
             null,
             false,
-            fetchContext,
+            fetchConfig,
             requestClient);
     ClientGetStatusSnapshotBuilder builder = new ClientGetStatusSnapshotBuilder(request);
 
@@ -161,7 +160,7 @@ class ClientGetStatusSnapshotBuilderTest {
       ReturnType returnType,
       File targetFile,
       boolean binaryBlob,
-      FetchContext fetchContext,
+      ClientGetFetchConfig fetchConfig,
       RequestClient requestClient)
       throws Exception {
     ClientGet request = new ClientGet();
@@ -176,7 +175,7 @@ class ClientGetStatusSnapshotBuilderTest {
     setField(request, "returnType", returnType);
     setField(request, "targetFile", targetFile);
     setField(request, "binaryBlob", binaryBlob);
-    setField(request, "fctx", fetchContext);
+    setField(request, "fetchConfig", fetchConfig);
     setField(request, "lowLevelClient", requestClient);
     return request;
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -7,7 +7,10 @@ import java.time.Instant;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.InsertContext.CompatibilityMode;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.CompatibilityAnalyser;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.SplitfileProgressTimestamps;
@@ -29,6 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
@@ -233,6 +240,42 @@ class ClientGetTest {
     assertFalse(clientGet.isDirect());
   }
 
+  @Test
+  void onResume_whenSerializedExecutionMissing_recreatesAndStartsExecution() throws Exception {
+    ClientGet clientGet = newClientGet();
+    setField(clientGet, "identifier", "resume-get");
+    setField(clientGet, "clientName", "resume-client");
+    setField(clientGet, "persistence", ClientRequest.Persistence.FOREVER);
+    setField(clientGet, "global", false);
+    setField(clientGet, "realTime", false);
+    setField(clientGet, "started", true);
+    setField(clientGet, "priorityClass", (short) 3);
+    setField(clientGet, "uri", new FreenetURI("KSK@resume-get"));
+    setField(clientGet, "execution", null);
+    clientGet.state().setFoundDataLength(32L);
+    clientGet.state().setFoundDataMimeType("text/plain");
+
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    ClientRequester requester = mock(ClientRequester.class);
+    when(execution.requester()).thenReturn(requester);
+    FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
+    when(fetchRuntimeSupport.createExecution(any())).thenReturn(execution);
+
+    PersistentRequestRoot root = new PersistentRequestRoot();
+    root.setFetchRuntimeSupport(fetchRuntimeSupport);
+    PersistentRequestClient resumedClient = root.registerForeverClient("resume-client", null);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "resume-client")).thenReturn(resumedClient);
+    when(coordinator.resumePersistentRequest(clientGet, false, "resume-client"))
+        .thenReturn(resumedClient);
+
+    clientGet.onResume(newContextWithCoordinator(coordinator));
+
+    verify(fetchRuntimeSupport).createExecution(any());
+    verify(execution).start();
+    verify(requester).onResume(any(ClientContext.class));
+  }
+
   private ClientGet newClientGet() {
     ClientGet clientGet = new ClientGet();
     clientGet.state().setCompatibilityAnalyser(new CompatibilityAnalyser());
@@ -260,5 +303,18 @@ class ClientGetTest {
       }
     }
     throw new IllegalArgumentException("Field not found: " + fieldName);
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static ClientContext newContextWithCoordinator(PersistentRequestCoordinator coordinator) {
+    ClientContext context = mock(ClientContext.class);
+    try {
+      Field field = ClientContext.class.getDeclaredField("persistentRequestCoordinator");
+      field.setAccessible(true);
+      field.set(context, coordinator);
+      return context;
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Failed to set ClientContext.persistentRequestCoordinator", e);
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.time.Instant;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.InsertContext.CompatibilityMode;
@@ -26,16 +25,15 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ClientGetTest {
 
-  @Mock private FetchContext fetchContext;
   @Mock private Bucket directBucket;
 
   @Test
@@ -185,8 +183,10 @@ class ClientGetTest {
 
   @Test
   void filterData_whenFetchContextDemandsFiltering_returnsTrue() {
-    when(fetchContext.getFilterData()).thenReturn(true);
     ClientGet clientGet = newClientGet();
+    ClientGetFetchConfig fetchConfig = clientGet.fetchConfig();
+    assertNotNull(fetchConfig);
+    fetchConfig.setFilterData(true);
 
     assertTrue(clientGet.filterData());
   }
@@ -236,7 +236,7 @@ class ClientGetTest {
   private ClientGet newClientGet() {
     ClientGet clientGet = new ClientGet();
     clientGet.state().setCompatibilityAnalyser(new CompatibilityAnalyser());
-    setField(clientGet, "fctx", fetchContext);
+    setField(clientGet, "fetchConfig", new ClientGetFetchConfig());
     return clientGet;
   }
 

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
-import network.crypta.client.FetchContext;
 import network.crypta.client.FetchResult;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
@@ -641,48 +640,51 @@ class FcpServerPersistentOpsTest {
   }
 
   private FcpServerPersistentOps newOps(PersistentRequestRoot root) {
-    Supplier<ClientContext> clientContextSupplier = core::getClientContext;
-    BooleanSupplier persistenceDisabledSupplier = core::killedDatabase;
-    Supplier<BucketFactory> tempBucketFactorySupplier = core::getTempBucketFactory;
-    Supplier<PersistentTempBucketFactory> persistentTempBucketFactorySupplier =
-        core::getPersistentTempBucketFactory;
-    Supplier<RandomSource> randomSourceSupplier = core::getRandom;
-    FcpServerRuntimeSupport runtimeSupport =
-        new FcpServerRuntimeSupport() {
-          @Override
-          public ClientContext clientContext() {
-            return clientContextSupplier.get();
-          }
-
-          @Override
-          public boolean persistenceDisabled() {
-            return persistenceDisabledSupplier.getAsBoolean();
-          }
-
-          @Override
-          public BucketFactory tempBucketFactory() {
-            return tempBucketFactorySupplier.get();
-          }
-
-          @Override
-          public PersistentTempBucketFactory persistentTempBucketFactory() {
-            return persistentTempBucketFactorySupplier.get();
-          }
-
-          @Override
-          public void fillSecureRandom(byte[] bytes) {
-            randomSourceSupplier.get().nextBytes(bytes);
-          }
-        };
+    FcpServerRuntimeSupport runtimeSupport = newRuntimeSupport();
     lenient().when(server.runtime()).thenReturn(runtimePorts);
     lenient().when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
     lenient().when(server.fetchRuntimeSupport()).thenReturn(fetchRuntimeSupport);
     lenient().when(runtimePorts.transferAccess()).thenReturn(transferAccess);
     lenient().when(fetchRuntimeSupport.transferAccess()).thenReturn(transferAccess);
     lenient()
-        .when(fetchRuntimeSupport.defaultPersistentFetchContext())
-        .thenReturn(mock(FetchContext.class));
+        .when(fetchRuntimeSupport.defaultPersistentFetchConfig())
+        .thenReturn(new ClientGetFetchConfig());
     return new FcpServerPersistentOps(server, runtimeSupport, root);
+  }
+
+  private FcpServerRuntimeSupport newRuntimeSupport() {
+    Supplier<ClientContext> clientContextSupplier = core::getClientContext;
+    BooleanSupplier persistenceDisabledSupplier = core::killedDatabase;
+    Supplier<BucketFactory> tempBucketFactorySupplier = core::getTempBucketFactory;
+    Supplier<PersistentTempBucketFactory> persistentTempBucketFactorySupplier =
+        core::getPersistentTempBucketFactory;
+    Supplier<RandomSource> randomSourceSupplier = core::getRandom;
+    return new FcpServerRuntimeSupport() {
+      @Override
+      public ClientContext clientContext() {
+        return clientContextSupplier.get();
+      }
+
+      @Override
+      public boolean persistenceDisabled() {
+        return persistenceDisabledSupplier.getAsBoolean();
+      }
+
+      @Override
+      public BucketFactory tempBucketFactory() {
+        return tempBucketFactorySupplier.get();
+      }
+
+      @Override
+      public PersistentTempBucketFactory persistentTempBucketFactory() {
+        return persistentTempBucketFactorySupplier.get();
+      }
+
+      @Override
+      public void fillSecureRandom(byte[] bytes) {
+        randomSourceSupplier.get().nextBytes(bytes);
+      }
+    };
   }
 
   private static void setField(Object target, String fieldName, Object value) throws Exception {


### PR DESCRIPTION
## Summary
- complete the first FCP-side GET runtime handoff for PR-172 by replacing live fetch-runtime types in `:adapter-fcp` with adapter-owned detached config and execution seams
- move concrete GET execution assembly, fetch-context translation, restore helpers, and Binary Blob bucket handling into `:bridge-fcp-runtime`
- update GET-path tests, boundary coverage, and Javadoc for the new seam classes while preserving FCP wire behavior and persisted request format

## How to test
- `./gradlew :adapter-fcp:test --tests network.crypta.clients.fcp.AdapterFcpBoundaryTest`
- `./gradlew :bridge-fcp-runtime:test --tests network.crypta.clients.fcp.bridge.CoreFcpFetchRuntimeSupportTest --tests network.crypta.clients.fcp.bridge.CoreFcpServerDependenciesFactoryTest --tests network.crypta.clients.fcp.bridge.FcpPersistentRequestRecoveryCodecTest`
- `./gradlew :test --tests network.crypta.clients.fcp.ClientGetFactoryTest --tests network.crypta.clients.fcp.ClientGetGetterFactoryTest --tests network.crypta.clients.fcp.ClientGetPersistenceCodecTest --tests network.crypta.clients.fcp.ClientGetPersistenceIOTest --tests network.crypta.clients.fcp.ClientGetRestartCoordinatorTest --tests network.crypta.clients.fcp.ClientGetLifecycleTest --tests network.crypta.clients.fcp.ClientGetStatusSnapshotBuilderTest --tests network.crypta.clients.fcp.ClientGetTest --tests network.crypta.clients.fcp.ClientGetMessageReplayTest --tests network.crypta.clients.fcp.FCPServerTest --tests network.crypta.clients.fcp.ClientGetFetchConfigTest`
- `./gradlew test`