### PR TITLE
refactor(fcp): Detach persistent put-dir runtime helpers

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutComplexDirMessage.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import network.crypta.client.Metadata;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.SimpleFieldSet;
@@ -134,7 +133,7 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
       Object o = byName.get(before);
       if (o != null) {
         if (o instanceof Map) {
-          addFile(Metadata.forceMap(o), after, f);
+          addFile(ManifestTreeMaps.forceMap(o), after, f);
         } else {
           throw new MessageInvalidException(
               ProtocolErrorMessage.INVALID_MESSAGE,
@@ -259,7 +258,7 @@ public final class ClientPutComplexDirMessage extends ClientPutDirMessage {
       String tempName = entry.getKey();
       Object val = entry.getValue();
       if (val instanceof HashMap) {
-        Map<String, Object> h = Metadata.forceMap(val);
+        Map<String, Object> h = ManifestTreeMaps.forceMap(val);
         HashMap<String, Object> manifests = new HashMap<>();
         manifestElements.put(tempName, manifests);
         convertFilesByNameToManifestElements(h, manifests, transferAccess);

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -9,17 +9,12 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
 import java.io.Serial;
 import java.net.MalformedURLException;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import network.crypta.client.DefaultMIMETypes;
-import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
-import network.crypta.client.Metadata;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.ManifestElement;
-import network.crypta.support.io.FileBucket;
 import network.crypta.support.io.ResumeFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -200,13 +195,13 @@ public final class ClientPutDir extends ClientPutBase {
    * Scans a local directory tree and schedules it for encrypted asynchronous insertion.
    *
    * <p>This overload inspects the filesystem on behalf of desktop or node-local tooling. It walks
-   * the directory, optionally skipping hidden files, builds {@link ManifestElement} instances
-   * backed by {@link FileBucket}s, and configures retry, compression, and persistence knobs before
-   * the request is registered with a {@link PersistentRequestClient}. The constructor immediately
-   * counts files and bytes, so progress meters have deterministic totals, and it captures the
-   * optional override splitfile key for callers who precompute keys. After construction, invoke
-   * {@link #start(network.crypta.client.async.ClientContext) start(ClientContext)} to stream blocks
-   * while leveraging the provided {@link FCPServer}.
+   * the directory, optionally skipping hidden files, builds {@link ManifestElement} instances for
+   * local files, and configures retry, compression, and persistence knobs before the request is
+   * registered with a {@link PersistentRequestClient}. The constructor immediately counts files and
+   * bytes, so progress meters have deterministic totals, and it captures the optional override
+   * splitfile key for callers who precompute keys. After construction, invoke {@link
+   * #start(network.crypta.client.async.ClientContext) start(ClientContext)} to stream blocks while
+   * leveraging the provided {@link FCPServer}.
    *
    * <pre>{@code
    * var request =
@@ -276,7 +271,9 @@ public final class ClientPutDir extends ClientPutBase {
     wasDiskPut = true;
     this.overrideSplitfileCryptoKey = options.overrideSplitfileCryptoKey();
     // debug level captured via LOG.isDebugEnabled()
-    this.manifestElements = makeDiskDirManifest(dir, "", allowUnreadableFiles, includeHiddenFiles);
+    this.manifestElements =
+        ClientPutDirManifestSupport.buildDiskManifest(
+            dir, allowUnreadableFiles, includeHiddenFiles);
     this.defaultName = defaultName;
     makePutter(runtimeSupport, requestParams);
     if (putter != null) {
@@ -406,85 +403,6 @@ public final class ClientPutDir extends ClientPutBase {
     }
   }
 
-  private Map<String, Object> makeDiskDirManifest(
-      File dir, String prefix, boolean allowUnreadableFiles, boolean includeHiddenFiles)
-      throws FileNotFoundException {
-
-    Map<String, Object> map = new HashMap<>();
-    File[] files = dir.listFiles();
-
-    if (files == null) throw new IllegalArgumentException("No such directory");
-
-    for (File file : files) {
-      if (shouldSkipHiddenFile(file, includeHiddenFiles)) {
-        continue;
-      }
-
-      if (!file.exists() || !file.canRead()) {
-        handleUnreadableFile(file, allowUnreadableFiles);
-      } else if (file.isFile()) {
-        addFileEntry(map, file, prefix);
-      } else if (file.isDirectory()) {
-        addDirectoryEntry(map, file, prefix, allowUnreadableFiles, includeHiddenFiles);
-      } else {
-        handleUnsupportedEntry(file, allowUnreadableFiles);
-      }
-    }
-
-    return map;
-  }
-
-  private boolean shouldSkipHiddenFile(File file, boolean includeHiddenFiles) {
-    return file.isHidden() && !includeHiddenFiles;
-  }
-
-  private void handleUnreadableFile(File file, boolean allowUnreadableFiles)
-      throws FileNotFoundException {
-    if (!allowUnreadableFiles) {
-      throw new FileNotFoundException("The file does not exist or is unreadable : " + file);
-    }
-  }
-
-  private void handleUnsupportedEntry(File file, boolean allowUnreadableFiles)
-      throws FileNotFoundException {
-    if (!allowUnreadableFiles) {
-      throw new FileNotFoundException("Not a file and not a directory : " + file);
-    }
-  }
-
-  private void addFileEntry(Map<String, Object> map, File file, String prefix) {
-    FileBucket bucket = new FileBucket(file, true, false, false, false);
-    if (LOG.isDebugEnabled()) LOG.debug("Manifest add file path={}", file.getAbsolutePath());
-
-    map.put(
-        file.getName(),
-        new ManifestElement(
-            file.getName(),
-            prefix + file.getName(),
-            bucket,
-            DefaultMIMETypes.guessMIMEType(file.getName(), true),
-            file.length()));
-  }
-
-  private void addDirectoryEntry(
-      Map<String, Object> map,
-      File directory,
-      String prefix,
-      boolean allowUnreadableFiles,
-      boolean includeHiddenFiles)
-      throws FileNotFoundException {
-    if (LOG.isDebugEnabled())
-      LOG.debug("Manifest add directory path={}", directory.getAbsolutePath());
-
-    map.put(
-        directory.getName(),
-        makeDiskDirManifest(
-            directory,
-            prefix + directory.getName() + "/",
-            allowUnreadableFiles,
-            includeHiddenFiles));
-  }
-
   private void makePutter(FcpInsertRuntimeSupport runtimeSupport, ClientRequestParams requestParams)
       throws network.crypta.client.async.TooManyFilesInsertException {
     putter =
@@ -558,27 +476,8 @@ public final class ClientPutDir extends ClientPutBase {
     }
     if (LOG.isDebugEnabled())
       LOG.debug("Free-data continue request={} persistence={}", this, persistence);
-    // We have to commit everything, so activating everything here costs us little memory...?
-    freeData(manifestElements);
+    ClientPutDirManifestSupport.freeManifest(manifestElements);
     manifestElements = null;
-  }
-
-  private void freeData(Map<String, Object> manifestElements) {
-    if (LOG.isDebugEnabled())
-      LOG.debug(
-          "Free-data recurse request={} persistence={} size={}",
-          this,
-          persistence,
-          manifestElements.size());
-    for (Object o : manifestElements.values()) {
-      if (o instanceof Map) {
-        freeData(Metadata.forceMap(o));
-      } else {
-        ManifestElement e = (ManifestElement) o;
-        if (LOG.isDebugEnabled()) LOG.debug("Free-data release element={}", e);
-        e.freeData();
-      }
-    }
   }
 
   /**
@@ -611,40 +510,7 @@ public final class ClientPutDir extends ClientPutBase {
    */
   @Override
   protected FCPMessage persistentTagMessage() {
-    if (lowLevelClient == null) LOG.warn("Persistent snapshot missing low-level client");
-    if (putter == null) LOG.warn("Persistent snapshot missing putter");
-    HashMap<String, Object> manifestSnapshot =
-        manifestElements != null ? new HashMap<>(manifestElements) : null;
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            publicURI,
-            identifier,
-            verbosity,
-            priorityClass,
-            persistence,
-            isRealTime(),
-            clientToken,
-            global);
-    PersistentPutRequestMetadata metadata =
-        new PersistentPutRequestMetadata(
-            uri,
-            started,
-            ctx.getMaxInsertRetries(),
-            this.ctx.getCompatibilityMode(),
-            ctx.isDontCompress(),
-            ctx.getCompressorDescriptor(),
-            putter != null ? putter.getSplitfileCryptoKey() : null);
-    return new PersistentPutDir(requestParams, metadata, defaultName, manifestSnapshot, wasDiskPut);
-  }
-
-  private boolean isRealTime() {
-    if (lowLevelClient == null) {
-      // This can happen but only due to data corruption - old databases on which various bugs have
-      // resulted in it getting deleted and also possibly failed deletions.
-      LOG.warn("Realtime flag unavailable: lowLevelClient is null");
-      return false;
-    }
-    return lowLevelClient.realTimeFlag();
+    return new ClientPutDirPersistentTagBuilder(this).persistentTagMessage();
   }
 
   /**
@@ -825,56 +691,7 @@ public final class ClientPutDir extends ClientPutBase {
 
   @Override
   RequestStatus getStatus() {
-    FreenetURI finalURI = getFinalURI();
-    InsertExceptionMode failureCode = null;
-    String failureReasonShort = null;
-    PutFailedMessage failureMessage = getFailureMessage();
-    if (failureMessage != null) {
-      failureCode = failureMessage.failureMode;
-      failureReasonShort = failureMessage.getLongFailedMessage();
-    }
-
-    int total = 0;
-    int min = 0;
-    int fetched = 0;
-    int fatal = 0;
-    int failed = 0;
-    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
-    Instant latestSuccess = Instant.now();
-    Instant latestFailure = null;
-    boolean totalFinalized = false;
-
-    FCPMessage progressSnapshot = getProgressMessageSnapshot();
-    if (progressSnapshot instanceof SimpleProgressMessage msg) {
-      total = (int) msg.getTotalBlocks();
-      min = (int) msg.getMinBlocks();
-      fetched = (int) msg.getFetchedBlocks();
-      latestSuccess = msg.getLatestSuccess();
-      fatal = (int) msg.getFatalyFailedBlocks();
-      failed = (int) msg.getFailedBlocks();
-      latestFailure = msg.getLatestFailure();
-      totalFinalized = msg.isTotalFinalized();
-    }
-
-    RequestStatusSnapshot statusSnapshot =
-        new RequestStatusSnapshot(
-            identifier,
-            persistence,
-            started,
-            finished,
-            succeeded,
-            total,
-            min,
-            fetched,
-            latestSuccess,
-            fatal,
-            failed,
-            latestFailure,
-            totalFinalized,
-            priorityClass);
-    UploadRequestStatusDetails details =
-        new UploadRequestStatusDetails(finalURI, uri, failureCode, failureReasonShort, null);
-    return new UploadDirRequestStatus(statusSnapshot, details, totalSize, numberOfFiles);
+    return ClientPutDirStatusSnapshotBuilder.build(this);
   }
 
   /**
@@ -917,6 +734,22 @@ public final class ClientPutDir extends ClientPutBase {
   @Override
   public boolean fullyResumed() {
     return false;
+  }
+
+  ClientPutDirExecution persistentTagExecution() {
+    return putter;
+  }
+
+  String persistentTagDefaultName() {
+    return defaultName;
+  }
+
+  boolean persistentTagWasDiskPut() {
+    return wasDiskPut;
+  }
+
+  Map<String, Object> persistentTagManifestElements() {
+    return manifestElements;
   }
 
   @Override

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecution.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.fcp;
 
+import java.util.List;
 import java.util.Map;
 import network.crypta.support.io.ResumeFailedException;
 
@@ -41,6 +42,17 @@ public interface ClientPutDirExecution extends ClientPutExecution {
    * @return total number of payload bytes represented by this manifest execution
    */
   long totalSize();
+
+  /**
+   * Returns a detached snapshot of the manifest entries for persistent-tag serialization.
+   *
+   * <p>The bridge/runtime side owns manifest flattening and upload-source classification. The
+   * adapter consumes only the resulting detached entry descriptors when rebuilding a {@link
+   * PersistentPutDir} message.
+   *
+   * @return detached manifest entry snapshots in the wire order expected by {@code Files.N}
+   */
+  List<PersistentPutDirEntrySnapshot> persistentPutDirEntries();
 
   /**
    * Rehydrates transient manifest metadata after a persistent request resumes.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirManifestSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirManifestSupport.java
@@ -1,0 +1,192 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+import network.crypta.client.DefaultMIMETypes;
+import network.crypta.support.api.ManifestElement;
+import network.crypta.support.io.FileBucket;
+
+/**
+ * Builds and releases the nested manifest trees used by package-local directory insert paths.
+ *
+ * <p>{@link ClientPutDir} still stores directory contents in the long-lived legacy shape used by
+ * the FCP insert stack: a mutable {@code Map<String, Object>} whose values are either nested
+ * directory maps or {@link ManifestElement} leaves. This helper keeps that structural logic out of
+ * the request shell. Callers use it in two places only: once when the node scans a local filesystem
+ * tree into manifest entries, and later when the request is done with the staged buckets and needs
+ * to release them without reintroducing runtime-owned metadata helpers.
+ *
+ * <p>The utility is intentionally package-private and stateless. It does not cache filesystem
+ * state, sort entries, or attempt to normalize away the legacy manifest representation. Its job is
+ * narrower: preserve the current on-node directory upload behavior while isolating the tree-build
+ * and tree-teardown mechanics behind one adapter-owned surface.
+ *
+ * <ul>
+ *   <li>Builds the in-memory manifest tree for disk-backed directory inserts.
+ *   <li>Preserves the legacy nested-map representation expected by surrounding FCP code.
+ *   <li>Recursively frees {@link ManifestElement} buckets once the request no longer needs them.
+ * </ul>
+ */
+final class ClientPutDirManifestSupport {
+
+  /** Utility class; callers use the static helpers only. */
+  private ClientPutDirManifestSupport() {}
+
+  /**
+   * Scans a local directory and returns the manifest tree used by {@link ClientPutDir}.
+   *
+   * <p>The scan is recursive and preserves the relative path structure by nesting child maps under
+   * their directory names. Regular files become {@link ManifestElement} instances backed by {@link
+   * FileBucket}. Hidden entries are included only when requested, unreadable or unsupported entries
+   * either fail fast or are skipped according to {@code allowUnreadableFiles}, and missing or
+   * non-directory roots fail deterministically through the underlying filesystem checks.
+   *
+   * @param dir root directory to enumerate into the legacy manifest-tree shape
+   * @param allowUnreadableFiles whether unreadable or unsupported entries should be skipped instead
+   *     of aborting the scan
+   * @param includeHiddenFiles whether hidden files and directories should be kept in the manifest
+   * @return mutable manifest tree keyed by child name and containing nested maps or manifest leaves
+   * @throws FileNotFoundException if the scan encounters an unreadable or unsupported entry and the
+   *     caller requested fail-fast behavior
+   */
+  static Map<String, Object> buildDiskManifest(
+      File dir, boolean allowUnreadableFiles, boolean includeHiddenFiles)
+      throws FileNotFoundException {
+    return buildDiskManifest(dir, "", allowUnreadableFiles, includeHiddenFiles);
+  }
+
+  /**
+   * Recursively frees the bucket data held by every {@link ManifestElement} in a manifest tree.
+   *
+   * <p>The method walks the same nested map structure returned by {@link #buildDiskManifest(File,
+   * boolean, boolean)} and delegates to {@link ManifestElement#freeData()} at the leaves. It does
+   * not clear the enclosing maps or null out references; callers remain responsible for dropping
+   * the now-released manifest tree once they no longer need its structure.
+   *
+   * @param manifestElements manifest tree whose file-entry buckets should be released
+   */
+  static void freeManifest(Map<String, Object> manifestElements) {
+    for (Object value : manifestElements.values()) {
+      if (value instanceof Map) {
+        freeManifest(ManifestTreeMaps.forceMap(value));
+      } else {
+        ((ManifestElement) value).freeData();
+      }
+    }
+  }
+
+  /**
+   * Recursively scans one directory node while preserving the current relative-path prefix.
+   *
+   * @param dir directory whose immediate children should be converted into manifest entries
+   * @param prefix relative path prefix to prepend to child file names in nested directories
+   * @param allowUnreadableFiles whether unreadable or unsupported entries should be skipped
+   * @param includeHiddenFiles whether hidden entries should remain visible to the scan
+   * @return mutable manifest node for the supplied directory
+   * @throws FileNotFoundException if fail-fast mode is enabled and an entry cannot be represented
+   */
+  private static Map<String, Object> buildDiskManifest(
+      File dir, String prefix, boolean allowUnreadableFiles, boolean includeHiddenFiles)
+      throws FileNotFoundException {
+    Map<String, Object> map = new HashMap<>();
+    File[] files = dir.listFiles();
+
+    if (files == null) {
+      throw new IllegalArgumentException("No such directory");
+    }
+
+    for (File file : files) {
+      if (file.isHidden() && !includeHiddenFiles) {
+        continue;
+      }
+
+      if (!file.exists() || !file.canRead()) {
+        handleUnreadableFile(file, allowUnreadableFiles);
+      } else if (file.isFile()) {
+        addFileEntry(map, file, prefix);
+      } else if (file.isDirectory()) {
+        addDirectoryEntry(map, file, prefix, allowUnreadableFiles, includeHiddenFiles);
+      } else {
+        handleUnsupportedEntry(file, allowUnreadableFiles);
+      }
+    }
+
+    return map;
+  }
+
+  /**
+   * Throws when an unreadable entry should abort the scan.
+   *
+   * @param file unreadable or missing entry encountered during scanning
+   * @param allowUnreadableFiles whether the caller requested skip-on-error behavior
+   * @throws FileNotFoundException if unreadable entries are not allowed
+   */
+  private static void handleUnreadableFile(File file, boolean allowUnreadableFiles)
+      throws FileNotFoundException {
+    if (!allowUnreadableFiles) {
+      throw new FileNotFoundException("The file does not exist or is unreadable : " + file);
+    }
+  }
+
+  /**
+   * Throws when a filesystem entry is neither a regular file nor a directory and cannot be kept.
+   *
+   * @param file unsupported filesystem entry encountered during scanning
+   * @param allowUnreadableFiles whether the caller requested skip-on-error behavior
+   * @throws FileNotFoundException if unsupported entries are not allowed
+   */
+  private static void handleUnsupportedEntry(File file, boolean allowUnreadableFiles)
+      throws FileNotFoundException {
+    if (!allowUnreadableFiles) {
+      throw new FileNotFoundException("Not a file and not a directory : " + file);
+    }
+  }
+
+  /**
+   * Creates one disk-backed manifest leaf for a regular file.
+   *
+   * @param map manifest node receiving the new leaf entry
+   * @param file regular file discovered during the scan
+   * @param prefix relative path prefix used to preserve the nested directory structure
+   */
+  private static void addFileEntry(Map<String, Object> map, File file, String prefix) {
+    FileBucket bucket = new FileBucket(file, true, false, false, false);
+    map.put(
+        file.getName(),
+        new ManifestElement(
+            file.getName(),
+            prefix + file.getName(),
+            bucket,
+            DefaultMIMETypes.guessMIMEType(file.getName(), true),
+            file.length()));
+  }
+
+  /**
+   * Recursively creates one nested manifest node for a child directory.
+   *
+   * @param map manifest node receiving the child directory entry
+   * @param directory child directory discovered during the scan
+   * @param prefix relative path prefix used for descendants
+   * @param allowUnreadableFiles whether unreadable or unsupported descendants should be skipped
+   * @param includeHiddenFiles whether hidden descendants should remain visible to the scan
+   * @throws FileNotFoundException if fail-fast mode is enabled and a descendant cannot be
+   *     represented
+   */
+  private static void addDirectoryEntry(
+      Map<String, Object> map,
+      File directory,
+      String prefix,
+      boolean allowUnreadableFiles,
+      boolean includeHiddenFiles)
+      throws FileNotFoundException {
+    map.put(
+        directory.getName(),
+        buildDiskManifest(
+            directory,
+            prefix + directory.getName() + "/",
+            allowUnreadableFiles,
+            includeHiddenFiles));
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirPersistentTagBuilder.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirPersistentTagBuilder.java
@@ -1,0 +1,141 @@
+package network.crypta.clients.fcp;
+
+import java.io.InvalidObjectException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Builds replayable {@link PersistentPutDir} messages from the mutable state held by {@link
+ * ClientPutDir}.
+ *
+ * <p>The surrounding request tracks live execution state, legacy persistence metadata, and the
+ * manifest tree that may survive node restarts. This helper turns that mix of state back into the
+ * detached FCP wire message used for reconnection replies, persistent-request listings, and other
+ * replay-style responses. The class deliberately keeps that snapshot assembly out of the request
+ * shell so the request can focus on lifecycle transitions rather than on serializing itself back
+ * into FCP-visible DTOs.
+ *
+ * <p>Its most important behavior is the fallback path. When a live {@link ClientPutDirExecution}
+ * wrapper is available, the builder prefers the bridge-owned detached manifest snapshots from that
+ * execution. When the wrapper is missing but the persisted manifest tree is still present, the
+ * builder asks the legacy bridge to snapshot that stored tree instead. That preserves the existing
+ * replay semantics for durable directory inserts instead of silently reporting an empty manifest.
+ *
+ * <ul>
+ *   <li>Builds the stable {@code PersistentPutDir} wire representation for one request.
+ *   <li>Prefers live-detached entry snapshots when an execution wrapper is available.
+ *   <li>Falls back to the restored manifest tree when replaying partially rehydrated requests.
+ * </ul>
+ */
+final class ClientPutDirPersistentTagBuilder {
+  /** Logger used for replay-path diagnostics when a persistent state is only partially attached. */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientPutDirPersistentTagBuilder.class);
+
+  /** Request whose mutable and restored state will be translated into a detached FCP reply. */
+  private final ClientPutDir request;
+
+  /**
+   * Creates a builder bound to one directory insert request.
+   *
+   * @param request request whose current and restored state should be serialized back into FCP
+   */
+  ClientPutDirPersistentTagBuilder(ClientPutDir request) {
+    this.request = Objects.requireNonNull(request, "request");
+  }
+
+  /**
+   * Builds the persistent-tag reply that mirrors the current request state.
+   *
+   * <p>The returned message includes the request identifiers, insert settings, compatibility hints,
+   * optional splitfile crypto key, and the best available detached manifest snapshot. Missing live
+   * runtime collaborators are tolerated because persistent requests may be replayed while they are
+   * only partially reattached after deserialization. In that case the builder logs the gap and
+   * falls back to the persisted manifest tree when possible.
+   *
+   * @return detached {@link PersistentPutDir} message ready for FCP replay
+   */
+  FCPMessage persistentTagMessage() {
+    ClientPutDirExecution execution = request.persistentTagExecution();
+    if (request.lowLevelClient == null) {
+      LOG.warn("Persistent snapshot missing low-level client");
+    }
+    if (execution == null) {
+      LOG.warn("Persistent snapshot missing putter");
+    }
+
+    List<PersistentPutDirEntrySnapshot> manifestSnapshot = manifestSnapshot(execution);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            request.publicURI,
+            request.identifier,
+            request.verbosity,
+            request.priorityClass,
+            request.persistence,
+            realTimeFlag(),
+            request.clientToken,
+            request.global);
+    PersistentPutRequestMetadata metadata =
+        new PersistentPutRequestMetadata(
+            request.uri,
+            request.started,
+            request.ctx.getMaxInsertRetries(),
+            request.ctx.getCompatibilityMode(),
+            request.ctx.isDontCompress(),
+            request.ctx.getCompressorDescriptor(),
+            execution != null ? execution.getSplitfileCryptoKey() : null);
+    return new PersistentPutDir(
+        requestParams,
+        metadata,
+        request.persistentTagDefaultName(),
+        manifestSnapshot,
+        request.persistentTagWasDiskPut());
+  }
+
+  /**
+   * Selects the manifest snapshot source for persistent-tag serialization.
+   *
+   * <p>Live executions already expose bridge-owned {@link PersistentPutDirEntrySnapshot} values and
+   * therefore remain the preferred source. When the execution wrapper is missing, the method
+   * attempts to rebuild the same detached entry list from the restored manifest tree through the
+   * legacy bridge. If no manifest is available, or the bridge cannot be resolved, the builder
+   * degrades to an empty snapshot rather than failing the reply path.
+   *
+   * @param execution live execution wrapper, or {@code null} during replay-only fallback paths
+   * @return detached manifest entry snapshots in the order expected by {@code PersistentPutDir}
+   */
+  private List<PersistentPutDirEntrySnapshot> manifestSnapshot(ClientPutDirExecution execution) {
+    if (execution != null) {
+      return execution.persistentPutDirEntries();
+    }
+    Map<String, Object> manifestElements = request.persistentTagManifestElements();
+    if (manifestElements == null) {
+      return List.of();
+    }
+    try {
+      return LegacyInsertExecutionBridgeLoader.load()
+          .snapshotPersistentPutDirEntries(manifestElements);
+    } catch (InvalidObjectException e) {
+      LOG.warn("Persistent snapshot manifest fallback unavailable", e);
+      return List.of();
+    }
+  }
+
+  /**
+   * Returns the real-time scheduling flag for the replayed request.
+   *
+   * <p>Older or partially corrupted persistent requests may be missing the low-level request
+   * client. In that case the builder preserves the historical defensive behavior and reports {@code
+   * false} rather than throwing while generating the persistent-tag reply.
+   *
+   * @return current real-time flag, or {@code false} when the low-level client is unavailable
+   */
+  private boolean realTimeFlag() {
+    if (request.lowLevelClient == null) {
+      return false;
+    }
+    return request.lowLevelClient.realTimeFlag();
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirStatusSnapshotBuilder.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirStatusSnapshotBuilder.java
@@ -1,0 +1,114 @@
+package network.crypta.clients.fcp;
+
+import java.time.Instant;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Builds immutable upload-directory status DTOs from the mutable state held by {@link
+ * ClientPutDir}.
+ *
+ * <p>{@link ClientPutDir} tracks a mix of long-lived request flags, optional failure details, and
+ * transient progress messages produced by the live insert engine. The FCP layer, by contrast, needs
+ * a detached status object that can be handed to polling code, queue views, or reconnect replies
+ * without exposing the mutable request internals themselves. This helper performs that translation
+ * in one place so the request shell does not need to interleave lifecycle mutations with DTO
+ * assembly logic.
+ *
+ * <p>The builder preserves the existing status defaults used by the request path. If there is no
+ * current failure message, failure fields stay empty. If there is no live progress snapshot yet,
+ * block counters stay at zero, and the latest-success timestamp falls back to the current instant
+ * in the same way the pre-refactor code did. The result is a stable adapter-owned snapshot rather
+ * than a live view over mutable request fields.
+ *
+ * <ul>
+ *   <li>Extracts final URI and failure details from the current request state.
+ *   <li>Copies live progress counters when a {@link SimpleProgressMessage} is available.
+ *   <li>Returns detached status DTOs suitable for queue and replay surfaces.
+ * </ul>
+ */
+final class ClientPutDirStatusSnapshotBuilder {
+  /** Utility class; callers use the static snapshot helpers only. */
+  private ClientPutDirStatusSnapshotBuilder() {}
+
+  /**
+   * Builds the full directory-upload status snapshot for one request.
+   *
+   * <p>The returned object contains both the generic request counters and the directory-specific
+   * totals for file count and aggregate data size. Failure details are included only when the
+   * request already holds a {@link PutFailedMessage}. Otherwise, the builder leaves those fields
+   * empty and reports the request as an in-flight or successful upload, according to the enclosing
+   * request flags.
+   *
+   * @param request live request whose current state should be copied into detached status DTOs
+   * @return immutable directory-upload status assembled from the request's current state
+   */
+  static UploadDirRequestStatus build(ClientPutDir request) {
+    FreenetURI finalURI = request.getFinalURI();
+    InsertExceptionMode failureCode = null;
+    String failureReasonShort = null;
+    PutFailedMessage failureMessage = request.getFailureMessage();
+    if (failureMessage != null) {
+      failureCode = failureMessage.failureMode;
+      failureReasonShort = failureMessage.getLongFailedMessage();
+    }
+
+    RequestStatusSnapshot statusSnapshot = buildStatusSnapshot(request);
+    UploadRequestStatusDetails details =
+        new UploadRequestStatusDetails(
+            finalURI, request.uri, failureCode, failureReasonShort, null);
+    return new UploadDirRequestStatus(
+        statusSnapshot, details, request.getTotalDataSize(), request.getNumberOfFiles());
+  }
+
+  /**
+   * Builds the generic request-status portion shared with other upload status DTOs.
+   *
+   * <p>The method reads the latest progress message snapshot when one exists and copies its block
+   * counters and timestamps into a detached {@link RequestStatusSnapshot}. When no progress message
+   * is available yet, the builder preserves the legacy defaults so callers still receive a usable
+   * status object before the insert engine has reported any progress.
+   *
+   * @param request live request whose current progress state should be copied
+   * @return detached generic request-status snapshot for the directory insert
+   */
+  private static RequestStatusSnapshot buildStatusSnapshot(ClientPutDir request) {
+    int total = 0;
+    int min = 0;
+    int fetched = 0;
+    int fatal = 0;
+    int failed = 0;
+    // See ClientRequester.getLatestSuccess() for why this defaults to the current time.
+    Instant latestSuccess = Instant.now();
+    Instant latestFailure = null;
+    boolean totalFinalized = false;
+
+    FCPMessage progressSnapshot = request.getProgressMessageSnapshot();
+    if (progressSnapshot instanceof SimpleProgressMessage msg) {
+      total = (int) msg.getTotalBlocks();
+      min = (int) msg.getMinBlocks();
+      fetched = (int) msg.getFetchedBlocks();
+      latestSuccess = msg.getLatestSuccess();
+      fatal = (int) msg.getFatalyFailedBlocks();
+      failed = (int) msg.getFailedBlocks();
+      latestFailure = msg.getLatestFailure();
+      totalFinalized = msg.isTotalFinalized();
+    }
+
+    return new RequestStatusSnapshot(
+        request.identifier,
+        request.persistence,
+        request.started,
+        request.finished,
+        request.succeeded,
+        total,
+        min,
+        fetched,
+        latestSuccess,
+        fatal,
+        failed,
+        latestFailure,
+        totalFinalized,
+        request.priorityClass);
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutPreparedDataFactory.java
@@ -2,8 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.io.IOException;
 import network.crypta.client.ClientMetadata;
-import network.crypta.client.Metadata.DocumentType;
-import network.crypta.client.Metadata;
 import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.RandomAccessBucket;
@@ -19,10 +17,10 @@ import org.slf4j.LoggerFactory;
  * the redirect target URI if applicable. The logic is deterministic and avoids mutating the input
  * buckets beyond any work required to serialize redirect metadata.
  *
- * <p>When the upload is a redirect, the factory serializes a {@link Metadata} document into a new
- * bucket created by the appropriate bucket factory. For direct uploads the original bucket is
- * returned unchanged. This separation keeps the request constructors focused on lifecycle wiring
- * while ensuring consistent redirect behavior across persistent and connection-scoped flows.
+ * <p>When the upload is a redirect, the factory delegates metadata-bucket construction to the
+ * insert runtime seam. For direct uploads the original bucket is returned unchanged. This
+ * separation keeps the request constructors focused on lifecycle wiring while ensuring consistent
+ * redirect behavior across persistent and connection-scoped flows.
  *
  * <ul>
  *   <li>Builds redirect metadata buckets when {@link ClientPutBase.UploadFrom#REDIRECT} is chosen.
@@ -46,11 +44,10 @@ final class ClientPutPreparedDataFactory {
   /**
    * Prepares data for persistent inserts, optionally serializing redirect metadata.
    *
-   * <p>When the upload source is {@link ClientPutBase.UploadFrom#REDIRECT}, the method constructs a
-   * {@link Metadata} document that points at the supplied target and serializes it into a new
-   * bucket created by the persistent bucket factory. For all other sources, the original bucket is
-   * returned and the target URI is cleared. The method does not modify the contents of the original
-   * bucket.
+   * <p>When the upload source is {@link ClientPutBase.UploadFrom#REDIRECT}, the method asks the
+   * insert runtime seam to serialize a redirect metadata document into a new bucket aligned with
+   * the request persistence. For all other sources, the original bucket is returned and the target
+   * URI is cleared. The method does not modify the contents of the original bucket.
    *
    * @param uploadFrom upload source describing whether this is a redirect or direct upload.
    * @param metadata client metadata used when generating redirect documents; must not be null.
@@ -73,10 +70,8 @@ final class ClientPutPreparedDataFactory {
       boolean persistentForever)
       throws MetadataUnresolvedException, IOException {
     if (uploadFrom == ClientPutBase.UploadFrom.REDIRECT) {
-      Metadata redirectMetadata =
-          new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
       RandomAccessBucket redirectData =
-          redirectMetadata.toBucket(runtimeSupport.bucketFactory(persistentForever));
+          runtimeSupport.createRedirectMetadataBucket(metadata, redirectTarget, persistentForever);
       return new PreparedData(redirectData, true, redirectTarget);
     }
     return new PreparedData(data, false, null);
@@ -86,9 +81,9 @@ final class ClientPutPreparedDataFactory {
    * Prepares to upload data for a live FCP message, translating redirects when requested.
    *
    * <p>The method reads the bucket supplied by {@link ClientPutMessage} and emits a debug trace of
-   * the upload source. For redirect uploads, it serializes redirect metadata into a new bucket
-   * using the server’s bucket factory. Any metadata serialization failure is reported as a protocol
-   * error, so the client receives a deterministic failure response.
+   * the upload source. For redirect uploads, it asks the insert runtime seam to serialize redirect
+   * metadata into a new bucket. Any metadata serialization failure is reported as a protocol error,
+   * so the client receives a deterministic failure response.
    *
    * @param message parsed FCP message containing the data bucket; must not be {@code null}.
    * @param metadata client metadata attached to the upload; must not be {@code null}.
@@ -115,11 +110,10 @@ final class ClientPutPreparedDataFactory {
     if (LOG.isDebugEnabled()) LOG.debug(DATA_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
     if (uploadFrom == ClientPutBase.UploadFrom.REDIRECT) {
       FreenetURI redirectTarget = message.redirectTarget;
-      Metadata metadataDoc =
-          new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
       try {
         RandomAccessBucket redirectData =
-            metadataDoc.toBucket(runtimeSupport.bucketFactory(persistentForever));
+            runtimeSupport.createRedirectMetadataBucket(
+                metadata, redirectTarget, persistentForever);
         return new PreparedData(redirectData, true, redirectTarget);
       } catch (MetadataUnresolvedException e) {
         throw new MessageInvalidException(

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertRuntimeSupport.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.fcp;
 
 import java.io.IOException;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -66,6 +68,24 @@ public interface FcpInsertRuntimeSupport {
    * @return bucket factory aligned with the insert persistence mode
    */
   BucketFactory bucketFactory(boolean persistentForever);
+
+  /**
+   * Builds a redirect metadata bucket aligned with the insert persistence mode.
+   *
+   * <p>Single-file put requests use this when {@code UploadFrom=redirect} is selected. Keeping the
+   * metadata construction behind the runtime seam lets the adapter prepare redirect inserts without
+   * importing the runtime-owned metadata implementation.
+   *
+   * @param metadata client metadata to embed in the redirect document
+   * @param redirectTarget redirect target URI
+   * @param persistentForever whether the surrounding request persists forever
+   * @return bucket containing serialized redirect metadata
+   * @throws MetadataUnresolvedException if the redirect metadata cannot be serialized
+   * @throws IOException if bucket allocation or serialization fails
+   */
+  RandomAccessBucket createRedirectMetadataBucket(
+      ClientMetadata metadata, FreenetURI redirectTarget, boolean persistentForever)
+      throws MetadataUnresolvedException, IOException;
 
   /**
    * Allocates a forever-persistent upload bucket for inbound FCP payloads.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpLegacyInsertExecutionBridge.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpLegacyInsertExecutionBridge.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.fcp;
 
 import java.io.InvalidObjectException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Re-wraps legacy runtime-owned insert executions during persistent-request deserialization.
@@ -64,4 +66,20 @@ public interface FcpLegacyInsertExecutionBridge {
    */
   ClientPutDirExecution wrapLegacyDirectoryExecution(
       Object legacyPutter, ClientPutDirExecutionSpec executionSpec) throws InvalidObjectException;
+
+  /**
+   * Converts a persisted manifest tree into detached directory-entry snapshots for replay.
+   *
+   * <p>This replay-only fallback exists for persistent directory requests whose serialized manifest
+   * survived deserialization but whose live execution wrapper could not be reattached. The bridge
+   * owns any runtime-specific bucket classification needed to preserve the historical {@code
+   * PersistentPutDir} wire output in that state.
+   *
+   * @param manifestElements persisted manifest tree restored from the serialized request, or {@code
+   *     null} when none is available
+   * @return detached manifest-entry snapshots in the wire order expected by {@code Files.N}
+   * @throws InvalidObjectException if the manifest cannot be converted safely
+   */
+  List<PersistentPutDirEntrySnapshot> snapshotPersistentPutDirEntries(
+      Map<String, Object> manifestElements) throws InvalidObjectException;
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ManifestTreeMaps.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ManifestTreeMaps.java
@@ -1,0 +1,71 @@
+package network.crypta.clients.fcp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides the smallest adapter-owned map helper needed for legacy manifest-tree traversal.
+ *
+ * <p>The FCP adapter still stores directory manifests in the long-standing nested shape used by the
+ * insert path: directory nodes are mutable {@code Map<String, Object>} instances and leaf entries
+ * are {@code ManifestElement} values. Most call sites do not need a rich metadata API to work with
+ * those nodes; they only need a safe way to treat an arbitrary object as one of the directory maps.
+ * This helper exists to keep that one structural concern inside {@code :adapter-fcp} instead of
+ * importing the broader runtime-owned metadata implementation for a simple cast-or-copy operation.
+ *
+ * <p>The method intentionally preserves mutability. Existing callers recurse into nested maps, free
+ * manifest leaves, or rebuild detached entry lists, all of which expect a writable {@code
+ * HashMap}-compatible view rather than an immutable wrapper.
+ */
+final class ManifestTreeMaps {
+
+  /** Utility class; callers use {@link #forceMap(Object)} directly. */
+  private ManifestTreeMaps() {}
+
+  /**
+   * Returns a mutable {@code Map<String, Object>} view over a nested manifest directory node.
+   *
+   * <p>If the supplied object is already a {@link HashMap}, the original instance is returned.
+   * Other {@link Map} implementations are copied into a new {@link HashMap} after validating that
+   * every key is a string.
+   *
+   * @param value object expected to represent one directory node in a manifest tree
+   * @return mutable typed map for the directory node
+   * @throws ClassCastException if {@code value} is not a map or any key is not a string
+   */
+  static Map<String, Object> forceMap(Object value) {
+    if (value instanceof HashMap<?, ?> raw) {
+      return uncheckedCast(raw);
+    }
+    if (value instanceof Map<?, ?> map) {
+      HashMap<String, Object> typed = new HashMap<>();
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        Object key = entry.getKey();
+        if (!(key instanceof String stringKey)) {
+          throw new ClassCastException(
+              "Expected String keys in map, got "
+                  + (key == null ? "null" : key.getClass().getName()));
+        }
+        typed.put(stringKey, entry.getValue());
+      }
+      return typed;
+    }
+    throw new ClassCastException(
+        "Expected Map, got " + (value == null ? "null" : value.getClass().getName()));
+  }
+
+  /**
+   * Performs the unchecked cast used by the fast path for genuine {@link HashMap} instances.
+   *
+   * <p>The cast is safe under the helper's contract because the caller already identified the value
+   * as a legacy manifest directory node. Keeping the cast isolated here avoids repeating the
+   * suppression at each call site.
+   *
+   * @param raw hash map already known to represent one manifest directory node
+   * @return the same instance cast to the typed manifest-map view used by the adapter
+   */
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> uncheckedCast(Map<?, ?> raw) {
+    return (Map<String, Object>) raw;
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentPutDir.java
@@ -1,52 +1,37 @@
 package network.crypta.clients.fcp;
 
+import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import network.crypta.client.async.BaseManifestPutter;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
-import network.crypta.crypt.EncryptedRandomAccessBucket;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.HexUtil;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.api.Bucket;
-import network.crypta.support.api.ManifestElement;
-import network.crypta.support.io.DelayedFreeBucket;
-import network.crypta.support.io.DelayedFreeRandomAccessBucket;
-import network.crypta.support.io.FileBucket;
-import network.crypta.support.io.NullBucket;
-import network.crypta.support.io.PaddedEphemerallyEncryptedBucket;
-import network.crypta.support.io.PersistentTempFileBucket;
-import network.crypta.support.io.TempBucketFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Builds the wire representation of a persistent directory insert request for the FCP layer.
  *
- * <p>This helper gathers the manifest entries, default name, compression hints, persistence
- * expectations, and encryption material required to serialize a {@code PersistentPutDir} message
- * that the server sends back to clients. The instance is immutable after construction; all data is
- * pre-flattened into a {@link SimpleFieldSet} so callers can transmit the message repeatedly
- * without re-walking the manifest tree. Use this class when the node needs to mirror a client's
- * persistent directory insertion, for example, during reconnections or resumptions where the node
- * must restate the pending request.
+ * <p>This helper gathers detached manifest-entry snapshots, default name, compression hints,
+ * persistence expectations, and encryption material required to serialize a {@code
+ * PersistentPutDir} message that the server sends back to clients. The instance is immutable after
+ * construction; all data is pre-flattened into a {@link SimpleFieldSet} so callers can transmit the
+ * message repeatedly without re-walking the manifest tree. Use this class when the node needs to
+ * mirror a client's persistent directory insertion, for example, during reconnections or
+ * resumptions where the node must restate the pending request.
  *
  * <p>Concurrency: the object contains only final fields and is thread-safe for read-only access.
  * Large manifests are supported by avoiding eager string copies where possible; however, the
  * resulting field set can still be sizable, so callers should reuse instances rather than building
- * them per sending. The class does not perform I/O beyond inspecting the supplied buckets.
+ * them per sending. The class does not perform I/O beyond serializing the supplied detached entry
+ * data.
  *
  * <ul>
- *   <li><strong>Responsibilities:</strong> normalize manifest elements, emit stable message fields,
- *       attach optional metadata such as compression, retry limits, and crypto keys.
+ *   <li><strong>Responsibilities:</strong> emit stable message fields from detached manifest-entry
+ *       data and attach optional metadata such as compression, retry limits, and crypto keys.
  *   <li><strong>Notable behaviors:</strong> treats redirected targets as lightweight entries and
- *       rejects unknown bucket types with a clear {@link IllegalStateException}.
+ *       preserves the established {@code Files.N} wire layout.
  * </ul>
- *
- * @see BaseManifestPutter#flatten(Map)
  */
 public final class PersistentPutDir extends FCPMessage {
-  private static final Logger LOG = LoggerFactory.getLogger(PersistentPutDir.class);
   private static final String NAME = "PersistentPutDir";
   private static final String UPLOAD_FROM = "UploadFrom";
 
@@ -57,7 +42,6 @@ public final class PersistentPutDir extends FCPMessage {
   final short priorityClass;
   final Persistence persistence;
   final boolean global;
-  private final Map<String, Object> manifestElements;
   final String defaultName;
   final String token;
   final boolean started;
@@ -73,16 +57,16 @@ public final class PersistentPutDir extends FCPMessage {
   /**
    * Creates a persistent directory insert message snapshot with all supporting metadata.
    *
-   * <p>The constructor performs the manifest flattening immediately and caches the resulting field
-   * set so repeated invocations of {@link #getFieldSet()} are cheap. Callers should pass the URIs
-   * exactly as issued by the node; no additional validation or escaping is performed here.
+   * <p>The constructor consumes already-detached manifest-entry snapshots and caches the resulting
+   * field set so repeated invocations of {@link #getFieldSet()} are cheap. Callers should pass the
+   * URIs exactly as issued by the node; no additional validation or escaping is performed here.
    *
    * @param requestParams core request identifiers, scheduling flags, and persistence settings
    * @param metadata shared persistent insert metadata such as retries and compression flags
    * @param defaultName the default filename applied to manifest entries lacking an explicit name;
    *     also used by UI layers when constructing links.
-   * @param manifestElements flattened or hierarchical manifest elements supplied by the client; any
-   *     redirect entries must include a target URI while file entries must carry data buckets.
+   * @param manifestEntries detached manifest-entry snapshots in the order expected by the FCP wire
+   *     format
    * @param wasDiskPut whether the original request streamed from disk; affects how the node
    *     represents the upload source within the field set.
    */
@@ -90,7 +74,7 @@ public final class PersistentPutDir extends FCPMessage {
       ClientRequestParams requestParams,
       PersistentPutRequestMetadata metadata,
       String defaultName,
-      Map<String, Object> manifestElements,
+      List<PersistentPutDirEntrySnapshot> manifestEntries,
       boolean wasDiskPut) {
     this.clientIdentifier = requestParams.identifier();
     this.uri = requestParams.uri();
@@ -100,7 +84,6 @@ public final class PersistentPutDir extends FCPMessage {
     this.persistence = requestParams.persistence();
     this.global = requestParams.global();
     this.defaultName = defaultName;
-    this.manifestElements = manifestElements;
     this.token = requestParams.clientToken();
     this.started = metadata.started();
     this.maxRetries = metadata.maxRetries();
@@ -110,14 +93,13 @@ public final class PersistentPutDir extends FCPMessage {
     this.realTime = requestParams.realTime();
     this.splitfileCryptoKey = metadata.splitfileCryptoKey();
     this.compatMode = metadata.compatMode();
-    cached = generateFieldSet();
+    cached = generateFieldSet(manifestEntries == null ? List.of() : manifestEntries);
   }
 
-  private SimpleFieldSet generateFieldSet() {
+  private SimpleFieldSet generateFieldSet(List<PersistentPutDirEntrySnapshot> manifestEntries) {
     SimpleFieldSet fs = createBaseFieldSet();
-    ManifestElement[] elements = BaseManifestPutter.flatten(manifestElements);
     fs.putSingle("DefaultName", defaultName);
-    fs.put("Files", createFilesFieldSet(elements));
+    fs.put("Files", createFilesFieldSet(manifestEntries));
     addOptionalFields(fs);
     return fs;
   }
@@ -136,72 +118,37 @@ public final class PersistentPutDir extends FCPMessage {
     return fs;
   }
 
-  private SimpleFieldSet createFilesFieldSet(ManifestElement[] elements) {
+  private SimpleFieldSet createFilesFieldSet(List<PersistentPutDirEntrySnapshot> manifestEntries) {
     SimpleFieldSet files = new SimpleFieldSet(false);
-    for (int i = 0; i < elements.length; i++) {
-      files.put(Integer.toString(i), createElementFieldSet(elements[i]));
+    for (int i = 0; i < manifestEntries.size(); i++) {
+      files.put(Integer.toString(i), createElementFieldSet(manifestEntries.get(i)));
     }
-    files.put("Count", elements.length);
+    files.put("Count", manifestEntries.size());
     return files;
   }
 
-  private SimpleFieldSet createElementFieldSet(ManifestElement element) {
+  private SimpleFieldSet createElementFieldSet(PersistentPutDirEntrySnapshot entry) {
     SimpleFieldSet subset = new SimpleFieldSet(false);
-    subset.putSingle("Name", element.getName());
-    FreenetURI targetURI = element.getTargetURI();
-    if (targetURI != null) {
+    subset.putSingle("Name", entry.name());
+    if (entry.uploadFrom() == ClientPutBase.UploadFrom.REDIRECT && entry.targetUri() != null) {
       subset.putSingle(UPLOAD_FROM, "redirect");
-      subset.putSingle("TargetURI", targetURI.toString());
+      subset.putSingle("TargetURI", entry.targetUri().toString());
       return subset;
     }
-    Bucket data = unwrapBucket(element.getData());
-    subset.put("DataLength", element.getSize());
-    String mimeOverride = element.getMimeTypeOverride();
+    subset.put("DataLength", entry.dataLength());
+    String mimeOverride = entry.mimeTypeOverride();
     if (mimeOverride != null) {
       subset.putSingle("Metadata.ContentType", mimeOverride);
     }
-    populateUploadSource(subset, data, element);
-    return subset;
-  }
-
-  private void populateUploadSource(SimpleFieldSet subset, Bucket data, ManifestElement element) {
-    if (data == null) {
-      LOG.error(
-          "Bucket already freed: {} for {} for {} for {}",
-          element.getData(),
-          element,
-          element.getName(),
-          clientIdentifier);
-      return;
-    }
-    if (data instanceof FileBucket bucket) {
+    if (entry.uploadFrom() == ClientPutBase.UploadFrom.DISK) {
       subset.putSingle(UPLOAD_FROM, "disk");
-      subset.putSingle("Filename", bucket.getFile().getPath());
-      return;
-    }
-    if (isDirectUploadBucket(data)) {
+      if (entry.filename() != null) {
+        subset.putSingle("Filename", entry.filename());
+      }
+    } else if (entry.uploadFrom() == ClientPutBase.UploadFrom.DIRECT) {
       subset.putSingle(UPLOAD_FROM, "direct");
-      return;
     }
-    throw new IllegalStateException("Don't know what to do with bucket: " + data);
-  }
-
-  private boolean isDirectUploadBucket(Bucket data) {
-    return data instanceof PaddedEphemerallyEncryptedBucket
-        || data instanceof NullBucket
-        || data instanceof PersistentTempFileBucket
-        || data instanceof TempBucketFactory.TempBucket
-        || data instanceof EncryptedRandomAccessBucket;
-  }
-
-  private Bucket unwrapBucket(Bucket data) {
-    if (data instanceof DelayedFreeBucket bucket) {
-      return bucket.getUnderlying();
-    }
-    if (data instanceof DelayedFreeRandomAccessBucket bucket) {
-      return bucket.getUnderlying();
-    }
-    return data;
+    return subset;
   }
 
   private void addOptionalFields(SimpleFieldSet fs) {

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentPutDirEntrySnapshot.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/PersistentPutDirEntrySnapshot.java
@@ -1,0 +1,41 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.keys.FreenetURI;
+
+/**
+ * Carries the detached, wire-facing state for one flattened manifest entry in a persistent
+ * directory insert.
+ *
+ * <p>{@link PersistentPutDir} serializes directory inserts as a flat {@code Files.N} field set, but
+ * the live request path holds richer runtime-owned manifest trees and bucket wrappers. This record
+ * is the adapter-owned boundary object between those two representations. Bridge/runtime code
+ * classifies each live entry into one of the supported FCP upload-source forms and records only the
+ * data that the wire format actually needs. The adapter can then replay persistent directory
+ * requests without depending directly on runtime-owned manifest classes.
+ *
+ * <p>The fields intentionally allow sparse combinations because the FCP wire format itself is
+ * sparse. Redirect entries use {@link #targetUri()} and ignore filename data. Disk-backed entries
+ * use {@link #filename()} to preserve the original on-disk source path. Direct entries omit both.
+ * When the bridge cannot represent an upload source faithfully, it may leave {@link #uploadFrom()}
+ * as {@code null} so the serializer can omit the field instead of inventing a misleading value.
+ *
+ * @param name flattened manifest path relative to the directory root, for example {@code
+ *     "subdir/file.txt"}
+ * @param uploadFrom FCP upload-source classification for this entry, or {@code null} when the
+ *     serializer should omit the field rather than misclassify the source
+ * @param dataLength source payload length in bytes, or {@code -1} for redirect-style entries that
+ *     do not carry file payload data
+ * @param filename original disk filename for {@link ClientPutBase.UploadFrom#DISK} entries, or
+ *     {@code null} when the entry is not represented as a disk-backed upload
+ * @param mimeTypeOverride explicit MIME override that should become {@code Metadata.ContentType},
+ *     or {@code null} when the wire output should omit that field
+ * @param targetUri redirect destination for {@link ClientPutBase.UploadFrom#REDIRECT} entries, or
+ *     {@code null} when the entry is not a redirect
+ */
+public record PersistentPutDirEntrySnapshot(
+    String name,
+    ClientPutBase.UploadFrom uploadFrom,
+    long dataLength,
+    String filename,
+    String mimeTypeOverride,
+    FreenetURI targetUri) {}

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -80,6 +80,12 @@ class AdapterFcpBoundaryTest {
   private static final Path FCP_MESSAGE_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("FCPMessage.java");
   private static final Path CLIENT_PUT_COMPLEX_DIR_MESSAGE_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutComplexDirMessage.java");
+  private static final Path CLIENT_PUT_DIR_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutDir.java");
+  private static final Path CLIENT_PUT_PREPARED_DATA_FACTORY_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutPreparedDataFactory.java");
+  private static final Path PERSISTENT_PUT_DIR_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("PersistentPutDir.java");
   private static final Path FCP_CONNECTION_INPUT_HANDLER_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("FCPConnectionInputHandler.java");
   private static final Path FCP_SERVER_DEPENDENCIES_SOURCE =
@@ -102,11 +108,12 @@ class AdapterFcpBoundaryTest {
       Set.of(
           ADAPTER_FCP_MAIN_JAVA.resolve("FcpInsertRuntimeSupport.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("ClientPut.java"),
-          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutDir.java"),
-          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutPreparedDataFactory.java"),
+          CLIENT_PUT_DIR_SOURCE,
+          CLIENT_PUT_PREPARED_DATA_FACTORY_SOURCE,
           ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutPutterFactory.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutMessage.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutDirMessage.java"),
+          PERSISTENT_PUT_DIR_SOURCE,
           ADAPTER_FCP_MAIN_JAVA.resolve("SubscribeUSK.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("FCPConnectionHandler.java"));
   private static final Set<Path> DETACHED_COMPATIBILITY_SOURCES =
@@ -233,6 +240,20 @@ class AdapterFcpBoundaryTest {
           "network.crypta.clients.fcp.NodeHelloMessage");
   private static final Set<String> FORBIDDEN_PERSISTENT_TEMP_BUCKET_IMPORTS =
       Set.of("network.crypta.support.io.PersistentTempBucketFactory");
+  private static final Set<Path> FORBIDDEN_METADATA_CLUSTER_SOURCES =
+      Set.of(
+          CLIENT_PUT_COMPLEX_DIR_MESSAGE_SOURCE,
+          CLIENT_PUT_DIR_SOURCE,
+          CLIENT_PUT_PREPARED_DATA_FACTORY_SOURCE);
+  private static final Set<String> FORBIDDEN_METADATA_CLUSTER_IMPORTS =
+      Set.of("network.crypta.client.Metadata");
+  private static final Set<String> FORBIDDEN_PERSISTENT_PUT_DIR_RUNTIME_IMPORTS =
+      Set.of(
+          "network.crypta.client.async.BaseManifestPutter",
+          "network.crypta.support.io.DelayedFreeBucket",
+          "network.crypta.support.io.DelayedFreeRandomAccessBucket",
+          "network.crypta.support.io.PaddedEphemerallyEncryptedBucket",
+          "network.crypta.support.io.TempBucketFactory");
 
   @Test
   void mainSourceLayout_whenCheckingFcpOwnership_expectLeafOwnsPackageTree() throws IOException {
@@ -478,6 +499,45 @@ class AdapterFcpBoundaryTest {
         "Persistent bucket adapter sources must not import PersistentTempBucketFactory."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void adapterFcpMain_whenCheckingMetadataBoundary_expectNoRuntimeMetadataImports()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path source : FORBIDDEN_METADATA_CLUSTER_SOURCES) {
+      Set<String> imports = readImports(repoRoot.resolve(source));
+      Set<String> forbiddenImports = new TreeSet<>(imports);
+      forbiddenImports.retainAll(FORBIDDEN_METADATA_CLUSTER_IMPORTS);
+      if (!forbiddenImports.isEmpty()) {
+        violations.add(source + " -> " + String.join(", ", forbiddenImports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "Metadata boundary adapter sources must not import runtime-owned Metadata."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void adapterFcpMain_whenCheckingPersistentPutDirBoundary_expectNoRuntimeManifestHelpers()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Set<String> imports = readImports(repoRoot.resolve(PERSISTENT_PUT_DIR_SOURCE));
+    Set<String> forbiddenImports = new TreeSet<>(imports);
+    forbiddenImports.retainAll(FORBIDDEN_PERSISTENT_PUT_DIR_RUNTIME_IMPORTS);
+
+    assertTrue(
+        forbiddenImports.isEmpty(),
+        "PersistentPutDir must not import runtime-owned manifest helpers or bucket wrappers."
+            + System.lineSeparator()
+            + PERSISTENT_PUT_DIR_SOURCE
+            + " -> "
+            + String.join(", ", forbiddenImports));
   }
 
   @Test

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
@@ -4,13 +4,18 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
 import network.crypta.client.InsertException;
+import network.crypta.client.Metadata.DocumentType;
+import network.crypta.client.Metadata;
+import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.client.async.BaseClientPutter;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.ClientPutCallback;
@@ -49,6 +54,7 @@ import network.crypta.clients.fcp.FcpInsertOptions;
 import network.crypta.clients.fcp.FcpInsertRuntimeSupport;
 import network.crypta.clients.fcp.FcpInsertTuningOptions;
 import network.crypta.clients.fcp.FcpRequesterHandle;
+import network.crypta.clients.fcp.PersistentPutDirEntrySnapshot;
 import network.crypta.clients.fcp.SubscribeUSKCallbacks;
 import network.crypta.clients.fcp.SubscribeUSKMessage;
 import network.crypta.clients.fcp.UskSubscriptionHandle;
@@ -95,6 +101,15 @@ record CoreFcpInsertRuntimeSupport(
   @Override
   public BucketFactory bucketFactory(boolean persistentForever) {
     return clientContext().getBucketFactory(persistentForever);
+  }
+
+  @Override
+  public RandomAccessBucket createRedirectMetadataBucket(
+      ClientMetadata metadata, FreenetURI redirectTarget, boolean persistentForever)
+      throws MetadataUnresolvedException, IOException {
+    Metadata redirectMetadata =
+        new Metadata(DocumentType.SIMPLE_REDIRECT, null, null, redirectTarget, metadata);
+    return redirectMetadata.toBucket(bucketFactory(persistentForever));
   }
 
   @Override
@@ -406,6 +421,11 @@ record CoreFcpInsertRuntimeSupport(
     @Override
     public long totalSize() {
       return putter.totalSize();
+    }
+
+    @Override
+    public List<PersistentPutDirEntrySnapshot> persistentPutDirEntries() {
+      return CorePersistentPutDirSnapshotter.snapshot(spec.manifestElements());
     }
 
     @Override

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerDependenciesFactory.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerDependenciesFactory.java
@@ -1,6 +1,8 @@
 package network.crypta.clients.fcp.bridge;
 
 import java.io.InvalidObjectException;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import network.crypta.clients.fcp.ClientPutDirExecution;
 import network.crypta.clients.fcp.ClientPutDirExecutionSpec;
@@ -13,6 +15,7 @@ import network.crypta.clients.fcp.FcpLegacyInsertExecutionBridge;
 import network.crypta.clients.fcp.FcpMessageRuntimeSupport;
 import network.crypta.clients.fcp.FcpServerDependencies;
 import network.crypta.clients.fcp.FcpServerRuntimeSupport;
+import network.crypta.clients.fcp.PersistentPutDirEntrySnapshot;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -77,6 +80,12 @@ public final class CoreFcpServerDependenciesFactory {
             throws InvalidObjectException {
           return CoreFcpInsertRuntimeSupport.wrapLegacyDirectoryExecution(
               legacyPutter, executionSpec);
+        }
+
+        @Override
+        public List<PersistentPutDirEntrySnapshot> snapshotPersistentPutDirEntries(
+            Map<String, Object> manifestElements) {
+          return CorePersistentPutDirSnapshotter.snapshot(manifestElements);
         }
       };
 

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CorePersistentPutDirSnapshotter.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CorePersistentPutDirSnapshotter.java
@@ -1,0 +1,174 @@
+package network.crypta.clients.fcp.bridge;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import network.crypta.client.Metadata;
+import network.crypta.clients.fcp.ClientPutBase;
+import network.crypta.clients.fcp.PersistentPutDirEntrySnapshot;
+import network.crypta.crypt.EncryptedRandomAccessBucket;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.api.ManifestElement;
+import network.crypta.support.io.DelayedFreeBucket;
+import network.crypta.support.io.DelayedFreeRandomAccessBucket;
+import network.crypta.support.io.FileBucket;
+import network.crypta.support.io.NullBucket;
+import network.crypta.support.io.PaddedEphemerallyEncryptedBucket;
+import network.crypta.support.io.PersistentTempFileBucket;
+import network.crypta.support.io.TempBucketFactory;
+
+/**
+ * Converts runtime-owned manifest trees into adapter-owned {@link PersistentPutDirEntrySnapshot}
+ * values.
+ *
+ * <p>The bridge layer still owns the details of manifest flattening, bucket unwrapping, and
+ * upload-source classification for persistent directory inserts. Those details depend on runtime
+ * types such as delayed-free wrappers, temporary bucket implementations, and the legacy metadata
+ * helper used for nested manifest maps. This helper concentrates that knowledge in one bridge-only
+ * place. The adapter receives only detached entry snapshots and can therefore serialize {@code
+ * PersistentPutDir} replies without importing the runtime classes that describe live bucket state.
+ *
+ * <p>The same conversion path is used for two situations: normal live executions and replay-only
+ * fallback when a durable request has restored its stored manifest tree but not its live execution
+ * wrapper. Keeping both paths on the same helper preserves the historical wire behavior for disk,
+ * direct, redirect, delayed-free, and already-freed entries. Unknown bucket types still fail
+ * deterministically, so callers do not silently misreport the upload source.
+ *
+ * <ul>
+ *   <li>Flattens nested manifest maps into the {@code Files.N} ordering expected by FCP.
+ *   <li>Classifies disk, direct, redirect, and already-freed entries from the runtime bucket state.
+ *   <li>Preserves the same replay behavior for live and compatibility fallback paths.
+ * </ul>
+ */
+final class CorePersistentPutDirSnapshotter {
+
+  /** Utility class; callers use the static snapshot helpers only. */
+  private CorePersistentPutDirSnapshotter() {}
+
+  /**
+   * Snapshots a manifest tree into detached persistent-put-dir entry descriptors.
+   *
+   * <p>The returned list is ordered by the iteration order of the nested manifest maps, matching
+   * the legacy-flattening behavior expected by the FCP serializer. A {@code null} manifest yields
+   * an empty list so replay callers can keep generating replies even when no stored tree is
+   * available.
+   *
+   * @param manifestElements nested manifest tree restored from the request or live execution spec
+   * @return detached entry snapshots ready for {@code PersistentPutDir} serialization
+   */
+  static List<PersistentPutDirEntrySnapshot> snapshot(Map<String, Object> manifestElements) {
+    List<PersistentPutDirEntrySnapshot> entries = new ArrayList<>();
+    if (manifestElements == null) {
+      return entries;
+    }
+    snapshot(manifestElements, entries, "");
+    return entries;
+  }
+
+  /**
+   * Recursively walks one manifest directory node and appends flattened entry snapshots.
+   *
+   * @param manifestElements current manifest directory node
+   * @param entries destination list receiving flattened entry snapshots
+   * @param prefix path prefix accumulated from parent directories
+   */
+  private static void snapshot(
+      Map<String, Object> manifestElements,
+      List<PersistentPutDirEntrySnapshot> entries,
+      String prefix) {
+    for (Map.Entry<String, Object> entry : manifestElements.entrySet()) {
+      String name = entry.getKey();
+      String fullName = prefix.isEmpty() ? name : prefix + '/' + name;
+      Object value = entry.getValue();
+      if (value instanceof Map) {
+        snapshot(Metadata.forceMap(value), entries, fullName);
+      } else if (value instanceof ManifestElement manifestElement) {
+        entries.add(toPersistentPutDirEntrySnapshot(fullName, manifestElement));
+      } else {
+        throw new IllegalStateException(String.valueOf(value));
+      }
+    }
+  }
+
+  /**
+   * Converts one manifest leaf into the detached snapshot form used by the adapter layer.
+   *
+   * <p>Redirect entries are emitted without inspecting the bucket state. File-backed entries are
+   * classified from their runtime bucket implementation after delayed-free wrappers are removed.
+   * When the bucket has already been freed, the helper preserves the entry name, size, and MIME
+   * override but leaves the upload source unset so the serializer can omit it.
+   *
+   * @param fullName flattened path for the manifest entry relative to the directory root
+   * @param element live manifest element carrying runtime bucket and metadata state
+   * @return detached snapshot that captures only the fields needed by {@code PersistentPutDir}
+   */
+  private static PersistentPutDirEntrySnapshot toPersistentPutDirEntrySnapshot(
+      String fullName, ManifestElement element) {
+    FreenetURI targetUri = element.getTargetURI();
+    if (targetUri != null) {
+      return new PersistentPutDirEntrySnapshot(
+          fullName,
+          ClientPutBase.UploadFrom.REDIRECT,
+          element.getSize(),
+          null,
+          element.getMimeTypeOverride(),
+          targetUri);
+    }
+    Bucket data = unwrapPersistentPutDirBucket(element.getData());
+    if (data == null) {
+      return new PersistentPutDirEntrySnapshot(
+          fullName, null, element.getSize(), null, element.getMimeTypeOverride(), null);
+    }
+    if (data instanceof FileBucket bucket) {
+      return new PersistentPutDirEntrySnapshot(
+          fullName,
+          ClientPutBase.UploadFrom.DISK,
+          element.getSize(),
+          bucket.getFile().getPath(),
+          element.getMimeTypeOverride(),
+          null);
+    }
+    if (isPersistentPutDirDirectBucket(data)) {
+      return new PersistentPutDirEntrySnapshot(
+          fullName,
+          ClientPutBase.UploadFrom.DIRECT,
+          element.getSize(),
+          null,
+          element.getMimeTypeOverride(),
+          null);
+    }
+    throw new IllegalStateException("Don't know what to do with bucket: " + data);
+  }
+
+  /**
+   * Reports whether a runtime bucket should be exposed as {@code UploadFrom=direct}.
+   *
+   * @param data runtime bucket implementation for one manifest entry
+   * @return {@code true} when the bucket represents a direct-style upload source
+   */
+  private static boolean isPersistentPutDirDirectBucket(Bucket data) {
+    return data instanceof PaddedEphemerallyEncryptedBucket
+        || data instanceof NullBucket
+        || data instanceof PersistentTempFileBucket
+        || data instanceof TempBucketFactory.TempBucket
+        || data instanceof EncryptedRandomAccessBucket;
+  }
+
+  /**
+   * Removes delayed-free wrappers so disk/direct classification sees the underlying bucket type.
+   *
+   * @param data runtime bucket possibly wrapped in delayed-free adapters
+   * @return underlying bucket used for upload-source classification, or the original bucket when no
+   *     wrapper is present
+   */
+  private static Bucket unwrapPersistentPutDirBucket(Bucket data) {
+    if (data instanceof DelayedFreeBucket bucket) {
+      return bucket.getUnderlying();
+    }
+    if (data instanceof DelayedFreeRandomAccessBucket bucket) {
+      return bucket.getUnderlying();
+    }
+    return data;
+  }
+}

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
@@ -3,9 +3,20 @@ package network.crypta.clients.fcp.bridge;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectOutputStream;
-import java.lang.reflect.Constructor;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
 import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
@@ -30,15 +41,22 @@ import network.crypta.clients.fcp.FcpInsertContextHandle;
 import network.crypta.clients.fcp.FcpInsertContextLimits;
 import network.crypta.clients.fcp.FcpInsertOptions;
 import network.crypta.clients.fcp.FcpInsertTuningOptions;
+import network.crypta.clients.fcp.PersistentPutDirEntrySnapshot;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
 import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.BucketFactory;
+import network.crypta.support.api.ManifestElement;
 import network.crypta.support.api.RandomAccessBucket;
+import network.crypta.support.io.DelayedFreeRandomAccessBucket;
+import network.crypta.support.io.FileBucket;
+import network.crypta.support.io.NullBucket;
+import network.crypta.support.io.PersistentFileTracker;
 import network.crypta.support.io.PersistentTempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -58,6 +76,17 @@ import static org.mockito.Mockito.withSettings;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class CoreFcpInsertRuntimeSupportTest {
+  private static final String MIME_TEXT_PLAIN = "text/plain";
+  private static final String DISK_FILE_NAME = "disk.dat";
+  private static final String TARGET_NAME = "target";
+  private static final String REDIRECT_FILE_NAME = "redirect.bin";
+  private static final String VALID_CHK =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
+          + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+  private static final String WRAPPED_FILE_NAME = "wrapped.dat";
+  private static final String DEFAULT_NAME = "index.html";
+  private static final Supplier<ClientPutDir> CLIENT_PUT_DIR_FACTORY = clientPutDirFactory();
+  private static final VarHandle MANIFEST_ELEMENTS_HANDLE = manifestElementsHandle();
 
   @Mock private NodeClientCore core;
   @Mock private ClientContext clientContext;
@@ -65,6 +94,8 @@ class CoreFcpInsertRuntimeSupportTest {
   @Mock private BucketFactory bucketFactory;
   @Mock private PersistentTempBucketFactory persistentTempBucketFactory;
   @Mock private RandomAccessBucket bucket;
+
+  @TempDir Path tempDir;
 
   @Test
   void defaultPersistentInsertContextHandle_whenRequested_returnsDetachedCopyOfClientDefaults() {
@@ -227,6 +258,25 @@ class CoreFcpInsertRuntimeSupportTest {
   }
 
   @Test
+  void createRedirectMetadataBucket_whenRedirectRequested_returnsNewMetadataBucket()
+      throws Exception {
+    ClientMetadata metadata = new ClientMetadata(MIME_TEXT_PLAIN);
+    FreenetURI redirectTarget = new FreenetURI(VALID_CHK);
+    RandomAccessBucket redirectBucket = new NullBucket();
+    when(core.getClientContext()).thenReturn(clientContext);
+    when(clientContext.getBucketFactory(true)).thenReturn(bucketFactory);
+    when(bucketFactory.makeBucket(-1)).thenReturn(redirectBucket);
+    CoreFcpInsertRuntimeSupport support =
+        new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
+
+    RandomAccessBucket actual =
+        support.createRedirectMetadataBucket(metadata, redirectTarget, true);
+
+    assertSame(redirectBucket, actual);
+    verify(clientContext).getBucketFactory(true);
+  }
+
+  @Test
   void allocatePersistentUploadBucket_whenDatabaseKilled_throwsPersistenceDisabledException() {
     when(core.killedDatabase()).thenReturn(true);
     CoreFcpInsertRuntimeSupport support =
@@ -255,12 +305,98 @@ class CoreFcpInsertRuntimeSupportTest {
   }
 
   @Test
+  void persistentPutDirEntries_whenManifestContainsDiskDirectAndRedirect_snapshotsDetachedEntries()
+      throws Exception {
+    Path diskFilePath = Files.createFile(tempDir.resolve(DISK_FILE_NAME));
+    FileBucket diskBucket = new FileBucket(diskFilePath.toFile(), false, false, false, false);
+    ManifestElement diskElement =
+        new ManifestElement(DISK_FILE_NAME, diskBucket, MIME_TEXT_PLAIN, 4);
+    ManifestElement directElement =
+        new ManifestElement("nested.bin", new NullBucket(8), "application/octet-stream", 8);
+    FreenetURI redirectUri = new FreenetURI("CHK", TARGET_NAME);
+    ManifestElement redirectElement = new ManifestElement(REDIRECT_FILE_NAME, redirectUri, null);
+
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put(DISK_FILE_NAME, diskElement);
+    Map<String, Object> subdir = new LinkedHashMap<>();
+    subdir.put("nested.bin", directElement);
+    manifest.put("subdir", subdir);
+    manifest.put(REDIRECT_FILE_NAME, redirectElement);
+
+    ClientPutDirExecution execution = newDirectoryExecution(manifest);
+
+    List<PersistentPutDirEntrySnapshot> entries = execution.persistentPutDirEntries();
+
+    assertEquals(3, entries.size());
+    assertEquals(
+        new PersistentPutDirEntrySnapshot(
+            DISK_FILE_NAME,
+            network.crypta.clients.fcp.ClientPutBase.UploadFrom.DISK,
+            4,
+            diskFilePath.toFile().getPath(),
+            MIME_TEXT_PLAIN,
+            null),
+        entries.getFirst());
+    assertEquals(
+        new PersistentPutDirEntrySnapshot(
+            "subdir/nested.bin",
+            network.crypta.clients.fcp.ClientPutBase.UploadFrom.DIRECT,
+            8,
+            null,
+            "application/octet-stream",
+            null),
+        entries.get(1));
+    assertEquals(
+        new PersistentPutDirEntrySnapshot(
+            REDIRECT_FILE_NAME,
+            network.crypta.clients.fcp.ClientPutBase.UploadFrom.REDIRECT,
+            -1,
+            null,
+            null,
+            redirectUri),
+        entries.get(2));
+  }
+
+  @Test
+  void persistentPutDirEntries_whenBucketWrappedInDelayedFree_usesUnderlyingFileBucket()
+      throws Exception {
+    Path wrappedFilePath = Files.createFile(tempDir.resolve(WRAPPED_FILE_NAME));
+    FileBucket underlyingBucket =
+        new FileBucket(wrappedFilePath.toFile(), false, false, false, false);
+    PersistentFileTracker tracker = mock(PersistentFileTracker.class);
+    when(tracker.commitID()).thenReturn(1L);
+    DelayedFreeRandomAccessBucket wrapped =
+        new DelayedFreeRandomAccessBucket(tracker, underlyingBucket);
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put(WRAPPED_FILE_NAME, new ManifestElement(WRAPPED_FILE_NAME, wrapped, null, 12));
+
+    List<PersistentPutDirEntrySnapshot> entries =
+        newDirectoryExecution(manifest).persistentPutDirEntries();
+
+    assertEquals(1, entries.size());
+    PersistentPutDirEntrySnapshot entry = entries.getFirst();
+    assertSame(network.crypta.clients.fcp.ClientPutBase.UploadFrom.DISK, entry.uploadFrom());
+    assertEquals(wrappedFilePath.toFile().getPath(), entry.filename());
+  }
+
+  @Test
+  void persistentPutDirEntries_whenBucketTypeUnknown_throwsIllegalStateException()
+      throws Exception {
+    Map<String, Object> manifest = new LinkedHashMap<>();
+    manifest.put("unknown.bin", new ManifestElement("unknown.bin", bucket, null, 2));
+
+    ClientPutDirExecution execution = newDirectoryExecution(manifest);
+
+    assertThrows(IllegalStateException.class, execution::persistentPutDirEntries);
+  }
+
+  @Test
   void directoryExecution_whenSerialized_doesNotCaptureEnclosingRuntimeSupport() throws Exception {
     ClientPutDirExecutionSpec executionSpec =
         new ClientPutDirExecutionSpec(
             newSerializableClientPutDir(),
             new ClientRequestParams(
-                new FreenetURI("CHK", "target"),
+                new FreenetURI("CHK", TARGET_NAME),
                 "put-dir",
                 0,
                 (short) 1,
@@ -269,7 +405,7 @@ class CoreFcpInsertRuntimeSupportTest {
                 null,
                 false),
             mock(FcpInsertContextHandle.class, withSettings().serializable()),
-            "index.html",
+            DEFAULT_NAME,
             null);
     ManifestPutter putter = mock(ManifestPutter.class, withSettings().serializable());
 
@@ -291,7 +427,7 @@ class CoreFcpInsertRuntimeSupportTest {
         new ClientPutExecutionSpec(
             callback,
             new ClientRequestParams(
-                new FreenetURI("CHK", "target"),
+                new FreenetURI("CHK", TARGET_NAME),
                 "put-file",
                 0,
                 (short) 1,
@@ -308,9 +444,9 @@ class CoreFcpInsertRuntimeSupportTest {
                         true, true, "GZIP", 2, 3, FcpCompatibilityMode.COMPAT_1468),
                     null)),
             uploadBucket,
-            new ClientMetadata("text/plain"),
+            new ClientMetadata(MIME_TEXT_PLAIN),
             false,
-            new ClientPutExecutionSpec.ExecutionOptions("index.html", false, null, -1));
+            new ClientPutExecutionSpec.ExecutionOptions(DEFAULT_NAME, false, null, -1));
     CoreFcpInsertRuntimeSupport support =
         new CoreFcpInsertRuntimeSupport(core, () -> transferAccess);
 
@@ -323,24 +459,47 @@ class CoreFcpInsertRuntimeSupportTest {
   }
 
   private static ClientPutDirExecution instantiateDirectoryExecution(
-      ClientPutDirExecutionSpec executionSpec, ManifestPutter putter) throws Exception {
-    Class<?> executionClass =
-        Class.forName(CoreFcpInsertRuntimeSupport.class.getName() + "$CoreClientPutDirExecution");
+      ClientPutDirExecutionSpec executionSpec, ManifestPutter putter)
+      throws InvalidObjectException {
+    ClientPutDirExecution execution =
+        CoreFcpInsertRuntimeSupport.wrapLegacyDirectoryExecution(putter, executionSpec);
+    Class<?> executionClass = execution.getClass();
     assertTrue(Modifier.isStatic(executionClass.getModifiers()));
-    Constructor<?> constructor =
-        executionClass.getDeclaredConstructor(
-            ClientPutDirExecutionSpec.class, ManifestPutter.class);
-    constructor.setAccessible(true);
-    return (ClientPutDirExecution) constructor.newInstance(executionSpec, putter);
+    return execution;
   }
 
-  private static ClientPutDir newSerializableClientPutDir() throws Exception {
-    Constructor<ClientPutDir> constructor = ClientPutDir.class.getDeclaredConstructor();
-    constructor.setAccessible(true);
-    return constructor.newInstance();
+  private static ClientPutDirExecution newDirectoryExecution(Map<String, Object> manifest)
+      throws InvalidObjectException {
+    ClientPutDir request = newSerializableClientPutDir();
+    setManifestElements(request, manifest);
+    ClientPutDirExecutionSpec executionSpec =
+        new ClientPutDirExecutionSpec(
+            request,
+            new ClientRequestParams(
+                new FreenetURI("CHK", TARGET_NAME),
+                "put-dir",
+                0,
+                (short) 1,
+                Persistence.REBOOT,
+                false,
+                null,
+                false),
+            mock(FcpInsertContextHandle.class, withSettings().serializable()),
+            DEFAULT_NAME,
+            null);
+    return instantiateDirectoryExecution(
+        executionSpec, mock(ManifestPutter.class, withSettings().serializable()));
   }
 
-  private static byte[] serialize(Object value) throws Exception {
+  private static ClientPutDir newSerializableClientPutDir() {
+    return CLIENT_PUT_DIR_FACTORY.get();
+  }
+
+  private static void setManifestElements(ClientPutDir request, Map<String, Object> manifest) {
+    MANIFEST_ELEMENTS_HANDLE.set(request, manifest);
+  }
+
+  private static byte[] serialize(Object value) throws IOException {
     try (ByteArrayOutputStream output = new ByteArrayOutputStream();
         ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
       objectOutput.writeObject(value);
@@ -349,7 +508,7 @@ class CoreFcpInsertRuntimeSupportTest {
     }
   }
 
-  private static byte[] serialize(CompatibilityAnalyser analyser) throws Exception {
+  private static byte[] serialize(CompatibilityAnalyser analyser) throws IOException {
     try (ByteArrayOutputStream output = new ByteArrayOutputStream();
         DataOutputStream dataOutput = new DataOutputStream(output)) {
       analyser.writeTo(dataOutput);
@@ -358,12 +517,42 @@ class CoreFcpInsertRuntimeSupportTest {
     }
   }
 
-  private static byte[] serialize(FcpCompatibilityAnalysis analysis) throws Exception {
+  private static byte[] serialize(FcpCompatibilityAnalysis analysis) throws IOException {
     try (ByteArrayOutputStream output = new ByteArrayOutputStream();
         DataOutputStream dataOutput = new DataOutputStream(output)) {
       analysis.writeTo(dataOutput);
       dataOutput.flush();
       return output.toByteArray();
+    }
+  }
+
+  private static VarHandle manifestElementsHandle() {
+    try {
+      return MethodHandles.privateLookupIn(ClientPutDir.class, MethodHandles.lookup())
+          .findVarHandle(ClientPutDir.class, "manifestElements", Map.class);
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static Supplier<ClientPutDir> clientPutDirFactory() {
+    try {
+      MethodHandle constructor =
+          MethodHandles.privateLookupIn(ClientPutDir.class, MethodHandles.lookup())
+              .findConstructor(ClientPutDir.class, MethodType.methodType(void.class));
+      return () -> instantiateClientPutDir(constructor);
+    } catch (IllegalAccessException | NoSuchMethodException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private static ClientPutDir instantiateClientPutDir(MethodHandle constructor) {
+    try {
+      return (ClientPutDir) constructor.invoke();
+    } catch (RuntimeException | Error e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new IllegalStateException(t);
     }
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirManifestSupportTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirManifestSupportTest.java
@@ -1,0 +1,102 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import network.crypta.support.api.ManifestElement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("java:S100")
+class ClientPutDirManifestSupportTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void buildDiskManifest_whenDirectoryContainsNestedFiles_returnsManifestTree() throws Exception {
+    Files.writeString(tempDir.resolve("root.txt"), "root");
+    Path nestedDir = Files.createDirectory(tempDir.resolve("subdir"));
+    Files.writeString(nestedDir.resolve("child.txt"), "child");
+
+    Map<String, Object> manifest =
+        ClientPutDirManifestSupport.buildDiskManifest(tempDir.toFile(), false, false);
+
+    Object rootValue = manifest.get("root.txt");
+    assertInstanceOf(ManifestElement.class, rootValue);
+    ManifestElement rootElement = (ManifestElement) rootValue;
+    assertEquals("root.txt", rootElement.getName());
+    assertEquals("root.txt", rootElement.fullName);
+
+    Object subdirValue = manifest.get("subdir");
+    assertInstanceOf(Map.class, subdirValue);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> subdir = (Map<String, Object>) subdirValue;
+    ManifestElement nestedElement = (ManifestElement) subdir.get("child.txt");
+    assertNotNull(nestedElement);
+    assertEquals("child.txt", nestedElement.getName());
+    assertEquals("subdir/child.txt", nestedElement.fullName);
+  }
+
+  @Test
+  void freeManifest_whenManifestContainsNestedElements_freesAllEntries() {
+    ManifestElement rootElement = mock(ManifestElement.class);
+    ManifestElement nestedElement = mock(ManifestElement.class);
+    Map<String, Object> nested = new LinkedHashMap<>();
+    nested.put("child", nestedElement);
+    Map<String, Object> manifest = new HashMap<>();
+    manifest.put("root", rootElement);
+    manifest.put("subdir", nested);
+
+    ClientPutDirManifestSupport.freeManifest(manifest);
+
+    verify(rootElement).freeData();
+    verify(nestedElement).freeData();
+  }
+
+  @Test
+  void buildDiskManifest_whenHiddenFilesExcluded_skipsHiddenEntries() throws Exception {
+    Files.writeString(tempDir.resolve(".hidden.txt"), "secret");
+    Files.writeString(tempDir.resolve("visible.txt"), "visible");
+
+    Map<String, Object> manifest =
+        ClientPutDirManifestSupport.buildDiskManifest(tempDir.toFile(), false, false);
+
+    assertEquals(1, manifest.size());
+    assertNotNull(manifest.get("visible.txt"));
+    assertNull(manifest.get(".hidden.txt"));
+  }
+
+  @Test
+  void buildDiskManifest_whenHiddenFilesIncluded_keepsHiddenEntries() throws Exception {
+    Files.writeString(tempDir.resolve(".hidden.txt"), "secret");
+
+    Map<String, Object> manifest =
+        ClientPutDirManifestSupport.buildDiskManifest(tempDir.toFile(), false, true);
+
+    Object hiddenValue = manifest.get(".hidden.txt");
+    assertInstanceOf(ManifestElement.class, hiddenValue);
+    ManifestElement hiddenElement = (ManifestElement) hiddenValue;
+    assertEquals(".hidden.txt", hiddenElement.getName());
+    assertEquals(".hidden.txt", hiddenElement.fullName);
+  }
+
+  @Test
+  void buildDiskManifest_whenPathIsNotDirectory_throwsIllegalArgumentException() throws Exception {
+    Path file = Files.writeString(tempDir.resolve("plain.txt"), "data");
+    File nonDirectory = file.toFile();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ClientPutDirManifestSupport.buildDiskManifest(nonDirectory, false, false));
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirPersistentTagBuilderTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirPersistentTagBuilderTest.java
@@ -1,0 +1,196 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.RequestClient;
+import network.crypta.support.SimpleFieldSet;
+import network.crypta.support.api.ManifestElement;
+import network.crypta.support.io.FileBucket;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({"java:S100", "java:S3011"})
+class ClientPutDirPersistentTagBuilderTest {
+
+  @Test
+  void persistentTagMessage_whenAllFieldsPresent_preservesPersistentPutDirLayout()
+      throws Exception {
+    ClientPutDir request = new ClientPutDir();
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
+    RequestClient requestClient = mock(RequestClient.class);
+    when(requestClient.realTimeFlag()).thenReturn(true);
+    when(putter.getSplitfileCryptoKey()).thenReturn(new byte[] {0x01, 0x02, 0x0A, (byte) 0xFF});
+    when(putter.persistentPutDirEntries())
+        .thenReturn(
+            List.of(
+                new PersistentPutDirEntrySnapshot(
+                    "disk.dat",
+                    ClientPutBase.UploadFrom.DISK,
+                    4,
+                    "/tmp/disk.dat",
+                    "text/plain",
+                    null)));
+
+    setField(request, "publicURI", new FreenetURI("KSK", "public"));
+    setField(request, "uri", new FreenetURI("KSK", "private"));
+    setField(request, "identifier", "id-123");
+    setField(request, "verbosity", 2);
+    setField(request, "priorityClass", (short) 5);
+    setField(request, "persistence", ClientRequest.Persistence.FOREVER);
+    setField(request, "clientToken", "token-abc");
+    setField(request, "global", true);
+    setField(request, "started", true);
+    setField(request, "ctx", newContext(3, true, "lzma", FcpCompatibilityMode.COMPAT_1468));
+    setField(request, "defaultName", "index.html");
+    setField(request, "wasDiskPut", true);
+    setField(request, "lowLevelClient", requestClient);
+    setField(request, "putter", putter);
+
+    ClientPutDirPersistentTagBuilder builder = new ClientPutDirPersistentTagBuilder(request);
+
+    FCPMessage message = builder.persistentTagMessage();
+
+    SimpleFieldSet fs = message.getFieldSet();
+    assertEquals("id-123", fs.get("Identifier"));
+    assertEquals("KSK@public", fs.get("URI"));
+    assertEquals("KSK@private", fs.get("PrivateURI"));
+    assertEquals("2", fs.get("Verbosity"));
+    assertEquals("5", fs.get("PriorityClass"));
+    assertEquals("forever", fs.get("Persistence"));
+    assertEquals("true", fs.get("Global"));
+    assertEquals("disk", fs.get("PutDirType"));
+    assertEquals("index.html", fs.get("DefaultName"));
+    assertEquals("token-abc", fs.get("ClientToken"));
+    assertEquals("true", fs.get("Started"));
+    assertEquals("3", fs.get("MaxRetries"));
+    assertEquals("true", fs.get("DontCompress"));
+    assertEquals("lzma", fs.get("Codecs"));
+    assertEquals("true", fs.get("RealTime"));
+    assertEquals("01020aff", fs.get("SplitfileCryptoKey"));
+    SimpleFieldSet files = message.getFieldSet().subset("Files");
+    assertNotNull(files);
+    assertEquals("1", files.get("Count"));
+    SimpleFieldSet file = files.subset("0");
+    assertNotNull(file);
+    assertEquals("disk.dat", file.get("Name"));
+    assertEquals("disk", file.get("UploadFrom"));
+    assertEquals("/tmp/disk.dat", file.get("Filename"));
+  }
+
+  @Test
+  void persistentTagMessage_whenPutterAndRuntimeFlagAbsent_usesEmptyFilesAndRealtimeFalse()
+      throws Exception {
+    ClientPutDir request = new ClientPutDir();
+    setField(request, "publicURI", new FreenetURI("KSK", "public"));
+    setField(request, "uri", new FreenetURI("KSK", "private"));
+    setField(request, "identifier", "id-optional");
+    setField(request, "verbosity", 0);
+    setField(request, "priorityClass", (short) 1);
+    setField(request, "persistence", ClientRequest.Persistence.REBOOT);
+    setField(request, "global", false);
+    setField(request, "started", false);
+    setField(request, "ctx", newContext(0, false, null, FcpCompatibilityMode.COMPAT_UNKNOWN));
+    setField(request, "defaultName", "default");
+    setField(request, "wasDiskPut", false);
+    setField(request, "lowLevelClient", null);
+    setField(request, "putter", null);
+
+    ClientPutDirPersistentTagBuilder builder = new ClientPutDirPersistentTagBuilder(request);
+
+    FCPMessage message = builder.persistentTagMessage();
+
+    SimpleFieldSet fs = message.getFieldSet();
+    assertEquals("false", fs.get("RealTime"));
+    assertNull(fs.get("SplitfileCryptoKey"));
+    SimpleFieldSet files = message.getFieldSet().subset("Files");
+    assertNotNull(files);
+    assertEquals("0", files.get("Count"));
+  }
+
+  @Test
+  void persistentTagMessage_whenPutterMissingButManifestRestored_preservesSerializedFiles()
+      throws Exception {
+    Path file = Files.createTempFile("persistent-put-dir", ".txt");
+    Files.writeString(file, "data");
+
+    ClientPutDir request = new ClientPutDir();
+    Map<String, Object> manifestElements = new HashMap<>();
+    manifestElements.put(
+        "disk.dat",
+        new ManifestElement(
+            "disk.dat",
+            "disk.dat",
+            new FileBucket(file.toFile(), true, false, false, false),
+            "text/plain",
+            4));
+    setField(request, "manifestElements", manifestElements);
+    setField(request, "publicURI", new FreenetURI("KSK", "public"));
+    setField(request, "uri", new FreenetURI("KSK", "private"));
+    setField(request, "identifier", "id-restored");
+    setField(request, "verbosity", 0);
+    setField(request, "priorityClass", (short) 1);
+    setField(request, "persistence", ClientRequest.Persistence.REBOOT);
+    setField(request, "global", false);
+    setField(request, "started", false);
+    setField(request, "ctx", newContext(0, false, null, FcpCompatibilityMode.COMPAT_CURRENT));
+    setField(request, "defaultName", "default");
+    setField(request, "wasDiskPut", true);
+    setField(request, "lowLevelClient", null);
+    setField(request, "putter", null);
+
+    ClientPutDirPersistentTagBuilder builder = new ClientPutDirPersistentTagBuilder(request);
+
+    FCPMessage message = builder.persistentTagMessage();
+
+    SimpleFieldSet files = message.getFieldSet().subset("Files");
+    assertNotNull(files);
+    assertEquals("1", files.get("Count"));
+    SimpleFieldSet restored = files.subset("0");
+    assertNotNull(restored);
+    assertEquals("disk.dat", restored.get("Name"));
+    assertEquals("disk", restored.get("UploadFrom"));
+    assertEquals(file.toString(), restored.get("Filename"));
+  }
+
+  private static DefaultFcpInsertContextHandle newContext(
+      int maxRetries,
+      boolean dontCompress,
+      String compressorDescriptor,
+      FcpCompatibilityMode compatibilityMode) {
+    return new DefaultFcpInsertContextHandle(
+        new FcpInsertContextLimits(0, 0, 0),
+        new FcpInsertOptions(
+            new FcpInsertBehaviorOptions(
+                false, dontCompress, false, maxRetries, false, false, false),
+            new FcpInsertTuningOptions(false, false, compressorDescriptor, 0, 0, compatibilityMode),
+            null));
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = findField(target.getClass(), fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Field findField(Class<?> type, String fieldName) throws NoSuchFieldException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException _) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirStatusSnapshotBuilderTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirStatusSnapshotBuilderTest.java
@@ -1,0 +1,79 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.InsertException;
+import network.crypta.client.events.SplitfileProgressCounts;
+import network.crypta.client.events.SplitfileProgressEvent;
+import network.crypta.client.events.SplitfileProgressTimestamps;
+import network.crypta.keys.FreenetURI;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+@SuppressWarnings({"java:S100", "java:S3011"})
+class ClientPutDirStatusSnapshotBuilderTest {
+
+  @Test
+  void build_whenProgressAndFailurePresent_returnsUploadDirRequestStatus() throws Exception {
+    ClientPutDir request = new ClientPutDir();
+    Instant success = Instant.ofEpochMilli(1000L);
+    Instant failure = Instant.ofEpochMilli(2000L);
+    SplitfileProgressCounts counts = new SplitfileProgressCounts(10, 3, 2, 1, 5, 0, true);
+    SplitfileProgressTimestamps timestamps = new SplitfileProgressTimestamps(success, failure);
+    SplitfileProgressEvent event = new SplitfileProgressEvent(counts, timestamps);
+    SimpleProgressMessage progressMessage = new SimpleProgressMessage("id", false, event);
+    InsertException exception =
+        new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
+    PutFailedMessage failureMessage = new PutFailedMessage(exception, "id", false);
+    FreenetURI finalUri = mock(FreenetURI.class);
+    FreenetURI targetUri = mock(FreenetURI.class);
+
+    setField(request, "identifier", "id");
+    setField(request, "persistence", ClientRequest.Persistence.FOREVER);
+    setField(request, "started", true);
+    setField(request, "finished", true);
+    setField(request, "succeeded", false);
+    setField(request, "priorityClass", (short) 5);
+    setField(request, "generatedURI", finalUri);
+    setField(request, "uri", targetUri);
+    setField(request, "totalSize", 2048L);
+    setField(request, "numberOfFiles", 7);
+    setField(request, "progressMessage", progressMessage);
+    setField(request, "putFailedMessage", failureMessage);
+
+    UploadDirRequestStatus status = ClientPutDirStatusSnapshotBuilder.build(request);
+
+    assertInstanceOf(UploadDirRequestStatus.class, status);
+    assertEquals(2048L, status.getTotalDataSize());
+    assertEquals(7, status.getNumberOfFiles());
+    assertEquals(finalUri, status.getFinalURI());
+    assertEquals(targetUri, status.getTargetURI());
+    assertEquals(10, status.getTotalBlocks());
+    assertEquals(3, status.getFetchedBlocks());
+    assertEquals(failureMessage.getLongFailedMessage(), status.getFailureReason(false));
+    assertNull(status.getFailureReason(true));
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = findField(target.getClass(), name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
+    Class<?> current = type;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(name);
+      } catch (NoSuchFieldException _) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(name);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
@@ -9,6 +9,7 @@ import java.io.ObjectStreamClass;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
@@ -21,6 +22,7 @@ import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.SplitfileProgressTimestamps;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
+import network.crypta.support.SimpleFieldSet;
 import network.crypta.support.api.ManifestElement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -367,6 +370,40 @@ class ClientPutDirTest {
 
     assertEquals(6, spec.priorityClass());
     assertSame(manifest, spec.manifestElements());
+  }
+
+  @Test
+  void persistentTagMessage_whenPutterExposesDetachedEntries_serializesSnapshot() throws Exception {
+    ClientPutDir putDir = newClientPutDir();
+    ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
+    setField(ClientPutDir.class, putDir, "putter", putter);
+    setField(ClientPutDir.class, putDir, "defaultName", "index.html");
+    setField(ClientPutBase.class, putDir, "ctx", newSerializableInsertContextHandle());
+    setField(ClientRequest.class, putDir, "identifier", "put-dir");
+    setField(ClientRequest.class, putDir, "uri", new FreenetURI("SSK", "private"));
+    setField(ClientPutBase.class, putDir, "publicURI", new FreenetURI("CHK", "public"));
+    setField(ClientRequest.class, putDir, "persistence", ClientRequest.Persistence.REBOOT);
+    when(putter.persistentPutDirEntries())
+        .thenReturn(
+            List.of(
+                new PersistentPutDirEntrySnapshot(
+                    "disk.dat",
+                    ClientPutBase.UploadFrom.DISK,
+                    4,
+                    "/tmp/disk.dat",
+                    "text/plain",
+                    null)));
+
+    PersistentPutDir message = (PersistentPutDir) putDir.persistentTagMessage();
+
+    SimpleFieldSet files = message.getFieldSet().subset("Files");
+    assertNotNull(files);
+    assertEquals("1", files.get("Count"));
+    SimpleFieldSet file = files.subset("0");
+    assertNotNull(file);
+    assertEquals("disk", file.get("UploadFrom"));
+    assertEquals("/tmp/disk.dat", file.get("Filename"));
+    verify(putter).persistentPutDirEntries();
   }
 
   private static ClientPutDir newClientPutDir() {

--- a/src/test/java/network/crypta/clients/fcp/ClientPutPreparedDataFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutPreparedDataFactoryTest.java
@@ -2,9 +2,10 @@ package network.crypta.clients.fcp;
 
 import java.io.IOException;
 import network.crypta.client.ClientMetadata;
+import network.crypta.client.MetadataResolutionTarget;
+import network.crypta.client.MetadataUnresolvedException;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.ArrayBucketFactory;
 import org.junit.jupiter.api.Test;
@@ -13,13 +14,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,30 +54,29 @@ class ClientPutPreparedDataFactoryTest {
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     FreenetURI target = new FreenetURI(VALID_CHK);
     FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
-
-    when(runtimeSupport.bucketFactory(true)).thenReturn(new ArrayBucketFactory());
+    RandomAccessBucket redirectBucket = new ArrayBucketFactory().makeBucket(-1);
+    when(runtimeSupport.createRedirectMetadataBucket(metadata, target, true))
+        .thenReturn(redirectBucket);
 
     PreparedData prepared =
         ClientPutPreparedDataFactory.prepareForPersistentUpload(
             ClientPutBase.UploadFrom.REDIRECT, metadata, bucket, target, runtimeSupport, true);
 
-    assertNotNull(prepared.bucket());
-    assertNotSame(bucket, prepared.bucket());
+    assertSame(redirectBucket, prepared.bucket());
     assertEquals(target, prepared.targetUri());
     assertTrue(prepared.isMetadata());
   }
 
   @Test
-  void prepareForPersistentUpload_whenBucketFactoryFails_throwsIOException() throws Exception {
+  void prepareForPersistentUpload_whenRedirectBucketCreationFails_throwsIOException()
+      throws Exception {
     ClientMetadata metadata = new ClientMetadata("text/plain");
     //noinspection resource
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     FreenetURI target = new FreenetURI(VALID_CHK);
     FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
-    BucketFactory bucketFactory = mock(BucketFactory.class);
-
-    when(runtimeSupport.bucketFactory(false)).thenReturn(bucketFactory);
-    when(bucketFactory.makeBucket(-1)).thenThrow(new IOException("fail"));
+    when(runtimeSupport.createRedirectMetadataBucket(metadata, target, false))
+        .thenThrow(new IOException("fail"));
 
     assertThrows(
         IOException.class,
@@ -96,12 +95,13 @@ class ClientPutPreparedDataFactoryTest {
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.DIRECT, null);
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     message.bucket = bucket;
+    FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
 
     PreparedData prepared =
         ClientPutPreparedDataFactory.prepareForMessage(
             message,
             new ClientMetadata("text/plain"),
-            mock(FcpInsertRuntimeSupport.class),
+            runtimeSupport,
             false,
             ClientPutBase.UploadFrom.DIRECT,
             "id",
@@ -110,31 +110,58 @@ class ClientPutPreparedDataFactoryTest {
     assertSame(bucket, prepared.bucket());
     assertFalse(prepared.isMetadata());
     assertNull(prepared.targetUri());
+    verifyNoInteractions(runtimeSupport);
   }
 
   @Test
   void prepareForMessage_whenRedirect_buildsMetadataBucket() throws Exception {
     ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.REDIRECT, VALID_CHK);
-    RandomAccessBucket bucket = mock(RandomAccessBucket.class);
-    message.bucket = bucket;
+    message.bucket = mock(RandomAccessBucket.class);
     FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
-
-    when(runtimeSupport.bucketFactory(true)).thenReturn(new ArrayBucketFactory());
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    RandomAccessBucket redirectBucket = new ArrayBucketFactory().makeBucket(-1);
+    when(runtimeSupport.createRedirectMetadataBucket(metadata, message.redirectTarget, true))
+        .thenReturn(redirectBucket);
 
     PreparedData prepared =
         ClientPutPreparedDataFactory.prepareForMessage(
             message,
-            new ClientMetadata("text/plain"),
+            metadata,
             runtimeSupport,
             true,
             ClientPutBase.UploadFrom.REDIRECT,
             "id",
             false);
 
-    assertNotNull(prepared.bucket());
-    assertNotSame(bucket, prepared.bucket());
+    assertSame(redirectBucket, prepared.bucket());
     assertEquals(message.redirectTarget, prepared.targetUri());
     assertTrue(prepared.isMetadata());
+  }
+
+  @Test
+  void prepareForMessage_whenRedirectMetadataUnresolved_throwsMessageInvalidException()
+      throws Exception {
+    ClientPutMessage message = buildMessage(ClientPutBase.UploadFrom.REDIRECT, VALID_CHK);
+    message.bucket = mock(RandomAccessBucket.class);
+    ClientMetadata metadata = new ClientMetadata("text/plain");
+    FcpInsertRuntimeSupport runtimeSupport = mock(FcpInsertRuntimeSupport.class);
+    when(runtimeSupport.createRedirectMetadataBucket(metadata, message.redirectTarget, false))
+        .thenThrow(new MetadataUnresolvedException(new MetadataResolutionTarget[0], "unresolved"));
+
+    MessageInvalidException exception =
+        assertThrows(
+            MessageInvalidException.class,
+            () ->
+                ClientPutPreparedDataFactory.prepareForMessage(
+                    message,
+                    metadata,
+                    runtimeSupport,
+                    false,
+                    ClientPutBase.UploadFrom.REDIRECT,
+                    "id",
+                    false));
+
+    assertEquals(ProtocolErrorMessage.INTERNAL_ERROR, exception.protocolCode);
   }
 
   private ClientPutMessage buildMessage(ClientPutBase.UploadFrom uploadFrom, String targetUri)

--- a/src/test/java/network/crypta/clients/fcp/ManifestTreeMapsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ManifestTreeMapsTest.java
@@ -1,0 +1,50 @@
+package network.crypta.clients.fcp;
+
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class ManifestTreeMapsTest {
+
+  @Test
+  void forceMap_whenHashMapProvided_returnsSameInstance() {
+    Map<String, Object> manifest = new java.util.HashMap<>();
+    manifest.put("file.txt", 1L);
+
+    Map<String, Object> actual = ManifestTreeMaps.forceMap(manifest);
+
+    assertSame(manifest, actual);
+  }
+
+  @Test
+  void forceMap_whenGenericMapProvided_returnsMutableHashMapCopy() {
+    Map<String, Object> manifest = new TreeMap<>();
+    manifest.put("file.txt", 1L);
+
+    Map<String, Object> actual = ManifestTreeMaps.forceMap(manifest);
+
+    assertInstanceOf(java.util.HashMap.class, actual);
+    assertNotSame(manifest, actual);
+    assertEquals(manifest, actual);
+  }
+
+  @Test
+  void forceMap_whenMapContainsNonStringKey_throwsClassCastException() {
+    Map<Object, Object> manifest = new TreeMap<>();
+    manifest.put(1, "value");
+
+    assertThrows(ClassCastException.class, () -> ManifestTreeMaps.forceMap(manifest));
+  }
+
+  @Test
+  void forceMap_whenValueIsNotMap_throwsClassCastException() {
+    assertThrows(ClassCastException.class, () -> ManifestTreeMaps.forceMap("not-a-map"));
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentPutDirTest.java
@@ -1,24 +1,14 @@
 package network.crypta.clients.fcp;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.SimpleFieldSet;
-import network.crypta.support.api.ManifestElement;
-import network.crypta.support.api.RandomAccessBucket;
-import network.crypta.support.io.DelayedFreeRandomAccessBucket;
-import network.crypta.support.io.FileBucket;
-import network.crypta.support.io.NullBucket;
-import network.crypta.support.io.PersistentFileTracker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +33,6 @@ class PersistentPutDirTest {
   private static final String FILENAME_KEY = "Filename";
   private static final String FILE_TXT_NAME = "file.txt";
   private static final String DEFAULT_NAME = "default";
-  private static final String WRAPPED_FILE_NAME = "wrapped.dat";
   private static final String[] ROOT_KEYS =
       new String[] {
         "Identifier",
@@ -65,35 +54,40 @@ class PersistentPutDirTest {
         SPLITFILE_KEY
       };
 
-  @TempDir Path tempDir;
-
   @Mock FCPConnectionHandler connectionHandler;
 
   @Test
-  void getFieldSet_whenDiskDirectAndRedirectElements_populatesAllFields() throws Exception {
+  void getFieldSet_whenDiskDirectAndRedirectEntries_populatesAllFields() {
     FreenetURI publicUri = new FreenetURI("CHK", "public");
     FreenetURI privateUri = new FreenetURI("SSK", "private");
-
-    File diskFile = Files.createFile(tempDir.resolve(DISK_FILE_NAME)).toFile();
-    FileBucket diskBucket = new FileBucket(diskFile, false, false, false, false);
-    ManifestElement diskElement = new ManifestElement(DISK_FILE_NAME, diskBucket, "text/plain", 4);
-
-    NullBucket directBucket = new NullBucket(8);
-    ManifestElement nestedElement =
-        new ManifestElement("nested.bin", directBucket, "application/octet-stream", 8);
-
     FreenetURI redirectUri = new FreenetURI("CHK", "target");
-    ManifestElement redirectElement = new ManifestElement(REDIRECT_FILE_NAME, redirectUri, null);
 
-    Map<String, Object> manifest = new LinkedHashMap<>();
-    manifest.put(DISK_FILE_NAME, diskElement);
-    Map<String, Object> subdir = new LinkedHashMap<>();
-    subdir.put("nested.bin", nestedElement);
-    manifest.put("subdir", subdir);
-    manifest.put(REDIRECT_FILE_NAME, redirectElement);
+    List<PersistentPutDirEntrySnapshot> manifestEntries =
+        List.of(
+            new PersistentPutDirEntrySnapshot(
+                DISK_FILE_NAME,
+                ClientPutBase.UploadFrom.DISK,
+                4,
+                "disk/path/" + DISK_FILE_NAME,
+                "text/plain",
+                null),
+            new PersistentPutDirEntrySnapshot(
+                "subdir/nested.bin",
+                ClientPutBase.UploadFrom.DIRECT,
+                8,
+                null,
+                "application/octet-stream",
+                null),
+            new PersistentPutDirEntrySnapshot(
+                REDIRECT_FILE_NAME,
+                ClientPutBase.UploadFrom.REDIRECT,
+                -1,
+                null,
+                null,
+                redirectUri));
 
     byte[] cryptoKey = new byte[] {0x0a, 0x0b, 0x0c};
-    SimpleFieldSet fs = buildFullFieldSet(manifest, publicUri, privateUri, cryptoKey);
+    SimpleFieldSet fs = buildFullFieldSet(manifestEntries, publicUri, privateUri, cryptoKey);
 
     Map<String, String> expectedRoot = new LinkedHashMap<>();
     expectedRoot.put("Identifier", "id-123");
@@ -124,7 +118,7 @@ class PersistentPutDirTest {
     Map<String, String> expectedFirst = new LinkedHashMap<>();
     expectedFirst.put("Name", DISK_FILE_NAME);
     expectedFirst.put(UPLOAD_FROM_KEY, "disk");
-    expectedFirst.put(FILENAME_KEY, diskFile.getPath());
+    expectedFirst.put(FILENAME_KEY, "disk/path/" + DISK_FILE_NAME);
     expectedFirst.put(DATA_LENGTH_KEY, "4");
     expectedFirst.put(CONTENT_TYPE_KEY, "text/plain");
     assertEquals(
@@ -157,12 +151,11 @@ class PersistentPutDirTest {
 
   @Test
   void getFieldSet_whenOptionalFieldsOmitted_doesNotIncludeThem() {
-    NullBucket bucket = new NullBucket(1);
-    ManifestElement element = new ManifestElement(FILE_TXT_NAME, bucket, null, 1);
-    Map<String, Object> manifest = new LinkedHashMap<>();
-    manifest.put(FILE_TXT_NAME, element);
-
-    SimpleFieldSet fs = buildOptionalFieldSet(manifest);
+    SimpleFieldSet fs =
+        buildOptionalFieldSet(
+            List.of(
+                new PersistentPutDirEntrySnapshot(
+                    FILE_TXT_NAME, ClientPutBase.UploadFrom.DIRECT, 1, null, null, null)));
 
     assertNull(fs.get(PRIVATE_URI_KEY));
     assertNull(fs.get(CLIENT_TOKEN_KEY));
@@ -171,26 +164,41 @@ class PersistentPutDirTest {
   }
 
   @Test
-  void generateFieldSet_whenBucketWrappedInDelayedFree_usesUnderlyingBucket() {
-    File underlyingFile = tempDir.resolve(WRAPPED_FILE_NAME).toFile();
-    RandomAccessBucket underlyingBucket =
-        new FileBucket(underlyingFile, false, false, false, false);
-    PersistentFileTracker tracker = Mockito.mock(PersistentFileTracker.class);
-    Mockito.when(tracker.commitID()).thenReturn(1L);
+  void getFieldSet_whenUploadSourceUnknown_omitsUploadFromButKeepsOtherFields() {
+    PersistentPutDir message =
+        buildMessage(
+            "id-wrap",
+            Persistence.REBOOT,
+            false,
+            List.of(
+                new PersistentPutDirEntrySnapshot(
+                    "wrapped.dat", null, 12, null, "application/octet-stream", null)));
 
-    DelayedFreeRandomAccessBucket wrapped =
-        new DelayedFreeRandomAccessBucket(tracker, underlyingBucket);
-    ManifestElement element = new ManifestElement(WRAPPED_FILE_NAME, wrapped, null, 12);
-    Map<String, Object> manifest = new LinkedHashMap<>();
-    manifest.put(WRAPPED_FILE_NAME, element);
-
-    PersistentPutDir message = buildWrappedMessage(manifest);
     SimpleFieldSet filesSubset = message.getFieldSet().subset("Files");
     assertNotNull(filesSubset);
     SimpleFieldSet fileSubset = filesSubset.subset("0");
     assertNotNull(fileSubset);
-    assertEquals("disk", fileSubset.get(UPLOAD_FROM_KEY));
-    assertEquals(underlyingFile.getPath(), fileSubset.get(FILENAME_KEY));
+    assertNull(fileSubset.get(UPLOAD_FROM_KEY));
+    assertEquals("12", fileSubset.get(DATA_LENGTH_KEY));
+    assertEquals("application/octet-stream", fileSubset.get(CONTENT_TYPE_KEY));
+  }
+
+  @Test
+  void run_whenInvoked_throwsMessageInvalidExceptionWithContext() {
+    PersistentPutDir message =
+        buildMessage(
+            "ident",
+            Persistence.CONNECTION,
+            true,
+            List.of(
+                new PersistentPutDirEntrySnapshot(
+                    FILE_TXT_NAME, ClientPutBase.UploadFrom.DIRECT, 1, null, null, null)));
+
+    MessageInvalidException ex =
+        assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler));
+    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
+    assertEquals("ident", ex.ident);
+    assertTrue(ex.global);
   }
 
   private Map<String, String> extract(SimpleFieldSet fieldSet, String... keys) {
@@ -202,7 +210,10 @@ class PersistentPutDirTest {
   }
 
   private SimpleFieldSet buildFullFieldSet(
-      Map<String, Object> manifest, FreenetURI publicUri, FreenetURI privateUri, byte[] cryptoKey) {
+      List<PersistentPutDirEntrySnapshot> manifestEntries,
+      FreenetURI publicUri,
+      FreenetURI privateUri,
+      byte[] cryptoKey) {
     ClientRequestParams requestParams =
         new ClientRequestParams(
             publicUri, "id-123", 2, (short) 3, Persistence.FOREVER, true, "client-token", true);
@@ -210,108 +221,33 @@ class PersistentPutDirTest {
         new PersistentPutRequestMetadata(
             privateUri, true, 5, FcpCompatibilityMode.COMPAT_1468, true, "gzip", cryptoKey);
     PersistentPutDir message =
-        new PersistentPutDir(
-            requestParams, metadata, "index.html", new LinkedHashMap<>(manifest), true);
+        new PersistentPutDir(requestParams, metadata, "index.html", manifestEntries, true);
     return message.getFieldSet();
   }
 
-  private SimpleFieldSet buildOptionalFieldSet(Map<String, Object> manifest) {
+  private SimpleFieldSet buildOptionalFieldSet(
+      List<PersistentPutDirEntrySnapshot> manifestEntries) {
+    return buildMessage("id-opt", Persistence.CONNECTION, false, manifestEntries).getFieldSet();
+  }
+
+  private PersistentPutDir buildMessage(
+      String identifier,
+      Persistence persistence,
+      boolean global,
+      List<PersistentPutDirEntrySnapshot> manifestEntries) {
     ClientRequestParams requestParams =
         new ClientRequestParams(
             new FreenetURI("CHK", "pub"),
-            "id-opt",
+            identifier,
             0,
             (short) 1,
-            Persistence.CONNECTION,
+            persistence,
             false,
             null,
-            false);
+            global);
     PersistentPutRequestMetadata metadata =
         new PersistentPutRequestMetadata(
             null, false, 0, FcpCompatibilityMode.COMPAT_CURRENT, false, null, null);
-    PersistentPutDir message =
-        new PersistentPutDir(
-            requestParams, metadata, DEFAULT_NAME, new LinkedHashMap<>(manifest), false);
-    return message.getFieldSet();
-  }
-
-  private PersistentPutDir buildWrappedMessage(Map<String, Object> manifest) {
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            new FreenetURI("CHK", "pub2"),
-            "id-wrap",
-            1,
-            (short) 1,
-            Persistence.REBOOT,
-            false,
-            null,
-            false);
-    PersistentPutRequestMetadata metadata =
-        new PersistentPutRequestMetadata(
-            null, false, 1, FcpCompatibilityMode.COMPAT_1250, false, null, null);
-    return new PersistentPutDir(
-        requestParams, metadata, "wrapped", new LinkedHashMap<>(manifest), false);
-  }
-
-  private PersistentPutDir buildRunMessage(Map<String, Object> manifest) {
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            new FreenetURI("CHK", "pub3"),
-            "ident",
-            1,
-            (short) 1,
-            Persistence.CONNECTION,
-            false,
-            null,
-            true);
-    PersistentPutRequestMetadata metadata =
-        new PersistentPutRequestMetadata(
-            null, false, 0, FcpCompatibilityMode.COMPAT_CURRENT, false, null, null);
-    return new PersistentPutDir(
-        requestParams, metadata, DEFAULT_NAME, new LinkedHashMap<>(manifest), false);
-  }
-
-  @Test
-  void run_whenInvoked_throwsMessageInvalidExceptionWithContext() {
-    NullBucket bucket = new NullBucket();
-    ManifestElement element = new ManifestElement(FILE_TXT_NAME, bucket, null, 1);
-    Map<String, Object> manifest = new LinkedHashMap<>();
-    manifest.put(FILE_TXT_NAME, element);
-
-    PersistentPutDir message = buildRunMessage(manifest);
-
-    MessageInvalidException ex =
-        assertThrows(MessageInvalidException.class, () -> message.run(connectionHandler));
-    assertEquals(ProtocolErrorMessage.INVALID_MESSAGE, ex.protocolCode);
-    assertEquals("ident", ex.ident);
-    assertTrue(ex.global);
-  }
-
-  @Test
-  void constructor_whenBucketTypeUnknown_throwsIllegalStateException() {
-    RandomAccessBucket unknownBucket = Mockito.mock(RandomAccessBucket.class);
-    ManifestElement element = new ManifestElement("unknown.bin", unknownBucket, null, 2);
-    Map<String, Object> manifest = new LinkedHashMap<>();
-    manifest.put("unknown.bin", element);
-
-    assertThrows(IllegalStateException.class, () -> createPersistentPutDirWith(manifest));
-  }
-
-  private void createPersistentPutDirWith(Map<String, Object> manifest) {
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            new FreenetURI("CHK", "pub4"),
-            "id-bad",
-            0,
-            (short) 1,
-            Persistence.CONNECTION,
-            false,
-            null,
-            false);
-    PersistentPutRequestMetadata metadata =
-        new PersistentPutRequestMetadata(
-            null, false, 0, FcpCompatibilityMode.COMPAT_CURRENT, false, null, null);
-    new PersistentPutDir(
-        requestParams, metadata, DEFAULT_NAME, new LinkedHashMap<>(manifest), false);
+    return new PersistentPutDir(requestParams, metadata, DEFAULT_NAME, manifestEntries, false);
   }
 }


### PR DESCRIPTION
## Summary

- remove the remaining metadata and persistent put-dir helper cluster of `:adapter-fcp -> :runtime-node` coupling from the FCP insert path
- introduce adapter-owned detached helpers and DTOs for persistent put-dir serialization, plus a bridge-owned snapshotter for runtime bucket classification and manifest flattening
- preserve replay behavior for persistent directory requests when the live execution wrapper is missing, and tighten the adapter/bridge regression tests and boundary coverage

## How to test

- `./gradlew :adapter-fcp:test --tests "network.crypta.clients.fcp.AdapterFcpBoundaryTest"`
- `./gradlew :bridge-fcp-runtime:test --tests "network.crypta.clients.fcp.bridge.CoreFcpInsertRuntimeSupportTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.ClientPutPreparedDataFactoryTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.ClientPutComplexDirMessageTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.PersistentPutDirTest"`
- `./gradlew :test --tests "network.crypta.clients.fcp.ClientPutDirTest"`
- `./gradlew test`

## Notes

- base branch: `develop`
- branch: `feature/fcp-putdir-detach`