### PR TITLE
refactor(fcp): Detach requester and insert callback seams

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -12,7 +12,6 @@ import java.io.Serializable;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
@@ -597,17 +596,17 @@ public final class ClientGet extends ClientRequest {
   }
 
   /**
-   * Exposes the underlying {@link ClientRequester} for base-class scheduling operations.
+   * Exposes the underlying requester handle for base-class scheduling operations.
    *
    * <p>The base {@link ClientRequest} infrastructure uses this accessor to determine which
    * requester instance owns the in-flight operation for persistence, cancellation, and stats
    * tracking. The returned object is the request's active requester and should be treated as
    * read-only by callers outside the request lifecycle.
    *
-   * @return client requester instance used to run this request.
+   * @return requester handle used to run this request.
    */
   @Override
-  protected ClientRequester getClientRequest() {
+  protected FcpRequesterHandle getClientRequest() {
     return execution == null ? null : execution.requester();
   }
 
@@ -915,10 +914,10 @@ public final class ClientGet extends ClientRequest {
   /**
    * Returns a textual explanation for the most recent failure, if any.
    *
-   * <p>The summary is derived from the cached {@link GetFailedMessage} and may include additional
-   * diagnostic text when requested. It returns {@code null} when no failure has been recorded,
-   * which typically means the request is still running or has completed successfully. The returned
-   * text is suitable for UI display and is not guaranteed to be stable across versions.
+   * <p>The summary is derived from the cached failure state and may include additional diagnostic
+   * text when requested. It returns {@code null} when no failure has been recorded, which typically
+   * means the request is still running or has completed successfully. The returned text is suitable
+   * for UI display and is not guaranteed to be stable across versions.
    *
    * <p>This accessor does not alter the request state. Callers should treat the value as a snapshot
    * of the last recorded failure rather than a live view of the underlying fetcher.
@@ -929,10 +928,6 @@ public final class ClientGet extends ClientRequest {
   @Override
   public String getFailureReason(boolean longDescription) {
     return helpers().statusReporter().getFailureReason(longDescription);
-  }
-
-  GetFailedMessage getFailureMessage() {
-    return state.getFailedMessage();
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetExecution.java
@@ -5,7 +5,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import network.crypta.client.FetchException;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
@@ -50,16 +49,16 @@ public interface ClientGetExecution extends Serializable {
   void onResume(PersistentRequestRuntimeContext context);
 
   /**
-   * Returns the low-level requester currently backing this execution.
+   * Returns the detached requester handle currently backing this execution.
    *
    * <p>The request lifecycle uses this value for diagnostics, persistent tagging, and other legacy
-   * integration points that still operate on the common requester abstraction. The returned object
-   * belongs to the live runtime execution and should be treated as an observational handle rather
-   * than as an ownership transfer.
+   * integration points that still operate on the common requester abstraction. The returned handle
+   * remains bridge-owned and should be treated as an observational/control handle rather than as an
+   * ownership transfer.
    *
-   * @return runtime-backed requester associated with this fetch attempt.
+   * @return detached requester handle associated with this fetch attempt.
    */
-  ClientRequester requester();
+  FcpRequesterHandle requester();
 
   /**
    * Starts the live fetch using the runtime-bound execution context.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertException;
 import network.crypta.client.MetadataUnresolvedException;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -43,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @see ClientPutBase
- * @see ClientRequester
+ * @see FcpRequesterHandle
  */
 public final class ClientPut extends ClientPutBase {
   /** Logger for lifecycle and diagnostic messages. */
@@ -459,7 +458,7 @@ public final class ClientPut extends ClientPutBase {
     if (putter == null) {
       return null;
     }
-    Object requester = putter.requester();
+    Object requester = putter.legacySerializableRequester();
     if (requester == null) {
       return null;
     }
@@ -479,6 +478,33 @@ public final class ClientPut extends ClientPutBase {
     } catch (ClassNotFoundException e) {
       throw new ExceptionInInitializerError(e);
     }
+  }
+
+  ClientRequestParams currentRequestParams() {
+    return new ClientRequestParams(
+        publicURI,
+        identifier,
+        verbosity,
+        priorityClass,
+        persistence,
+        isRealTime(),
+        clientToken,
+        client.isGlobalQueue);
+  }
+
+  ClientPutUpload persistentUploadDescriptor() {
+    return new ClientPutUpload(
+        uploadFrom,
+        origFilename,
+        clientMetadata.getMIMEType(),
+        null,
+        targetURI,
+        targetFilename,
+        binaryBlob);
+  }
+
+  byte[] splitfileCryptoKeyForPersistentTag() {
+    return putter != null ? putter.getSplitfileCryptoKey() : null;
   }
 
   @Override
@@ -529,13 +555,14 @@ public final class ClientPut extends ClientPutBase {
       synchronized (this) {
         started = true;
       }
-      onFailure(e, null);
+      onFailure(e, (FcpInsertCallbackState) null);
     } catch (Exception t) {
       synchronized (this) {
         started = true;
       }
       onFailure(
-          new InsertException(InsertException.InsertExceptionMode.INTERNAL_ERROR, t, null), null);
+          new InsertException(InsertException.InsertExceptionMode.INTERNAL_ERROR, t, null),
+          (FcpInsertCallbackState) null);
     }
   }
 
@@ -552,42 +579,14 @@ public final class ClientPut extends ClientPutBase {
   }
 
   @Override
-  protected ClientRequester getClientRequest() {
+  protected FcpRequesterHandle getClientRequest() {
     return putter == null ? null : putter.requester();
   }
 
   @Override
   protected FCPMessage persistentTagMessage() {
     if (putter == null) LOG.warn("putter == null");
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            publicURI,
-            identifier,
-            verbosity,
-            priorityClass,
-            persistence,
-            isRealTime(),
-            clientToken,
-            client.isGlobalQueue);
-    PersistentPutRequestMetadata metadata =
-        new PersistentPutRequestMetadata(
-            uri,
-            started,
-            ctx.getMaxInsertRetries(),
-            this.ctx.getCompatibilityMode(),
-            this.ctx.isDontCompress(),
-            this.ctx.getCompressorDescriptor(),
-            putter != null ? putter.getSplitfileCryptoKey() : null);
-    ClientPutUpload upload =
-        new ClientPutUpload(
-            uploadFrom,
-            origFilename,
-            clientMetadata.getMIMEType(),
-            null,
-            targetURI,
-            targetFilename,
-            binaryBlob);
-    return new PersistentPut(requestParams, upload, metadata, getDataSize());
+    return new ClientPutPersistentTagBuilder(this).persistentTagMessage();
   }
 
   /**
@@ -758,8 +757,8 @@ public final class ClientPut extends ClientPutBase {
    * <p>Before scheduling the new attempt, the method resets the local state, updates status caches,
    * and notifies observers that the request left the finished state. Failures during {@link
    * ClientPutExecution} startup are handed to {@link ClientPutBase#onFailure(InsertException,
-   * network.crypta.client.async.BaseClientPutter)} so retry logic remains consistent with the
-   * normal start path. The method returns immediately if the request is not eligible for restart.
+   * FcpInsertCallbackState)} so retry logic remains consistent with the normal start path. The
+   * method returns immediately if the request is not eligible for restart.
    *
    * @param context execution context containing shared schedulers and crypto factories; must not be
    *     {@code null} and should be active.
@@ -792,7 +791,7 @@ public final class ClientPut extends ClientPutBase {
       }
       return true;
     } catch (InsertException e) {
-      onFailure(e, null);
+      onFailure(e, (FcpInsertCallbackState) null);
       return false;
     }
   }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -12,8 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
-import network.crypta.client.async.BaseClientPutter;
-import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.events.ClientEvent;
 import network.crypta.client.events.ClientEventDispatchContext;
 import network.crypta.client.events.ClientEventListener;
@@ -33,10 +31,9 @@ import org.slf4j.LoggerFactory;
  * wiring FCP-facing identifiers, scheduling metadata, persistence constraints, and node callbacks
  * into a single state machine. Instances travel through connection-bound and forever-persistent
  * modes, reattaching to {@link network.crypta.client.async.ClientContext ClientContext}s after
- * deserialization, driving {@link BaseClientPutter} progress, and translating internal events into
- * client-visible FCP messages. It is designed to be thread-aware: mutations happen under
- * synchronization, while outbound messages are dispatched via handler abstractions to avoid
- * deadlocks.
+ * deserialization, driving insert progress, and translating internal events into client-visible FCP
+ * messages. It is designed to be thread-aware: mutations happen under synchronization, while
+ * outbound messages are dispatched via handler abstractions to avoid deadlocks.
  *
  * <p>Typical usage involves subclassing to provide data-specific logic (single file or directory
  * tree) while relying on {@code ClientPutBase} to manage retries, metadata capture, and reporting.
@@ -54,7 +51,9 @@ import org.slf4j.LoggerFactory;
  * @see ClientPutDir
  */
 public abstract class ClientPutBase extends ClientRequest
-    implements ClientPutCallback, ClientEventListener {
+    implements FcpInsertCallback,
+        ClientEventListener,
+        network.crypta.client.async.ClientPutCallback {
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutBase.class);
   private static final String LEGACY_INSERT_CONTEXT_TYPE = "network.crypta.client.InsertContext";
   private static final String FIELD_SUCCEEDED = "succeeded";
@@ -109,8 +108,8 @@ public abstract class ClientPutBase extends ClientRequest
 
   /**
    * Final URI published by the inserter. The field remains {@code null} until {@link
-   * #onGeneratedURI(FreenetURI, BaseClientPutter)} runs, after which it never changes. Subclasses
-   * and clients should treat it as immutable and safe for reuse across threads.
+   * #onGeneratedURI(FreenetURI, FcpInsertCallbackState)} runs, after which it never changes.
+   * Subclasses and clients should treat it as immutable and safe for reuse across threads.
    */
   protected FreenetURI generatedURI;
 
@@ -329,7 +328,7 @@ public abstract class ClientPutBase extends ClientRequest
    * simply triggers {@link #cancel(network.crypta.client.async.ClientContext)
    * cancel(ClientContext)} for requests that were declared {@link Persistence#CONNECTION}.
    * Persistent and forever requests ignore the event because they expect to be resumed through
-   * {@link network.crypta.client.async.ClientRequester} after deserialization.
+   * their detached requester handle after deserialization.
    *
    * @param context client context that supplies cancellation helpers and resource pools; the value
    *     may be reused across many requests and must not be {@code null}
@@ -353,7 +352,7 @@ public abstract class ClientPutBase extends ClientRequest
    *     debugging
    */
   @Override
-  public void onSuccess(BaseClientPutter state) {
+  public void onSuccess(FcpInsertCallbackState state) {
     FreenetURI resolvedGeneratedUri = generatedUriOrFallback(state);
     synchronized (this) {
       // Including these helps with certain bugs...
@@ -372,7 +371,12 @@ public abstract class ClientPutBase extends ClientRequest
     if (client != null) client.notifySuccess(this);
   }
 
-  private FreenetURI generatedUriOrFallback(BaseClientPutter state) {
+  @Override
+  public final void onSuccess(network.crypta.client.async.BaseClientPutter state) {
+    onSuccess(legacyState(state));
+  }
+
+  private FreenetURI generatedUriOrFallback(FcpInsertCallbackState state) {
     synchronized (this) {
       if (generatedURI != null) {
         return generatedURI;
@@ -403,7 +407,7 @@ public abstract class ClientPutBase extends ClientRequest
    * @param state inserter that triggered the failure; used only for logging context
    */
   @Override
-  public void onFailure(InsertException e, BaseClientPutter state) {
+  public void onFailure(InsertException e, FcpInsertCallbackState state) {
     if (finished) return;
     synchronized (this) {
       started = true; // Keep the started flag set for resume compatibility.
@@ -419,6 +423,12 @@ public abstract class ClientPutBase extends ClientRequest
     if (client != null) client.notifyFailure(this);
   }
 
+  @Override
+  public final void onFailure(
+      InsertException e, network.crypta.client.async.BaseClientPutter state) {
+    onFailure(e, legacyState(state));
+  }
+
   /**
    * Accepts the newly derived final URI from the inserter and propagates it to listeners and caches
    * exactly once.
@@ -432,7 +442,7 @@ public abstract class ClientPutBase extends ClientRequest
    * @param state inserter providing the URI; used for diagnostics only
    */
   @Override
-  public void onGeneratedURI(FreenetURI uri, BaseClientPutter state) {
+  public void onGeneratedURI(FreenetURI uri, FcpInsertCallbackState state) {
     synchronized (this) {
       if (generatedURI != null) {
         if (!uri.equals(generatedURI))
@@ -453,12 +463,18 @@ public abstract class ClientPutBase extends ClientRequest
     }
   }
 
+  @Override
+  public final void onGeneratedURI(
+      FreenetURI uri, network.crypta.client.async.BaseClientPutter state) {
+    onGeneratedURI(uri, legacyState(state));
+  }
+
   /**
    * Returns the final URI assigned to this insert once {@link #onGeneratedURI(FreenetURI,
-   * BaseClientPutter)} has run. Callers should treat the value as immutable and thread-safe because
-   * access is synchronized, and they should avoid caching {@code null} results since future calls
-   * may return a valid URI after the inserter finishes. The method never throws and therefore fits
-   * polling loops or status pages.
+   * FcpInsertCallbackState)} has run. Callers should treat the value as immutable and thread-safe
+   * because access is synchronized, and they should avoid caching {@code null} results since future
+   * calls may return a valid URI after the inserter finishes. The method never throws and therefore
+   * fits polling loops or status pages.
    *
    * @return generated URI or {@code null} when the insert has not produced one yet
    */
@@ -478,7 +494,7 @@ public abstract class ClientPutBase extends ClientRequest
    * @param state inserter reporting metadata generation; used for logging context only
    */
   @Override
-  public void onGeneratedMetadata(Bucket metadata, BaseClientPutter state) {
+  public void onGeneratedMetadata(Bucket metadata, FcpInsertCallbackState state) {
     boolean delete = false;
     synchronized (this) {
       if (generatedURI != null)
@@ -495,6 +511,12 @@ public abstract class ClientPutBase extends ClientRequest
     } else {
       trySendGeneratedMetadataMessage(metadata, null, null);
     }
+  }
+
+  @Override
+  public final void onGeneratedMetadata(
+      Bucket metadata, network.crypta.client.async.BaseClientPutter state) {
+    onGeneratedMetadata(metadata, legacyState(state));
   }
 
   /**
@@ -545,8 +567,8 @@ public abstract class ClientPutBase extends ClientRequest
   }
 
   /**
-   * Consumes asynchronous events emitted by {@link BaseClientPutter} and converts them into a
-   * stable stream of FCP messages according to the active verbosity mask.
+   * Consumes asynchronous events emitted by the live insert runtime and converts them into a stable
+   * stream of FCP messages according to the active verbosity mask.
    *
    * <p>The method is careful to short-circuit quickly when the request has already finished. It
    * handles four event types—splitfile progress, compression start/end, and expected hashes—and
@@ -634,11 +656,11 @@ public abstract class ClientPutBase extends ClientRequest
    * when clients prefer minimal updates. It is safe to call even when the final URI has not been
    * persisted yet because the method reads the current value under synchronization.
    *
-   * @param putter inserter announcing fetchability; it is not dereferenced here but kept for API
-   *     symmetry with the callback interface
+   * @param state minimal bridge-owned state view announcing fetchability; it is not dereferenced
+   *     here but kept for API symmetry with the callback interface
    */
   @Override
-  public void onFetchable(BaseClientPutter putter) {
+  public void onFetchable(FcpInsertCallbackState state) {
     if (finished) return;
     if ((verbosity & VERBOSITY_PUT_FETCHABLE) == VERBOSITY_PUT_FETCHABLE) {
       FreenetURI temp;
@@ -647,6 +669,29 @@ public abstract class ClientPutBase extends ClientRequest
       }
       PutFetchableMessage msg = new PutFetchableMessage(identifier, global, temp);
       trySendProgressMessage(msg, VERBOSITY_PUT_FETCHABLE, null);
+    }
+  }
+
+  @Override
+  public final void onFetchable(network.crypta.client.async.BaseClientPutter state) {
+    onFetchable(legacyState(state));
+  }
+
+  private static FcpInsertCallbackState legacyState(
+      network.crypta.client.async.BaseClientPutter state) {
+    return state == null ? null : new LegacyInsertCallbackState(state);
+  }
+
+  private record LegacyInsertCallbackState(network.crypta.client.async.BaseClientPutter putter)
+      implements FcpInsertCallbackState {
+    @Override
+    public FreenetURI getURI() {
+      return putter.getURI();
+    }
+
+    @Override
+    public String toString() {
+      return putter.toString();
     }
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -16,7 +16,6 @@ import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.Metadata;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.ManifestElement;
@@ -371,7 +370,7 @@ public final class ClientPutDir extends ClientPutBase {
     if (putter == null) {
       return null;
     }
-    Object requester = putter.requester();
+    Object requester = putter.legacySerializableRequester();
     if (requester == null) {
       return null;
     }
@@ -533,7 +532,7 @@ public final class ClientPutDir extends ClientPutBase {
       }
     } catch (InsertException e) {
       started = true;
-      onFailure(e, null);
+      onFailure(e, (FcpInsertCallbackState) null);
     }
   }
 
@@ -583,7 +582,7 @@ public final class ClientPutDir extends ClientPutBase {
   }
 
   /**
-   * Exposes the underlying {@link ClientRequester} so schedulers can introspect progress.
+   * Exposes the underlying requester handle so schedulers can introspect progress.
    *
    * <p>The manifest putter encapsulates all block scheduling and retry logic. Returning it here
    * lets the superclass manage cross-cutting behaviors such as throttling, serialization, and
@@ -591,11 +590,11 @@ public final class ClientPutDir extends ClientPutBase {
    * {@link #freeData()} runs or the request completes, the putter may be {@code null} and should
    * not be reused.
    *
-   * @return currently active requester coordinating splitfile inserts, or {@code null} when torn
-   *     down.
+   * @return currently active requester handle coordinating splitfile inserts, or {@code null} when
+   *     torn down.
    */
   @Override
-  protected ClientRequester getClientRequest() {
+  protected FcpRequesterHandle getClientRequest() {
     return putter == null ? null : putter.requester();
   }
 
@@ -765,7 +764,7 @@ public final class ClientPutDir extends ClientPutBase {
         }
       }
     } catch (InsertException e) {
-      this.onFailure(e, null);
+      this.onFailure(e, (FcpInsertCallbackState) null);
       return false;
     }
     if (client != null) {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecution.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.io.Serializable;
 import network.crypta.client.InsertException;
-import network.crypta.client.async.ClientRequester;
 
 /**
  * Opaque adapter-owned handle for one live single-file insert execution.
@@ -23,15 +22,27 @@ import network.crypta.client.async.ClientRequester;
 public interface ClientPutExecution extends Serializable {
 
   /**
-   * Returns the low-level requester backing this execution.
+   * Returns the detached requester handle backing this execution.
    *
-   * <p>The adapter uses the requester for generic request bookkeeping such as diagnostics, cache
-   * updates, and priority changes. Callers should treat the returned object as a bridge-owned live
-   * state and should not assume that its concrete type is stable across implementations.
+   * <p>The adapter uses the handle for generic request bookkeeping such as diagnostics, cache
+   * updates, and priority changes. Callers should treat the returned object as a bridge-owned
+   * runtime control surface and should not assume that its concrete type is stable across
+   * implementations.
    *
-   * @return live requester that currently backs this insert execution
+   * @return detached requester handle that currently backs this insert execution
    */
-  ClientRequester requester();
+  FcpRequesterHandle requester();
+
+  /**
+   * Returns the legacy runtime requester object that must be written into older serialized fields.
+   *
+   * <p>{@link ClientPut} and {@link ClientPutDir} still preserve Java-serialization compatibility
+   * by writing the original runtime putter object into their legacy serial fields. The adapter uses
+   * this opaque hook instead of importing the runtime requester type directly.
+   *
+   * @return legacy runtime requester object suitable for legacy serialization, or {@code null}
+   */
+  Object legacySerializableRequester();
 
   /**
    * Starts the live insert execution in the supplied client context.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecutionSpec.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecutionSpec.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.async.ClientPutCallback;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.RandomAccessBucket;
 
@@ -20,7 +19,7 @@ import network.crypta.support.api.RandomAccessBucket;
  */
 public final class ClientPutExecutionSpec {
   /** Callback surface that receives progress, completion, and failure notifications. */
-  private final ClientPutCallback callback;
+  private final FcpInsertCallback callback;
 
   /** Detached request identity and persistence metadata for the insert. */
   private final ClientRequestParams requestParams;
@@ -57,7 +56,7 @@ public final class ClientPutExecutionSpec {
    * @param executionOptions nested option group containing single-file putter settings
    */
   public ClientPutExecutionSpec(
-      ClientPutCallback callback,
+      FcpInsertCallback callback,
       ClientRequestParams requestParams,
       FcpInsertContextHandle insertContext,
       RandomAccessBucket data,
@@ -81,7 +80,7 @@ public final class ClientPutExecutionSpec {
    *
    * @return callback to use for this single-file insert execution
    */
-  public ClientPutCallback callback() {
+  public FcpInsertCallback callback() {
     return callback;
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutPersistentTagBuilder.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutPersistentTagBuilder.java
@@ -1,0 +1,81 @@
+package network.crypta.clients.fcp;
+
+import java.util.Objects;
+
+/**
+ * Builds the replayable {@link PersistentPut} tag for a {@link ClientPut}.
+ *
+ * <p>{@link ClientPut} still owns the mutable insert lifecycle, the bridge-owned live execution,
+ * and the Java-serialization hooks that preserve older persistent-request formats. This helper
+ * isolates just the FCP-facing tag assembly step so the request class does not also need to know
+ * how the stable {@code PersistentPut} wire payload is reconstructed. Callers typically use it when
+ * replaying a running request to a reconnecting client or when re-emitting the persistent tag
+ * before cached progress and completion messages.
+ *
+ * <p>The builder is deliberately shallow and read-only. It samples the request's current detached
+ * request parameters, upload descriptor, insert-tuning metadata, and best-known data size, then
+ * packages those values into a fresh {@link PersistentPut}. It never mutates the request, caches
+ * state, or retains derived objects between calls, so repeated invocations simply reflect the
+ * request snapshot visible at that moment.
+ *
+ * <p>The field mapping intentionally mirrors the historical in-request construction logic. That
+ * keeps the FCP wire representation stable while letting the larger request class shed one cohesive
+ * responsibility and a few type-level dependencies.
+ *
+ * <ul>
+ *   <li>Reads detached request metadata from the current {@link ClientPut} snapshot.
+ *   <li>Preserves the established {@link PersistentPut} field layout and semantics.
+ *   <li>Produces a new message instance for each call so callers can queue or mutate it safely.
+ * </ul>
+ *
+ * @see ClientPut
+ * @see PersistentPut
+ */
+final class ClientPutPersistentTagBuilder {
+  /** Request whose persistent insert state is being rendered into a tag message. */
+  private final ClientPut request;
+
+  /**
+   * Creates a builder bound to one insert request snapshot source.
+   *
+   * <p>The builder stores only the owning request reference and derives all message content lazily
+   * when {@link #persistentTagMessage()} runs. It does not capture a frozen snapshot at
+   * construction time, so callers should create the builder near the point where they need the
+   * resulting tag.
+   *
+   * @param request request whose current persistent-tag state should be rendered into a {@link
+   *     PersistentPut} message
+   */
+  ClientPutPersistentTagBuilder(ClientPut request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  /**
+   * Builds the current persistent tag message for the request.
+   *
+   * <p>The returned {@link PersistentPut} preserves the existing FCP tag layout. It carries the
+   * detached request parameters exposed to clients, the current upload descriptor, the insert
+   * tuning values held in {@link ClientPutBase#ctx}, and the best-known data size for the payload.
+   * The message is assembled from the request's current fields, so callers can use it for replay
+   * and status publication without manually duplicating the mapping logic in multiple places.
+   *
+   * @return fresh {@link PersistentPut} message suitable for queue replay, reconnect handling, or
+   *     other status publication paths that need the persistent insert tag
+   */
+  FCPMessage persistentTagMessage() {
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            request.uri,
+            request.started,
+            request.ctx.getMaxInsertRetries(),
+            request.ctx.getCompatibilityMode(),
+            request.ctx.isDontCompress(),
+            request.ctx.getCompressorDescriptor(),
+            request.splitfileCryptoKeyForPersistentTag());
+    return new PersistentPut(
+        request.currentRequestParams(),
+        request.persistentUploadDescriptor(),
+        metadata,
+        request.getDataSize());
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -7,7 +7,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Locale;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
@@ -50,7 +49,7 @@ import static network.crypta.clients.fcp.RequestIdentifier.RequestType.GET;
  *
  * @see RequestIdentifier
  * @see PersistentRequestClient
- * @see ClientRequester
+ * @see FcpRequesterHandle
  */
 public abstract class ClientRequest implements Serializable, PersistentRequestHandle {
   private static final Logger LOG = LoggerFactory.getLogger(ClientRequest.class);
@@ -458,19 +457,19 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   /**
    * Cancels this request and releases any associated resources.
    *
-   * <p>If the underlying {@link ClientRequester} is still active it is asked to cancel itself via
-   * the supplied {@link ClientContext}. Persistent state and any cached buckets are then freed by
+   * <p>If the underlying requester handle is still active, it is asked to cancel itself via the
+   * supplied {@link ClientContext}. Persistent state and any cached buckets are then freed by
    * calling {@link #freeData()}. This method is idempotent and may be invoked after completion when
    * the caller no longer cares about remaining notifications.
    *
    * @param context client context used when propagating the cancellation into the core node
    */
   public void cancel(ClientContext context) {
-    ClientRequester cr = getClientRequest();
+    FcpRequesterHandle requester = getClientRequest();
     // It might have been finished on startup.
     if (LOG.isDebugEnabled())
-      LOG.debug("Cancelling {} for {} persistence = {}", cr, this, persistence);
-    if (cr != null) cr.cancel(context);
+      LOG.debug("Cancelling {} for {} persistence = {}", requester, this, persistence);
+    if (requester != null) requester.cancel(context);
     freeData();
   }
 
@@ -547,11 +546,11 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   }
 
   /**
-   * Assigns this request's diagnostics identifier to a low-level requester.
+   * Assigns this request's diagnostics identifier to a detached requester handle.
    *
    * @param requester requester that should carry the diagnostics identifier
    */
-  protected final void applyDiagnosticIdentifier(ClientRequester requester) {
+  protected final void applyDiagnosticIdentifier(FcpRequesterHandle requester) {
     if (requester == null) {
       return;
     }
@@ -559,15 +558,15 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   }
 
   /**
-   * Returns the underlying {@link ClientRequester} that performs the actual network work.
+   * Returns the underlying requester handle that performs the actual network work.
    *
    * <p>Subclasses typically create a concrete requester in {@link #start(ClientContext)} and return
    * it here so that lifecycle callbacks such as {@link #cancel(ClientContext)} and {@link
    * #onShutdown(ClientContext)} can delegate to it.
    *
-   * @return currently associated requester instance, or {@code null} when no requester is active
+   * @return currently associated requester handle, or {@code null} when no requester is active
    */
-  protected abstract ClientRequester getClientRequest();
+  protected abstract FcpRequesterHandle getClientRequest();
 
   /**
    * Invoked when a completed request is dropped without explicit client acknowledgement.
@@ -714,7 +713,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * Returns whether this request has completed successfully according to the subclass semantics.
    *
    * <p>Implementations typically base this on internal counters or status codes reported by the
-   * {@link ClientRequester}. It must return {@code false} while the request is still running.
+   * requester handle. It must return {@code false} while the request is still running.
    *
    * @return {@code true} when the request has finished and was considered successful
    */
@@ -787,7 +786,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
       return false;
     }
     priorityClass = newPriorityClass;
-    ClientRequester requester = getClientRequest();
+    FcpRequesterHandle requester = getClientRequest();
     requester.setPriorityClass(priorityClass, server.serverRuntimeSupport().clientContext());
     if (client != null) {
       RequestStatusCache cache = client.getRequestStatusCache();
@@ -1055,8 +1054,8 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   /**
    * Reconnects this request to runtime services after it has been deserialized.
    *
-   * <p>This method is invoked by the owning {@link ClientRequester} immediately after the request
-   * has been read from persistent storage. It recreates transient collaborators such as the {@link
+   * <p>This method is invoked by the owning requester immediately after the request has been read
+   * from persistent storage. It recreates transient collaborators such as the {@link
    * PersistentRequestClient}, low-level {@link RequestClient} and any subclass state via {@link
    * #innerResume(ClientContext)} before registering the request with the persistent-request
    * coordinator again.
@@ -1073,8 +1072,8 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   /**
    * Reconnects this request to runtime services after it has been deserialized.
    *
-   * <p>This method is invoked by the owning {@link ClientRequester} immediately after the request
-   * has been read from persistent storage. It recreates transient collaborators such as the {@link
+   * <p>This method is invoked by the owning requester immediately after the request has been read
+   * from persistent storage. It recreates transient collaborators such as the {@link
    * PersistentRequestClient}, low-level {@link RequestClient} and any subclass state via {@link
    * #innerResume(ClientContext)} before registering the request with the persistent-request
    * coordinator again.
@@ -1089,8 +1088,8 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
             context.persistentRequestCoordinator.getOrCreateClientHandle(global, clientName));
     lowLevelClient = client.lowLevelClient(realTime);
     innerResume(context);
-    ClientRequester req = getClientRequest();
-    if (req != null) req.onResume(context); // Can legally be null.
+    FcpRequesterHandle requester = getClientRequest();
+    if (requester != null) requester.onResume(context); // Can legally be null.
     context.persistentRequestCoordinator.resumePersistentRequest(this, global, clientName);
   }
 
@@ -1098,8 +1097,8 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * Performs subclass-specific reattachment work during {@link #onResume(ClientContext)}.
    *
    * <p>Implementations should recreate transient structures that cannot be serialized directly,
-   * such as bucket references or auxiliary state, but must not call back into the {@link
-   * ClientRequester} tree to avoid recursion.
+   * such as bucket references or auxiliary state, but must not call back into the requester tree to
+   * avoid recursion.
    *
    * @param context client context providing access to node-wide services required to resume
    * @throws ResumeFailedException if required, resources cannot be reacquired during resumption
@@ -1150,7 +1149,8 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    *
    * @param dis input stream positioned at the start of a client-detail record
    * @param reqID identifier describing the request type and queue used during serialization
-   * @param fetchRuntimeSupport fetch runtime support used to rebuild detached GET execution state
+   * @param fetchRuntimeSupport fetch runtime support used to rebuild the detached GET execution
+   *     state
    * @param context client context used to create any dependent objects during restart
    * @param checker checksum helper responsible for validating the integrity of the serialized data
    * @return reconstructed request instance, or {@code null} when the type is not supported here
@@ -1176,7 +1176,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    *
    * <p>Subclasses can override this hook to flush any outstanding state to disk or perform
    * bookkeeping that cannot be recovered automatically after restart. The default implementation
-   * forwards the call to the underlying {@link ClientRequester}, if present.
+   * forwards the call to the underlying requester handle, if present.
    *
    * @param context client context giving access to persistence mechanisms used during shutdown
    */
@@ -1190,12 +1190,12 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    *
    * <p>Subclasses can override this hook to flush any outstanding state to disk or perform
    * bookkeeping that cannot be recovered automatically after restart. The default implementation
-   * forwards the call to the underlying {@link ClientRequester}, if present.
+   * forwards the call to the underlying requester handle, if present.
    *
    * @param context client context giving access to persistence mechanisms used during shutdown
    */
   public void onShutdown(ClientContext context) {
-    ClientRequester request = getClientRequest();
-    if (request != null) request.onShutdown(context);
+    FcpRequesterHandle requester = getClientRequest();
+    if (requester != null) requester.onShutdown(context);
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallback.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallback.java
@@ -1,0 +1,160 @@
+package network.crypta.clients.fcp;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
+import network.crypta.client.InsertException;
+import network.crypta.client.async.ClientContext;
+import network.crypta.crypt.ChecksumChecker;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ResumeFailedException;
+
+/**
+ * Adapter-owned callback contract for live insert lifecycle events.
+ *
+ * <p>This interface is the adapter-side replacement for the runtime {@code ClientPutCallback}. The
+ * bridge runtime owns the concrete daemon inserter and adapts that inserter back to this detached
+ * surface, which lets {@code :adapter-fcp} react to insert progress without importing the
+ * runtime-owned callback or putter classes directly. In practice, implementations are long-lived
+ * request objects such as {@link ClientPutBase} descendants that need to survive reconnections,
+ * Java serialization, and persistent-request resume.
+ *
+ * <p>The contract deliberately mixes two kinds of responsibilities. First, it carries the
+ * user-visible lifecycle events that the FCP layer exposes, such as generated URIs, metadata-only
+ * completion, fetchable hints, terminal success, and terminal failure. Second, because persistent
+ * requests still serialize a higher-level client description, it also exposes the small recovery
+ * hooks needed to resume and identify the owning request across restarts. That combination keeps
+ * the seam narrow while preserving the historical persistent-request behavior.
+ *
+ * <p>Implementations should treat the callback as request-scoped rather than reusable. The bridge
+ * may call these methods on runtime worker threads, so implementors should avoid long blocking work
+ * and should treat the supplied {@link FcpInsertCallbackState} as a transient, read-only snapshot
+ * of the current live putter.
+ *
+ * <ul>
+ *   <li>Receives user-visible insert lifecycle notifications from the bridge runtime.
+ *   <li>Provides persistent-request resume and serialization hooks for the owning request.
+ *   <li>Hides the concrete runtime {@code ClientPutCallback} and putter types from the adapter.
+ * </ul>
+ */
+public interface FcpInsertCallback extends Serializable {
+
+  /**
+   * Stable serialization version for callback implementations that survive persistent-request
+   * snapshots.
+   */
+  @Serial long serialVersionUID = 1L;
+
+  /**
+   * Reattaches transient runtime collaborators after persistent-request resume.
+   *
+   * <p>Persistent FCP requests are Java-serialized and later rebound to a fresh daemon runtime. The
+   * bridge invokes this hook during that resume flow so the owning request can recreate any
+   * transient state that depends on the live {@link ClientContext}, such as persistent-request
+   * coordinator handles, bucket factories, or scheduler-facing state.
+   *
+   * @param context live client context supplied during resume; it carries the runtime services
+   *     needed to reattach the owning request safely
+   * @throws ResumeFailedException if the request cannot rebind its transient collaborators and
+   *     should therefore fail, resume rather than continue in a partially attached state
+   */
+  void onResume(ClientContext context) throws ResumeFailedException;
+
+  /**
+   * Returns the low-level request client associated with the owning request.
+   *
+   * <p>The bridge forwards this identity into the runtime inserter, so scheduling and persistence
+   * continue to attribute work to the same logical FCP client. Implementations should therefore
+   * return the stable request-scoped {@link RequestClient}, not an ephemeral wrapper created for a
+   * single callback invocation.
+   *
+   * @return low-level request client for the owning request; callers expect the same logical
+   *     identity across the lifetime of a persistent request
+   */
+  RequestClient getRequestClient();
+
+  /**
+   * Writes compact client detail used by persistent request serialization.
+   *
+   * <p>The runtime requester still persists a higher-level summary of the owning request so it can
+   * be reconstructed even when a full Java object graph cannot be trusted. This hook lets the
+   * adapter-owned request encode that compact description while the bridge continues to own the
+   * live inserter and callback adaptation.
+   *
+   * @param dos destination stream for the client detail payload; implementations should append only
+   *     the request-owned recovery detail and leave stream lifecycle management to the caller
+   * @param checker checksum helper used during serialization to protect the emitted recovery data
+   * @throws IOException if writing the persistent client detail fails
+   */
+  void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException;
+
+  /**
+   * Reports successful insert completion.
+   *
+   * <p>This is the terminal success signal for the current insert attempt. The supplied state may
+   * expose a final URI fallback when the owning request has not yet cached one, but callers should
+   * treat it as a best-effort runtime state rather than a durable object they can retain.
+   *
+   * @param state minimal bridge-owned state view for the live putter, or {@code null} when the
+   *     runtime completed without a state object that can be surfaced through the detached seam
+   */
+  void onSuccess(FcpInsertCallbackState state);
+
+  /**
+   * Reports insert failure.
+   *
+   * <p>This is the terminal failure signal for the current insert attempt. The exception describes
+   * the runtime failure mode, while the optional state can still provide a best-known URI or debug
+   * identity that helps the owning request reconcile partially completed work.
+   *
+   * @param exception failure reported by the runtime insert path; implementations typically convert
+   *     it into FCP-facing failure messages or cached status
+   * @param state minimal bridge-owned state view for the live putter, or {@code null} when no
+   *     detached state snapshot is available
+   */
+  void onFailure(InsertException exception, FcpInsertCallbackState state);
+
+  /**
+   * Reports the final generated URI for the insert.
+   *
+   * <p>The bridge issues this callback as soon as the runtime can expose the stable final URI for
+   * the insert. The owning request can cache the URI immediately and publish it to reconnecting FCP
+   * clients even before the overall insert reports terminal success.
+   *
+   * @param uri generated URI supplied by the runtime insert path; implementations should treat it
+   *     as immutable request output
+   * @param state minimal bridge-owned state view for the live putter, or {@code null} when only the
+   *     generated URI itself is available
+   */
+  void onGeneratedURI(FreenetURI uri, FcpInsertCallbackState state);
+
+  /**
+   * Reports generated metadata produced instead of a final URI.
+   *
+   * <p>Some insert flows return metadata instead of a final URI, for example, when the metadata
+   * falls below the configured threshold. Ownership of the supplied bucket follows the historical
+   * runtime callback behavior: the receiver is responsible for deciding whether to retain, forward,
+   * or free it.
+   *
+   * @param metadata metadata bucket produced by the runtime insert path; implementations should
+   *     treat it as owned by the callback receiver once delivered
+   * @param state minimal bridge-owned state view for the live putter, or {@code null} when no
+   *     detached runtime state snapshot accompanies the metadata
+   */
+  void onGeneratedMetadata(Bucket metadata, FcpInsertCallbackState state);
+
+  /**
+   * Reports that the insert has become fetchable before final completion.
+   *
+   * <p>This is an advisory callback rather than a terminal outcome. It tells the owning request
+   * that the runtime considers the inserted content fetchable already, which is useful for
+   * progress-oriented FCP messages and status pages that want to surface early availability.
+   *
+   * @param state minimal bridge-owned state view for the live putter, or {@code null} when the
+   *     bridge can report fetchability without an accompanying detached state snapshot
+   */
+  void onFetchable(FcpInsertCallbackState state);
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallbackState.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallbackState.java
@@ -1,0 +1,36 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Minimal adapter-owned view of the live insert state that goes with callback events.
+ *
+ * <p>The bridge uses this interface to expose only the tiny subset of runtime putter state that the
+ * adapter still needs after requester and callback detachment. Today that subset is intentionally
+ * small: the owning request may need a best-known URI fallback before it has cached one locally,
+ * and it may want the wrapped object's diagnostic {@link Object#toString()} representation for
+ * logs. Everything else about the live runtime putter stays hidden behind the bridge boundary.
+ *
+ * <p>Implementations should treat this view as ephemeral and observational. Callers should not
+ * cache it as a durable request state, assume it exposes a stable concrete type, or attempt to
+ * mutate the underlying runtime insert machinery through it.
+ *
+ * <ul>
+ *   <li>Supplies the current URI fallback visible from the live runtime putter.
+ *   <li>Leaves debug rendering to the implementation's own {@code toString()}.
+ *   <li>Intentionally omits a broader runtime state to keep the adapter/runtime seam narrow.
+ * </ul>
+ */
+public interface FcpInsertCallbackState {
+
+  /**
+   * Returns the best-known URI currently exposed by the live insert state.
+   *
+   * <p>This is primarily a fallback for request objects that need to publish a URI during success
+   * handling before their own cached generated URI has been populated. The value is advisory and
+   * may still be {@code null} when the runtime has not yet produced a stable URI.
+   *
+   * @return current URI, or {@code null} when the live insert state does not yet expose one
+   */
+  FreenetURI getURI();
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequesterHandle.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequesterHandle.java
@@ -1,0 +1,97 @@
+package network.crypta.clients.fcp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import network.crypta.client.async.ClientContext;
+import network.crypta.support.io.ResumeFailedException;
+
+/**
+ * Adapter-owned control surface for one live runtime requester.
+ *
+ * <p>This interface is the detached requester seam between {@code :adapter-fcp} and the
+ * bridge-owned runtime bindings. The FCP adapter still owns a handful of cross-cutting operations
+ * that apply to both GET and PUT request lifecycles, such as cancellation, priority changes,
+ * diagnostics tagging, persistent-request resume, and orderly shutdown. Rather than exposing the
+ * concrete daemon {@code ClientRequester} type directly, the bridge wraps that runtime object in an
+ * implementation of this interface and hands the adapter only this narrow control handle.
+ *
+ * <p>The handle is request-scoped and serializable because persistent FCP requests may retain an
+ * execution object across Java serialization and later rebind it to a fresh daemon runtime. The
+ * interface therefore avoids broad inspection methods and focuses on the specific operations the
+ * adapter still needs to perform during request orchestration. Callers should treat implementations
+ * as opaque bridge-owned objects and should not rely on any concrete type, identity, or
+ * thread-affinity beyond the declared methods.
+ *
+ * <ul>
+ *   <li>Lets the adapter cancel or reprioritize an in-flight runtime requester.
+ *   <li>Preserves resume and shutdown hooks for persistent-request lifecycle management.
+ *   <li>Keeps the concrete runtime requester type out of the adapter module's API surface.
+ * </ul>
+ */
+public interface FcpRequesterHandle extends Serializable {
+
+  /** Stable serialization version for bridge-owned requester-handle implementations. */
+  @Serial long serialVersionUID = 1L;
+
+  /**
+   * Requests cancellation of the underlying runtime work.
+   *
+   * <p>This is the detached equivalent of invoking cancellation on the runtime requester directly.
+   * The supplied {@link ClientContext} provides the live runtime services needed to stop work and
+   * release any request-owned state cleanly.
+   *
+   * @param context live client context used by the runtime requester when performing cancellation
+   */
+  void cancel(ClientContext context);
+
+  /**
+   * Updates the scheduling priority class on the underlying runtime requester.
+   *
+   * <p>FCP clients can mutate request priority after a request has been accepted. This hook lets
+   * the adapter forward that change through the bridge without learning about the concrete runtime
+   * requester implementation.
+   *
+   * @param priorityClass new priority class to apply to the underlying runtime requester
+   * @param context live client context used by the runtime requester while applying the new
+   *     scheduling priority
+   */
+  void setPriorityClass(short priorityClass, ClientContext context);
+
+  /**
+   * Assigns an external diagnostics identifier to the underlying runtime requester.
+   *
+   * <p>The adapter uses this for FCP-visible identifiers and logging correlation. Implementations
+   * should forward the value directly to the runtime requester and tolerate {@code null} when the
+   * caller wants to clear the diagnostic tag.
+   *
+   * @param externalRequestIdentifier diagnostics identifier, or {@code null} when no external tag
+   *     should remain on the runtime requester
+   */
+  void setExternalRequestIdentifier(String externalRequestIdentifier);
+
+  /**
+   * Rebinds transient runtime collaborators after deserialization.
+   *
+   * <p>Persistent FCP requests may deserialize with an execution object that still needs to
+   * reconnect to a fresh daemon runtime. The adapter invokes this hook during request resume so the
+   * bridge can reattach any transient runtime collaborators behind the detached requester seam.
+   *
+   * @param context live client context supplied during persistent-request resume; it carries the
+   *     runtime services needed to rebind the underlying requester
+   * @throws ResumeFailedException if the runtime requester cannot be reattached safely during
+   *     persistent-request resume
+   */
+  void onResume(ClientContext context) throws ResumeFailedException;
+
+  /**
+   * Invokes the runtime requester's shutdown hook.
+   *
+   * <p>This is used during node or request shutdown flows to give the runtime requester a final
+   * chance to flush, detach, or release transient state that depends on the live {@link
+   * ClientContext}. Implementations should treat the call as best-effort cleanup rather than as a
+   * normal lifecycle transition.
+   *
+   * @param context live client context supplied during shutdown
+   */
+  void onShutdown(ClientContext context);
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.ListPersistentRequestsMessage.PersistentListJob;
@@ -252,14 +251,14 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
   }
 
   private void handleDownloadCompletion(ClientGet download) {
-    GetFailedMessage msg = download.getFailureMessage();
+    GetFailedMessage failureMessage = download.state().getFailedMessage();
     FetchExceptionMode failureCode = null;
     String shortFailMessage = null;
     String longFailMessage = null;
-    if (msg != null) {
-      failureCode = msg.failureMode;
-      shortFailMessage = msg.getShortFailedMessage();
-      longFailMessage = msg.getLongFailedMessage();
+    if (failureMessage != null) {
+      failureCode = failureMessage.failureMode;
+      shortFailMessage = failureMessage.getShortFailedMessage();
+      longFailMessage = failureMessage.getLongFailedMessage();
     }
     Bucket shadow = download.getBucket();
     if (shadow != null) shadow = shadow.createShadow();
@@ -860,13 +859,13 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
   }
 
   /**
-   * Appends the {@link ClientRequester} objects for all tracked requests to the supplied list.
+   * Appends the requester handles for all tracked requests to the supplied list.
    *
-   * @param requesters destination list that will be populated with requesters from running and
-   *     completed requests; must not be {@code null}.
+   * @param requesters destination list that will be populated with requester handles from running
+   *     and completed requests; must not be {@code null}.
    */
   @SuppressWarnings("unused")
-  public void addPersistentRequesters(List<ClientRequester> requesters) {
+  public void addPersistentRequesters(List<FcpRequesterHandle> requesters) {
     for (ClientRequest req : runningPersistentRequests) requesters.add(req.getClientRequest());
     for (ClientRequest req : completedUnackedRequests) requesters.add(req.getClientRequest());
   }

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -167,6 +167,11 @@ class AdapterFcpBoundaryTest {
           "network.crypta.client.async.USKFoundEdition",
           "network.crypta.client.async.USKManager",
           "network.crypta.client.async.USKProgressCallback");
+  private static final Set<String> FORBIDDEN_REQUESTER_CALLBACK_IMPORTS =
+      Set.of(
+          "network.crypta.client.async.BaseClientPutter",
+          "network.crypta.client.async.ClientPutCallback",
+          "network.crypta.client.async.ClientRequester");
   private static final Set<Path> GET_RUNTIME_SEAM_SOURCES =
       Set.of(
           FCP_FETCH_RUNTIME_SUPPORT_SOURCE,
@@ -447,6 +452,31 @@ class AdapterFcpBoundaryTest {
     assertTrue(
         violations.isEmpty(),
         "Insert-family adapter sources must not import live runtime insert execution types."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void adapterFcpMain_whenScanningRequesterCallbackImports_expectNoLiveRequesterOrCallbackLeaks()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+    Path adapterFcpMain = repoRoot.resolve(ADAPTER_FCP_MAIN_JAVA);
+
+    for (Path sourceFile : findJavaSources(adapterFcpMain)) {
+      Set<String> imports = readImports(sourceFile);
+      Set<String> forbiddenImports = new TreeSet<>(imports);
+      forbiddenImports.retainAll(FORBIDDEN_REQUESTER_CALLBACK_IMPORTS);
+      if (!forbiddenImports.isEmpty()) {
+        violations.add(
+            repoRoot.relativize(sourceFile) + " -> " + String.join(", ", forbiddenImports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        ":adapter-fcp main sources must not import live requester or insert-callback runtime "
+            + "types."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
   }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
@@ -30,6 +30,7 @@ import network.crypta.clients.fcp.ClientGetExecution;
 import network.crypta.clients.fcp.ClientGetExecutionSpec;
 import network.crypta.clients.fcp.ClientGetFetchConfig;
 import network.crypta.clients.fcp.FcpFetchRuntimeSupport;
+import network.crypta.clients.fcp.FcpRequesterHandle;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
 import network.crypta.keys.FreenetURI;
@@ -227,6 +228,7 @@ record CoreFcpFetchRuntimeSupport(
 
     private transient Supplier<ClientContext> clientContextSupplier;
     private final ClientGetter getter;
+    private FcpRequesterHandle requesterHandle;
 
     private CoreClientGetExecution(
         Supplier<ClientContext> clientContextSupplier, ClientGetExecutionSpec executionSpec)
@@ -240,11 +242,15 @@ record CoreFcpFetchRuntimeSupport(
               callback, executionSpec.uri(), fetchContext, executionSpec.priorityClass());
       ClientGetterOptions options = createOptions(executionSpec, fetchContext);
       this.getter = new ClientGetter(getterRequest, options);
+      this.requesterHandle = new CoreRequesterHandle(getter);
     }
 
     @Override
-    public ClientRequester requester() {
-      return getter;
+    public FcpRequesterHandle requester() {
+      if (requesterHandle == null) {
+        requesterHandle = new CoreRequesterHandle(getter);
+      }
+      return requesterHandle;
     }
 
     @Override
@@ -305,6 +311,18 @@ record CoreFcpFetchRuntimeSupport(
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
       in.defaultReadObject();
       clientContextSupplier = null;
+      if (requesterHandle == null) {
+        requesterHandle = new CoreRequesterHandle(getter);
+      }
+    }
+
+    private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {
+      if (context instanceof ClientContext clientContext) {
+        return clientContext;
+      }
+      String contextType = context == null ? "null" : context.getClass().getName();
+      throw new IllegalArgumentException(
+          "FCP GET execution resume requires ClientContext but got " + contextType);
     }
 
     private ClientGetterOptions createOptions(
@@ -374,19 +392,20 @@ record CoreFcpFetchRuntimeSupport(
     }
   }
 
-  @SuppressWarnings("ClassCanBeRecord")
   private static final class CallbackSuccessExecution implements ClientGetExecution {
     @Serial private static final long serialVersionUID = 1L;
 
     private final ClientGetter getter;
+    private final FcpRequesterHandle requesterHandle;
 
     private CallbackSuccessExecution(ClientGetter getter) {
       this.getter = Objects.requireNonNull(getter);
+      this.requesterHandle = new CoreRequesterHandle(getter);
     }
 
     @Override
-    public ClientRequester requester() {
-      return getter;
+    public FcpRequesterHandle requester() {
+      return requesterHandle;
     }
 
     @Override
@@ -441,12 +460,44 @@ record CoreFcpFetchRuntimeSupport(
     }
   }
 
-  private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {
-    if (context instanceof ClientContext clientContext) {
-      return clientContext;
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class CoreRequesterHandle implements FcpRequesterHandle {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final ClientRequester requester;
+
+    private CoreRequesterHandle(ClientRequester requester) {
+      this.requester = Objects.requireNonNull(requester);
     }
-    String contextType = context == null ? "null" : context.getClass().getName();
-    throw new IllegalArgumentException(
-        "FCP GET execution resume requires ClientContext but got " + contextType);
+
+    @Override
+    public void cancel(ClientContext context) {
+      requester.cancel(context);
+    }
+
+    @Override
+    public void setPriorityClass(short priorityClass, ClientContext context) {
+      requester.setPriorityClass(priorityClass, context);
+    }
+
+    @Override
+    public void setExternalRequestIdentifier(String externalRequestIdentifier) {
+      requester.setExternalRequestIdentifier(externalRequestIdentifier);
+    }
+
+    @Override
+    public void onResume(ClientContext context) throws ResumeFailedException {
+      requester.onResume(context);
+    }
+
+    @Override
+    public void onShutdown(ClientContext context) {
+      requester.onShutdown(context);
+    }
+
+    @Override
+    public String toString() {
+      return requester.toString();
+    }
   }
 }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
@@ -1,7 +1,9 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serial;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -9,7 +11,9 @@ import java.util.function.Supplier;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.BaseClientPutter;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientPutterOptions;
 import network.crypta.client.async.ClientPutterRequest;
@@ -21,6 +25,7 @@ import network.crypta.client.async.InsertRequestParams;
 import network.crypta.client.async.ManifestPutter;
 import network.crypta.client.async.ManifestPutterParams;
 import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentClientCallback;
 import network.crypta.client.async.TooManyFilesInsertException;
 import network.crypta.client.async.USKCallback;
 import network.crypta.client.async.USKFoundEdition;
@@ -36,20 +41,25 @@ import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FcpCompatibilityAnalysis;
 import network.crypta.clients.fcp.FcpCompatibilityMode;
 import network.crypta.clients.fcp.FcpInsertBehaviorOptions;
+import network.crypta.clients.fcp.FcpInsertCallback;
+import network.crypta.clients.fcp.FcpInsertCallbackState;
 import network.crypta.clients.fcp.FcpInsertContextHandle;
 import network.crypta.clients.fcp.FcpInsertContextLimits;
 import network.crypta.clients.fcp.FcpInsertOptions;
 import network.crypta.clients.fcp.FcpInsertRuntimeSupport;
 import network.crypta.clients.fcp.FcpInsertTuningOptions;
+import network.crypta.clients.fcp.FcpRequesterHandle;
 import network.crypta.clients.fcp.SubscribeUSKCallbacks;
 import network.crypta.clients.fcp.SubscribeUSKMessage;
 import network.crypta.clients.fcp.UskSubscriptionHandle;
+import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
 import network.crypta.keys.USK;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
+import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.ResumeFailedException;
@@ -290,7 +300,7 @@ record CoreFcpInsertRuntimeSupport(
       ClientPutterRequest putterRequest =
           new ClientPutterRequest(
               new InsertRequestParams(
-                  spec.callback(),
+                  new CoreInsertCallbackAdapter(spec.callback()),
                   spec.targetURI(),
                   toRuntimeInsertContext(spec.insertContext()),
                   spec.requestParams().priorityClass()),
@@ -311,7 +321,12 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public ClientRequester requester() {
+    public FcpRequesterHandle requester() {
+      return new CoreRequesterHandle(putter);
+    }
+
+    @Override
+    public Object legacySerializableRequester() {
       return putter;
     }
 
@@ -348,7 +363,12 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public ClientRequester requester() {
+    public FcpRequesterHandle requester() {
+      return new CoreRequesterHandle(putter);
+    }
+
+    @Override
+    public Object legacySerializableRequester() {
       return putter;
     }
 
@@ -400,7 +420,7 @@ record CoreFcpInsertRuntimeSupport(
     ManifestPutterParams params =
         new ManifestPutterParams(
             new InsertRequestParams(
-                spec.callback(),
+                new CoreInsertCallbackAdapter(spec.callback()),
                 spec.requestParams().uri(),
                 toRuntimeInsertContext(spec.insertContext()),
                 spec.priorityClass()),
@@ -410,6 +430,122 @@ record CoreFcpInsertRuntimeSupport(
             context);
     return DefaultManifestPutter.create(
         params, spec.requestParams().persistence() == Persistence.FOREVER);
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class CoreRequesterHandle implements FcpRequesterHandle {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final ClientRequester requester;
+
+    private CoreRequesterHandle(ClientRequester requester) {
+      this.requester = Objects.requireNonNull(requester);
+    }
+
+    @Override
+    public void cancel(ClientContext context) {
+      requester.cancel(context);
+    }
+
+    @Override
+    public void setPriorityClass(short priorityClass, ClientContext context) {
+      requester.setPriorityClass(priorityClass, context);
+    }
+
+    @Override
+    public void setExternalRequestIdentifier(String externalRequestIdentifier) {
+      requester.setExternalRequestIdentifier(externalRequestIdentifier);
+    }
+
+    @Override
+    public void onResume(ClientContext context) throws ResumeFailedException {
+      requester.onResume(context);
+    }
+
+    @Override
+    public void onShutdown(ClientContext context) {
+      requester.onShutdown(context);
+    }
+
+    @Override
+    public String toString() {
+      return requester.toString();
+    }
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class CoreInsertCallbackAdapter
+      implements ClientPutCallback, PersistentClientCallback, Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final FcpInsertCallback callback;
+
+    private CoreInsertCallbackAdapter(FcpInsertCallback callback) {
+      this.callback = Objects.requireNonNull(callback);
+    }
+
+    @Override
+    public void onGeneratedURI(FreenetURI uri, BaseClientPutter state) {
+      callback.onGeneratedURI(uri, wrapState(state));
+    }
+
+    @Override
+    public void onGeneratedMetadata(Bucket metadata, BaseClientPutter state) {
+      callback.onGeneratedMetadata(metadata, wrapState(state));
+    }
+
+    @Override
+    public void onFetchable(BaseClientPutter state) {
+      callback.onFetchable(wrapState(state));
+    }
+
+    @Override
+    public void onSuccess(BaseClientPutter state) {
+      callback.onSuccess(wrapState(state));
+    }
+
+    @Override
+    public void onFailure(InsertException e, BaseClientPutter state) {
+      callback.onFailure(e, wrapState(state));
+    }
+
+    @Override
+    public void onResume(ClientContext context) throws ResumeFailedException {
+      callback.onResume(context);
+    }
+
+    @Override
+    public RequestClient getRequestClient() {
+      return callback.getRequestClient();
+    }
+
+    @Override
+    public void getClientDetail(DataOutputStream dos, ChecksumChecker checker) throws IOException {
+      callback.getClientDetail(dos, checker);
+    }
+
+    private static FcpInsertCallbackState wrapState(BaseClientPutter state) {
+      return state == null ? null : new CoreInsertCallbackState(state);
+    }
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class CoreInsertCallbackState implements FcpInsertCallbackState {
+    private final BaseClientPutter putter;
+
+    private CoreInsertCallbackState(BaseClientPutter putter) {
+      this.putter = Objects.requireNonNull(putter);
+    }
+
+    @Override
+    public FreenetURI getURI() {
+      return putter.getURI();
+    }
+
+    @Override
+    public String toString() {
+      return putter.toString();
+    }
   }
 
   private final class CoreUskSubscription implements UskSubscriptionHandle {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupportTest.java
@@ -4,6 +4,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.util.function.Supplier;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
@@ -13,6 +17,7 @@ import network.crypta.clients.fcp.ClientGet;
 import network.crypta.clients.fcp.ClientGetExecution;
 import network.crypta.clients.fcp.ClientGetExecutionSpec;
 import network.crypta.clients.fcp.ClientGetFetchConfig;
+import network.crypta.clients.fcp.FcpRequesterHandle;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
@@ -176,8 +181,61 @@ class CoreFcpFetchRuntimeSupportTest {
     verify(clientContext, never()).getBucketFactory(false);
   }
 
+  @Test
+  void requester_whenLegacyExecutionHasNoSerializedHandle_rebuildsHandle() throws Exception {
+    when(request.getRequestClient()).thenReturn(requestClient);
+    when(clientContext.getBucketFactory(false)).thenReturn(transientBucketFactory);
+    when(transientBucketFactory.makeBucket(128L)).thenReturn(bucket);
+    CoreFcpFetchRuntimeSupport support =
+        new CoreFcpFetchRuntimeSupport(clientContext, () -> firstTransferAccess);
+    ClientGetExecution execution = createBinaryBlobExecution(support);
+    Field requesterHandleField = execution.getClass().getDeclaredField("requesterHandle");
+    requesterHandleField.setAccessible(true);
+    requesterHandleField.set(execution, null);
+
+    FcpRequesterHandle rebuilt = execution.requester();
+
+    assertNotNull(rebuilt);
+    assertSame(rebuilt, requesterHandleField.get(execution));
+  }
+
+  @Test
+  void readObject_whenLegacyExecutionHasNoSerializedHandle_rebuildsHandle() throws Exception {
+    when(clientContext.getBucketFactory(false)).thenReturn(transientBucketFactory);
+    when(transientBucketFactory.makeBucket(128L)).thenReturn(bucket);
+    CoreFcpFetchRuntimeSupport support = support();
+    ClientGet serializableRequest = newSerializableRequestForExecution(support);
+    ClientGetExecution execution = createBinaryBlobExecution(support, serializableRequest);
+    Field requesterHandleField = execution.getClass().getDeclaredField("requesterHandle");
+    requesterHandleField.setAccessible(true);
+    requesterHandleField.set(execution, null);
+    byte[] serialized;
+    try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+      objectOutput.writeObject(execution);
+      objectOutput.flush();
+      serialized = output.toByteArray();
+    }
+
+    ClientGetExecution restored;
+    try (ObjectInputStream objectInput =
+        new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      restored = (ClientGetExecution) objectInput.readObject();
+    }
+
+    assertNotNull(restored.requester());
+    Field restoredRequesterHandleField = restored.getClass().getDeclaredField("requesterHandle");
+    restoredRequesterHandleField.setAccessible(true);
+    assertNotNull(restoredRequesterHandleField.get(restored));
+  }
+
   private ClientGetExecution createBinaryBlobExecution(CoreFcpFetchRuntimeSupport support)
       throws Exception {
+    return createBinaryBlobExecution(support, request);
+  }
+
+  private ClientGetExecution createBinaryBlobExecution(
+      CoreFcpFetchRuntimeSupport support, ClientGet request) throws Exception {
     return support.createExecution(
         new ClientGetExecutionSpec(
             request,
@@ -191,6 +249,74 @@ class CoreFcpFetchRuntimeSupportTest {
             null,
             null,
             eventListener));
+  }
+
+  private CoreFcpFetchRuntimeSupport support() {
+    return new CoreFcpFetchRuntimeSupport(clientContext, () -> firstTransferAccess);
+  }
+
+  private ClientGet newSerializableRequestForExecution(CoreFcpFetchRuntimeSupport support)
+      throws Exception {
+    Constructor<ClientGet> constructor = ClientGet.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    ClientGet serializableRequest = constructor.newInstance();
+    setRequestProfile(
+        serializableRequest,
+        withRuntimeFetchSupport(
+            withNoneReturnType(
+                withFetchConfig(getRequestProfile(serializableRequest), binaryBlobFetchConfig())),
+            support));
+    Field lowLevelClientField =
+        network.crypta.clients.fcp.ClientRequest.class.getDeclaredField("lowLevelClient");
+    lowLevelClientField.setAccessible(true);
+    lowLevelClientField.set(serializableRequest, requestClient);
+    return serializableRequest;
+  }
+
+  private static Object withFetchConfig(Object requestProfile, ClientGetFetchConfig fetchConfig)
+      throws Exception {
+    return invokeProfileMethod(
+        requestProfile,
+        "withFetchConfig",
+        new Class<?>[] {ClientGetFetchConfig.class},
+        new Object[] {fetchConfig});
+  }
+
+  private static Object withNoneReturnType(Object requestProfile) throws Exception {
+    return invokeProfileMethod(
+        requestProfile,
+        "withReturnType",
+        new Class<?>[] {ClientGet.ReturnType.class},
+        new Object[] {ClientGet.ReturnType.NONE});
+  }
+
+  private static Object withRuntimeFetchSupport(
+      Object requestProfile, CoreFcpFetchRuntimeSupport support) throws Exception {
+    return invokeProfileMethod(
+        requestProfile,
+        "withRuntimeFetchSupport",
+        new Class<?>[] {Class.forName("network.crypta.clients.fcp.FcpFetchRuntimeSupport")},
+        new Object[] {support});
+  }
+
+  private static Object invokeProfileMethod(
+      Object requestProfile, String name, Class<?>[] parameterTypes, Object[] args)
+      throws Exception {
+    var method = requestProfile.getClass().getDeclaredMethod(name, parameterTypes);
+    method.setAccessible(true);
+    return method.invoke(requestProfile, args);
+  }
+
+  private static Object getRequestProfile(ClientGet target) throws Exception {
+    Field field = target.getClass().getDeclaredField("requestProfile");
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  private static void setRequestProfile(ClientGet target, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField("requestProfile");
+    field.setAccessible(true);
+    field.set(target, value);
   }
 
   private static ClientGetFetchConfig sampleFetchConfig() {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
@@ -6,8 +6,10 @@ import java.io.DataOutputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.client.async.ManifestPutter;
 import network.crypta.client.async.PersistenceDisabledException;
@@ -15,18 +17,22 @@ import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.clients.fcp.ClientPutDir;
 import network.crypta.clients.fcp.ClientPutDirExecution;
 import network.crypta.clients.fcp.ClientPutDirExecutionSpec;
+import network.crypta.clients.fcp.ClientPutExecution;
+import network.crypta.clients.fcp.ClientPutExecutionSpec;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.ClientRequestParams;
 import network.crypta.clients.fcp.DefaultFcpInsertContextHandle;
 import network.crypta.clients.fcp.FcpCompatibilityAnalysis;
 import network.crypta.clients.fcp.FcpCompatibilityMode;
 import network.crypta.clients.fcp.FcpInsertBehaviorOptions;
+import network.crypta.clients.fcp.FcpInsertCallback;
 import network.crypta.clients.fcp.FcpInsertContextHandle;
 import network.crypta.clients.fcp.FcpInsertContextLimits;
 import network.crypta.clients.fcp.FcpInsertOptions;
 import network.crypta.clients.fcp.FcpInsertTuningOptions;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
@@ -271,6 +277,48 @@ class CoreFcpInsertRuntimeSupportTest {
 
     byte[] serialized = serialize(execution);
 
+    assertTrue(serialized.length > 0);
+  }
+
+  @Test
+  void singleFileExecution_whenLegacyPutterSerialized_keepsSerializableCallbackAdapter()
+      throws Exception {
+    FcpInsertCallback callback = mock(FcpInsertCallback.class, withSettings().serializable());
+    RequestClient requestClient = mock(RequestClient.class, withSettings().serializable());
+    RandomAccessBucket uploadBucket = mock(RandomAccessBucket.class, withSettings().serializable());
+    when(callback.getRequestClient()).thenReturn(requestClient);
+    ClientPutExecutionSpec executionSpec =
+        new ClientPutExecutionSpec(
+            callback,
+            new ClientRequestParams(
+                new FreenetURI("CHK", "target"),
+                "put-file",
+                0,
+                (short) 1,
+                Persistence.REBOOT,
+                false,
+                null,
+                false),
+            new DefaultFcpInsertContextHandle(
+                new SimpleEventProducer(),
+                new FcpInsertContextLimits(4, 10, 11),
+                new FcpInsertOptions(
+                    new FcpInsertBehaviorOptions(true, true, true, 9, true, false, true),
+                    new FcpInsertTuningOptions(
+                        true, true, "GZIP", 2, 3, FcpCompatibilityMode.COMPAT_1468),
+                    null)),
+            uploadBucket,
+            new ClientMetadata("text/plain"),
+            false,
+            new ClientPutExecutionSpec.ExecutionOptions("index.html", false, null, -1));
+    CoreFcpInsertRuntimeSupport support =
+        new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
+
+    ClientPutExecution execution = support.createSingleFileExecution(executionSpec);
+    Object legacyPutter = execution.legacySerializableRequester();
+    byte[] serialized = serialize(legacyPutter);
+
+    assertInstanceOf(ClientPutter.class, legacyPutter);
     assertTrue(serialized.length > 0);
   }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -6,7 +6,6 @@ import java.net.Socket;
 import java.nio.file.Path;
 import java.util.Arrays;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -44,7 +43,7 @@ class ClientGetFactoryTest {
 
   @Mock private FcpFetchRuntimeSupport fetchRuntimeSupport;
   @Mock private ClientGetExecution execution;
-  @Mock private ClientRequester requester;
+  @Mock private FcpRequesterHandle requester;
   @Mock private TransferAccessPort transferAccess;
 
   @Test
@@ -464,7 +463,7 @@ class ClientGetFactoryTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return null;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
@@ -425,7 +425,6 @@ class ClientGetPersistenceCodecTest {
     import java.io.File;
     import java.io.Serial;
     import network.crypta.client.async.ClientContext;
-    import network.crypta.client.async.ClientRequester;
     import network.crypta.support.api.Bucket;
     import network.crypta.support.io.ResumeFailedException;
 
@@ -475,7 +474,7 @@ class ClientGetPersistenceCodecTest {
       public void start(ClientContext context) {}
 
       @Override
-      protected ClientRequester getClientRequest() {
+      protected FcpRequesterHandle getClientRequest() {
         return null;
       }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
@@ -257,7 +256,7 @@ class ClientGetTest {
     clientGet.state().setFoundDataMimeType("text/plain");
 
     ClientGetExecution execution = mock(ClientGetExecution.class);
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     when(execution.requester()).thenReturn(requester);
     FcpFetchRuntimeSupport fetchRuntimeSupport = mock(FcpFetchRuntimeSupport.class);
     when(fetchRuntimeSupport.createExecution(any())).thenReturn(execution);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
@@ -8,7 +8,6 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.BaseClientPutter;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.FinishedCompressionEvent;
 import network.crypta.client.events.SimpleEventProducer;
@@ -120,7 +119,7 @@ class ClientPutBaseTest {
   void onSuccess_whenConnectionScoped_freesDataSendsSuccessAndNotifiesClient() throws Exception {
     TestClientPutBase request = new TestClientPutBase();
     PersistentRequestClient client = mock(PersistentRequestClient.class);
-    BaseClientPutter state = mock(BaseClientPutter.class);
+    FcpInsertCallbackState state = mock(FcpInsertCallbackState.class);
     FreenetURI generatedUri = mock(FreenetURI.class);
     setField(ClientRequest.class, request, "identifier", "success-id");
     setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
@@ -143,9 +142,32 @@ class ClientPutBaseTest {
   void onSuccess_whenGeneratedUriMissing_usesStateUriForPutSuccessfulAndStatus() throws Exception {
     TestClientPutBase request = new TestClientPutBase();
     PersistentRequestClient client = mock(PersistentRequestClient.class);
-    BaseClientPutter state = mock(BaseClientPutter.class);
+    FcpInsertCallbackState state = mock(FcpInsertCallbackState.class);
     FreenetURI generatedUri = new FreenetURI("KSK", "fallback-uri");
     setField(ClientRequest.class, request, "identifier", "fallback-id");
+    setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
+    setField(ClientRequest.class, request, "origHandler", handler);
+    setField(ClientRequest.class, request, "client", client);
+    when(state.getURI()).thenReturn(generatedUri);
+
+    request.onSuccess(state);
+
+    ArgumentCaptor<PutSuccessfulMessage> successCaptor =
+        ArgumentCaptor.forClass(PutSuccessfulMessage.class);
+    verify(handler).send(successCaptor.capture());
+    assertSame(generatedUri, request.getGeneratedURI());
+    assertSame(generatedUri, successCaptor.getValue().uri);
+    verify(client).notifySuccess(request);
+  }
+
+  @Test
+  void onSuccess_whenLegacyBaseClientPutterProvided_usesStateUriForPutSuccessfulAndStatus()
+      throws Exception {
+    TestClientPutBase request = new TestClientPutBase();
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    BaseClientPutter state = mock(BaseClientPutter.class);
+    FreenetURI generatedUri = new FreenetURI("KSK", "legacy-fallback-uri");
+    setField(ClientRequest.class, request, "identifier", "legacy-fallback-id");
     setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
     setField(ClientRequest.class, request, "origHandler", handler);
     setField(ClientRequest.class, request, "client", client);
@@ -165,7 +187,7 @@ class ClientPutBaseTest {
   void onFailure_whenConnectionScoped_freesDataSendsFailureAndNotifiesClient() throws Exception {
     TestClientPutBase request = new TestClientPutBase();
     PersistentRequestClient client = mock(PersistentRequestClient.class);
-    BaseClientPutter state = mock(BaseClientPutter.class);
+    FcpInsertCallbackState state = mock(FcpInsertCallbackState.class);
     InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
     setField(ClientRequest.class, request, "identifier", "failure-id");
     setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
@@ -346,7 +368,7 @@ class ClientPutBaseTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return null;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
@@ -192,7 +192,7 @@ class ClientPutDirTest {
 
     putDir.start(mock(ClientContext.class));
 
-    verify(putDir).onFailure(failure, null);
+    verify(putDir).onFailure(failure, (FcpInsertCallbackState) null);
   }
 
   @Test
@@ -310,7 +310,7 @@ class ClientPutDirTest {
     ClientPutDir putDir = newClientPutDir();
     ManifestPutter legacyPutter = mock(ManifestPutter.class, withSettings().serializable());
     ClientPutDirExecution execution = mock(ClientPutDirExecution.class);
-    when(execution.requester()).thenReturn(legacyPutter);
+    when(execution.legacySerializableRequester()).thenReturn(legacyPutter);
     setField(ClientPutDir.class, putDir, "putter", execution);
     setField(ClientPutDir.class, putDir, "manifestElements", new HashMap<>());
     setField(ClientPutDir.class, putDir, "defaultName", "index.html");
@@ -323,7 +323,10 @@ class ClientPutDirTest {
 
     assertInstanceOf(ClientPutDirExecution.class, getField(ClientPutDir.class, restored, "putter"));
     assertInstanceOf(FcpInsertContextHandle.class, getField(ClientPutBase.class, restored, "ctx"));
-    assertInstanceOf(ManifestPutter.class, restored.getClientRequest());
+    ClientPutDirExecution restoredExecution =
+        (ClientPutDirExecution) getField(ClientPutDir.class, restored, "putter");
+    assertInstanceOf(ManifestPutter.class, restoredExecution.legacySerializableRequester());
+    assertInstanceOf(FcpRequesterHandle.class, restored.getClientRequest());
   }
 
   @Test
@@ -333,7 +336,7 @@ class ClientPutDirTest {
     ClientPutDir putDir = newClientPutDir();
     ClientRequester requester = mock(ClientRequester.class, withSettings().serializable());
     ClientPutDirExecution execution = mock(ClientPutDirExecution.class);
-    when(execution.requester()).thenReturn(requester);
+    when(execution.legacySerializableRequester()).thenReturn(requester);
     setField(ClientPutDir.class, putDir, "putter", execution);
 
     assertThrows(NotSerializableException.class, () -> roundTrip(putDir));

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPersistentTagBuilderTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPersistentTagBuilderTest.java
@@ -1,0 +1,186 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import network.crypta.client.ClientMetadata;
+import network.crypta.clients.fcp.ClientPutBase.UploadFrom;
+import network.crypta.clients.fcp.ClientRequest.Persistence;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.RandomAccessBucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"java:S100", "java:S3011"})
+@ExtendWith(MockitoExtension.class)
+class ClientPutPersistentTagBuilderTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void persistentTagMessage_whenAllFieldsPresent_preservesLegacyPersistentPutLayout()
+      throws Exception {
+    FreenetURI publicUri = new FreenetURI("KSK", "public");
+    FreenetURI privateUri = new FreenetURI("KSK", "private");
+    FreenetURI targetUri = new FreenetURI("KSK", "target");
+    File originalFile = tempDir.resolve("upload.bin").toFile();
+    byte[] cryptoKey = new byte[] {0x01, 0x02, 0x0A, (byte) 0xFF};
+    RandomAccessBucket data = mock(RandomAccessBucket.class);
+    when(data.size()).thenReturn(1024L);
+    RequestClient requestClient = requestClient(true);
+    ClientPutExecution putter = mock(ClientPutExecution.class);
+    when(putter.getSplitfileCryptoKey()).thenReturn(cryptoKey);
+
+    ClientPut request = new ClientPut();
+    setField(request, "publicURI", publicUri);
+    setField(request, "uri", privateUri);
+    setField(request, "identifier", "id-123");
+    setField(request, "verbosity", 2);
+    setField(request, "priorityClass", (short) 5);
+    setField(request, "persistence", Persistence.FOREVER);
+    setField(request, "clientToken", "token-abc");
+    setField(request, "started", true);
+    setField(request, "client", new PersistentRequestRoot().getGlobalForeverClient());
+    setField(request, "lowLevelClient", requestClient);
+    setField(request, "ctx", newContext(3, true, "lzma", FcpCompatibilityMode.COMPAT_1468));
+    setField(request, "clientMetadata", new ClientMetadata("text/plain"));
+    setField(request, "uploadFrom", UploadFrom.DISK);
+    setField(request, "origFilename", originalFile);
+    setField(request, "targetURI", targetUri);
+    setField(request, "targetFilename", "target.dat");
+    setField(request, "binaryBlob", true);
+    setField(request, "data", data);
+    setField(request, "putter", putter);
+
+    ClientPutPersistentTagBuilder builder = new ClientPutPersistentTagBuilder(request);
+
+    FCPMessage message = builder.persistentTagMessage();
+
+    SimpleFieldSet fs = message.getFieldSet();
+    assertEquals("id-123", fs.get("Identifier"));
+    assertEquals(publicUri.toString(false, false), fs.get("URI"));
+    assertEquals(privateUri.toString(false, false), fs.get("PrivateURI"));
+    assertEquals("2", fs.get("Verbosity"));
+    assertEquals("5", fs.get("PriorityClass"));
+    assertEquals("disk", fs.get("UploadFrom"));
+    assertEquals("forever", fs.get("Persistence"));
+    assertEquals(originalFile.getAbsolutePath(), fs.get("Filename"));
+    assertEquals(targetUri.toString(), fs.get("TargetURI"));
+    assertEquals("text/plain", fs.get("Metadata.ContentType"));
+    assertEquals("true", fs.get("Global"));
+    assertEquals("1024", fs.get("DataLength"));
+    assertEquals("token-abc", fs.get("ClientToken"));
+    assertEquals("true", fs.get("Started"));
+    assertEquals("3", fs.get("MaxRetries"));
+    assertEquals("target.dat", fs.get("TargetFilename"));
+    assertEquals("true", fs.get("BinaryBlob"));
+    assertEquals("COMPAT_1468", fs.get("CompatibilityMode"));
+    assertEquals("true", fs.get("DontCompress"));
+    assertEquals("lzma", fs.get("Codecs"));
+    assertEquals("true", fs.get("RealTime"));
+    assertEquals("01020aff", fs.get("SplitfileCryptoKey"));
+  }
+
+  @Test
+  void persistentTagMessage_whenOptionalFieldsAbsent_omitsNullableEntriesAndKeepsDefaultMime()
+      throws Exception {
+    ClientPut request = new ClientPut();
+    setField(request, "publicURI", new FreenetURI("KSK", "public"));
+    setField(request, "uri", new FreenetURI("KSK", "private"));
+    setField(request, "identifier", "id-optional");
+    setField(request, "verbosity", 0);
+    setField(request, "priorityClass", (short) 0);
+    setField(request, "persistence", Persistence.REBOOT);
+    setField(request, "clientToken", null);
+    setField(request, "started", false);
+    setField(
+        request,
+        "client",
+        new PersistentRequestClient("client", null, false, null, Persistence.REBOOT, null));
+    setField(request, "lowLevelClient", requestClient(false));
+    setField(request, "ctx", newContext(0, false, null, FcpCompatibilityMode.COMPAT_UNKNOWN));
+    setField(request, "clientMetadata", new ClientMetadata(null));
+    setField(request, "uploadFrom", UploadFrom.REDIRECT);
+    setField(request, "origFilename", null);
+    setField(request, "targetURI", null);
+    setField(request, "targetFilename", null);
+    setField(request, "binaryBlob", false);
+    setField(request, "finishedSize", -1L);
+    setField(request, "putter", null);
+
+    ClientPutPersistentTagBuilder builder = new ClientPutPersistentTagBuilder(request);
+
+    FCPMessage message = builder.persistentTagMessage();
+
+    SimpleFieldSet fs = message.getFieldSet();
+    assertEquals("id-optional", fs.get("Identifier"));
+    assertEquals("redirect", fs.get("UploadFrom"));
+    assertEquals("reboot", fs.get("Persistence"));
+    assertEquals("false", fs.get("Global"));
+    assertEquals("false", fs.get("Started"));
+    assertEquals("0", fs.get("MaxRetries"));
+    assertEquals("COMPAT_UNKNOWN", fs.get("CompatibilityMode"));
+    assertEquals("false", fs.get("DontCompress"));
+    assertEquals("false", fs.get("RealTime"));
+    assertNull(fs.get("Filename"));
+    assertNull(fs.get("TargetURI"));
+    assertEquals("application/octet-stream", fs.get("Metadata.ContentType"));
+    assertNull(fs.get("DataLength"));
+    assertNull(fs.get("ClientToken"));
+    assertNull(fs.get("TargetFilename"));
+    assertNull(fs.get("BinaryBlob"));
+    assertNull(fs.get("Codecs"));
+    assertNull(fs.get("SplitfileCryptoKey"));
+    assertFalse(fs.getBoolean("BinaryBlob", false));
+    assertInstanceOf(PersistentPut.class, message);
+  }
+
+  private static DefaultFcpInsertContextHandle newContext(
+      int maxRetries,
+      boolean dontCompress,
+      String compressorDescriptor,
+      FcpCompatibilityMode compatibilityMode) {
+    return new DefaultFcpInsertContextHandle(
+        new FcpInsertContextLimits(0, 0, 0),
+        new FcpInsertOptions(
+            new FcpInsertBehaviorOptions(
+                false, dontCompress, false, maxRetries, false, false, false),
+            new FcpInsertTuningOptions(false, false, compressorDescriptor, 0, 0, compatibilityMode),
+            null));
+  }
+
+  private static RequestClient requestClient(boolean realTime) {
+    RequestClient requestClient = mock(RequestClient.class);
+    when(requestClient.realTimeFlag()).thenReturn(realTime);
+    return requestClient;
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = findField(target.getClass(), fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Field findField(Class<?> type, String fieldName) throws NoSuchFieldException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException _) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPutterFactoryTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.async.ClientPutCallback;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.support.io.ArrayBucket;
@@ -20,7 +19,7 @@ class ClientPutPutterFactoryTest {
 
   @Test
   void create_whenExecutionSpecProvided_delegatesToRuntimeSupport() throws Exception {
-    ClientPutCallback callback = mock(ClientPutCallback.class);
+    FcpInsertCallback callback = mock(FcpInsertCallback.class);
     RequestClient requestClient = mock(RequestClient.class);
     when(callback.getRequestClient()).thenReturn(requestClient);
     FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
@@ -7,11 +7,14 @@ import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
+import java.io.Serial;
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.events.SimpleEventProducer;
@@ -244,7 +247,7 @@ class ClientPutTest {
 
     put.start(context);
 
-    verify(put).onFailure(failure, null);
+    verify(put).onFailure(failure, (FcpInsertCallbackState) null);
   }
 
   @Test
@@ -260,7 +263,7 @@ class ClientPutTest {
 
   @Test
   void innerResume_whenPutterPresent_reappliesDiagnosticIdentifier() throws Exception {
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     ClientPutExecution putter = createExecution(requester);
     setField(ClientPut.class, clientPut, "putter", putter);
     ClientContext context = mock(ClientContext.class);
@@ -355,7 +358,7 @@ class ClientPutTest {
     boolean restarted = spyPut.restart(context, false);
 
     assertFalse(restarted);
-    verify(spyPut).onFailure(failure, null);
+    verify(spyPut).onFailure(failure, (FcpInsertCallbackState) null);
   }
 
   @Test
@@ -392,7 +395,7 @@ class ClientPutTest {
 
   @Test
   void getClientRequest_whenPutterSet_returnsPutter() throws Exception {
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     ClientPutExecution putter = createExecution(requester);
     setField(ClientPut.class, clientPut, "putter", putter);
 
@@ -434,6 +437,15 @@ class ClientPutTest {
   }
 
   @Test
+  void legacyClientPutCallbackField_whenRoundTripped_acceptsClientPutInstance() throws Exception {
+    LegacyClientPutCallbackHolder restored =
+        roundTripObject(
+            new LegacyClientPutCallbackHolder(clientPut), LegacyClientPutCallbackHolder.class);
+
+    assertInstanceOf(ClientPut.class, restored.callback);
+  }
+
+  @Test
   void serialization_whenRoundTripped_restoresExecutionFromLegacyClientPutter() throws Exception {
     ClientPutter legacyPutter = mock(ClientPutter.class, withSettings().serializable());
     ClientPutExecution execution = createExecution(legacyPutter);
@@ -444,7 +456,10 @@ class ClientPutTest {
 
     assertInstanceOf(ClientPutExecution.class, getField(ClientPut.class, restored, "putter"));
     assertInstanceOf(FcpInsertContextHandle.class, getField(ClientPutBase.class, restored, "ctx"));
-    assertInstanceOf(ClientPutter.class, restored.getClientRequest());
+    ClientPutExecution restoredExecution =
+        (ClientPutExecution) getField(ClientPut.class, restored, "putter");
+    assertInstanceOf(ClientPutter.class, restoredExecution.legacySerializableRequester());
+    assertInstanceOf(FcpRequesterHandle.class, restored.getClientRequest());
   }
 
   @Test
@@ -476,13 +491,23 @@ class ClientPutTest {
     return mock(ClientPutExecution.class);
   }
 
-  private static ClientPutExecution createExecution(ClientRequester requester) {
+  private static ClientPutExecution createExecution(FcpRequesterHandle requester) {
     ClientPutExecution execution = mock(ClientPutExecution.class);
     when(execution.requester()).thenReturn(requester);
     return execution;
   }
 
+  private static ClientPutExecution createExecution(ClientRequester requester) {
+    ClientPutExecution execution = mock(ClientPutExecution.class);
+    when(execution.legacySerializableRequester()).thenReturn(requester);
+    return execution;
+  }
+
   private static ClientPut roundTrip(ClientPut value) throws Exception {
+    return roundTripObject(value, ClientPut.class);
+  }
+
+  private static <T> T roundTripObject(Object value, Class<T> type) throws Exception {
     byte[] serialized;
     try (ByteArrayOutputStream output = new ByteArrayOutputStream();
         ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
@@ -492,7 +517,18 @@ class ClientPutTest {
     }
     try (ObjectInputStream objectInput =
         new ObjectInputStream(new ByteArrayInputStream(serialized))) {
-      return (ClientPut) objectInput.readObject();
+      return type.cast(objectInput.readObject());
+    }
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class LegacyClientPutCallbackHolder implements Serializable {
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final ClientPutCallback callback;
+
+    private LegacyClientPutCallbackHolder(ClientPutCallback callback) {
+      this.callback = callback;
     }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.lang.reflect.Field;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.PersistentJobRunner;
 import network.crypta.keys.FreenetURI;
@@ -32,7 +31,7 @@ class ClientRequestModifyRequestTest {
     when(runtimeSupport.clientContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     PersistentRequestClient client =
         spy(
             new PersistentRequestClient(
@@ -68,7 +67,7 @@ class ClientRequestModifyRequestTest {
     when(runtimeSupport.clientContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     PersistentRequestClient client =
         spy(
             new PersistentRequestClient(
@@ -181,9 +180,9 @@ class ClientRequestModifyRequestTest {
   }
 
   private static final class TestClientRequest extends ClientRequest {
-    private final ClientRequester requester;
+    private final FcpRequesterHandle requester;
 
-    private TestClientRequest(ConstructorInit init, ClientRequester requester) {
+    private TestClientRequest(ConstructorInit init, FcpRequesterHandle requester) {
       super(init);
       this.requester = requester;
     }
@@ -193,7 +192,7 @@ class ClientRequestModifyRequestTest {
         short priorityClass,
         String clientToken,
         PersistentRequestClient client,
-        ClientRequester requester) {
+        FcpRequesterHandle requester) {
       return new TestClientRequest(
           prepareConstructorInit(
               new ClientRequestParams(
@@ -223,7 +222,7 @@ class ClientRequestModifyRequestTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return requester;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
@@ -3,7 +3,6 @@ package network.crypta.clients.fcp;
 import java.io.Serial;
 import java.lang.reflect.Field;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.PersistentJobRunner;
 import network.crypta.node.PrioRunnable;
@@ -178,7 +177,7 @@ class ClientRequestRestartAsyncTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return null;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.Serial;
 import java.lang.reflect.Field;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.client.async.persistence.PersistentRequestCoordinator;
 import network.crypta.client.async.persistence.PersistentRequestIdentifier;
@@ -136,7 +135,7 @@ class ClientRequestTest {
 
   @Test
   void applyDiagnosticIdentifier_whenRequesterPresent_expectPrefixedIdentifierAssigned() {
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     TestClientRequest request =
         new TestClientRequest(
             ClientRequest.prepareConstructorInit(
@@ -161,7 +160,7 @@ class ClientRequestTest {
   @Test
   void cancel_whenRequesterPresent_expectRequesterCancelledAndDataFreed() {
     // Arrange
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     ClientContext context = mock(ClientContext.class);
     PersistentRequestRuntimeContext runtimeContext = context;
     PersistentRequestRoot root = new PersistentRequestRoot();
@@ -187,7 +186,7 @@ class ClientRequestTest {
   @Test
   void onShutdown_whenRequesterPresent_expectDelegatesToRequester() {
     // Arrange
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     ClientContext context = mock(ClientContext.class);
     PersistentRequestRuntimeContext runtimeContext = context;
     PersistentRequestRoot root = new PersistentRequestRoot();
@@ -362,7 +361,7 @@ class ClientRequestTest {
             false,
             false,
             root.registerForeverClient("resume-client", null),
-            mock(ClientRequester.class));
+            mock(FcpRequesterHandle.class));
     PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
     when(coordinator.getOrCreateClientHandle(false, "resume-client"))
         .thenReturn(new OpaqueHandle());
@@ -375,7 +374,7 @@ class ClientRequestTest {
   void onResume_whenRequesterPresent_expectInnerResumeRequesterAndCoordinator()
       throws ResumeFailedException {
     // Arrange
-    ClientRequester requester = mock(ClientRequester.class);
+    FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     PersistentRequestRoot originalRoot = new PersistentRequestRoot();
     TestClientRequest request =
         TestClientRequest.forever(
@@ -487,12 +486,12 @@ class ClientRequestTest {
   private static final class TestClientRequest extends ClientRequest {
     @Serial private static final long serialVersionUID = 1L;
 
-    private final ClientRequester requester;
+    private final FcpRequesterHandle requester;
     private transient ClientContext innerResumeContext;
     private transient ClientContext startContext;
     private int freeDataCalls;
 
-    private TestClientRequest(ConstructorInit init, ClientRequester requester) {
+    private TestClientRequest(ConstructorInit init, FcpRequesterHandle requester) {
       super(init);
       this.requester = requester;
     }
@@ -501,7 +500,7 @@ class ClientRequestTest {
         DataInputStream input,
         RequestIdentifier requestIdentifier,
         ClientContext context,
-        ClientRequester requester)
+        FcpRequesterHandle requester)
         throws IOException, StorageFormatException {
       super(input, requestIdentifier, context);
       this.requester = requester;
@@ -515,7 +514,7 @@ class ClientRequestTest {
         boolean global,
         boolean realTime,
         PersistentRequestClient client,
-        ClientRequester requester) {
+        FcpRequesterHandle requester) {
       return new TestClientRequest(
           ClientRequest.prepareConstructorInit(
               new ClientRequestParams(
@@ -556,7 +555,7 @@ class ClientRequestTest {
       return diagnosticIdentifier();
     }
 
-    void applyDiagnosticIdentifierTo(ClientRequester requester) {
+    void applyDiagnosticIdentifierTo(FcpRequesterHandle requester) {
       applyDiagnosticIdentifier(requester);
     }
 
@@ -584,7 +583,7 @@ class ClientRequestTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return requester;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/CoreFcpPersistentRequestCatalogTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CoreFcpPersistentRequestCatalogTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 import network.crypta.clients.fcp.bridge.CoreFcpPersistentRequestCatalog;
@@ -107,7 +106,7 @@ class CoreFcpPersistentRequestCatalogTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return null;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestClientTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestClientTest.java
@@ -1,7 +1,11 @@
 package network.crypta.clients.fcp;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
@@ -12,6 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -162,6 +168,32 @@ class PersistentRequestClientTest {
     verify(callback).notifyFailure(request);
   }
 
+  @Test
+  void finishedClientRequest_whenFailedDownloadCompleted_cachesCanonicalLongFailureMessage()
+      throws Exception {
+    PersistentRequestClient client =
+        new PersistentRequestClient(
+            "client", mock(FCPConnectionHandler.class), true, null, Persistence.REBOOT, null);
+    ClientGet download = newPersistentClientGet("download-1", Persistence.REBOOT);
+    client.register(download);
+    GetFailedMessage failureMessage =
+        new GetFailedMessage(
+            new FetchException(FetchExceptionMode.ALL_DATA_NOT_FOUND, "details"),
+            "download-1",
+            false);
+    download.state().setFailedMessage(failureMessage);
+
+    client.finishedClientRequest(download);
+
+    RequestStatusCache cache = client.getRequestStatusCache();
+    assertNotNull(cache);
+    List<RequestStatus> statuses = new ArrayList<>();
+    cache.addTo(statuses);
+    DownloadRequestStatus status = assertInstanceOf(DownloadRequestStatus.class, statuses.get(0));
+    assertEquals(failureMessage.getShortFailedMessage(), status.getFailureReason(false));
+    assertEquals(failureMessage.getLongFailedMessage(), status.getFailureReason(true));
+  }
+
   private static final class TestClientRequest extends ClientRequest {
     int pendingMessagesCalls;
     int cancelCalls;
@@ -197,7 +229,7 @@ class PersistentRequestClientTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return null;
     }
 
@@ -295,6 +327,24 @@ class PersistentRequestClientTest {
     public void requestWasRemoved(ClientContext context) {
       requestRemovedCalls++;
     }
+  }
+
+  private static ClientGet newPersistentClientGet(String identifier, Persistence persistence)
+      throws Exception {
+    ClientGet request = new ClientGet();
+    ClientGetTestProfiles.setFetchConfig(request, new ClientGetFetchConfig());
+    ClientGetTestProfiles.setReturnType(request, ClientGet.ReturnType.NONE);
+    setField(ClientRequest.class, request, "identifier", identifier);
+    setField(ClientRequest.class, request, "persistence", persistence);
+    setField(ClientRequest.class, request, "uri", new FreenetURI("KSK@" + identifier));
+    return request;
+  }
+
+  private static void setField(Class<?> owner, Object target, String name, Object value)
+      throws ReflectiveOperationException {
+    Field field = owner.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
   }
 
   private static final class TestRequestStatus extends RequestStatus {

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
@@ -1,7 +1,6 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientRequester;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
@@ -235,7 +234,7 @@ class PersistentRequestRootTest {
     }
 
     @Override
-    protected ClientRequester getClientRequest() {
+    protected FcpRequesterHandle getClientRequest() {
       return null;
     }
 


### PR DESCRIPTION
## Summary

- replace adapter-owned `ClientRequester` exposure with detached `FcpRequesterHandle` seams across FCP request and execution contracts
- replace adapter-owned `ClientPutCallback` / `BaseClientPutter` exposure with detached `FcpInsertCallback` and `FcpInsertCallbackState` surfaces
- keep concrete requester and callback adaptation in `:bridge-fcp-runtime`, including legacy persistence compatibility for older persisted GET and single-file PUT request state
- preserve persistent-request wire and Java-serialization behavior while tightening the adapter boundary tests
- add focused regression coverage for legacy resume/serialization paths and improve Javadocs on the new adapter-owned seam types

## How to test

- `./gradlew :adapter-fcp:test --tests "network.crypta.clients.fcp.AdapterFcpBoundaryTest"`
- `./gradlew :bridge-fcp-runtime:test --tests "network.crypta.clients.fcp.bridge.BridgeFcpRuntimeBoundaryTest" --tests "network.crypta.clients.fcp.bridge.CoreFcpFetchRuntimeSupportTest"`
- `./gradlew :bridge-fcp-runtime:test --tests "network.crypta.clients.fcp.bridge.CoreFcpInsertRuntimeSupportTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.ClientPutBaseTest" --tests "network.crypta.clients.fcp.ClientPutTest"`
- `./gradlew test`
