### PR TITLE
refactor(fcp): Detach filter and persistent bucket seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,11 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.support` / `network.crypta.support.io` / `network.crypta.support.api` subset
   after the generic HTTP, multimap, size-formatting, and file-backed bucket slice moved into
   `:foundation-support` and the manifest/model helper subset moved into `:kernel-content`.
-- `:adapter-fcp` owns the protocol-side `network.crypta.clients.fcp` package tree.
+- `:adapter-fcp` owns the protocol-side `network.crypta.clients.fcp` package tree and its
+  protocol-side persistent-bucket/filter seams.
 - `:bridge-fcp-runtime` owns the concrete runtime-binding bridge package
-  `network.crypta.clients.fcp.bridge`.
+  `network.crypta.clients.fcp.bridge`, including the live persistent-bucket and content-filter
+  bindings.
 - `:adapter-http-legacy-admin` owns the shared legacy `network.crypta.clients.http` shell, the
   admin toadlets, the `/api/v1/` and `/app/node/` bridge entrypoints, and the matching
   `network/crypta/clients/http/**` main resources such as `staticfiles/**` and `templates/**`.
@@ -792,10 +794,11 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `CoreFcpServerDependenciesFactory`, with package-local seams such as
   `FcpServerRuntimeSupport`, `FcpMessageRuntimeSupport`, `FcpFetchRuntimeSupport`, and
   `FcpInsertRuntimeSupport` splitting server-owned, message-owned, GET/fetch, and insert/USK
-  concerns. Runtime-owned FCP seam types now live under `network.crypta.runtime.fcp` and
-  `network.crypta.runtime.endpoints.fcp`, while concrete persistent-request services, queue
-  adapters, alert-feed adapters, and endpoint-handle wrappers now live under
-  `network.crypta.clients.fcp.bridge` in `:bridge-fcp-runtime`.
+  concerns. The protocol leaf also keeps the persistent-bucket and filter seams detached from the
+  concrete runtime, while runtime-owned FCP seam types now live under `network.crypta.runtime.fcp`
+  and `network.crypta.runtime.endpoints.fcp`. Concrete persistent-request services, queue
+  adapters, alert-feed adapters, persistent-bucket bindings, filter bindings, and endpoint-handle
+  wrappers now live under `network.crypta.clients.fcp.bridge` in `:bridge-fcp-runtime`.
   `network.crypta.clients.http` now lives in `:adapter-http-legacy-admin` together with its
   `staticfiles/**` and `templates/**` resources, excluding `network.crypta.clients.http.bridge`
   and `network.crypta.clients.http.geoip`. The legacy HTTP surface now has a physical browse leaf:
@@ -885,8 +888,10 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled
   transport/message execution code, and the remaining daemon-coupled support helpers outside the
   small `:kernel-content` manifest/model helper subset;
-  `:adapter-fcp` provides `network.crypta.clients.fcp`;
-  `:bridge-fcp-runtime` provides `network.crypta.clients.fcp.bridge`;
+  `:adapter-fcp` provides `network.crypta.clients.fcp` plus the protocol-side persistent-bucket
+  and filter seams;
+  `:bridge-fcp-runtime` provides `network.crypta.clients.fcp.bridge` plus the concrete
+  persistent-bucket and filter bindings;
   `:bridge-http-runtime` provides `network.crypta.clients.http.bridge` and
   `network.crypta.clients.http.geoip`;
   `:adapter-http-legacy-browse` provides the concrete legacy browse/FProxy classes and browse-only

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -13,7 +13,6 @@ import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.ManifestElement;
-import network.crypta.support.io.PersistentTempBucketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,11 +81,11 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
    *
    * @param fs structured field set describing {@code Files.*} entries plus metadata
    * @param bfTemp transient bucket factory for non-forever uploads and streaming buffers
-   * @param bfPersistent a persistent bucket factory keeping FOREVER payloads durably available
+   * @param bfPersistent the persistent bucket factory keeping FOREVER payloads durably available
    * @throws MessageInvalidException if mandatory headers are missing or hierarchy rules break
    */
   public ClientPutComplexDirMessage(
-      SimpleFieldSet fs, BucketFactory bfTemp, PersistentTempBucketFactory bfPersistent)
+      SimpleFieldSet fs, BucketFactory bfTemp, BucketFactory bfPersistent)
       throws MessageInvalidException {
     SimpleFieldSet files = requireFilesSection(fs);
     super(parseCommonFields(fs));

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPMessage.java
@@ -5,7 +5,6 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
-import network.crypta.support.io.PersistentTempBucketFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,8 +22,8 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>serializing messages to an {@link OutputStream} via {@link #send(OutputStream)}
  *   <li>providing factory methods {@link #create(String, SimpleFieldSet, BucketFactory,
- *       PersistentTempBucketFactory)} and {@link #create(String, SimpleFieldSet)} to reify messages
- *       received from the network
+ *       BucketFactory)} and {@link #create(String, SimpleFieldSet)} to reify messages received from
+ *       the network
  *   <li>defining an execution hook {@link #run(FCPConnectionHandler)} for processing messages on
  *       the server side
  * </ul>
@@ -241,8 +240,8 @@ public abstract class FCPMessage {
    * Returns the FCP message name used on the wire.
    *
    * <p>The name is written as the first line of the serialized message output and is also used by
-   * the static {@link #create(String, SimpleFieldSet, BucketFactory, PersistentTempBucketFactory)}
-   * method to select a concrete implementation when decoding messages from clients.
+   * the static {@link #create(String, SimpleFieldSet, BucketFactory, BucketFactory)} method to
+   * select a concrete implementation when decoding messages from clients.
    *
    * @return non-{@code null} message name token that uniquely identifies the concrete FCP message
    *     type within the protocol
@@ -277,10 +276,7 @@ public abstract class FCPMessage {
    *     the requirements of the corresponding message constructor
    */
   public static FCPMessage create(
-      String name,
-      SimpleFieldSet fs,
-      BucketFactory bfTemp,
-      PersistentTempBucketFactory bfPersistent)
+      String name, SimpleFieldSet fs, BucketFactory bfTemp, BucketFactory bfPersistent)
       throws MessageInvalidException {
     FCPMessage message = createClientMessages(name, fs);
     if (message != null) {
@@ -359,10 +355,7 @@ public abstract class FCPMessage {
   }
 
   private static FCPMessage createSubscriptionAndProbeMessages(
-      String name,
-      SimpleFieldSet fs,
-      BucketFactory bfTemp,
-      PersistentTempBucketFactory bfPersistent)
+      String name, SimpleFieldSet fs, BucketFactory bfTemp, BucketFactory bfPersistent)
       throws MessageInvalidException {
     return switch (name) {
       case ClientPutComplexDirMessage.NAME ->
@@ -381,8 +374,8 @@ public abstract class FCPMessage {
    * Convenience overload that creates a message without bucket factories.
    *
    * <p>This method delegates to {@link #create(String, SimpleFieldSet, BucketFactory,
-   * PersistentTempBucketFactory)} with {@code null} factories and is therefore only suitable for
-   * message types that do not require temporary or persistent bucket storage.
+   * BucketFactory)} with {@code null} factories and is therefore only suitable for message types
+   * that do not require temporary or persistent bucket storage.
    *
    * @param name protocol message name to resolve to a concrete implementation
    * @param fs decoded field set representing the message payload received from the client

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPServer.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FCPServer.java
@@ -678,7 +678,8 @@ public class FCPServer implements Runnable, FcpDownloadCache {
    * Returns runtime support for residual message-level FCP infrastructure concerns.
    *
    * <p>This package-local seam keeps message execution code independent of direct daemon-core
-   * access while preserving the current runtime behavior. It is an internal wiring detail of {@code
+   * access while preserving the current runtime behavior. It now also owns the detached
+   * content-filter bridge used by {@link FilterMessage}. It is an internal wiring detail of {@code
    * clients.fcp}, not a public server API.
    *
    * @return message runtime support backing the remaining message-level FCP operations

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpFilterResult.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpFilterResult.java
@@ -1,0 +1,69 @@
+package network.crypta.clients.fcp;
+
+/**
+ * Adapter-owned outcome of a single FCP content-filter pass.
+ *
+ * <p>{@code FilterMessage} uses this detached record to receive only the protocol-visible parts of
+ * filtering while the concrete runtime implementation remains behind the {@code
+ * FcpMessageRuntimeSupport} seam. That keeps {@code :adapter-fcp} independent of runtime-owned
+ * filter classes without changing the wire behavior seen by FCP clients. The record deliberately
+ * carries a small surface: the effective charset, the effective MIME type, and an explicit flag
+ * describing whether the runtime rejected the payload as unsafe.
+ *
+ * <p>The value is immutable and therefore safe to pass across message-handling boundaries without
+ * additional synchronization. Safe results may still contain {@code null} charset or MIME values
+ * when the runtime has nothing more specific to report. Unsafe results follow a stronger invariant:
+ * callers should expect {@code unsafeContentType()} to be {@code true} and both metadata fields to
+ * be {@code null}, so reply construction can stay deterministic.
+ *
+ * <ul>
+ *   <li>Represents one filter attempt, not a reusable session or mutable accumulator.
+ *   <li>Exposes only FCP-visible metadata needed to build a {@code FilterResultMessage}.
+ *   <li>Allows the bridge layer to translate runtime exceptions into a stable adapter contract.
+ * </ul>
+ *
+ * @param charset charset reported by the filter, or {@code null} when the runtime does not provide
+ *     one or when the payload is rejected as unsafe
+ * @param mimeType MIME type reported by the filter, or {@code null} when the runtime does not
+ *     provide one or when the payload is rejected as unsafe
+ * @param unsafeContentType whether the runtime rejected the payload as unsafe and therefore
+ *     suppressed MIME and charset output
+ */
+public record FcpFilterResult(String charset, String mimeType, boolean unsafeContentType) {
+
+  /**
+   * Builds a result describing content that completed filtering without an unsafe-content
+   * rejection.
+   *
+   * <p>Callers typically use this factory in bridge code after the concrete runtime filter returns
+   * successfully. The method preserves whatever MIME or charset metadata the runtime exposed,
+   * including {@code null} values when the runtime leaves one of those fields unspecified. The
+   * returned record always reports {@code unsafeContentType()} as {@code false}.
+   *
+   * @param charset charset reported by the filter, or {@code null} when the runtime did not provide
+   *     a specific charset
+   * @param mimeType MIME type reported by the filter, or {@code null} when the runtime did not
+   *     provide a specific MIME type
+   * @return detached safe result carrying the protocol-visible metadata needed for an FCP filter
+   *     reply
+   */
+  public static FcpFilterResult safe(String charset, String mimeType) {
+    return new FcpFilterResult(charset, mimeType, false);
+  }
+
+  /**
+   * Builds a result describing content rejected by the runtime as unsafe.
+   *
+   * <p>This factory intentionally drops MIME and charset details so adapter callers do not
+   * accidentally mix partial metadata with an unsafe outcome. Use it when the runtime-side filter
+   * reports an unsafe-content failure that should become the existing FCP unsafe flag behavior. The
+   * returned record always has {@code null} metadata and {@code unsafeContentType()} set to {@code
+   * true}.
+   *
+   * @return detached unsafe result with no exposed MIME or charset payload, suitable for building a
+   *     stable {@code FilterResultMessage}
+   */
+  public static FcpFilterResult unsafe() {
+    return new FcpFilterResult(null, null, true);
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpMessageRuntimeSupport.java
@@ -1,6 +1,9 @@
 package network.crypta.clients.fcp;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 import network.crypta.keys.FreenetURI;
 
@@ -19,9 +22,9 @@ import network.crypta.keys.FreenetURI;
  * runtime-spi}, and it is not intended to become a general daemon abstraction. Its job is narrower:
  * preserve existing node behavior while removing direct core dependencies from message-level
  * execution paths, so later refactors can adjust server bootstrap and configuration seams without
- * touching protocol handlers again. Peer lookup, probe execution, and AddPeer peer-reference
- * loading now use adapter-owned seam types, so the protocol package no longer imports concrete node
- * peer, probe, or client/fetch classes directly.
+ * touching protocol handlers again. Peer lookup, probe execution, AddPeer peer-reference loading,
+ * and the detached filter pass now use adapter-owned seam types, so the protocol package no longer
+ * imports concrete node peer, probe, or filter runtime classes directly.
  *
  * <ul>
  *   <li>Exposes only the runtime actions still needed by residual message classes.
@@ -93,6 +96,25 @@ public interface FcpMessageRuntimeSupport {
    * @param reason shutdown reason passed through to the node lifecycle machinery
    */
   void shutdownNode(String reason);
+
+  /**
+   * Filters content through the live runtime filter implementation.
+   *
+   * <p>This operation is intentionally narrow: the adapter provides the already-prepared input and
+   * output buckets, the MIME type that should be evaluated, and the fake/loopback URI used for
+   * filter context. The runtime-side implementation owns the concrete filter request and callback
+   * objects, then returns the protocol-visible filter outcome, including whether the payload was
+   * rejected as unsafe.
+   *
+   * @param input filtered input stream supplied by the message layer
+   * @param output destination stream for filtered output
+   * @param mimeType MIME type to present to the filter
+   * @param fakeUri loopback URI used to preserve historical filter context behavior
+   * @return detached protocol-visible outcome from the filter pass
+   * @throws IOException if the filter or underlying I/O fails
+   */
+  FcpFilterResult filterContent(
+      InputStream input, OutputStream output, String mimeType, URI fakeUri) throws IOException;
 
   /**
    * Resolves a peer node by its FCP node identifier.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerDependencies.java
@@ -13,7 +13,8 @@ import network.crypta.runtime.spi.RuntimePorts;
  * @param runtimePorts runtime SPI bridge used by server-owned infrastructure
  * @param persistentRoot persistence root used to access global clients and caches
  * @param serverRuntimeSupport server-owned runtime seam for persistent ops and connection handling
- * @param messageRuntimeSupport residual message-path runtime seam
+ * @param messageRuntimeSupport residual message-path runtime seam, including the detached filter
+ *     operation now owned by the bridge
  * @param fetchRuntimeSupport GET/fetch runtime seam for server-owned request flows
  * @param messageFetchRuntimeSupport GET/fetch runtime seam for inbound message request flows
  * @param insertRuntimeSupport insert/USK runtime seam for server-owned request flows

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
@@ -4,7 +4,6 @@ import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.support.api.BucketFactory;
-import network.crypta.support.io.PersistentTempBucketFactory;
 
 /**
  * Narrow runtime support seam for server-owned FCP infrastructure.
@@ -65,9 +64,9 @@ public interface FcpServerRuntimeSupport {
   /**
    * Returns the persistent temporary bucket factory used for forever-persistent inbound payloads.
    *
-   * @return persistent temporary bucket factory owned by the current runtime
+   * @return persistent bucket factory owned by the current runtime
    */
-  PersistentTempBucketFactory persistentTempBucketFactory();
+  BucketFactory persistentTempBucketFactory();
 
   /**
    * Fills the supplied byte array with secure random data from the owning runtime.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FilterMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FilterMessage.java
@@ -7,13 +7,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.filter.ContentFilter.FilterStatus;
-import network.crypta.client.filter.ContentFilter;
-import network.crypta.client.filter.ContentFilterCallbacks;
-import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
-import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.node.FSParseException;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
@@ -26,12 +20,13 @@ import org.slf4j.LoggerFactory;
  * Encapsulates a single FCP message that exercises the node's content filter pipeline and reports
  * whether a payload would be accepted for publication.
  *
- * <p>The instance mediates between untrusted client input and the {@link ContentFilter} subsystem:
- * it parses the {@link SimpleFieldSet}, determines whether the payload is streamed directly or read
+ * <p>The instance mediates between untrusted client input and the runtime-backed filter seam: it
+ * parses the {@link SimpleFieldSet}, determines whether the payload is streamed directly or read
  * from disk, infers MIME metadata when absent, and stages data inside a {@link Bucket} so the
- * filter can treat the request identically to production traffic. Each message is short-lived and
- * is designed to be instantiated, validated, and consumed entirely on a single thread while the
- * caller holds the relevant protocol connection locks; no shared mutable state escapes the object.
+ * bridge-side filter implementation can treat the request identically to production traffic. Each
+ * message is short-lived and is designed to be instantiated, validated, and consumed entirely on a
+ * single thread while the caller holds the relevant protocol connection locks; no shared mutable
+ * state escapes the object.
  *
  * <p>Typical callers build a {@code Filter} FCP message before uploading content that might trip
  * safety policies. The reply, {@link FilterResultMessage}, lets the client decide whether to redact
@@ -48,7 +43,6 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @see FilterResultMessage
- * @see ContentFilter
  */
 public final class FilterMessage extends DataCarryingMessage {
   private static final Logger LOG = LoggerFactory.getLogger(FilterMessage.class);
@@ -298,8 +292,8 @@ public final class FilterMessage extends DataCarryingMessage {
   }
 
   /**
-   * Executes the content filter by streaming the prepared payload through {@link ContentFilter} and
-   * returning a {@link FilterResultMessage} to the caller.
+   * Executes the content filter by streaming the prepared payload through the runtime-backed filter
+   * seam and returning a {@link FilterResultMessage} to the caller.
    *
    * <p>The method allocates a result bucket, relays bytes through the filtering pipeline, captures
    * MIME or charset adjustments, and records whether the content was rejected as unsafe. It is
@@ -324,17 +318,16 @@ public final class FilterMessage extends DataCarryingMessage {
     } catch (IOException e) {
       throw internalError("Failed to create temporary bucket", e);
     }
-    String resultCharset = null;
-    String resultMimeType = null;
-    boolean unsafe = false;
+    String resultCharset;
+    String resultMimeType;
+    boolean unsafe;
     try (InputStream input = bucket.getInputStream();
         OutputStream output = resultBucket.getOutputStream()) {
-      FilterStatus status =
-          applyFilter(input, output, handler.getServer().serverRuntimeSupport().clientContext());
-      resultCharset = status.charset;
-      resultMimeType = status.mimeType;
-    } catch (UnsafeContentTypeException _) {
-      unsafe = true;
+      FcpFilterResult status =
+          applyFilter(input, output, handler.getServer().messageRuntimeSupport());
+      resultCharset = status.charset();
+      resultMimeType = status.mimeType();
+      unsafe = status.unsafeContentType();
     } catch (IOException e) {
       throw internalError("IO error running content filter", e);
     }
@@ -343,16 +336,11 @@ public final class FilterMessage extends DataCarryingMessage {
     handler.send(response);
   }
 
-  private FilterStatus applyFilter(
-      InputStream input, OutputStream output, ClientContext clientContext) throws IOException {
+  private FcpFilterResult applyFilter(
+      InputStream input, OutputStream output, FcpMessageRuntimeSupport runtimeSupport)
+      throws IOException {
     URI fakeUri = resolveFilterUri();
-    // ContentFilter currently only supports read filtering; update once write filtering is
-    // available.
-    ContentFilterRequest request =
-        new ContentFilterRequest(input, output, mimeType, null, null, null);
-    ContentFilterCallbacks callbacks =
-        new ContentFilterCallbacks(fakeUri, null, null, clientContext.linkFilterExceptionProvider);
-    return ContentFilter.filter(request, callbacks);
+    return runtimeSupport.filterContent(input, output, mimeType, fakeUri);
   }
 
   private URI resolveFilterUri() {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/package-info.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/package-info.java
@@ -10,9 +10,10 @@
  * the hierarchy distinguishes download/insert commands, node stats, and connection control.
  * Persistent requests, bandwidth probes, and peer-management commands maintain explicit identifiers
  * so clients can survive reconnections without duplicating work. This package also owns the
- * adapter-side peer, probe, and peer-reference loading seams used by residual message handlers,
+ * adapter-side peer, probe, persistent-bucket, and filter seams used by residual message handlers,
  * while the concrete bridge layer that binds those abstractions back to live node peers, probe
- * listeners, and runtime-backed noderef loading lives in {@code :bridge-fcp-runtime}.
+ * listeners, runtime-backed persistent-bucket factories, and content-filter execution lives in
+ * {@code :bridge-fcp-runtime}.
  *
  * <p>Messages are designed for streaming and back-pressure: {@link
  * network.crypta.clients.fcp.FCPConnectionInputHandler} parses frames incrementally, while {@link

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -75,6 +75,15 @@ class AdapterFcpBoundaryTest {
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpServerPersistentOps.java");
   private static final Path FCP_SERVER_RUNTIME_SUPPORT_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("FcpServerRuntimeSupport.java");
+  private static final Path FILTER_MESSAGE_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FilterMessage.java");
+  private static final Path FCP_MESSAGE_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("FCPMessage.java");
+  private static final Path CLIENT_PUT_COMPLEX_DIR_MESSAGE_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutComplexDirMessage.java");
+  private static final Path FCP_CONNECTION_INPUT_HANDLER_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FCPConnectionInputHandler.java");
+  private static final Path FCP_SERVER_DEPENDENCIES_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("FcpServerDependencies.java");
   private static final Path COMPATIBILITY_MODE_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("CompatibilityMode.java");
   private static final Path FCP_COMPATIBILITY_MODE_SOURCE =
@@ -184,6 +193,12 @@ class AdapterFcpBoundaryTest {
           "network.crypta.client.async.ClientContext",
           "network.crypta.client.async.PersistentJob",
           "network.crypta.client.async.DownloadCache");
+  private static final Set<String> FORBIDDEN_FILTER_RUNTIME_IMPORTS =
+      Set.of(
+          "network.crypta.client.async.ClientContext",
+          "network.crypta.client.filter.ContentFilter",
+          "network.crypta.client.filter.ContentFilterCallbacks",
+          "network.crypta.client.filter.ContentFilterRequest");
   private static final Set<Path> GET_RUNTIME_SEAM_SOURCES =
       Set.of(
           FCP_FETCH_RUNTIME_SUPPORT_SOURCE,
@@ -209,6 +224,8 @@ class AdapterFcpBoundaryTest {
           "network.crypta.clients.fcp.FCPServer",
           "network.crypta.clients.fcp.MessageInvalidException",
           "network.crypta.clients.fcp.NodeHelloMessage");
+  private static final Set<String> FORBIDDEN_PERSISTENT_TEMP_BUCKET_IMPORTS =
+      Set.of("network.crypta.support.io.PersistentTempBucketFactory");
 
   @Test
   void mainSourceLayout_whenCheckingFcpOwnership_expectLeafOwnsPackageTree() throws IOException {
@@ -397,6 +414,62 @@ class AdapterFcpBoundaryTest {
     assertFalse(
         messageRuntimeSupportSource.contains(" makeClient("),
         "FcpMessageRuntimeSupport must not expose raw makeClient(...) anymore");
+  }
+
+  @Test
+  void adapterFcpMain_whenCheckingPersistentBucketSeam_expectNoLegacyTempFactoryImports()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path source :
+        Set.of(
+            FCP_MESSAGE_SOURCE,
+            CLIENT_PUT_COMPLEX_DIR_MESSAGE_SOURCE,
+            FCP_CONNECTION_INPUT_HANDLER_SOURCE,
+            FCP_SERVER_RUNTIME_SUPPORT_SOURCE,
+            FCP_SERVER_DEPENDENCIES_SOURCE)) {
+      Set<String> imports = readImports(repoRoot.resolve(source));
+      Set<String> forbiddenImports = new TreeSet<>(imports);
+      forbiddenImports.retainAll(FORBIDDEN_PERSISTENT_TEMP_BUCKET_IMPORTS);
+      if (!forbiddenImports.isEmpty()) {
+        violations.add(source + " -> " + String.join(", ", forbiddenImports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Persistent bucket adapter sources must not import PersistentTempBucketFactory."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void adapterFcpMain_whenCheckingFilterSeam_expectNoLegacyRuntimeFilterImports()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path source :
+        Set.of(
+            FILTER_MESSAGE_SOURCE,
+            FCP_MESSAGE_RUNTIME_SUPPORT_SOURCE,
+            FCP_SERVER_SOURCE,
+            FCP_SERVER_DEPENDENCIES_SOURCE)) {
+      Set<String> imports = readImports(repoRoot.resolve(source));
+      Set<String> forbiddenImports = new TreeSet<>(imports);
+      forbiddenImports.retainAll(FORBIDDEN_FILTER_RUNTIME_IMPORTS);
+      if (!forbiddenImports.isEmpty()) {
+        violations.add(source + " -> " + String.join(", ", forbiddenImports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Filter adapter sources must not import ClientContext, ContentFilter, "
+            + "ContentFilterCallbacks, or ContentFilterRequest."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
   }
 
   @Test

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupport.java
@@ -1,12 +1,20 @@
 package network.crypta.clients.fcp.bridge;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
 import network.crypta.client.FetchException;
+import network.crypta.client.filter.ContentFilter;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
+import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FCPServer;
 import network.crypta.clients.fcp.FcpDarknetPeerHandle;
+import network.crypta.clients.fcp.FcpFilterResult;
 import network.crypta.clients.fcp.FcpMessageRuntimeSupport;
 import network.crypta.clients.fcp.FcpPeerLookupResult;
 import network.crypta.clients.fcp.FcpPeerReferenceFetchException;
@@ -111,6 +119,22 @@ record CoreFcpMessageRuntimeSupport(NodeClientCore core) implements FcpMessageRu
   @Override
   public void shutdownNode(String reason) {
     core.getNode().exit(reason);
+  }
+
+  @Override
+  public FcpFilterResult filterContent(
+      InputStream input, OutputStream output, String mimeType, URI fakeUri) throws IOException {
+    ContentFilterRequest request =
+        new ContentFilterRequest(input, output, mimeType, null, null, null);
+    ContentFilterCallbacks callbacks =
+        new ContentFilterCallbacks(
+            fakeUri, null, null, core.getClientContext().linkFilterExceptionProvider);
+    try {
+      ContentFilter.FilterStatus status = ContentFilter.filter(request, callbacks);
+      return FcpFilterResult.safe(status.charset, status.mimeType);
+    } catch (UnsafeContentTypeException _) {
+      return FcpFilterResult.unsafe();
+    }
   }
 
   /**

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerDependenciesFactory.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerDependenciesFactory.java
@@ -30,11 +30,12 @@ import network.crypta.runtime.spi.RuntimePorts;
  * <p>The factory is stateless and creates one fresh {@link FcpServerDependencies} bundle per call.
  * Each bundle contains lightweight adapters over live daemon services rather than detached
  * snapshots, so later requests still observe the current transfer-access policy, client context,
- * and persistence state exposed by the node.
+ * filter runtime, and persistence state exposed by the node.
  *
  * <ul>
  *   <li>Builds server-owned runtime support for listener, persistence, and connection plumbing.
- *   <li>Builds message-path runtime support for residual FCP protocol handlers.
+ *   <li>Builds message-path runtime support for residual FCP protocol handlers, including the
+ *       detached content-filter bridge.
  *   <li>Preserves the intentional split between server-owned and core-owned transfer policy
  *       lookups.
  * </ul>

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupport.java
@@ -10,7 +10,6 @@ import network.crypta.clients.fcp.FcpPersistentJob;
 import network.crypta.clients.fcp.FcpServerRuntimeSupport;
 import network.crypta.node.NodeClientCore;
 import network.crypta.support.api.BucketFactory;
-import network.crypta.support.io.PersistentTempBucketFactory;
 
 /**
  * Core-backed implementation of {@link FcpServerRuntimeSupport}.
@@ -105,7 +104,7 @@ record CoreFcpServerRuntimeSupport(NodeClientCore core) implements FcpServerRunt
   }
 
   @Override
-  public PersistentTempBucketFactory persistentTempBucketFactory() {
+  public BucketFactory persistentTempBucketFactory() {
     return core.getPersistentTempBucketFactory();
   }
 

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpMessageRuntimeSupportTest.java
@@ -1,13 +1,25 @@
 package network.crypta.clients.fcp.bridge;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.filter.ContentFilter;
+import network.crypta.client.filter.ContentFilterCallbacks;
+import network.crypta.client.filter.ContentFilterRequest;
+import network.crypta.client.filter.LinkFilterExceptionProvider;
+import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.clients.fcp.FCPConnectionHandler;
 import network.crypta.clients.fcp.FcpDarknetPeerHandle;
+import network.crypta.clients.fcp.FcpFilterResult;
 import network.crypta.clients.fcp.FcpPeerLookupResult;
 import network.crypta.clients.fcp.FcpPeerReferenceFetchException;
 import network.crypta.clients.fcp.FcpProbeError;
@@ -33,9 +45,13 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
@@ -52,6 +68,7 @@ class CoreFcpMessageRuntimeSupportTest {
   @Mock private DarknetPeerNode darknetPeerNode;
   @Mock private PeerNode peerNode;
   @Mock private FCPConnectionHandler handler;
+  @Mock private LinkFilterExceptionProvider linkFilterExceptionProvider;
 
   private static final class RecordingAlerts extends UserAlertManager {
     private FcpUserAlertFeedSubscriber watched;
@@ -215,6 +232,116 @@ class CoreFcpMessageRuntimeSupportTest {
   }
 
   @Test
+  void filterContent_whenCalled_delegatesToContentFilterAndWrapsResult() throws Exception {
+    byte[] payload = "payload".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    InputStream input = new ByteArrayInputStream(payload);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    ClientContext clientContext = clientContextWith(linkFilterExceptionProvider);
+    when(core.getClientContext()).thenReturn(clientContext);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    URI fakeUri = URI.create("http://127.0.0.1:8888/");
+
+    try (MockedStatic<ContentFilter> staticFilter =
+        org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+      staticFilter
+          .when(
+              () ->
+                  ContentFilter.filter(
+                      any(ContentFilterRequest.class), any(ContentFilterCallbacks.class)))
+          .thenAnswer(
+              invocation -> {
+                ContentFilterRequest request = invocation.getArgument(0);
+                //noinspection resource
+                request.output().write(request.input().readAllBytes());
+                ContentFilterCallbacks callbacks = invocation.getArgument(1);
+                assertEquals(fakeUri, callbacks.baseURI());
+                assertSame(linkFilterExceptionProvider, callbacks.linkFilterExceptionProvider());
+                return filterStatusUtf8Text();
+              });
+
+      FcpFilterResult actual = support.filterContent(input, output, "text/plain", fakeUri);
+
+      assertEquals("UTF-8", actual.charset());
+      assertEquals("text/plain", actual.mimeType());
+      assertFalse(actual.unsafeContentType());
+    }
+
+    assertEquals("payload", output.toString(java.nio.charset.StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void filterContent_whenRuntimeRejectsUnsafe_returnsUnsafeResult() throws Exception {
+    InputStream input = new ByteArrayInputStream(new byte[] {1, 2, 3});
+    OutputStream output = new ByteArrayOutputStream();
+    ClientContext clientContext = clientContextWith(linkFilterExceptionProvider);
+    when(core.getClientContext()).thenReturn(clientContext);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    UnsafeContentTypeException unsafe =
+        new UnsafeContentTypeException() {
+          @Override
+          public String getMessage() {
+            return "unsafe";
+          }
+
+          @Override
+          public String getHTMLEncodedTitle() {
+            return "unsafe";
+          }
+
+          @Override
+          public String getRawTitle() {
+            return "unsafe";
+          }
+        };
+
+    try (MockedStatic<ContentFilter> staticFilter =
+        org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+      staticFilter
+          .when(
+              () ->
+                  ContentFilter.filter(
+                      any(ContentFilterRequest.class), any(ContentFilterCallbacks.class)))
+          .thenThrow(unsafe);
+
+      FcpFilterResult actual =
+          support.filterContent(input, output, "text/plain", URI.create("http://127.0.0.1:8888/"));
+
+      assertTrue(actual.unsafeContentType());
+      assertNull(actual.charset());
+      assertNull(actual.mimeType());
+    }
+  }
+
+  @Test
+  void filterContent_whenFilterThrowsIo_propagatesIOException() throws Exception {
+    InputStream input = new ByteArrayInputStream(new byte[] {1, 2, 3});
+    OutputStream output = new ByteArrayOutputStream();
+    ClientContext clientContext = clientContextWith(linkFilterExceptionProvider);
+    when(core.getClientContext()).thenReturn(clientContext);
+    CoreFcpMessageRuntimeSupport support = new CoreFcpMessageRuntimeSupport(core);
+    IOException ioException = new IOException("filter failed");
+
+    try (MockedStatic<ContentFilter> staticFilter =
+        org.mockito.Mockito.mockStatic(ContentFilter.class)) {
+      staticFilter
+          .when(
+              () ->
+                  ContentFilter.filter(
+                      any(ContentFilterRequest.class), any(ContentFilterCallbacks.class)))
+          .thenThrow(ioException);
+
+      IOException actual =
+          assertThrows(
+              IOException.class,
+              () ->
+                  support.filterContent(
+                      input, output, "text/plain", URI.create("http://127.0.0.1:8888/")));
+
+      assertSame(ioException, actual);
+    }
+  }
+
+  @Test
   void findPeer_whenPeerUnknown_returnsUnknownResult() {
     when(core.getNode()).thenReturn(node);
     when(node.network()).thenReturn(network);
@@ -361,5 +488,26 @@ class CoreFcpMessageRuntimeSupportTest {
 
   private static StringBuilder referenceText(String text) {
     return new StringBuilder().append(text);
+  }
+
+  private static ClientContext clientContextWith(LinkFilterExceptionProvider provider)
+      throws ReflectiveOperationException {
+    ClientContext context = mock(ClientContext.class);
+    Field field = ClientContext.class.getField("linkFilterExceptionProvider");
+    field.setAccessible(true);
+    field.set(context, provider);
+    return context;
+  }
+
+  @SuppressWarnings("java:S3011")
+  private static ContentFilter.FilterStatus filterStatusUtf8Text() {
+    try {
+      java.lang.reflect.Constructor<ContentFilter.FilterStatus> constructor =
+          ContentFilter.FilterStatus.class.getDeclaredConstructor(String.class, String.class);
+      constructor.setAccessible(true);
+      return constructor.newInstance("UTF-8", "text/plain");
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Unable to construct FilterStatus", e);
+    }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutComplexDirMessageTest.java
@@ -16,7 +16,6 @@ import network.crypta.support.api.ManifestElement;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.ArrayBucket;
 import network.crypta.support.io.ArrayBucketFactory;
-import network.crypta.support.io.PersistentTempBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +46,7 @@ class ClientPutComplexDirMessageTest {
 
   private final BucketFactory tempBucketFactory = new ArrayBucketFactory();
 
-  @Mock private PersistentTempBucketFactory persistentBucketFactory;
+  @Mock private BucketFactory persistentBucketFactory;
   @Mock private FCPConnectionHandler handler;
   @Mock private FCPServer server;
   @Mock private RuntimePorts runtimePorts;
@@ -97,7 +96,7 @@ class ClientPutComplexDirMessageTest {
     addDirectFile(fs, 0, "payload.bin", 9);
 
     BucketFactory tempFactory = mock(BucketFactory.class);
-    PersistentTempBucketFactory persistentFactory = mock(PersistentTempBucketFactory.class);
+    BucketFactory persistentFactory = mock(BucketFactory.class);
     when(persistentFactory.makeBucket(9L)).thenReturn(new ArrayBucket());
 
     new ClientPutComplexDirMessage(fs, tempFactory, persistentFactory);

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionInputHandlerTest.java
@@ -20,7 +20,6 @@ import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.LineReadingInputStream;
-import network.crypta.support.io.PersistentTempBucketFactory;
 import network.crypta.support.io.TempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -322,7 +321,7 @@ class FCPConnectionInputHandlerTest {
     ctx.runtimeSupport = mock(FcpServerRuntimeSupport.class);
     ctx.runtimePorts = mock(RuntimePorts.class);
     ctx.nodeInfoPort = mock(NodeInfoPort.class);
-    ctx.persistentFactory = mock(PersistentTempBucketFactory.class);
+    ctx.persistentFactory = mock(BucketFactory.class);
     ctx.socket = mock(Socket.class);
 
     when(ctx.handler.getSocket()).thenReturn(ctx.socket);
@@ -387,7 +386,7 @@ class FCPConnectionInputHandlerTest {
     NodeInfoPort nodeInfoPort;
     Socket socket;
     TempBucketFactory bucketFactory;
-    PersistentTempBucketFactory persistentFactory;
+    BucketFactory persistentFactory;
   }
 
   private static final class FakeDataMessage extends BaseDataCarryingMessage {

--- a/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
+import network.crypta.support.io.ArrayBucket;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -111,5 +113,27 @@ class FCPMessageTest {
 
     assertThrows(
         MessageInvalidException.class, () -> FCPMessage.create("GetPluginInfo", fs, null, null));
+  }
+
+  @Test
+  void create_whenComplexDirPersistenceForever_usesPersistentBucketFactory() throws Exception {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle(FCPMessage.IDENTIFIER, IDENTIFIER);
+    fs.putSingle("URI", "KSK@site");
+    fs.putSingle("Persistence", "forever");
+    fs.putSingle("Files.0.Name", "payload.bin");
+    fs.putSingle("Files.0.UploadFrom", "direct");
+    fs.put("Files.0.DataLength", 4L);
+    BucketFactory tempFactory = mock(BucketFactory.class);
+    BucketFactory persistentFactory = mock(BucketFactory.class);
+    when(persistentFactory.makeBucket(4L)).thenReturn(new ArrayBucket());
+
+    FCPMessage message =
+        FCPMessage.create(ClientPutComplexDirMessage.NAME, fs, tempFactory, persistentFactory);
+
+    assertInstanceOf(ClientPutComplexDirMessage.class, message);
+    //noinspection resource
+    verify(persistentFactory).makeBucket(4L);
+    verifyNoInteractions(tempFactory);
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -21,7 +21,6 @@ import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
-import network.crypta.support.io.PersistentTempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -661,7 +660,7 @@ class FcpServerPersistentOpsTest {
     Supplier<ClientContext> clientContextSupplier = core::getClientContext;
     BooleanSupplier persistenceDisabledSupplier = core::killedDatabase;
     Supplier<BucketFactory> tempBucketFactorySupplier = core::getTempBucketFactory;
-    Supplier<PersistentTempBucketFactory> persistentTempBucketFactorySupplier =
+    Supplier<BucketFactory> persistentTempBucketFactorySupplier =
         core::getPersistentTempBucketFactory;
     Supplier<RandomSource> randomSourceSupplier = core::getRandom;
     return new FcpServerRuntimeSupport() {
@@ -697,7 +696,7 @@ class FcpServerPersistentOpsTest {
       }
 
       @Override
-      public PersistentTempBucketFactory persistentTempBucketFactory() {
+      public BucketFactory persistentTempBucketFactory() {
         return persistentTempBucketFactorySupplier.get();
       }
 

--- a/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FilterMessageTest.java
@@ -3,26 +3,20 @@ package network.crypta.clients.fcp;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Constructor;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import network.crypta.client.async.ClientContext;
-import network.crypta.client.filter.ContentFilter.FilterStatus;
-import network.crypta.client.filter.ContentFilter;
-import network.crypta.client.filter.ContentFilterCallbacks;
-import network.crypta.client.filter.ContentFilterRequest;
 import network.crypta.client.filter.FilterOperation;
-import network.crypta.client.filter.UnsafeContentTypeException;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.ArrayBucketFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,8 +34,16 @@ import static org.junit.jupiter.api.Assertions.fail;
 class FilterMessageTest {
 
   private static final BucketFactory ARRAY_BUCKET_FACTORY = new ArrayBucketFactory();
+  private static final String FILTER_URI_PROPERTY =
+      "network.crypta.clients.fcp.FilterMessage.loopbackUri";
+  private static final URI DEFAULT_FILTER_URI = URI.create("http://127.0.0.1:8888/");
 
   @TempDir Path tempDir;
+
+  @AfterEach
+  void clearFilterUriProperty() {
+    System.clearProperty(FILTER_URI_PROPERTY);
+  }
 
   @Test
   void constructor_directSourceWithoutMimeType_expectMissingField() {
@@ -149,7 +151,8 @@ class FilterMessageTest {
     FilterMessage message = createDirectMessage("req-run-nobucket", new byte[] {1, 2, 3});
     message.bucket = null;
 
-    FCPConnectionHandler handler = handlerWithContext(Mockito.mock(ClientContext.class));
+    FcpMessageRuntimeSupport runtimeSupport = Mockito.mock(FcpMessageRuntimeSupport.class);
+    FCPConnectionHandler handler = handlerWithRuntimeSupport(runtimeSupport);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> message.run(handler));
@@ -174,7 +177,8 @@ class FilterMessageTest {
     FilterMessage message = new FilterMessage(fs, failingFactory);
     message.bucket = new SimpleReadOnlyArrayBucket(new byte[] {9, 9, 9, 9});
 
-    FCPConnectionHandler handler = handlerWithContext(Mockito.mock(ClientContext.class));
+    FcpMessageRuntimeSupport runtimeSupport = Mockito.mock(FcpMessageRuntimeSupport.class);
+    FCPConnectionHandler handler = handlerWithRuntimeSupport(runtimeSupport);
 
     MessageInvalidException exception =
         assertThrows(MessageInvalidException.class, () -> message.run(handler));
@@ -185,38 +189,39 @@ class FilterMessageTest {
   }
 
   @Test
-  @SuppressWarnings("resource")
   void run_whenContentFilterSucceeds_sendsResultMessage() throws Exception {
     byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
     FilterMessage message = createDirectMessage("req-run-success", payload);
 
-    ClientContext clientContext = Mockito.mock(ClientContext.class);
-    FCPConnectionHandler handler = handlerWithContext(clientContext);
+    FcpMessageRuntimeSupport runtimeSupport = Mockito.mock(FcpMessageRuntimeSupport.class);
+    FCPConnectionHandler handler = handlerWithRuntimeSupport(runtimeSupport);
     ArgumentCaptor<FilterResultMessage> responseCaptor =
         ArgumentCaptor.forClass(FilterResultMessage.class);
+    ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
 
-    FilterStatus status = filterStatusUtf8Text();
+    Mockito.when(
+            runtimeSupport.filterContent(
+                Mockito.any(InputStream.class),
+                Mockito.any(OutputStream.class),
+                Mockito.anyString(),
+                uriCaptor.capture()))
+        .thenAnswer(
+            invocation -> {
+              InputStream input = invocation.getArgument(0);
+              OutputStream output = invocation.getArgument(1);
+              output.write(input.readAllBytes());
+              return FcpFilterResult.safe("UTF-8", "text/plain");
+            });
 
-    try (MockedStatic<ContentFilter> staticFilter = Mockito.mockStatic(ContentFilter.class)) {
-      staticFilter
-          .when(
-              () ->
-                  ContentFilter.filter(
-                      Mockito.any(ContentFilterRequest.class),
-                      Mockito.any(ContentFilterCallbacks.class)))
-          .thenAnswer(
-              invocation -> {
-                ContentFilterRequest request = invocation.getArgument(0);
-                InputStream input = request.input();
-                OutputStream output = request.output();
-                output.write(input.readAllBytes());
-                return status;
-              });
-
-      message.run(handler);
-    }
+    message.run(handler);
 
     Mockito.verify(handler).send(responseCaptor.capture());
+    Mockito.verify(runtimeSupport)
+        .filterContent(
+            Mockito.any(InputStream.class),
+            Mockito.any(OutputStream.class),
+            Mockito.eq("text/plain"),
+            Mockito.any(URI.class));
     FilterResultMessage response = responseCaptor.getValue();
 
     assertEquals("req-run-success", response.getIdentifier());
@@ -230,35 +235,92 @@ class FilterMessageTest {
     } catch (IOException e) {
       fail(e);
     }
+    assertEquals(DEFAULT_FILTER_URI, uriCaptor.getValue());
   }
 
   @Test
-  @SuppressWarnings("resource")
-  void run_whenContentFilterSucceeds_readsClientContextFromServerRuntimeSupport() throws Exception {
+  void run_whenFilterUriPropertyValid_usesConfiguredUri() throws Exception {
+    byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+    FilterMessage message = createDirectMessage("req-run-custom-uri", payload);
+    URI configuredUri = URI.create("http://127.0.0.1:9999/filter");
+
+    System.setProperty(FILTER_URI_PROPERTY, configuredUri.toString());
+
+    FcpMessageRuntimeSupport runtimeSupport = Mockito.mock(FcpMessageRuntimeSupport.class);
+    FCPConnectionHandler handler = handlerWithRuntimeSupport(runtimeSupport);
+    ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+
+    Mockito.when(
+            runtimeSupport.filterContent(
+                Mockito.any(InputStream.class),
+                Mockito.any(OutputStream.class),
+                Mockito.anyString(),
+                uriCaptor.capture()))
+        .thenAnswer(
+            invocation -> {
+              OutputStream output = invocation.getArgument(1);
+              output.write(invocation.getArgument(0, InputStream.class).readAllBytes());
+              return FcpFilterResult.safe("UTF-8", "text/plain");
+            });
+
+    message.run(handler);
+
+    assertEquals(configuredUri, uriCaptor.getValue());
+  }
+
+  @Test
+  void run_whenFilterUriPropertyInvalid_fallsBackToDefaultUri() throws Exception {
     byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
     FilterMessage message = createDirectMessage("req-run-context", payload);
 
-    ClientContext clientContext = Mockito.mock(ClientContext.class);
-    FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
-    FCPServer server = Mockito.mock(FCPServer.class);
-    FcpServerRuntimeSupport runtimeSupport = Mockito.mock(FcpServerRuntimeSupport.class);
-    Mockito.when(handler.getServer()).thenReturn(server);
-    Mockito.when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
-    Mockito.when(runtimeSupport.clientContext()).thenReturn(clientContext);
+    System.setProperty(FILTER_URI_PROPERTY, "not a uri");
 
-    try (MockedStatic<ContentFilter> staticFilter = Mockito.mockStatic(ContentFilter.class)) {
-      staticFilter
-          .when(
-              () ->
-                  ContentFilter.filter(
-                      Mockito.any(ContentFilterRequest.class),
-                      Mockito.any(ContentFilterCallbacks.class)))
-          .thenReturn(filterStatusUtf8Text());
+    FcpMessageRuntimeSupport runtimeSupport = Mockito.mock(FcpMessageRuntimeSupport.class);
+    FCPConnectionHandler handler = handlerWithRuntimeSupport(runtimeSupport);
+    ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
 
-      message.run(handler);
-    }
+    Mockito.when(
+            runtimeSupport.filterContent(
+                Mockito.any(InputStream.class),
+                Mockito.any(OutputStream.class),
+                Mockito.anyString(),
+                uriCaptor.capture()))
+        .thenAnswer(
+            invocation -> {
+              OutputStream output = invocation.getArgument(1);
+              output.write(invocation.getArgument(0, InputStream.class).readAllBytes());
+              return FcpFilterResult.safe("UTF-8", "text/plain");
+            });
 
-    Mockito.verify(runtimeSupport).clientContext();
+    message.run(handler);
+
+    assertEquals(DEFAULT_FILTER_URI, uriCaptor.getValue());
+  }
+
+  @Test
+  void run_whenRuntimeFilterThrowsIo_expectInternalError() throws Exception {
+    byte[] payload = "payload".getBytes(StandardCharsets.UTF_8);
+    FilterMessage message = createDirectMessage("req-run-io", payload);
+    IOException ioException = new IOException("filter failed");
+
+    FcpMessageRuntimeSupport runtimeSupport = Mockito.mock(FcpMessageRuntimeSupport.class);
+    FCPConnectionHandler handler = handlerWithRuntimeSupport(runtimeSupport);
+    Mockito.when(
+            runtimeSupport.filterContent(
+                Mockito.any(InputStream.class),
+                Mockito.any(OutputStream.class),
+                Mockito.anyString(),
+                Mockito.any(URI.class)))
+        .thenThrow(ioException);
+
+    MessageInvalidException exception =
+        assertThrows(MessageInvalidException.class, () -> message.run(handler));
+
+    assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, exception.protocolCode);
+    assertEquals("IO error running content filter", exception.getMessage());
+    assertEquals("req-run-io", exception.ident);
+    assertEquals(ioException, exception.getCause());
+    Mockito.verify(handler, Mockito.never()).send(Mockito.any());
   }
 
   @Test
@@ -266,40 +328,20 @@ class FilterMessageTest {
     byte[] payload = "unsafe".getBytes(StandardCharsets.UTF_8);
     FilterMessage message = createDirectMessage("req-run-unsafe", payload);
 
-    ClientContext clientContext = Mockito.mock(ClientContext.class);
-    FCPConnectionHandler handler = handlerWithContext(clientContext);
+    FcpMessageRuntimeSupport runtimeSupport = Mockito.mock(FcpMessageRuntimeSupport.class);
+    FCPConnectionHandler handler = handlerWithRuntimeSupport(runtimeSupport);
     ArgumentCaptor<FilterResultMessage> responseCaptor =
         ArgumentCaptor.forClass(FilterResultMessage.class);
 
-    UnsafeContentTypeException unsafe =
-        new UnsafeContentTypeException() {
-          @Override
-          public String getMessage() {
-            return "unsafe";
-          }
+    Mockito.when(
+            runtimeSupport.filterContent(
+                Mockito.any(InputStream.class),
+                Mockito.any(OutputStream.class),
+                Mockito.anyString(),
+                Mockito.any(URI.class)))
+        .thenReturn(FcpFilterResult.unsafe());
 
-          @Override
-          public String getHTMLEncodedTitle() {
-            return "unsafe";
-          }
-
-          @Override
-          public String getRawTitle() {
-            return "unsafe";
-          }
-        };
-
-    try (MockedStatic<ContentFilter> staticFilter = Mockito.mockStatic(ContentFilter.class)) {
-      staticFilter
-          .when(
-              () ->
-                  ContentFilter.filter(
-                      Mockito.any(ContentFilterRequest.class),
-                      Mockito.any(ContentFilterCallbacks.class)))
-          .thenThrow(unsafe);
-
-      message.run(handler);
-    }
+    message.run(handler);
 
     Mockito.verify(handler).send(responseCaptor.capture());
     FilterResultMessage response = responseCaptor.getValue();
@@ -328,25 +370,11 @@ class FilterMessageTest {
     return fs;
   }
 
-  private FCPConnectionHandler handlerWithContext(ClientContext context) {
+  private FCPConnectionHandler handlerWithRuntimeSupport(FcpMessageRuntimeSupport runtimeSupport) {
     FCPConnectionHandler handler = Mockito.mock(FCPConnectionHandler.class);
     FCPServer server = Mockito.mock(FCPServer.class);
-    FcpServerRuntimeSupport runtimeSupport = Mockito.mock(FcpServerRuntimeSupport.class);
     Mockito.lenient().when(handler.getServer()).thenReturn(server);
-    Mockito.lenient().when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
-    Mockito.lenient().when(runtimeSupport.clientContext()).thenReturn(context);
+    Mockito.lenient().when(server.messageRuntimeSupport()).thenReturn(runtimeSupport);
     return handler;
-  }
-
-  @SuppressWarnings("java:S3011")
-  private FilterStatus filterStatusUtf8Text() {
-    try {
-      Constructor<FilterStatus> constructor =
-          ContentFilter.FilterStatus.class.getDeclaredConstructor(String.class, String.class);
-      constructor.setAccessible(true);
-      return constructor.newInstance("UTF-8", "text/plain");
-    } catch (ReflectiveOperationException e) {
-      throw new IllegalStateException("Unable to construct FilterStatus", e);
-    }
   }
 }


### PR DESCRIPTION
## Summary
- widen the adapter-owned persistent bucket seam from `PersistentTempBucketFactory` to `BucketFactory` so `:adapter-fcp` no longer exposes the runtime concrete type
- move concrete content-filter execution behind `FcpMessageRuntimeSupport`, add adapter-owned `FcpFilterResult`, and remove `ContentFilter*` / `ClientContext` imports from `FilterMessage`
- tighten FCP boundary tests, add focused regression coverage for the new seam behavior, and update the affected docs to reflect adapter ownership of the protocol-side seams

## Scope notes
- this keeps the PR intentionally narrow around the filter + persistent-bucket cluster
- the remaining `adapter-fcp -> runtime-node` direct-import clusters were left untouched on purpose, including the `ClientContext` lifecycle/requester APIs, the `Metadata`/put-manifest path, `FileUtil`-based DDA helpers, and `SplitfileCompatibilityModeEvent`

## Testing
- `./gradlew :adapter-fcp:compileJava :bridge-fcp-runtime:compileJava compileTestJava`
- `./gradlew :adapter-fcp:test --tests network.crypta.clients.fcp.AdapterFcpBoundaryTest`
- `./gradlew :bridge-fcp-runtime:test --tests network.crypta.clients.fcp.bridge.BridgeFcpRuntimeBoundaryTest --tests network.crypta.clients.fcp.bridge.CoreFcpMessageRuntimeSupportTest --tests network.crypta.clients.fcp.bridge.CoreFcpServerRuntimeSupportTest`
- `./gradlew :test --tests network.crypta.clients.fcp.FilterMessageTest --tests network.crypta.clients.fcp.FCPMessageTest --tests network.crypta.clients.fcp.ClientPutComplexDirMessageTest --tests network.crypta.clients.fcp.FCPConnectionInputHandlerTest --tests network.crypta.clients.fcp.FcpServerPersistentOpsTest`
- `./gradlew test`

## Notes
- root `:test` was used for the root-owned FCP tests so the `--tests` filter would not be propagated into leaf tasks that do not own those classes
- `FcpFilterResult` also received expanded Javadoc as part of the new adapter-owned seam
