### PR TITLE
refactor(fcp): Detach server runtime seams

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 import java.util.Locale;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestIdentifier;
@@ -361,6 +360,15 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * @param context client context providing access to schedulers, queues, and persistent roots
    */
   public abstract void onLostConnection(ClientContext context);
+
+  /**
+   * Detached wrapper for {@link #onLostConnection(ClientContext)} used by server-owned callers.
+   *
+   * @param context detached runtime context backed by the live daemon runtime
+   */
+  public final void onLostConnection(PersistentRequestRuntimeContext context) {
+    onLostConnection(requireClientContext(context, "lost-connection"));
+  }
 
   /**
    * Sends any queued protocol messages for this request to a reconnecting client.
@@ -723,8 +731,9 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * Indicates whether this request can currently be restarted.
    *
    * <p>Subclasses may disallow restarts after certain fatal errors or once resources have been
-   * discarded. Callers usually check this before invoking {@link #restart(ClientContext, boolean)}
-   * or {@link #restartAsync(FCPServer, boolean)}.
+   * discarded. Callers usually check this before invoking {@link
+   * #restart(PersistentRequestRuntimeContext, boolean)} or {@link #restartAsync(FCPServer,
+   * boolean)}.
    *
    * @return {@code true} if restarting is supported in the current state
    */
@@ -748,6 +757,19 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
       throws PersistenceDisabledException;
 
   /**
+   * Detached wrapper for {@link #restart(ClientContext, boolean)}.
+   *
+   * @param context detached runtime context backed by the live daemon runtime
+   * @param disableFilterData whether associated filter data should be disabled for the restart
+   * @return {@code true} if the restart was submitted successfully and should be visible to clients
+   * @throws PersistenceDisabledException if persistent storage required for restart is not enabled
+   */
+  public final boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData)
+      throws PersistenceDisabledException {
+    return restart(requireClientContext(context, "restart"), disableFilterData);
+  }
+
+  /**
    * Called after a ModifyPersistentRequest. Sends a PersistentRequestModified message to clients if
    * any value changed.
    *
@@ -763,7 +785,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
       return;
     }
 
-    server.serverRuntimeSupport().clientContext().jobRunner.setCheckpointASAP();
+    server.serverRuntimeSupport().setCheckpointASAP();
 
     PersistentRequestModifiedMessage modifiedMsg =
         buildPersistentRequestModifiedMessage(clientTokenChanged, priorityClassChanged);
@@ -837,20 +859,24 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
       }
     }
     if (persistence == Persistence.FOREVER) {
-      runtimeSupport
-          .clientContext()
-          .jobRunner
-          .queue(
-              (PersistentJob)
-                  context -> {
-                    try {
-                      restart(context, disableFilterData);
-                    } catch (PersistenceDisabledException _) {
-                      // Impossible
-                    }
-                    return true;
-                  },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+      runtimeSupport.queuePersistentJob(
+          new FcpPersistentJob() {
+            @Override
+            public boolean run(PersistentRequestRuntimeContext context) {
+              try {
+                restart(context, disableFilterData);
+              } catch (PersistenceDisabledException _) {
+                // Impossible
+              }
+              return true;
+            }
+
+            @Override
+            public String toString() {
+              return "FCP request restartAsync";
+            }
+          },
+          NativeThread.PriorityLevel.HIGH_PRIORITY.value);
     } else {
       server
           .runtime()
@@ -866,7 +892,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
                 @Override
                 public void run() {
                   try {
-                    restart(runtimeSupport.clientContext(), disableFilterData);
+                    restart(runtimeSupport.persistentRequestRuntimeContext(), disableFilterData);
                   } catch (PersistenceDisabledException _) {
                     // Impossible
                   }
@@ -896,6 +922,15 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * @param context client context that can be used to access persistence services if necessary
    */
   public void requestWasRemoved(ClientContext context) {}
+
+  /**
+   * Detached wrapper for {@link #requestWasRemoved(ClientContext)} used by server-owned callers.
+   *
+   * @param context detached runtime context backed by the live daemon runtime
+   */
+  public final void requestWasRemoved(PersistentRequestRuntimeContext context) {
+    requestWasRemoved(requireClientContext(context, "remove"));
+  }
 
   /**
    * Returns whether this request belongs to one of the global queues.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPConnectionHandler.java
@@ -11,8 +11,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.TooManyFilesInsertException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
 import network.crypta.support.HexUtil;
@@ -267,9 +267,9 @@ public class FCPConnectionHandler implements Closeable {
   }
 
   private void notifyLostRequests(ClientRequest[] requests) {
-    network.crypta.client.async.ClientContext clientContext = serverClientContext();
+    PersistentRequestRuntimeContext runtimeContext = serverRuntimeContext();
     for (ClientRequest request : requests) {
-      request.onLostConnection(clientContext);
+      request.onLostConnection(runtimeContext);
     }
   }
 
@@ -281,21 +281,28 @@ public class FCPConnectionHandler implements Closeable {
 
   private void enqueueClientCleanup() {
     try {
-      serverClientContext()
-          .jobRunner
-          .queue(
-              (PersistentJob)
-                  _ -> {
-                    if ((rebootClient != null) && !rebootClient.hasPersistentRequests()) {
-                      server.unregisterClient(rebootClient);
-                    }
-                    PersistentRequestClient cleanupForeverClient = foreverClient.get();
-                    if ((cleanupForeverClient != null)
-                        && !cleanupForeverClient.hasPersistentRequests()) {
-                      server.unregisterClient(cleanupForeverClient);
-                    }
-                    return false;
-                  },
+      server
+          .serverRuntimeSupport()
+          .queuePersistentJob(
+              new FcpPersistentJob() {
+                @Override
+                public boolean run(PersistentRequestRuntimeContext context) {
+                  if ((rebootClient != null) && !rebootClient.hasPersistentRequests()) {
+                    server.unregisterClient(rebootClient);
+                  }
+                  PersistentRequestClient cleanupForeverClient = foreverClient.get();
+                  if ((cleanupForeverClient != null)
+                      && !cleanupForeverClient.hasPersistentRequests()) {
+                    server.unregisterClient(cleanupForeverClient);
+                  }
+                  return false;
+                }
+
+                @Override
+                public String toString() {
+                  return "FCP connection cleanup";
+                }
+              },
               NativeThread.PriorityLevel.NORM_PRIORITY.value);
     } catch (PersistenceDisabledException _) {
       // Ignore: cleanups already best-effort.
@@ -481,7 +488,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(serverClientContext());
+    request.start(serverRuntimeContext());
   }
 
   private void startRebootClientGet(ClientGetMessage message) {
@@ -492,7 +499,7 @@ public class FCPConnectionHandler implements Closeable {
     if (!registerPersistentRequest(request, message.identifier, message.global)) {
       return;
     }
-    request.start(serverClientContext());
+    request.start(serverRuntimeContext());
   }
 
   private void startForeverClientGet(ClientGetMessage message) {
@@ -578,7 +585,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(serverClientContext());
+    request.start(serverRuntimeContext());
   }
 
   private void startRebootClientPut(ClientPutMessage message) {
@@ -590,7 +597,7 @@ public class FCPConnectionHandler implements Closeable {
       request.freeData();
       return;
     }
-    request.start(serverClientContext());
+    request.start(serverRuntimeContext());
   }
 
   private void startForeverClientPut(ClientPutMessage message) {
@@ -659,17 +666,16 @@ public class FCPConnectionHandler implements Closeable {
       return;
     }
     RegistrationResult registration = registerConnectionScopedRequest(message.identifier, request);
-    network.crypta.client.async.ClientContext clientContext = serverClientContext();
     if (registration == RegistrationResult.DUPLICATE) {
-      request.cancel(clientContext);
+      request.cancel(serverRuntimeContext());
       handleIdentifierCollision(message.identifier, message.global);
       return;
     }
     if (registration == RegistrationResult.CLOSED) {
-      request.cancel(clientContext);
+      request.cancel(serverRuntimeContext());
       return;
     }
-    request.start(clientContext);
+    request.start(serverRuntimeContext());
   }
 
   private void startRebootClientPutDir(
@@ -678,12 +684,11 @@ public class FCPConnectionHandler implements Closeable {
     if (request == null) {
       return;
     }
-    network.crypta.client.async.ClientContext clientContext = serverClientContext();
     if (!registerPersistentRequest(request, message.identifier, message.global)) {
-      request.cancel(clientContext);
+      request.cancel(serverRuntimeContext());
       return;
     }
-    request.start(clientContext);
+    request.start(serverRuntimeContext());
   }
 
   private void startForeverClientPutDir(
@@ -695,7 +700,7 @@ public class FCPConnectionHandler implements Closeable {
             return false;
           }
           if (!registerPersistentRequest(request, message.identifier, message.global)) {
-            request.cancel(serverClientContext());
+            request.cancel(serverRuntimeContext());
             return false;
           }
           request.start(context);
@@ -799,11 +804,11 @@ public class FCPConnectionHandler implements Closeable {
             ProtocolErrorMessage.TOO_MANY_FILES_IN_INSERT, true, null, identifier, global));
   }
 
-  private void queuePersistentJob(PersistentJob job, String identifier, boolean global) {
+  private void queuePersistentJob(FcpPersistentJob job, String identifier, boolean global) {
     try {
-      serverClientContext()
-          .jobRunner
-          .queue(job, NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
+      server
+          .serverRuntimeSupport()
+          .queuePersistentJob(job, NativeThread.PriorityLevel.HIGH_PRIORITY.value - 1);
     } catch (PersistenceDisabledException _) {
       sendPersistenceDisabled(identifier, global);
     }
@@ -1001,9 +1006,9 @@ public class FCPConnectionHandler implements Closeable {
       req = requestsByIdentifier.remove(identifier);
     }
     if (req != null) {
-      network.crypta.client.async.ClientContext clientContext = serverClientContext();
-      if (kill) req.cancel(clientContext);
-      req.requestWasRemoved(clientContext);
+      PersistentRequestRuntimeContext runtimeContext = serverRuntimeContext();
+      if (kill) req.cancel(runtimeContext);
+      req.requestWasRemoved(runtimeContext);
     }
     return req;
   }
@@ -1022,7 +1027,7 @@ public class FCPConnectionHandler implements Closeable {
     PersistentRequestClient client = global ? server.getGlobalRebootClient() : getRebootClient();
     ClientRequest req = client.getRequest(identifier);
     if (req != null) {
-      client.removeByIdentifier(identifier, true, server, serverClientContext());
+      client.removeByIdentifier(identifier, true, server, serverRuntimeContext());
     }
     return req;
   }
@@ -1031,13 +1036,13 @@ public class FCPConnectionHandler implements Closeable {
     PersistentRequestClient client = global ? server.getGlobalForeverClient() : getForeverClient();
     ClientRequest req = client.getRequest(identifier);
     if (req != null) {
-      client.removeByIdentifier(identifier, true, server, serverClientContext());
+      client.removeByIdentifier(identifier, true, server, serverRuntimeContext());
     }
     return req;
   }
 
-  private network.crypta.client.async.ClientContext serverClientContext() {
-    return server.serverRuntimeSupport().clientContext();
+  private PersistentRequestRuntimeContext serverRuntimeContext() {
+    return server.serverRuntimeSupport().persistentRequestRuntimeContext();
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -4,9 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import network.crypta.client.FetchResult;
 import network.crypta.client.async.CacheFetchResult;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.DownloadCache;
 import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.config.Config;
 import network.crypta.io.AllowedHosts;
 import network.crypta.keys.FreenetURI;
@@ -21,8 +20,8 @@ import network.crypta.support.api.Bucket;
  * and the download cache so clients can resume work across node restarts. The server is created
  * from configured defaults, started lazily through {@link #maybeStart()}, and runs a dedicated
  * accept-loop on a daemon thread so shutdown does not block. Runtime-facing listener work is
- * scheduled through {@link RuntimePorts#execution()}, and request jobs are marshaled onto the
- * {@link ClientContext} job runner.
+ * scheduled through {@link RuntimePorts#execution()}, and persistence-affecting work is routed
+ * through the server runtime-support seam.
  *
  * <p>Responsibilities include:
  *
@@ -37,7 +36,7 @@ import network.crypta.support.api.Bucket;
  * thread-confined startup hooks. Network listeners are long-lived and started only when enabled by
  * configuration.
  */
-public class FCPServer implements Runnable, DownloadCache {
+public class FCPServer implements Runnable, FcpDownloadCache {
 
   /**
    * Default TCP port (9481) exposed by the FCP listener for network clients.
@@ -667,7 +666,11 @@ public class FCPServer implements Runnable, DownloadCache {
    */
   @Override
   public CacheFetchResult lookup(
-      FreenetURI key, boolean noFilter, ClientContext context, boolean mustCopy, Bucket preferred) {
+      FreenetURI key,
+      boolean noFilter,
+      PersistentRequestRuntimeContext context,
+      boolean mustCopy,
+      Bucket preferred) {
     return persistentOps.lookup(key, noFilter, context, mustCopy, preferred);
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpDownloadCache.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpDownloadCache.java
@@ -1,0 +1,72 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.CacheFetchResult;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+
+/**
+ * Adapter-owned cache seam for FCP-local completed-request lookups.
+ *
+ * <p>This interface represents the narrow cache behavior that the FCP adapter still needs after the
+ * server/runtime detachment work. Implementations answer only from already-completed local FCP
+ * requests; they do not schedule new fetches, consult wider node caches, or expose the full
+ * runtime-owned {@code DownloadCache} contract. The bridge layer is responsible for adapting this
+ * seam back to runtime-facing callers that still expect the older cache interface.
+ *
+ * <p>Typical callers are server-owned helper paths such as persistent-request replay and
+ * get-completed-request lookups. Those call sites need immediate access to previously downloaded
+ * data, but they should not depend directly on runtime-owned cache abstractions or on a live {@code
+ * ClientContext}. The interface therefore stays intentionally small and keeps the copy, filtering,
+ * and detached-runtime-context decisions explicit at the call site.
+ *
+ * <ul>
+ *   <li>Never starts network work or waits for an in-flight request to finish.
+ *   <li>Exposes only the lookup variants currently required by FCP server infrastructure.
+ *   <li>Keeps runtime-specific cache adaptation in {@code :bridge-fcp-runtime}.
+ * </ul>
+ */
+public interface FcpDownloadCache {
+
+  /**
+   * Performs a non-blocking cache lookup without scheduling additional work.
+   *
+   * <p>Use this variant when the caller already knows that no runtime context is needed for the
+   * lookup. Implementations must limit themselves to data that is already available locally and
+   * should return quickly even on a miss. When {@code mustCopy} is {@code false}, the returned
+   * bucket may share underlying storage with the cached request and should therefore be treated as
+   * short-lived and effectively read-only by callers.
+   *
+   * @param key exact Freenet key used to identify the cached payload
+   * @param noFilter whether the caller requires raw bytes instead of filtered content
+   * @param mustCopy whether the result must be copied into dedicated caller-owned storage
+   * @param preferred optional destination bucket to reuse when copying is required
+   * @return cached result when a matching completed request exists, or {@code null} on a miss
+   */
+  CacheFetchResult lookupInstant(
+      FreenetURI key, boolean noFilter, boolean mustCopy, Bucket preferred);
+
+  /**
+   * Performs a cache lookup using the supplied detached runtime context when needed.
+   *
+   * <p>This overload exists for server-owned call paths that still carry a detached persistent
+   * runtime context while remaining independent of live runtime-owned infrastructure types. The
+   * current FCP implementations may ignore the context for purely local lookups, but callers should
+   * still pass the appropriate detached token so future implementations can use it without widening
+   * the adapter boundary again. As with {@link #lookupInstant(FreenetURI, boolean, boolean,
+   * Bucket)}, the lookup is local-only and must not trigger new network activity.
+   *
+   * @param key exact Freenet key used to identify the cached payload
+   * @param noFilter whether the caller requires raw bytes instead of filtered content
+   * @param context detached runtime context associated with the surrounding persistent operation
+   * @param mustCopy whether the result must be copied into dedicated caller-owned storage
+   * @param preferred optional destination bucket to reuse when copying is required
+   * @return cached result when a matching completed request exists, or {@code null} on a miss
+   */
+  CacheFetchResult lookup(
+      FreenetURI key,
+      boolean noFilter,
+      PersistentRequestRuntimeContext context,
+      boolean mustCopy,
+      Bucket preferred);
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpPersistentJob.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpPersistentJob.java
@@ -1,0 +1,42 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+
+/**
+ * Detached persistent-job seam used by adapter-owned FCP server infrastructure.
+ *
+ * <p>This functional interface represents the small amount of queued, persistence-affecting work
+ * that still originates inside the FCP adapter after the server/runtime boundary hardening. It is
+ * intentionally narrower than the runtime-owned persistent-job contract: the adapter can describe
+ * what work should run and whether that work should request a checkpoint, but it does not own the
+ * live job-runner type or the concrete daemon-core scheduling machinery.
+ *
+ * <p>Typical jobs wrap operations such as restart, remove, or connection-cleanup handling for
+ * persistent FCP requests. The bridge layer converts each instance into the runtime-owned job type
+ * and executes it against a live daemon context. Adapter code therefore stays detached from
+ * runtime-owned infrastructure types while preserving the same queue ordering, checkpoint
+ * semantics, and operational labels that the underlying runtime still expects.
+ *
+ * <ul>
+ *   <li>Describes only server-owned FCP persistence work, not a generic platform job API.
+ *   <li>Runs against a detached persistent-request runtime context supplied by the bridge layer.
+ *   <li>Returns a checkpoint hint so the existing persistence timing stays unchanged.
+ * </ul>
+ */
+@FunctionalInterface
+public interface FcpPersistentJob {
+
+  /**
+   * Runs one unit of queued FCP persistent work.
+   *
+   * <p>Implementations should perform only the minimal persistent operation that was queued and
+   * then return promptly. The supplied context is detached at the adapter boundary but backed by
+   * the live daemon runtime, so implementations may pass it into other detached FCP seams without
+   * reintroducing direct runtime-owned job types. Returning {@code true} preserves the existing
+   * behavior of jobs that ask the runtime to checkpoint state immediately after completion.
+   *
+   * @param context detached runtime context associated with the live persistent-job execution
+   * @return {@code true} when the job should request an immediate persistence checkpoint
+   */
+  boolean run(PersistentRequestRuntimeContext context);
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerPersistentOps.java
@@ -13,10 +13,8 @@ import network.crypta.client.ClientMetadata;
 import network.crypta.client.DefaultMIMETypes;
 import network.crypta.client.FetchResult;
 import network.crypta.client.async.CacheFetchResult;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.DownloadCache;
 import network.crypta.client.async.PersistenceDisabledException;
-import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -38,23 +36,23 @@ import org.slf4j.LoggerFactory;
  * class is intentionally package-private, so the server façade can delegate to it while keeping
  * persistence-specific details localized.
  *
- * <p>The instance uses the {@link ClientContext} job runner for operations that must be serialized
- * against persistent state. Methods that call into {@link PersistentRequestClient} may block until
- * a queued job completes, so callers should avoid invoking them from latency-sensitive threads.
- * Synchronization is limited to the reboot-client map and does not cover the underlying request
- * queues, which manage their own concurrency.
+ * <p>The instance uses the detached persistent-job seam on {@link FcpServerRuntimeSupport} for
+ * operations that must be serialized against persistent state. Methods that call into {@link
+ * PersistentRequestClient} may block until a queued job completes, so callers should avoid invoking
+ * them from latency-sensitive threads. Synchronization is limited to the reboot-client map and does
+ * not cover the underlying request queues, which manage their own concurrency.
  *
  * <ul>
  *   <li>Registers persistent clients and routes global queue operations.
  *   <li>Schedules persistence-affecting work on the job runner.
- *   <li>Implements {@link DownloadCache} lookups for completed requests.
+ *   <li>Implements {@link FcpDownloadCache} lookups for completed requests.
  * </ul>
  *
  * @see FCPServer
  * @see PersistentRequestClient
  * @see PersistentRequestRoot
  */
-final class FcpServerPersistentOps implements DownloadCache {
+final class FcpServerPersistentOps implements FcpDownloadCache {
   /** Logger for persistence operations and cache lookup diagnostics. */
   private static final Logger LOG = LoggerFactory.getLogger(FcpServerPersistentOps.class);
 
@@ -224,36 +222,32 @@ final class FcpServerPersistentOps implements DownloadCache {
    * @throws PersistenceDisabledException when persistence is unavailable or disabled.
    */
   boolean removeGlobalRequestBlocking(final String identifier) throws PersistenceDisabledException {
-    if (!globalRebootClient.removeByIdentifier(identifier, true, server, clientContext())) {
+    if (!globalRebootClient.removeByIdentifier(identifier, true, server, runtimeContext())) {
       final CountDownLatch done = new CountDownLatch(1);
       final AtomicBoolean success = new AtomicBoolean();
-      clientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
+      runtimeSupport.queuePersistentJob(
+          new FcpPersistentJob() {
+            @Override
+            public boolean run(PersistentRequestRuntimeContext context) {
+              boolean succeeded = false;
+              try {
+                succeeded =
+                    globalForeverClient.removeByIdentifier(identifier, true, server, context);
+              } catch (Exception e) {
+                LOG.error("Caught removing identifier {}: {}", identifier, e, e);
+              } finally {
+                success.set(succeeded);
+                done.countDown();
+              }
+              return true;
+            }
 
-                @Override
-                public String toString() {
-                  return "FCP removeGlobalRequestBlocking";
-                }
-
-                @Override
-                public boolean run(ClientContext context) {
-                  boolean succeeded = false;
-                  try {
-                    succeeded =
-                        globalForeverClient.removeByIdentifier(
-                            identifier, true, server, clientContext());
-                  } catch (Exception e) {
-                    LOG.error("Caught removing identifier {}: {}", identifier, e, e);
-                  } finally {
-                    success.set(succeeded);
-                    done.countDown();
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+            @Override
+            public String toString() {
+              return "FCP removeGlobalRequestBlocking";
+            }
+          },
+          NativeThread.PriorityLevel.HIGH_PRIORITY.value);
       try {
         done.await();
       } catch (InterruptedException _) {
@@ -277,32 +271,29 @@ final class FcpServerPersistentOps implements DownloadCache {
     globalRebootClient.removeAll();
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicBoolean success = new AtomicBoolean();
-    clientContext()
-        .jobRunner
-        .queue(
-            new PersistentJob() {
+    runtimeSupport.queuePersistentJob(
+        new FcpPersistentJob() {
+          @Override
+          public boolean run(PersistentRequestRuntimeContext context) {
+            boolean succeeded = false;
+            try {
+              globalForeverClient.removeAll();
+              succeeded = true;
+            } catch (Exception e) {
+              LOG.error("Caught while processing panic: {}", e, e);
+            } finally {
+              success.set(succeeded);
+              done.countDown();
+            }
+            return true;
+          }
 
-              @Override
-              public String toString() {
-                return "FCP removeAllGlobalRequestsBlocking";
-              }
-
-              @Override
-              public boolean run(ClientContext context) {
-                boolean succeeded = false;
-                try {
-                  globalForeverClient.removeAll();
-                  succeeded = true;
-                } catch (Exception e) {
-                  LOG.error("Caught while processing panic: {}", e, e);
-                } finally {
-                  success.set(succeeded);
-                  done.countDown();
-                }
-                return true;
-              }
-            },
-            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+          @Override
+          public String toString() {
+            return "FCP removeAllGlobalRequestsBlocking";
+          }
+        },
+        NativeThread.PriorityLevel.HIGH_PRIORITY.value);
     try {
       done.await();
     } catch (InterruptedException _) {
@@ -337,34 +328,31 @@ final class FcpServerPersistentOps implements DownloadCache {
         boolean done;
       }
       final OutputWrapper ow = new OutputWrapper();
-      clientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
-
-                @Override
-                public String toString() {
-                  return "FCP modifyGlobalRequestBlocking";
+      runtimeSupport.queuePersistentJob(
+          new FcpPersistentJob() {
+            @Override
+            public boolean run(PersistentRequestRuntimeContext context) {
+              boolean success = false;
+              try {
+                ClientRequest req = globalForeverClient.getRequest(identifier);
+                if (req != null) req.modifyRequest(newToken, newPriority, server);
+                success = true;
+              } finally {
+                synchronized (ow) {
+                  ow.success = success;
+                  ow.done = true;
+                  ow.notifyAll();
                 }
+              }
+              return true;
+            }
 
-                @Override
-                public boolean run(ClientContext context) {
-                  boolean success = false;
-                  try {
-                    ClientRequest req = globalForeverClient.getRequest(identifier);
-                    if (req != null) req.modifyRequest(newToken, newPriority, server);
-                    success = true;
-                  } finally {
-                    synchronized (ow) {
-                      ow.success = success;
-                      ow.done = true;
-                      ow.notifyAll();
-                    }
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+            @Override
+            public String toString() {
+              return "FCP modifyGlobalRequestBlocking";
+            }
+          },
+          NativeThread.PriorityLevel.HIGH_PRIORITY.value);
 
       synchronized (ow) {
         while (true) {
@@ -399,36 +387,33 @@ final class FcpServerPersistentOps implements DownloadCache {
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicReference<NotAllowedException> notAllowed = new AtomicReference<>();
     final AtomicReference<IOException> ioException = new AtomicReference<>();
-    clientContext()
-        .jobRunner
-        .queue(
-            new PersistentJob() {
+    runtimeSupport.queuePersistentJob(
+        new FcpPersistentJob() {
+          @Override
+          public boolean run(PersistentRequestRuntimeContext context) {
+            try {
+              makePersistentGlobalRequest(params);
+              return true;
+            } catch (NotAllowedException e) {
+              notAllowed.set(e);
+              return false;
+            } catch (IOException e) {
+              ioException.set(e);
+              return false;
+            } catch (Exception t) {
+              LOG.error("Failed to make persistent request: {}", t, t);
+              return false;
+            } finally {
+              done.countDown();
+            }
+          }
 
-              @Override
-              public String toString() {
-                return "FCP makePersistentGlobalRequestBlocking";
-              }
-
-              @Override
-              public boolean run(ClientContext context) {
-                try {
-                  makePersistentGlobalRequest(params);
-                  return true;
-                } catch (NotAllowedException e) {
-                  notAllowed.set(e);
-                  return false;
-                } catch (IOException e) {
-                  ioException.set(e);
-                  return false;
-                } catch (Exception t) {
-                  LOG.error("Failed to make persistent request: {}", t, t);
-                  return false;
-                } finally {
-                  done.countDown();
-                }
-              }
-            },
-            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+          @Override
+          public String toString() {
+            return "FCP makePersistentGlobalRequestBlocking";
+          }
+        },
+        NativeThread.PriorityLevel.HIGH_PRIORITY.value);
 
     try {
       done.await();
@@ -635,7 +620,7 @@ final class FcpServerPersistentOps implements DownloadCache {
             requestConfig,
             fetchRuntimeSupport);
     cg.register(false);
-    cg.start(clientContext());
+    cg.start(runtimeContext());
   }
 
   PersistentRequestClient getGlobalForeverClient() {
@@ -656,34 +641,31 @@ final class FcpServerPersistentOps implements DownloadCache {
   void startBlocking(final ClientRequest req)
       throws IdentifierCollisionException, PersistenceDisabledException {
     if (req.persistence == Persistence.REBOOT) {
-      req.start(clientContext());
+      req.start(runtimeContext());
     } else {
       final CountDownLatch done = new CountDownLatch(1);
       final AtomicReference<IdentifierCollisionException> collision = new AtomicReference<>();
-      clientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
+      runtimeSupport.queuePersistentJob(
+          new FcpPersistentJob() {
+            @Override
+            public boolean run(PersistentRequestRuntimeContext context) {
+              try {
+                req.register(false);
+                req.start(context);
+              } catch (IdentifierCollisionException e) {
+                collision.set(e);
+              } finally {
+                done.countDown();
+              }
+              return true;
+            }
 
-                @Override
-                public String toString() {
-                  return "FCP startBlocking";
-                }
-
-                @Override
-                public boolean run(ClientContext context) {
-                  try {
-                    req.register(false);
-                    req.start(context);
-                  } catch (IdentifierCollisionException e) {
-                    collision.set(e);
-                  } finally {
-                    done.countDown();
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+            @Override
+            public String toString() {
+              return "FCP startBlocking";
+            }
+          },
+          NativeThread.PriorityLevel.HIGH_PRIORITY.value);
 
       try {
         done.await();
@@ -700,42 +682,39 @@ final class FcpServerPersistentOps implements DownloadCache {
       throws PersistenceDisabledException {
     ClientRequest req = globalRebootClient.getRequest(identifier);
     if (req != null) {
-      req.restart(clientContext(), disableFilterData);
+      req.restart(runtimeContext(), disableFilterData);
       return true;
     } else {
       final CountDownLatch done = new CountDownLatch(1);
       final AtomicBoolean success = new AtomicBoolean();
       if (LOG.isDebugEnabled()) LOG.debug("Queueing restart of {}", identifier);
-      clientContext()
-          .jobRunner
-          .queue(
-              new PersistentJob() {
-
-                @Override
-                public String toString() {
-                  return "FCP restartBlocking";
+      runtimeSupport.queuePersistentJob(
+          new FcpPersistentJob() {
+            @Override
+            public boolean run(PersistentRequestRuntimeContext context) {
+              boolean restarted = false;
+              try {
+                ClientRequest req = globalForeverClient.getRequest(identifier);
+                if (LOG.isDebugEnabled()) LOG.debug("Restarting {} for {}", req, identifier);
+                if (req != null) {
+                  req.restart(context, disableFilterData);
+                  restarted = true;
                 }
+              } catch (PersistenceDisabledException e) {
+                LOG.error("Failed to restart {}: {}", identifier, e.getMessage(), e);
+              } finally {
+                success.set(restarted);
+                done.countDown();
+              }
+              return true;
+            }
 
-                @Override
-                public boolean run(ClientContext context) {
-                  boolean restarted = false;
-                  try {
-                    ClientRequest req = globalForeverClient.getRequest(identifier);
-                    if (LOG.isDebugEnabled()) LOG.debug("Restarting {} for {}", req, identifier);
-                    if (req != null) {
-                      req.restart(context, disableFilterData);
-                      restarted = true;
-                    }
-                  } catch (PersistenceDisabledException e) {
-                    LOG.error("Failed to restart {}: {}", identifier, e.getMessage(), e);
-                  } finally {
-                    success.set(restarted);
-                    done.countDown();
-                  }
-                  return true;
-                }
-              },
-              NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+            @Override
+            public String toString() {
+              return "FCP restartBlocking";
+            }
+          },
+          NativeThread.PriorityLevel.HIGH_PRIORITY.value);
 
       try {
         done.await();
@@ -761,28 +740,25 @@ final class FcpServerPersistentOps implements DownloadCache {
 
     final CountDownLatch done = new CountDownLatch(1);
     final AtomicReference<FetchResult> resultRef = new AtomicReference<>();
-    clientContext()
-        .jobRunner
-        .queue(
-            new PersistentJob() {
+    runtimeSupport.queuePersistentJob(
+        new FcpPersistentJob() {
+          @Override
+          public boolean run(PersistentRequestRuntimeContext context) {
+            try {
+              CacheFetchResult lookup = lookup(key, false, context, false, null);
+              resultRef.set(lookup);
+            } finally {
+              done.countDown();
+            }
+            return false;
+          }
 
-              @Override
-              public String toString() {
-                return "FCP getCompletedRequestBlocking";
-              }
-
-              @Override
-              public boolean run(ClientContext context) {
-                try {
-                  CacheFetchResult lookup = lookup(key, false, context, false, null);
-                  resultRef.set(lookup);
-                } finally {
-                  done.countDown();
-                }
-                return false;
-              }
-            },
-            NativeThread.PriorityLevel.HIGH_PRIORITY.value);
+          @Override
+          public String toString() {
+            return "FCP getCompletedRequestBlocking";
+          }
+        },
+        NativeThread.PriorityLevel.HIGH_PRIORITY.value);
 
     try {
       done.await();
@@ -843,7 +819,11 @@ final class FcpServerPersistentOps implements DownloadCache {
 
   @Override
   public CacheFetchResult lookup(
-      FreenetURI key, boolean noFilter, ClientContext context, boolean mustCopy, Bucket preferred) {
+      FreenetURI key,
+      boolean noFilter,
+      PersistentRequestRuntimeContext context,
+      boolean mustCopy,
+      Bucket preferred) {
     if (globalForeverClient == null) return null;
     ClientGet get = globalForeverClient.getCompletedRequest(key);
     if (get != null) {
@@ -881,7 +861,7 @@ final class FcpServerPersistentOps implements DownloadCache {
     return globalRebootClient;
   }
 
-  private ClientContext clientContext() {
-    return runtimeSupport.clientContext();
+  private PersistentRequestRuntimeContext runtimeContext() {
+    return runtimeSupport.persistentRequestRuntimeContext();
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.PersistentTempBucketFactory;
 
@@ -13,12 +15,31 @@ import network.crypta.support.io.PersistentTempBucketFactory;
  * factories, and secure randomness currently required by the FCP server's infrastructure classes.
  *
  * <p>The seam remains owned by {@code clients.fcp} even though core-backed implementations now live
- * under runtime bootstrap wiring. It is public only so those runtime-owned adapters can implement
+ * under runtime bootstrap wiring. It is public only, so those runtime-owned adapters can implement
  * it from outside this package. It is not a new shared platform API; callers should add methods
  * only when a later refactoring needs another demonstrably server-infrastructure-specific
  * capability.
  */
 public interface FcpServerRuntimeSupport {
+
+  /**
+   * Returns the detached runtime context used by server-owned persistent request flows.
+   *
+   * @return detached runtime context backed by the current live daemon runtime
+   */
+  PersistentRequestRuntimeContext persistentRequestRuntimeContext();
+
+  /**
+   * Queues detached persistent work on the live runtime-owned persistent job runner.
+   *
+   * @param job detached persistent job to execute
+   * @param priority queue priority for the underlying runtime job runner
+   * @throws PersistenceDisabledException if persistent storage is unavailable
+   */
+  void queuePersistentJob(FcpPersistentJob job, int priority) throws PersistenceDisabledException;
+
+  /** Requests an immediate persistence checkpoint from the live runtime. */
+  void setCheckpointASAP();
 
   /**
    * Returns the live client context used for request lifecycle and persistent job work.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestClient.java
@@ -5,17 +5,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import network.crypta.client.FetchException.FetchExceptionMode;
-import network.crypta.client.InsertException.InsertExceptionMode;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.ListPersistentRequestsMessage.PersistentListJob;
 import network.crypta.clients.fcp.ListPersistentRequestsMessage.TransientListJob;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.RequestQueuePort;
-import network.crypta.support.api.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,14 +99,13 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
     lowLevelClientRT = new FCPClientRequestClient(this, forever, true);
     completionCallbacks = new ArrayList<>();
     if (cb != null) completionCallbacks.add(cb);
+    statusTracker = new PersistentRequestClientStatusTracker(isGlobalQueue);
     if (persistence == Persistence.FOREVER) {
       if (root == null) {
         throw new IllegalArgumentException("Persistent root must be provided for FOREVER mode");
       }
       this.root = root;
     } else this.root = null;
-    if (isGlobalQueue) statusCache = new RequestStatusCache();
-    else statusCache = null;
   }
 
   /** The persistent root object, null if persistence is PERSIST_REBOOT */
@@ -145,9 +141,7 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
   private final RequestClient lowLevelClient;
   private final RequestClient lowLevelClientRT;
   private List<RequestCompletionCallback> completionCallbacks;
-
-  /** The cache where ClientRequests report their progress */
-  private final RequestStatusCache statusCache;
+  private final PersistentRequestClientStatusTracker statusTracker;
 
   /** Connection mode */
   final Persistence persistence;
@@ -222,56 +216,7 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
         completedUnackedRequests.add(get);
       }
     }
-    if (statusCache != null) {
-      switch (get) {
-        case ClientGet download -> handleDownloadCompletion(download);
-        case ClientPutBase upload -> handleUploadCompletion(upload);
-        default -> throw new IllegalStateException("Unexpected request type: " + get.getClass());
-      }
-    }
-  }
-
-  private void handleUploadCompletion(ClientPutBase upload) {
-    PutFailedMessage msg = upload.getFailureMessage();
-    InsertExceptionMode failureCode = null;
-    String shortFailMessage = null;
-    String longFailMessage = null;
-    if (msg != null) {
-      failureCode = msg.failureMode;
-      shortFailMessage = msg.getShortFailedMessage();
-      longFailMessage = msg.getLongFailedMessage();
-    }
-    statusCache.finishedUpload(
-        upload.getIdentifier(),
-        upload.hasSucceeded(),
-        upload.getGeneratedURI(),
-        failureCode,
-        shortFailMessage,
-        longFailMessage);
-  }
-
-  private void handleDownloadCompletion(ClientGet download) {
-    GetFailedMessage failureMessage = download.state().getFailedMessage();
-    FetchExceptionMode failureCode = null;
-    String shortFailMessage = null;
-    String longFailMessage = null;
-    if (failureMessage != null) {
-      failureCode = failureMessage.failureMode;
-      shortFailMessage = failureMessage.getShortFailedMessage();
-      longFailMessage = failureMessage.getLongFailedMessage();
-    }
-    Bucket shadow = download.getBucket();
-    if (shadow != null) shadow = shadow.createShadow();
-    DownloadOutcomeInfo outcome =
-        new DownloadOutcomeInfo(
-            download.getDataSize(),
-            download.getMIMEType(),
-            failureCode,
-            shortFailMessage,
-            longFailMessage,
-            shadow,
-            download.filterData());
-    statusCache.finishedDownload(download.getIdentifier(), download.hasSucceeded(), outcome);
+    statusTracker.finishedClientRequest(get);
   }
 
   /**
@@ -404,13 +349,7 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
       }
       clientRequestsByIdentifier.put(ident, cg);
     }
-    if (statusCache != null) {
-      if (cg instanceof ClientGet) {
-        statusCache.addDownload((DownloadRequestStatus) cg.getStatus());
-      } else if (cg instanceof ClientPutBase) {
-        statusCache.addUpload((UploadRequestStatus) cg.getStatus());
-      }
-    }
+    statusTracker.register(cg);
   }
 
   /**
@@ -429,12 +368,12 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
    * @return {@code true} if a matching request was found and removed; {@code false} otherwise.
    */
   public boolean removeByIdentifier(
-      String identifier, boolean kill, FCPServer server, ClientContext context) {
+      String identifier, boolean kill, FCPServer server, PersistentRequestRuntimeContext context) {
     if (server == null) {
       LOG.warn("removeByIdentifier invoked without server instance for {}", identifier);
     }
     if (LOG.isDebugEnabled()) LOG.debug("removeByIdentifier({},{})", identifier, kill);
-    if (statusCache != null) statusCache.removeByIdentifier(identifier);
+    statusTracker.removeByIdentifier(identifier);
     ClientRequest req = removeTrackedRequest(identifier);
     if (req == null) return false;
     if (kill) {
@@ -541,35 +480,18 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
     }
   }
 
-  /** From database */
-  private void addPersistentRequestStatusFromDatabase(List<RequestStatus> status) {
-    // Merging with addPersistentRequests would require revisiting locking semantics.
-    List<ClientRequest> reqs = new ArrayList<>();
-    addPersistentRequests(reqs, true);
-    for (ClientRequest req : reqs) {
-      try {
-        status.add(req.getStatus());
-      } catch (Exception t) {
-        // Try to load the rest.
-        LOG.error("BROKEN REQUEST LOADING PERSISTENT REQUEST STATUS: {}", t.getMessage(), t);
-        // Consider surfacing this to the user if it becomes frequent.
-      }
-      // The deactivation policy depends on callers; keep current behavior.
-    }
-  }
-
   /**
    * Adds cached status snapshots for all tracked requests to the supplied list.
    *
-   * <p>Unlike {@link #addPersistentRequestStatusFromDatabase(List)}, this relies on the in-memory
-   * {@link RequestStatusCache} populated during the current runtime. It appends to the provided
-   * list, preserving any existing entries, and does not clear the cache.
+   * <p>This relies on the in-memory {@link RequestStatusCache} populated during the current
+   * runtime. It appends to the provided list, preserving any existing entries, and does not clear
+   * the cache.
    *
    * @param status destination list that will receive status objects for both uploads and downloads;
    *     must be mutable and non-null.
    */
   public void addPersistentRequestStatus(List<RequestStatus> status) {
-    statusCache.addTo(status);
+    statusTracker.addPersistentRequestStatus(status);
   }
 
   /**
@@ -785,7 +707,7 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
    * required.
    */
   public void removeAll() {
-    if (statusCache != null) statusCache.clear();
+    statusTracker.clear();
     synchronized (this) {
       runningPersistentRequests.clear();
       completedUnackedRequests.clear();
@@ -804,14 +726,7 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
    *     same URI is present.
    */
   public ClientGet getCompletedRequest(FreenetURI key) {
-    // Potential optimization: a transient hashmap keyed by URI could speed lookups.
-    for (ClientRequest req : completedUnackedRequests) {
-      if (!(req instanceof ClientGet getter)) continue;
-      if (getter.getURI().equals(key)) {
-        return getter;
-      }
-    }
-    return null;
+    return statusTracker.getCompletedRequest(completedUnackedRequests, key);
   }
 
   /**
@@ -821,7 +736,7 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
    *     configured as the global queue.
    */
   public RequestStatusCache getRequestStatusCache() {
-    return statusCache;
+    return statusTracker.getRequestStatusCache();
   }
 
   /**
@@ -831,18 +746,10 @@ public final class PersistentRequestClient implements PersistentRequestClientHan
    * disk-backed request state. No effect occurs for reboot-persistent clients.
    */
   public void updateRequestStatusCache() {
-    updateRequestStatusCache(statusCache);
-  }
-
-  private void updateRequestStatusCache(RequestStatusCache cache) {
     if (persistence == Persistence.FOREVER) {
-      LOG.info("Loading cache of request statuses...");
-      ArrayList<RequestStatus> statuses = new ArrayList<>();
-      addPersistentRequestStatusFromDatabase(statuses);
-      for (RequestStatus status : statuses) {
-        if (status instanceof DownloadRequestStatus requestStatus) cache.addDownload(requestStatus);
-        else cache.addUpload((UploadRequestStatus) status);
-      }
+      List<ClientRequest> requests = new ArrayList<>();
+      addPersistentRequests(requests, true);
+      statusTracker.updateRequestStatusCache(requests);
     }
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestClientStatusTracker.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentRequestClientStatusTracker.java
@@ -1,0 +1,267 @@
+package network.crypta.clients.fcp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks status-cache state for a {@link PersistentRequestClient}.
+ *
+ * <p>This helper exists primarily to satisfy Sonar rule {@code java:S6539} ("Monster Class") by
+ * separating status-cache translation and rebuild logic from the connection, replay, and watcher
+ * coordination that remains on {@link PersistentRequestClient}. It owns the optional {@link
+ * RequestStatusCache} used by global queues and translates live request outcomes into cached upload
+ * and download status entries.
+ *
+ * <p>The class is deliberately package-private because it is an implementation detail of {@link
+ * PersistentRequestClient}, not a reusable status service for the wider FCP adapter. It operates on
+ * already-materialized {@link ClientRequest} instances, keeps the global-queue cache optional, and
+ * preserves the existing request-status behavior for reboot and forever queues without changing
+ * request persistence or replay semantics. Callers hand it requests at key lifecycle moments such
+ * as register, finish, remove, and cache rebuild, and the helper converts those events into the
+ * concrete cache mutations that UI and API status consumers already expect.
+ *
+ * <ul>
+ *   <li>Owns the optional {@link RequestStatusCache} instance for global queues.
+ *   <li>Translates live request outcomes into detached download and upload status snapshots.
+ *   <li>Rebuilds cached status state from persistent requests after restart when needed.
+ * </ul>
+ */
+final class PersistentRequestClientStatusTracker {
+  /** Logger used for status-cache rebuild failures and other internal tracker diagnostics. */
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PersistentRequestClientStatusTracker.class);
+
+  /**
+   * Optional cache exposed to global-queue status consumers.
+   *
+   * <p>The cache is present only for global queues because connection-local request clients do not
+   * publish long-lived status snapshots through the same status APIs.
+   */
+  private final RequestStatusCache statusCache;
+
+  /**
+   * Creates a tracker for one persistent-request client.
+   *
+   * <p>Global clients receive a dedicated {@link RequestStatusCache}, while non-global clients keep
+   * the field {@code null} and effectively turn the helper into a no-op for cache-specific work.
+   * That mirrors the pre-refactor behavior without forcing callers to branch at every status update
+   * site.
+   *
+   * @param globalQueue whether the owning persistent client contributes to the global status cache
+   */
+  PersistentRequestClientStatusTracker(boolean globalQueue) {
+    statusCache = globalQueue ? new RequestStatusCache() : null;
+  }
+
+  /**
+   * Adds a newly registered request to the in-memory status cache when one exists.
+   *
+   * <p>The method snapshots the request's current status object and indexes it under the correct
+   * download or upload collection. Unknown request subtypes are intentionally ignored here because
+   * only download and insert requests are expected to populate the FCP status cache.
+   *
+   * @param request newly registered request whose current status should be cached
+   */
+  void register(ClientRequest request) {
+    if (statusCache == null) {
+      return;
+    }
+    if (request instanceof ClientGet) {
+      statusCache.addDownload((DownloadRequestStatus) request.getStatus());
+    } else if (request instanceof ClientPutBase) {
+      statusCache.addUpload((UploadRequestStatus) request.getStatus());
+    }
+  }
+
+  /**
+   * Applies terminal request state to the cache when the owning request finishes.
+   *
+   * <p>Downloads and uploads use different outcome payloads, so the method dispatches to
+   * type-specific completion helpers rather than trying to update the cache through a uniform
+   * object model. Any unexpected request subtype is treated as a programming error because it would
+   * indicate that a non-cacheable request reached a cache-oriented lifecycle hook.
+   *
+   * @param request finished request whose terminal status should be reflected in the cache
+   */
+  void finishedClientRequest(ClientRequest request) {
+    if (statusCache == null) {
+      return;
+    }
+    switch (request) {
+      case ClientGet download -> handleDownloadCompletion(download);
+      case ClientPutBase upload -> handleUploadCompletion(upload);
+      default -> throw new IllegalStateException("Unexpected request type: " + request.getClass());
+    }
+  }
+
+  /**
+   * Removes one cached status entry by request identifier when the owning request is deleted.
+   *
+   * @param identifier request identifier to evict from the in-memory status cache
+   */
+  void removeByIdentifier(String identifier) {
+    if (statusCache != null) {
+      statusCache.removeByIdentifier(identifier);
+    }
+  }
+
+  /** Clears every cached status entry when the owning client drops all requests. */
+  void clear() {
+    if (statusCache != null) {
+      statusCache.clear();
+    }
+  }
+
+  /**
+   * Appends all cached status entries to the supplied output list.
+   *
+   * <p>Callers use this to expose the current global status view without giving external code
+   * direct write access to the cache instance itself.
+   *
+   * @param status destination list that receives the cached request statuses
+   */
+  void addPersistentRequestStatus(List<RequestStatus> status) {
+    requireStatusCache().addTo(status);
+  }
+
+  /**
+   * Finds the completed download request for the supplied key among unacknowledged completions.
+   *
+   * <p>The search stays intentionally simple because the completed list is already maintained by
+   * the owning {@link PersistentRequestClient}. Only {@link ClientGet} instances are relevant here;
+   * all other request types are skipped.
+   *
+   * @param completedUnackedRequests finished requests that still await client acknowledgement
+   * @param key key whose completed download request should be returned
+   * @return matching completed {@link ClientGet}, or {@code null} when none is present
+   */
+  ClientGet getCompletedRequest(List<ClientRequest> completedUnackedRequests, FreenetURI key) {
+    for (ClientRequest request : completedUnackedRequests) {
+      if (!(request instanceof ClientGet getter)) {
+        continue;
+      }
+      if (getter.getURI().equals(key)) {
+        return getter;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the backing status cache if this tracker owns one.
+   *
+   * @return global status cache for the owning client, or {@code null} for non-global queues
+   */
+  RequestStatusCache getRequestStatusCache() {
+    return statusCache;
+  }
+
+  /**
+   * Rebuilds the status cache from a list of persistent requests loaded after restart.
+   *
+   * <p>The rebuild is best-effort: one broken request status should not prevent the remainder of
+   * the cache from being reconstructed. Requests are first converted into detached {@link
+   * RequestStatus} snapshots and then re-indexed as downloads or uploads to preserve the existing
+   * cache layout.
+   *
+   * @param persistentRequests live persistent requests whose cached status state should be rebuilt
+   */
+  void updateRequestStatusCache(List<ClientRequest> persistentRequests) {
+    RequestStatusCache cache = requireStatusCache();
+    LOG.info("Loading cache of request statuses...");
+    List<RequestStatus> statuses = new ArrayList<>();
+    for (ClientRequest request : persistentRequests) {
+      try {
+        statuses.add(request.getStatus());
+      } catch (Exception t) {
+        LOG.error("BROKEN REQUEST LOADING PERSISTENT REQUEST STATUS: {}", t.getMessage(), t);
+      }
+    }
+    for (RequestStatus status : statuses) {
+      if (status instanceof DownloadRequestStatus requestStatus) {
+        cache.addDownload(requestStatus);
+      } else {
+        cache.addUpload((UploadRequestStatus) status);
+      }
+    }
+  }
+
+  /**
+   * Translates a finished upload request into the cached upload-status representation.
+   *
+   * <p>The helper extracts the final URI and any available failure details from the request's
+   * {@link PutFailedMessage}, then forwards that terminal state into {@link RequestStatusCache}.
+   *
+   * @param upload finished upload request whose outcome should update the cache
+   */
+  private void handleUploadCompletion(ClientPutBase upload) {
+    PutFailedMessage message = upload.getFailureMessage();
+    InsertExceptionMode failureCode = null;
+    String shortFailMessage = null;
+    String longFailMessage = null;
+    if (message != null) {
+      failureCode = message.failureMode;
+      shortFailMessage = message.getShortFailedMessage();
+      longFailMessage = message.getLongFailedMessage();
+    }
+    statusCache.finishedUpload(
+        upload.getIdentifier(),
+        upload.hasSucceeded(),
+        upload.getGeneratedURI(),
+        failureCode,
+        shortFailMessage,
+        longFailMessage);
+  }
+
+  /**
+   * Translates a finished download request into the cached download-status representation.
+   *
+   * <p>The helper captures failure details, MIME type, byte count, filter state, and a shadow copy
+   * of the final bucket when one is available. That keeps the status cache detached from the live
+   * request object while preserving the local-cache lookup behavior expected by higher layers.
+   *
+   * @param download finished download request whose outcome should update the cache
+   */
+  private void handleDownloadCompletion(ClientGet download) {
+    GetFailedMessage failureMessage = download.state().getFailedMessage();
+    FetchExceptionMode failureCode = null;
+    String shortFailMessage = null;
+    String longFailMessage = null;
+    if (failureMessage != null) {
+      failureCode = failureMessage.failureMode;
+      shortFailMessage = failureMessage.getShortFailedMessage();
+      longFailMessage = failureMessage.getLongFailedMessage();
+    }
+    Bucket shadow = download.getBucket();
+    if (shadow != null) {
+      shadow = shadow.createShadow();
+    }
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(
+            download.getDataSize(),
+            download.getMIMEType(),
+            failureCode,
+            shortFailMessage,
+            longFailMessage,
+            shadow,
+            download.filterData());
+    statusCache.finishedDownload(download.getIdentifier(), download.hasSucceeded(), outcome);
+  }
+
+  /**
+   * Returns the backing cache or fails fast when the owning client has no global cache.
+   *
+   * @return non-null status cache owned by this tracker
+   * @throws NullPointerException when called for a non-global queue without a status cache
+   */
+  private RequestStatusCache requireStatusCache() {
+    return Objects.requireNonNull(statusCache, "statusCache");
+  }
+}

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -62,6 +62,9 @@ class AdapterFcpBoundaryTest {
       ADAPTER_FCP_MAIN_JAVA.resolve("DownloadRequestStatus.java");
   private static final Path DOWNLOAD_REQUEST_STATUS_DETAILS_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("DownloadRequestStatusDetails.java");
+  private static final Path CLIENT_REQUEST_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientRequest.java");
+  private static final Path FCP_SERVER_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("FCPServer.java");
   private static final Path FCP_CONNECTION_HANDLER_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("FCPConnectionHandler.java");
   private static final Path FCP_FETCH_RUNTIME_SUPPORT_SOURCE =
@@ -70,6 +73,8 @@ class AdapterFcpBoundaryTest {
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpMessageRuntimeSupport.java");
   private static final Path FCP_SERVER_PERSISTENT_OPS_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpServerPersistentOps.java");
+  private static final Path FCP_SERVER_RUNTIME_SUPPORT_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FcpServerRuntimeSupport.java");
   private static final Path COMPATIBILITY_MODE_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("CompatibilityMode.java");
   private static final Path FCP_COMPATIBILITY_MODE_SOURCE =
@@ -80,6 +85,8 @@ class AdapterFcpBoundaryTest {
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpInsertContextHandle.java");
   private static final Path DEFAULT_FCP_INSERT_CONTEXT_HANDLE_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("DefaultFcpInsertContextHandle.java");
+  private static final Path PERSISTENT_REQUEST_CLIENT_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("PersistentRequestClient.java");
   private static final Path REQUEST_STATUS_CACHE_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("RequestStatusCache.java");
   private static final Set<Path> INSERT_FAMILY_SEAM_SOURCES =
@@ -172,6 +179,11 @@ class AdapterFcpBoundaryTest {
           "network.crypta.client.async.BaseClientPutter",
           "network.crypta.client.async.ClientPutCallback",
           "network.crypta.client.async.ClientRequester");
+  private static final Set<String> FORBIDDEN_SERVER_INFRA_RUNTIME_TYPES =
+      Set.of(
+          "network.crypta.client.async.ClientContext",
+          "network.crypta.client.async.PersistentJob",
+          "network.crypta.client.async.DownloadCache");
   private static final Set<Path> GET_RUNTIME_SEAM_SOURCES =
       Set.of(
           FCP_FETCH_RUNTIME_SUPPORT_SOURCE,
@@ -481,6 +493,177 @@ class AdapterFcpBoundaryTest {
             + String.join(System.lineSeparator(), violations));
   }
 
+  @Test
+  void serverInfrastructure_whenCheckingDetachedRuntimeSeams_expectNoLiveRuntimeInfraLeaks()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+    String serverSource = Files.readString(repoRoot.resolve(FCP_SERVER_SOURCE));
+    String persistentOpsSource =
+        Files.readString(repoRoot.resolve(FCP_SERVER_PERSISTENT_OPS_SOURCE));
+    String connectionHandlerSource =
+        Files.readString(repoRoot.resolve(FCP_CONNECTION_HANDLER_SOURCE));
+    String persistentRequestClientSource =
+        Files.readString(repoRoot.resolve(PERSISTENT_REQUEST_CLIENT_SOURCE));
+    String clientRequestSource = Files.readString(repoRoot.resolve(CLIENT_REQUEST_SOURCE));
+    String runtimeSupportSource =
+        Files.readString(repoRoot.resolve(FCP_SERVER_RUNTIME_SUPPORT_SOURCE));
+
+    collectForbiddenRuntimeInfraImportViolations(violations, FCP_SERVER_SOURCE, repoRoot);
+    collectForbiddenRuntimeInfraImportViolations(
+        violations, FCP_SERVER_PERSISTENT_OPS_SOURCE, repoRoot);
+    collectForbiddenRuntimeInfraImportViolations(
+        violations, FCP_CONNECTION_HANDLER_SOURCE, repoRoot);
+    collectForbiddenRuntimeInfraImportViolations(
+        violations, PERSISTENT_REQUEST_CLIENT_SOURCE, repoRoot);
+
+    requireAbsent(
+        violations,
+        FCP_SERVER_SOURCE,
+        serverSource,
+        "implements Runnable, DownloadCache",
+        "must not implement runtime-owned DownloadCache");
+    requireAbsent(
+        violations,
+        FCP_SERVER_SOURCE,
+        serverSource,
+        "lookup(\n      FreenetURI key, boolean noFilter, ClientContext context",
+        "must not expose cache lookup with live ClientContext");
+
+    requireAbsent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "new PersistentJob()",
+        "must not allocate runtime-owned PersistentJob directly");
+    requireAbsent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "run(ClientContext context)",
+        "must not declare queued work against live ClientContext");
+    requireAbsent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "req.restart(clientContext(),",
+        "must use detached restart wrapper");
+    requireAbsent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "clientContext().jobRunner.queue(",
+        "must queue through the detached server runtime seam");
+    requireAbsent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "lookup(\n      FreenetURI key, boolean noFilter, ClientContext context",
+        "must not expose cache lookup with live ClientContext");
+    requireAbsent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "private ClientContext clientContext()",
+        "must not keep a live ClientContext helper");
+    requirePresent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "implements FcpDownloadCache",
+        "must implement the detached FcpDownloadCache seam");
+    requirePresent(
+        violations,
+        FCP_SERVER_PERSISTENT_OPS_SOURCE,
+        persistentOpsSource,
+        "runtimeSupport.queuePersistentJob(",
+        "must queue persistent work through the detached runtime seam");
+
+    requireAbsent(
+        violations,
+        FCP_CONNECTION_HANDLER_SOURCE,
+        connectionHandlerSource,
+        "new PersistentJob()",
+        "must not allocate runtime-owned PersistentJob directly");
+    requireAbsent(
+        violations,
+        FCP_CONNECTION_HANDLER_SOURCE,
+        connectionHandlerSource,
+        "serverRuntimeSupport().clientContext()",
+        "must not reach through to live ClientContext for server infrastructure");
+    requireAbsent(
+        violations,
+        FCP_CONNECTION_HANDLER_SOURCE,
+        connectionHandlerSource,
+        "private ClientContext serverClientContext()",
+        "must not keep a live ClientContext helper");
+    requirePresent(
+        violations,
+        FCP_CONNECTION_HANDLER_SOURCE,
+        connectionHandlerSource,
+        "private void queuePersistentJob(FcpPersistentJob job",
+        "must queue detached FcpPersistentJob work");
+
+    requireAbsent(
+        violations,
+        PERSISTENT_REQUEST_CLIENT_SOURCE,
+        persistentRequestClientSource,
+        "removeByIdentifier(\n"
+            + "      String identifier, boolean kill, FCPServer server, ClientContext context)",
+        "must not require live ClientContext in removeByIdentifier");
+    requirePresent(
+        violations,
+        PERSISTENT_REQUEST_CLIENT_SOURCE,
+        persistentRequestClientSource,
+        "PersistentRequestRuntimeContext context",
+        "must use detached PersistentRequestRuntimeContext");
+
+    requirePresent(
+        violations,
+        CLIENT_REQUEST_SOURCE,
+        clientRequestSource,
+        "public final boolean restart(PersistentRequestRuntimeContext context, boolean"
+            + " disableFilterData)",
+        "must expose detached restart wrapper");
+    requireAbsent(
+        violations,
+        CLIENT_REQUEST_SOURCE,
+        clientRequestSource,
+        "restart(runtimeSupport.clientContext(), disableFilterData)",
+        "must not restart through live ClientContext reach-through");
+    requirePresent(
+        violations,
+        CLIENT_REQUEST_SOURCE,
+        clientRequestSource,
+        "runtimeSupport.queuePersistentJob(",
+        "must queue restart work through the detached runtime seam");
+
+    requirePresent(
+        violations,
+        FCP_SERVER_RUNTIME_SUPPORT_SOURCE,
+        runtimeSupportSource,
+        "PersistentRequestRuntimeContext persistentRequestRuntimeContext();",
+        "must expose detached runtime context");
+    requirePresent(
+        violations,
+        FCP_SERVER_RUNTIME_SUPPORT_SOURCE,
+        runtimeSupportSource,
+        "void queuePersistentJob(FcpPersistentJob job, int priority)",
+        "must expose detached persistent job queueing");
+    requirePresent(
+        violations,
+        FCP_SERVER_RUNTIME_SUPPORT_SOURCE,
+        runtimeSupportSource,
+        "void setCheckpointASAP();",
+        "must expose detached checkpoint signaling");
+
+    assertTrue(
+        violations.isEmpty(),
+        "Server/runtime infrastructure sources must use detached adapter-owned seams only."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
   private static List<Path> findJavaSources(Path root) throws IOException {
     try (Stream<Path> walk = Files.walk(root)) {
       return walk.filter(Files::isRegularFile)
@@ -544,6 +727,41 @@ class AdapterFcpBoundaryTest {
           .filter(line -> !line.isEmpty())
           .filter(line -> !line.startsWith("#"))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static void collectForbiddenRuntimeInfraImportViolations(
+      List<String> violations, Path source, Path repoRoot) throws IOException {
+    Set<String> imports = readImports(repoRoot.resolve(source));
+    Set<String> forbiddenImports = new TreeSet<>(imports);
+    forbiddenImports.retainAll(FORBIDDEN_SERVER_INFRA_RUNTIME_TYPES);
+    if (!forbiddenImports.isEmpty()) {
+      violations.add(
+          source
+              + " must not import live server/runtime infrastructure types: "
+              + forbiddenImports);
+    }
+  }
+
+  private static void requireAbsent(
+      List<String> violations,
+      Path source,
+      String sourceText,
+      String forbiddenSnippet,
+      String requirement) {
+    if (sourceText.contains(forbiddenSnippet)) {
+      violations.add(source + " " + requirement + " [found: " + forbiddenSnippet + ']');
+    }
+  }
+
+  private static void requirePresent(
+      List<String> violations,
+      Path source,
+      String sourceText,
+      String requiredSnippet,
+      String requirement) {
+    if (!sourceText.contains(requiredSnippet)) {
+      violations.add(source + " " + requirement + " [missing: " + requiredSnippet + ']');
     }
   }
 

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpEndpointHandle.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpEndpointHandle.java
@@ -3,7 +3,9 @@ package network.crypta.clients.fcp.bridge;
 import java.util.Objects;
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpDownloadCache;
 import network.crypta.keys.FreenetURI;
 import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
 import network.crypta.support.api.Bucket;
@@ -20,7 +22,7 @@ import network.crypta.support.api.Bucket;
  * runtime package a stable seam for later decoupling work.
  */
 @SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
-final class CoreFcpEndpointHandle implements FcpEndpointHandle {
+final class CoreFcpEndpointHandle implements FcpEndpointHandle, FcpDownloadCache {
   /** Concrete FCP server that still owns queue state, startup, and cache lookups. */
   private final FCPServer server;
 
@@ -58,6 +60,16 @@ final class CoreFcpEndpointHandle implements FcpEndpointHandle {
   @Override
   public CacheFetchResult lookup(
       FreenetURI key, boolean noFilter, ClientContext context, boolean mustCopy, Bucket preferred) {
+    return server.lookup(key, noFilter, context, mustCopy, preferred);
+  }
+
+  @Override
+  public CacheFetchResult lookup(
+      FreenetURI key,
+      boolean noFilter,
+      PersistentRequestRuntimeContext context,
+      boolean mustCopy,
+      Bucket preferred) {
     return server.lookup(key, noFilter, context, mustCopy, preferred);
   }
 

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupport.java
@@ -2,6 +2,11 @@ package network.crypta.clients.fcp.bridge;
 
 import java.util.Objects;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.PersistenceDisabledException;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+import network.crypta.clients.fcp.FcpPersistentJob;
 import network.crypta.clients.fcp.FcpServerRuntimeSupport;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.BucketFactory;
@@ -46,6 +51,49 @@ record CoreFcpServerRuntimeSupport(NodeClientCore core) implements FcpServerRunt
     return core.getClientContext();
   }
 
+  /**
+   * Returns the detached persistence-runtime context for server-side bridge helpers.
+   *
+   * <p>The returned context is still the live client context at runtime, but adapter-side code can
+   * depend on the narrower {@link PersistentRequestRuntimeContext} seam when it only needs to
+   * schedule persistent work or resume durable requests.
+   *
+   * @return detached persistence-runtime context backed by the live client context
+   */
+  @Override
+  public PersistentRequestRuntimeContext persistentRequestRuntimeContext() {
+    return core.getClientContext();
+  }
+
+  /**
+   * Queues a detached persistent job on the live job runner.
+   *
+   * <p>This keeps the bridge-owned mapping from detached server work back to the live {@link
+   * PersistentJobRunner} while allowing server-side code to stop importing the runtime job type
+   * directly.
+   *
+   * @param job detached persistent job to queue
+   * @param threadPriority thread priority used for the live runner submission
+   * @throws PersistenceDisabledException if the underlying job runner cannot accept work
+   */
+  @Override
+  public void queuePersistentJob(FcpPersistentJob job, int threadPriority)
+      throws PersistenceDisabledException {
+    ClientContext clientContext = clientContext();
+    clientContext.jobRunner.queue(new CorePersistentJob(job), threadPriority);
+  }
+
+  /**
+   * Requests an early checkpoint on the live persistent job runner.
+   *
+   * <p>Bridge code uses this for the same checkpoint-as-soon-as-possible behavior the adapter used
+   * to trigger by reaching through the live client context directly.
+   */
+  @Override
+  public void setCheckpointASAP() {
+    clientContext().jobRunner.setCheckpointASAP();
+  }
+
   @Override
   public boolean persistenceDisabled() {
     return core.killedDatabase();
@@ -64,5 +112,24 @@ record CoreFcpServerRuntimeSupport(NodeClientCore core) implements FcpServerRunt
   @Override
   public void fillSecureRandom(byte[] bytes) {
     core.getRandom().nextBytes(bytes);
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class CorePersistentJob implements PersistentJob {
+    private final FcpPersistentJob job;
+
+    private CorePersistentJob(FcpPersistentJob job) {
+      this.job = Objects.requireNonNull(job);
+    }
+
+    @Override
+    public boolean run(ClientContext context) {
+      return job.run(context);
+    }
+
+    @Override
+    public String toString() {
+      return job.toString();
+    }
   }
 }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/FcpEndpointHandles.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/FcpEndpointHandles.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp.bridge;
 
 import java.util.Objects;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpDownloadCache;
 import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
 
 /**
@@ -37,6 +38,19 @@ public final class FcpEndpointHandles {
   }
 
   /**
+   * Returns the detached cache-view seam backed by the supplied concrete server.
+   *
+   * <p>Use this when bridge-owned code needs the lookup behavior without the runtime-owned {@link
+   * FcpEndpointHandle} contract.
+   *
+   * @param server concrete FCP server to expose behind the detached cache seam
+   * @return bridge-owned detached cache view that delegates to {@code server}
+   */
+  public static FcpDownloadCache downloadCache(FCPServer server) {
+    return new CoreFcpEndpointHandle(server);
+  }
+
+  /**
    * Returns the concrete FCP server behind the supplied handle.
    *
    * <p>This is the strict unwrapping path for bridge code that still needs full FCP access. It
@@ -65,6 +79,34 @@ public final class FcpEndpointHandles {
    */
   public static FCPServer serverOrNull(FcpEndpointHandle endpointHandle) {
     return endpointHandle == null ? null : requireCoreHandle(endpointHandle).server();
+  }
+
+  /**
+   * Returns the detached cache view when present, otherwise {@code null}.
+   *
+   * @param endpointHandle runtime-owned handle, or {@code null}
+   * @return detached cache view, or {@code null} when no handle is available
+   * @throws IllegalArgumentException if the handle was not created by this bridge package
+   */
+  public static FcpDownloadCache downloadCacheOrNull(FcpEndpointHandle endpointHandle) {
+    return endpointHandle == null ? null : requireCoreHandle(endpointHandle);
+  }
+
+  /**
+   * Returns the detached cache view or throws when no handle is available.
+   *
+   * @param endpointHandle runtime-owned handle expected to wrap a live FCP server
+   * @return detached cache view backed by the wrapped server
+   * @throws IllegalStateException if {@code endpointHandle} is {@code null}
+   * @throws IllegalArgumentException if the handle was not created by this bridge package
+   */
+  @SuppressWarnings("unused")
+  public static FcpDownloadCache requireDownloadCache(FcpEndpointHandle endpointHandle) {
+    FcpDownloadCache downloadCache = downloadCacheOrNull(endpointHandle);
+    if (downloadCache == null) {
+      throw new IllegalStateException("FCP download cache unavailable");
+    }
+    return downloadCache;
   }
 
   /**

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpServerDependenciesFactoryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpServerDependenciesFactoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -68,6 +69,7 @@ class CoreFcpServerDependenciesFactoryTest {
     // Assert
     assertSame(runtimePorts, dependencies.runtimePorts());
     assertSame(persistentRoot, dependencies.persistentRoot());
+    assertInstanceOf(CoreFcpServerRuntimeSupport.class, dependencies.serverRuntimeSupport());
     assertNotNull(dependencies.serverRuntimeSupport());
     assertNotNull(dependencies.messageRuntimeSupport());
     assertNotNull(dependencies.fetchRuntimeSupport());

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupportTest.java
@@ -1,18 +1,51 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.util.Random;
+import network.crypta.client.ArchiveManager;
+import network.crypta.client.FetchContext;
+import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientContextDefaults;
+import network.crypta.client.async.ClientContextRafFactories;
+import network.crypta.client.async.ClientContextResources;
+import network.crypta.client.async.ClientContextRuntime;
+import network.crypta.client.async.ClientContextServices;
+import network.crypta.client.async.ClientContextStorageFactories;
+import network.crypta.client.async.ClientLayerPersister;
+import network.crypta.client.async.DatastoreChecker;
+import network.crypta.client.async.HealingQueue;
+import network.crypta.client.async.PersistentJob;
+import network.crypta.client.async.USKManager;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.clients.fcp.FcpPersistentJob;
+import network.crypta.config.Config;
+import network.crypta.crypt.MasterSecret;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.NodeClientCore;
+import network.crypta.support.MemoryLimitedJobRunner;
+import network.crypta.support.PriorityAwareExecutor;
+import network.crypta.support.Ticker;
+import network.crypta.support.api.LockableRandomAccessBufferFactory;
+import network.crypta.support.compress.RealCompressor;
+import network.crypta.support.io.FileRandomAccessBufferFactory;
+import network.crypta.support.io.FilenameGenerator;
+import network.crypta.support.io.PersistentFileTracker;
 import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +54,7 @@ import static org.mockito.Mockito.when;
 class CoreFcpServerRuntimeSupportTest {
 
   @Mock private NodeClientCore core;
-  @Mock private ClientContext clientContext;
+  @Mock private ClientLayerPersister jobRunner;
   @Mock private TempBucketFactory tempBucketFactory;
   @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
   @Mock private RandomSource randomSource;
@@ -33,11 +66,62 @@ class CoreFcpServerRuntimeSupportTest {
 
   @Test
   void clientContext_whenQueried_returnsCoreClientContext() {
+    ClientContext clientContext = createClientContext(jobRunner);
     when(core.getClientContext()).thenReturn(clientContext);
 
     CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
 
     assertSame(clientContext, support.clientContext());
+  }
+
+  @Test
+  void persistentRequestRuntimeContext_whenQueried_returnsCoreClientContext() {
+    ClientContext clientContext = createClientContext(jobRunner);
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
+
+    assertSame(clientContext, support.persistentRequestRuntimeContext());
+  }
+
+  @Test
+  void queuePersistentJob_whenCalled_delegatesToCoreJobRunnerAndPreservesLabel() throws Exception {
+    ClientContext clientContext = createClientContext(jobRunner);
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
+    FcpPersistentJob persistentJob =
+        new FcpPersistentJob() {
+          @Override
+          public boolean run(PersistentRequestRuntimeContext context) {
+            assertSame(clientContext, context);
+            return true;
+          }
+
+          @Override
+          public String toString() {
+            return "FCP restartBlocking";
+          }
+        };
+
+    support.queuePersistentJob(persistentJob, 123);
+
+    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
+    verify(jobRunner).queue(jobCaptor.capture(), eq(123));
+    assertEquals("FCP restartBlocking", jobCaptor.getValue().toString());
+    assertTrue(jobCaptor.getValue().run(clientContext));
+  }
+
+  @Test
+  void setCheckpointASAP_whenCalled_delegatesToCoreJobRunner() {
+    ClientContext clientContext = createClientContext(jobRunner);
+    when(core.getClientContext()).thenReturn(clientContext);
+
+    CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
+
+    support.setCheckpointASAP();
+
+    verify(jobRunner).setCheckpointASAP();
   }
 
   @Test
@@ -62,5 +146,64 @@ class CoreFcpServerRuntimeSupportTest {
     support.fillSecureRandom(bytes);
 
     verify(randomSource).nextBytes(bytes);
+  }
+
+  private static ClientContext createClientContext(ClientLayerPersister jobRunner) {
+    ArchiveManager archiveManager = mock(ArchiveManager.class);
+    PersistentTempBucketFactory persistentBucketFactory = mock(PersistentTempBucketFactory.class);
+    TempBucketFactory tempBucketFactory = mock(TempBucketFactory.class);
+    PersistentFileTracker persistentFileTracker = mock(PersistentFileTracker.class);
+    FilenameGenerator filenameGenerator = mock(FilenameGenerator.class);
+    FilenameGenerator persistentFilenameGenerator = mock(FilenameGenerator.class);
+    FileRandomAccessBufferFactory fileRAFTransient = mock(FileRandomAccessBufferFactory.class);
+    FileRandomAccessBufferFactory fileRAFPersistent = mock(FileRandomAccessBufferFactory.class);
+    LockableRandomAccessBufferFactory tempRAFFactory =
+        mock(LockableRandomAccessBufferFactory.class);
+    LockableRandomAccessBufferFactory persistentRAFFactory =
+        mock(LockableRandomAccessBufferFactory.class);
+    PriorityAwareExecutor mainExecutor = mock(PriorityAwareExecutor.class);
+    MemoryLimitedJobRunner memoryLimitedJobRunner = mock(MemoryLimitedJobRunner.class);
+    Ticker ticker = mock(Ticker.class);
+    RandomSource strongRandom = mock(RandomSource.class);
+    MasterSecret masterSecret = mock(MasterSecret.class);
+    PersistentRequestCoordinator persistentRequestCoordinator =
+        mock(PersistentRequestCoordinator.class);
+    RealCompressor compressor = mock(RealCompressor.class);
+    DatastoreChecker checker = mock(DatastoreChecker.class);
+    LinkFilterExceptionProvider linkFilterExceptionProvider =
+        mock(LinkFilterExceptionProvider.class);
+    FetchContext fetchContext = mock(FetchContext.class);
+    InsertContext insertContext = mock(InsertContext.class);
+    Config config = mock(Config.class);
+    HealingQueue healingQueue = mock(HealingQueue.class);
+    USKManager uskManager = mock(USKManager.class);
+
+    return new ClientContext(
+        1L,
+        new ClientContextRuntime(
+            jobRunner,
+            mainExecutor,
+            memoryLimitedJobRunner,
+            ticker,
+            strongRandom,
+            new Random(123),
+            masterSecret),
+        new ClientContextStorageFactories(
+            persistentBucketFactory,
+            tempBucketFactory,
+            persistentFileTracker,
+            filenameGenerator,
+            persistentFilenameGenerator,
+            fileRAFTransient,
+            fileRAFPersistent),
+        new ClientContextRafFactories(tempRAFFactory, persistentRAFFactory),
+        new ClientContextServices(
+            new ClientContextResources(archiveManager, healingQueue),
+            uskManager,
+            compressor,
+            checker,
+            persistentRequestCoordinator,
+            linkFilterExceptionProvider),
+        new ClientContextDefaults(fetchContext, insertContext, config));
   }
 }

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/FcpEndpointHandlesTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/FcpEndpointHandlesTest.java
@@ -2,7 +2,9 @@ package network.crypta.clients.fcp.bridge;
 
 import network.crypta.client.async.CacheFetchResult;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.FCPServer;
+import network.crypta.clients.fcp.FcpDownloadCache;
 import network.crypta.keys.FreenetURI;
 import network.crypta.runtime.endpoints.fcp.FcpEndpointHandle;
 import network.crypta.support.api.Bucket;
@@ -26,28 +28,39 @@ class FcpEndpointHandlesTest {
     FcpEndpointHandle handle = FcpEndpointHandles.wrap(server);
     FreenetURI key = mock(FreenetURI.class);
     ClientContext context = mock(ClientContext.class);
+    PersistentRequestRuntimeContext detachedContext = mock(PersistentRequestRuntimeContext.class);
     Bucket preferred = mock(Bucket.class);
     CacheFetchResult instantResult = mock(CacheFetchResult.class);
     CacheFetchResult lookupResult = mock(CacheFetchResult.class);
+    CacheFetchResult detachedLookupResult = mock(CacheFetchResult.class);
     when(server.lookupInstant(key, true, false, preferred)).thenReturn(instantResult);
     when(server.lookup(key, false, context, true, preferred)).thenReturn(lookupResult);
+    when(server.lookup(key, false, detachedContext, false, preferred))
+        .thenReturn(detachedLookupResult);
 
     // Act
+    FcpDownloadCache detachedCache = FcpEndpointHandles.downloadCache(server);
     handle.load();
     handle.maybeStart();
     CacheFetchResult actualInstant = handle.lookupInstant(key, true, false, preferred);
     CacheFetchResult actualLookup = handle.lookup(key, false, context, true, preferred);
+    CacheFetchResult actualDetachedLookup =
+        detachedCache.lookup(key, false, detachedContext, false, preferred);
 
     // Assert
     assertSame(server, FcpEndpointHandles.unwrap(handle));
     assertSame(server, FcpEndpointHandles.serverOrNull(handle));
     assertSame(server, FcpEndpointHandles.requireServer(handle));
+    assertSame(handle, FcpEndpointHandles.downloadCacheOrNull(handle));
+    assertSame(handle, FcpEndpointHandles.requireDownloadCache(handle));
     assertSame(instantResult, actualInstant);
     assertSame(lookupResult, actualLookup);
+    assertSame(detachedLookupResult, actualDetachedLookup);
     verify(server).load();
     verify(server).maybeStart();
     verify(server).lookupInstant(key, true, false, preferred);
     verify(server).lookup(key, false, context, true, preferred);
+    verify(server).lookup(key, false, detachedContext, false, preferred);
   }
 
   @Test
@@ -103,6 +116,16 @@ class FcpEndpointHandlesTest {
         FreenetURI key,
         boolean noFilter,
         ClientContext context,
+        boolean mustCopy,
+        Bucket preferred) {
+      return null;
+    }
+
+    @SuppressWarnings("unused")
+    public CacheFetchResult lookup(
+        FreenetURI key,
+        boolean noFilter,
+        PersistentRequestRuntimeContext context,
         boolean mustCopy,
         Bucket preferred) {
       return null;

--- a/runtime-node/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandle.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/endpoints/fcp/FcpEndpointHandle.java
@@ -8,7 +8,9 @@ import network.crypta.client.async.DownloadCache;
  * <p>The runtime-endpoints package depends on this narrow handle rather than directly on the
  * concrete {@code network.crypta.clients.fcp.FCPServer}. Bridge code in this package can still
  * unwrap the legacy server when it needs protocol-specific operations. Higher-level runtime wiring
- * uses the seam only for endpoint lifecycle and cache registration.
+ * uses the seam only for endpoint lifecycle and cache registration. Bridge code may also expose a
+ * detached cache-view seam alongside this handle when adapter-owned infrastructure needs the lookup
+ * behavior without the full runtime contract.
  *
  * <p>Typical usage is straightforward: endpoint bootstrap creates one handle, registers it as the
  * {@link DownloadCache}, and later asks it to load persistent requests and maybe start listening.

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -292,12 +292,10 @@ class ClientGetFactoryTest {
   private FCPConnectionHandler newConnectionHandler() {
     FCPServer server = mock(FCPServer.class);
     FcpServerRuntimeSupport serverRuntimeSupport = mock(FcpServerRuntimeSupport.class);
-    ClientContext clientContext = mock(ClientContext.class);
     Socket socket = mock(Socket.class);
     RuntimePorts handlerRuntimePorts = mock(RuntimePorts.class);
     RandomnessPort randomnessPort = mock(RandomnessPort.class);
     when(server.serverRuntimeSupport()).thenReturn(serverRuntimeSupport);
-    when(serverRuntimeSupport.clientContext()).thenReturn(clientContext);
     when(server.runtime()).thenReturn(handlerRuntimePorts);
     when(handlerRuntimePorts.randomness()).thenReturn(randomnessPort);
     doAnswer(

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
@@ -1,14 +1,10 @@
 package network.crypta.clients.fcp;
 
-import java.lang.reflect.Field;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.PersistentJobRunner;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -25,8 +21,7 @@ class ClientRequestModifyRequestTest {
 
   @Test
   void modifyRequest_whenPriorityAndTokenChange_updatesRequesterCacheAndQueuesMessage() {
-    TrackingJobRunner jobRunner = new TrackingJobRunner();
-    ClientContext context = newContextWithJobRunner(jobRunner);
+    ClientContext context = mock(ClientContext.class);
     FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
     when(runtimeSupport.clientContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
@@ -45,7 +40,7 @@ class ClientRequestModifyRequestTest {
 
     verify(requester).setPriorityClass((short) 4, context);
     verify(client).queueClientRequestMessage(any(PersistentRequestModifiedMessage.class), eq(0));
-    assertEquals(1, jobRunner.checkpointRequests);
+    verify(runtimeSupport).setCheckpointASAP();
     assertEquals(4, request.priorityClass);
     assertEquals("token-b", request.clientToken);
     assertEquals(4, status.getPriority());
@@ -61,8 +56,7 @@ class ClientRequestModifyRequestTest {
 
   @Test
   void modifyRequest_whenNothingChanges_skipsCheckpointRequesterAndMessageQueue() {
-    TrackingJobRunner jobRunner = new TrackingJobRunner();
-    ClientContext context = newContextWithJobRunner(jobRunner);
+    ClientContext context = mock(ClientContext.class);
     FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
     when(runtimeSupport.clientContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
@@ -77,24 +71,9 @@ class ClientRequestModifyRequestTest {
 
     request.modifyRequest("same-token", (short) 2, server);
 
-    assertEquals(0, jobRunner.checkpointRequests);
+    verify(runtimeSupport, never()).setCheckpointASAP();
     verify(requester, never()).setPriorityClass(any(short.class), any(ClientContext.class));
     verify(client, never()).queueClientRequestMessage(any(FCPMessage.class), eq(0));
-  }
-
-  @SuppressWarnings("java:S3011")
-  private static ClientContext newContextWithJobRunner(PersistentJobRunner jobRunner) {
-    ClientContext context =
-        Mockito.mock(
-            ClientContext.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-    try {
-      Field field = ClientContext.class.getDeclaredField("jobRunner");
-      field.setAccessible(true);
-      field.set(context, jobRunner);
-      return context;
-    } catch (ReflectiveOperationException e) {
-      throw new LinkageError("Failed to set ClientContext.jobRunner", e);
-    }
   }
 
   private static RequestStatusCache requireStatusCache(PersistentRequestClient client) {
@@ -128,55 +107,6 @@ class ClientRequestModifyRequestTest {
         new DownloadRequestStatusDetails(
             outcome, null, null, null, mock(FreenetURI.class), false, false);
     return new DownloadRequestStatus(statusSnapshot, details);
-  }
-
-  private static final class TrackingJobRunner implements PersistentJobRunner {
-    private int checkpointRequests;
-
-    @Override
-    public void queue(PersistentJob persistentJob, int threadPriority) {
-      throw new UnsupportedOperationException("Not used by modifyRequest()");
-    }
-
-    @Override
-    public void queueNormalOrDrop(PersistentJob persistentJob) {
-      throw new UnsupportedOperationException("Not used by modifyRequest()");
-    }
-
-    @Override
-    public void queueInternal(PersistentJob job, int threadPriority) {
-      throw new UnsupportedOperationException("Not used by modifyRequest()");
-    }
-
-    @Override
-    public void queueInternal(PersistentJob job) {
-      throw new UnsupportedOperationException("Not used by modifyRequest()");
-    }
-
-    @Override
-    public void setCheckpointASAP() {
-      checkpointRequests++;
-    }
-
-    @Override
-    public boolean hasLoaded() {
-      return true;
-    }
-
-    @Override
-    public CheckpointLock lock() {
-      return (_, _) -> {};
-    }
-
-    @Override
-    public boolean newSalt() {
-      return false;
-    }
-
-    @Override
-    public boolean shuttingDown() {
-      return false;
-    }
   }
 
   private static final class TestClientRequest extends ClientRequest {

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
@@ -1,17 +1,13 @@
 package network.crypta.clients.fcp;
 
 import java.io.Serial;
-import java.lang.reflect.Field;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.PersistentJob;
-import network.crypta.client.async.PersistentJobRunner;
 import network.crypta.node.PrioRunnable;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.io.NativeThread;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,10 +33,9 @@ class ClientRequestRestartAsyncTest {
     ExecutionPort executionPort = mock(ExecutionPort.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     when(runtimePorts.execution()).thenReturn(executionPort);
-    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
-    ClientContext context = newContextWithJobRunner(jobRunner);
+    ClientContext context = mock(ClientContext.class);
     FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
-    when(runtimeSupport.clientContext()).thenReturn(context);
+    when(runtimeSupport.persistentRequestRuntimeContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.runtime()).thenReturn(runtimePorts);
     when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
@@ -54,7 +49,7 @@ class ClientRequestRestartAsyncTest {
     assertFalse(request.isStarted());
     ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
     verify(executionPort).execute(taskCaptor.capture(), eq("Restart request"));
-    verify(jobRunner, never()).queue(any(PersistentJob.class), anyInt());
+    verify(runtimeSupport, never()).queuePersistentJob(any(FcpPersistentJob.class), anyInt());
     Runnable submittedTask = taskCaptor.getValue();
     PrioRunnable prioRunnable = assertInstanceOf(PrioRunnable.class, submittedTask);
     assertEquals(NativeThread.PriorityLevel.NORM_PRIORITY.value, prioRunnable.getPriority());
@@ -73,10 +68,8 @@ class ClientRequestRestartAsyncTest {
     ExecutionPort executionPort = mock(ExecutionPort.class);
     RuntimePorts runtimePorts = mock(RuntimePorts.class);
     when(runtimePorts.execution()).thenReturn(executionPort);
-    PersistentJobRunner jobRunner = mock(PersistentJobRunner.class);
-    ClientContext context = newContextWithJobRunner(jobRunner);
+    ClientContext context = mock(ClientContext.class);
     FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
-    when(runtimeSupport.clientContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.runtime()).thenReturn(runtimePorts);
     when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
@@ -88,9 +81,10 @@ class ClientRequestRestartAsyncTest {
 
     // Assert
     assertFalse(request.isStarted());
-    ArgumentCaptor<PersistentJob> jobCaptor = ArgumentCaptor.forClass(PersistentJob.class);
-    verify(jobRunner)
-        .queue(jobCaptor.capture(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
+    ArgumentCaptor<FcpPersistentJob> jobCaptor = ArgumentCaptor.forClass(FcpPersistentJob.class);
+    verify(runtimeSupport)
+        .queuePersistentJob(
+            jobCaptor.capture(), eq(NativeThread.PriorityLevel.HIGH_PRIORITY.value));
     verify(executionPort, never()).execute(any(), anyString());
 
     boolean checkpointRequested = jobCaptor.getValue().run(context);
@@ -99,21 +93,6 @@ class ClientRequestRestartAsyncTest {
     assertEquals(1, request.restartCalls);
     assertSame(context, request.lastRestartContext);
     assertFalse(request.lastDisableFilterData);
-  }
-
-  @SuppressWarnings("java:S3011")
-  private static ClientContext newContextWithJobRunner(PersistentJobRunner jobRunner) {
-    ClientContext context =
-        Mockito.mock(
-            ClientContext.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
-    try {
-      Field field = ClientContext.class.getDeclaredField("jobRunner");
-      field.setAccessible(true);
-      field.set(context, jobRunner);
-      return context;
-    } catch (ReflectiveOperationException e) {
-      throw new LinkageError("Failed to set ClientContext.jobRunner", e);
-    }
   }
 
   private static final class TestClientRequest extends ClientRequest {

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.crypt.EntropySource;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.RequestClient;
@@ -58,6 +59,9 @@ class FCPConnectionHandlerTest {
 
     lenient().when(server.serverRuntimeSupport()).thenReturn(serverRuntimeSupport);
     lenient().when(serverRuntimeSupport.clientContext()).thenReturn(clientContext);
+    lenient()
+        .when(serverRuntimeSupport.persistentRequestRuntimeContext())
+        .thenReturn(clientContext);
     lenient().when(server.runtime()).thenReturn(runtimePorts);
     lenient().when(runtimePorts.randomness()).thenReturn(randomnessPort);
     lenient()
@@ -126,8 +130,8 @@ class FCPConnectionHandlerTest {
     ClientRequest removed = handler.removeRequestByIdentifier("id", true);
 
     assertSame(request, removed);
-    verify(request).cancel(clientContext);
-    verify(request).requestWasRemoved(clientContext);
+    verify(request).cancel((PersistentRequestRuntimeContext) clientContext);
+    verify(request).requestWasRemoved((PersistentRequestRuntimeContext) clientContext);
     verifyNoMoreInteractions(request);
   }
 
@@ -139,7 +143,7 @@ class FCPConnectionHandlerTest {
     ClientRequest removed = handler.removeRequestByIdentifier("id", false);
 
     assertSame(request, removed);
-    verify(request).requestWasRemoved(clientContext);
+    verify(request).requestWasRemoved((PersistentRequestRuntimeContext) clientContext);
     verifyNoMoreInteractions(request);
   }
 
@@ -268,7 +272,7 @@ class FCPConnectionHandlerTest {
       handler.startClientPut(message);
 
       ClientPut request = ignored.constructed().getFirst();
-      verify(request).start(clientContext);
+      verify(request).start((PersistentRequestRuntimeContext) clientContext);
     }
   }
 
@@ -281,7 +285,7 @@ class FCPConnectionHandlerTest {
 
       ClientPut request = ignored.constructed().getFirst();
       verify(request).register(false);
-      verify(request).start(clientContext);
+      verify(request).start((PersistentRequestRuntimeContext) clientContext);
     }
   }
 
@@ -295,7 +299,7 @@ class FCPConnectionHandlerTest {
       handler.startClientPutDir(message, buckets, true);
 
       ClientPutDir request = ignored.constructed().getFirst();
-      verify(request).start(clientContext);
+      verify(request).start((PersistentRequestRuntimeContext) clientContext);
     }
   }
 
@@ -310,7 +314,7 @@ class FCPConnectionHandlerTest {
 
       ClientPutDir request = ignored.constructed().getFirst();
       verify(request).register(false);
-      verify(request).start(clientContext);
+      verify(request).start((PersistentRequestRuntimeContext) clientContext);
     }
   }
 

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -12,6 +12,7 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.PersistentJob;
 import network.crypta.client.async.PersistentJobRunner;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.crypt.RandomSource;
 import network.crypta.keys.FreenetURI;
@@ -240,7 +241,9 @@ class FcpServerPersistentOpsTest {
     ClientContext context = clientContextWithJobRunner(new ImmediateJobRunner());
     when(core.getClientContext()).thenReturn(context);
     when(rebootClient.removeByIdentifier("id", true, server, context)).thenReturn(false);
-    when(foreverClient.removeByIdentifier("id", true, server, context)).thenReturn(true);
+    when(foreverClient.removeByIdentifier(
+            eq("id"), eq(true), eq(server), any(PersistentRequestRuntimeContext.class)))
+        .thenReturn(true);
     setField(ops, "globalRebootClient", rebootClient);
     setField(ops, "globalForeverClient", foreverClient);
 
@@ -249,7 +252,9 @@ class FcpServerPersistentOpsTest {
 
     // Assert
     assertTrue(result);
-    verify(foreverClient).removeByIdentifier("id", true, server, context);
+    verify(foreverClient)
+        .removeByIdentifier(
+            eq("id"), eq(true), eq(server), any(PersistentRequestRuntimeContext.class));
   }
 
   @Test
@@ -499,7 +504,7 @@ class FcpServerPersistentOpsTest {
     ops.startBlocking(request);
 
     // Assert
-    verify(request).start(any(ClientContext.class));
+    verify(request).start(any(PersistentRequestRuntimeContext.class));
   }
 
   @Test
@@ -516,7 +521,7 @@ class FcpServerPersistentOpsTest {
 
     // Assert
     verify(request).register(false);
-    verify(request).start(any(ClientContext.class));
+    verify(request).start(any(PersistentRequestRuntimeContext.class));
   }
 
   @Test
@@ -535,7 +540,7 @@ class FcpServerPersistentOpsTest {
 
     // Assert
     assertTrue(result);
-    verify(request).restart(context, true);
+    verify(request).restart((PersistentRequestRuntimeContext) context, true);
   }
 
   @Test
@@ -557,7 +562,7 @@ class FcpServerPersistentOpsTest {
 
     // Assert
     assertTrue(result);
-    verify(request).restart(any(ClientContext.class), eq(false));
+    verify(request).restart(any(PersistentRequestRuntimeContext.class), eq(false));
   }
 
   @Test
@@ -660,6 +665,22 @@ class FcpServerPersistentOpsTest {
         core::getPersistentTempBucketFactory;
     Supplier<RandomSource> randomSourceSupplier = core::getRandom;
     return new FcpServerRuntimeSupport() {
+      @Override
+      public ClientContext persistentRequestRuntimeContext() {
+        return clientContextSupplier.get();
+      }
+
+      @Override
+      public void queuePersistentJob(FcpPersistentJob job, int priority)
+          throws PersistenceDisabledException {
+        clientContextSupplier.get().jobRunner.queue(job::run, priority);
+      }
+
+      @Override
+      public void setCheckpointASAP() {
+        clientContextSupplier.get().jobRunner.setCheckpointASAP();
+      }
+
       @Override
       public ClientContext clientContext() {
         return clientContextSupplier.get();

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestClientStatusTrackerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestClientStatusTrackerTest.java
@@ -1,0 +1,222 @@
+package network.crypta.clients.fcp;
+
+import java.util.ArrayList;
+import java.util.List;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.InsertException;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class PersistentRequestClientStatusTrackerTest {
+
+  @Test
+  void register_whenDownloadAndUploadRequests_expectStatusesCopiedIntoCache() {
+    PersistentRequestClientStatusTracker tracker = new PersistentRequestClientStatusTracker(true);
+    ClientGet download = mock(ClientGet.class);
+    ClientPutBase upload = mock(ClientPutBase.class);
+    DownloadRequestStatus downloadStatus = newDownloadStatus("download-1");
+    UploadFileRequestStatus uploadStatus = newUploadStatus("upload-1");
+    when(download.getStatus()).thenReturn(downloadStatus);
+    when(upload.getStatus()).thenReturn(uploadStatus);
+
+    tracker.register(download);
+    tracker.register(upload);
+
+    List<RequestStatus> statuses = new ArrayList<>();
+    tracker.addPersistentRequestStatus(statuses);
+
+    assertEquals(2, statuses.size());
+    assertTrue(
+        statuses.stream()
+            .anyMatch(
+                status ->
+                    status instanceof DownloadRequestStatus
+                        && status.getIdentifier().equals("download-1")));
+    assertTrue(
+        statuses.stream()
+            .anyMatch(
+                status ->
+                    status instanceof UploadFileRequestStatus
+                        && status.getIdentifier().equals("upload-1")));
+  }
+
+  @Test
+  void finishedClientRequest_whenDownloadCompletes_expectOutcomeReflectedInCache() {
+    PersistentRequestClientStatusTracker tracker = new PersistentRequestClientStatusTracker(true);
+    ClientGet download = mock(ClientGet.class);
+    ClientGetState state = mock(ClientGetState.class);
+    Bucket bucket = mock(Bucket.class);
+    Bucket shadow = mock(Bucket.class);
+    DownloadRequestStatus initialStatus = newDownloadStatus("download-2");
+    GetFailedMessage failureMessage =
+        new GetFailedMessage(
+            new FetchException(FetchExceptionMode.ALL_DATA_NOT_FOUND, "details"),
+            "download-2",
+            false);
+
+    when(download.getStatus()).thenReturn(initialStatus);
+    when(download.state()).thenReturn(state);
+    when(state.getFailedMessage()).thenReturn(failureMessage);
+    when(download.getBucket()).thenReturn(bucket);
+    when(bucket.createShadow()).thenReturn(shadow);
+    when(download.getDataSize()).thenReturn(42L);
+    when(download.getMIMEType()).thenReturn("text/plain");
+    when(download.filterData()).thenReturn(true);
+    when(download.getIdentifier()).thenReturn("download-2");
+    when(download.hasSucceeded()).thenReturn(false);
+
+    tracker.register(download);
+    tracker.finishedClientRequest(download);
+
+    List<RequestStatus> statuses = new ArrayList<>();
+    tracker.addPersistentRequestStatus(statuses);
+    DownloadRequestStatus cached =
+        assertInstanceOf(DownloadRequestStatus.class, statuses.getFirst());
+
+    assertEquals(42L, cached.getDataSize());
+    assertEquals("text/plain", cached.getMIMEType());
+    assertEquals(failureMessage.getShortFailedMessage(), cached.getFailureReason(false));
+    assertEquals(failureMessage.getLongFailedMessage(), cached.getFailureReason(true));
+    assertSame(shadow, cached.getDataShadow());
+  }
+
+  @Test
+  void finishedClientRequest_whenUploadCompletes_expectOutcomeReflectedInCache() {
+    PersistentRequestClientStatusTracker tracker = new PersistentRequestClientStatusTracker(true);
+    ClientPutBase upload = mock(ClientPutBase.class);
+    UploadFileRequestStatus initialStatus = newUploadStatus("upload-2");
+    FreenetURI finalUri = mock(FreenetURI.class);
+    PutFailedMessage failureMessage =
+        new PutFailedMessage(
+            new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", finalUri),
+            "upload-2",
+            false);
+
+    when(upload.getStatus()).thenReturn(initialStatus);
+    when(upload.getFailureMessage()).thenReturn(failureMessage);
+    when(upload.getGeneratedURI()).thenReturn(finalUri);
+    when(upload.getIdentifier()).thenReturn("upload-2");
+    when(upload.hasSucceeded()).thenReturn(false);
+
+    tracker.register(upload);
+    tracker.finishedClientRequest(upload);
+
+    List<RequestStatus> statuses = new ArrayList<>();
+    tracker.addPersistentRequestStatus(statuses);
+    UploadFileRequestStatus cached =
+        assertInstanceOf(UploadFileRequestStatus.class, statuses.getFirst());
+
+    assertFalse(cached.hasSucceeded());
+    assertSame(finalUri, cached.getFinalURI());
+    assertEquals(failureMessage.getShortFailedMessage(), cached.getFailureReason(false));
+    assertEquals(failureMessage.getLongFailedMessage(), cached.getFailureReason(true));
+  }
+
+  @Test
+  void removeAndUpdateRequestStatusCache_whenInvoked_expectCachePrunedAndRebuilt() {
+    PersistentRequestClientStatusTracker tracker = new PersistentRequestClientStatusTracker(true);
+    ClientRequest downloadRequest = mock(ClientRequest.class);
+    ClientRequest uploadRequest = mock(ClientRequest.class);
+    DownloadRequestStatus downloadStatus = newDownloadStatus("download-3");
+    UploadFileRequestStatus uploadStatus = newUploadStatus("upload-3");
+    when(downloadRequest.getStatus()).thenReturn(downloadStatus);
+    when(uploadRequest.getStatus()).thenReturn(uploadStatus);
+
+    tracker.updateRequestStatusCache(List.of(downloadRequest, uploadRequest));
+    tracker.removeByIdentifier("download-3");
+
+    List<RequestStatus> statuses = new ArrayList<>();
+    tracker.addPersistentRequestStatus(statuses);
+
+    assertEquals(1, statuses.size());
+    assertEquals("upload-3", statuses.getFirst().getIdentifier());
+
+    tracker.clear();
+    statuses.clear();
+    tracker.addPersistentRequestStatus(statuses);
+
+    assertTrue(statuses.isEmpty());
+  }
+
+  @Test
+  void getCompletedRequest_whenMatchingCompletedDownloadPresent_expectMatchingGetterReturned() {
+    PersistentRequestClientStatusTracker tracker = new PersistentRequestClientStatusTracker(false);
+    ClientRequest nonDownload = mock(ClientRequest.class);
+    ClientGet otherDownload = mock(ClientGet.class);
+    ClientGet matchingDownload = mock(ClientGet.class);
+    FreenetURI key = mock(FreenetURI.class);
+
+    when(otherDownload.getURI()).thenReturn(mock(FreenetURI.class));
+    when(matchingDownload.getURI()).thenReturn(key);
+
+    ClientGet result =
+        tracker.getCompletedRequest(List.of(nonDownload, otherDownload, matchingDownload), key);
+
+    assertSame(matchingDownload, result);
+  }
+
+  private static DownloadRequestStatus newDownloadStatus(String identifier) {
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            identifier,
+            ClientRequest.Persistence.REBOOT,
+            false,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 1);
+    DownloadOutcomeInfo outcome =
+        new DownloadOutcomeInfo(10, "text/plain", null, null, null, null, false);
+    DownloadRequestStatusDetails details =
+        new DownloadRequestStatusDetails(
+            outcome, null, null, null, mock(FreenetURI.class), false, false);
+    return new DownloadRequestStatus(statusSnapshot, details);
+  }
+
+  private static UploadFileRequestStatus newUploadStatus(String identifier) {
+    RequestStatusSnapshot statusSnapshot =
+        new RequestStatusSnapshot(
+            identifier,
+            ClientRequest.Persistence.REBOOT,
+            false,
+            false,
+            false,
+            0,
+            0,
+            0,
+            null,
+            0,
+            0,
+            null,
+            false,
+            (short) 1);
+    UploadRequestStatusDetails details =
+        new UploadRequestStatusDetails(null, mock(FreenetURI.class), null, null, null);
+    return new UploadFileRequestStatus(
+        statusSnapshot,
+        details,
+        25L,
+        "application/octet-stream",
+        null,
+        ClientPut.COMPRESS_STATE.WAITING);
+  }
+}


### PR DESCRIPTION
## Summary
- detach FCP server infrastructure from the runtime-owned `ClientContext`, `PersistentJob`, and `DownloadCache` types
- add the adapter-owned `FcpPersistentJob` and `FcpDownloadCache` seams plus detached `ClientRequest` lifecycle wrappers for restart and server-owned request cleanup
- move the concrete queue, checkpoint, and cache adaptation into `:bridge-fcp-runtime`, extract `PersistentRequestClientStatusTracker`, and tighten the affected boundary and regression tests

## Testing
- `./gradlew :bridge-fcp-runtime:test --tests "network.crypta.clients.fcp.bridge.FcpEndpointHandlesTest" --tests "network.crypta.clients.fcp.bridge.CoreFcpServerRuntimeSupportTest" --tests "network.crypta.clients.fcp.bridge.BridgeFcpRuntimeBoundaryTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.ClientGetFactoryTest" --tests "network.crypta.clients.fcp.PersistentRequestClientStatusTrackerTest"`
- `./gradlew test`
