### PR TITLE
refactor(adapter-fcp): Detach FileUtil via foundation helpers

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetMessage.java
@@ -14,7 +14,7 @@ import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.io.BucketTools;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -190,7 +190,9 @@ public final class ClientGetMessage extends BaseDataCarryingMessage {
           ProtocolErrorMessage.DISK_TARGET_EXISTS, null, identifier, global);
     }
     try {
-      File temp = FileUtil.createTempFile(target.getName(), ".freenet-tmp", target.getParentFile());
+      File temp =
+          LegacyFileSupport.createTempFile(
+              target.getName(), ".freenet-tmp", target.getParentFile());
       Files.delete(temp.toPath());
     } catch (IOException e) {
       throw new MessageInvalidException(

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/DataCarryingMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/DataCarryingMessage.java
@@ -8,7 +8,7 @@ import network.crypta.support.api.Bucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.BucketTools;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import network.crypta.support.io.NullBucket;
 import network.crypta.support.io.NullOutputStream;
 
@@ -59,9 +59,9 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
    *     value reported by {@link #dataLength()}
    * @param server the FCP server context; overriding implementations may consult it to select a
    *     persistent or transient bucket factory as appropriate
-   * @return a new {@link RandomAccessBucket} whose capacity is sufficient for the requested length;
-   *     the caller is responsible for eventually freeing it
-   * @throws IOException if the underlying storage cannot be allocated or another I/O problem is
+   * @return a new {@link RandomAccessBucket} whose capacity is enough for the requested length; the
+   *     caller is responsible for eventually freeing it
+   * @throws IOException if the underlying storage cannot be allocated, or another I/O problem is
    *     detected while preparing the bucket
    * @throws PersistenceDisabledException if persistence is disabled and a persistent bucket would
    *     be required; typically thrown by overrides that use persistent storage
@@ -89,8 +89,8 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
    * Request that the payload bucket be freed automatically after the message has been written.
    *
    * <p>This is a convenience for callers that attach a transient bucket and want to ensure it is
-   * released as soon as the corresponding network write completes. It only affects subsequent calls
-   * to {@link #writeData(OutputStream)} and has no impact on how the payload is read.
+   * released as soon as the corresponding network writing completes. It only affects later calls to
+   * {@link #writeData(OutputStream)} and has no impact on how the payload is read.
    */
   void setFreeOnSent() {
     freeOnSent = true;
@@ -113,7 +113,7 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
    *     #createBucket(BucketFactory, long, FCPServer)} so subclasses can make persistence decisions
    * @throws IOException if an I/O error occurs while allocating the bucket or copying bytes from
    *     the input stream into the bucket
-   * @throws MessageInvalidException if the payload cannot be stored, for example because
+   * @throws MessageInvalidException if the payload cannot be stored, for example, because
    *     persistence is disabled or an internal error occurs while creating the bucket
    */
   @Override
@@ -129,11 +129,11 @@ public abstract class DataCarryingMessage extends BaseDataCarryingMessage {
     try {
       tempBucket = createBucket(bf, len, server);
     } catch (IOException e) {
-      FileUtil.copy(is, new NullOutputStream(), len);
+      LegacyFileSupport.copy(is, new NullOutputStream(), len);
       throw new MessageInvalidException(
           ProtocolErrorMessage.INTERNAL_ERROR, e.toString(), getIdentifier(), isGlobal());
     } catch (PersistenceDisabledException _) {
-      FileUtil.copy(is, new NullOutputStream(), len);
+      LegacyFileSupport.copy(is, new NullOutputStream(), len);
       throw new MessageInvalidException(
           ProtocolErrorMessage.PERSISTENCE_DISABLED, null, getIdentifier(), isGlobal());
     }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/DdaAccessController.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/DdaAccessController.java
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Random;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import org.slf4j.Logger;
 
 /**
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
  * deterministic marker files so external clients can deliberately prove that the node can touch the
  * desired directory tree.
  *
- * <p>Callers typically obtain a single instance from {@link FCPServer}, invoke {@link
+ * <p>Callers typically get a single instance from {@link FCPServer}, invoke {@link
  * #enqueueDDACheck(String, boolean, boolean)} to create a job, feed the result back through {@link
  * #registerTestDDAResult(String, boolean, boolean)}, and later query {@link #allowDDAFrom(File,
  * boolean)} whenever an upload or download request references new filesystem paths. All access to
@@ -84,7 +84,7 @@ final class DdaAccessController {
    * @return {@code true} when cached permissions or server defaults authorize the requested mode.
    */
   boolean allowDDAFrom(File filename, boolean writeRequest) {
-    String parentDirectory = FileUtil.getCanonicalFile(filename).getParent();
+    String parentDirectory = LegacyFileSupport.getCanonicalFile(filename).getParent();
     DirectoryAccess access;
     synchronized (checkedDirectories) {
       access = checkedDirectories.get(parentDirectory);
@@ -128,8 +128,8 @@ final class DdaAccessController {
    *
    * <p>The controller validates that the directory exists, rejects duplicate concurrent checks, and
    * constructs temporary marker files tailored to the requested read or write assertions. When read
-   * testing is enabled the method creates, populates, and schedules deletion of a random file so
-   * the job can later verify its contents. When write testing is enabled the job records a random
+   * testing is enabled, the method creates, populates, and schedules deletion of a random file so
+   * the job can later verify its contents. When write testing is enabled, the job records a random
    * filename for remote clients to manipulate. The returned job is ready for serialization through
    * FCP responses.
    *
@@ -137,11 +137,12 @@ final class DdaAccessController {
    * @param read {@code true} to include read verification, {@code false} to skip creating test
    *     data.
    * @param write {@code true} to request write verification, including unique temporary filenames.
-   * @return configured job containing marker filenames and expected file contents for validation.
+   * @return the configured job containing marker filenames and expected file contents for
+   *     validation.
    * @throws IllegalArgumentException if the path is invalid or already under active testing.
    */
   DdaCheckJob enqueueDDACheck(String path, boolean read, boolean write) {
-    File directory = FileUtil.getCanonicalFile(new File(path));
+    File directory = LegacyFileSupport.getCanonicalFile(new File(path));
     if (!directory.exists() || !directory.isDirectory()) {
       throw new IllegalArgumentException(
           "The specified path isn't a directory! or doesn't exist or the node doesn't have access"
@@ -191,14 +192,14 @@ final class DdaAccessController {
    * <p>This call mirrors {@link #enqueueDDACheck(String, boolean, boolean)} and should be used
    * after the job completes or times out so the controller can accept future checks targeting the
    * same directory. The method performs the same canonical-path validation and throws the standard
-   * exception if the directory is missing to prevent accidental clean-up of unrelated locations.
+   * exception if the directory is missing to prevent accidental cleanup of unrelated locations.
    *
-   * @param path canonical directory path previously supplied while enqueuing a DDA verification.
+   * @param path canonical directory path previously supplied while enqueuing DDA verification.
    * @return the job that was tracking verification state, or {@code null} when none was stored.
    * @throws IllegalArgumentException if the directory no longer exists or is not a directory.
    */
   DdaCheckJob popDDACheck(String path) {
-    File directory = FileUtil.getCanonicalFile(new File(path));
+    File directory = LegacyFileSupport.getCanonicalFile(new File(path));
     if (!directory.exists() || !directory.isDirectory()) {
       throw new IllegalArgumentException(
           "The specified path isn't a directory! or doesn't exist or the node doesn't have access"
@@ -214,9 +215,9 @@ final class DdaAccessController {
    *
    * <p>Call this method during shutdown or after fatal errors to guarantee that orphaned temporary
    * files do not accumulate on disk. The method iterates through the tracked jobs, attempts to
-   * delete any read marker files, and logs non-fatal failures while keeping the rest of the
-   * clean-up proceeding. Because the underlying map is synchronized, the cleanup safely coexists
-   * with other job lifecycle operations.
+   * delete any read marker files, and logs non-fatal failures while keeping the rest of the cleanup
+   * proceeding. Because the underlying map is synchronized, the cleanup safely coexists with other
+   * job lifecycle operations.
    */
   void freeDDAJobs() {
     synchronized (inTestDirectories) {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/TestDdaCompleteMessage.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,9 +14,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This message is sent by the node after the DDA handshake sequence finishes. During the
  * exchange the client first asks for temporary filenames, writes test content, and echoes back
- * values so the node can validate both directions of access. This class encapsulates the final
- * outcome and conveys it in a compact {@link SimpleFieldSet} that the client parses before
- * unblocking further DDA usage. The instance is immutable after construction; the referenced {@link
+ * values so the node can validate both directions of access. This class encapsulates the outcome
+ * and conveys it in a compact {@link SimpleFieldSet} that the client parses before unblocking
+ * further DDA usage. The instance is immutable after construction; the referenced {@link
  * DdaCheckJob} must therefore be fully populated up front. Side effects, such as deleting temporary
  * files and registering the result with the connection handler, are performed when the field set is
  * built, mirroring historical behavior.
@@ -47,7 +47,7 @@ public class TestDdaCompleteMessage extends FCPMessage {
   /**
    * Field name set to {@code true} or {@code false} indicating whether the node successfully read
    * the client-provided test file from the negotiated directory. Callers rely on this key to decide
-   * whether subsequent DDA reads are permitted.
+   * whether later DDA reads are permitted.
    */
   public static final String READ_ALLOWED = "ReadDirectoryAllowed";
 
@@ -91,7 +91,7 @@ public class TestDdaCompleteMessage extends FCPMessage {
    *
    * <p>When a read filename is present, the method compares the client's echoed content with the
    * original expectation, records the boolean outcome, and deletes the temporary read file. For
-   * write checks it reads back the node-side file, compares it to the staged content, and infers
+   * writing checks it reads back the node-side file, compares it to the staged content, and infers
    * whether the client possessed write access. After both checks, the handler is notified so higher
    * layers can update DDA capability caches. The returned field set contains directory information
    * plus {@link #READ_ALLOWED} and {@link #WRITE_ALLOWED} keys when applicable.
@@ -110,7 +110,7 @@ public class TestDdaCompleteMessage extends FCPMessage {
 
     if (checkJob.readFilename != null) {
       isReadAllowed = checkJob.readContent.equals(readContentFromClient);
-      // cleanup in any case : we created it!... let's hope the client will do the same on its side.
+      // cleanup in any case: we created it!... let's hope the client will do the same on its side.
       try {
         Files.deleteIfExists(checkJob.readFilename.toPath());
       } catch (IOException e) {
@@ -123,7 +123,7 @@ public class TestDdaCompleteMessage extends FCPMessage {
       File maybeWrittenFile = checkJob.writeFilename;
       if (maybeWrittenFile.exists() && maybeWrittenFile.isFile() && maybeWrittenFile.canRead()) {
         try {
-          String existingContent = FileUtil.readUTF(maybeWrittenFile).toString().trim();
+          String existingContent = LegacyFileSupport.readUTF(maybeWrittenFile).toString().trim();
           isWriteAllowed = checkJob.writeContent.equals(existingContent);
         } catch (IOException e) {
           LOG.error(
@@ -159,8 +159,8 @@ public class TestDdaCompleteMessage extends FCPMessage {
    * should never be executed as a client-originated command.
    *
    * <p>Any attempt to process this message via the generic execution path signals a protocol
-   * misuse. The exception includes the message name so upstream logging and diagnostics can
-   * pinpoint the source frame that violated the flow. No side effects occur prior to throwing the
+   * misuse. The exception includes the message name, so upstream logging and diagnostics can
+   * pinpoint the source frame that violated the flow. No side effects occur before throwing the
    * exception.
    *
    * @param handler connection handler that attempted to execute the message; ignored because the

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/UnsupportedPluginMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/UnsupportedPluginMessage.java
@@ -5,7 +5,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.BucketFactory;
-import network.crypta.support.io.FileUtil;
+import network.crypta.support.io.LegacyFileSupport;
 import network.crypta.support.io.NullOutputStream;
 
 /**
@@ -18,9 +18,9 @@ import network.crypta.support.io.NullOutputStream;
  * an explicit protocol-level rejection.
  *
  * <p>This approach keeps the connection stream synchronized after a rejected command and avoids
- * turning a legacy feature use into cascading parser errors for subsequent messages on the same
- * socket. The class is intentionally narrow and side-effect free: it never performs plugin
- * execution, state mutation outside protocol responses, or server-originated payload writes.
+ * turning a legacy feature use into cascading parser errors for later messages on the same socket.
+ * The class is intentionally narrow and side-effect-free: it never performs plugin execution, state
+ * mutation outside protocol responses, or server-originated payload writes.
  *
  * <ul>
  *   <li><b>Primary responsibility:</b> preserve deterministic FCP compatibility for removed plugin
@@ -100,7 +100,7 @@ final class UnsupportedPluginMessage extends BaseDataCarryingMessage {
     if (payloadLength <= 0) {
       return;
     }
-    FileUtil.copy(is, new NullOutputStream(), payloadLength);
+    LegacyFileSupport.copy(is, new NullOutputStream(), payloadLength);
   }
 
   @Override
@@ -170,6 +170,11 @@ final class UnsupportedPluginMessage extends BaseDataCarryingMessage {
           false);
     }
 
+    return parsePayloadLength(dataLengthField, requestIdentifier);
+  }
+
+  private static long parsePayloadLength(String dataLengthField, String requestIdentifier)
+      throws MessageInvalidException {
     long parsedLength;
     try {
       parsedLength = Long.parseLong(dataLengthField, 10);

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -128,6 +128,13 @@ class AdapterFcpBoundaryTest {
           DOWNLOAD_REQUEST_STATUS_SOURCE,
           DOWNLOAD_REQUEST_STATUS_DETAILS_SOURCE,
           REQUEST_STATUS_CACHE_SOURCE);
+  private static final Set<Path> FILE_UTIL_DETACHMENT_SOURCES =
+      Set.of(
+          ADAPTER_FCP_MAIN_JAVA.resolve("DataCarryingMessage.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("DdaAccessController.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetMessage.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("UnsupportedPluginMessage.java"),
+          ADAPTER_FCP_MAIN_JAVA.resolve("TestDdaCompleteMessage.java"));
   private static final Path BRIDGE_FCP_RUNTIME_MAIN_JAVA =
       Path.of(
           "bridge-fcp-runtime",
@@ -307,6 +314,35 @@ class AdapterFcpBoundaryTest {
         EXPECTED_ADD_REF_IMPORTS,
         addRefImports,
         "AddRef must remain the narrow tool-owned FCP exception");
+  }
+
+  @Test
+  void adapterFcpMain_whenScanningFileUtilImports_expectNoRuntimeFileUtilLeak() throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path source : FILE_UTIL_DETACHMENT_SOURCES) {
+      Set<String> imports = readImports(repoRoot.resolve(source));
+      if (imports.contains("network.crypta.support.io.FileUtil")) {
+        violations.add(source + " -> network.crypta.support.io.FileUtil");
+      }
+    }
+
+    for (Path sourceFile : findJavaSources(repoRoot.resolve(ADAPTER_FCP_MAIN_JAVA))) {
+      if (FILE_UTIL_DETACHMENT_SOURCES.contains(repoRoot.relativize(sourceFile))) {
+        continue;
+      }
+      Set<String> imports = readImports(sourceFile);
+      if (imports.contains("network.crypta.support.io.FileUtil")) {
+        violations.add(repoRoot.relativize(sourceFile) + " -> network.crypta.support.io.FileUtil");
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        ":adapter-fcp main sources must not import network.crypta.support.io.FileUtil."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
   }
 
   @Test

--- a/foundation-support/src/main/java/network/crypta/support/io/LegacyFileSupport.java
+++ b/foundation-support/src/main/java/network/crypta/support/io/LegacyFileSupport.java
@@ -1,9 +1,14 @@
 package network.crypta.support.io;
 
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import network.crypta.fs.AppEnv;
 
@@ -14,9 +19,10 @@ import network.crypta.fs.AppEnv;
  * <p>This class exists so code such as the legacy HTTP admin UI can keep a handful of historical
  * behaviors without depending on the much larger runtime-owned {@code FileUtil}. The exported
  * surface is intentionally narrow: it covers filename suggestions used in download headers,
- * canonical-path normalization for human-readable status pages, tail reading for wrapper logs, and
- * stable operating-system naming for localized UI copy. Callers should treat these helpers as
- * compatibility shims rather than as a new general-purpose file API.
+ * canonical-path normalization for human-readable status pages, bounded stream copying for FCP
+ * payload drains, temp-file creation with legacy prefix padding, UTF-8 file reads, tail reading for
+ * wrapper logs, and stable operating-system naming for localized UI copy. Callers should treat
+ * these helpers as compatibility shims rather than as a new general-purpose file API.
  *
  * <p>The implementation favors behavioral continuity over abstraction purity. It preserves the old
  * filename and log-tail semantics closely enough that existing admin pages and tests do not need to
@@ -32,6 +38,8 @@ import network.crypta.fs.AppEnv;
  * </ul>
  */
 public final class LegacyFileSupport {
+  private static final int COPY_BUFFER_SIZE = 32 * 1024;
+
   private enum LegacyOperatingSystem {
     UNKNOWN(false, false, false),
     MAC_OS(false, true, true),
@@ -121,6 +129,84 @@ public final class LegacyFileSupport {
       return file.getAbsoluteFile().getCanonicalFile();
     } catch (IOException _) {
       return file.getAbsoluteFile();
+    }
+  }
+
+  /**
+   * Copies bytes from {@code source} to {@code destination} with legacy bounded-length semantics.
+   *
+   * <p>When {@code length == -1}, the copy runs until end-of-stream. Otherwise, the method copies
+   * exactly {@code length} bytes and throws an {@link EOFException} if the source ends too early.
+   * This method closes neither stream.
+   *
+   * @param source input stream to read from
+   * @param destination output stream to write to
+   * @param length number of bytes to copy, or {@code -1} to copy until EOF
+   * @throws IOException if reading, writing, or the exact-length EOF contract fails
+   */
+  public static void copy(InputStream source, OutputStream destination, long length)
+      throws IOException {
+    long remaining = length == -1 ? Long.MAX_VALUE : length;
+    byte[] buffer = new byte[(int) Math.min(remaining, COPY_BUFFER_SIZE)];
+    int read;
+    while (remaining > 0
+        && (read = source.read(buffer, 0, (int) Math.min(remaining, COPY_BUFFER_SIZE))) != -1) {
+      destination.write(buffer, 0, read);
+      remaining -= read;
+    }
+    if (remaining > 0 && length != -1) {
+      throw new EOFException("stream reached eof");
+    }
+  }
+
+  /**
+   * Creates a temporary file while preserving the legacy short-prefix padding behavior.
+   *
+   * <p>When {@code directory} is {@code null}, the current working directory is used. If the
+   * supplied prefix is shorter than three characters, {@code -TMP} is appended before delegating to
+   * {@link File#createTempFile(String, String, File)} so historical callers continue to satisfy the
+   * JDK's minimum prefix requirement.
+   *
+   * @param prefix filename prefix
+   * @param suffix filename suffix
+   * @param directory directory in which to create the file, or {@code null} for the current working
+   *     directory
+   * @return the created temporary file
+   * @throws IOException if the file cannot be created
+   */
+  public static File createTempFile(String prefix, String suffix, File directory)
+      throws IOException {
+    if (directory == null) {
+      directory = new File(".");
+    }
+    if (prefix.length() < 3) {
+      prefix += "-TMP";
+    }
+    return File.createTempFile(prefix, suffix, directory);
+  }
+
+  /**
+   * Reads an entire file as UTF-8 into a {@link StringBuilder}.
+   *
+   * @param file file to read
+   * @return decoded UTF-8 content
+   * @throws IOException if the file cannot be opened or read
+   */
+  public static StringBuilder readUTF(File file) throws IOException {
+    try (FileInputStream fis = new FileInputStream(file)) {
+      return readUTF(fis);
+    }
+  }
+
+  private static StringBuilder readUTF(InputStream stream) throws IOException {
+    try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+      StringBuilder result = new StringBuilder();
+      char[] buf = new char[4096];
+      int length;
+      while ((length = reader.read(buf)) > 0) {
+        result.append(buf, 0, length);
+      }
+      return result;
     }
   }
 

--- a/foundation-support/src/test/java/network/crypta/support/io/LegacyFileSupportTest.java
+++ b/foundation-support/src/test/java/network/crypta/support/io/LegacyFileSupportTest.java
@@ -1,5 +1,10 @@
 package network.crypta.support.io;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
@@ -7,8 +12,11 @@ import network.crypta.fs.AppEnv;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LegacyFileSupportTest {
 
@@ -49,6 +57,65 @@ class LegacyFileSupportTest {
     Path dotted = nested.resolve("..").resolve("nested");
 
     assertEquals(nested.toRealPath().toFile(), LegacyFileSupport.getCanonicalFile(dotted.toFile()));
+  }
+
+  @Test
+  void copy_whenLengthMinusOne_expectCopiesToEOF() throws Exception {
+    byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    LegacyFileSupport.copy(new ByteArrayInputStream(data), out, -1);
+
+    assertArrayEquals(data, out.toByteArray());
+  }
+
+  @Test
+  void copy_whenExactLength_expectCopiesExactBytes() throws Exception {
+    byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    LegacyFileSupport.copy(new ByteArrayInputStream(data), out, data.length);
+
+    assertArrayEquals(data, out.toByteArray());
+  }
+
+  @Test
+  void copy_whenLengthTooLarge_expectEofException() {
+    byte[] data = {1, 2, 3};
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    assertThrows(
+        EOFException.class, () -> LegacyFileSupport.copy(new ByteArrayInputStream(data), out, 10));
+    assertArrayEquals(data, out.toByteArray());
+  }
+
+  @Test
+  void createTempFile_whenPrefixShort_expectLegacyPadding(@TempDir Path tempDir) throws Exception {
+    File temp = LegacyFileSupport.createTempFile("ab", ".txt", tempDir.toFile());
+
+    assertTrue(temp.getName().startsWith("ab-TMP"));
+    assertTrue(temp.exists());
+  }
+
+  @Test
+  void createTempFile_whenDirectoryNull_expectCurrentWorkingDirectory() throws Exception {
+    File temp = LegacyFileSupport.createTempFile("abc", ".txt", null);
+
+    try {
+      assertTrue(temp.exists());
+      assertEquals(Path.of("").toRealPath().toFile(), temp.getParentFile().getCanonicalFile());
+    } finally {
+      Files.deleteIfExists(temp.toPath());
+    }
+  }
+
+  @Test
+  void readUTF_whenUtf8ContentPresent_expectDecodedText(@TempDir Path tempDir) throws Exception {
+    Path file = tempDir.resolve("utf8.txt");
+    String content = "abc\néé\nxyz";
+    Files.writeString(file, content);
+
+    assertEquals(content, LegacyFileSupport.readUTF(file.toFile()).toString());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPMessageTest.java
@@ -116,6 +116,40 @@ class FCPMessageTest {
   }
 
   @Test
+  void
+      create_whenUnsupportedFcpPluginMessageUsesNonNumericDataLength_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle(FCPMessage.IDENTIFIER, IDENTIFIER);
+    fs.putSingle("DataLength", "bogus");
+    fs.setEndMarker("Data");
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> FCPMessage.create("FCPPluginMessage", fs, null, null));
+
+    assertEquals(ProtocolErrorMessage.ERROR_PARSING_NUMBER, exception.protocolCode);
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
+  void
+      create_whenUnsupportedFcpPluginMessageUsesNegativeDataLength_throwsMessageInvalidException() {
+    SimpleFieldSet fs = new SimpleFieldSet(true);
+    fs.putSingle(FCPMessage.IDENTIFIER, IDENTIFIER);
+    fs.putSingle("DataLength", "-1");
+    fs.setEndMarker("Data");
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class,
+            () -> FCPMessage.create("FCPPluginMessage", fs, null, null));
+
+    assertEquals(ProtocolErrorMessage.INVALID_FIELD, exception.protocolCode);
+    assertEquals(IDENTIFIER, exception.ident);
+  }
+
+  @Test
   void create_whenComplexDirPersistenceForever_usesPersistentBucketFactory() throws Exception {
     SimpleFieldSet fs = new SimpleFieldSet(true);
     fs.putSingle(FCPMessage.IDENTIFIER, IDENTIFIER);


### PR DESCRIPTION
## Summary
- continue PR-178 boundary hardening by adding the minimal foundation-safe `LegacyFileSupport` subset needed for the remaining `adapter-fcp` `FileUtil` usages
- switch the affected FCP leaf classes from runtime-owned `FileUtil` to `LegacyFileSupport` without widening into the remaining runtime execution seams
- tighten `AdapterFcpBoundaryTest` to block `network.crypta.support.io.FileUtil` imports in `adapter-fcp` main sources and extend focused tests for the helper and unsupported plugin `DataLength` parsing paths

## Testing
- `./gradlew :foundation-support:test --tests "network.crypta.support.io.LegacyFileSupportTest" :adapter-fcp:test --tests "network.crypta.clients.fcp.AdapterFcpBoundaryTest" :test --tests "network.crypta.clients.fcp.DdaAccessControllerTest" --tests "network.crypta.clients.fcp.ClientGetMessageTest" --tests "network.crypta.clients.fcp.TestDdaCompleteMessageTest" --tests "network.crypta.clients.fcp.FCPMessageTest"`
- `./gradlew :foundation-support:test --tests "network.crypta.support.io.LegacyFileSupportTest" :test --tests "network.crypta.clients.fcp.FCPMessageTest"`
- `./gradlew test`