### PR TITLE
refactor(client-events): Detach splitfile compatibility event

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.client.async.alerts`, `network.crypta.client.async.persistence`, the leaf-safe
   `network.crypta.client.events` contract/helper subset (`ClientEventListener`,
   `ClientEventProducer`, `SimpleEventProducer`, `EventLogger`, `EventDumper`,
-  `SplitfileProgressEvent`), the leaf-safe `network.crypta.client.async` utility/value subset (`BlockSet`, `BinaryBlob`,
+  `SplitfileProgressEvent`, `SplitfileCompatibilityModeEvent`, `SplitfileCompatibilityMode`), the
+  leaf-safe `network.crypta.client.async` utility/value subset (`BlockSet`, `BinaryBlob`,
   `BinaryBlobFormatException`, `BinaryBlobWriter`, `CacheFetchResult`, `ClientGetterOptions`,
   `ClientPutterOptions`, `PersistenceDisabledException`, `TooManyFilesInsertException`), the
   client failure/filter exception subset, the MIME helper `network.crypta.support.MediaType`, and
@@ -635,9 +636,10 @@ Root build also includes:
   `network.crypta.client.async.alerts`, `network.crypta.client.async.persistence`, the
   `network.crypta.client.events` contract/helper subset (`ClientEventListener`,
   `ClientEventProducer`, `SimpleEventProducer`, `EventLogger`, `EventDumper`,
-  `SplitfileProgressEvent`), the leaf-safe `network.crypta.client.async` utility/value subset, the leaf-safe
-  client failure/filter exception subset, `network.crypta.support.MediaType`, and the small
-  manifest/model helper subset under `network.crypta.support.*`.
+  `SplitfileProgressEvent`, `SplitfileCompatibilityModeEvent`, `SplitfileCompatibilityMode`), the
+  leaf-safe `network.crypta.client.async` utility/value subset, the leaf-safe client
+  failure/filter exception subset, `network.crypta.support.MediaType`, and the small manifest/model
+  helper subset under `network.crypta.support.*`.
 - `:kernel-transport`: compile-neutral phase-1 transport leaf spanning selected
   `network.crypta.io`, `network.crypta.io.comm`, and `network.crypta.io.xfer` helpers such as
   allowlist parsing, listener abstraction, statistics collection, throttling, and partially

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetEventHandling.java
@@ -10,6 +10,7 @@ import network.crypta.client.events.ExpectedFileSizeEvent;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.ExpectedMIMEEvent;
 import network.crypta.client.events.SendingToNetworkEvent;
+import network.crypta.client.events.SplitfileCompatibilityMode;
 import network.crypta.client.events.SplitfileCompatibilityModeEvent;
 import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.support.io.NativeThread;
@@ -151,8 +152,8 @@ final class ClientGetEventHandling implements ClientEventListener {
                 request
                     .state()
                     .mergeCompatibilityMode(
-                        FcpCompatibilityMode.byCode(event.minCompatibilityMode.code),
-                        FcpCompatibilityMode.byCode(event.maxCompatibilityMode.code),
+                        toFcpCompatibilityMode(event.minCompatibilityMode),
+                        toFcpCompatibilityMode(event.maxCompatibilityMode),
                         event.splitfileCryptoKey,
                         event.dontCompress,
                         event.bottomLayer);
@@ -168,12 +169,16 @@ final class ClientGetEventHandling implements ClientEventListener {
         request
             .state()
             .mergeCompatibilityMode(
-                FcpCompatibilityMode.byCode(event.minCompatibilityMode.code),
-                FcpCompatibilityMode.byCode(event.maxCompatibilityMode.code),
+                toFcpCompatibilityMode(event.minCompatibilityMode),
+                toFcpCompatibilityMode(event.maxCompatibilityMode),
                 event.splitfileCryptoKey,
                 event.dontCompress,
                 event.bottomLayer);
       }
     }
+  }
+
+  private static FcpCompatibilityMode toFcpCompatibilityMode(SplitfileCompatibilityMode mode) {
+    return FcpCompatibilityMode.byCode(mode.code);
   }
 }

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -30,6 +30,8 @@ class AdapterFcpBoundaryTest {
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "fcp");
   private static final Path ADD_PEER_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("AddPeer.java");
   private static final Path CLIENT_GET_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("ClientGet.java");
+  private static final Path CLIENT_GET_EVENT_HANDLING_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetEventHandling.java");
   private static final Path CLIENT_GET_FACTORY_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetFactory.java");
   private static final Path CLIENT_GET_GETTER_FACTORY_SOURCE =
@@ -119,6 +121,7 @@ class AdapterFcpBoundaryTest {
   private static final Set<Path> DETACHED_COMPATIBILITY_SOURCES =
       Set.of(
           CLIENT_GET_SOURCE,
+          CLIENT_GET_EVENT_HANDLING_SOURCE,
           CLIENT_GET_GETTER_FACTORY_SOURCE,
           CLIENT_GET_MESSAGE_REPLAY_SOURCE,
           CLIENT_GET_PERSISTENCE_CODEC_SOURCE,
@@ -157,6 +160,10 @@ class AdapterFcpBoundaryTest {
       Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
   private static final Path BRIDGE_OWNERSHIP_METADATA =
       Path.of("bridge-fcp-runtime", "gradle", "owned-output-patterns.txt");
+  private static final Path KERNEL_CONTENT_OWNERSHIP_METADATA =
+      Path.of("kernel-content", "gradle", "owned-output-patterns.txt");
+  private static final Path RUNTIME_NODE_OWNERSHIP_METADATA =
+      Path.of("runtime-node", "gradle", "owned-output-patterns.txt");
   private static final Path DEFAULT_BRIDGE_FACTORIES =
       Path.of(
           "src",
@@ -278,6 +285,10 @@ class AdapterFcpBoundaryTest {
     Set<String> metadataPatterns = readOwnershipPatterns(repoRoot.resolve(OWNERSHIP_METADATA));
     Set<String> bridgeMetadataPatterns =
         readOwnershipPatterns(repoRoot.resolve(BRIDGE_OWNERSHIP_METADATA));
+    Set<String> kernelContentPatterns =
+        readOwnershipPatterns(repoRoot.resolve(KERNEL_CONTENT_OWNERSHIP_METADATA));
+    Set<String> runtimeNodePatterns =
+        readOwnershipPatterns(repoRoot.resolve(RUNTIME_NODE_OWNERSHIP_METADATA));
 
     assertTrue(settings.contains("\":adapter-fcp\""));
     assertTrue(settings.contains("\":bridge-fcp-runtime\""));
@@ -294,6 +305,17 @@ class AdapterFcpBoundaryTest {
     assertTrue(Files.isRegularFile(repoRoot.resolve(FCP_COMPATIBILITY_ANALYSIS_SOURCE)));
     assertTrue(Files.isRegularFile(repoRoot.resolve(FCP_INSERT_CONTEXT_HANDLE_SOURCE)));
     assertTrue(Files.isRegularFile(repoRoot.resolve(DEFAULT_FCP_INSERT_CONTEXT_HANDLE_SOURCE)));
+    assertTrue(
+        kernelContentPatterns.contains(
+            "network/crypta/client/events/SplitfileCompatibilityMode.class"));
+    assertTrue(
+        kernelContentPatterns.contains(
+            "network/crypta/client/events/SplitfileCompatibilityModeEvent.class"));
+    assertTrue(kernelContentPatterns.contains("network/crypta/client/events/package-info*"));
+    assertFalse(
+        runtimeNodePatterns.contains(
+            "network/crypta/client/events/SplitfileCompatibilityModeEvent.class"));
+    assertFalse(runtimeNodePatterns.contains("network/crypta/client/events/package-info*"));
   }
 
   @Test

--- a/kernel-content/gradle/owned-output-patterns.txt
+++ b/kernel-content/gradle/owned-output-patterns.txt
@@ -55,6 +55,10 @@ network/crypta/client/events/FinishedCompressionEvent.class
 network/crypta/client/events/FinishedCompressionEvent$*.class
 network/crypta/client/events/SendingToNetworkEvent.class
 network/crypta/client/events/SendingToNetworkEvent$*.class
+network/crypta/client/events/SplitfileCompatibilityMode.class
+network/crypta/client/events/SplitfileCompatibilityMode$*.class
+network/crypta/client/events/SplitfileCompatibilityModeEvent.class
+network/crypta/client/events/SplitfileCompatibilityModeEvent$*.class
 network/crypta/client/events/SplitfileProgressCounts.class
 network/crypta/client/events/SplitfileProgressCounts$*.class
 network/crypta/client/events/SplitfileProgressTimestamps.class
@@ -69,6 +73,7 @@ network/crypta/client/events/EventDumper.class
 network/crypta/client/events/EventDumper$*.class
 network/crypta/client/events/EventLogger.class
 network/crypta/client/events/EventLogger$*.class
+network/crypta/client/events/package-info*
 network/crypta/client/events/SimpleEventProducer.class
 network/crypta/client/events/SimpleEventProducer$*.class
 network/crypta/client/events/SplitfileProgressEvent.class

--- a/kernel-content/src/main/java/network/crypta/client/events/SplitfileCompatibilityMode.java
+++ b/kernel-content/src/main/java/network/crypta/client/events/SplitfileCompatibilityMode.java
@@ -1,0 +1,162 @@
+package network.crypta.client.events;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines the detached compatibility-mode values carried by {@link
+ * SplitfileCompatibilityModeEvent}.
+ *
+ * <p>This enum preserves the stable symbolic names and numeric codes that the runtime layer already
+ * uses when it reasons about splitfile compatibility, but it keeps those values in a leaf-safe form
+ * that {@code :kernel-content} can own directly. Use it when an event, adapter boundary, or other
+ * compile-neutral surface needs to report compatibility choices without exposing the live-runtime
+ * {@code InsertContext} model.
+ *
+ * <p>The values are intentionally small and stable. Each constant carries the short code used for
+ * boundary translation and persistence-facing reporting, while runtime code remains responsible for
+ * mapping from the live compatibility state into this detached representation. The enum itself is
+ * immutable and thread-safe. Callers should treat it as a boundary value object rather than as a
+ * place to add runtime policy.
+ *
+ * <ul>
+ *   <li>Responsibility: provide detached, compile-neutral splitfile compatibility vocabulary.
+ *   <li>Stability: retain the existing symbolic names and short codes used across boundaries.
+ *   <li>Scope: model event payload values, not runtime policy or compatibility selection rules.
+ * </ul>
+ *
+ * @see SplitfileCompatibilityModeEvent
+ */
+public enum SplitfileCompatibilityMode {
+  /**
+   * Indicates that no concrete compatibility information is available yet.
+   *
+   * <p>Producers typically use this when they have not learned enough about the splitfile layout to
+   * announce a real lower or upper bound. It is primarily useful for progress and status surfaces
+   * that need to distinguish "unknown" from a concrete historical mode.
+   */
+  COMPAT_UNKNOWN((short) 0),
+
+  /**
+   * Indicates that the current build's latest concrete compatibility mode should be used.
+   *
+   * <p>This remains a detached mirror of the runtime-side pseudo-current value. Boundary code may
+   * still transport it as a stable enum constant, but runtime code should resolve it to a concrete
+   * mode before it affects splitfile layout decisions that must remain reproducible.
+   */
+  COMPAT_CURRENT((short) 1),
+
+  /**
+   * Represents the exact 1250-era segment layout.
+   *
+   * <p>This mode preserves the older behavior where segments contain exactly 128 data blocks and
+   * 128 check blocks, with the check-block count matching the data-block count. It is the most
+   * specific detached representation of the pre-1250 exact layout.
+   */
+  COMPAT_1250_EXACT((short) 2),
+
+  /**
+   * Represents the broader 1250-or-earlier compatibility behavior.
+   *
+   * <p>In this mode, segments may contain up to 128 data blocks and 128 check blocks, with the
+   * check-block count constrained to {@code <=} the data-block count. Use this detached value when
+   * callers need the historical 1250 behavior without requiring the exact-layout variant above.
+   */
+  COMPAT_1250((short) 3),
+
+  /**
+   * Represents the 1251/1252/1253 compatibility behavior.
+   *
+   * <p>This mode captures the first even-splitting behavior used after the 1250 variants, including
+   * the capped extra-check handling for smaller segment sizes. It remains a concrete detached mode
+   * that can cross event and adapter boundaries safely.
+   */
+  COMPAT_1251((short) 4),
+
+  /**
+   * Represents the 1255 compatibility behavior.
+   *
+   * <p>This mode captures the second-stage even-splitting update together with the related hash
+   * behavior changes introduced at that time. It is a concrete historical mode rather than a
+   * placeholder or policy flag.
+   */
+  COMPAT_1255((short) 5),
+
+  /**
+   * Represents the 1416 compatibility behavior.
+   *
+   * <p>This detached value marks the splitfile mode associated with the newer CHK encryption
+   * behavior. Event consumers can use it to report or merge the selected compatibility window
+   * without importing the runtime insert context directly.
+   */
+  COMPAT_1416((short) 6),
+
+  /**
+   * Represents the 1468 compatibility behavior.
+   *
+   * <p>This mode records the splitfile behavior that includes explicit top-level compression and
+   * compatibility metadata. It is currently the newest concrete detached mode defined by this enum.
+   */
+  COMPAT_1468((short) 7);
+
+  /**
+   * Lookup table used by {@link #byCode(short)}.
+   *
+   * <p>The map is built once during class initialization and then wrapped as unmodifiable, so
+   * lookup stays deterministic for the lifetime of the JVM. Keys are the stable short codes carried
+   * across detached event boundaries.
+   */
+  private static final Map<Short, SplitfileCompatibilityMode> MODES_BY_CODE;
+
+  static {
+    HashMap<Short, SplitfileCompatibilityMode> modesByCode = new HashMap<>();
+    for (SplitfileCompatibilityMode mode : values()) {
+      if (modesByCode.put(mode.code, mode) != null) {
+        throw new IllegalStateException("Duplicated compatibility mode code: " + mode.code);
+      }
+    }
+    MODES_BY_CODE = Collections.unmodifiableMap(modesByCode);
+  }
+
+  /**
+   * Stable numeric code preserved for event delivery and boundary translations.
+   *
+   * <p>The code is part of the detached compatibility contract used by runtime-to-kernel and
+   * kernel-to-adapter mapping logic. It is final, read-only, and intended for lookup or reporting
+   * rather than for arithmetic or ordinal-style comparisons in callers.
+   */
+  public final short code;
+
+  /**
+   * Creates one detached compatibility-mode constant with its stable short code.
+   *
+   * @param code stable short code associated with this enum constant.
+   */
+  SplitfileCompatibilityMode(short code) {
+    this.code = code;
+  }
+
+  /**
+   * Resolves a stable numeric compatibility code back into the detached enum.
+   *
+   * <p>Use this helper at module boundaries where code-based translation is safer than relying on
+   * enum declaration order or symbolic-name parsing. The lookup accepts only codes known to this
+   * build. Callers that receive an unknown code should treat that as a version or boundary mismatch
+   * rather than silently guessing.
+   *
+   * @param code stable short compatibility code received from a boundary translation path or stored
+   *     event payload.
+   * @return the detached compatibility mode associated with {@code code}; never {@code null} for a
+   *     known value.
+   * @throws IllegalArgumentException if {@code code} does not map to any detached compatibility
+   *     mode known to this build.
+   */
+  public static SplitfileCompatibilityMode byCode(short code) {
+    SplitfileCompatibilityMode mode = MODES_BY_CODE.get(code);
+    if (mode == null) {
+      throw new IllegalArgumentException("Unknown compatibility mode code: " + code);
+    }
+    return mode;
+  }
+}

--- a/kernel-content/src/main/java/network/crypta/client/events/SplitfileCompatibilityModeEvent.java
+++ b/kernel-content/src/main/java/network/crypta/client/events/SplitfileCompatibilityModeEvent.java
@@ -1,16 +1,14 @@
 package network.crypta.client.events;
 
-import network.crypta.client.InsertContext.CompatibilityMode;
-
 /**
  * Event describing the compatibility window and encoding flags chosen for a splitfile operation.
  *
  * <p>This value object is emitted by higher-level insert/fetch logic to announce the selected
- * {@link CompatibilityMode} range a splitfile should honor as it is encoded or interpreted, along
- * with auxiliary properties that influence the on-disk representation. The event is useful for
- * operators and UIs that want to display why a particular splitfile layout was picked, and for
- * programmatic consumers that gate behavior based on a stable event code exposed via {@link
- * #getCode()}.
+ * {@link SplitfileCompatibilityMode} range a splitfile should honor as it is encoded or
+ * interpreted, along with auxiliary properties that influence the on-disk representation. The event
+ * is useful for operators and UIs that want to display why a particular splitfile layout was
+ * picked, and for programmatic consumers that gate behavior based on a stable event code exposed
+ * via {@link #getCode()}.
  *
  * <p>Instances carry a lower and upper bound for compatibility, an optional cryptographic key
  * associated with the splitfile, and two booleans that indicate compression and layer context. The
@@ -25,28 +23,29 @@ import network.crypta.client.InsertContext.CompatibilityMode;
  * </ul>
  *
  * @see ClientEvent
- * @see CompatibilityMode
+ * @see SplitfileCompatibilityMode
  */
+@SuppressWarnings("ClassCanBeRecord")
 public class SplitfileCompatibilityModeEvent implements ClientEvent {
 
   /**
-   * The minimum {@link CompatibilityMode} that the operation must satisfy.
+   * The minimum {@link SplitfileCompatibilityMode} that the operation must satisfy.
    *
    * <p>This lower bound constrains how data is laid out so previously deployed readers can still
-   * process the splitfile. It is typically determined by configuration or the environment’s
+   * process the splitfile. It is typically determined by configuration or the environment's
    * defaults. The value is inclusive; producers choose parameters at or above this level depending
    * on the {@link #maxCompatibilityMode} bound.
    */
-  public final CompatibilityMode minCompatibilityMode;
+  public final SplitfileCompatibilityMode minCompatibilityMode;
 
   /**
-   * The maximum {@link CompatibilityMode} that the operation may target.
+   * The maximum {@link SplitfileCompatibilityMode} that the operation may target.
    *
    * <p>This upper bound allows newer, more efficient layouts to be used when available while still
    * honoring {@link #minCompatibilityMode}. It is inclusive and represents the highest mode that a
    * consumer of the resulting data is expected to understand.
    */
-  public final CompatibilityMode maxCompatibilityMode;
+  public final SplitfileCompatibilityMode maxCompatibilityMode;
 
   /**
    * Opaque cryptographic key material associated with the splitfile, if any.
@@ -62,7 +61,7 @@ public class SplitfileCompatibilityModeEvent implements ClientEvent {
    *
    * <p>When {@code true}, producers skip applying compression for the associated portion of the
    * splitfile, preserving exact bytes at the cost of larger size. When {@code false}, compression
-   * policy is left to the producer’s defaults.
+   * policy is left to the producer's defaults.
    */
   public final boolean dontCompress;
 
@@ -82,36 +81,11 @@ public class SplitfileCompatibilityModeEvent implements ClientEvent {
    */
   public static final int CODE = 0x0D;
 
-  /**
-   * Returns the stable integer identifier for this event type.
-   *
-   * <p>Clients may switch on this code to aggregate metrics or to route the event to specialized
-   * handlers. The value is constant for all instances of this class and does not depend on field
-   * contents.
-   *
-   * @return a stable integer code identifying the compatibility-mode event; suitable for
-   *     comparisons and counters across instances.
-   */
   @Override
   public int getCode() {
     return CODE;
   }
 
-  /**
-   * Returns a concise, human-readable summary of the compatibility range.
-   *
-   * <p>The description lists the lower and upper {@link CompatibilityMode} bounds selected for the
-   * splitfile. It is intended for logs, progress displays, and diagnostics and should not be parsed
-   * programmatically. Use {@link #getCode()} for machine handling when needed.
-   *
-   * <pre>{@code
-   * // Example: record the chosen window
-   * LOG.info("Selected: {}", event.getDescription());
-   * }</pre>
-   *
-   * @return a non-null summary describing the minimum and maximum compatibility modes in plain
-   *     text; callers must treat the returned string as read-only.
-   */
   @Override
   public String getDescription() {
     return "CompatibilityMode between " + minCompatibilityMode + " and " + maxCompatibilityMode;
@@ -121,13 +95,13 @@ public class SplitfileCompatibilityModeEvent implements ClientEvent {
    * Creates a new event with the provided compatibility window and flags.
    *
    * <p>The array reference for {@code splitfileCryptoKey} is stored directly and is not copied.
-   * Pass a fresh or immutable instance if later modification is a concern. Booleans control
+   * Pass a fresh or immutable instance if a later modification is a concern. Booleans controls
    * compression policy and layer context used by producers or UIs.
    *
-   * @param min the lower, inclusive {@link CompatibilityMode} bound to honor; must not be {@code
-   *     null} when a concrete mode is required by the producer.
-   * @param max the upper, inclusive {@link CompatibilityMode} bound allowed for encoding; must not
-   *     be {@code null} when a concrete mode is required by the producer.
+   * @param min the lower, inclusive {@link SplitfileCompatibilityMode} bound to honor; may be
+   *     {@code null} if the producer has not learned a concrete lower bound yet.
+   * @param max the upper, inclusive {@link SplitfileCompatibilityMode} bound allowed for encoding;
+   *     may be {@code null} if the producer has not learned a concrete upper bound yet.
    * @param splitfileCryptoKey optional key bytes associated with the splitfile; reference is stored
    *     as-is and must not be mutated after construction; may be {@code null}.
    * @param dontCompress {@code true} to disable compression for the relevant layer; {@code false}
@@ -136,8 +110,8 @@ public class SplitfileCompatibilityModeEvent implements ClientEvent {
    *     refers to a higher layer or global context.
    */
   public SplitfileCompatibilityModeEvent(
-      CompatibilityMode min,
-      CompatibilityMode max,
+      SplitfileCompatibilityMode min,
+      SplitfileCompatibilityMode max,
       byte[] splitfileCryptoKey,
       boolean dontCompress,
       boolean bottomLayer) {

--- a/kernel-content/src/main/java/network/crypta/client/events/package-info.java
+++ b/kernel-content/src/main/java/network/crypta/client/events/package-info.java
@@ -1,8 +1,9 @@
 /**
  * Compile-neutral client event contracts and value types extracted into {@code :kernel-content}.
  *
- * <p>This package now owns the listener/producer contracts, the simple in-process producer and
- * helper listeners, the narrow dispatch seam used during event delivery, and the leaf-safe event
- * value subset that stays free of runtime-node, adapter, and root-composition dependencies.
+ * <p>This package owns the listener/producer contracts, the simple in-process producer and helper
+ * listeners, the narrow dispatch seam used during event delivery, and the leaf-safe event value
+ * subset that stays free of runtime-node, adapter, and root-composition dependencies. That subset
+ * now includes the detached splitfile compatibility event and its detached compatibility-mode enum.
  */
 package network.crypta.client.events;

--- a/kernel-content/src/test/java/network/crypta/client/events/SplitfileCompatibilityModeEventTest.java
+++ b/kernel-content/src/test/java/network/crypta/client/events/SplitfileCompatibilityModeEventTest.java
@@ -1,17 +1,14 @@
 package network.crypta.client.events;
 
-import network.crypta.client.InsertContext.CompatibilityMode;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class SplitfileCompatibilityModeEventTest {
 
@@ -21,7 +18,11 @@ class SplitfileCompatibilityModeEventTest {
     byte[] key = new byte[] {1, 2, 3, 4};
     SplitfileCompatibilityModeEvent evt =
         new SplitfileCompatibilityModeEvent(
-            CompatibilityMode.COMPAT_1250, CompatibilityMode.COMPAT_1468, key, false, true);
+            SplitfileCompatibilityMode.COMPAT_1250,
+            SplitfileCompatibilityMode.COMPAT_1468,
+            key,
+            false,
+            true);
 
     // Act
     int code = evt.getCode();
@@ -37,7 +38,11 @@ class SplitfileCompatibilityModeEventTest {
     byte[] key = new byte[] {9};
     SplitfileCompatibilityModeEvent evt =
         new SplitfileCompatibilityModeEvent(
-            CompatibilityMode.COMPAT_1250_EXACT, CompatibilityMode.COMPAT_1468, key, true, false);
+            SplitfileCompatibilityMode.COMPAT_1250_EXACT,
+            SplitfileCompatibilityMode.COMPAT_1468,
+            key,
+            true,
+            false);
 
     // Act
     String description = evt.getDescription();
@@ -49,8 +54,8 @@ class SplitfileCompatibilityModeEventTest {
   @Test
   void constructor_whenValuesProvided_setsAllFields() {
     // Arrange
-    CompatibilityMode min = CompatibilityMode.COMPAT_1251;
-    CompatibilityMode max = CompatibilityMode.COMPAT_1416;
+    SplitfileCompatibilityMode min = SplitfileCompatibilityMode.COMPAT_1251;
+    SplitfileCompatibilityMode max = SplitfileCompatibilityMode.COMPAT_1416;
     byte[] key = new byte[] {10, 11, 12};
     boolean dontCompress = true;
     boolean bottomLayer = true;
@@ -87,12 +92,33 @@ class SplitfileCompatibilityModeEventTest {
     // Arrange
     SplitfileCompatibilityModeEvent evt =
         new SplitfileCompatibilityModeEvent(
-            null, CompatibilityMode.COMPAT_1250, new byte[] {1}, false, false);
+            null, SplitfileCompatibilityMode.COMPAT_1250, new byte[] {1}, false, false);
 
     // Act
     String description = evt.getDescription();
 
     // Assert
     assertEquals("CompatibilityMode between null and COMPAT_1250", description);
+  }
+
+  @Test
+  void byCode_whenKnownCode_returnsDetachedMode() {
+    // Arrange
+    short code = SplitfileCompatibilityMode.COMPAT_1416.code;
+
+    // Act
+    SplitfileCompatibilityMode mode = SplitfileCompatibilityMode.byCode(code);
+
+    // Assert
+    assertSame(SplitfileCompatibilityMode.COMPAT_1416, mode);
+  }
+
+  @Test
+  void byCode_whenUnknownCode_throwsIllegalArgumentException() {
+    // Arrange
+    short code = 99;
+
+    // Act & Assert
+    assertThrows(IllegalArgumentException.class, () -> SplitfileCompatibilityMode.byCode(code));
   }
 }

--- a/runtime-node/gradle/owned-output-patterns.txt
+++ b/runtime-node/gradle/owned-output-patterns.txt
@@ -63,9 +63,6 @@ network/crypta/client/SplitfilePayload.class
 network/crypta/client/SplitfilePayload$*.class
 network/crypta/client/TopLayerBlockInfo.class
 network/crypta/client/TopLayerBlockInfo$*.class
-network/crypta/client/events/package-info*
-network/crypta/client/events/SplitfileCompatibilityModeEvent.class
-network/crypta/client/events/SplitfileCompatibilityModeEvent$*.class
 network/crypta/client/filter/package-info*
 network/crypta/client/filter/BMPFilter.class
 network/crypta/client/filter/BMPFilter$*.class

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientGetter.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientGetter.java
@@ -31,6 +31,7 @@ import network.crypta.client.events.ExpectedFileSizeEvent;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.ExpectedMIMEEvent;
 import network.crypta.client.events.SendingToNetworkEvent;
+import network.crypta.client.events.SplitfileCompatibilityMode;
 import network.crypta.client.events.SplitfileCompatibilityModeEvent;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
@@ -1372,10 +1373,21 @@ public class ClientGetter extends BaseClientGetter
               ClientEventProducer.dispatchEvent(
                   ctx.getEventProducer(),
                   new SplitfileCompatibilityModeEvent(
-                      min, max, customSplitfileKey, dontCompress, bottomLayer || definitiveAnyway),
+                      detachCompatibilityMode(min),
+                      detachCompatibilityMode(max),
+                      customSplitfileKey,
+                      dontCompress,
+                      bottomLayer || definitiveAnyway),
                   context1);
               return false;
             });
+  }
+
+  private static SplitfileCompatibilityMode detachCompatibilityMode(CompatibilityMode mode) {
+    if (mode == null) {
+      return null;
+    }
+    return SplitfileCompatibilityMode.byCode(mode.code);
   }
 
   @Override

--- a/runtime-node/src/main/java/network/crypta/client/events/package-info.java
+++ b/runtime-node/src/main/java/network/crypta/client/events/package-info.java
@@ -1,8 +1,0 @@
-/**
- * Runtime-owned residue in the client event layer.
- *
- * <p>The compile-neutral event contracts, helper listeners, simple producer, and progress helpers
- * now live in {@code :kernel-content}. This runtime package currently retains only the
- * compatibility-mode event that still depends on runtime-owned content context types.
- */
-package network.crypta.client.events;

--- a/src/test/java/network/crypta/client/async/ClientGetterTest.java
+++ b/src/test/java/network/crypta/client/async/ClientGetterTest.java
@@ -20,7 +20,11 @@ import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
 import network.crypta.client.InsertContext;
 import network.crypta.client.InsertContextOptions;
+import network.crypta.client.events.ClientEvent;
+import network.crypta.client.events.ClientEventListener;
 import network.crypta.client.events.SimpleEventProducer;
+import network.crypta.client.events.SplitfileCompatibilityMode;
+import network.crypta.client.events.SplitfileCompatibilityModeEvent;
 import network.crypta.client.filter.LinkFilterExceptionProvider;
 import network.crypta.clients.fcp.PersistentRequestRoot;
 import network.crypta.config.Config;
@@ -55,8 +59,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -484,6 +490,62 @@ class ClientGetterTest {
     assertEquals(uri, getter.getURI());
     // completion file is null for non-FileBucket
     assertNull(getter.getCompletionFile());
+  }
+
+  @Test
+  void onSplitfileCompatibilityMode_whenConcreteModesProvided_dispatchesDetachedEvent() {
+    // Arrange
+    FetchContext fctx = newFetchContext(false);
+    ClientContext ctx = newContext(fctx, newInsertContext());
+    ClientGetter getter = newGetter(new FreenetURI("KSK", "compat"), fctx, null, null);
+    ClientEventListener listener = Mockito.mock(ClientEventListener.class);
+    fctx.getEventProducer().addEventListener(listener);
+    byte[] splitfileKey = new byte[] {1, 2, 3};
+
+    // Act
+    getter.onSplitfileCompatibilityMode(
+        InsertContext.CompatibilityMode.COMPAT_1250,
+        InsertContext.CompatibilityMode.COMPAT_1468,
+        splitfileKey,
+        true,
+        false,
+        true,
+        ctx);
+
+    // Assert
+    ArgumentCaptor<ClientEvent> eventCaptor = ArgumentCaptor.forClass(ClientEvent.class);
+    verify(listener).receive(eventCaptor.capture(), eq(ctx));
+    SplitfileCompatibilityModeEvent event =
+        assertInstanceOf(SplitfileCompatibilityModeEvent.class, eventCaptor.getValue());
+    assertSame(SplitfileCompatibilityMode.COMPAT_1250, event.minCompatibilityMode);
+    assertSame(SplitfileCompatibilityMode.COMPAT_1468, event.maxCompatibilityMode);
+    assertSame(splitfileKey, event.splitfileCryptoKey);
+    assertTrue(event.dontCompress);
+    assertTrue(event.bottomLayer);
+  }
+
+  @Test
+  void onSplitfileCompatibilityMode_whenBoundsNull_preservesNullModes() {
+    // Arrange
+    FetchContext fctx = newFetchContext(false);
+    ClientContext ctx = newContext(fctx, newInsertContext());
+    ClientGetter getter = newGetter(new FreenetURI("KSK", "compat-null"), fctx, null, null);
+    ClientEventListener listener = Mockito.mock(ClientEventListener.class);
+    fctx.getEventProducer().addEventListener(listener);
+
+    // Act
+    getter.onSplitfileCompatibilityMode(null, null, null, false, false, false, ctx);
+
+    // Assert
+    ArgumentCaptor<ClientEvent> eventCaptor = ArgumentCaptor.forClass(ClientEvent.class);
+    verify(listener).receive(eventCaptor.capture(), eq(ctx));
+    SplitfileCompatibilityModeEvent event =
+        assertInstanceOf(SplitfileCompatibilityModeEvent.class, eventCaptor.getValue());
+    assertNull(event.minCompatibilityMode);
+    assertNull(event.maxCompatibilityMode);
+    assertNull(event.splitfileCryptoKey);
+    assertFalse(event.dontCompress);
+    assertFalse(event.bottomLayer);
   }
 
   // no helper methods

--- a/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetEventHandlingTest.java
@@ -2,7 +2,6 @@ package network.crypta.clients.fcp;
 
 import java.lang.reflect.Field;
 import java.time.Instant;
-import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.events.ClientEvent;
 import network.crypta.client.events.ClientEventDispatchContext;
@@ -12,6 +11,7 @@ import network.crypta.client.events.ExpectedFileSizeEvent;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.ExpectedMIMEEvent;
 import network.crypta.client.events.SendingToNetworkEvent;
+import network.crypta.client.events.SplitfileCompatibilityMode;
 import network.crypta.client.events.SplitfileCompatibilityModeEvent;
 import network.crypta.client.events.SplitfileProgressCounts;
 import network.crypta.client.events.SplitfileProgressEvent;
@@ -262,8 +262,8 @@ class ClientGetEventHandlingTest {
     ClientGetEventHandling handler = new ClientGetEventHandling(request);
     SplitfileCompatibilityModeEvent event =
         new SplitfileCompatibilityModeEvent(
-            CompatibilityMode.COMPAT_1250,
-            CompatibilityMode.COMPAT_1468,
+            SplitfileCompatibilityMode.COMPAT_1250,
+            SplitfileCompatibilityMode.COMPAT_1468,
             new byte[] {1, 2, 3},
             true,
             false);
@@ -295,8 +295,8 @@ class ClientGetEventHandlingTest {
     ClientGetEventHandling handler = new ClientGetEventHandling(request);
     SplitfileCompatibilityModeEvent event =
         new SplitfileCompatibilityModeEvent(
-            CompatibilityMode.COMPAT_1250,
-            CompatibilityMode.COMPAT_1468,
+            SplitfileCompatibilityMode.COMPAT_1250,
+            SplitfileCompatibilityMode.COMPAT_1468,
             new byte[] {4, 5, 6},
             false,
             true);
@@ -327,8 +327,8 @@ class ClientGetEventHandlingTest {
     ClientGetEventHandling handler = new ClientGetEventHandling(request);
     SplitfileCompatibilityModeEvent event =
         new SplitfileCompatibilityModeEvent(
-            CompatibilityMode.COMPAT_1250,
-            CompatibilityMode.COMPAT_1468,
+            SplitfileCompatibilityMode.COMPAT_1250,
+            SplitfileCompatibilityMode.COMPAT_1468,
             new byte[] {7, 8, 9},
             true,
             true);


### PR DESCRIPTION
## Summary

- move `SplitfileCompatibilityModeEvent` from `:runtime-node` into `:kernel-content`
- add detached `SplitfileCompatibilityMode` codes for the event surface and translate runtime values in `ClientGetter`
- keep adapter-side compatibility handling on stable numeric codes while updating ownership metadata, package docs, and focused boundary tests
- add focused `ClientGetter` coverage for the new detached event translation path

## How to test

- `./gradlew :kernel-content:test --tests network.crypta.client.events.SplitfileCompatibilityModeEventTest`
- `./gradlew :test --tests network.crypta.clients.fcp.ClientGetEventHandlingTest`
- `./gradlew :adapter-fcp:test --tests network.crypta.clients.fcp.AdapterFcpBoundaryTest`
- `./gradlew :test --tests network.crypta.client.async.ClientGetterTest`
- `./gradlew test`

## Notes

- base branch: `develop`
- branch: `feature/splitfile-compatibility-mode-detachment`
- doclint check for `kernel-content/src/main/java/network/crypta/client/events/SplitfileCompatibilityMode.java` passes with `javadoc -quiet -Xdoclint:all -classpath kernel-content/build/classes/java/main -d /tmp/doclint-out kernel-content/src/main/java/network/crypta/client/events/SplitfileCompatibilityMode.java`
