### PR TITLE
refactor(fcp): Complete insert runtime handoff

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -2,20 +2,17 @@ package network.crypta.clients.fcp;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamField;
 import java.io.Serial;
 import java.io.Serializable;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertException;
 import network.crypta.client.MetadataUnresolvedException;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientPutter;
-import network.crypta.client.async.ClientPutterOptions;
-import network.crypta.client.async.ClientPutterRequest;
 import network.crypta.client.async.ClientRequester;
-import network.crypta.client.async.InsertRequestParams;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -30,7 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The class mediates between user requests and the asynchronous node core: it validates disk
  * access, synthesizes redirect metadata, resolves MIME metadata, and constructs the underlying
- * {@link ClientPutter}. Instances encapsulate all mutable states needed to monitor progress,
+ * {@link ClientPutExecution}. Instances encapsulate all mutable states needed to monitor progress,
  * respond to retries, and surface status updates across reconnections. Persistent requests are
  * serialized so the node can resume in-flight inserts after restart without reloading the client’s
  * original configuration.
@@ -64,34 +61,52 @@ public final class ClientPut extends ClientPutBase {
   /** Serialization version for persistent request snapshots. */
   @Serial private static final long serialVersionUID = 1L;
 
-  /**
-   * Active {@link ClientPutter} driving the insert; nulled only after FOREVER persistence removal.
-   */
-  ClientPutter putter;
+  private static final String LEGACY_PUTTER_TYPE = "network.crypta.client.async.ClientPutter";
+
+  private static final String BRIDGE_RUNTIME_SUPPORT =
+      "network.crypta.clients.fcp.bridge.CoreFcpInsertRuntimeSupport";
+
+  @SuppressWarnings("UnusedVariable")
+  private static final ObjectStreamField[] serialPersistentFields =
+      new ObjectStreamField[] {
+        new ObjectStreamField("putter", requiredClass(LEGACY_PUTTER_TYPE)),
+        new ObjectStreamField("uploadFrom", UploadFrom.class),
+        new ObjectStreamField("origFilename", File.class),
+        new ObjectStreamField("targetURI", FreenetURI.class),
+        new ObjectStreamField("data", RandomAccessBucket.class),
+        new ObjectStreamField("clientMetadata", ClientMetadata.class),
+        new ObjectStreamField("finishedSize", long.class),
+        new ObjectStreamField("targetFilename", String.class),
+        new ObjectStreamField("binaryBlob", boolean.class),
+        new ObjectStreamField("compressed", boolean.class)
+      };
+
+  /** Active execution handle driving the insert; nulled only after FOREVER persistence removal. */
+  ClientPutExecution putter;
 
   /** Describes how payload bytes are obtained (direct, disk, redirect, or in-memory). */
-  private final UploadFrom uploadFrom;
+  private UploadFrom uploadFrom;
 
   /** Original filename if from disk, otherwise null. Purely for PersistentPut. */
-  private final File origFilename;
+  private File origFilename;
 
   /** If uploadFrom==UPLOAD_FROM_REDIRECT, this is the target of the redirect */
-  private final FreenetURI targetURI;
+  private FreenetURI targetURI;
 
   /** Bucket storing user data or generated redirect metadata for the pending insert. */
   private RandomAccessBucket data;
 
   /** MIME and ancillary metadata persisted for status reporting and manifest/CHK generation. */
-  private final ClientMetadata clientMetadata;
+  private ClientMetadata clientMetadata;
 
   /** We store the size of inserted data before freeing it */
   private volatile long finishedSize;
 
   /** Filename if the file has one */
-  private final String targetFilename;
+  private String targetFilename;
 
   /** If true, we are inserting a binary blob: No metadata, no URI is generated. */
-  private final boolean binaryBlob;
+  private boolean binaryBlob;
 
   /** Indicates whether compression is currently scheduled since the last restart. */
   private transient boolean compressing;
@@ -105,11 +120,11 @@ public final class ClientPut extends ClientPutBase {
    * Creates a persistent insert originating from a long-lived client or FProxy.
    *
    * <p>The constructor enforces disk-access policy, builds redirect metadata when needed, captures
-   * MIME hints, and sets up {@link ClientPutter} with the retry and redundancy settings supplied by
-   * the caller. It is intended for uploads that must survive restarts, so the node takes ownership
-   * of persistence and retry state while the caller keeps the backing bucket readable for the
-   * request’s lifetime. Compression settings are honored exactly as supplied, allowing clients to
-   * trade throughput for deterministic behavior.
+   * MIME hints, and sets up the backing {@link ClientPutExecution} with the retry and redundancy
+   * settings supplied by the caller. It is intended for uploads that must survive restarts, so the
+   * node takes ownership of persistence and retry state while the caller keeps the backing bucket
+   * readable for the request’s lifetime. Compression settings are honored exactly as supplied,
+   * allowing clients to trade throughput for deterministic behavior.
    *
    * @param request persistent request metadata including URI, identifier, and queue settings; must
    *     not be {@code null} and should reflect the intended persistence scope.
@@ -133,7 +148,7 @@ public final class ClientPut extends ClientPutBase {
     FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
     ClientRequestParams requestParams =
         new ClientRequestParams(
-            checkEmptySSK(request.uri(), upload.targetFilename(), runtimeSupport.clientContext()),
+            checkEmptySSK(request.uri(), upload.targetFilename(), runtimeSupport),
             ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
             request.verbosity(),
             request.priorityClass(),
@@ -181,21 +196,22 @@ public final class ClientPut extends ClientPutBase {
     this.data = preparedData.bucket();
     this.clientMetadata = cm;
     this.targetURI = preparedData.targetUri();
-
-    ClientPutterRequest putterRequest =
-        new ClientPutterRequest(
-            new InsertRequestParams(this, this.uri, ctx, priorityClass),
-            data,
-            cm,
-            preparedData.isMetadata());
-    ClientPutterOptions putterOptions =
-        new ClientPutterOptions(
-            this.uri.getDocName() == null ? uploadTargetFilename : null,
-            this.binaryBlob,
-            options.overrideSplitfileCryptoKey(),
-            -1);
-    putter = ClientPutPutterFactory.create(putterRequest, putterOptions);
-    applyDiagnosticIdentifier(putter);
+    putter =
+        ClientPutPutterFactory.create(
+            runtimeSupport,
+            new ClientPutExecutionSpec(
+                this,
+                requestParams,
+                ctx,
+                data,
+                cm,
+                preparedData.isMetadata(),
+                new ClientPutExecutionSpec.ExecutionOptions(
+                    this.uri.getDocName() == null ? uploadTargetFilename : null,
+                    this.binaryBlob,
+                    options.overrideSplitfileCryptoKey(),
+                    -1)));
+    applyDiagnosticIdentifier(putter.requester());
   }
 
   /**
@@ -206,8 +222,8 @@ public final class ClientPut extends ClientPutBase {
    * by the client before crafting in-memory buckets or redirecting metadata. Because the handler
    * may multiplex many inserts, identifier validation is performed against the connection’s map to
    * avoid collisions that would otherwise corrupt status routing. All costly bucket conversions
-   * happen before {@link ClientPutter} starts so any validation errors surface immediately to the
-   * client.
+   * happen before the {@link ClientPutExecution} starts so any validation errors surface
+   * immediately to the client.
    *
    * @param handler live FCP connection handler coordinating per-connection identifiers and DDA
    *     rights; must not be {@code null} and should represent the active socket.
@@ -217,7 +233,7 @@ public final class ClientPut extends ClientPutBase {
    *     {@code null}.
    * @throws IdentifierCollisionException if another request on the connection already uses the
    *     identifier.
-   * @throws MessageInvalidException when client supplied fields (hashes, MIME, permissions) are
+   * @throws MessageInvalidException when client-supplied fields (hashes, MIME, permissions) are
    *     invalid or violate protocol constraints.
    * @throws IOException when message-provided buckets cannot be read to compute salted hashes.
    */
@@ -244,7 +260,7 @@ public final class ClientPut extends ClientPutBase {
             message.overrideSplitfileCryptoKey);
     ClientRequestParams requestParams =
         new ClientRequestParams(
-            checkEmptySSK(message.uri, message.targetFilename, runtimeSupport.clientContext()),
+            checkEmptySSK(message.uri, message.targetFilename, runtimeSupport),
             ensureConnectionIdentifierAvailable(handler, message),
             message.verbosity,
             message.priorityClass,
@@ -291,20 +307,22 @@ public final class ClientPut extends ClientPutBase {
     ClientPutDiskUploadValidator.verifySaltedHash(diskContext, data, identifier, global);
 
     if (LOG.isDebugEnabled()) LOG.debug(MESSAGE_UPLOAD_LOG_TEMPLATE, data, uploadFrom);
-    ClientPutterRequest putterRequest =
-        new ClientPutterRequest(
-            new InsertRequestParams(this, this.uri, ctx, priorityClass),
-            data,
-            cm,
-            preparedData.isMetadata());
-    ClientPutterOptions putterOptions =
-        new ClientPutterOptions(
-            this.uri.getDocName() == null ? targetFilename : null,
-            binaryBlob,
-            message.overrideSplitfileCryptoKey,
-            message.metadataThreshold);
-    putter = ClientPutPutterFactory.create(putterRequest, putterOptions);
-    applyDiagnosticIdentifier(putter);
+    putter =
+        ClientPutPutterFactory.create(
+            runtimeSupport,
+            new ClientPutExecutionSpec(
+                this,
+                requestParams,
+                ctx,
+                data,
+                cm,
+                preparedData.isMetadata(),
+                new ClientPutExecutionSpec.ExecutionOptions(
+                    this.uri.getDocName() == null ? targetFilename : null,
+                    binaryBlob,
+                    message.overrideSplitfileCryptoKey,
+                    message.metadataThreshold)));
+    applyDiagnosticIdentifier(putter.requester());
   }
 
   /**
@@ -367,7 +385,7 @@ public final class ClientPut extends ClientPutBase {
    * <p>No operational fields are initialized here because {@link ObjectInputStream} populates them
    * immediately afterward. The placeholder values merely satisfy the JVM’s requirement for an
    * accessible no-arg constructor so saved queue snapshots can be deserialized before relinking to
-   * live {@link ClientPutter} instances.
+   * live {@link ClientPutExecution} instances.
    */
   ClientPut() {
     // For serialization.
@@ -392,7 +410,18 @@ public final class ClientPut extends ClientPutBase {
     if (data != null && !(data instanceof Serializable)) {
       throw new NotSerializableException(data.getClass().getName());
     }
-    out.defaultWriteObject();
+    ObjectOutputStream.PutField fields = out.putFields();
+    fields.put("putter", legacyPutterForSerialization());
+    fields.put("uploadFrom", uploadFrom);
+    fields.put("origFilename", origFilename);
+    fields.put("targetURI", targetURI);
+    fields.put("data", data);
+    fields.put("clientMetadata", clientMetadata);
+    fields.put("finishedSize", finishedSize);
+    fields.put("targetFilename", targetFilename);
+    fields.put("binaryBlob", binaryBlob);
+    fields.put("compressed", compressed);
+    out.writeFields();
   }
 
   /**
@@ -404,7 +433,66 @@ public final class ClientPut extends ClientPutBase {
    */
   @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-    in.defaultReadObject();
+    ObjectInputStream.GetField fields = in.readFields();
+    putter = wrapLegacySingleFileExecution(fields.get("putter", null));
+    uploadFrom = (UploadFrom) fields.get("uploadFrom", null);
+    origFilename = (File) fields.get("origFilename", null);
+    targetURI = (FreenetURI) fields.get("targetURI", null);
+    data = (RandomAccessBucket) fields.get("data", null);
+    clientMetadata = (ClientMetadata) fields.get("clientMetadata", null);
+    finishedSize = fields.get("finishedSize", 0L);
+    targetFilename = (String) fields.get("targetFilename", null);
+    binaryBlob = fields.get("binaryBlob", false);
+    compressed = fields.get("compressed", false);
+  }
+
+  private Object legacyPutterForSerialization() throws NotSerializableException {
+    if (putter == null) {
+      return null;
+    }
+    Object requester = putter.requester();
+    if (requester == null) {
+      return null;
+    }
+    if (!requiredClass(LEGACY_PUTTER_TYPE).isInstance(requester)) {
+      throw new NotSerializableException(
+          "Single-file putter requester is not compatible with "
+              + LEGACY_PUTTER_TYPE
+              + ": "
+              + requester.getClass().getName());
+    }
+    return requester;
+  }
+
+  private static ClientPutExecution wrapLegacySingleFileExecution(Object legacyPutter)
+      throws InvalidObjectException {
+    if (legacyPutter == null) {
+      return null;
+    }
+    try {
+      Class<?> bridgeClass = Class.forName(BRIDGE_RUNTIME_SUPPORT);
+      java.lang.reflect.Method method =
+          bridgeClass.getDeclaredMethod("wrapLegacySingleFileExecution", Object.class);
+      method.setAccessible(true);
+      return (ClientPutExecution) method.invoke(null, legacyPutter);
+    } catch (ReflectiveOperationException e) {
+      InvalidObjectException failure =
+          new InvalidObjectException("Could not restore legacy single-file putter");
+      failure.initCause(rootCause(e));
+      throw failure;
+    }
+  }
+
+  private static Class<?> requiredClass(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static Throwable rootCause(ReflectiveOperationException e) {
+    return e.getCause() == null ? e : e.getCause();
   }
 
   @Override
@@ -417,7 +505,7 @@ public final class ClientPut extends ClientPutBase {
   }
 
   /**
-   * Starts the underlying {@link ClientPutter}, queuing compression and insert work for this
+   * Starts the underlying {@link ClientPutExecution}, queuing compression and insert work for this
    * request.
    *
    * <p>The method is idempotent: if the request already finished or the putter previously started,
@@ -431,13 +519,13 @@ public final class ClientPut extends ClientPutBase {
    *     pools; must not be {@code null} and should be the active runtime context.
    */
   @Override
-  public void start(ClientContext context) {
+  public void start(network.crypta.client.async.ClientContext context) {
     if (LOG.isDebugEnabled()) LOG.debug("Starting {} : {}", this, identifier);
     if (isFinishedRequest()) {
       return;
     }
     try {
-      putter.start(false, context);
+      putter.start(context);
       if (shouldQueuePersistentTag()) {
         FCPMessage msg = persistentTagMessage();
         client.queueClientRequestMessage(msg, 0);
@@ -479,7 +567,7 @@ public final class ClientPut extends ClientPutBase {
 
   @Override
   protected ClientRequester getClientRequest() {
-    return putter;
+    return putter == null ? null : putter.requester();
   }
 
   @Override
@@ -534,8 +622,8 @@ public final class ClientPut extends ClientPutBase {
   /**
    * Reports whether the put operation permanently succeeded, meaning the final URI is committed.
    *
-   * <p>The flag flips to {@code true} only after {@link ClientPutter} notifies completion and
-   * remains {@code true} even if future retries occur, allowing UIs to treat the request as
+   * <p>The flag flips to {@code true} only after the {@link ClientPutExecution} notifies completion
+   * and remains {@code true} even if future retries occur, allowing UIs to treat the request as
    * immutable history. It is safe to poll frequently because the underlying field is synchronized
    * via {@link ClientPutBase} access patterns.
    *
@@ -658,9 +746,9 @@ public final class ClientPut extends ClientPutBase {
    * Checks whether the insert can be retried by re-running compression and routing logic.
    *
    * <p>The method enforces the lifecycle contract: only completed yet failed requests are eligible,
-   * and {@link ClientPutter} must agree that cached state still exists. Operators typically call
-   * this before surfacing a retry action in the UI. The check is read-only and does not mutate any
-   * request state.
+   * and the {@link ClientPutExecution} must agree that cached state still exists. Operators
+   * typically call this before surfacing a retry action in the UI. The check is read-only and does
+   * not mutate any request state.
    *
    * @return {@code true} when the request finished unsuccessfully and the putter retained restart
    *     data.
@@ -675,7 +763,7 @@ public final class ClientPut extends ClientPutBase {
       LOG.debug("Cannot restart because succeeded for {}", identifier);
       return false;
     }
-    return putter.canRestart();
+    return putter != null && putter.canRestart();
   }
 
   /**
@@ -683,7 +771,7 @@ public final class ClientPut extends ClientPutBase {
    *
    * <p>Before scheduling the new attempt, the method resets the local state, updates status caches,
    * and notifies observers that the request left the finished state. Failures during {@link
-   * ClientPutter} startup are handed to {@link ClientPutBase#onFailure(InsertException,
+   * ClientPutExecution} startup are handed to {@link ClientPutBase#onFailure(InsertException,
    * network.crypta.client.async.BaseClientPutter)} so retry logic remains consistent with the
    * normal start path. The method returns immediately if the request is not eligible for restart.
    *
@@ -693,7 +781,8 @@ public final class ClientPut extends ClientPutBase {
    * @return {@code true} when the restart was scheduled successfully; {@code false} otherwise.
    */
   @Override
-  public boolean restart(ClientContext context, final boolean disableFilterData) {
+  public boolean restart(
+      network.crypta.client.async.ClientContext context, final boolean disableFilterData) {
     if (!canRestart()) return false;
     setVarsRestart();
     try {
@@ -744,8 +833,8 @@ public final class ClientPut extends ClientPutBase {
   /**
    * Handles cleanup when the request leaves the queue completely.
    *
-   * <p>FOREVER-persistent inserts null the {@link ClientPutter} reference so the object graph can
-   * be garbage-collected while the serialized form remains on disk. Subclasses may extend this
+   * <p>FOREVER-persistent inserts null the {@link ClientPutExecution} reference so the object graph
+   * can be garbage-collected while the serialized form remains on disk. Subclasses may extend this
    * point to release more resources. The provided context is the one supplied by the queue at
    * removal time.
    *
@@ -753,7 +842,7 @@ public final class ClientPut extends ClientPutBase {
    *     null}.
    */
   @Override
-  public void requestWasRemoved(ClientContext context) {
+  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
     if (persistence == Persistence.FOREVER) {
       putter = null;
     }
@@ -852,8 +941,11 @@ public final class ClientPut extends ClientPutBase {
    * @throws ResumeFailedException If any bucket cannot restore the backing store for reading.
    */
   @Override
-  public void innerResume(ClientContext context) throws ResumeFailedException {
-    applyDiagnosticIdentifier(putter);
+  public void innerResume(network.crypta.client.async.ClientContext context)
+      throws ResumeFailedException {
+    if (putter != null) {
+      applyDiagnosticIdentifier(putter.requester());
+    }
     if (data != null) data.onResume(context);
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -13,7 +13,6 @@ import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.BaseClientPutter;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.events.ClientEvent;
 import network.crypta.client.events.ClientEventDispatchContext;
@@ -23,7 +22,6 @@ import network.crypta.client.events.FinishedCompressionEvent;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.StartedCompressionEvent;
 import network.crypta.keys.FreenetURI;
-import network.crypta.keys.InsertableClientSSK;
 import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,10 +32,11 @@ import org.slf4j.LoggerFactory;
  * <p>The class centralizes common state tracking for {@link ClientPut} and {@link ClientPutDir},
  * wiring FCP-facing identifiers, scheduling metadata, persistence constraints, and node callbacks
  * into a single state machine. Instances travel through connection-bound and forever-persistent
- * modes, reattaching to {@link ClientContext}s after deserialization, driving {@link
- * BaseClientPutter} progress, and translating internal events into client-visible FCP messages. It
- * is designed to be thread-aware: mutations happen under synchronization, while outbound messages
- * are dispatched via handler abstractions to avoid deadlocks.
+ * modes, reattaching to {@link network.crypta.client.async.ClientContext ClientContext}s after
+ * deserialization, driving {@link BaseClientPutter} progress, and translating internal events into
+ * client-visible FCP messages. It is designed to be thread-aware: mutations happen under
+ * synchronization, while outbound messages are dispatched via handler abstractions to avoid
+ * deadlocks.
  *
  * <p>Typical usage involves subclassing to provide data-specific logic (single file or directory
  * tree) while relying on {@code ClientPutBase} to manage retries, metadata capture, and reporting.
@@ -63,7 +62,8 @@ public abstract class ClientPutBase extends ClientRequest
   /**
    * Per-request insert context seeded from the node defaults. It carries retry rules, redundancy
    * knobs, and compatibility flags and therefore must be explicitly cleaned up in {@link
-   * #requestWasRemoved(ClientContext)} to avoid leaking stale listeners.
+   * #requestWasRemoved(network.crypta.client.async.ClientContext) requestWasRemoved(ClientContext)}
+   * to avoid leaking stale listeners.
    */
   final InsertContext ctx;
 
@@ -236,19 +236,13 @@ public abstract class ClientPutBase extends ClientRequest
    *
    * @param uri candidate URI that may lack routing data; callers must not pass {@code null}
    * @param filename optional document name; when missing the method chooses {@code "key"}
-   * @param context client context providing the randomness source used to mint new keys
+   * @param runtimeSupport insert runtime support that owns placeholder-SSK normalization
    * @return original URI when already complete or a freshly derived insert URI with the filename
    *     applied; the result is never {@code null}
    */
-  static FreenetURI checkEmptySSK(FreenetURI uri, String filename, ClientContext context) {
-    if ("SSK".equals(uri.getKeyType()) && uri.getDocName() == null && uri.getRoutingKey() == null) {
-      if (filename == null || filename.isEmpty()) filename = "key";
-      // SSK@ = use a random SSK.
-      InsertableClientSSK key = InsertableClientSSK.createRandom(context.random, "");
-      return key.getInsertURI().setDocName(filename);
-    } else {
-      return uri;
-    }
+  static FreenetURI checkEmptySSK(
+      FreenetURI uri, String filename, FcpInsertRuntimeSupport runtimeSupport) {
+    return runtimeSupport.normalizeInsertUri(uri, filename);
   }
 
   /**
@@ -313,16 +307,16 @@ public abstract class ClientPutBase extends ClientRequest
    * leaving persistent ones untouched so they can resume later without extra chatter.
    *
    * <p>The method keeps side effects intentionally small. It does not throw nor block; instead it
-   * simply triggers {@link #cancel(ClientContext)} for requests that were declared {@link
-   * Persistence#CONNECTION}. Persistent and forever requests ignore the event because they expect
-   * to be resumed through {@link network.crypta.client.async.ClientRequester} after
-   * deserialization.
+   * simply triggers {@link #cancel(network.crypta.client.async.ClientContext)
+   * cancel(ClientContext)} for requests that were declared {@link Persistence#CONNECTION}.
+   * Persistent and forever requests ignore the event because they expect to be resumed through
+   * {@link network.crypta.client.async.ClientRequester} after deserialization.
    *
    * @param context client context that supplies cancellation helpers and resource pools; the value
    *     may be reused across many requests and must not be {@code null}
    */
   @Override
-  public void onLostConnection(ClientContext context) {
+  public void onLostConnection(network.crypta.client.async.ClientContext context) {
     if (persistence == Persistence.CONNECTION) cancel(context);
     // otherwise ignore
   }
@@ -496,7 +490,7 @@ public abstract class ClientPutBase extends ClientRequest
    * @param context client context through which cleanup helpers and factories can be reached
    */
   @Override
-  public void requestWasRemoved(ClientContext context) {
+  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
     // if the request is still running, send a PutFailed with code=canceled
     if (!finished) {
       synchronized (this) {
@@ -960,7 +954,8 @@ public abstract class ClientPutBase extends ClientRequest
 
   /**
    * Restores persistent fields during deserialization. Subclasses are expected to rebuild transient
-   * collaborators during {@link #innerResume(ClientContext)} rather than in this hook.
+   * collaborators during {@link #innerResume(network.crypta.client.async.ClientContext)
+   * innerResume(ClientContext)} rather than in this hook.
    *
    * @param in source stream containing a previously serialized form of the object
    * @throws IOException when reading fails

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -3,8 +3,11 @@ package network.crypta.clients.fcp;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamField;
 import java.io.Serial;
 import java.net.MalformedURLException;
 import java.time.Instant;
@@ -14,14 +17,7 @@ import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.Metadata;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientRequester;
-import network.crypta.client.async.ContainerInserter;
-import network.crypta.client.async.DefaultManifestPutter;
-import network.crypta.client.async.InsertRequestParams;
-import network.crypta.client.async.ManifestPutter;
-import network.crypta.client.async.ManifestPutterParams;
-import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.ManifestElement;
@@ -34,19 +30,20 @@ import org.slf4j.LoggerFactory;
  * Coordinates the lifecycle of inserting an entire directory tree into Crypta via the Freenet
  * Client Protocol (FCP).
  *
- * <p>Instances bundle files into a manifest, track sizes, and feed work to a {@link ManifestPutter}
- * so that complex directory uploads can be paused, resumed, and monitored without re-enumerating
- * the source tree. Typical callers construct this class either from a {@link ClientPutDirMessage}
- * delivered by the network stack or from an on-disk directory chosen by an operator, register it
- * with a {@code PersistentRequestClient}, and finally invoke {@link #start(ClientContext)} to
- * launch the asynchronous transfer. The object records defaults such as the preferred manifest
- * name, cryptographic overrides, persistence flavor, and file counts so that serialized requests
- * can survive node restarts.
+ * <p>Instances bundle files into a manifest, track sizes, and feed work to an opaque execution
+ * handle so that complex directory uploads can be paused, resumed, and monitored without
+ * re-enumerating the source tree. Typical callers construct this class either from a {@link
+ * ClientPutDirMessage} delivered by the network stack or from an on-disk directory chosen by an
+ * operator, register it with a {@code PersistentRequestClient}, and finally invoke {@link
+ * #start(network.crypta.client.async.ClientContext)} to launch the asynchronous transfer. The
+ * object records defaults such as the preferred manifest name, cryptographic overrides, persistence
+ * flavor, and file counts so that serialized requests can survive node restarts.
  *
  * <p>The class is not thread-safe; the owning request scheduler must serialize calls such as {@link
- * #start(ClientContext)}, {@link #restart(ClientContext, boolean)}, and {@link
- * #requestWasRemoved(ClientContext)}. Internal caches are mutable until {@link #freeData()} runs,
- * after which the manifest tree is eligible for garbage collection.
+ * #start(network.crypta.client.async.ClientContext)}, {@link
+ * #restart(network.crypta.client.async.ClientContext, boolean)}, and {@link
+ * #requestWasRemoved(network.crypta.client.async.ClientContext)}. Internal caches are mutable until
+ * {@link #freeData()} runs, after which the manifest tree is eligible for garbage collection.
  *
  * <ul>
  *   <li>Builds manifests from disk or pre-parsed maps.
@@ -55,36 +52,49 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @see ClientPutBase
- * @see ManifestPutter
  */
 public final class ClientPutDir extends ClientPutBase {
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutDir.class);
 
   @Serial private static final long serialVersionUID = 1L;
 
+  private static final String LEGACY_PUTTER_TYPE = "network.crypta.client.async.ManifestPutter";
+
+  private static final String BRIDGE_RUNTIME_SUPPORT =
+      "network.crypta.clients.fcp.bridge.CoreFcpInsertRuntimeSupport";
+
+  @SuppressWarnings("UnusedVariable")
+  private static final ObjectStreamField[] serialPersistentFields =
+      new ObjectStreamField[] {
+        new ObjectStreamField("manifestElements", Map.class),
+        new ObjectStreamField("putter", requiredClass(LEGACY_PUTTER_TYPE)),
+        new ObjectStreamField("defaultName", String.class),
+        new ObjectStreamField("totalSize", long.class),
+        new ObjectStreamField("numberOfFiles", int.class),
+        new ObjectStreamField("wasDiskPut", boolean.class),
+        new ObjectStreamField("overrideSplitfileCryptoKey", byte[].class)
+      };
+
   /** Mutable tree describing pending manifest elements keyed by child name. */
   private Map<String, Object> manifestElements;
 
-  /**
-   * Worker responsible for chunking content, scheduling inserts, and reporting progress back to the
-   * client request cache.
-   */
-  private ManifestPutter putter;
+  /** Worker responsible for chunking content, scheduling inserts, and reporting progress. */
+  private ClientPutDirExecution putter;
 
   /** Default manifest name used when callers omit an explicit index document. */
-  private final String defaultName;
+  private String defaultName;
 
   /** Aggregate byte size of every file discovered when the manifest was created. */
-  private final long totalSize;
+  private long totalSize;
 
   /** Number of discrete files queued for upload, or {@code -1} when unknown. */
-  private final int numberOfFiles;
+  private int numberOfFiles;
 
   /** Flag indicating whether the manifest originated from a local disk scan. */
-  private final boolean wasDiskPut;
+  private boolean wasDiskPut;
 
   /** Optional caller-provided symmetric key overriding the generated splitfile key ladder. */
-  private final byte[] overrideSplitfileCryptoKey;
+  private byte[] overrideSplitfileCryptoKey;
 
   // Legacy threshold callback removed.
 
@@ -94,9 +104,10 @@ public final class ClientPutDir extends ClientPutBase {
    * <p>Use this constructor when the remote client already described the directory layout and
    * optional {@link ManifestElement} entries. The initializer validates the URI, copies the
    * manifest tree locally, wires persistence, throttling, and crypto settings as requested, and
-   * instantiates a {@link ManifestPutter} so file counts and total sizes are available for quick
-   * replies. Typical callers construct the object, register it with the persistent client cache,
-   * and then call {@link #start(ClientContext)} to launch asynchronous transmission toward peers.
+   * instantiates the backing {@link ClientPutDirExecution} so file counts and total sizes are
+   * available for quick replies. Typical callers construct the object, register it with the
+   * persistent client cache, and then call {@link #start(network.crypta.client.async.ClientContext)
+   * start(ClientContext)} to launch asynchronous transmission toward peers.
    *
    * <pre>{@code
    * var request = new ClientPutDir(handler, msg, msg.manifest, false, server);
@@ -109,7 +120,8 @@ public final class ClientPutDir extends ClientPutBase {
    * @param wasDiskPut true if the manifest originated from a disk enumeration on the node.
    * @param server FCP server reference providing access to the shared node client core.
    * @throws MalformedURLException if the request URI cannot be parsed or canonicalized.
-   * @throws TooManyFilesInsertException if the manifest exceeds the allowed file count budget.
+   * @throws network.crypta.client.async.TooManyFilesInsertException if the manifest exceeds the
+   *     allowed file count budget.
    */
   public ClientPutDir(
       FCPConnectionHandler handler,
@@ -117,7 +129,7 @@ public final class ClientPutDir extends ClientPutBase {
       Map<String, Object> manifestElements,
       boolean wasDiskPut,
       FCPServer server)
-      throws MalformedURLException, TooManyFilesInsertException {
+      throws MalformedURLException, network.crypta.client.async.TooManyFilesInsertException {
     FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
     FcpInsertOptions options =
         new FcpInsertOptions(
@@ -142,7 +154,7 @@ public final class ClientPutDir extends ClientPutBase {
             checkEmptySSK(
                 message.uri,
                 message.targetFilename != null ? message.targetFilename : "site",
-                runtimeSupport.clientContext()),
+                runtimeSupport),
             message.identifier,
             message.verbosity,
             message.priorityClass,
@@ -168,7 +180,7 @@ public final class ClientPutDir extends ClientPutBase {
     this.manifestElements.putAll(manifestElements);
 
     this.defaultName = message.defaultName;
-    makePutter(runtimeSupport.clientContext());
+    makePutter(runtimeSupport, requestParams);
     if (putter != null) {
       numberOfFiles = putter.countFiles();
       totalSize = putter.totalSize();
@@ -189,7 +201,8 @@ public final class ClientPutDir extends ClientPutBase {
    * the request is registered with a {@link PersistentRequestClient}. The constructor immediately
    * counts files and bytes, so progress meters have deterministic totals, and it captures the
    * optional override splitfile key for callers who precompute keys. After construction, invoke
-   * {@link #start(ClientContext)} to stream blocks while leveraging the provided {@link FCPServer}.
+   * {@link #start(network.crypta.client.async.ClientContext) start(ClientContext)} to stream blocks
+   * while leveraging the provided {@link FCPServer}.
    *
    * <pre>{@code
    * var request =
@@ -223,7 +236,8 @@ public final class ClientPutDir extends ClientPutBase {
    * @param server owning server providing insert runtime support and cryptographic settings.
    * @throws FileNotFoundException if unreadable files are encountered while not permitted.
    * @throws MalformedURLException if the URI cannot be parsed, normalized, or validated.
-   * @throws TooManyFilesInsertException if the directory exceeds the configured file limit.
+   * @throws network.crypta.client.async.TooManyFilesInsertException if the directory exceeds the
+   *     configured file limit.
    */
   public ClientPutDir(
       FcpInsertRequest request,
@@ -233,11 +247,13 @@ public final class ClientPutDir extends ClientPutBase {
       boolean allowUnreadableFiles,
       boolean includeHiddenFiles,
       FCPServer server)
-      throws FileNotFoundException, MalformedURLException, TooManyFilesInsertException {
+      throws FileNotFoundException,
+          MalformedURLException,
+          network.crypta.client.async.TooManyFilesInsertException {
     FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
     ClientRequestParams requestParams =
         new ClientRequestParams(
-            checkEmptySSK(request.uri(), "site", runtimeSupport.clientContext()),
+            checkEmptySSK(request.uri(), "site", runtimeSupport),
             request.identifier(),
             request.verbosity(),
             request.priorityClass(),
@@ -258,7 +274,7 @@ public final class ClientPutDir extends ClientPutBase {
     // debug level captured via LOG.isDebugEnabled()
     this.manifestElements = makeDiskDirManifest(dir, "", allowUnreadableFiles, includeHiddenFiles);
     this.defaultName = defaultName;
-    makePutter(runtimeSupport.clientContext());
+    makePutter(runtimeSupport, requestParams);
     if (putter != null) {
       numberOfFiles = putter.countFiles();
       totalSize = putter.totalSize();
@@ -293,24 +309,32 @@ public final class ClientPutDir extends ClientPutBase {
    * Writes the minimal serialization form so persistent request queues can be resumed verbatim.
    *
    * <p>The implementation delegates to {@link ObjectOutputStream#defaultWriteObject()} because all
-   * mutable fields participate in standard Java serialization. No transient handles are written, so
-   * callers must reconstruct runtime collaborators (such as {@link ManifestPutter}) separately.
+   * mutable fields participate in standard Java serialization. The serialized form deliberately
+   * avoids eagerly rebuilding bridge-owned runtime collaborators during persistence operations.
    *
    * @param out destination stream that will receive the serialized state for this object.
    * @throws IOException if the stream fails, is closed, or otherwise rejects the serialized data.
    */
   @Serial
   private void writeObject(ObjectOutputStream out) throws IOException {
-    out.defaultWriteObject();
+    ObjectOutputStream.PutField fields = out.putFields();
+    fields.put("manifestElements", manifestElements);
+    fields.put("putter", legacyPutterForSerialization());
+    fields.put("defaultName", defaultName);
+    fields.put("totalSize", totalSize);
+    fields.put("numberOfFiles", numberOfFiles);
+    fields.put("wasDiskPut", wasDiskPut);
+    fields.put("overrideSplitfileCryptoKey", overrideSplitfileCryptoKey);
+    out.writeFields();
   }
 
   /**
    * Restores persisted fields so the request can rejoin the scheduler after JVM restarts.
    *
    * <p>Only the raw data required to reconstruct manifests and statistics is restored here; higher
-   * level collaborators will be rebuilt later through {@link #makePutter(ClientContext)} or other
-   * initialization paths. The method intentionally leaves runtime caches null to avoid premature
-   * resource allocation during deserialization.
+   * level collaborators will be rebuilt later through {@link #makePutter(FcpInsertRuntimeSupport,
+   * ClientRequestParams)} or other initialization paths. The method intentionally leaves runtime
+   * caches null to avoid premature resource allocation during deserialization.
    *
    * @param in source stream from which serialized field values are read sequentially.
    * @throws IOException if the serialized form is truncated or cannot be read.
@@ -318,7 +342,78 @@ public final class ClientPutDir extends ClientPutBase {
    */
   @Serial
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-    in.defaultReadObject();
+    ObjectInputStream.GetField fields = in.readFields();
+    manifestElements = castManifestElements(fields.get("manifestElements", null));
+    defaultName = (String) fields.get("defaultName", null);
+    totalSize = fields.get("totalSize", 0L);
+    numberOfFiles = fields.get("numberOfFiles", 0);
+    wasDiskPut = fields.get("wasDiskPut", false);
+    overrideSplitfileCryptoKey = (byte[]) fields.get("overrideSplitfileCryptoKey", null);
+    putter =
+        wrapLegacyDirectoryExecution(
+            fields.get("putter", null),
+            new ClientPutDirExecutionSpec(
+                this, currentRequestParams(), ctx, defaultName, overrideSplitfileCryptoKey));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> castManifestElements(Object manifestElements) {
+    return manifestElements == null ? null : (Map<String, Object>) manifestElements;
+  }
+
+  private Object legacyPutterForSerialization() throws NotSerializableException {
+    if (putter == null) {
+      return null;
+    }
+    Object requester = putter.requester();
+    if (requester == null) {
+      return null;
+    }
+    if (!requiredClass(LEGACY_PUTTER_TYPE).isInstance(requester)) {
+      throw new NotSerializableException(
+          "Directory putter requester is not compatible with "
+              + LEGACY_PUTTER_TYPE
+              + ": "
+              + requester.getClass().getName());
+    }
+    return requester;
+  }
+
+  private ClientRequestParams currentRequestParams() {
+    return new ClientRequestParams(
+        uri, identifier, verbosity, priorityClass, persistence, realTime, clientToken, global);
+  }
+
+  private static ClientPutDirExecution wrapLegacyDirectoryExecution(
+      Object legacyPutter, ClientPutDirExecutionSpec executionSpec) throws InvalidObjectException {
+    if (legacyPutter == null) {
+      return null;
+    }
+    try {
+      Class<?> bridgeClass = Class.forName(BRIDGE_RUNTIME_SUPPORT);
+      java.lang.reflect.Method method =
+          bridgeClass.getDeclaredMethod(
+              "wrapLegacyDirectoryExecution", Object.class, ClientPutDirExecutionSpec.class);
+      method.setAccessible(true);
+      return (ClientPutDirExecution) method.invoke(null, legacyPutter, executionSpec);
+    } catch (ReflectiveOperationException e) {
+      InvalidObjectException failure =
+          new InvalidObjectException("Could not restore legacy directory putter");
+      failure.initCause(rootCause(e));
+      throw failure;
+    }
+  }
+
+  private static Class<?> requiredClass(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static Throwable rootCause(ReflectiveOperationException e) {
+    return e.getCause() == null ? e : e.getCause();
   }
 
   @Override
@@ -409,32 +504,33 @@ public final class ClientPutDir extends ClientPutBase {
             includeHiddenFiles));
   }
 
-  private void makePutter(ClientContext context) throws TooManyFilesInsertException {
+  private void makePutter(FcpInsertRuntimeSupport runtimeSupport, ClientRequestParams requestParams)
+      throws network.crypta.client.async.TooManyFilesInsertException {
     putter =
-        DefaultManifestPutter.create(
-            new ManifestPutterParams(
-                new InsertRequestParams(this, uri, ctx, priorityClass),
-                manifestElements,
-                defaultName,
-                overrideSplitfileCryptoKey,
-                context),
-            persistence == Persistence.FOREVER);
+        runtimeSupport.createDirectoryExecution(
+            new ClientPutDirExecutionSpec(
+                this, requestParams, ctx, defaultName, overrideSplitfileCryptoKey));
+  }
+
+  Map<String, Object> manifestElementsForExecution() {
+    return manifestElements;
   }
 
   /**
-   * Begins manifest insertion by arming the {@link ManifestPutter} and notifying interested
+   * Begins manifest insertion by arming the {@link ClientPutDirExecution} and notifying interested
    * clients.
    *
    * <p>The method is idempotent: repeated calls after the first successful start are ignored. It
    * configures the request cache so that CALL/RESULT messages reflect the running state, queues a
    * persistent tag message when applicable, and handles {@link InsertException}s by reporting
-   * immediate failure. Callers should provide the same {@link ClientContext} used during
-   * construction so caches, thread pools, and retry policies remain consistent.
+   * immediate failure. Callers should provide the same {@link
+   * network.crypta.client.async.ClientContext ClientContext} used during construction so caches,
+   * thread pools, and retry policies remain consistent.
    *
    * @param context client context supplying thread pools and scheduler knobs for this transfer.
    */
   @Override
-  public void start(ClientContext context) {
+  public void start(network.crypta.client.async.ClientContext context) {
     if (finished) return;
     if (started) return;
     try {
@@ -518,7 +614,7 @@ public final class ClientPutDir extends ClientPutBase {
    */
   @Override
   protected ClientRequester getClientRequest() {
-    return putter;
+    return putter == null ? null : putter.requester();
   }
 
   /**
@@ -573,11 +669,12 @@ public final class ClientPutDir extends ClientPutBase {
   /**
    * Reports whether the insert completed successfully according to the latest status snapshot.
    *
-   * <p>The flag is updated by the {@link ManifestPutter} when the final block commits or when a
-   * fatal error occurs. Consumers should treat the value as monotonic: once {@code true}, the
-   * request will not revert even if further callbacks arrive. A {@code false} value may still mean
-   * work is ongoing, so callers should also consult the general completion flags exposed by the FCP
-   * status APIs before deciding whether retries or restarts are appropriate.
+   * <p>The flag is updated by the backing {@link ClientPutDirExecution} when the final block
+   * commits or when a fatal error occurs. Consumers should treat the value as monotonic: once
+   * {@code true}, the request will not revert even if further callbacks arrive. A {@code false}
+   * value may still mean work is ongoing, so callers should also consult the general completion
+   * flags exposed by the FCP status APIs before deciding whether retries or restarts are
+   * appropriate.
    *
    * @return {@code true} after every file has been inserted and the final URI has been published.
    */
@@ -604,10 +701,11 @@ public final class ClientPutDir extends ClientPutBase {
   /**
    * Reports how many discrete files were counted when the manifest was constructed.
    *
-   * <p>The count is derived from the {@link ManifestPutter} during initialization and therefore
-   * reflects the directory structure at scan time, not real-time filesystem changes. When the
-   * manifest is provided by a remote client, the number reflects that client's enumeration. A value
-   * of {@code -1} indicates that counting was skipped because the putter could not be created.
+   * <p>The count is derived from the {@link ClientPutDirExecution} during initialization and
+   * therefore reflects the directory structure at scan time, not real-time filesystem changes. When
+   * the manifest is provided by a remote client, the number reflects that client's enumeration. A
+   * value of {@code -1} indicates that counting was skipped because the putter could not be
+   * created.
    *
    * @return non-negative number of file entries, or {@code -1} when unavailable.
    */
@@ -635,7 +733,7 @@ public final class ClientPutDir extends ClientPutBase {
    * <p>The method blocks restarts while work is still running or after success, only allowing
    * retries for finished-but-failed requests. It also emits debug logging so operators can diagnose
    * why a restart attempt was rejected. Callers should check this flag before invoking {@link
-   * #restart(ClientContext, boolean)} to avoid unnecessarily rebuilding manifests.
+   * #restart(network.crypta.client.async.ClientContext, boolean) restart(ClientContext, boolean)}.
    *
    * @return {@code true} when the request is finished, not successful, and eligible for restart.
    */
@@ -649,24 +747,26 @@ public final class ClientPutDir extends ClientPutBase {
       LOG.debug("Restart blocked: request already succeeded id={}", identifier);
       return false;
     }
-    return true;
+    return putter != null && putter.canRestart();
   }
 
   /**
    * Rebuilds transient state and re-queues the request after a recoverable failure.
    *
    * <p>The restart sequence verifies eligibility via {@link #canRestart()}, resets counters,
-   * refreshes persistent cache entries, and constructs a new {@link ManifestPutter}. If manifest
-   * enumeration now exceeds configured limits, the method surfaces an {@link InsertException} and
-   * aborts. Successful restarts immediately call {@link #start(ClientContext)} so callers do not
-   * need to issue two API operations.
+   * refreshes persistent cache entries, and delegates the retry to the existing {@link
+   * ClientPutDirExecution}. Successful persistent restarts also emit a fresh {@link
+   * PersistentPutDir} tag so connected FCP clients observe the renewed {@code Started} state and
+   * any updated splitfile key. If the bridge reports an {@link InsertException}, the method aborts
+   * and surfaces the failure through the usual request path.
    *
    * @param context client context used for thread pools, throttling, and crypto settings.
    * @param disableFilterData ignored flag maintained for backwards compatibility with filters.
    * @return {@code true} when the restart was scheduled; {@code false} if prerequisites failed.
    */
   @Override
-  public boolean restart(ClientContext context, final boolean disableFilterData) {
+  public boolean restart(
+      network.crypta.client.async.ClientContext context, final boolean disableFilterData) {
     if (!canRestart()) return false;
     setVarsRestart();
     if (client != null) {
@@ -676,14 +776,26 @@ public final class ClientPutDir extends ClientPutBase {
       }
     }
     try {
-      makePutter(context);
-    } catch (TooManyFilesInsertException _) {
-      this.onFailure(
-          new InsertException(
-              InsertException.InsertExceptionMode.TOO_MANY_FILES, (String) null, null),
-          null);
+      if (putter.restart(context)) {
+        synchronized (this) {
+          generatedURI = null;
+          started = true;
+        }
+      }
+    } catch (InsertException e) {
+      this.onFailure(e, null);
+      return false;
     }
-    start(context);
+    if (client != null) {
+      RequestStatusCache cache = client.getRequestStatusCache();
+      if (cache != null) {
+        cache.updateStarted(identifier, true);
+      }
+    }
+    if (persistence != Persistence.CONNECTION && !finished) {
+      FCPMessage msg = persistentTagMessage();
+      client.queueClientRequestMessage(msg, 0);
+    }
     return true;
   }
 
@@ -691,14 +803,14 @@ public final class ClientPutDir extends ClientPutBase {
    * Handles eviction from the scheduler or request cache by releasing runtime helpers.
    *
    * <p>Persistent FOREVER requests can survive removal events, so this hook nulls out the {@link
-   * ManifestPutter} to avoid holding on to stale channels until a later resuming occurs. The
+   * ClientPutDirExecution} to avoid holding on to stale channels until a later resuming occurs. The
    * superclass observes the event as well, ensuring that shared bookkeeping such as rate limiting
    * and identifier mappings stay consistent.
    *
    * @param context client context associated with the scheduler issuing the removal.
    */
   @Override
-  public void requestWasRemoved(ClientContext context) {
+  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
     if (persistence == Persistence.FOREVER) {
       putter = null;
     }
@@ -706,12 +818,12 @@ public final class ClientPutDir extends ClientPutBase {
   }
 
   /**
-   * Intentionally left empty because directory inserts rely on {@link ManifestPutter} compression
-   * reporting instead of request-level callbacks.
+   * Intentionally left empty because directory inserts rely on the backing {@link
+   * ClientPutDirExecution} for compression reporting instead of request-level callbacks.
    *
-   * <p>The {@link ContainerInserter} owns all compressor instances for manifests, so there is no
-   * additional bookkeeping required when compression starts or stops. The override exists only to
-   * acknowledge the lifecycle hook and documents that no state transition occurs here.
+   * <p>The bridge-owned manifest execution owns all compressor instances for manifests, so there is
+   * no additional bookkeeping required when compression starts or stops. The override exists only
+   * to acknowledge the lifecycle hook and documents that no state transition occurs here.
    */
   @Override
   protected void onStartCompressing() {
@@ -721,9 +833,9 @@ public final class ClientPutDir extends ClientPutBase {
   /**
    * Intentionally left empty because no per-request cleanup is needed when compression stops.
    *
-   * <p>Directory inserts delegate to {@link ManifestPutter}, which owns the compressor lifetime and
-   * frees its resources once chunks are flushed. Leaving this hook empty prevents duplicate
-   * bookkeeping while still satisfying the superclass contract.
+   * <p>Directory inserts delegate to the backing {@link ClientPutDirExecution}, which owns the
+   * compressor lifetime and frees its resources once chunks are flushed. Leaving this hook empty
+   * prevents duplicate bookkeeping while still satisfying the superclass contract.
    */
   @Override
   protected void onStopCompressing() {
@@ -785,20 +897,25 @@ public final class ClientPutDir extends ClientPutBase {
   }
 
   /**
-   * Reattaches persisted manifests to a live {@link ClientContext} during resume sequences.
+   * Reattaches persisted manifests to a live {@link network.crypta.client.async.ClientContext
+   * ClientContext} during resume sequences.
    *
-   * <p>The method delegates to {@link ContainerInserter#resumeMetadata(Map, ClientContext)}, which
-   * rebuilds transient metadata for each {@link ManifestElement} so the putter can continue where
-   * it left off. Any metadata mismatch triggers a {@link ResumeFailedException}, signaling that the
-   * request should be abandoned or rebuilt from disk.
+   * <p>The method delegates to {@link ClientPutDirExecution#resumeMetadata(Map,
+   * network.crypta.client.async.ClientContext)}, which rebuilds transient metadata for each {@link
+   * ManifestElement} so the putter can continue where it left off. Any metadata mismatch triggers a
+   * {@link ResumeFailedException}, signaling that the request should be abandoned or rebuilt from
+   * disk.
    *
    * @param context context supplying the memory pools and cryptographic providers required for
    *     resumed manifests.
    * @throws ResumeFailedException if the persisted manifest cannot be revalidated or restored.
    */
   @Override
-  public void innerResume(ClientContext context) throws ResumeFailedException {
-    ContainerInserter.resumeMetadata(manifestElements, context);
+  public void innerResume(network.crypta.client.async.ClientContext context)
+      throws ResumeFailedException {
+    if (putter != null) {
+      putter.resumeMetadata(manifestElements, context);
+    }
   }
 
   @Override
@@ -810,9 +927,9 @@ public final class ClientPutDir extends ClientPutBase {
    * Indicates whether every component of the request has been fully restored after resuming.
    *
    * <p>Directory inserts currently resume lazily, rebuilding manifest metadata only when {@link
-   * #innerResume(ClientContext)} is invoked later in the lifecycle. Consequently, this method
-   * always returns {@code false}, signaling to higher layers that additional resume work may be
-   * pending.
+   * #innerResume(network.crypta.client.async.ClientContext) innerResume(ClientContext)} is invoked
+   * later in the lifecycle. Consequently, this method always returns {@code false}, signaling to
+   * higher layers that additional resume work may be pending.
    *
    * @return always {@code false} because manifest metadata is resumed incrementally.
    */

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecution.java
@@ -1,0 +1,63 @@
+package network.crypta.clients.fcp;
+
+import java.util.Map;
+import network.crypta.support.io.ResumeFailedException;
+
+/**
+ * Opaque adapter-owned handle for one live directory/manifest insert execution.
+ *
+ * <p>The bridge owns the concrete manifest putter, while the adapter keeps only the request-scoped
+ * lifecycle contract and the minimal resume hook used by persistent manifests. Callers treat an
+ * instance of this interface as the live execution state for a single directory insert attempt:
+ * they can inspect the file count and aggregate size that were computed when the manifest was
+ * prepared, start or restart the transfer through the inherited methods, and reattach transient
+ * metadata when a persistent request is resumed after a restart.
+ *
+ * <p>The handle is intentionally narrow. It does not expose the runtime-owned manifest putter type,
+ * container builder state, or scheduler internals. That keeps the insert-specific boundary aligned
+ * with the Phase 2 split: {@code :adapter-fcp} owns request lifecycle and protocol reporting, while
+ * {@code :bridge-fcp-runtime} owns the daemon-core wiring and the concrete insert engine.
+ */
+public interface ClientPutDirExecution extends ClientPutExecution {
+
+  /**
+   * Returns the number of files counted for the current manifest execution.
+   *
+   * <p>The value reflects the manifest tree handed to the bridge when the execution was
+   * constructed. It is primarily used to populate FCP status messages and persistent tags so
+   * clients can display deterministic progress information before the transfer starts.
+   *
+   * @return non-negative count of file entries represented by this manifest execution
+   */
+  int countFiles();
+
+  /**
+   * Returns the aggregate byte size tracked for the current manifest execution.
+   *
+   * <p>This is the total raw content size derived from the manifest elements, not a measure of
+   * protocol overhead or encoded container size. The adapter uses it for user-visible progress
+   * reporting and persistence snapshots.
+   *
+   * @return total number of payload bytes represented by this manifest execution
+   */
+  long totalSize();
+
+  /**
+   * Rehydrates transient manifest metadata after a persistent request resumes.
+   *
+   * <p>Persistent directory inserts can survive JVM restarts, but nested manifest elements may need
+   * to reopen buckets or rebuild runtime-owned metadata before insertion can continue. The adapter
+   * calls this hook during request resume, passing the request-owned manifest tree and the current
+   * client context so the bridge can restore that transient state without leaking runtime types
+   * back into the adapter layer.
+   *
+   * @param manifestElements request-owned manifest tree whose elements should be reattached to live
+   *     runtime state
+   * @param context live client context that provides resume-time factories and services
+   * @throws ResumeFailedException if any manifest element cannot restore the required transient
+   *     runtime state
+   */
+  void resumeMetadata(
+      Map<String, Object> manifestElements, network.crypta.client.async.ClientContext context)
+      throws ResumeFailedException;
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecutionSpec.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecutionSpec.java
@@ -1,0 +1,154 @@
+package network.crypta.clients.fcp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Map;
+import network.crypta.client.InsertContext;
+
+/**
+ * Detached directory insert description consumed by the bridge runtime.
+ *
+ * <p>This specification captures the adapter-owned inputs that the bridge needs to create or
+ * recreate a live manifest putter for a {@link ClientPutDir}. It deliberately keeps request
+ * identity, insert policy, and manifest access together while leaving the concrete daemon-owned
+ * execution types on the bridge side of the module boundary. Unlike the earlier refactor draft, it
+ * does not clone the whole manifest tree; instead, it reads the request-owned manifest lazily
+ * through the callback. That preserves persistent-request behavior without retaining duplicate
+ * manifest copies for large site inserts.
+ */
+public final class ClientPutDirExecutionSpec implements Serializable {
+  /** Serialization identifier preserved for persistent request compatibility. */
+  @Serial private static final long serialVersionUID = 1L;
+
+  /** The owning request that supplies callbacks, current priority, and the live manifest tree. */
+  private final ClientPutDir callback;
+
+  /** Request-scoped identity and persistence metadata captured when the execution is assembled. */
+  private final ClientRequestParams requestParams;
+
+  /** The insert policy snapshot that the bridge forwards into the manifest putter. */
+  private final InsertContext insertContext;
+
+  /** Preferred default document name for the inserted manifest, if any. */
+  private final String defaultName;
+
+  /** Optional splitfile crypto key override supplied by the client. */
+  private final byte[] forceCryptoKey;
+
+  /**
+   * Creates a detached manifest-execution specification for one directory insert request.
+   *
+   * <p>The constructor stores the request callback and the stable insert parameters needed to build
+   * a live manifest putter later. It does not touch the filesystem, allocate buckets, or copy the
+   * request manifest tree. Bridge code can therefore keep this object alongside a persistent
+   * request without introducing another full manifest clone in memory.
+   *
+   * @param callback owning directory insert request that provides callbacks and manifest access
+   * @param requestParams detached request identity and persistence metadata for this insert
+   * @param insertContext insert policy snapshot to apply when the bridge creates a manifest putter
+   * @param defaultName preferred default document name for manifest fetches, or {@code null}
+   * @param forceCryptoKey optional splitfile crypto key override, or {@code null}
+   */
+  public ClientPutDirExecutionSpec(
+      ClientPutDir callback,
+      ClientRequestParams requestParams,
+      InsertContext insertContext,
+      String defaultName,
+      byte[] forceCryptoKey) {
+    this.callback = callback;
+    this.requestParams = requestParams;
+    this.insertContext = insertContext;
+    this.defaultName = defaultName;
+    this.forceCryptoKey = forceCryptoKey;
+  }
+
+  /**
+   * Returns the callback surface that should receive insert lifecycle notifications.
+   *
+   * <p>The bridge uses this callback when wiring a concrete manifest putter so that completion,
+   * failure, and progress events flow back into the existing {@link ClientPutDir} request logic.
+   *
+   * @return owning request callback for the directory insert execution
+   */
+  public ClientPutBase callback() {
+    return callback;
+  }
+
+  /**
+   * Returns the detached request metadata associated with this manifest execution.
+   *
+   * <p>The returned value includes the target URI, identifier, persistence mode, and original
+   * priority snapshot. Bridge code uses it for restart-time reconstruction and for settings that do
+   * not need to track the later mutable request state.
+   *
+   * @return request-scoped metadata captured for this directory insert execution
+   */
+  public ClientRequestParams requestParams() {
+    return requestParams;
+  }
+
+  /**
+   * Returns the insert policy snapshot that governs manifest creation.
+   *
+   * <p>This context carries retry, compression, caching, and compatibility settings that should be
+   * applied when the bridge creates a live manifest putter. The bridge treats it as the
+   * request-specific insert policy for this execution.
+   *
+   * @return the insert policy snapshot to pass into the runtime-owned manifest putter
+   */
+  public InsertContext insertContext() {
+    return insertContext;
+  }
+
+  /**
+   * Returns the current priority class that should be used for a restart.
+   *
+   * <p>Persistent requests can be reprioritized after construction through {@code
+   * ModifyPersistentRequest}. When the owning callback is available, this method reflects that
+   * current request priority instead of the original snapshot in {@link #requestParams()}. The
+   * fallback keeps recovery code safe if a callback is unavailable.
+   *
+   * @return current effective priority class for the directory insert execution
+   */
+  public short priorityClass() {
+    return callback == null ? requestParams.priorityClass() : callback.priorityClass;
+  }
+
+  /**
+   * Returns the preferred default document name for the manifest.
+   *
+   * <p>The bridge forwards this value to the concrete manifest putter so that directory fetches can
+   * resolve an index document consistently with the original FCP request semantics.
+   *
+   * @return default document name for the manifest, or {@code null} if none was requested
+   */
+  public String defaultName() {
+    return defaultName;
+  }
+
+  /**
+   * Returns the explicit splitfile crypto key override if one was provided.
+   *
+   * <p>The bridge uses this key when reconstructing a manifest putter, so restart behavior remains
+   * consistent with the original insert request.
+   *
+   * @return explicit splitfile crypto key override, or {@code null} when the runtime should choose
+   *     its normal keying behavior
+   */
+  public byte[] forceCryptoKey() {
+    return forceCryptoKey;
+  }
+
+  /**
+   * Returns the request-owned manifest tree for this execution.
+   *
+   * <p>The manifest is resolved lazily from the owning {@link ClientPutDir} rather than being
+   * duplicated inside the spec. That keeps the bridge supplied with the authoritative manifest
+   * structure while avoiding a second in-memory tree for large persistent directory inserts.
+   *
+   * @return live request-owned manifest tree used to assemble the manifest putter
+   */
+  public Map<String, Object> manifestElements() {
+    return callback.manifestElementsForExecution();
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirMessage.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.net.MalformedURLException;
 import java.util.Locale;
 import java.util.Optional;
-import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -194,11 +193,11 @@ public abstract class ClientPutDirMessage extends BaseDataCarryingMessage {
     String compressorDescriptor = parseCompressorDescriptor(fs, identifier, global);
     boolean forkOnCacheable = parseForkOnCacheable(fs);
     int extraInsertsSingleBlock =
-        fs.getInt("ExtraInsertsSingleBlock", HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK);
+        fs.getInt("ExtraInsertsSingleBlock", FcpInsertDefaults.EXTRA_INSERTS_SINGLE_BLOCK_DEFAULT);
     int extraInsertsSplitfileHeaderBlock =
         fs.getInt(
             "ExtraInsertsSplitfileHeaderBlock",
-            HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER);
+            FcpInsertDefaults.EXTRA_INSERTS_SPLITFILE_HEADER_DEFAULT);
     boolean realTimeFlag = fs.getBoolean("RealTimeFlag", false);
     String targetFilename = fs.get("TargetFilename");
     boolean ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecution.java
@@ -1,0 +1,83 @@
+package network.crypta.clients.fcp;
+
+import java.io.Serializable;
+import network.crypta.client.InsertException;
+import network.crypta.client.async.ClientRequester;
+
+/**
+ * Opaque adapter-owned handle for one live single-file insert execution.
+ *
+ * <p>The adapter treats this as the boundary object for a request attempt. The bridge module owns
+ * the concrete daemon inserter and exposes only the lifecycle and observation operations that the
+ * FCP request classes need. A {@code ClientPutExecution} instance represents one live insert
+ * attempt for a {@link ClientPut}: callers can inspect the low-level requester for status and
+ * priority propagation, start the execution once the request has been registered, and ask the
+ * bridge to restart the insert when the underlying runtime object still retains enough states to do
+ * so.
+ *
+ * <p>The interface is intentionally small and serializable. Persistent request objects may keep a
+ * handle across node restarts, but the concrete runtime-owned requester still lives entirely behind
+ * the bridge boundary. That allows the FCP adapter to preserve request lifecycle behavior without
+ * compiling directly against the daemon insert-engine implementation classes.
+ */
+public interface ClientPutExecution extends Serializable {
+
+  /**
+   * Returns the low-level requester backing this execution.
+   *
+   * <p>The adapter uses the requester for generic request bookkeeping such as diagnostics, cache
+   * updates, and priority changes. Callers should treat the returned object as a bridge-owned live
+   * state and should not assume that its concrete type is stable across implementations.
+   *
+   * @return live requester that currently backs this insert execution
+   */
+  ClientRequester requester();
+
+  /**
+   * Starts the live insert execution in the supplied client context.
+   *
+   * <p>This is the normal transition from a constructed FCP request into an actively running
+   * insert. Implementations should schedule the underlying work promptly and report any immediate
+   * start-up validation failures through the declared exception.
+   *
+   * @param context live client context that provides schedulers, randomness, and persistence hooks
+   * @throws InsertException if the insert cannot be started with the supplied runtime state
+   */
+  void start(network.crypta.client.async.ClientContext context) throws InsertException;
+
+  /**
+   * Returns whether the current execution can be restarted.
+   *
+   * <p>This reports whether the underlying runtime object still has enough retained states for a
+   * restart attempt to succeed. The adapter uses it to decide whether a finished failed request
+   * should offer a retry path.
+   *
+   * @return {@code true} when a later call to {@link
+   *     #restart(network.crypta.client.async.ClientContext)} may succeed
+   */
+  boolean canRestart();
+
+  /**
+   * Restarts the live insert execution in the supplied client context.
+   *
+   * <p>Implementations may either reuse the retained runtime state or rebuild a new runtime-owned
+   * inserter behind the seam. Callers expect the restart to preserve the user-visible FCP request
+   * semantics for the surrounding {@link ClientPut}.
+   *
+   * @param context live client context to use for the restart attempt
+   * @return {@code true} when the restart was scheduled successfully
+   * @throws InsertException if the restart cannot be scheduled
+   */
+  boolean restart(network.crypta.client.async.ClientContext context) throws InsertException;
+
+  /**
+   * Returns the splitfile crypto key currently associated with this execution, if any.
+   *
+   * <p>Persistent FCP tags use this value to report the effective splitfile key back to connected
+   * clients. Implementations may return {@code null} when no splitfile key is currently available
+   * or the active insert mode does not expose one.
+   *
+   * @return current splitfile crypto key for this execution, or {@code null} when unavailable
+   */
+  byte[] getSplitfileCryptoKey();
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecutionSpec.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecutionSpec.java
@@ -1,0 +1,291 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertContext;
+import network.crypta.client.async.ClientPutCallback;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.RandomAccessBucket;
+
+/**
+ * Detached single-file insert description consumed by the bridge runtime.
+ *
+ * <p>This specification carries the adapter-owned inputs that the bridge needs to construct a live
+ * single-file insert execution for a {@link ClientPut}. It groups the request callback, identity,
+ * insert policy, payload bucket, metadata, and a small nested option set so the bridge can build a
+ * concrete runtime-owned putter without forcing {@code :adapter-fcp} to import the daemon insert
+ * engine classes directly.
+ *
+ * <p>The object is intentionally simple and read-only. It is assembled from the already validated
+ * FCP request state, then handed across the module boundary where the bridge translates it into the
+ * concrete runtime operation for the current insert attempt.
+ */
+public final class ClientPutExecutionSpec {
+  /** Callback surface that receives progress, completion, and failure notifications. */
+  private final ClientPutCallback callback;
+
+  /** Detached request identity and persistence metadata for the insert. */
+  private final ClientRequestParams requestParams;
+
+  /** The insert policy snapshot governing retries, compression, and compatibility. */
+  private final InsertContext insertContext;
+
+  /** Payload bucket to insert or redirect metadata bucket for metadata-only inserts. */
+  private final RandomAccessBucket data;
+
+  /** Client-visible metadata associated with the payload being inserted. */
+  private final ClientMetadata clientMetadata;
+
+  /** Flag indicating whether {@link #data} currently contains metadata rather than raw payload. */
+  private final boolean isMetadata;
+
+  /** Nested option group containing the putter-only execution settings. */
+  private final ExecutionOptions executionOptions;
+
+  /**
+   * Creates a detached single-file execution specification for the bridge runtime.
+   *
+   * <p>The constructor stores the already prepared request state that a bridge implementation needs
+   * when constructing a live runtime-owned putter. It does not validate or normalize the inputs
+   * further; higher-level FCP request assembly is expected to provide a coherent payload bucket,
+   * insert context, and option set before handing the spec to the runtime bridge.
+   *
+   * @param callback callback that should receive insert lifecycle notifications
+   * @param requestParams detached request identity and persistence metadata for the insert
+   * @param insertContext insert policy snapshot that should govern this execution
+   * @param data payload or metadata bucket to hand to the runtime-owned putter
+   * @param clientMetadata client-visible metadata associated with the insert
+   * @param isMetadata whether the bucket currently represents metadata rather than raw content
+   * @param executionOptions nested option group containing single-file putter settings
+   */
+  public ClientPutExecutionSpec(
+      ClientPutCallback callback,
+      ClientRequestParams requestParams,
+      InsertContext insertContext,
+      RandomAccessBucket data,
+      ClientMetadata clientMetadata,
+      boolean isMetadata,
+      ExecutionOptions executionOptions) {
+    this.callback = callback;
+    this.requestParams = requestParams;
+    this.insertContext = insertContext;
+    this.data = data;
+    this.clientMetadata = clientMetadata;
+    this.isMetadata = isMetadata;
+    this.executionOptions = executionOptions;
+  }
+
+  /**
+   * Returns the callback that should receive insert lifecycle notifications.
+   *
+   * <p>The bridge passes this callback directly into the runtime-owned putter so that progress,
+   * completion, and failure events continue to flow back into the owning FCP request.
+   *
+   * @return callback to use for this single-file insert execution
+   */
+  public ClientPutCallback callback() {
+    return callback;
+  }
+
+  /**
+   * Returns the detached request metadata for this insert execution.
+   *
+   * <p>The bridge uses this metadata for stable values such as the target URI, request identifier,
+   * persistence mode, and the original priority snapshot that was present when the execution was
+   * assembled.
+   *
+   * @return request-scoped metadata associated with this execution attempt
+   */
+  public ClientRequestParams requestParams() {
+    return requestParams;
+  }
+
+  /**
+   * Returns the insert policy snapshot for this execution.
+   *
+   * <p>This context captures the retry, compression, and compatibility policy that should be used
+   * by the runtime-owned insert engine when the bridge constructs the concrete putter.
+   *
+   * @return the insert policy snapshot to apply to the runtime-owned execution
+   */
+  public InsertContext insertContext() {
+    return insertContext;
+  }
+
+  /**
+   * Returns the bucket that supplies bytes for this insert.
+   *
+   * <p>The bucket may contain raw payload bytes or generated redirect metadata, depending on the
+   * surrounding request assembly. The bridge treats it as the authoritative data source for the
+   * current single-file insert attempt.
+   *
+   * @return payload or metadata bucket for the runtime-owned putter
+   */
+  public RandomAccessBucket data() {
+    return data;
+  }
+
+  /**
+   * Returns the client-visible metadata associated with this insert.
+   *
+   * <p>This metadata is supplied alongside the payload bucket so the runtime-owned putter can
+   * preserve MIME and related client-facing details during insert assembly.
+   *
+   * @return client metadata associated with the insert payload
+   */
+  public ClientMetadata clientMetadata() {
+    return clientMetadata;
+  }
+
+  /**
+   * Returns whether the payload bucket currently contains metadata.
+   *
+   * <p>Redirect and some manifest-related insert paths encode metadata into the bucket and should
+   * be flagged accordingly, so the runtime-owned putter handles the bucket correctly.
+   *
+   * @return {@code true} when {@link #data()} contains metadata rather than raw payload content
+   */
+  public boolean isMetadata() {
+    return isMetadata;
+  }
+
+  /**
+   * Returns the optional target filename to supply to the runtime-owned putter.
+   *
+   * <p>This value is drawn from the nested execution options and typically matters when the target
+   * URI needs a document name synthesized from the uploaded filename.
+   *
+   * @return target filename hint for the runtime-owned single-file putter, or {@code null}
+   */
+  public String targetFilename() {
+    return executionOptions.targetFilename();
+  }
+
+  /**
+   * Returns whether this insert should be treated as a binary blob.
+   *
+   * <p>Binary blob inserts suppress normal metadata handling and final URI generation semantics.
+   * The bridge forwards this flag directly into the runtime-owned putter options.
+   *
+   * @return {@code true} when the insert should use binary-blob semantics
+   */
+  public boolean binaryBlob() {
+    return executionOptions.binaryBlob();
+  }
+
+  /**
+   * Returns the explicit splitfile crypto key override, if present.
+   *
+   * <p>This value is passed through unchanged, so restart and initial execution use the same
+   * explicit keying behavior whenever a client requested one.
+   *
+   * @return splitfile crypto key override, or {@code null} when default keying should apply
+   */
+  public byte[] overrideSplitfileCryptoKey() {
+    return executionOptions.overrideSplitfileCryptoKey();
+  }
+
+  /**
+   * Returns the metadata threshold configured for this execution.
+   *
+   * <p>The runtime-owned putter uses this threshold when deciding how to treat insert metadata. The
+   * adapter keeps it in the detached spec so the bridge can reconstruct identical runtime behavior
+   * on restart.
+   *
+   * @return metadata threshold value to apply to the insert execution
+   */
+  public long metadataThreshold() {
+    return executionOptions.metadataThreshold();
+  }
+
+  /**
+   * Returns the target URI for this insert execution.
+   *
+   * <p>This is a convenience accessor over the detached request metadata because the bridge needs
+   * the target URI frequently when constructing a runtime-owned putter.
+   *
+   * @return target insert URI associated with this execution attempt
+   */
+  public FreenetURI targetURI() {
+    return requestParams.uri();
+  }
+
+  /**
+   * Single-file putter options detached from the runtime-owned putter types.
+   *
+   * <p>This nested object keeps the putter-specific knobs together without widening {@link
+   * ClientRequestParams}. It is limited to the execution details that matter only when the bridge
+   * instantiates a live single-file putter.
+   */
+  @SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+  public static final class ExecutionOptions {
+    /** Optional filename hint used when synthesizing a target document name. */
+    private final String targetFilename;
+
+    /** Whether the insert should use binary-blob behavior instead of normal metadata handling. */
+    private final boolean binaryBlob;
+
+    /** Optional explicit splitfile crypto key override supplied by the client. */
+    private final byte[] overrideSplitfileCryptoKey;
+
+    /** Threshold value forwarded to the runtime-owned putter metadata handling logic. */
+    private final long metadataThreshold;
+
+    /**
+     * Creates a detached set of single-file putter options.
+     *
+     * <p>The values are stored exactly as provided and later consumed by the bridge when it
+     * constructs the runtime-owned putter for a single-file insert attempt.
+     *
+     * @param targetFilename optional filename hint for target URI document-name handling
+     * @param binaryBlob whether the insert should use binary-blob behavior
+     * @param overrideSplitfileCryptoKey optional explicit splitfile crypto key override
+     * @param metadataThreshold threshold to forward to runtime metadata handling
+     */
+    public ExecutionOptions(
+        String targetFilename,
+        boolean binaryBlob,
+        byte[] overrideSplitfileCryptoKey,
+        long metadataThreshold) {
+      this.targetFilename = targetFilename;
+      this.binaryBlob = binaryBlob;
+      this.overrideSplitfileCryptoKey = overrideSplitfileCryptoKey;
+      this.metadataThreshold = metadataThreshold;
+    }
+
+    /**
+     * Returns the optional target filename hint for the putter.
+     *
+     * @return target filename hint, or {@code null} when no hint should be applied
+     */
+    public String targetFilename() {
+      return targetFilename;
+    }
+
+    /**
+     * Returns whether the insert should use binary-blob behavior.
+     *
+     * @return {@code true} when the runtime-owned putter should treat the insert as a binary blob
+     */
+    public boolean binaryBlob() {
+      return binaryBlob;
+    }
+
+    /**
+     * Returns the explicit splitfile crypto key override, if any.
+     *
+     * @return splitfile crypto key override, or {@code null} when default keying should apply
+     */
+    public byte[] overrideSplitfileCryptoKey() {
+      return overrideSplitfileCryptoKey;
+    }
+
+    /**
+     * Returns the metadata threshold to apply to the runtime-owned putter.
+     *
+     * @return metadata threshold value associated with this execution option set
+     */
+    public long metadataThreshold() {
+      return metadataThreshold;
+    }
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutMessage.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Locale;
-import network.crypta.client.HighLevelSimpleClientImpl;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
@@ -42,7 +41,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see ClientPutBase
  * @see ClientRequest
- * @see HighLevelSimpleClientImpl
  */
 public final class ClientPutMessage extends DataCarryingMessage {
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutMessage.class);
@@ -161,11 +159,11 @@ public final class ClientPutMessage extends DataCarryingMessage {
       forkOnCacheable = fs.getBoolean("ForkOnCacheable", false);
     else forkOnCacheable = FcpInsertDefaults.FORK_ON_CACHEABLE_DEFAULT;
     extraInsertsSingleBlock =
-        fs.getInt("ExtraInsertsSingleBlock", HighLevelSimpleClientImpl.EXTRA_INSERTS_SINGLE_BLOCK);
+        fs.getInt("ExtraInsertsSingleBlock", FcpInsertDefaults.EXTRA_INSERTS_SINGLE_BLOCK_DEFAULT);
     extraInsertsSplitfileHeaderBlock =
         fs.getInt(
             "ExtraInsertsSplitfileHeaderBlock",
-            HighLevelSimpleClientImpl.EXTRA_INSERTS_SPLITFILE_HEADER);
+            FcpInsertDefaults.EXTRA_INSERTS_SPLITFILE_HEADER_DEFAULT);
     realTimeFlag = fs.getBoolean("RealTimeFlag", false);
     metadataThreshold = fs.getLong("MetadataThreshold", -1);
     ignoreUSKDatehints = fs.getBoolean("IgnoreUSKDatehints", false);

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutPutterFactory.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutPutterFactory.java
@@ -1,51 +1,20 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientPutter;
-import network.crypta.client.async.ClientPutterOptions;
-import network.crypta.client.async.ClientPutterRequest;
+import java.io.IOException;
 
 /**
- * Creates {@link ClientPutter} instances for single-file insert requests.
+ * Creates opaque single-file insert execution handles for FCP requests.
  *
- * <p>This factory centralizes the final assembly of {@link ClientPutter} objects after higher-level
- * request logic has already prepared a {@link ClientPutterRequest} and {@link ClientPutterOptions}.
- * Keeping the construction in one place makes it easier to enforce consistent wiring when request
- * constructors evolve, and it isolates the putter instantiation details from the surrounding FCP
- * request classes.
- *
- * <p>The factory performs no validation beyond delegating to the {@link ClientPutter} constructor;
- * callers are expected to pass fully configured, non-null request and options objects. The method
- * is deterministic and side-effect free, so it is safe to call from any thread that is building a
- * request.
- *
- * <ul>
- *   <li>Constructs a {@link ClientPutter} from prepared request and option objects.
- *   <li>Preserves all wiring performed by the caller without additional mutation.
- * </ul>
- *
- * @see ClientPutter
- * @see ClientPutterRequest
- * @see ClientPutterOptions
+ * <p>The adapter builds a detached execution spec and asks the runtime bridge to translate it into
+ * a live inserter. This keeps the concrete daemon client-engine types out of {@code :adapter-fcp}
+ * while preserving the existing request assembly flow.
  */
 final class ClientPutPutterFactory {
-  /** Prevents instantiation; this class provides a single static factory method. */
   private ClientPutPutterFactory() {}
 
-  /**
-   * Creates a new {@link ClientPutter} using the supplied request and options.
-   *
-   * <p>The method simply delegates to the {@link ClientPutter} constructor and returns the result.
-   * It does not mutate the request or options and performs no I/O. Callers should ensure that the
-   * request object already contains the target URI, bucket, metadata, and any persistence flags
-   * required by the insert pipeline.
-   *
-   * @param request prepared {@link ClientPutterRequest} containing callback, bucket, and metadata;
-   *     must not be {@code null}.
-   * @param options prepared {@link ClientPutterOptions} describing filename, binary-blob state, and
-   *     metadata thresholds; must not be {@code null}.
-   * @return a new {@link ClientPutter} instance wired to the given request and options.
-   */
-  static ClientPutter create(ClientPutterRequest request, ClientPutterOptions options) {
-    return new ClientPutter(request, options);
+  static ClientPutExecution create(
+      FcpInsertRuntimeSupport runtimeSupport, ClientPutExecutionSpec executionSpec)
+      throws IOException {
+    return runtimeSupport.createSingleFileExecution(executionSpec);
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequestParams.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequestParams.java
@@ -1,5 +1,7 @@
 package network.crypta.clients.fcp;
 
+import java.io.Serial;
+import java.io.Serializable;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 
@@ -27,4 +29,7 @@ public record ClientRequestParams(
     Persistence persistence,
     boolean realTime,
     String clientToken,
-    boolean global) {}
+    boolean global)
+    implements Serializable {
+  @Serial private static final long serialVersionUID = 1L;
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -10,7 +10,6 @@ import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
@@ -268,7 +267,7 @@ public class FCPConnectionHandler implements Closeable {
   }
 
   private void notifyLostRequests(ClientRequest[] requests) {
-    ClientContext clientContext = serverClientContext();
+    network.crypta.client.async.ClientContext clientContext = serverClientContext();
     for (ClientRequest request : requests) {
       request.onLostConnection(clientContext);
     }
@@ -579,7 +578,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(server.insertRuntimeSupport().clientContext());
+    request.start(serverClientContext());
   }
 
   private void startRebootClientPut(ClientPutMessage message) {
@@ -591,7 +590,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(server.insertRuntimeSupport().clientContext());
+    request.start(serverClientContext());
   }
 
   private void startForeverClientPut(ClientPutMessage message) {
@@ -660,7 +659,7 @@ public class FCPConnectionHandler implements Closeable {
       return;
     }
     RegistrationResult registration = registerConnectionScopedRequest(message.identifier, request);
-    ClientContext clientContext = server.insertRuntimeSupport().clientContext();
+    network.crypta.client.async.ClientContext clientContext = serverClientContext();
     if (registration == RegistrationResult.DUPLICATE) {
       request.cancel(clientContext);
       handleIdentifierCollision(message.identifier, message.global);
@@ -679,7 +678,7 @@ public class FCPConnectionHandler implements Closeable {
     if (request == null) {
       return;
     }
-    ClientContext clientContext = server.insertRuntimeSupport().clientContext();
+    network.crypta.client.async.ClientContext clientContext = serverClientContext();
     if (!registerPersistentRequest(request, message.identifier, message.global)) {
       request.cancel(clientContext);
       return;
@@ -1002,7 +1001,7 @@ public class FCPConnectionHandler implements Closeable {
       req = requestsByIdentifier.remove(identifier);
     }
     if (req != null) {
-      ClientContext clientContext = serverClientContext();
+      network.crypta.client.async.ClientContext clientContext = serverClientContext();
       if (kill) req.cancel(clientContext);
       req.requestWasRemoved(clientContext);
     }
@@ -1037,7 +1036,7 @@ public class FCPConnectionHandler implements Closeable {
     return req;
   }
 
-  private ClientContext serverClientContext() {
+  private network.crypta.client.async.ClientContext serverClientContext() {
     return server.serverRuntimeSupport().clientContext();
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertDefaults.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertDefaults.java
@@ -23,6 +23,12 @@ final class FcpInsertDefaults {
    */
   static final boolean FORK_ON_CACHEABLE_DEFAULT = true;
 
+  /** Default number of extra inserts for single-block payloads. */
+  static final int EXTRA_INSERTS_SINGLE_BLOCK_DEFAULT = 2;
+
+  /** Default number of extra inserts for splitfile header blocks. */
+  static final int EXTRA_INSERTS_SPLITFILE_HEADER_DEFAULT = 2;
+
   /** Prevents instantiation of this constants-only helper type. */
   private FcpInsertDefaults() {}
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertRuntimeSupport.java
@@ -2,9 +2,8 @@ package network.crypta.clients.fcp;
 
 import java.io.IOException;
 import network.crypta.client.InsertContext;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.USKManager;
+import network.crypta.keys.FreenetURI;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
@@ -16,9 +15,9 @@ import network.crypta.support.api.RandomAccessBucket;
  * wiring independent of direct {@code NodeClientCore} access while preserving the current runtime
  * behavior. It exposes only the insert-specific services needed by {@link ClientPutBase}, {@link
  * ClientPut}, {@link ClientPutDir}, {@link ClientPutPreparedDataFactory}, {@link ClientPutMessage},
- * and {@link SubscribeUSK}: the live {@link ClientContext}, the default persistent {@link
- * InsertContext}, transfer-policy checks, bucket factories, forever-persistent upload allocation,
- * and the {@link USKManager}.
+ * and {@link SubscribeUSK}: the default persistent {@link InsertContext}, transfer-policy checks,
+ * bucket factories, forever-persistent upload allocation, URI normalization, and opaque execution
+ * handle creation.
  *
  * <p>Typical call paths get one instance from {@link FCPServer} and thread it through request
  * constructors while they normalize URIs, validate disk access, allocate temporary buckets, and
@@ -34,18 +33,6 @@ import network.crypta.support.api.RandomAccessBucket;
  * types.
  */
 public interface FcpInsertRuntimeSupport {
-
-  /**
-   * Returns the live client context used to start, resume, or validate insert requests.
-   *
-   * <p>Insert assembly uses this context when it needs request-level defaults that still depend on
-   * the live daemon, for example, generating placeholder SSKs or starting the resulting putter from
-   * {@link FCPConnectionHandler}. Implementations should return the current context in effect for
-   * the owning node rather than a cached copy.
-   *
-   * @return current client context backing FCP insert operations
-   */
-  ClientContext clientContext();
 
   /**
    * Returns the default persistent insert context template for new put requests.
@@ -97,13 +84,44 @@ public interface FcpInsertRuntimeSupport {
       throws IOException, PersistenceDisabledException;
 
   /**
-   * Returns the live USK manager used by subscription flows.
+   * Normalizes insert URIs that omit routing or document names.
    *
-   * <p>{@link SubscribeUSK} uses the returned manager to register, poll, and later remove USK
-   * subscriptions. The seam does not abstract USK behavior further; it only provides the concrete
-   * manager instance needed by the existing FCP subscription workflow.
+   * <p>This preserves the legacy {@code SSK@} handling used by FCP insert requests while keeping
+   * the randomness source hidden behind the runtime bridge.
    *
-   * @return current USK manager backing FCP subscriptions
+   * @param uri candidate insert URI
+   * @param filename filename to apply when the URI lacks a document name
+   * @return original or normalized insert URI
    */
-  USKManager uskManager();
+  FreenetURI normalizeInsertUri(FreenetURI uri, String filename);
+
+  /**
+   * Creates a single-file insert execution handle.
+   *
+   * @param executionSpec detached execution inputs for the request attempt
+   * @return opaque live execution handle
+   * @throws IOException if the runtime cannot construct the execution
+   */
+  ClientPutExecution createSingleFileExecution(ClientPutExecutionSpec executionSpec)
+      throws IOException;
+
+  /**
+   * Creates a directory/manifest insert execution handle.
+   *
+   * @param executionSpec detached execution inputs for the request attempt
+   * @return opaque live execution handle
+   */
+  ClientPutDirExecution createDirectoryExecution(ClientPutDirExecutionSpec executionSpec)
+      throws network.crypta.client.async.TooManyFilesInsertException;
+
+  /**
+   * Creates and registers a USK subscription handle.
+   *
+   * @param message parsed subscription request
+   * @param callbacks adapter-owned callback surface receiving runtime events
+   * @param handler owning FCP connection handler
+   * @return opaque live subscription handle
+   */
+  UskSubscriptionHandle subscribeUSK(
+      SubscribeUSKMessage message, SubscribeUSKCallbacks callbacks, FCPConnectionHandler handler);
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/SubscribeUSK.java
@@ -1,62 +1,33 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.USKCallback;
-import network.crypta.client.async.USKFoundEdition;
-import network.crypta.client.async.USKProgressCallback;
 import network.crypta.keys.USK;
 
 /**
- * Bridges an FCP client subscription to the node's USK manager.
+ * Bridges an FCP client subscription to the adapter-owned USK subscription seam.
  *
- * <p>This helper wires a {@link SubscribeUSKMessage} received over FCP into the asynchronous USK
- * subscription facilities provided by the insert runtime support seam. It registers itself as the
- * {@link USKProgressCallback} so that progress, network activity, and discovered editions are fed
- * back to the originating {@link FCPConnectionHandler}. Instances are intentionally lightweight and
- * short-lived: they register with the node on construction and can be removed via {@link
- * #unsubscribe()} when the client disconnects or no longer requires updates.
- *
- * <p>Typical usage is driven by the FCP protocol flow: the handler constructs this class when a
- * client issues a subscription request, lets the node push progress callbacks, and eventually calls
- * {@link #unsubscribe()} during teardown. The object does not perform retries itself; it relies on
- * the underlying USK manager for polling cadence, sparse polling decisions, and cache ownership.
- * All callbacks are expected to be invoked on the node's internal threads, so callers should avoid
- * long-running work and keep message emission cheap. Thread-safety is limited to delegating into
- * the handler and USK manager; the class itself is effectively single-use per subscription.
- *
- * <ul>
- *   <li>Relays edition discoveries, including whether data was newly accepted.
- *   <li>Reports network-send phases and polling round completion to the FCP client.
- *   <li>Preserves the polling priorities supplied by the client for normal and progress phases.
- * </ul>
- *
- * @see USKProgressCallback
- * @see network.crypta.client.async.USKManager#subscribe
- * @see network.crypta.client.async.USKManager#subscribeSparse
+ * <p>This helper keeps the FCP-side subscription state and message emission in {@code :adapter-fcp}
+ * while delegating all live USK manager interaction to {@link FcpInsertRuntimeSupport}. The bridge
+ * implementation owns the concrete runtime subscription and calls back through {@link
+ * SubscribeUSKCallbacks} whenever editions are found or polling progress changes.
  */
-public final class SubscribeUSK implements USKProgressCallback {
+public final class SubscribeUSK implements SubscribeUSKCallbacks {
   final FCPConnectionHandler handler;
   final String clientIdentifier;
-  final FcpInsertRuntimeSupport runtimeSupport;
-  final boolean dontPoll;
   final short prio;
   final short prioProgress;
-  final USK usk;
-  final USKCallback toUnsub;
+  private final UskSubscriptionHandle subscriptionHandle;
 
   /**
    * Creates and registers a subscription that reflects the caller's FCP request parameters.
    *
-   * <p>The constructor immediately adds this callback to both the connection handler and the USK
-   * manager. Depending on the {@code dontPoll} and {@code sparsePoll} flags in the supplied
-   * message, it chooses either sparse subscription mode or the default polling behavior. No
-   * additional initialization is required after construction.
+   * <p>The constructor first registers the identifier with the connection handler, so collisions
+   * are reported using the existing FCP behavior. It then asks {@link FcpInsertRuntimeSupport} to
+   * create the live runtime subscription behind an opaque handle owned by the adapter.
    *
-   * @param message parsed FCP subscribe request containing keys, flags, and priorities; never null.
-   * @param runtimeSupport insert runtime support that owns the USK manager and polling logic.
-   * @param handler connection handler used to emit FCP responses back to the requesting client.
-   * @throws IdentifierCollisionException if the identifier already exists on this handler and
-   *     cannot be reused for another subscription.
+   * @param message parsed FCP subscribe request containing keys, flags, and priorities
+   * @param runtimeSupport insert runtime support that owns the concrete runtime subscription wiring
+   * @param handler connection handler used to emit FCP responses back to the requesting client
+   * @throws IdentifierCollisionException if the identifier already exists on this handler
    */
   SubscribeUSK(
       SubscribeUSKMessage message,
@@ -64,72 +35,18 @@ public final class SubscribeUSK implements USKProgressCallback {
       FCPConnectionHandler handler)
       throws IdentifierCollisionException {
     this.handler = handler;
-    this.dontPoll = message.dontPoll;
     this.clientIdentifier = message.clientIdentifier;
-    this.runtimeSupport = runtimeSupport;
-    this.usk = message.key;
-    prio = message.prio;
-    prioProgress = message.prioProgress;
+    this.prio = message.prio;
+    this.prioProgress = message.prioProgress;
     handler.addUSKSubscription(clientIdentifier, this);
-    if (!message.dontPoll && message.sparsePoll)
-      toUnsub =
-          runtimeSupport
-              .uskManager()
-              .subscribeSparse(
-                  message.key,
-                  this,
-                  message.ignoreUSKDatehints,
-                  handler.getRebootClient().lowLevelClient(message.realTimeFlag));
-    else {
-      runtimeSupport
-          .uskManager()
-          .subscribe(
-              message.key,
-              this,
-              !message.dontPoll,
-              message.ignoreUSKDatehints,
-              handler.getRebootClient().lowLevelClient(message.realTimeFlag));
-      toUnsub = this;
-    }
-  }
-
-  /**
-   * Receives notification that a specific USK edition was located and processed.
-   *
-   * <p>The callback is triggered by the USK manager whenever it fetches an edition for this
-   * subscription. It forwards a {@link SubscribedUSKUpdate} over FCP unless the handler has been
-   * closed, in which case it unsubscribes to conserve resources. Data bytes are not sent here; only
-   * edition and freshness metadata travel across the connection.
-   *
-   * @param foundEdition The payload describing the discovered edition and its metadata.
-   */
-  @Override
-  public void onFoundEdition(USKFoundEdition foundEdition) {
-    USK key = foundEdition.key();
-    if (handler.isClosed()) {
-      runtimeSupport.uskManager().unsubscribe(key, toUnsub);
-      return;
-    }
-    FCPMessage msg =
-        new SubscribedUSKUpdate(
-            clientIdentifier,
-            foundEdition.edition(),
-            key,
-            foundEdition.newKnownGood(),
-            foundEdition.newSlotToo());
-    handler.send(msg);
+    this.subscriptionHandle = runtimeSupport.subscribeUSK(message, this, handler);
   }
 
   /**
    * Returns the client-requested priority for regular polling cycles.
    *
-   * <p>The value originates from the FCP subscribe message and is passed through unchanged, so the
-   * USK manager can schedule this subscription relative to others. Lower values typically denote
-   * higher priority depending on the underlying scheduler configuration.
-   *
-   * @return priority hint for normal polling, as supplied by the subscribing client.
+   * @return priority hint for normal polling, as supplied by the subscribing client
    */
-  @Override
   public short getPollingPriorityNormal() {
     return prio;
   }
@@ -137,54 +54,53 @@ public final class SubscribeUSK implements USKProgressCallback {
   /**
    * Returns the client-requested priority used while progress feedback is being emitted.
    *
-   * <p>This priority can differ from the normal polling priority to bias subscriptions that are
-   * mid-transfer or issuing updates to clients. It is not modified by this class; the USK manager
-   * is free to interpret the value according to its scheduling rules.
-   *
-   * @return priority hint for progress phases, mirroring the value in the original request.
+   * @return priority hint for progress phases, mirroring the value in the original request
    */
-  @Override
   public short getPollingPriorityProgress() {
     return prioProgress;
   }
 
   /**
-   * Cancels the active subscription with the USK manager.
+   * Cancels the active subscription through the opaque runtime handle.
    *
-   * <p>Callers should invoke this when the FCP connection closes or when the client issues an
-   * unsubscribed request. The method forwards the removal to the node's USK manager using the key
-   * captured at construction. It is safe to call multiple times; the manager ignores redundant
-   * calls.
+   * <p>Callers invoke this when the FCP connection closes or the client explicitly unsubscribes.
    */
   public void unsubscribe() {
-    runtimeSupport.uskManager().unsubscribe(usk, toUnsub);
+    subscriptionHandle.unsubscribe();
   }
 
-  /**
-   * Signals that a polling cycle is actively sending a request to the network.
-   *
-   * <p>The callback relays a {@link SubscribedUSKSendingToNetworkMessage} to the FCP client so it
-   * can display activity state. It does not include payload details; its purpose is purely
-   * observational, allowing clients to track when network traffic begins for a given subscription.
-   *
-   * @param context client context for the poll; may be shared with other progress callbacks.
-   */
   @Override
-  public void onSendingToNetwork(ClientContext context) {
+  public boolean isClosed() {
+    return handler.isClosed();
+  }
+
+  @Override
+  public String clientIdentifier() {
+    return clientIdentifier;
+  }
+
+  @Override
+  public short pollingPriorityNormal() {
+    return prio;
+  }
+
+  @Override
+  public short pollingPriorityProgress() {
+    return prioProgress;
+  }
+
+  @Override
+  public void onFoundEdition(long edition, USK key, boolean newKnownGood, boolean newSlotToo) {
+    handler.send(new SubscribedUSKUpdate(clientIdentifier, edition, key, newKnownGood, newSlotToo));
+  }
+
+  @Override
+  public void onSendingToNetwork() {
     handler.send(new SubscribedUSKSendingToNetworkMessage(clientIdentifier));
   }
 
-  /**
-   * Notifies listeners that a polling round completed for this subscription.
-   *
-   * <p>When invoked, the method emits a {@link SubscribedUSKRoundFinishedMessage} to the FCP client
-   * to mark the end of the current poll cycle. No guarantees are made about the presence of new
-   * editions; the signal merely brackets a batch of network activity.
-   *
-   * @param context client context associated with the concluded round; may be reused by the caller.
-   */
   @Override
-  public void onRoundFinished(ClientContext context) {
+  public void onRoundFinished() {
     handler.send(new SubscribedUSKRoundFinishedMessage(clientIdentifier));
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/SubscribeUSKCallbacks.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/SubscribeUSKCallbacks.java
@@ -1,0 +1,84 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.keys.USK;
+
+/**
+ * Adapter-owned callback surface used by the bridge USK subscription helper.
+ *
+ * <p>The bridge runtime owns the concrete USK manager subscription and invokes this interface to
+ * report discovered editions and polling progress back into {@code :adapter-fcp}. Implementations
+ * typically live on top of {@link SubscribeUSK} and translate the callback events into FCP wire
+ * messages without importing the runtime-owned USK callback types directly.
+ */
+public interface SubscribeUSKCallbacks {
+
+  /**
+   * Returns whether the owning FCP connection has already closed.
+   *
+   * <p>The bridge uses this as a guard before emitting more USK updates, so it can tear down the
+   * runtime subscription promptly when the client is no longer available.
+   *
+   * @return {@code true} when the owning connection should no longer receive callback events
+   */
+  boolean isClosed();
+
+  /**
+   * Returns the client-visible identifier used when sending FCP messages.
+   *
+   * <p>The returned identifier is echoed in protocol messages generated from callback events so the
+   * subscribing client can correlate updates with the original {@code SubscribeUSK} request.
+   *
+   * @return client-visible identifier associated with the active USK subscription
+   */
+  String clientIdentifier();
+
+  /**
+   * Returns the steady-state polling priority.
+   *
+   * <p>The bridge forwards this value into the runtime subscription, so normal background polling
+   * competes with other work at the same priority level the FCP client requested.
+   *
+   * @return steady-state polling priority for the USK subscription
+   */
+  short pollingPriorityNormal();
+
+  /**
+   * Returns the startup or progress polling priority.
+   *
+   * <p>This secondary priority allows the runtime subscription to bias startup or progress-related
+   * polling differently from steady-state operation when the underlying USK machinery supports it.
+   *
+   * @return priority to use for startup or progress-oriented polling work
+   */
+  short pollingPriorityProgress();
+
+  /**
+   * Handles a discovered USK edition.
+   *
+   * <p>The bridge invokes this when the runtime subscription finds an edition or advances its known
+   * slot state. Implementations typically convert the callback into a {@code SubscribedUSKUpdate}
+   * FCP message.
+   *
+   * @param edition discovered edition number
+   * @param key resolved USK key associated with the discovered edition
+   * @param newKnownGood whether the discovered edition became a new known-good edition
+   * @param newSlotToo whether the discovered edition also advanced the newest known slot
+   */
+  void onFoundEdition(long edition, USK key, boolean newKnownGood, boolean newSlotToo);
+
+  /**
+   * Handles a polling round entering network I/O.
+   *
+   * <p>Implementations typically turn this into a lightweight protocol notification so clients can
+   * observe that the USK subscription is actively talking to the network.
+   */
+  void onSendingToNetwork();
+
+  /**
+   * Handles the end of a polling round.
+   *
+   * <p>This callback marks the completion of one polling cycle, regardless of whether a new edition
+   * was found during that round.
+   */
+  void onRoundFinished();
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/SubscribeUSKMessage.java
@@ -121,6 +121,31 @@ public final class SubscribeUSKMessage extends FCPMessage {
     return NAME;
   }
 
+  /** Returns the parsed USK key targeted by this subscription request. */
+  public USK key() {
+    return key;
+  }
+
+  /** Returns whether background polling should remain enabled for this subscription. */
+  public boolean shouldPoll() {
+    return !dontPoll;
+  }
+
+  /** Returns whether the client requested sparse polling updates. */
+  public boolean sparsePoll() {
+    return sparsePoll;
+  }
+
+  /** Returns whether the subscription should use the realtime request client. */
+  public boolean realTimeFlag() {
+    return realTimeFlag;
+  }
+
+  /** Returns whether USK date hints should be ignored while polling. */
+  public boolean ignoreUSKDatehints() {
+    return ignoreUSKDatehints;
+  }
+
   /**
    * Executes the subscription by wiring the parsed options into the node and acknowledging the
    * client.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/UskSubscriptionHandle.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/UskSubscriptionHandle.java
@@ -1,0 +1,27 @@
+package network.crypta.clients.fcp;
+
+import java.io.Serializable;
+
+/**
+ * Opaque adapter-owned handle for one live USK subscription.
+ *
+ * <p>The adapter stores this handle as the minimal representation of an active runtime-backed USK
+ * subscription. The concrete subscription wiring remains in {@code :bridge-fcp-runtime}; the
+ * adapter uses the handle only to end that live subscription when the client disconnects,
+ * unsubscribes, or otherwise stops caring about updates.
+ *
+ * <p>Implementations are expected to be idempotent with respect to unsubscription. Callers should
+ * not assume anything about the underlying runtime callback object or USK manager token beyond the
+ * fact that invoking {@link #unsubscribe()} severs the live subscription.
+ */
+public interface UskSubscriptionHandle extends Serializable {
+
+  /**
+   * Unsubscribes the live USK callback from the runtime manager.
+   *
+   * <p>This releases the concrete runtime-owned subscription that the bridge created on behalf of
+   * the FCP adapter. After this call returns, the owning client should no longer receive USK update
+   * callbacks for the associated subscription.
+   */
+  void unsubscribe();
+}

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -58,6 +58,17 @@ class AdapterFcpBoundaryTest {
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpMessageRuntimeSupport.java");
   private static final Path FCP_SERVER_PERSISTENT_OPS_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpServerPersistentOps.java");
+  private static final Set<Path> INSERT_FAMILY_SEAM_SOURCES =
+      Set.of(
+          ADAPTER_FCP_MAIN_JAVA.resolve("FcpInsertRuntimeSupport.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPut.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutDir.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutPreparedDataFactory.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutPutterFactory.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutMessage.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutDirMessage.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("SubscribeUSK.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("FCPConnectionHandler.java"));
   private static final Path BRIDGE_FCP_RUNTIME_MAIN_JAVA =
       Path.of(
           "bridge-fcp-runtime",
@@ -97,6 +108,22 @@ class AdapterFcpBoundaryTest {
           "network.crypta.client.async.ClientContext",
           "network.crypta.client.async.ClientGetter",
           "network.crypta.client.async.ClientGetterRequest");
+  private static final Set<String> FORBIDDEN_INSERT_RUNTIME_IMPORTS =
+      Set.of(
+          "network.crypta.client.HighLevelSimpleClientImpl",
+          "network.crypta.client.async.ClientContext",
+          "network.crypta.client.async.ClientPutter",
+          "network.crypta.client.async.ClientPutterOptions",
+          "network.crypta.client.async.ClientPutterRequest",
+          "network.crypta.client.async.ContainerInserter",
+          "network.crypta.client.async.DefaultManifestPutter",
+          "network.crypta.client.async.InsertRequestParams",
+          "network.crypta.client.async.ManifestPutter",
+          "network.crypta.client.async.ManifestPutterParams",
+          "network.crypta.client.async.USKCallback",
+          "network.crypta.client.async.USKFoundEdition",
+          "network.crypta.client.async.USKManager",
+          "network.crypta.client.async.USKProgressCallback");
   private static final Set<Path> GET_RUNTIME_SEAM_SOURCES =
       Set.of(
           FCP_FETCH_RUNTIME_SUPPORT_SOURCE,
@@ -330,6 +357,28 @@ class AdapterFcpBoundaryTest {
     assertFalse(connectionHandler.contains("defaultPersistentFetchContext("));
     assertFalse(persistentOps.contains("fetchRuntimeSupport.clientContext()"));
     assertFalse(persistentOps.contains("defaultPersistentFetchContext("));
+  }
+
+  @Test
+  void adapterFcpMain_whenCheckingInsertFamilySeam_expectNoLiveInsertRuntimeImports()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path source : INSERT_FAMILY_SEAM_SOURCES) {
+      Set<String> imports = readImports(repoRoot.resolve(source));
+      Set<String> forbiddenImports = new TreeSet<>(imports);
+      forbiddenImports.retainAll(FORBIDDEN_INSERT_RUNTIME_IMPORTS);
+      if (!forbiddenImports.isEmpty()) {
+        violations.add(source + " -> " + String.join(", ", forbiddenImports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Insert-family adapter sources must not import live runtime insert execution types."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
   }
 
   private static List<Path> findJavaSources(Path root) throws IOException {

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
@@ -1,50 +1,59 @@
 package network.crypta.clients.fcp.bridge;
 
 import java.io.IOException;
+import java.io.Serial;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import network.crypta.client.InsertContext;
+import network.crypta.client.InsertException;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientPutterOptions;
+import network.crypta.client.async.ClientPutterRequest;
+import network.crypta.client.async.ClientRequester;
+import network.crypta.client.async.ContainerInserter;
+import network.crypta.client.async.DefaultManifestPutter;
+import network.crypta.client.async.InsertRequestParams;
+import network.crypta.client.async.ManifestPutter;
+import network.crypta.client.async.ManifestPutterParams;
 import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.TooManyFilesInsertException;
+import network.crypta.client.async.USKCallback;
+import network.crypta.client.async.USKFoundEdition;
 import network.crypta.client.async.USKManager;
-import network.crypta.clients.fcp.FCPServer;
+import network.crypta.client.async.USKProgressCallback;
+import network.crypta.clients.fcp.ClientPutDirExecution;
+import network.crypta.clients.fcp.ClientPutDirExecutionSpec;
+import network.crypta.clients.fcp.ClientPutExecution;
+import network.crypta.clients.fcp.ClientPutExecutionSpec;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FcpInsertRuntimeSupport;
+import network.crypta.clients.fcp.SubscribeUSKCallbacks;
+import network.crypta.clients.fcp.SubscribeUSKMessage;
+import network.crypta.clients.fcp.UskSubscriptionHandle;
+import network.crypta.keys.FreenetURI;
+import network.crypta.keys.InsertableClientSSK;
+import network.crypta.keys.USK;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.ResumeFailedException;
 
 /**
  * Core-backed implementation of {@link FcpInsertRuntimeSupport}.
  *
- * <p>This adapter is the insert/USK assembly seam between {@code clients.fcp} and the broader
- * daemon runtime. It keeps insert-specific wiring local to runtime-owned bootstrap code by
- * translating the small set of insert dependencies into direct delegations on the wrapped {@link
- * NodeClientCore} plus the transfer-access policy supplier used for upload validation. The adapter
- * is immutable after construction and observes the live daemon state on each call.
- *
- * @param core live daemon core used for insert contexts, bucket allocation, and USK subscriptions
- * @param transferAccessSupplier live transfer-policy lookup used for upload DDA checks; callers
- *     typically bind this to {@code core.getRuntimePorts().transferAccess()} to preserve legacy
- *     insert validation behavior
+ * <p>This adapter owns the concrete translation between the adapter-owned detached insert/USK seam
+ * and the live daemon runtime.
  */
 record CoreFcpInsertRuntimeSupport(
     NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier)
     implements FcpInsertRuntimeSupport {
 
-  /**
-   * Creates an insert-runtime adapter over the supplied live daemon services.
-   *
-   * <p>The adapter does not snapshot state. Later calls continue to observe the current client
-   * context, bucket factories, USK manager, and transfer policy exposed by the wrapped core and the
-   * supplied transfer-policy lookup. Callers usually construct one instance per {@link FCPServer}
-   * and reuse it for all insert and USK request assembly in that server.
-   *
-   * @param core live daemon core providing insert contexts, persistent bucket factories, and USK
-   *     services for the FCP insert path
-   * @param transferAccessSupplier live transfer-policy lookup that should stay aligned with the
-   *     legacy insert validation policy while requests are being created
-   */
   CoreFcpInsertRuntimeSupport(
       NodeClientCore core, Supplier<TransferAccessPort> transferAccessSupplier) {
     this.core = Objects.requireNonNull(core);
@@ -52,13 +61,8 @@ record CoreFcpInsertRuntimeSupport(
   }
 
   @Override
-  public ClientContext clientContext() {
-    return core.getClientContext();
-  }
-
-  @Override
   public InsertContext defaultPersistentInsertContext() {
-    return core.getClientContext().getDefaultPersistentInsertContext();
+    return clientContext().getDefaultPersistentInsertContext();
   }
 
   @Override
@@ -68,7 +72,7 @@ record CoreFcpInsertRuntimeSupport(
 
   @Override
   public BucketFactory bucketFactory(boolean persistentForever) {
-    return core.getClientContext().getBucketFactory(persistentForever);
+    return clientContext().getBucketFactory(persistentForever);
   }
 
   @Override
@@ -81,7 +85,276 @@ record CoreFcpInsertRuntimeSupport(
   }
 
   @Override
-  public USKManager uskManager() {
-    return core.getUskManager();
+  public FreenetURI normalizeInsertUri(FreenetURI uri, String filename) {
+    if ("SSK".equals(uri.getKeyType()) && uri.getDocName() == null && uri.getRoutingKey() == null) {
+      String resolvedFilename = (filename == null || filename.isEmpty()) ? "key" : filename;
+      InsertableClientSSK key = InsertableClientSSK.createRandom(clientContext().random, "");
+      return key.getInsertURI().setDocName(resolvedFilename);
+    }
+    return uri;
+  }
+
+  @Override
+  public ClientPutExecution createSingleFileExecution(ClientPutExecutionSpec executionSpec) {
+    return new CoreClientPutExecution(executionSpec);
+  }
+
+  @Override
+  public ClientPutDirExecution createDirectoryExecution(ClientPutDirExecutionSpec executionSpec)
+      throws TooManyFilesInsertException {
+    return new CoreClientPutDirExecution(
+        executionSpec, createManifestPutter(executionSpec, clientContext()));
+  }
+
+  @Override
+  public UskSubscriptionHandle subscribeUSK(
+      SubscribeUSKMessage message, SubscribeUSKCallbacks callbacks, FCPConnectionHandler handler) {
+    return new CoreUskSubscription(message, callbacks, handler);
+  }
+
+  private ClientContext clientContext() {
+    return Objects.requireNonNull(core.getClientContext());
+  }
+
+  static ClientPutExecution wrapLegacySingleFileExecution(Object legacyPutter) {
+    if (legacyPutter == null) {
+      return null;
+    }
+    if (legacyPutter instanceof ClientPutter putter) {
+      return new CoreClientPutExecution(putter);
+    }
+    throw new IllegalArgumentException(
+        "Legacy single-file putter is not a ClientPutter: " + legacyPutter.getClass().getName());
+  }
+
+  static ClientPutDirExecution wrapLegacyDirectoryExecution(
+      Object legacyPutter, ClientPutDirExecutionSpec executionSpec) {
+    if (legacyPutter == null) {
+      return null;
+    }
+    if (legacyPutter instanceof ManifestPutter putter) {
+      return new CoreClientPutDirExecution(executionSpec, putter);
+    }
+    throw new IllegalArgumentException(
+        "Legacy directory putter is not a ManifestPutter: " + legacyPutter.getClass().getName());
+  }
+
+  private static final class CoreClientPutExecution implements ClientPutExecution {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final ClientPutter putter;
+
+    private CoreClientPutExecution(ClientPutExecutionSpec spec) {
+      ClientPutterRequest putterRequest =
+          new ClientPutterRequest(
+              new InsertRequestParams(
+                  spec.callback(),
+                  spec.targetURI(),
+                  spec.insertContext(),
+                  spec.requestParams().priorityClass()),
+              spec.data(),
+              spec.clientMetadata(),
+              spec.isMetadata());
+      ClientPutterOptions putterOptions =
+          new ClientPutterOptions(
+              spec.targetFilename(),
+              spec.binaryBlob(),
+              spec.overrideSplitfileCryptoKey(),
+              spec.metadataThreshold());
+      this.putter = new ClientPutter(putterRequest, putterOptions);
+    }
+
+    private CoreClientPutExecution(ClientPutter putter) {
+      this.putter = Objects.requireNonNull(putter);
+    }
+
+    @Override
+    public ClientRequester requester() {
+      return putter;
+    }
+
+    @Override
+    public void start(ClientContext context) throws InsertException {
+      putter.start(context);
+    }
+
+    @Override
+    public boolean canRestart() {
+      return putter.canRestart();
+    }
+
+    @Override
+    public boolean restart(ClientContext context) throws InsertException {
+      return putter.restart(context);
+    }
+
+    @Override
+    public byte[] getSplitfileCryptoKey() {
+      return putter.getSplitfileCryptoKey();
+    }
+  }
+
+  private static final class CoreClientPutDirExecution implements ClientPutDirExecution {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final ClientPutDirExecutionSpec spec;
+    private ManifestPutter putter;
+
+    private CoreClientPutDirExecution(ClientPutDirExecutionSpec spec, ManifestPutter putter) {
+      this.spec = spec;
+      this.putter = putter;
+    }
+
+    @Override
+    public ClientRequester requester() {
+      return putter;
+    }
+
+    @Override
+    public void start(ClientContext context) throws InsertException {
+      putter.start(context);
+    }
+
+    @Override
+    public boolean canRestart() {
+      return putter != null;
+    }
+
+    @Override
+    public boolean restart(ClientContext context) throws InsertException {
+      try {
+        putter = createManifestPutter(spec, context);
+      } catch (TooManyFilesInsertException e) {
+        throw new InsertException(InsertException.InsertExceptionMode.TOO_MANY_FILES, e, null);
+      }
+      putter.start(context);
+      return true;
+    }
+
+    @Override
+    public byte[] getSplitfileCryptoKey() {
+      return putter.getSplitfileCryptoKey();
+    }
+
+    @Override
+    public int countFiles() {
+      return putter.countFiles();
+    }
+
+    @Override
+    public long totalSize() {
+      return putter.totalSize();
+    }
+
+    @Override
+    public void resumeMetadata(Map<String, Object> manifestElements, ClientContext context)
+        throws ResumeFailedException {
+      ContainerInserter.resumeMetadata(manifestElements, context);
+    }
+  }
+
+  private static ManifestPutter createManifestPutter(
+      ClientPutDirExecutionSpec spec, ClientContext context) throws TooManyFilesInsertException {
+    ManifestPutterParams params =
+        new ManifestPutterParams(
+            new InsertRequestParams(
+                spec.callback(),
+                spec.requestParams().uri(),
+                spec.insertContext(),
+                spec.priorityClass()),
+            spec.manifestElements(),
+            spec.defaultName(),
+            spec.forceCryptoKey(),
+            context);
+    return DefaultManifestPutter.create(
+        params, spec.requestParams().persistence() == Persistence.FOREVER);
+  }
+
+  private final class CoreUskSubscription implements UskSubscriptionHandle {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final USK usk;
+    private final AtomicReference<USKCallback> unsubscribeToken = new AtomicReference<>();
+
+    private CoreUskSubscription(
+        SubscribeUSKMessage message,
+        SubscribeUSKCallbacks callbacks,
+        FCPConnectionHandler handler) {
+      this.usk = message.key();
+      USKProgressAdapter progressAdapter = new USKProgressAdapter(callbacks);
+      RequestClient requestClient =
+          handler.getRebootClient().lowLevelClient(message.realTimeFlag());
+
+      USKCallback token;
+      if (message.shouldPoll() && message.sparsePoll()) {
+        token =
+            uskManager()
+                .subscribeSparse(
+                    message.key(), progressAdapter, message.ignoreUSKDatehints(), requestClient);
+      } else {
+        uskManager()
+            .subscribe(
+                message.key(),
+                progressAdapter,
+                message.shouldPoll(),
+                message.ignoreUSKDatehints(),
+                requestClient);
+        token = progressAdapter;
+      }
+      unsubscribeToken.set(token);
+    }
+
+    @Override
+    public void unsubscribe() {
+      USKCallback token = unsubscribeToken.getAndSet(null);
+      if (token != null) {
+        uskManager().unsubscribe(usk, token);
+      }
+    }
+
+    private USKManager uskManager() {
+      return core.getUskManager();
+    }
+
+    private final class USKProgressAdapter implements USKProgressCallback {
+      private final SubscribeUSKCallbacks callbacks;
+
+      private USKProgressAdapter(SubscribeUSKCallbacks callbacks) {
+        this.callbacks = Objects.requireNonNull(callbacks);
+      }
+
+      @Override
+      public void onFoundEdition(USKFoundEdition foundEdition) {
+        if (callbacks.isClosed()) {
+          unsubscribe();
+          return;
+        }
+        callbacks.onFoundEdition(
+            foundEdition.edition(),
+            foundEdition.key(),
+            foundEdition.newKnownGood(),
+            foundEdition.newSlotToo());
+      }
+
+      @Override
+      public short getPollingPriorityNormal() {
+        return callbacks.pollingPriorityNormal();
+      }
+
+      @Override
+      public short getPollingPriorityProgress() {
+        return callbacks.pollingPriorityProgress();
+      }
+
+      @Override
+      public void onSendingToNetwork(ClientContext context) {
+        callbacks.onSendingToNetwork();
+      }
+
+      @Override
+      public void onRoundFinished(ClientContext context) {
+        callbacks.onRoundFinished();
+      }
+    }
   }
 }

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
@@ -1,7 +1,19 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ManifestPutter;
 import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.clients.fcp.ClientPutDir;
+import network.crypta.clients.fcp.ClientPutDirExecution;
+import network.crypta.clients.fcp.ClientPutDirExecutionSpec;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.clients.fcp.ClientRequestParams;
+import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.BucketFactory;
@@ -14,9 +26,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
@@ -28,6 +43,28 @@ class CoreFcpInsertRuntimeSupportTest {
   @Mock private BucketFactory bucketFactory;
   @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
   @Mock private RandomAccessBucket bucket;
+
+  @Test
+  void defaultPersistentInsertContext_whenRequested_returnsClientContextDefault() {
+    InsertContext defaultInsertContext = mock(InsertContext.class);
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(clientContext.getDefaultPersistentInsertContext()).thenReturn(defaultInsertContext);
+    CoreFcpInsertRuntimeSupport support =
+        new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
+
+    InsertContext actual = support.defaultPersistentInsertContext();
+
+    assertSame(defaultInsertContext, actual);
+    verify(clientContext).getDefaultPersistentInsertContext();
+  }
+
+  @Test
+  void transferAccess_whenRequested_returnsSupplierValue() {
+    CoreFcpInsertRuntimeSupport support =
+        new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
+
+    assertSame(transferAccess, support.transferAccess());
+  }
 
   @Test
   void bucketFactory_whenPersistenceFlagProvided_returnsClientContextFactory() {
@@ -68,5 +105,58 @@ class CoreFcpInsertRuntimeSupportTest {
     assertSame(bucket, actual);
     //noinspection resource
     verify(persistentTempBucketFactory).makeBucket(128L);
+  }
+
+  @Test
+  void directoryExecution_whenSerialized_doesNotCaptureEnclosingRuntimeSupport() throws Exception {
+    ClientPutDirExecutionSpec executionSpec =
+        new ClientPutDirExecutionSpec(
+            newSerializableClientPutDir(),
+            new ClientRequestParams(
+                new FreenetURI("CHK", "target"),
+                "put-dir",
+                0,
+                (short) 1,
+                Persistence.REBOOT,
+                false,
+                null,
+                false),
+            mock(InsertContext.class, withSettings().serializable()),
+            "index.html",
+            null);
+    ManifestPutter putter = mock(ManifestPutter.class, withSettings().serializable());
+
+    ClientPutDirExecution execution = instantiateDirectoryExecution(executionSpec, putter);
+
+    byte[] serialized = serialize(execution);
+
+    assertTrue(serialized.length > 0);
+  }
+
+  private static ClientPutDirExecution instantiateDirectoryExecution(
+      ClientPutDirExecutionSpec executionSpec, ManifestPutter putter) throws Exception {
+    Class<?> executionClass =
+        Class.forName(CoreFcpInsertRuntimeSupport.class.getName() + "$CoreClientPutDirExecution");
+    assertTrue(Modifier.isStatic(executionClass.getModifiers()));
+    Constructor<?> constructor =
+        executionClass.getDeclaredConstructor(
+            ClientPutDirExecutionSpec.class, ManifestPutter.class);
+    constructor.setAccessible(true);
+    return (ClientPutDirExecution) constructor.newInstance(executionSpec, putter);
+  }
+
+  private static ClientPutDir newSerializableClientPutDir() throws Exception {
+    Constructor<ClientPutDir> constructor = ClientPutDir.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    return constructor.newInstance();
+  }
+
+  private static byte[] serialize(Object value) throws Exception {
+    try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+      objectOutput.writeObject(value);
+      objectOutput.flush();
+      return output.toByteArray();
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
@@ -1,13 +1,20 @@
 package network.crypta.clients.fcp;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import network.crypta.client.InsertContext;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ContainerInserter;
+import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.ManifestPutter;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
@@ -17,25 +24,29 @@ import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.ManifestElement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
@@ -137,7 +148,7 @@ class ClientPutDirTest {
   @Test
   void start_whenPersistentRequestStarts_updatesCacheAndQueuesTag() throws Exception {
     ClientPutDir putDir = spy(newClientPutDir());
-    ManifestPutter putter = mock(ManifestPutter.class);
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     RequestStatusCache cache = mock(RequestStatusCache.class);
     FCPMessage tagMessage = mock(FCPMessage.class);
@@ -160,7 +171,7 @@ class ClientPutDirTest {
   @Test
   void start_whenAlreadyStarted_doesNothing() throws Exception {
     ClientPutDir putDir = newClientPutDir();
-    ManifestPutter putter = mock(ManifestPutter.class);
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
     setField(ClientPutDir.class, putDir, "putter", putter);
     setField(ClientRequest.class, putDir, "started", true);
 
@@ -172,7 +183,7 @@ class ClientPutDirTest {
   @Test
   void start_whenPutterThrowsInsertException_invokesOnFailure() throws Exception {
     ClientPutDir putDir = spy(newClientPutDir());
-    ManifestPutter putter = mock(ManifestPutter.class);
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
     InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
     doThrow(failure).when(putter).start(any());
     setField(ClientPutDir.class, putDir, "putter", putter);
@@ -188,13 +199,14 @@ class ClientPutDirTest {
   void innerResume_whenManifestPresent_delegatesToContainerInserter() throws Exception {
     ClientPutDir putDir = newClientPutDir();
     Map<String, Object> manifest = new HashMap<>();
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
     setField(ClientPutDir.class, putDir, "manifestElements", manifest);
+    setField(ClientPutDir.class, putDir, "putter", putter);
     ClientContext context = mock(ClientContext.class);
 
-    try (MockedStatic<ContainerInserter> mocked = mockStatic(ContainerInserter.class)) {
-      putDir.innerResume(context);
-      mocked.verify(() -> ContainerInserter.resumeMetadata(manifest, context));
-    }
+    putDir.innerResume(context);
+
+    verify(putter).resumeMetadata(manifest, context);
   }
 
   @Test
@@ -217,10 +229,44 @@ class ClientPutDirTest {
   @Test
   void canRestart_whenFinishedAndFailed_returnsTrue() throws Exception {
     ClientPutDir putDir = newClientPutDir();
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
     setField(ClientRequest.class, putDir, "finished", true);
     setField(ClientPutBase.class, putDir, "succeeded", false);
+    setField(ClientPutDir.class, putDir, "putter", putter);
+    when(putter.canRestart()).thenReturn(true);
 
     assertTrue(putDir.canRestart());
+  }
+
+  @Test
+  void restart_whenPersistentRequestRestarts_requeuesTagAndUpdatesCache() throws Exception {
+    ClientPutDir putDir = spy(newClientPutDir());
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    FCPMessage tagMessage = mock(FCPMessage.class);
+    ClientContext context = mock(ClientContext.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    when(putter.canRestart()).thenReturn(true);
+    when(putter.restart(context)).thenReturn(true);
+    doReturn(tagMessage).when(putDir).persistentTagMessage();
+    setField(ClientPutDir.class, putDir, "putter", putter);
+    setField(ClientRequest.class, putDir, "identifier", "dir-restart");
+    setField(ClientRequest.class, putDir, "persistence", ClientRequest.Persistence.REBOOT);
+    setField(ClientRequest.class, putDir, "client", client);
+    setField(ClientRequest.class, putDir, "finished", true);
+    setField(ClientPutBase.class, putDir, "succeeded", false);
+    setField(ClientPutBase.class, putDir, "generatedURI", mock(FreenetURI.class));
+
+    boolean restarted = putDir.restart(context, false);
+
+    assertTrue(restarted);
+    assertNull(getField(ClientPutBase.class, putDir, "generatedURI"));
+    assertTrue((boolean) getField(ClientRequest.class, putDir, "started"));
+    InOrder order = inOrder(cache);
+    order.verify(cache).updateStarted("dir-restart", false);
+    order.verify(cache).updateStarted("dir-restart", true);
+    verify(client).queueClientRequestMessage(tagMessage, 0);
   }
 
   @Test
@@ -231,7 +277,7 @@ class ClientPutDirTest {
   @Test
   void requestWasRemoved_whenForeverPersistence_clearsPutter() throws Exception {
     ClientPutDir putDir = newClientPutDir();
-    ManifestPutter putter = mock(ManifestPutter.class);
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
     setField(ClientPutDir.class, putDir, "putter", putter);
     setField(ClientRequest.class, putDir, "persistence", ClientRequest.Persistence.FOREVER);
     setField(ClientRequest.class, putDir, "client", persistentRequestClient);
@@ -242,12 +288,85 @@ class ClientPutDirTest {
     assertNull(getField(ClientPutDir.class, putDir, "putter"));
     verify(persistentRequestClient)
         .queueClientRequestMessage(any(PersistentRequestRemovedMessage.class), anyInt());
-    verify(putter, never()).cancel(any());
+    verifyNoInteractions(putter);
   }
 
   @Test
   void fullyResumed_alwaysReturnsFalse() {
     assertFalse(newClientPutDir().fullyResumed());
+  }
+
+  @Test
+  void serializationFields_whenInspected_keepLegacyManifestPutterType() {
+    ObjectStreamClass descriptor = ObjectStreamClass.lookup(ClientPutDir.class);
+
+    assertEquals(
+        "network.crypta.client.async.ManifestPutter",
+        descriptor.getField("putter").getType().getName());
+  }
+
+  @Test
+  void serialization_whenRoundTripped_restoresExecutionFromLegacyManifestPutter() throws Exception {
+    ClientPutDir putDir = newClientPutDir();
+    ManifestPutter legacyPutter = mock(ManifestPutter.class, withSettings().serializable());
+    ClientPutDirExecution execution = mock(ClientPutDirExecution.class);
+    when(execution.requester()).thenReturn(legacyPutter);
+    setField(ClientPutDir.class, putDir, "putter", execution);
+    setField(ClientPutDir.class, putDir, "manifestElements", new HashMap<>());
+    setField(ClientPutDir.class, putDir, "defaultName", "index.html");
+    setField(
+        ClientPutBase.class,
+        putDir,
+        "ctx",
+        mock(InsertContext.class, withSettings().serializable()));
+    setField(ClientRequest.class, putDir, "identifier", "put-dir");
+    setField(ClientRequest.class, putDir, "uri", new FreenetURI("CHK", "target"));
+    setField(ClientRequest.class, putDir, "persistence", ClientRequest.Persistence.REBOOT);
+
+    ClientPutDir restored = roundTrip(putDir);
+
+    assertInstanceOf(ClientPutDirExecution.class, getField(ClientPutDir.class, restored, "putter"));
+    assertInstanceOf(ManifestPutter.class, restored.getClientRequest());
+  }
+
+  @Test
+  void
+      serialization_whenExecutionRequesterIsNotLegacyManifestPutter_throwsNotSerializableException()
+          throws Exception {
+    ClientPutDir putDir = newClientPutDir();
+    ClientRequester requester = mock(ClientRequester.class, withSettings().serializable());
+    ClientPutDirExecution execution = mock(ClientPutDirExecution.class);
+    when(execution.requester()).thenReturn(requester);
+    setField(ClientPutDir.class, putDir, "putter", execution);
+
+    assertThrows(NotSerializableException.class, () -> roundTrip(putDir));
+  }
+
+  @Test
+  void executionSpecPriorityClass_whenRequestReprioritized_returnsCurrentPriority()
+      throws Exception {
+    ClientPutDir putDir = newClientPutDir();
+    Map<String, Object> manifest = new HashMap<>();
+    setField(ClientRequest.class, putDir, "priorityClass", (short) 6);
+    setField(ClientPutDir.class, putDir, "manifestElements", manifest);
+    ClientPutDirExecutionSpec spec =
+        new ClientPutDirExecutionSpec(
+            putDir,
+            new ClientRequestParams(
+                new FreenetURI("CHK", "target"),
+                "put-dir",
+                0,
+                (short) 1,
+                ClientRequest.Persistence.REBOOT,
+                false,
+                null,
+                false),
+            mock(InsertContext.class, withSettings().serializable()),
+            "index.html",
+            null);
+
+    assertEquals(6, spec.priorityClass());
+    assertSame(manifest, spec.manifestElements());
   }
 
   private static ClientPutDir newClientPutDir() {
@@ -277,6 +396,20 @@ class ClientPutDirTest {
     Field field = owner.getDeclaredField(name);
     field.setAccessible(true);
     return field.get(target);
+  }
+
+  private static ClientPutDir roundTrip(ClientPutDir value) throws Exception {
+    byte[] serialized;
+    try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+      objectOutput.writeObject(value);
+      objectOutput.flush();
+      serialized = output.toByteArray();
+    }
+    try (ObjectInputStream objectInput =
+        new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      return (ClientPutDir) objectInput.readObject();
+    }
   }
 
   private static final Field MANIFEST_ELEMENTS_FIELD;

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
@@ -1,29 +1,19 @@
 package network.crypta.clients.fcp;
 
-import java.lang.reflect.Field;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
 import network.crypta.client.async.ClientPutCallback;
-import network.crypta.client.async.ClientPutter;
-import network.crypta.client.async.ClientPutterOptions;
-import network.crypta.client.async.ClientPutterRequest;
-import network.crypta.client.async.InsertRequestParams;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.support.io.ArrayBucket;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class ClientPutPutterFactoryTest {
   private static final String VALID_CHK =
@@ -31,42 +21,37 @@ class ClientPutPutterFactoryTest {
           + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
 
   @Test
-  void create_whenValidInput_returnsConfiguredPutter() throws Exception {
+  void create_whenExecutionSpecProvided_delegatesToRuntimeSupport() throws Exception {
     ClientPutCallback callback = mock(ClientPutCallback.class);
     RequestClient requestClient = mock(RequestClient.class);
     when(callback.getRequestClient()).thenReturn(requestClient);
+    FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
+    ClientPutExecution execution = mock(ClientPutExecution.class);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            new FreenetURI(VALID_CHK),
+            "identifier",
+            0,
+            (short) 3,
+            ClientRequest.Persistence.CONNECTION,
+            false,
+            "token",
+            false);
+    ClientPutExecutionSpec executionSpec =
+        new ClientPutExecutionSpec(
+            callback,
+            requestParams,
+            new InsertContext(InsertContextOptions.builder().build()),
+            new ArrayBucket(),
+            new ClientMetadata("text/plain"),
+            true,
+            new ClientPutExecutionSpec.ExecutionOptions(
+                "file.txt", true, new byte[] {1, 2, 3}, 42L));
+    when(runtimeSupport.createSingleFileExecution(executionSpec)).thenReturn(execution);
 
-    ClientMetadata metadata = new ClientMetadata("text/plain");
-    ArrayBucket data = new ArrayBucket();
-    FreenetURI targetUri = new FreenetURI(VALID_CHK);
-    InsertContext insertContext = new InsertContext(InsertContextOptions.builder().build());
-    ClientPutterRequest request =
-        new ClientPutterRequest(
-            new InsertRequestParams(callback, targetUri, insertContext, (short) 3),
-            data,
-            metadata,
-            true);
-    byte[] overrideCrypto = new byte[] {1, 2, 3};
-    ClientPutterOptions options = new ClientPutterOptions("file.txt", true, overrideCrypto, 42L);
+    ClientPutExecution actual = ClientPutPutterFactory.create(runtimeSupport, executionSpec);
 
-    ClientPutter putter = ClientPutPutterFactory.create(request, options);
-
-    assertNotNull(putter);
-    assertSame(callback, getField(putter, "callback"));
-    assertSame(data, getField(putter, "data"));
-    assertSame(targetUri, getField(putter, "targetURI"));
-    assertSame(metadata, getField(putter, "cm"));
-    assertSame(insertContext, getField(putter, "ctx"));
-    assertEquals("file.txt", getField(putter, "targetFilename"));
-    assertTrue((Boolean) getField(putter, "binaryBlob"));
-    assertSame(overrideCrypto, getField(putter, "overrideSplitfileCrypto"));
-    assertEquals(42L, getField(putter, "metadataThreshold"));
-    assertTrue((Boolean) getField(putter, "isMetadata"));
-  }
-
-  private static Object getField(ClientPutter putter, String name) throws Exception {
-    Field field = ClientPutter.class.getDeclaredField(name);
-    field.setAccessible(true);
-    return field.get(putter);
+    assertSame(execution, actual);
+    verify(runtimeSupport).createSingleFileExecution(executionSpec);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
@@ -1,6 +1,12 @@
 package network.crypta.clients.fcp;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.lang.reflect.Field;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext.CompatibilityMode;
@@ -10,6 +16,7 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientPutter;
+import network.crypta.client.async.ClientRequester;
 import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.clients.fcp.ClientPut.COMPRESS_STATE;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
@@ -26,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,6 +47,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
@@ -204,7 +213,7 @@ class ClientPutTest {
 
   @Test
   void start_whenPersistentRequestStarts_updatesCacheAndQueuesTag() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     ClientContext context = mock(ClientContext.class);
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     RequestStatusCache cache = mock(RequestStatusCache.class);
@@ -219,7 +228,7 @@ class ClientPutTest {
 
     put.start(context);
 
-    verify(putter).start(false, context);
+    verify(putter).start(context);
     verify(client).queueClientRequestMessage(tagMessage, 0);
     verify(cache).updateStarted("start-id", true);
     assertTrue((boolean) getField(ClientRequest.class, put, "started"));
@@ -227,7 +236,7 @@ class ClientPutTest {
 
   @Test
   void start_whenPutterThrowsInsertException_invokesOnFailure() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     ClientContext context = mock(ClientContext.class);
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
@@ -235,7 +244,7 @@ class ClientPutTest {
     setField(ClientPut.class, put, "putter", putter);
     setField(ClientRequest.class, put, "persistence", Persistence.REBOOT);
     setField(ClientRequest.class, put, "client", client);
-    doThrow(failure).when(putter).start(false, context);
+    doThrow(failure).when(putter).start(context);
 
     put.start(context);
 
@@ -255,13 +264,14 @@ class ClientPutTest {
 
   @Test
   void innerResume_whenPutterPresent_reappliesDiagnosticIdentifier() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientRequester requester = mock(ClientRequester.class);
+    ClientPutExecution putter = createExecution(requester);
     setField(ClientPut.class, clientPut, "putter", putter);
     ClientContext context = mock(ClientContext.class);
 
     clientPut.innerResume(context);
 
-    verify(putter).setExternalRequestIdentifier("fcp:test-id");
+    verify(requester).setExternalRequestIdentifier("fcp:test-id");
   }
 
   @Test
@@ -277,7 +287,7 @@ class ClientPutTest {
 
   @Test
   void canRestart_whenNotFinished_returnsFalse() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     setField(ClientPut.class, clientPut, "putter", putter);
     setField(ClientRequest.class, clientPut, "finished", false);
 
@@ -287,7 +297,7 @@ class ClientPutTest {
 
   @Test
   void canRestart_whenSucceeded_returnsFalse() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     setField(ClientPut.class, clientPut, "putter", putter);
     setField(ClientRequest.class, clientPut, "finished", true);
     setField(ClientPutBase.class, clientPut, "succeeded", true);
@@ -298,7 +308,7 @@ class ClientPutTest {
 
   @Test
   void canRestart_whenDelegateAllows_returnsDelegateDecision() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     setField(ClientPut.class, clientPut, "putter", putter);
     setField(ClientRequest.class, clientPut, "finished", true);
     setField(ClientPutBase.class, clientPut, "succeeded", false);
@@ -309,7 +319,7 @@ class ClientPutTest {
 
   @Test
   void restart_whenDelegateSucceeds_updatesCacheAndState() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     ClientContext context = mock(ClientContext.class);
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     RequestStatusCache cache = mock(RequestStatusCache.class);
@@ -334,7 +344,7 @@ class ClientPutTest {
 
   @Test
   void restart_whenDelegateThrowsInsertException_invokesOnFailure() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     ClientContext context = mock(ClientContext.class);
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     setField(ClientPut.class, clientPut, "putter", putter);
@@ -369,7 +379,7 @@ class ClientPutTest {
 
   @Test
   void requestWasRemoved_whenForeverPersistence_clearsPutter() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientPutExecution putter = createExecution();
     PersistentRequestClient client = mock(PersistentRequestClient.class);
     setField(ClientPut.class, clientPut, "putter", putter);
     setField(ClientRequest.class, clientPut, "persistence", Persistence.FOREVER);
@@ -386,10 +396,11 @@ class ClientPutTest {
 
   @Test
   void getClientRequest_whenPutterSet_returnsPutter() throws Exception {
-    ClientPutter putter = mock(ClientPutter.class);
+    ClientRequester requester = mock(ClientRequester.class);
+    ClientPutExecution putter = createExecution(requester);
     setField(ClientPut.class, clientPut, "putter", putter);
 
-    assertSame(putter, clientPut.getClientRequest());
+    assertSame(requester, clientPut.getClientRequest());
   }
 
   @Test
@@ -417,6 +428,39 @@ class ClientPutTest {
     assertFalse(clientPut.fullyResumed());
   }
 
+  @Test
+  void serializationFields_whenInspected_keepLegacyClientPutterType() {
+    ObjectStreamClass descriptor = ObjectStreamClass.lookup(ClientPut.class);
+
+    assertEquals(
+        "network.crypta.client.async.ClientPutter",
+        descriptor.getField("putter").getType().getName());
+  }
+
+  @Test
+  void serialization_whenRoundTripped_restoresExecutionFromLegacyClientPutter() throws Exception {
+    ClientPutter legacyPutter = mock(ClientPutter.class, withSettings().serializable());
+    ClientPutExecution execution = createExecution(legacyPutter);
+    setField(ClientPut.class, clientPut, "putter", execution);
+    setField(ClientPut.class, clientPut, "uploadFrom", ClientPutBase.UploadFrom.DIRECT);
+
+    ClientPut restored = roundTrip(clientPut);
+
+    assertInstanceOf(ClientPutExecution.class, getField(ClientPut.class, restored, "putter"));
+    assertInstanceOf(ClientPutter.class, restored.getClientRequest());
+  }
+
+  @Test
+  void serialization_whenExecutionRequesterIsNotLegacyClientPutter_throwsNotSerializableException()
+      throws Exception {
+    ClientRequester requester = mock(ClientRequester.class, withSettings().serializable());
+    ClientPutExecution execution = createExecution(requester);
+    setField(ClientPut.class, clientPut, "putter", execution);
+    setField(ClientPut.class, clientPut, "uploadFrom", ClientPutBase.UploadFrom.DIRECT);
+
+    assertThrows(NotSerializableException.class, () -> roundTrip(clientPut));
+  }
+
   private static void setField(Class<?> owner, Object target, String name, Object value)
       throws ReflectiveOperationException {
     Field field = owner.getDeclaredField(name);
@@ -429,5 +473,29 @@ class ClientPutTest {
     Field field = owner.getDeclaredField(name);
     field.setAccessible(true);
     return field.get(target);
+  }
+
+  private static ClientPutExecution createExecution() {
+    return mock(ClientPutExecution.class);
+  }
+
+  private static ClientPutExecution createExecution(ClientRequester requester) {
+    ClientPutExecution execution = mock(ClientPutExecution.class);
+    when(execution.requester()).thenReturn(requester);
+    return execution;
+  }
+
+  private static ClientPut roundTrip(ClientPut value) throws Exception {
+    byte[] serialized;
+    try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+      objectOutput.writeObject(value);
+      objectOutput.flush();
+      serialized = output.toByteArray();
+    }
+    try (ObjectInputStream objectInput =
+        new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      return (ClientPut) objectInput.readObject();
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -49,8 +49,6 @@ class FCPConnectionHandlerTest {
   @Mock private Socket socket;
   @Mock private RuntimePorts runtimePorts;
   @Mock private RandomnessPort randomnessPort;
-  @Mock private FcpInsertRuntimeSupport insertRuntimeSupport;
-
   private FCPConnectionHandler handler;
 
   @BeforeEach
@@ -61,9 +59,7 @@ class FCPConnectionHandlerTest {
     lenient().when(server.serverRuntimeSupport()).thenReturn(serverRuntimeSupport);
     lenient().when(serverRuntimeSupport.clientContext()).thenReturn(clientContext);
     lenient().when(server.runtime()).thenReturn(runtimePorts);
-    lenient().when(server.insertRuntimeSupport()).thenReturn(insertRuntimeSupport);
     lenient().when(runtimePorts.randomness()).thenReturn(randomnessPort);
-    lenient().when(insertRuntimeSupport.clientContext()).thenReturn(clientContext);
     lenient()
         .doAnswer(
             invocation -> {

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -4,7 +4,6 @@ import network.crypta.client.InsertContext;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.USKManager;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.bridge.CoreFcpServerDependenciesFactory;
 import network.crypta.crypt.RandomSource;
@@ -38,7 +37,6 @@ class FCPServerTest {
   @Mock private TransferAccessPort coreTransferAccess;
   @Mock private ClientContext clientContext;
   @Mock private InsertContext insertContext;
-  @Mock private USKManager uskManager;
   @Mock private TempBucketFactory tempBucketFactory;
   @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
   @Mock private RandomSource randomSource;
@@ -65,7 +63,6 @@ class FCPServerTest {
     lenient().when(coreRuntimePorts.transferAccess()).thenReturn(coreTransferAccess);
     lenient().when(core.getClientContext()).thenReturn(clientContext);
     lenient().when(clientContext.getDefaultPersistentInsertContext()).thenReturn(insertContext);
-    lenient().when(core.getUskManager()).thenReturn(uskManager);
     lenient().when(core.getTempBucketFactory()).thenReturn(tempBucketFactory);
     lenient().when(core.getPersistentTempBucketFactory()).thenReturn(persistentTempBucketFactory);
     lenient().when(core.getRandom()).thenReturn(randomSource);
@@ -291,13 +288,11 @@ class FCPServerTest {
   }
 
   @Test
-  void insertRuntimeSupport_whenContextServicesQueried_delegatesToCore() {
+  void insertRuntimeSupport_whenInsertDefaultsQueried_delegatesToCore() {
     FCPServer server = newServer(false, false);
     FcpInsertRuntimeSupport support = server.insertRuntimeSupport();
 
-    assertSame(clientContext, support.clientContext());
     assertSame(insertContext, support.defaultPersistentInsertContext());
-    assertSame(uskManager, support.uskManager());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKMessageTest.java
@@ -1,7 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.USKManager;
-import network.crypta.node.RequestClient;
 import network.crypta.node.RequestStarter;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
@@ -18,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -36,11 +34,9 @@ class SubscribeUSKMessageTest {
           + "3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
 
   @Mock private FcpInsertRuntimeSupport runtimeSupport;
-  @Mock private USKManager uskManager;
+  @Mock private UskSubscriptionHandle subscriptionHandle;
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
-  @Mock private PersistentRequestClient rebootClient;
-  @Mock private RequestClient requestClient;
 
   @Test
   void constructor_whenIdentifierMissing_throwsMessageInvalidException() {
@@ -138,8 +134,8 @@ class SubscribeUSKMessageTest {
 
     when(handler.getServer()).thenReturn(server);
     when(server.insertRuntimeSupport()).thenReturn(runtimeSupport);
-    when(runtimeSupport.uskManager()).thenReturn(uskManager);
-    doNothing().when(uskManager).subscribe(any(), any(), anyBoolean(), anyBoolean(), any());
+    when(runtimeSupport.subscribeUSK(eq(message), any(SubscribeUSKCallbacks.class), eq(handler)))
+        .thenReturn(subscriptionHandle);
 
     message.run(handler);
 
@@ -174,8 +170,6 @@ class SubscribeUSKMessageTest {
   }
 
   private void wireHandlerForSuccessfulSubscribe() throws IdentifierCollisionException {
-    lenient().when(handler.getRebootClient()).thenReturn(rebootClient);
-    lenient().when(rebootClient.lowLevelClient(false)).thenReturn(requestClient);
     lenient().when(handler.getServer()).thenReturn(server);
     lenient().when(server.insertRuntimeSupport()).thenReturn(runtimeSupport);
     doNothing().when(handler).addUSKSubscription(any(), any(SubscribeUSK.class));

--- a/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
+++ b/src/test/java/network/crypta/clients/fcp/SubscribeUSKTest.java
@@ -1,13 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.USKFoundEdition;
-import network.crypta.client.async.USKFoundEditionPayload;
-import network.crypta.client.async.USKFoundEditionProgress;
-import network.crypta.client.async.USKManager;
-import network.crypta.client.async.USKSparseProxyCallback;
-import network.crypta.keys.USK;
-import network.crypta.node.RequestClient;
 import network.crypta.support.SimpleFieldSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,85 +25,35 @@ class SubscribeUSKTest {
       "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/";
 
   @Mock private FcpInsertRuntimeSupport runtimeSupport;
-  @Mock private USKManager uskManager;
   @Mock private FCPConnectionHandler handler;
-  @Mock private PersistentRequestClient persistentRequestClient;
-  @Mock private RequestClient requestClient;
-  @Mock private USKSparseProxyCallback sparseProxyCallback;
-  @Mock private ClientContext clientContext;
+  @Mock private UskSubscriptionHandle subscriptionHandle;
 
   @Test
-  void constructor_whenSparsePollRequested_usesSubscribeSparseAndStoresProxyForUnsubscribe()
-      throws Exception {
+  void constructor_whenCreated_registersWithHandlerAndRuntimeSupport() throws Exception {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-sparse", false, true, (short) 5, (short) 4, true, true);
-    mockCommonBehavior();
-    when(uskManager.subscribeSparse(eq(message.key), any(), eq(true), eq(requestClient)))
-        .thenReturn(sparseProxyCallback);
+    when(runtimeSupport.subscribeUSK(eq(message), any(SubscribeUSKCallbacks.class), eq(handler)))
+        .thenReturn(subscriptionHandle);
 
     SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
     verify(handler).addUSKSubscription("id-sparse", subscription);
-    verify(persistentRequestClient).lowLevelClient(true);
-    verify(uskManager).subscribeSparse(message.key, subscription, true, requestClient);
-    verify(uskManager, never()).subscribe(any(USK.class), any(), anyBoolean(), anyBoolean(), any());
+    verify(runtimeSupport).subscribeUSK(message, subscription, handler);
 
     subscription.unsubscribe();
 
-    verify(uskManager).unsubscribe(message.key, sparseProxyCallback);
-  }
-
-  @Test
-  void constructor_whenBackgroundPollingEnabled_subscribesWithPollingAndUsesSelfForUnsubscribe()
-      throws Exception {
-    SubscribeUSKMessage message =
-        buildSubscribeUSKMessage("id-poll", false, false, (short) 6, (short) 5, false, false);
-    mockCommonBehavior();
-
-    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
-
-    verify(handler).addUSKSubscription("id-poll", subscription);
-    verify(persistentRequestClient).lowLevelClient(false);
-    verify(uskManager).subscribe(message.key, subscription, true, false, requestClient);
-    verify(uskManager, never())
-        .subscribeSparse(eq(message.key), eq(subscription), anyBoolean(), eq(requestClient));
-
-    subscription.unsubscribe();
-
-    verify(uskManager).unsubscribe(message.key, subscription);
-  }
-
-  @Test
-  void onFoundEdition_whenHandlerClosed_unsubscribesWithoutSending() throws Exception {
-    SubscribeUSKMessage message =
-        buildSubscribeUSKMessage("id-closed", true, false, (short) 2, (short) 1, false, false);
-    mockCommonBehavior();
-    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
-    when(handler.isClosed()).thenReturn(true);
-
-    subscription.onFoundEdition(
-        new USKFoundEdition(
-            new USKFoundEditionPayload(7L, message.key, false, (short) 1, new byte[0]),
-            clientContext,
-            new USKFoundEditionProgress(true, false)));
-
-    verify(uskManager).unsubscribe(message.key, subscription);
-    verify(handler, never()).send(any());
+    verify(subscriptionHandle).unsubscribe();
   }
 
   @Test
   void onFoundEdition_whenHandlerOpen_sendsSubscribedUSKUpdate() throws Exception {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-open", true, false, (short) 3, (short) 1, false, false);
-    mockCommonBehavior();
+    when(runtimeSupport.subscribeUSK(eq(message), any(SubscribeUSKCallbacks.class), eq(handler)))
+        .thenReturn(subscriptionHandle);
     SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
-    when(handler.isClosed()).thenReturn(false);
 
-    subscription.onFoundEdition(
-        new USKFoundEdition(
-            new USKFoundEditionPayload(12L, message.key, false, (short) 1, null),
-            clientContext,
-            new USKFoundEditionProgress(true, false)));
+    subscription.onFoundEdition(12L, message.key, true, false);
 
     ArgumentCaptor<SubscribedUSKUpdate> captor = ArgumentCaptor.forClass(SubscribedUSKUpdate.class);
     verify(handler).send(captor.capture());
@@ -124,30 +64,32 @@ class SubscribeUSKTest {
     assertSame(message.key, update.key);
     assertTrue(update.newKnownGood);
     assertFalse(update.newSlotToo);
-
-    verify(uskManager, never()).unsubscribe(any(), any());
   }
 
   @Test
   void getPollingPriorityMethods_whenCalled_returnValuesFromMessage() throws Exception {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-prio", true, false, (short) 9, (short) 2, false, false);
-    mockCommonBehavior();
+    when(runtimeSupport.subscribeUSK(eq(message), any(SubscribeUSKCallbacks.class), eq(handler)))
+        .thenReturn(subscriptionHandle);
 
     SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
     assertEquals(9, subscription.getPollingPriorityNormal());
     assertEquals(2, subscription.getPollingPriorityProgress());
+    assertEquals(9, subscription.pollingPriorityNormal());
+    assertEquals(2, subscription.pollingPriorityProgress());
   }
 
   @Test
   void onSendingToNetwork_whenInvoked_sendsSendingToNetworkMessage() throws Exception {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-send", true, false, (short) 1, (short) 0, false, false);
-    mockCommonBehavior();
+    when(runtimeSupport.subscribeUSK(eq(message), any(SubscribeUSKCallbacks.class), eq(handler)))
+        .thenReturn(subscriptionHandle);
     SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
-    subscription.onSendingToNetwork(clientContext);
+    subscription.onSendingToNetwork();
 
     ArgumentCaptor<SubscribedUSKSendingToNetworkMessage> captor =
         ArgumentCaptor.forClass(SubscribedUSKSendingToNetworkMessage.class);
@@ -161,10 +103,11 @@ class SubscribeUSKTest {
   void onRoundFinished_whenInvoked_sendsRoundFinishedMessage() throws Exception {
     SubscribeUSKMessage message =
         buildSubscribeUSKMessage("id-round", true, false, (short) 1, (short) 0, false, false);
-    mockCommonBehavior();
+    when(runtimeSupport.subscribeUSK(eq(message), any(SubscribeUSKCallbacks.class), eq(handler)))
+        .thenReturn(subscriptionHandle);
     SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
 
-    subscription.onRoundFinished(clientContext);
+    subscription.onRoundFinished();
 
     ArgumentCaptor<SubscribedUSKRoundFinishedMessage> captor =
         ArgumentCaptor.forClass(SubscribedUSKRoundFinishedMessage.class);
@@ -174,11 +117,18 @@ class SubscribeUSKTest {
     assertEquals("id-round", finished.getFieldSet().get("Identifier"));
   }
 
-  private void mockCommonBehavior() {
-    when(runtimeSupport.uskManager()).thenReturn(uskManager);
-    when(handler.getRebootClient()).thenReturn(persistentRequestClient);
-    when(persistentRequestClient.lowLevelClient(anyBoolean())).thenReturn(requestClient);
-    lenient().when(requestClient.persistent()).thenReturn(false);
+  @Test
+  void callbackSurface_whenQueried_reflectsCurrentSubscriptionState() throws Exception {
+    SubscribeUSKMessage message =
+        buildSubscribeUSKMessage("id-state", true, false, (short) 7, (short) 6, false, false);
+    when(runtimeSupport.subscribeUSK(eq(message), any(SubscribeUSKCallbacks.class), eq(handler)))
+        .thenReturn(subscriptionHandle);
+    when(handler.isClosed()).thenReturn(true);
+    SubscribeUSK subscription = new SubscribeUSK(message, runtimeSupport, handler);
+
+    assertTrue(subscription.isClosed());
+    assertEquals("id-state", subscription.clientIdentifier());
+    verify(handler, never()).send(any());
   }
 
   private SubscribeUSKMessage buildSubscribeUSKMessage(


### PR DESCRIPTION
## Summary
- narrow the FCP insert seam so `:adapter-fcp` no longer constructs or imports the live PUT, manifest, and USK runtime execution types in the insert family
- move the concrete single-file PUT, directory/manifest PUT, and USK subscription wiring into `:bridge-fcp-runtime` behind adapter-owned execution and subscription handles
- preserve persistent request behavior by keeping legacy serialized putter shapes compatible, requeueing persistent directory tags on restart, and covering the new boundary with focused tests and improved Javadoc on the new seam types

## How to test
- `./gradlew :adapter-fcp:test --tests network.crypta.clients.fcp.AdapterFcpBoundaryTest`
- `./gradlew :test --tests network.crypta.clients.fcp.ClientPutTest --tests network.crypta.clients.fcp.ClientPutDirTest :bridge-fcp-runtime:test --tests network.crypta.clients.fcp.bridge.CoreFcpInsertRuntimeSupportTest`
- `./gradlew test`

## Notes
- base branch: `develop`
- branch: `bugfix/fcp-insert-runtime-handoff`