### PR TITLE
refactor(fcp): Detach FCP request lifecycle from ClientContext

### DIFF
--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGet.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -12,6 +11,7 @@ import java.io.Serializable;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
@@ -35,10 +35,9 @@ import network.crypta.support.io.StorageFormatException;
  * returned objects or assuming immediate cross-thread visibility without synchronization.
  *
  * <p>Typical usage is to construct the request from a {@link ClientGetMessage}, register it with
- * the owning client queue, and then invoke {@link
- * #start(network.crypta.client.async.ClientContext)}. The request may persist across reconnections,
- * and callers should treat it as a long-lived state machine whose outputs are FCP messages rather
- * than synchronous return values.
+ * the owning client queue, and then invoke {@link #start(PersistentRequestRuntimeContext)}. The
+ * request may persist across reconnections, and callers should treat it as a long-lived state
+ * machine whose outputs are FCP messages rather than synchronous return values.
  *
  * <ul>
  *   <li><strong>Queueing and persistence</strong>: registers against either the connection-scoped
@@ -304,11 +303,11 @@ public final class ClientGet extends ClientRequest {
    *
    * <p>All fields are intentionally left {@code null} (or primitive defaults) so that the
    * deserialization helpers can populate them explicitly via {@link
-   * #innerResume(network.crypta.client.async.ClientContext)} and related restoration methods.
-   * Production code should never invoke this constructor directly; always use one of the fully
-   * parameterized alternatives that configure detached fetch settings and a live execution handle.
-   * This constructor exists solely to satisfy the Java serialization framework and keep field
-   * initialization centralized in the resume path.
+   * #innerResume(FcpRequestRuntimeContext)} and related restoration methods. Production code should
+   * never invoke this constructor directly; always use one of the fully parameterized alternatives
+   * that configure detached fetch settings and a live execution handle. This constructor exists
+   * solely to satisfy the Java serialization framework and keep field initialization centralized in
+   * the resume path.
    */
   ClientGet() {
     // For serialization.
@@ -364,15 +363,7 @@ public final class ClientGet extends ClientRequest {
    */
   @Override
   void register(boolean noTags) throws IdentifierCollisionException {
-    if (persistence != Persistence.CONNECTION) {
-      // Non-connection requests are assembled with a persistent client before registration.
-      PersistentRequestClient persistentClient = client;
-      persistentClient.register(this);
-      if (!noTags) {
-        FCPMessage msg = persistentTagMessage();
-        persistentClient.queueClientRequestMessage(msg, 0);
-      }
-    }
+    helpers().lifecycle().register(noTags);
   }
 
   /**
@@ -392,46 +383,12 @@ public final class ClientGet extends ClientRequest {
    * caches remain consistent. Callers may invoke this multiple times safely; only the first call
    * before completion has any effect.
    *
-   * @param context client context provided by the legacy request API; the live execution keeps its
-   *     own runtime binding.
+   * @param context detached runtime context provided by the request API; the live execution keeps
+   *     its own runtime binding.
    */
   @Override
-  public void start(network.crypta.client.async.ClientContext context) {
-    try {
-      synchronized (requestLock()) {
-        if (finished) return;
-      }
-      execution.start();
-      if (shouldSendPersistentTag()) {
-        FCPMessage msg = persistentTagMessage();
-        client.queueClientRequestMessage(msg, 0);
-      }
-      synchronized (requestLock()) {
-        started = true;
-      }
-      if (client != null) {
-        RequestStatusCache cache = client.getRequestStatusCache();
-        if (cache != null) {
-          cache.updateStarted(identifier, true);
-        }
-      }
-    } catch (FetchException e) {
-      synchronized (requestLock()) {
-        started = true;
-      } // before the failure handler
-      onFailure(e);
-    } catch (Exception t) {
-      synchronized (requestLock()) {
-        started = true;
-      }
-      onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t));
-    }
-  }
-
-  private boolean shouldSendPersistentTag() {
-    synchronized (requestLock()) {
-      return persistence != Persistence.CONNECTION && !finished;
-    }
+  public void start(PersistentRequestRuntimeContext context) {
+    helpers().lifecycle().start();
   }
 
   /**
@@ -447,12 +404,11 @@ public final class ClientGet extends ClientRequest {
    * possible cancellation. It exists primarily so connection handlers can dispose of
    * connection-scoped work without leaking persistent tasks.
    *
-   * @param context client context owning the request and its scheduler association.
+   * @param context detached runtime context owning the request and its scheduler association.
    */
   @Override
-  public void onLostConnection(network.crypta.client.async.ClientContext context) {
-    if (persistence == Persistence.CONNECTION) cancel(context);
-    // Otherwise ignore
+  public void onLostConnection(PersistentRequestRuntimeContext context) {
+    helpers().lifecycle().onLostConnection(context);
   }
 
   /**
@@ -587,10 +543,11 @@ public final class ClientGet extends ClientRequest {
    * <p>The removal path does not attempt to stop network activity directly; it assumes the owning
    * scheduler has already detached the underlying live GET execution.
    *
-   * @param context client context invoking the removal for lifecycle bookkeeping.
+   * @param context detached runtime context invoking the removal for lifecycle bookkeeping.
    */
   @Override
-  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
+  public void requestWasRemoved(
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context) {
     helpers().lifecycle().requestWasRemoved();
     super.requestWasRemoved(context);
   }
@@ -989,8 +946,8 @@ public final class ClientGet extends ClientRequest {
    * <p>The getter must support restart semantics, the request must have finished, and it must not
    * have succeeded yet. Success cases require manual deletion or explicit reset before another
    * attempt. This method performs the minimal checks needed to decide if {@link
-   * #restart(network.crypta.client.async.ClientContext, boolean)} is likely to proceed without
-   * immediate failure.
+   * #restart(PersistentRequestRuntimeContext, boolean)} is likely to proceed without immediate
+   * failure.
    *
    * <p>This method does not modify the state; it is intended for UI or scheduler decisions before
    * initiating a restart.
@@ -1014,13 +971,14 @@ public final class ClientGet extends ClientRequest {
    * <p>Restarting does not guarantee success; it merely schedules a new attempt with the updated
    * parameters. The method returns quickly once the execution acknowledges the restart request.
    *
-   * @param context client context provided by the legacy request API.
+   * @param context detached runtime context provided by the request API.
    * @param disableFilterData {@code true} to disable filtering for the next attempt.
    * @return {@code true} when the restart is accepted and scheduled by the getter.
    */
   @Override
   public boolean restart(
-      network.crypta.client.async.ClientContext context, final boolean disableFilterData) {
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context,
+      final boolean disableFilterData) {
     return helpers().restartCoordinator().restart(disableFilterData);
   }
 
@@ -1090,21 +1048,23 @@ public final class ClientGet extends ClientRequest {
     ClientGetPersistenceCodec.writeClientDetail(this, dos, checker);
   }
 
-  ClientGet(
-      DataInputStream dis,
-      RequestIdentifier reqID,
-      FcpFetchRuntimeSupport fetchRuntimeSupport,
-      network.crypta.client.async.ClientContext context,
-      ChecksumChecker checker)
+  ClientGet(ClientGetRestoreInput restoreInput)
       throws IOException, StorageFormatException, ResumeFailedException {
-    super(dis, reqID, context);
+    super(restoreInput.input(), restoreInput.requestIdentifier(), restoreInput.runtimeContext());
     state = new ClientGetState(this);
     ClientGetPersistenceCodec.BasicRestoreData restoreData =
-        ClientGetPersistenceCodec.readBasicRestoreData(dis, fetchRuntimeSupport, checker);
+        ClientGetPersistenceCodec.readBasicRestoreData(
+            restoreInput.input(), restoreInput.fetchRuntimeSupport(), restoreInput.checker());
     uri = restoreData.uri();
-    requestProfile = ClientGetRequestProfile.fromRestoreData(restoreData, fetchRuntimeSupport);
+    requestProfile =
+        ClientGetRequestProfile.fromRestoreData(restoreData, restoreInput.fetchRuntimeSupport());
     ClientGetExecution restoredExecution =
-        ClientGetPersistenceCodec.restoreState(this, dis, reqID, fetchRuntimeSupport, checker);
+        ClientGetPersistenceCodec.restoreState(
+            this,
+            restoreInput.input(),
+            restoreInput.requestIdentifier(),
+            restoreInput.fetchRuntimeSupport(),
+            restoreInput.checker());
     state.ensureCompatibilityMode();
     if (restoredExecution == null) {
       restoredExecution = makeExecutionForPersistence(makePersistenceBucket());
@@ -1125,12 +1085,11 @@ public final class ClientGet extends ClientRequest {
    *
    * <p>Callers should invoke this only during resume flows and not during normal execution.
    *
-   * @param context client context used for bucket resume callbacks and defaults.
+   * @param context detached request runtime context used for bucket resume callbacks and defaults.
    * @throws ResumeFailedException if bucket resume logic reports unrecoverable failure.
    */
   @Override
-  protected void innerResume(network.crypta.client.async.ClientContext context)
-      throws ResumeFailedException {
+  protected void innerResume(FcpRequestRuntimeContext context) throws ResumeFailedException {
     ClientGetPersistenceIO.resume(this, context);
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetLifecycle.java
@@ -3,6 +3,7 @@ package network.crypta.clients.fcp;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ResumeFailedException;
 import org.slf4j.Logger;
@@ -48,6 +49,84 @@ final class ClientGetLifecycle {
    */
   ClientGetLifecycle(ClientGet request) {
     this.request = request;
+  }
+
+  /**
+   * Registers a newly constructed request with its owning persistent client when required.
+   *
+   * <p>Connection-scoped requests are already owned by the active handler and therefore do not
+   * participate in persistent-client registration. Reboot- and forever-persistent requests are
+   * registered with their client immediately and may queue a persistent tag message unless the
+   * caller explicitly suppresses tag emission.
+   *
+   * @param noTags {@code true} to suppress the initial persistent-tag message after registration
+   * @throws IdentifierCollisionException if the request identifier is already in use
+   */
+  void register(boolean noTags) throws IdentifierCollisionException {
+    if (request.persistence != ClientRequest.Persistence.CONNECTION) {
+      PersistentRequestClient persistentClient = request.client;
+      persistentClient.register(request);
+      if (!noTags) {
+        FCPMessage msg = request.persistentTagMessage();
+        persistentClient.queueClientRequestMessage(msg, 0);
+      }
+    }
+  }
+
+  /**
+   * Starts the live GET execution and synchronizes queue-side bookkeeping.
+   *
+   * <p>The method preserves the request's original lifecycle semantics: it skips terminal requests,
+   * starts the underlying execution, emits a persistent tag for non-connection requests, records
+   * the {@code started} flag, and updates any associated {@link RequestStatusCache}. Failures are
+   * normalized through the request's existing failure path, so cleanup and client notifications
+   * remain unchanged.
+   */
+  void start() {
+    try {
+      synchronized (request.requestLock()) {
+        if (request.finished) return;
+      }
+      request.execution().start();
+      if (shouldSendPersistentTag()) {
+        FCPMessage msg = request.persistentTagMessage();
+        request.client.queueClientRequestMessage(msg, 0);
+      }
+      synchronized (request.requestLock()) {
+        request.started = true;
+      }
+      if (request.client != null) {
+        RequestStatusCache cache = request.client.getRequestStatusCache();
+        if (cache != null) {
+          cache.updateStarted(request.identifier, true);
+        }
+      }
+    } catch (FetchException e) {
+      synchronized (request.requestLock()) {
+        request.started = true;
+      }
+      request.onFailure(e);
+    } catch (Exception t) {
+      synchronized (request.requestLock()) {
+        request.started = true;
+      }
+      request.onFailure(new FetchException(FetchExceptionMode.INTERNAL_ERROR, t));
+    }
+  }
+
+  /**
+   * Handles loss of the transport or scheduler association for the request.
+   *
+   * <p>Only connection-scoped requests are canceled immediately because they can no longer deliver
+   * results once the owning connection disappears. Persistent requests stay in their queues and are
+   * expected to resume delivery on reconnection.
+   *
+   * @param context detached runtime context used when canceling connection-scoped work
+   */
+  void onLostConnection(PersistentRequestRuntimeContext context) {
+    if (request.persistence == ClientRequest.Persistence.CONNECTION) {
+      request.cancel(context);
+    }
   }
 
   /**
@@ -221,5 +300,11 @@ final class ClientGetLifecycle {
     }
 
     request.freeData();
+  }
+
+  private boolean shouldSendPersistentTag() {
+    synchronized (request.requestLock()) {
+      return request.persistence != ClientRequest.Persistence.CONNECTION && !request.finished;
+    }
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceCodec.java
@@ -66,6 +66,8 @@ final class ClientGetPersistenceCodec {
    * @param dis input stream positioned at the serialized client-detail payload.
    * @param reqID identifier tuple describing the request owner and scope.
    * @param fetchRuntimeSupport fetch runtime support providing factories for restoration.
+   * @param context detached runtime context used to rebuild persistent-client ownership during
+   *     restart
    * @param checker checksum helper verifying embedded bucket sections.
    * @return reconstructed {@link ClientGet} instance ready for registration.
    * @throws StorageFormatException when magic or version checks fail.
@@ -76,10 +78,11 @@ final class ClientGetPersistenceCodec {
       DataInputStream dis,
       RequestIdentifier reqID,
       FcpFetchRuntimeSupport fetchRuntimeSupport,
-      network.crypta.client.async.ClientContext context,
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context,
       ChecksumChecker checker)
       throws StorageFormatException, IOException, ResumeFailedException {
-    return new ClientGet(dis, reqID, fetchRuntimeSupport, context, checker);
+    return new ClientGet(
+        new ClientGetRestoreInput(dis, reqID, fetchRuntimeSupport, context, checker));
   }
 
   /**

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetPersistenceIO.java
@@ -259,7 +259,7 @@ final class ClientGetPersistenceIO {
     }
   }
 
-  static void resume(ClientGet request, network.crypta.client.async.ClientContext context)
+  static void resume(ClientGet request, FcpRequestRuntimeContext context)
       throws ResumeFailedException {
     if (request.execution() != null) {
       request.execution().onResume(context);
@@ -271,19 +271,31 @@ final class ClientGetPersistenceIO {
         throw new ResumeFailedException(e);
       }
     }
-    Bucket returnBucket = request.state().getReturnBucketDirect();
-    if (returnBucket != null) {
-      returnBucket.onResume(context);
-    }
-    Bucket initialMetadata = request.requestProfile().initialMetadata();
-    if (initialMetadata != null) {
-      initialMetadata.onResume(context);
-    }
+    resumeOwnedBucket(request.state().getReturnBucketDirect(), context);
+    resumeOwnedBucket(request.requestProfile().initialMetadata(), context);
     if (request.execution() != null && request.state().getFoundDataLength() <= 0) {
       request.state().setFoundDataLength(request.execution().expectedSize());
     }
     if (request.execution() != null && request.state().getFoundDataMimeType() == null) {
       request.state().setFoundDataMimeType(request.execution().expectedMime());
+    }
+  }
+
+  /**
+   * Resumes a request-owned bucket without transferring or releasing ownership.
+   *
+   * <p>{@link Bucket#close()} is a terminal-free operation, so these buckets must not be wrapped in
+   * try-with-resources during resume. The request continues to own the bucket after the resume
+   * callback returns.
+   *
+   * @param bucket request-owned bucket to reattach, or {@code null} when absent
+   * @param context detached resume context used by the bucket
+   * @throws ResumeFailedException if the bucket cannot reattach to its persisted state
+   */
+  private static void resumeOwnedBucket(Bucket bucket, FcpRequestRuntimeContext context)
+      throws ResumeFailedException {
+    if (bucket != null) {
+      bucket.onResume(context);
     }
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetRestoreInput.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientGetRestoreInput.java
@@ -1,0 +1,39 @@
+package network.crypta.clients.fcp;
+
+import java.io.DataInputStream;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+import network.crypta.crypt.ChecksumChecker;
+
+/**
+ * Bundles the restore-only inputs needed to rebuild a persistent {@link ClientGet}.
+ *
+ * <p>{@link ClientGet} needs these collaborators only during the narrow replay window where it
+ * reconstructs itself from the on-disk client-detail payload. Grouping them into one package-local
+ * record keeps the persistence codec in charge of restore orchestration, narrows the request's
+ * constructor surface, and avoids leaking stream-oriented concerns onto the normal GET creation
+ * path. The record also makes the restore call site easier to audit because the stream, checksum,
+ * runtime seam, and request identity travel together instead of being rethreaded through a long
+ * positional parameter list.
+ *
+ * <p>The bundle is deliberately short-lived and immutable. Callers create it immediately before
+ * invoking the restore constructor, use it once while replaying the serialized payload, and then
+ * discard it. It is not itself part of the persisted request state and does not own any cleanup;
+ * stream lifetime and restored object lifetime remain the caller's responsibility.
+ *
+ * @param input stream already positioned at the serialized client-detail payload for the request;
+ *     callers are responsible for the stream lifecycle before and after replay
+ * @param requestIdentifier stable identifier tuple describing the restored request owner, queue
+ *     scope, and request type used during replay bookkeeping
+ * @param fetchRuntimeSupport live fetch runtime bridge used to rebuild getter execution state and
+ *     restore persisted buckets or fetch configuration fragments
+ * @param runtimeContext detached runtime context used when restoring persistent ownership and other
+ *     restart-only request infrastructure
+ * @param checker checksum helper used to validate embedded bucket payloads and other protected
+ *     segments while the serialized request is replayed
+ */
+record ClientGetRestoreInput(
+    DataInputStream input,
+    RequestIdentifier requestIdentifier,
+    FcpFetchRuntimeSupport fetchRuntimeSupport,
+    PersistentRequestRuntimeContext runtimeContext,
+    ChecksumChecker checker) {}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPut.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPut.java
@@ -11,9 +11,9 @@ import java.io.Serializable;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertException;
 import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
-import network.crypta.runtime.spi.TransferAccessPort;
 import network.crypta.support.api.RandomAccessBucket;
 import network.crypta.support.io.ResumeFailedException;
 import org.slf4j.Logger;
@@ -47,14 +47,6 @@ import org.slf4j.LoggerFactory;
 public final class ClientPut extends ClientPutBase {
   /** Logger for lifecycle and diagnostic messages. */
   private static final Logger LOG = LoggerFactory.getLogger(ClientPut.class);
-
-  /** Debugging template for persistent uploads to log bucket identity and source. */
-  private static final String PERSISTENT_UPLOAD_LOG_TEMPLATE =
-      "Prepared persistent upload data: data = {}, uploadFrom = {}";
-
-  /** Debugging template for message-based uploads to log bucket identity and source. */
-  private static final String MESSAGE_UPLOAD_LOG_TEMPLATE =
-      "Prepared message upload data: data = {}, uploadFrom = {}";
 
   /** Serialization version for persistent request snapshots. */
   @Serial private static final long serialVersionUID = 1L;
@@ -120,6 +112,8 @@ public final class ClientPut extends ClientPutBase {
   /** Records if compression finished once so we do not resignal redundant progress. */
   private boolean compressed;
 
+  private transient ClientPutLifecycle lifecycle;
+
   // Legacy threshold callback removed.
 
   /**
@@ -151,73 +145,7 @@ public final class ClientPut extends ClientPutBase {
           NotAllowedException,
           MetadataUnresolvedException,
           IOException {
-    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            checkEmptySSK(request.uri(), upload.targetFilename(), runtimeSupport),
-            ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
-            request.verbosity(),
-            request.priorityClass(),
-            request.persistence(),
-            options.realTimeFlag(),
-            null,
-            request.global());
-    super(
-        requestParams,
-        request.charset(),
-        options,
-        null,
-        request.client(),
-        runtimeSupport,
-        derivePublicURI(requestParams.uri()));
-    UploadFrom uploadFromType = upload.uploadFromType();
-    File uploadOrigFilename = upload.origFilename();
-    String contentType = upload.contentType();
-    String uploadTargetFilename = upload.targetFilename();
-    RandomAccessBucket tempData = upload.data();
-
-    if (uploadFromType == UploadFrom.DISK) {
-      ClientPutDiskUploadValidator.validatePersistentDiskUpload(
-          runtimeSupport.transferAccess(), uploadOrigFilename);
-    }
-
-    this.binaryBlob = upload.binaryBlob();
-    if (this.binaryBlob) contentType = null;
-    this.targetFilename = uploadTargetFilename;
-    this.uploadFrom = uploadFromType;
-    this.origFilename = uploadOrigFilename;
-    // Now go through the fields one at a time
-    String mimeType = contentType;
-    this.clientToken = request.clientToken();
-    ClientMetadata cm = new ClientMetadata(mimeType);
-    if (LOG.isDebugEnabled()) LOG.debug(PERSISTENT_UPLOAD_LOG_TEMPLATE, tempData, uploadFrom);
-    PreparedData preparedData =
-        ClientPutPreparedDataFactory.prepareForPersistentUpload(
-            uploadFrom,
-            cm,
-            tempData,
-            upload.redirectTarget(),
-            runtimeSupport,
-            isPersistentForever());
-    this.data = preparedData.bucket();
-    this.clientMetadata = cm;
-    this.targetURI = preparedData.targetUri();
-    putter =
-        ClientPutPutterFactory.create(
-            runtimeSupport,
-            new ClientPutExecutionSpec(
-                this,
-                requestParams,
-                ctx,
-                data,
-                cm,
-                preparedData.isMetadata(),
-                new ClientPutExecutionSpec.ExecutionOptions(
-                    this.uri.getDocName() == null ? uploadTargetFilename : null,
-                    this.binaryBlob,
-                    options.overrideSplitfileCryptoKey(),
-                    -1)));
-    applyDiagnosticIdentifier(putter.requester());
+    this(ClientPutConstructorSupport.fromPersistentRequest(request, options, upload, server));
   }
 
   /**
@@ -245,144 +173,20 @@ public final class ClientPut extends ClientPutBase {
    */
   public ClientPut(FCPConnectionHandler handler, ClientPutMessage message, FCPServer server)
       throws IdentifierCollisionException, MessageInvalidException, IOException {
-    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
-    FcpInsertOptions options =
-        new FcpInsertOptions(
-            new FcpInsertBehaviorOptions(
-                message.getCHKOnly,
-                message.dontCompress,
-                message.localRequestOnly,
-                message.maxRetries,
-                message.earlyEncode,
-                message.realTimeFlag,
-                message.ignoreUSKDatehints),
-            new FcpInsertTuningOptions(
-                message.canWriteClientCache,
-                message.forkOnCacheable,
-                message.compressorDescriptor,
-                message.extraInsertsSingleBlock,
-                message.extraInsertsSplitfileHeaderBlock,
-                message.compatibilityMode),
-            message.overrideSplitfileCryptoKey);
-    ClientRequestParams requestParams =
-        new ClientRequestParams(
-            checkEmptySSK(message.uri, message.targetFilename, runtimeSupport),
-            ensureConnectionIdentifierAvailable(handler, message),
-            message.verbosity,
-            message.priorityClass,
-            message.persistence,
-            options.realTimeFlag(),
-            message.clientToken,
-            message.global);
-    super(
-        requestParams,
-        null,
-        options,
-        handler,
-        runtimeSupport,
-        derivePublicURI(requestParams.uri()));
-    binaryBlob = message.binaryBlob;
-    TransferAccessPort transferAccess = runtimeSupport.transferAccess();
+    this(ClientPutConstructorSupport.fromMessage(handler, message, server));
+  }
 
-    DiskUploadContext diskContext =
-        ClientPutDiskUploadValidator.validateDiskUpload(
-            transferAccess, handler, message, message.identifier, message.global);
-
-    this.targetFilename = message.targetFilename;
-    this.uploadFrom = message.uploadFromType;
-    this.origFilename = message.origFilename;
-
-    String mimeType =
-        ClientPutMimeResolver.resolve(
-            message,
-            this.origFilename,
-            this.targetFilename,
-            binaryBlob,
-            message.identifier,
-            message.global);
-
-    clientToken = message.clientToken;
-    ClientMetadata cm = new ClientMetadata(mimeType);
-    PreparedData preparedData =
-        ClientPutPreparedDataFactory.prepareForMessage(
-            message, cm, runtimeSupport, isPersistentForever(), uploadFrom, identifier, global);
-    this.data = preparedData.bucket();
-    this.clientMetadata = cm;
-    this.targetURI = preparedData.targetUri();
-
-    ClientPutDiskUploadValidator.verifySaltedHash(diskContext, data, identifier, global);
-
-    if (LOG.isDebugEnabled()) LOG.debug(MESSAGE_UPLOAD_LOG_TEMPLATE, data, uploadFrom);
-    putter =
-        ClientPutPutterFactory.create(
-            runtimeSupport,
-            new ClientPutExecutionSpec(
-                this,
-                requestParams,
-                ctx,
-                data,
-                cm,
-                preparedData.isMetadata(),
-                new ClientPutExecutionSpec.ExecutionOptions(
-                    this.uri.getDocName() == null ? targetFilename : null,
-                    binaryBlob,
-                    message.overrideSplitfileCryptoKey,
-                    message.metadataThreshold)));
+  ClientPut(ClientPutConstructorSupport.Init init) throws IOException {
+    super(init.baseInit());
+    this.uploadFrom = init.uploadFrom();
+    this.origFilename = init.origFilename();
+    this.targetURI = init.targetUri();
+    this.data = init.data();
+    this.clientMetadata = init.clientMetadata();
+    this.targetFilename = init.targetFilename();
+    this.binaryBlob = init.binaryBlob();
+    putter = init.createExecution(this);
     applyDiagnosticIdentifier(putter.requester());
-  }
-
-  /**
-   * Ensures the request identifier is unused within a connection-scoped persistence map.
-   *
-   * @param handler connection handler tracking in-flight requests; must not be {@code null}.
-   * @param message parsed put message containing the requested identifier; must not be {@code
-   *     null}.
-   * @return the validated identifier string when no collision exists.
-   * @throws IdentifierCollisionException when the identifier already exists for the connection.
-   */
-  private static String ensureConnectionIdentifierAvailable(
-      FCPConnectionHandler handler, ClientPutMessage message) throws IdentifierCollisionException {
-    if (message.persistence != Persistence.CONNECTION) {
-      return message.identifier;
-    }
-    if (handler.requestsByIdentifier.containsKey(message.identifier)) {
-      throw new IdentifierCollisionException();
-    }
-    return message.identifier;
-  }
-
-  /**
-   * Ensures the identifier is free within the persistent request client, if present.
-   *
-   * @param client persistent request client, or {@code null} when not applicable.
-   * @param identifier identifier requested by the caller; must not be {@code null}.
-   * @return the identifier when it is not already in use.
-   * @throws IdentifierCollisionException when the identifier already exists in persistence.
-   */
-  private static String ensurePersistentIdentifierAvailable(
-      PersistentRequestClient client, String identifier) throws IdentifierCollisionException {
-    if (client != null && client.getRequest(identifier) != null) {
-      throw new IdentifierCollisionException();
-    }
-    return identifier;
-  }
-
-  /**
-   * Returns whether the request is already marked finished.
-   *
-   * @return {@code true} when the request has completed or failed.
-   */
-  private synchronized boolean isFinishedRequest() {
-    return finished;
-  }
-
-  /**
-   * Determines whether a persistent tag message should be queued now.
-   *
-   * @return {@code true} when persistence is enabled and the request is not finished.
-   */
-  private synchronized boolean shouldQueuePersistentTag() {
-    return persistence != Persistence.CONNECTION && !finished;
   }
 
   /**
@@ -402,6 +206,13 @@ public final class ClientPut extends ClientPutBase {
     finishedSize = 0;
     targetFilename = null;
     binaryBlob = false;
+  }
+
+  private ClientPutLifecycle lifecycle() {
+    if (lifecycle == null) {
+      lifecycle = new ClientPutLifecycle(this);
+    }
+    return lifecycle;
   }
 
   /**
@@ -509,11 +320,7 @@ public final class ClientPut extends ClientPutBase {
 
   @Override
   void register(boolean noTags) throws IdentifierCollisionException {
-    if (persistence != Persistence.CONNECTION) client.register(this);
-    if (persistence != Persistence.CONNECTION && !noTags) {
-      FCPMessage msg = persistentTagMessage();
-      client.queueClientRequestMessage(msg, 0);
-    }
+    lifecycle().register(noTags);
   }
 
   /**
@@ -527,43 +334,12 @@ public final class ClientPut extends ClientPutBase {
    * startup failures are routed through the standard failure handler so retry logic stays
    * consistent.
    *
-   * @param context client execution context providing schedulers, bucket factories, and thread
+   * @param context detached runtime context providing schedulers, bucket factories, and thread
    *     pools; must not be {@code null} and should be the active runtime context.
    */
   @Override
-  public void start(network.crypta.client.async.ClientContext context) {
-    if (LOG.isDebugEnabled()) LOG.debug("Starting {} : {}", this, identifier);
-    if (isFinishedRequest()) {
-      return;
-    }
-    try {
-      putter.start(context);
-      if (shouldQueuePersistentTag()) {
-        FCPMessage msg = persistentTagMessage();
-        client.queueClientRequestMessage(msg, 0);
-      }
-      synchronized (this) {
-        started = true;
-      }
-      if (client != null) {
-        RequestStatusCache cache = client.getRequestStatusCache();
-        if (cache != null) {
-          cache.updateStarted(identifier, true);
-        }
-      }
-    } catch (InsertException e) {
-      synchronized (this) {
-        started = true;
-      }
-      onFailure(e, (FcpInsertCallbackState) null);
-    } catch (Exception t) {
-      synchronized (this) {
-        started = true;
-      }
-      onFailure(
-          new InsertException(InsertException.InsertExceptionMode.INTERNAL_ERROR, t, null),
-          (FcpInsertCallbackState) null);
-    }
+  public void start(PersistentRequestRuntimeContext context) {
+    lifecycle().start(context);
   }
 
   @Override
@@ -760,40 +536,14 @@ public final class ClientPut extends ClientPutBase {
    * FcpInsertCallbackState)} so retry logic remains consistent with the normal start path. The
    * method returns immediately if the request is not eligible for restart.
    *
-   * @param context execution context containing shared schedulers and crypto factories; must not be
-   *     {@code null} and should be active.
+   * @param context detached runtime context containing shared schedulers and crypto factories; must
+   *     not be {@code null} and should be active.
    * @param disableFilterData whether client filtering data should be bypassed for this retry.
    * @return {@code true} when the restart was scheduled successfully; {@code false} otherwise.
    */
   @Override
-  public boolean restart(
-      network.crypta.client.async.ClientContext context, final boolean disableFilterData) {
-    if (!canRestart()) return false;
-    setVarsRestart();
-    try {
-      if (client != null) {
-        RequestStatusCache cache = client.getRequestStatusCache();
-        if (cache != null) {
-          cache.updateStarted(identifier, false);
-        }
-      }
-      if (putter.restart(context)) {
-        synchronized (this) {
-          generatedURI = null;
-          started = true;
-        }
-      }
-      if (client != null) {
-        RequestStatusCache cache = client.getRequestStatusCache();
-        if (cache != null) {
-          cache.updateStarted(identifier, true);
-        }
-      }
-      return true;
-    } catch (InsertException e) {
-      onFailure(e, (FcpInsertCallbackState) null);
-      return false;
-    }
+  public boolean restart(PersistentRequestRuntimeContext context, final boolean disableFilterData) {
+    return lifecycle().restart(context);
   }
 
   /**
@@ -806,13 +556,7 @@ public final class ClientPut extends ClientPutBase {
    */
   @Override
   public synchronized void setVarsRestart() {
-    super.setVarsRestart();
-    if (client != null) {
-      RequestStatusCache cache = client.getRequestStatusCache();
-      if (cache != null) {
-        cache.updateCompressionStatus(identifier, isCompressing());
-      }
-    }
+    lifecycle().setVarsRestart();
   }
 
   /**
@@ -827,11 +571,8 @@ public final class ClientPut extends ClientPutBase {
    *     null}.
    */
   @Override
-  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
-    if (persistence == Persistence.FOREVER) {
-      putter = null;
-    }
-    super.requestWasRemoved(context);
+  public void requestWasRemoved(PersistentRequestRuntimeContext context) {
+    lifecycle().requestWasRemoved(context);
   }
 
   /**
@@ -882,31 +623,12 @@ public final class ClientPut extends ClientPutBase {
 
   @Override
   protected void onStartCompressing() {
-    synchronized (this) {
-      if (compressed) return;
-      compressing = true;
-    }
-    if (client != null) {
-      RequestStatusCache cache = client.getRequestStatusCache();
-      if (cache != null) {
-        cache.updateCompressionStatus(identifier, COMPRESS_STATE.COMPRESSING);
-      }
-    }
+    lifecycle().onStartCompressing();
   }
 
   @Override
   protected void onStopCompressing() {
-    synchronized (this) {
-      if (compressed) return; // Race condition possible
-      compressing = false;
-      compressed = true;
-    }
-    if (client != null) {
-      RequestStatusCache cache = client.getRequestStatusCache();
-      if (cache != null) {
-        cache.updateCompressionStatus(identifier, COMPRESS_STATE.WORKING);
-      }
-    }
+    lifecycle().onStopCompressing();
   }
 
   @Override
@@ -926,8 +648,7 @@ public final class ClientPut extends ClientPutBase {
    * @throws ResumeFailedException If any bucket cannot restore the backing store for reading.
    */
   @Override
-  public void innerResume(network.crypta.client.async.ClientContext context)
-      throws ResumeFailedException {
+  public void innerResume(FcpRequestRuntimeContext context) throws ResumeFailedException {
     if (putter != null) {
       applyDiagnosticIdentifier(putter.requester());
     }
@@ -951,5 +672,30 @@ public final class ClientPut extends ClientPutBase {
   @Override
   public boolean fullyResumed() {
     return false;
+  }
+
+  void resetBaseVarsForRestart() {
+    super.setVarsRestart();
+  }
+
+  void requestWasRemovedBase(PersistentRequestRuntimeContext context) {
+    super.requestWasRemoved(context);
+  }
+
+  synchronized boolean markCompressionStarted() {
+    if (compressed) {
+      return false;
+    }
+    compressing = true;
+    return true;
+  }
+
+  synchronized boolean markCompressionFinished() {
+    if (compressed) {
+      return false;
+    }
+    compressing = false;
+    compressed = true;
+    return true;
   }
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.client.events.ClientEvent;
 import network.crypta.client.events.ClientEventDispatchContext;
 import network.crypta.client.events.ClientEventListener;
@@ -21,6 +22,7 @@ import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.StartedCompressionEvent;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,10 +32,10 @@ import org.slf4j.LoggerFactory;
  * <p>The class centralizes common state tracking for {@link ClientPut} and {@link ClientPutDir},
  * wiring FCP-facing identifiers, scheduling metadata, persistence constraints, and node callbacks
  * into a single state machine. Instances travel through connection-bound and forever-persistent
- * modes, reattaching to {@link network.crypta.client.async.ClientContext ClientContext}s after
- * deserialization, driving insert progress, and translating internal events into client-visible FCP
- * messages. It is designed to be thread-aware: mutations happen under synchronization, while
- * outbound messages are dispatched via handler abstractions to avoid deadlocks.
+ * modes, reattaching to runtime contexts after deserialization, driving insert progress, and
+ * translating internal events into client-visible FCP messages. It is designed to be thread-aware:
+ * mutations happen under synchronization, while outbound messages are dispatched via handler
+ * abstractions to avoid deadlocks.
  *
  * <p>Typical usage involves subclassing to provide data-specific logic (single file or directory
  * tree) while relying on {@code ClientPutBase} to manage retries, metadata capture, and reporting.
@@ -80,8 +82,7 @@ public abstract class ClientPutBase extends ClientRequest
   /**
    * Per-request detached insert-context handle seeded from the node defaults. It carries retry
    * rules, redundancy knobs, and compatibility flags and therefore must be explicitly cleaned up in
-   * {@link #requestWasRemoved(network.crypta.client.async.ClientContext)
-   * requestWasRemoved(ClientContext)} to avoid leaking stale listeners.
+   * {@link #requestWasRemoved(PersistentRequestRuntimeContext)} to avoid leaking stale listeners.
    */
   FcpInsertContextHandle ctx;
 
@@ -217,23 +218,9 @@ public abstract class ClientPutBase extends ClientRequest
       FCPConnectionHandler handler,
       FcpInsertRuntimeSupport runtimeSupport,
       FreenetURI publicURI) {
-    super(prepareConstructorInit(requestParams, handler));
-    warnIfUnsupportedCharset(charset);
-    ctx = runtimeSupport.defaultPersistentInsertContextHandle();
-    ctx.setGetCHKOnly(options.getCHKOnly());
-    ctx.setDontCompress(options.dontCompress());
-    ctx.addEventListener(this);
-    ctx.setMaxInsertRetries(options.maxRetries());
-    ctx.setCanWriteClientCache(options.canWriteClientCache());
-    ctx.setCompressorDescriptor(options.compressorDescriptor());
-    ctx.setForkOnCacheable(options.forkOnCacheable());
-    ctx.setExtraInsertsSingleBlock(options.extraInsertsSingleBlock());
-    ctx.setExtraInsertsSplitfileHeaderBlock(options.extraInsertsSplitfileHeaderBlock());
-    ctx.setCompatibilityMode(options.compatibilityMode());
-    ctx.setLocalRequestOnly(options.localRequestOnly());
-    ctx.setEarlyEncode(options.earlyEncode());
-    ctx.setIgnoreUSKDatehints(options.ignoreUSKDatehints());
-    this.publicURI = publicURI;
+    this(
+        new ClientPutConstructorSupport.BaseInit(
+            requestParams, charset, options, handler, null, runtimeSupport, publicURI));
   }
 
   /**
@@ -290,9 +277,20 @@ public abstract class ClientPutBase extends ClientRequest
       PersistentRequestClient client,
       FcpInsertRuntimeSupport runtimeSupport,
       FreenetURI publicURI) {
-    super(prepareConstructorInit(requestParams, handler, client));
-    warnIfUnsupportedCharset(charset);
-    ctx = runtimeSupport.defaultPersistentInsertContextHandle();
+    this(
+        new ClientPutConstructorSupport.BaseInit(
+            requestParams, charset, options, handler, client, runtimeSupport, publicURI));
+  }
+
+  ClientPutBase(ClientPutConstructorSupport.BaseInit init) {
+    super(
+        init.persistentClient() == null
+            ? prepareConstructorInit(init.requestParams(), init.handler())
+            : prepareConstructorInit(
+                init.requestParams(), init.handler(), init.persistentClient()));
+    warnIfUnsupportedCharset(init.charset());
+    FcpInsertOptions options = init.options();
+    ctx = init.runtimeSupport().defaultPersistentInsertContextHandle();
     ctx.setGetCHKOnly(options.getCHKOnly());
     ctx.setDontCompress(options.dontCompress());
     ctx.addEventListener(this);
@@ -306,7 +304,7 @@ public abstract class ClientPutBase extends ClientRequest
     ctx.setCompatibilityMode(options.compatibilityMode());
     ctx.setIgnoreUSKDatehints(options.ignoreUSKDatehints());
     ctx.setEarlyEncode(options.earlyEncode());
-    this.publicURI = publicURI;
+    this.publicURI = init.publicUri();
   }
 
   /**
@@ -325,18 +323,25 @@ public abstract class ClientPutBase extends ClientRequest
    * leaving persistent ones untouched so they can resume later without extra chatter.
    *
    * <p>The method keeps side effects intentionally small. It does not throw nor block; instead it
-   * simply triggers {@link #cancel(network.crypta.client.async.ClientContext)
-   * cancel(ClientContext)} for requests that were declared {@link Persistence#CONNECTION}.
-   * Persistent and forever requests ignore the event because they expect to be resumed through
-   * their detached requester handle after deserialization.
+   * simply triggers {@link #cancel(PersistentRequestRuntimeContext)} for requests that were
+   * declared {@link Persistence#CONNECTION}. Persistent and forever requests ignore the event
+   * because they expect to be resumed through their detached requester handle after
+   * deserialization.
    *
-   * @param context client context that supplies cancellation helpers and resource pools; the value
-   *     may be reused across many requests and must not be {@code null}
+   * @param context detached runtime context that supplies cancellation helpers and resource pools;
+   *     the value may be reused across many requests and must not be {@code null}
    */
   @Override
-  public void onLostConnection(network.crypta.client.async.ClientContext context) {
+  public void onLostConnection(
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context) {
     if (persistence == Persistence.CONNECTION) cancel(context);
     // otherwise ignore
+  }
+
+  @Override
+  public final void onResume(network.crypta.client.async.ClientContext context)
+      throws network.crypta.support.io.ResumeFailedException {
+    super.onResume(context);
   }
 
   /**
@@ -528,10 +533,12 @@ public abstract class ClientPutBase extends ClientRequest
    * the persistent client queue, frees metadata buckets, and resets URIs and messages when the
    * persistence tier is {@link Persistence#FOREVER} to avoid replaying stale data on requeue.
    *
-   * @param context client context through which cleanup helpers and factories can be reached
+   * @param context detached runtime context through which cleanup helpers and factories can be
+   *     reached
    */
   @Override
-  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
+  public void requestWasRemoved(
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context) {
     if (ctx != null) {
       ctx.removeEventListener(this);
     }
@@ -690,7 +697,7 @@ public abstract class ClientPutBase extends ClientRequest
     }
 
     @Override
-    public String toString() {
+    public @NotNull String toString() {
       return putter.toString();
     }
   }
@@ -1028,8 +1035,7 @@ public abstract class ClientPutBase extends ClientRequest
 
   /**
    * Restores persistent fields during deserialization. Subclasses are expected to rebuild transient
-   * collaborators during {@link #innerResume(network.crypta.client.async.ClientContext)
-   * innerResume(ClientContext)} rather than in this hook.
+   * collaborators during {@link #innerResume(FcpRequestRuntimeContext)} rather than in this hook.
    *
    * @param in source stream containing a previously serialized form of the object
    * @throws IOException when reading fails

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutConstructorSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutConstructorSupport.java
@@ -1,0 +1,388 @@
+package network.crypta.clients.fcp;
+
+import java.io.File;
+import java.io.IOException;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.MetadataUnresolvedException;
+import network.crypta.keys.FreenetURI;
+import network.crypta.support.api.RandomAccessBucket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Assembles detached construction state for {@link ClientPut} before the request instance exists.
+ *
+ * <p>The public {@link ClientPut} constructors accept FCP-facing request models, but the heavy
+ * assembly work they trigger is narrower and fully deterministic: identifier validation, disk/DDA
+ * checks, MIME resolution, redirect metadata preparation, and creation of the live single-file
+ * execution. This helper isolates that constructor-only responsibility so {@code ClientPut} itself
+ * can stay focused on request state, serialization, and public accessors.
+ *
+ * <p>The support class is intentionally stateless. Callers use one of the static factory methods to
+ * convert validated FCP inputs into an immutable {@link Init} bundle, then hand that bundle to the
+ * package-private {@link ClientPut} constructor. No request lifecycle state is retained here after
+ * the bundle is created, which keeps construction replayable and easier to reason about during
+ * persistence restores.
+ *
+ * <p>In practice this helper is the boundary between protocol parsing and request ownership. By the
+ * time one of its factory methods returns, the insert identifier has been checked, disk-access
+ * rules have been enforced, upload metadata has been normalized, and the detached execution inputs
+ * have been assembled in the exact shape that {@link ClientPutBase} and {@link ClientPut} expect.
+ * That separation reduces constructor sprawl without changing the observable behavior of FCP PUT
+ * requests.
+ */
+final class ClientPutConstructorSupport {
+  /**
+   * Logger used only for construction-time diagnostics while the upload state is being prepared.
+   */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientPutConstructorSupport.class);
+
+  /** Debugging template for persistent uploads to log bucket identity and source. */
+  private static final String PERSISTENT_UPLOAD_LOG_TEMPLATE =
+      "Prepared persistent upload data: data = {}, uploadFrom = {}";
+
+  /** Debugging template for message-based uploads to log bucket identity and source. */
+  private static final String MESSAGE_UPLOAD_LOG_TEMPLATE =
+      "Prepared message upload data: data = {}, uploadFrom = {}";
+
+  /** Prevents instantiation; this type exposes only static constructor-support utilities. */
+  private ClientPutConstructorSupport() {}
+
+  /**
+   * Immutable construction bundle for the package-private {@link ClientPut} constructor.
+   *
+   * <p>The bundle carries both the base-request initialization data and the prepared single-file
+   * insert state that must be installed on the concrete request once it exists. It also retains the
+   * detached execution inputs needed to create the live {@link ClientPutExecution} after the
+   * request has initialized its inherited context state.
+   *
+   * <p>The record deliberately separates "base" request state from the upload-specific pieces that
+   * only {@link ClientPut} owns. That split lets {@link ClientPutBase} rebuild its insert context
+   * and persistence identity first, then lets {@link ClientPut} install the prepared bucket,
+   * metadata, URI, and execution details in one place.
+   *
+   * @param baseInit detached base-request inputs consumed by {@link ClientPutBase}
+   * @param uploadFrom original upload source classification that drives later reporting and cleanup
+   * @param origFilename source filename for disk-backed uploads, or {@code null} when not
+   *     applicable
+   * @param targetUri normalized insert or redirect URI selected for the request
+   * @param data prepared request-owned bucket containing upload or metadata bytes
+   * @param clientMetadata normalized MIME metadata associated with the prepared upload
+   * @param targetFilename requested target filename used for metadata and persistent tags
+   * @param binaryBlob whether the request should run in Binary Blob mode
+   * @param metadataBucket whether {@code data} contains metadata rather than raw upload content
+   * @param executionOptions detached execution knobs passed to the runtime putter factory
+   * @param runtimeSupport runtime seam used to instantiate the live execution after the request
+   *     object exists
+   */
+  record Init(
+      BaseInit baseInit,
+      ClientPutBase.UploadFrom uploadFrom,
+      File origFilename,
+      FreenetURI targetUri,
+      RandomAccessBucket data,
+      ClientMetadata clientMetadata,
+      String targetFilename,
+      boolean binaryBlob,
+      boolean metadataBucket,
+      ClientPutExecutionSpec.ExecutionOptions executionOptions,
+      FcpInsertRuntimeSupport runtimeSupport) {
+
+    /**
+     * Creates the live runtime-backed single-file execution for a fully initialized request.
+     *
+     * <p>Callers invoke this only after {@link ClientPutBase} has restored the detached insert
+     * context and the concrete {@link ClientPut} instance has copied all record fields onto itself.
+     * The method then assembles the bridge-owned {@link ClientPutExecutionSpec} and delegates to
+     * {@link ClientPutPutterFactory}, preserving the same runtime construction order as the former
+     * in-constructor logic.
+     *
+     * @param request concrete request that will own the returned execution and receive its
+     *     callbacks
+     * @return live execution handle ready to be stored on {@code request}
+     * @throws IOException if the runtime putter cannot be created from the prepared state
+     */
+    ClientPutExecution createExecution(ClientPut request) throws IOException {
+      return ClientPutPutterFactory.create(
+          runtimeSupport,
+          new ClientPutExecutionSpec(
+              request,
+              baseInit.requestParams(),
+              request.ctx,
+              data,
+              clientMetadata,
+              metadataBucket,
+              executionOptions));
+    }
+  }
+
+  /**
+   * Immutable base-constructor input bundle consumed by {@link ClientPutBase}.
+   *
+   * <p>The record groups the detached request parameters, charset, insert options, runtime support,
+   * and either a connection handler or persistent client owner. That lets {@link ClientPutBase}
+   * reconstruct its shared state without forcing {@link ClientPut} to keep all constructor-only
+   * dependencies in its own type surface.
+   *
+   * @param requestParams detached request identity and persistence parameters
+   * @param charset optional charset hint supplied for metadata generation
+   * @param options detached insert options that should be copied onto the insert context handle
+   * @param handler connection owner for connection-scoped requests, or {@code null} when the
+   *     request is already persistent
+   * @param persistentClient persistent owner for reboot/forever requests, or {@code null} for
+   *     connection-scoped requests
+   * @param runtimeSupport runtime seam used to get factories and default insert context state
+   * @param publicUri precomputed request URI corresponding to the insert URI used by this request
+   */
+  record BaseInit(
+      ClientRequestParams requestParams,
+      String charset,
+      FcpInsertOptions options,
+      FCPConnectionHandler handler,
+      PersistentRequestClient persistentClient,
+      FcpInsertRuntimeSupport runtimeSupport,
+      FreenetURI publicUri) {}
+
+  /**
+   * Builds a detached constructor bundle for a persistent single-file insert request.
+   *
+   * <p>This path is used when a request already has a persistent owner and an upload description
+   * assembled outside the normal socket-message flow. The method validates identifier reuse,
+   * normalizes MIME and Binary Blob handling, performs any required persistent disk checks, and
+   * prepares the request-owned upload bucket or redirect metadata. The returned {@link Init} can be
+   * handed directly to the package-private {@link ClientPut} constructor.
+   *
+   * @param request persistent insert request definition including owner, identifier, and request
+   *     flags
+   * @param options detached insert options that will later be copied onto the request's insert
+   *     context handle
+   * @param upload normalized upload description containing the source bucket, filename, and
+   *     redirect information
+   * @param server FCP server used to resolve the insert runtime support seam
+   * @return immutable constructor bundle containing a prepared request and execution state
+   * @throws IdentifierCollisionException if the persistent owner already has a request with the
+   *     same identifier
+   * @throws NotAllowedException if the upload configuration violates the persistent disk-access
+   *     policy
+   * @throws MetadataUnresolvedException if redirect or metadata preparation cannot complete
+   * @throws IOException if bucket preparation or request setup fails
+   */
+  static Init fromPersistentRequest(
+      FcpInsertRequest request, FcpInsertOptions options, ClientPutUpload upload, FCPServer server)
+      throws IdentifierCollisionException,
+          NotAllowedException,
+          MetadataUnresolvedException,
+          IOException {
+    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            ClientPutBase.checkEmptySSK(request.uri(), upload.targetFilename(), runtimeSupport),
+            ensurePersistentIdentifierAvailable(request.client(), request.identifier()),
+            request.verbosity(),
+            request.priorityClass(),
+            request.persistence(),
+            options.realTimeFlag(),
+            request.clientToken(),
+            request.global());
+    BaseInit baseInit =
+        new BaseInit(
+            requestParams,
+            request.charset(),
+            options,
+            null,
+            request.client(),
+            runtimeSupport,
+            ClientPutBase.derivePublicURI(requestParams.uri()));
+
+    ClientPutBase.UploadFrom uploadFromType = upload.uploadFromType();
+    File uploadOrigFilename = upload.origFilename();
+    String contentType = upload.contentType();
+    String uploadTargetFilename = upload.targetFilename();
+    RandomAccessBucket tempData = upload.data();
+    boolean binaryBlob = upload.binaryBlob();
+
+    if (uploadFromType == ClientPutBase.UploadFrom.DISK) {
+      ClientPutDiskUploadValidator.validatePersistentDiskUpload(
+          runtimeSupport.transferAccess(), uploadOrigFilename);
+    }
+
+    if (binaryBlob) {
+      contentType = null;
+    }
+    ClientMetadata clientMetadata = new ClientMetadata(contentType);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(PERSISTENT_UPLOAD_LOG_TEMPLATE, tempData, uploadFromType);
+    }
+    PreparedData preparedData =
+        ClientPutPreparedDataFactory.prepareForPersistentUpload(
+            uploadFromType,
+            clientMetadata,
+            tempData,
+            upload.redirectTarget(),
+            runtimeSupport,
+            requestParams.persistence() == ClientRequest.Persistence.FOREVER);
+    return new Init(
+        baseInit,
+        uploadFromType,
+        uploadOrigFilename,
+        preparedData.targetUri(),
+        preparedData.bucket(),
+        clientMetadata,
+        uploadTargetFilename,
+        binaryBlob,
+        preparedData.isMetadata(),
+        new ClientPutExecutionSpec.ExecutionOptions(
+            requestParams.uri().getDocName() == null ? uploadTargetFilename : null,
+            binaryBlob,
+            options.overrideSplitfileCryptoKey(),
+            -1L),
+        runtimeSupport);
+  }
+
+  /**
+   * Builds a detached constructor bundle for a message-driven single-file insert request.
+   *
+   * <p>This path starts from the parsed {@link ClientPutMessage} sent over an active FCP
+   * connection. It reconstructs the detached insert options, validates connection-scoped identifier
+   * reuse, applies disk-access checks, resolves MIME handling, prepares the request bucket, and
+   * verifies any salted-hash constraint supplied by the client. The result is the same immutable
+   * {@link Init} shape used by the persistent-request path, which keeps later request construction
+   * uniform.
+   *
+   * @param handler connection handler that owns the request while the message is being processed
+   * @param message parsed FCP PUT message containing user-supplied options and upload data
+   * @param server FCP server used to resolve the insert runtime support seam
+   * @return immutable constructor bundle containing a prepared request and execution state
+   * @throws IdentifierCollisionException if the connection already owns a request with the same
+   *     identifier
+   * @throws MessageInvalidException if the message violates disk-access or request validation rules
+   * @throws IOException if bucket preparation or salted-hash verification fails
+   */
+  static Init fromMessage(FCPConnectionHandler handler, ClientPutMessage message, FCPServer server)
+      throws IdentifierCollisionException, MessageInvalidException, IOException {
+    FcpInsertRuntimeSupport runtimeSupport = server.insertRuntimeSupport();
+    FcpInsertOptions options =
+        new FcpInsertOptions(
+            new FcpInsertBehaviorOptions(
+                message.getCHKOnly,
+                message.dontCompress,
+                message.localRequestOnly,
+                message.maxRetries,
+                message.earlyEncode,
+                message.realTimeFlag,
+                message.ignoreUSKDatehints),
+            new FcpInsertTuningOptions(
+                message.canWriteClientCache,
+                message.forkOnCacheable,
+                message.compressorDescriptor,
+                message.extraInsertsSingleBlock,
+                message.extraInsertsSplitfileHeaderBlock,
+                message.compatibilityMode),
+            message.overrideSplitfileCryptoKey);
+    ClientRequestParams requestParams =
+        new ClientRequestParams(
+            ClientPutBase.checkEmptySSK(message.uri, message.targetFilename, runtimeSupport),
+            ensureConnectionIdentifierAvailable(handler, message),
+            message.verbosity,
+            message.priorityClass,
+            message.persistence,
+            options.realTimeFlag(),
+            message.clientToken,
+            message.global);
+    BaseInit baseInit =
+        new BaseInit(
+            requestParams,
+            null,
+            options,
+            handler,
+            null,
+            runtimeSupport,
+            ClientPutBase.derivePublicURI(requestParams.uri()));
+
+    boolean binaryBlob = message.binaryBlob;
+    DiskUploadContext diskContext =
+        ClientPutDiskUploadValidator.validateDiskUpload(
+            runtimeSupport.transferAccess(), handler, message, message.identifier, message.global);
+
+    String targetFilename = message.targetFilename;
+    ClientPutBase.UploadFrom uploadFrom = message.uploadFromType;
+    File origFilename = message.origFilename;
+    String mimeType =
+        ClientPutMimeResolver.resolve(
+            message, origFilename, targetFilename, binaryBlob, message.identifier, message.global);
+
+    ClientMetadata clientMetadata = new ClientMetadata(mimeType);
+    PreparedData preparedData =
+        ClientPutPreparedDataFactory.prepareForMessage(
+            message,
+            clientMetadata,
+            runtimeSupport,
+            requestParams.persistence() == ClientRequest.Persistence.FOREVER,
+            uploadFrom,
+            requestParams.identifier(),
+            requestParams.global());
+    RandomAccessBucket data = preparedData.bucket();
+    ClientPutDiskUploadValidator.verifySaltedHash(
+        diskContext, data, requestParams.identifier(), requestParams.global());
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(MESSAGE_UPLOAD_LOG_TEMPLATE, data, uploadFrom);
+    }
+    return new Init(
+        baseInit,
+        uploadFrom,
+        origFilename,
+        preparedData.targetUri(),
+        data,
+        clientMetadata,
+        targetFilename,
+        binaryBlob,
+        preparedData.isMetadata(),
+        new ClientPutExecutionSpec.ExecutionOptions(
+            requestParams.uri().getDocName() == null ? targetFilename : null,
+            binaryBlob,
+            message.overrideSplitfileCryptoKey,
+            message.metadataThreshold),
+        runtimeSupport);
+  }
+
+  /**
+   * Ensures that a connection-scoped PUT identifier is unique on the owning socket.
+   *
+   * <p>Only {@link ClientRequest.Persistence#CONNECTION} requests need this check because
+   * persistent owners track reboot and forever requests instead of the live handler map.
+   *
+   * @param handler connection handler that owns the in-flight request map
+   * @param message parsed PUT message carrying the requested identifier and persistence mode
+   * @return the identifier when it is valid for the current handler state
+   * @throws IdentifierCollisionException if the handler already owns a request with the same
+   *     identifier
+   */
+  private static String ensureConnectionIdentifierAvailable(
+      FCPConnectionHandler handler, ClientPutMessage message) throws IdentifierCollisionException {
+    if (message.persistence != ClientRequest.Persistence.CONNECTION) {
+      return message.identifier;
+    }
+    if (handler.requestsByIdentifier.containsKey(message.identifier)) {
+      throw new IdentifierCollisionException();
+    }
+    return message.identifier;
+  }
+
+  /**
+   * Ensures that a persistent request identifier is unique for the owning client.
+   *
+   * @param client persistent request owner, or {@code null} when no persistent owner is involved
+   * @param identifier identifier requested for the new persistent insert
+   * @return the identifier when no existing persistent request already owns it
+   * @throws IdentifierCollisionException if {@code client} already has a request with the same
+   *     identifier
+   */
+  private static String ensurePersistentIdentifierAvailable(
+      PersistentRequestClient client, String identifier) throws IdentifierCollisionException {
+    if (client != null && client.getRequest(identifier) != null) {
+      throw new IdentifierCollisionException();
+    }
+    return identifier;
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDir.java
@@ -12,6 +12,7 @@ import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.ManifestElement;
@@ -28,15 +29,15 @@ import org.slf4j.LoggerFactory;
  * re-enumerating the source tree. Typical callers construct this class either from a {@link
  * ClientPutDirMessage} delivered by the network stack or from an on-disk directory chosen by an
  * operator, register it with a {@code PersistentRequestClient}, and finally invoke {@link
- * #start(network.crypta.client.async.ClientContext)} to launch the asynchronous transfer. The
- * object records defaults such as the preferred manifest name, cryptographic overrides, persistence
- * flavor, and file counts so that serialized requests can survive node restarts.
+ * #start(PersistentRequestRuntimeContext)} to launch the asynchronous transfer. The object records
+ * defaults such as the preferred manifest name, cryptographic overrides, persistence flavor, and
+ * file counts so that serialized requests can survive node restarts.
  *
  * <p>The class is not thread-safe; the owning request scheduler must serialize calls such as {@link
- * #start(network.crypta.client.async.ClientContext)}, {@link
- * #restart(network.crypta.client.async.ClientContext, boolean)}, and {@link
- * #requestWasRemoved(network.crypta.client.async.ClientContext)}. Internal caches are mutable until
- * {@link #freeData()} runs, after which the manifest tree is eligible for garbage collection.
+ * #start(PersistentRequestRuntimeContext)}, {@link #restart(PersistentRequestRuntimeContext,
+ * boolean)}, and {@link #requestWasRemoved(PersistentRequestRuntimeContext)}. Internal caches are
+ * mutable until {@link #freeData()} runs, after which the manifest tree is eligible for garbage
+ * collection.
  *
  * <ul>
  *   <li>Builds manifests from disk or pre-parsed maps.
@@ -105,12 +106,12 @@ public final class ClientPutDir extends ClientPutBase {
    * manifest tree locally, wires persistence, throttling, and crypto settings as requested, and
    * instantiates the backing {@link ClientPutDirExecution} so file counts and total sizes are
    * available for quick replies. Typical callers construct the object, register it with the
-   * persistent client cache, and then call {@link #start(network.crypta.client.async.ClientContext)
-   * start(ClientContext)} to launch asynchronous transmission toward peers.
+   * persistent client cache, and then call {@link #start(PersistentRequestRuntimeContext)} to
+   * launch asynchronous transmission toward peers.
    *
    * <pre>{@code
    * var request = new ClientPutDir(handler, msg, msg.manifest, false, server);
-   * request.start(core.getClientContext());
+   * request.start(server.serverRuntimeSupport().persistentRequestRuntimeContext());
    * }</pre>
    *
    * @param handler the connection handler responsible for routing progress replies to the caller.
@@ -200,8 +201,8 @@ public final class ClientPutDir extends ClientPutBase {
    * registered with a {@link PersistentRequestClient}. The constructor immediately counts files and
    * bytes, so progress meters have deterministic totals, and it captures the optional override
    * splitfile key for callers who precompute keys. After construction, invoke {@link
-   * #start(network.crypta.client.async.ClientContext) start(ClientContext)} to stream blocks while
-   * leveraging the provided {@link FCPServer}.
+   * #start(PersistentRequestRuntimeContext)} to stream blocks while leveraging the provided {@link
+   * FCPServer}.
    *
    * <pre>{@code
    * var request =
@@ -223,7 +224,7 @@ public final class ClientPutDir extends ClientPutBase {
    *         false,
    *         false,
    *         core);
-   * request.start(core.getClientContext());
+   * request.start(server.serverRuntimeSupport().persistentRequestRuntimeContext());
    * }</pre>
    *
    * @param request persistent insert request metadata for the directory insert.
@@ -422,14 +423,15 @@ public final class ClientPutDir extends ClientPutBase {
    * <p>The method is idempotent: repeated calls after the first successful start are ignored. It
    * configures the request cache so that CALL/RESULT messages reflect the running state, queues a
    * persistent tag message when applicable, and handles {@link InsertException}s by reporting
-   * immediate failure. Callers should provide the same {@link
-   * network.crypta.client.async.ClientContext ClientContext} used during construction so caches,
-   * thread pools, and retry policies remain consistent.
+   * immediate failure. Callers should provide the same detached runtime context used during
+   * construction so caches, thread pools, and retry policies remain consistent.
    *
-   * @param context client context supplying thread pools and scheduler knobs for this transfer.
+   * @param context detached runtime context supplying thread pools and scheduler knobs for this
+   *     transfer.
    */
   @Override
-  public void start(network.crypta.client.async.ClientContext context) {
+  public void start(
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context) {
     if (finished) return;
     if (started) return;
     try {
@@ -580,7 +582,7 @@ public final class ClientPutDir extends ClientPutBase {
    * <p>The method blocks restarts while work is still running or after success, only allowing
    * retries for finished-but-failed requests. It also emits debug logging so operators can diagnose
    * why a restart attempt was rejected. Callers should check this flag before invoking {@link
-   * #restart(network.crypta.client.async.ClientContext, boolean) restart(ClientContext, boolean)}.
+   * #restart(PersistentRequestRuntimeContext, boolean)}.
    *
    * @return {@code true} when the request is finished, not successful, and eligible for restart.
    */
@@ -607,13 +609,14 @@ public final class ClientPutDir extends ClientPutBase {
    * any updated splitfile key. If the bridge reports an {@link InsertException}, the method aborts
    * and surfaces the failure through the usual request path.
    *
-   * @param context client context used for thread pools, throttling, and crypto settings.
+   * @param context detached runtime context used for thread pools, throttling, and crypto settings.
    * @param disableFilterData ignored flag maintained for backwards compatibility with filters.
    * @return {@code true} when the restart was scheduled; {@code false} if prerequisites failed.
    */
   @Override
   public boolean restart(
-      network.crypta.client.async.ClientContext context, final boolean disableFilterData) {
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context,
+      final boolean disableFilterData) {
     if (!canRestart()) return false;
     setVarsRestart();
     if (client != null) {
@@ -654,10 +657,11 @@ public final class ClientPutDir extends ClientPutBase {
    * superclass observes the event as well, ensuring that shared bookkeeping such as rate limiting
    * and identifier mappings stay consistent.
    *
-   * @param context client context associated with the scheduler issuing the removal.
+   * @param context detached runtime context associated with the scheduler issuing the removal.
    */
   @Override
-  public void requestWasRemoved(network.crypta.client.async.ClientContext context) {
+  public void requestWasRemoved(
+      network.crypta.client.async.persistence.PersistentRequestRuntimeContext context) {
     if (persistence == Persistence.FOREVER) {
       putter = null;
     }
@@ -695,22 +699,19 @@ public final class ClientPutDir extends ClientPutBase {
   }
 
   /**
-   * Reattaches persisted manifests to a live {@link network.crypta.client.async.ClientContext
-   * ClientContext} during resume sequences.
+   * Reattaches persisted manifests to the detached request runtime context during resume sequences.
    *
    * <p>The method delegates to {@link ClientPutDirExecution#resumeMetadata(Map,
-   * network.crypta.client.async.ClientContext)}, which rebuilds transient metadata for each {@link
-   * ManifestElement} so the putter can continue where it left off. Any metadata mismatch triggers a
-   * {@link ResumeFailedException}, signaling that the request should be abandoned or rebuilt from
-   * disk.
+   * FcpRequestRuntimeContext)}, which rebuilds transient metadata for each {@link ManifestElement}
+   * so the putter can continue where it left off. Any metadata mismatch triggers a {@link
+   * ResumeFailedException}, signaling that the request should be abandoned or rebuilt from disk.
    *
    * @param context context supplying the memory pools and cryptographic providers required for
    *     resumed manifests.
    * @throws ResumeFailedException if the persisted manifest cannot be revalidated or restored.
    */
   @Override
-  public void innerResume(network.crypta.client.async.ClientContext context)
-      throws ResumeFailedException {
+  public void innerResume(FcpRequestRuntimeContext context) throws ResumeFailedException {
     if (putter != null) {
       putter.resumeMetadata(manifestElements, context);
     }
@@ -725,9 +726,9 @@ public final class ClientPutDir extends ClientPutBase {
    * Indicates whether every component of the request has been fully restored after resuming.
    *
    * <p>Directory inserts currently resume lazily, rebuilding manifest metadata only when {@link
-   * #innerResume(network.crypta.client.async.ClientContext) innerResume(ClientContext)} is invoked
-   * later in the lifecycle. Consequently, this method always returns {@code false}, signaling to
-   * higher layers that additional resume work may be pending.
+   * #innerResume(FcpRequestRuntimeContext)} is invoked later in the lifecycle. Consequently, this
+   * method always returns {@code false}, signaling to higher layers that additional resume work may
+   * be pending.
    *
    * @return always {@code false} because manifest metadata is resumed incrementally.
    */

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutDirExecution.java
@@ -60,16 +60,16 @@ public interface ClientPutDirExecution extends ClientPutExecution {
    * <p>Persistent directory inserts can survive JVM restarts, but nested manifest elements may need
    * to reopen buckets or rebuild runtime-owned metadata before insertion can continue. The adapter
    * calls this hook during request resume, passing the request-owned manifest tree and the current
-   * client context so the bridge can restore that transient state without leaking runtime types
-   * back into the adapter layer.
+   * detached request runtime context so the bridge can restore that transient state without leaking
+   * runtime types back into the adapter layer.
    *
    * @param manifestElements request-owned manifest tree whose elements should be reattached to live
    *     runtime state
-   * @param context live client context that provides resume-time factories and services
+   * @param context detached request runtime context that provides resume-time factories and
+   *     services
    * @throws ResumeFailedException if any manifest element cannot restore the required transient
    *     runtime state
    */
-  void resumeMetadata(
-      Map<String, Object> manifestElements, network.crypta.client.async.ClientContext context)
+  void resumeMetadata(Map<String, Object> manifestElements, FcpRequestRuntimeContext context)
       throws ResumeFailedException;
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecution.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutExecution.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp;
 
 import java.io.Serializable;
 import network.crypta.client.InsertException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 
 /**
  * Opaque adapter-owned handle for one live single-file insert execution.
@@ -51,10 +52,11 @@ public interface ClientPutExecution extends Serializable {
    * insert. Implementations should schedule the underlying work promptly and report any immediate
    * start-up validation failures through the declared exception.
    *
-   * @param context live client context that provides schedulers, randomness, and persistence hooks
+   * @param context detached runtime context that provides schedulers, randomness, and persistence
+   *     hooks
    * @throws InsertException if the insert cannot be started with the supplied runtime state
    */
-  void start(network.crypta.client.async.ClientContext context) throws InsertException;
+  void start(PersistentRequestRuntimeContext context) throws InsertException;
 
   /**
    * Returns whether the current execution can be restarted.
@@ -63,8 +65,8 @@ public interface ClientPutExecution extends Serializable {
    * restart attempt to succeed. The adapter uses it to decide whether a finished failed request
    * should offer a retry path.
    *
-   * @return {@code true} when a later call to {@link
-   *     #restart(network.crypta.client.async.ClientContext)} may succeed
+   * @return {@code true} when a later call to {@link #restart(PersistentRequestRuntimeContext)} may
+   *     succeed
    */
   boolean canRestart();
 
@@ -75,11 +77,11 @@ public interface ClientPutExecution extends Serializable {
    * inserter behind the seam. Callers expect the restart to preserve the user-visible FCP request
    * semantics for the surrounding {@link ClientPut}.
    *
-   * @param context live client context to use for the restart attempt
+   * @param context detached runtime context to use for the restart attempt
    * @return {@code true} when the restart was scheduled successfully
    * @throws InsertException if the restart cannot be scheduled
    */
-  boolean restart(network.crypta.client.async.ClientContext context) throws InsertException;
+  boolean restart(PersistentRequestRuntimeContext context) throws InsertException;
 
   /**
    * Returns the splitfile crypto key currently associated with this execution, if any.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutLifecycle.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutLifecycle.java
@@ -1,0 +1,215 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.InsertException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies request-lifecycle bookkeeping for a single {@link ClientPut}.
+ *
+ * <p>{@link ClientPut} still owns the mutable insert state, Java-serialization hooks, and
+ * user-visible accessors. This helper isolates the queue-oriented lifecycle transitions that
+ * surround the live insert execution: registration, start, restart, compression-state cache
+ * updates, and final removal from persistent queues. Keeping those transitions together trims the
+ * request class without changing the observable behavior of FCP inserts.
+ *
+ * <p>The helper is request-bound and intentionally state-free beyond the request reference. Callers
+ * create one helper per request and delegate lifecycle entry points to it; the helper in turn
+ * mutates only the owning request and its related caches.
+ */
+final class ClientPutLifecycle {
+  /** Logger used for low-volume lifecycle diagnostics around start and restart transitions. */
+  private static final Logger LOG = LoggerFactory.getLogger(ClientPutLifecycle.class);
+
+  /** Request whose mutable state and caches are updated by this helper. */
+  private final ClientPut request;
+
+  /**
+   * Creates a lifecycle helper bound to one request instance.
+   *
+   * @param request request whose queue-facing lifecycle transitions should be coordinated
+   */
+  ClientPutLifecycle(ClientPut request) {
+    this.request = request;
+  }
+
+  /**
+   * Registers the request with its persistent owner and optionally queues the first persistent tag.
+   *
+   * <p>Connection-scoped inserts are already owned by the live socket and therefore skip
+   * persistent-client registration. Reboot and forever requests must be registered immediately so
+   * the owner can track identifier uniqueness and replay messages to reconnecting clients.
+   *
+   * @param noTags {@code true} to suppress the initial persistent-tag message after registration
+   * @throws IdentifierCollisionException if the persistent owner already tracks the identifier
+   */
+  void register(boolean noTags) throws IdentifierCollisionException {
+    if (request.persistence != ClientRequest.Persistence.CONNECTION) {
+      request.client.register(request);
+    }
+    if (request.persistence != ClientRequest.Persistence.CONNECTION && !noTags) {
+      FCPMessage msg = request.persistentTagMessage();
+      request.client.queueClientRequestMessage(msg, 0);
+    }
+  }
+
+  /**
+   * Starts the live insert execution and synchronizes queue-side bookkeeping around that start.
+   *
+   * <p>The helper preserves the existing request behavior: terminal requests are ignored, the live
+   * execution is started exactly once per entry, persistent requests may queue a tag message, and
+   * the started flag and request-status cache are updated on both success and failure paths. Any
+   * synchronous start failure is normalized through {@link ClientPut#onFailure(InsertException,
+   * FcpInsertCallbackState)} so client-visible error reporting does not change.
+   *
+   * @param context detached runtime context passed through to the live execution start path
+   */
+  void start(PersistentRequestRuntimeContext context) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Starting {} : {}", request, request.identifier);
+    }
+    synchronized (request) {
+      if (request.finished) {
+        return;
+      }
+    }
+    try {
+      request.putter.start(context);
+      synchronized (request) {
+        if (request.persistence != ClientRequest.Persistence.CONNECTION && !request.finished) {
+          FCPMessage msg = request.persistentTagMessage();
+          request.client.queueClientRequestMessage(msg, 0);
+        }
+        request.started = true;
+      }
+      RequestStatusCache cache = requestStatusCache();
+      if (cache != null) {
+        cache.updateStarted(request.identifier, true);
+      }
+    } catch (InsertException e) {
+      synchronized (request) {
+        request.started = true;
+      }
+      request.onFailure(e, (FcpInsertCallbackState) null);
+    } catch (Exception t) {
+      synchronized (request) {
+        request.started = true;
+      }
+      request.onFailure(
+          new InsertException(InsertException.InsertExceptionMode.INTERNAL_ERROR, t, null),
+          (FcpInsertCallbackState) null);
+    }
+  }
+
+  /**
+   * Restarts a finished insert attempt when the underlying execution still supports restart.
+   *
+   * <p>The helper first resets the request-owned restart state, then updates the status cache to
+   * show a stop/start transition around the restart call. A successful restart clears the generated
+   * URI and marks the request as started again. Insert failures are reported through the existing
+   * failure path, so persistent queues and clients observe the same behavior as before the helper
+   * extraction.
+   *
+   * @param context detached runtime context passed through to the live execution restart path
+   * @return {@code true} when the restart path was accepted and executed without synchronous
+   *     failure; otherwise {@code false}
+   */
+  boolean restart(PersistentRequestRuntimeContext context) {
+    if (!request.canRestart()) {
+      return false;
+    }
+    setVarsRestart();
+    try {
+      RequestStatusCache cache = requestStatusCache();
+      if (cache != null) {
+        cache.updateStarted(request.identifier, false);
+      }
+      if (request.putter.restart(context)) {
+        synchronized (request) {
+          request.generatedURI = null;
+          request.started = true;
+        }
+      }
+      if (cache != null) {
+        cache.updateStarted(request.identifier, true);
+      }
+      return true;
+    } catch (InsertException e) {
+      request.onFailure(e, (FcpInsertCallbackState) null);
+      return false;
+    }
+  }
+
+  /**
+   * Resets request-owned restart state and refreshes compression status in the request cache.
+   *
+   * <p>This keeps the cache aligned with the request's internal compression state before a restart
+   * attempt is made, even if the later restart fails synchronously.
+   */
+  void setVarsRestart() {
+    request.resetBaseVarsForRestart();
+    RequestStatusCache cache = requestStatusCache();
+    if (cache != null) {
+      cache.updateCompressionStatus(request.identifier, request.isCompressing());
+    }
+  }
+
+  /**
+   * Applies final request cleanup when the request is removed from persistent ownership.
+   *
+   * <p>Forever-persistent requests drop their live putter reference because that execution is not
+   * meaningful once the durable request has been removed. The helper then delegates to the base
+   * removal hook, so common insert cleanup still runs.
+   *
+   * @param context detached runtime context supplied by the removal path
+   */
+  void requestWasRemoved(PersistentRequestRuntimeContext context) {
+    if (request.persistence == ClientRequest.Persistence.FOREVER) {
+      request.putter = null;
+    }
+    request.requestWasRemovedBase(context);
+  }
+
+  /**
+   * Records that compression work has started and mirrors that state into the request cache.
+   *
+   * <p>The update is idempotent. If the request already recorded a terminal compression state, this
+   * method returns without emitting another cache update.
+   */
+  void onStartCompressing() {
+    if (!request.markCompressionStarted()) {
+      return;
+    }
+    RequestStatusCache cache = requestStatusCache();
+    if (cache != null) {
+      cache.updateCompressionStatus(request.identifier, ClientPut.COMPRESS_STATE.COMPRESSING);
+    }
+  }
+
+  /**
+   * Records that compression work has completed and mirrors that state into the request cache.
+   *
+   * <p>The helper only emits the cache transition once, even if multiple completion signals arrive
+   * because of legacy callback ordering.
+   */
+  void onStopCompressing() {
+    if (!request.markCompressionFinished()) {
+      return;
+    }
+    RequestStatusCache cache = requestStatusCache();
+    if (cache != null) {
+      cache.updateCompressionStatus(request.identifier, ClientPut.COMPRESS_STATE.WORKING);
+    }
+  }
+
+  /**
+   * Returns the request-status cache associated with the current persistent client, if any.
+   *
+   * @return request-status cache for this request's owner, or {@code null} when the request is not
+   *     currently attached to a persistent client
+   */
+  private RequestStatusCache requestStatusCache() {
+    return request.client == null ? null : request.client.getRequestStatusCache();
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientRequest.java
@@ -6,18 +6,24 @@ import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Locale;
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
+import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestCoordinatorContext;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.CryptoResumeContext;
+import network.crypta.crypt.MasterSecret;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.PrioRunnable;
 import network.crypta.node.RequestClient;
 import network.crypta.node.RequestClientBuilder;
+import network.crypta.support.api.ResumeContext;
 import network.crypta.support.io.NativeThread;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentFilenameGenerator;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
 import org.slf4j.Logger;
@@ -38,7 +44,7 @@ import static network.crypta.clients.fcp.RequestIdentifier.RequestType.GET;
  * <p>Requests may be connection-bound, reboot-persistent, or fully persistent on disk. Each
  * instance keeps a stable identifier, priority class, client token, and statistics that are used
  * for progress reporting and scheduling. Implementations are typically confined to the owning
- * {@link ClientContext} and must be safe to invoke from the node's worker threads.
+ * runtime context and must be safe to invoke from the node's worker threads.
  *
  * <ul>
  *   <li>Tracks client-visible metadata such as identifiers, tokens, and verbosity.
@@ -318,14 +324,80 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
         "Persistent request client handle is not a PersistentRequestClient: " + handle);
   }
 
-  private static ClientContext requireClientContext(
-      PersistentRequestRuntimeContext context, String operation) {
-    if (context instanceof ClientContext clientContext) {
-      return clientContext;
+  private static FcpRequestRuntimeContext requireRequestRuntimeContext(
+      PersistentRequestRuntimeContext context) {
+    if (context instanceof FcpRequestRuntimeContext requestContext) {
+      return requestContext;
+    }
+    if (context instanceof CryptoResumeContext cryptoResumeContext) {
+      return new CryptoResumeBackedRequestRuntimeContext(context, cryptoResumeContext);
+    }
+    if (context instanceof ResumeContext resumeContext) {
+      return new ResumeBackedRequestRuntimeContext(context, resumeContext);
     }
     String contextType = context == null ? "null" : context.getClass().getName();
     throw new IllegalArgumentException(
-        "FCP persistent request " + operation + " requires ClientContext but got " + contextType);
+        "FCP persistent request resume requires a resume-capable runtime context but got "
+            + contextType);
+  }
+
+  private static PersistentRequestCoordinator requirePersistentRequestCoordinator(
+      PersistentRequestRuntimeContext context, String operation) {
+    if (context instanceof PersistentRequestCoordinatorContext coordinatorContext) {
+      return coordinatorContext.persistentRequestCoordinator();
+    }
+    String contextType = context == null ? "null" : context.getClass().getName();
+    throw new IllegalArgumentException(
+        "FCP persistent request "
+            + operation
+            + " requires a persistent-request coordinator context but got "
+            + contextType);
+  }
+
+  private record ResumeBackedRequestRuntimeContext(
+      PersistentRequestRuntimeContext persistentRequestRuntimeContext, ResumeContext resumeContext)
+      implements FcpRequestRuntimeContext {
+
+    @Override
+    public java.util.Random fastWeakRandom() {
+      return resumeContext.fastWeakRandom();
+    }
+
+    @Override
+    public PersistentFilenameGenerator getPersistentFilenameGenerator() {
+      return resumeContext.getPersistentFilenameGenerator();
+    }
+
+    @Override
+    public PersistentFileTracker getPersistentFileTracker() {
+      return resumeContext.getPersistentFileTracker();
+    }
+  }
+
+  private record CryptoResumeBackedRequestRuntimeContext(
+      PersistentRequestRuntimeContext persistentRequestRuntimeContext,
+      CryptoResumeContext cryptoResumeContext)
+      implements FcpRequestRuntimeContext, CryptoResumeContext {
+
+    @Override
+    public java.util.Random fastWeakRandom() {
+      return cryptoResumeContext.fastWeakRandom();
+    }
+
+    @Override
+    public PersistentFilenameGenerator getPersistentFilenameGenerator() {
+      return cryptoResumeContext.getPersistentFilenameGenerator();
+    }
+
+    @Override
+    public PersistentFileTracker getPersistentFileTracker() {
+      return cryptoResumeContext.getPersistentFileTracker();
+    }
+
+    @Override
+    public MasterSecret getPersistentMasterSecret() {
+      return cryptoResumeContext.getPersistentMasterSecret();
+    }
   }
 
   /**
@@ -357,18 +429,10 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * job or be canceled outright. This callback is invoked on a node worker thread and should return
    * quickly.
    *
-   * @param context client context providing access to schedulers, queues, and persistent roots
+   * @param context detached runtime context providing access to schedulers, queues, and persistent
+   *     roots
    */
-  public abstract void onLostConnection(ClientContext context);
-
-  /**
-   * Detached wrapper for {@link #onLostConnection(ClientContext)} used by server-owned callers.
-   *
-   * @param context detached runtime context backed by the live daemon runtime
-   */
-  public final void onLostConnection(PersistentRequestRuntimeContext context) {
-    onLostConnection(requireClientContext(context, "lost-connection"));
-  }
+  public abstract void onLostConnection(PersistentRequestRuntimeContext context);
 
   /**
    * Sends any queued protocol messages for this request to a reconnecting client.
@@ -445,46 +509,24 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   abstract void register(boolean noTags) throws IdentifierCollisionException;
 
   /**
-   * Starts the request using the full daemon-owned client context.
-   *
-   * <p>Concrete FCP request implementations still operate directly on {@link ClientContext} because
-   * their scheduling, persistence, and queue interactions remain runtime-owned. The client-owned
-   * persistence seam delegates to this overload only after the adapter has narrowed the callback
-   * seam back to the expected daemon context type.
-   *
-   * @param context live daemon client context used to create and schedule the request
-   */
-  public abstract void start(ClientContext context);
-
-  /** {@inheritDoc} */
-  @Override
-  public final void start(PersistentRequestRuntimeContext context) {
-    start(requireClientContext(context, "start"));
-  }
-
-  /**
    * Cancels this request and releases any associated resources.
    *
    * <p>If the underlying requester handle is still active, it is asked to cancel itself via the
-   * supplied {@link ClientContext}. Persistent state and any cached buckets are then freed by
+   * supplied detached runtime context. Persistent state and any cached buckets are then freed by
    * calling {@link #freeData()}. This method is idempotent and may be invoked after completion when
    * the caller no longer cares about remaining notifications.
    *
-   * @param context client context used when propagating the cancellation into the core node
+   * @param context detached runtime context used when propagating the cancellation into the core
+   *     node
    */
-  public void cancel(ClientContext context) {
+  @Override
+  public void cancel(PersistentRequestRuntimeContext context) {
     FcpRequesterHandle requester = getClientRequest();
     // It might have been finished on startup.
     if (LOG.isDebugEnabled())
       LOG.debug("Cancelling {} for {} persistence = {}", requester, this, persistence);
     if (requester != null) requester.cancel(context);
     freeData();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public final void cancel(PersistentRequestRuntimeContext context) {
-    cancel(requireClientContext(context, "cancel"));
   }
 
   /**
@@ -568,9 +610,10 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   /**
    * Returns the underlying requester handle that performs the actual network work.
    *
-   * <p>Subclasses typically create a concrete requester in {@link #start(ClientContext)} and return
-   * it here so that lifecycle callbacks such as {@link #cancel(ClientContext)} and {@link
-   * #onShutdown(ClientContext)} can delegate to it.
+   * <p>Subclasses typically create a concrete requester in {@link
+   * #start(PersistentRequestRuntimeContext)} and return it here so that lifecycle callbacks such as
+   * {@link #cancel(PersistentRequestRuntimeContext)} and {@link
+   * #onShutdown(PersistentRequestRuntimeContext)} can delegate to it.
    *
    * @return currently associated requester handle, or {@code null} when no requester is active
    */
@@ -582,9 +625,9 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * <p>The default implementation cancels the internal requester again and frees cached data.
    * Subclasses may override this to perform additional accounting or logging as required.
    *
-   * @param context client context used when propagating the drop semantics into the core
+   * @param context detached runtime context used when propagating the drop semantics into the core
    */
-  public void dropped(ClientContext context) {
+  public void dropped(PersistentRequestRuntimeContext context) {
     cancel(context);
     freeData();
   }
@@ -702,7 +745,10 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   @SuppressWarnings("unused")
   public abstract boolean isTotalFinalized();
 
-  /** Indicates whether {@link #start(ClientContext)} has been invoked for this request. */
+  /**
+   * Indicates whether {@link #start(PersistentRequestRuntimeContext)} has been invoked for this
+   * request.
+   */
   protected boolean started;
 
   /**
@@ -748,26 +794,14 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * Depending on the request type, this operation can be expensive and may block briefly while
    * scheduling work.
    *
-   * @param context client context used to create new requesters and schedule work
+   * @param context detached runtime context used to create new requesters and schedule work
    * @param disableFilterData whether associated filter data should be disabled for the restart
    * @return {@code true} if the restart was submitted successfully and should be visible to clients
    * @throws PersistenceDisabledException if persistent storage required for restart is not enabled
    */
-  public abstract boolean restart(ClientContext context, boolean disableFilterData)
+  public abstract boolean restart(
+      PersistentRequestRuntimeContext context, boolean disableFilterData)
       throws PersistenceDisabledException;
-
-  /**
-   * Detached wrapper for {@link #restart(ClientContext, boolean)}.
-   *
-   * @param context detached runtime context backed by the live daemon runtime
-   * @param disableFilterData whether associated filter data should be disabled for the restart
-   * @return {@code true} if the restart was submitted successfully and should be visible to clients
-   * @throws PersistenceDisabledException if persistent storage required for restart is not enabled
-   */
-  public final boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData)
-      throws PersistenceDisabledException {
-    return restart(requireClientContext(context, "restart"), disableFilterData);
-  }
 
   /**
    * Called after a ModifyPersistentRequest. Sends a PersistentRequestModified message to clients if
@@ -809,7 +843,8 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
     }
     priorityClass = newPriorityClass;
     FcpRequesterHandle requester = getClientRequest();
-    requester.setPriorityClass(priorityClass, server.serverRuntimeSupport().clientContext());
+    requester.setPriorityClass(
+        priorityClass, server.serverRuntimeSupport().persistentRequestRuntimeContext());
     if (client != null) {
       RequestStatusCache cache = client.getRequestStatusCache();
       if (cache != null) {
@@ -919,18 +954,10 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * override to send {@code PersistentRequestRemoved} notifications or clean up any on-disk
    * artifacts. The request will no longer be visible in persistent listings after this point.
    *
-   * @param context client context that can be used to access persistence services if necessary
+   * @param context detached runtime context that can be used to access persistence services if
+   *     necessary
    */
-  public void requestWasRemoved(ClientContext context) {}
-
-  /**
-   * Detached wrapper for {@link #requestWasRemoved(ClientContext)} used by server-owned callers.
-   *
-   * @param context detached runtime context backed by the live daemon runtime
-   */
-  public final void requestWasRemoved(PersistentRequestRuntimeContext context) {
-    requestWasRemoved(requireClientContext(context, "remove"));
-  }
+  public void requestWasRemoved(PersistentRequestRuntimeContext context) {}
 
   /**
    * Returns whether this request belongs to one of the global queues.
@@ -1018,11 +1045,12 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    *
    * @param dis input stream positioned at the beginning of a client-detail record
    * @param reqID identifier that the caller expects, used to guard against mismatches
-   * @param context client execution context used to rebuild persistent client structures
+   * @param context detached runtime context used to rebuild persistent client structures
    * @throws IOException if reading from {@code dis} fails or is prematurely truncated
    * @throws StorageFormatException if the stored structure is incompatible or has invalid values
    */
-  protected ClientRequest(DataInputStream dis, RequestIdentifier reqID, ClientContext context)
+  protected ClientRequest(
+      DataInputStream dis, RequestIdentifier reqID, PersistentRequestRuntimeContext context)
       throws IOException, StorageFormatException {
     this(parsePersistentState(dis, reqID, context));
   }
@@ -1049,7 +1077,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
   }
 
   private static PersistentState parsePersistentState(
-      DataInputStream dis, RequestIdentifier reqID, ClientContext context)
+      DataInputStream dis, RequestIdentifier reqID, PersistentRequestRuntimeContext context)
       throws IOException, StorageFormatException {
     long magic = dis.readLong();
     if (magic != CLIENT_DETAIL_MAGIC) throw new StorageFormatException("Bad magic");
@@ -1067,10 +1095,11 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
     boolean finished = dis.readBoolean();
     // We can't wait until onResume() to get the client, because it may be used in the
     // constructors.
+    PersistentRequestCoordinator coordinator =
+        requirePersistentRequestCoordinator(context, "restart");
     PersistentRequestClient client =
         requirePersistentRequestClient(
-            context.persistentRequestCoordinator.getOrCreateClientHandle(
-                reqID.globalQueue, reqID.clientName));
+            coordinator.getOrCreateClientHandle(reqID.globalQueue, reqID.clientName));
     RequestClient lowLevelClient = client.lowLevelClient(realTime);
     return new PersistentState(
         realTime,
@@ -1092,53 +1121,46 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * <p>This method is invoked by the owning requester immediately after the request has been read
    * from persistent storage. It recreates transient collaborators such as the {@link
    * PersistentRequestClient}, low-level {@link RequestClient} and any subclass state via {@link
-   * #innerResume(ClientContext)} before registering the request with the persistent-request
-   * coordinator again.
+   * #innerResume(FcpRequestRuntimeContext)} before registering the request with the
+   * persistent-request coordinator again.
    *
-   * @param context client context that provides access to the persistent-request coordinator and
-   *     utility factories
+   * @param context detached request runtime context that provides access to utility factories
    * @throws ResumeFailedException if the request cannot be reattached to the runtime environment
    */
-  @Override
-  public final void onResume(PersistentRequestRuntimeContext context) throws ResumeFailedException {
-    onResume(requireClientContext(context, "resume"));
-  }
-
-  /**
-   * Reconnects this request to runtime services after it has been deserialized.
-   *
-   * <p>This method is invoked by the owning requester immediately after the request has been read
-   * from persistent storage. It recreates transient collaborators such as the {@link
-   * PersistentRequestClient}, low-level {@link RequestClient} and any subclass state via {@link
-   * #innerResume(ClientContext)} before registering the request with the persistent-request
-   * coordinator again.
-   *
-   * @param context client context that provides access to the persistent-request coordinator and
-   *     utility factories
-   * @throws ResumeFailedException if the request cannot be reattached to the runtime environment
-   */
-  public final void onResume(ClientContext context) throws ResumeFailedException {
+  public final void onResume(FcpRequestRuntimeContext context) throws ResumeFailedException {
+    PersistentRequestCoordinator coordinator =
+        requirePersistentRequestCoordinator(context.persistentRequestRuntimeContext(), "resume");
     client =
-        requirePersistentRequestClient(
-            context.persistentRequestCoordinator.getOrCreateClientHandle(global, clientName));
+        requirePersistentRequestClient(coordinator.getOrCreateClientHandle(global, clientName));
     lowLevelClient = client.lowLevelClient(realTime);
     innerResume(context);
     FcpRequesterHandle requester = getClientRequest();
-    if (requester != null) requester.onResume(context); // Can legally be null.
-    context.persistentRequestCoordinator.resumePersistentRequest(this, global, clientName);
+    if (requester != null) {
+      requester.onResume(context.persistentRequestRuntimeContext()); // Can legally be null.
+    }
+    coordinator.resumePersistentRequest(this, global, clientName);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public final void onResume(PersistentRequestRuntimeContext context) throws ResumeFailedException {
+    onResume(requireRequestRuntimeContext(context));
   }
 
   /**
-   * Performs subclass-specific reattachment work during {@link #onResume(ClientContext)}.
+   * Performs subclass-specific reattachment work during {@link
+   * #onResume(FcpRequestRuntimeContext)}.
    *
    * <p>Implementations should recreate transient structures that cannot be serialized directly,
    * such as bucket references or auxiliary state, but must not call back into the requester tree to
    * avoid recursion.
    *
-   * @param context client context providing access to node-wide services required to resume
+   * @param context detached request runtime context providing access to node-wide services required
+   *     to resume
    * @throws ResumeFailedException if required, resources cannot be reacquired during resumption
    */
-  protected abstract void innerResume(ClientContext context) throws ResumeFailedException;
+  protected abstract void innerResume(FcpRequestRuntimeContext context)
+      throws ResumeFailedException;
 
   /**
    * Returns the low-level {@link RequestClient} used to interact with the core node.
@@ -1186,7 +1208,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * @param reqID identifier describing the request type and queue used during serialization
    * @param fetchRuntimeSupport fetch runtime support used to rebuild the detached GET execution
    *     state
-   * @param context client context used to create any dependent objects during restart
+   * @param context detached runtime context used to create any dependent objects during restart
    * @param checker checksum helper responsible for validating the integrity of the serialized data
    * @return reconstructed request instance, or {@code null} when the type is not supported here
    * @throws StorageFormatException if the stored data is malformed or inconsistent with {@code
@@ -1198,7 +1220,7 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
       DataInputStream dis,
       RequestIdentifier reqID,
       FcpFetchRuntimeSupport fetchRuntimeSupport,
-      ClientContext context,
+      PersistentRequestRuntimeContext context,
       ChecksumChecker checker)
       throws StorageFormatException, IOException, ResumeFailedException {
     return reqID.type == GET
@@ -1213,23 +1235,11 @@ public abstract class ClientRequest implements Serializable, PersistentRequestHa
    * bookkeeping that cannot be recovered automatically after restart. The default implementation
    * forwards the call to the underlying requester handle, if present.
    *
-   * @param context client context giving access to persistence mechanisms used during shutdown
+   * @param context detached runtime context giving access to persistence mechanisms used during
+   *     shutdown
    */
   @Override
-  public final void onShutdown(PersistentRequestRuntimeContext context) {
-    onShutdown(requireClientContext(context, "shutdown"));
-  }
-
-  /**
-   * Called just before the node performs its final writing during shutdown.
-   *
-   * <p>Subclasses can override this hook to flush any outstanding state to disk or perform
-   * bookkeeping that cannot be recovered automatically after restart. The default implementation
-   * forwards the call to the underlying requester handle, if present.
-   *
-   * @param context client context giving access to persistence mechanisms used during shutdown
-   */
-  public void onShutdown(ClientContext context) {
+  public void onShutdown(PersistentRequestRuntimeContext context) {
     FcpRequesterHandle requester = getClientRequest();
     if (requester != null) requester.onShutdown(context);
   }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpDownloadCache.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpDownloadCache.java
@@ -16,8 +16,8 @@ import network.crypta.support.api.Bucket;
  *
  * <p>Typical callers are server-owned helper paths such as persistent-request replay and
  * get-completed-request lookups. Those call sites need immediate access to previously downloaded
- * data, but they should not depend directly on runtime-owned cache abstractions or on a live {@code
- * ClientContext}. The interface therefore stays intentionally small and keeps the copy, filtering,
+ * data, but they should not depend directly on runtime-owned cache abstractions or on a live
+ * runtime class. The interface therefore stays intentionally small and keeps the copy, filtering,
  * and detached-runtime-context decisions explicit at the call site.
  *
  * <ul>

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallback.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallback.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.Serial;
 import java.io.Serializable;
 import network.crypta.client.InsertException;
-import network.crypta.client.async.ClientContext;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.RequestClient;
@@ -52,16 +51,16 @@ public interface FcpInsertCallback extends Serializable {
    * Reattaches transient runtime collaborators after persistent-request resume.
    *
    * <p>Persistent FCP requests are Java-serialized and later rebound to a fresh daemon runtime. The
-   * bridge invokes this hook during that resume flow so the owning request can recreate any
-   * transient state that depends on the live {@link ClientContext}, such as persistent-request
-   * coordinator handles, bucket factories, or scheduler-facing state.
+   * bridge invokes this hook during that resume flow, so the owning request can recreate any
+   * transient state that depends on the detached request runtime context, such as
+   * persistent-request coordinator handles, bucket factories, or scheduler-facing state.
    *
-   * @param context live client context supplied during resume; it carries the runtime services
-   *     needed to reattach the owning request safely
+   * @param context detached request runtime context supplied during resume; it carries the runtime
+   *     services needed to reattach the owning request safely
    * @throws ResumeFailedException if the request cannot rebind its transient collaborators and
    *     should therefore fail, resume rather than continue in a partially attached state
    */
-  void onResume(ClientContext context) throws ResumeFailedException;
+  void onResume(FcpRequestRuntimeContext context) throws ResumeFailedException;
 
   /**
    * Returns the low-level request client associated with the owning request.

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequestRuntimeContext.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequestRuntimeContext.java
@@ -1,0 +1,37 @@
+package network.crypta.clients.fcp;
+
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+import network.crypta.support.api.ResumeContext;
+
+/**
+ * Detached FCP runtime context for request resume paths that also need bucket reattachment.
+ *
+ * <p>The FCP adapter uses this seam where a lifecycle path needs both the persistent-request
+ * runtime token and the narrower resume helpers required by buckets and other persisted storage
+ * objects. Implementations may wrap another {@link PersistentRequestRuntimeContext}; bridge-owned
+ * code can recover that underlying token through {@link #persistentRequestRuntimeContext()} when it
+ * needs to narrow back to a live runtime type.
+ *
+ * <p>The interface is intentionally small and asymmetric. Adapter-owned code should depend on this
+ * detached view when it needs restart-safe bucket or metadata reattachment, while bridge-owned code
+ * remains responsible for any narrowing back to live runtime classes such as the daemon's {@code
+ * ClientContext}. That keeps the adapter-side lifecycle logic independent of the live runtime
+ * implementation without weakening the resume contract needed by persistent storage.
+ */
+public interface FcpRequestRuntimeContext extends PersistentRequestRuntimeContext, ResumeContext {
+
+  /**
+   * Returns the underlying persistent-request runtime token that backs this detached view.
+   *
+   * <p>Implementations that are already the original runtime token can return {@code this}. Wrapper
+   * implementations should return the wrapped token so bridge-owned code can narrow there without
+   * leaking the live runtime type into {@code :adapter-fcp}. Callers should treat the returned
+   * value as the persistence/runtime identity for the current resume pass, not as permission to
+   * reach through to unrelated runtime services.
+   *
+   * @return underlying persistent-request runtime token for this detached context
+   */
+  default PersistentRequestRuntimeContext persistentRequestRuntimeContext() {
+    return this;
+  }
+}

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequestRuntimeContext.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequestRuntimeContext.java
@@ -14,9 +14,9 @@ import network.crypta.support.api.ResumeContext;
  *
  * <p>The interface is intentionally small and asymmetric. Adapter-owned code should depend on this
  * detached view when it needs restart-safe bucket or metadata reattachment, while bridge-owned code
- * remains responsible for any narrowing back to live runtime classes such as the daemon's {@code
- * ClientContext}. That keeps the adapter-side lifecycle logic independent of the live runtime
- * implementation without weakening the resume contract needed by persistent storage.
+ * remains responsible for any narrowing back to live daemon runtime types. That keeps the
+ * adapter-side lifecycle logic independent of the live runtime implementation without weakening the
+ * resume contract needed by persistent storage.
  */
 public interface FcpRequestRuntimeContext extends PersistentRequestRuntimeContext, ResumeContext {
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequesterHandle.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpRequesterHandle.java
@@ -2,7 +2,7 @@ package network.crypta.clients.fcp;
 
 import java.io.Serial;
 import java.io.Serializable;
-import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.support.io.ResumeFailedException;
 
 /**
@@ -37,12 +37,13 @@ public interface FcpRequesterHandle extends Serializable {
    * Requests cancellation of the underlying runtime work.
    *
    * <p>This is the detached equivalent of invoking cancellation on the runtime requester directly.
-   * The supplied {@link ClientContext} provides the live runtime services needed to stop work and
-   * release any request-owned state cleanly.
+   * The supplied detached runtime context provides the live runtime services needed to stop work
+   * and release any request-owned state cleanly.
    *
-   * @param context live client context used by the runtime requester when performing cancellation
+   * @param context detached runtime context used by the runtime requester when performing
+   *     cancellation
    */
-  void cancel(ClientContext context);
+  void cancel(PersistentRequestRuntimeContext context);
 
   /**
    * Updates the scheduling priority class on the underlying runtime requester.
@@ -52,10 +53,10 @@ public interface FcpRequesterHandle extends Serializable {
    * requester implementation.
    *
    * @param priorityClass new priority class to apply to the underlying runtime requester
-   * @param context live client context used by the runtime requester while applying the new
+   * @param context detached runtime context used by the runtime requester while applying the new
    *     scheduling priority
    */
-  void setPriorityClass(short priorityClass, ClientContext context);
+  void setPriorityClass(short priorityClass, PersistentRequestRuntimeContext context);
 
   /**
    * Assigns an external diagnostics identifier to the underlying runtime requester.
@@ -76,22 +77,22 @@ public interface FcpRequesterHandle extends Serializable {
    * reconnect to a fresh daemon runtime. The adapter invokes this hook during request resume so the
    * bridge can reattach any transient runtime collaborators behind the detached requester seam.
    *
-   * @param context live client context supplied during persistent-request resume; it carries the
-   *     runtime services needed to rebind the underlying requester
+   * @param context detached runtime context supplied during persistent-request resume; it carries
+   *     the runtime services needed to rebind the underlying requester
    * @throws ResumeFailedException if the runtime requester cannot be reattached safely during
    *     persistent-request resume
    */
-  void onResume(ClientContext context) throws ResumeFailedException;
+  void onResume(PersistentRequestRuntimeContext context) throws ResumeFailedException;
 
   /**
    * Invokes the runtime requester's shutdown hook.
    *
    * <p>This is used during node or request shutdown flows to give the runtime requester a final
-   * chance to flush, detach, or release transient state that depends on the live {@link
-   * ClientContext}. Implementations should treat the call as best-effort cleanup rather than as a
-   * normal lifecycle transition.
+   * chance to flush, detach, or release transient state that depends on the live runtime.
+   * Implementations should treat the call as best-effort cleanup rather than as a normal lifecycle
+   * transition.
    *
-   * @param context live client context supplied during shutdown
+   * @param context detached runtime context supplied during shutdown
    */
-  void onShutdown(ClientContext context);
+  void onShutdown(PersistentRequestRuntimeContext context);
 }

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpServerRuntimeSupport.java
@@ -1,6 +1,5 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.PersistenceDisabledException;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.support.api.BucketFactory;
@@ -10,8 +9,9 @@ import network.crypta.support.api.BucketFactory;
  *
  * <p>This adapter keeps connection handling, persistent request plumbing, and inbound message
  * parsing independent of direct {@code NodeClientCore} access while preserving the current runtime
- * behavior. It exposes only the live client context, persistence-availability check, bucket
- * factories, and secure randomness currently required by the FCP server's infrastructure classes.
+ * behavior. It exposes only the detached persistent-request context, persistence-availability
+ * check, bucket factories, and secure randomness currently required by the FCP server's
+ * infrastructure classes.
  *
  * <p>The seam remains owned by {@code clients.fcp} even though core-backed implementations now live
  * under runtime bootstrap wiring. It is public only, so those runtime-owned adapters can implement
@@ -39,13 +39,6 @@ public interface FcpServerRuntimeSupport {
 
   /** Requests an immediate persistence checkpoint from the live runtime. */
   void setCheckpointASAP();
-
-  /**
-   * Returns the live client context used for request lifecycle and persistent job work.
-   *
-   * @return current client context backing the owning FCP server
-   */
-  ClientContext clientContext();
 
   /**
    * Reports whether forever-persistent storage is currently unavailable.

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -82,6 +82,8 @@ class AdapterFcpBoundaryTest {
   private static final Path FCP_MESSAGE_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("FCPMessage.java");
   private static final Path CLIENT_PUT_COMPLEX_DIR_MESSAGE_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutComplexDirMessage.java");
+  private static final Path CLIENT_PUT_BASE_SOURCE =
+      ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutBase.java");
   private static final Path CLIENT_PUT_DIR_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutDir.java");
   private static final Path CLIENT_PUT_PREPARED_DATA_FACTORY_SOURCE =
@@ -145,6 +147,7 @@ class AdapterFcpBoundaryTest {
           ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetMessage.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("UnsupportedPluginMessage.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("TestDdaCompleteMessage.java"));
+  private static final Set<Path> CLIENT_CONTEXT_RESIDUE_ALLOWLIST = Set.of(CLIENT_PUT_BASE_SOURCE);
   private static final Path BRIDGE_FCP_RUNTIME_MAIN_JAVA =
       Path.of(
           "bridge-fcp-runtime",
@@ -591,6 +594,32 @@ class AdapterFcpBoundaryTest {
   }
 
   @Test
+  void adapterFcpMain_whenCheckingClientContextBoundary_expectNoLiveClientContextOutsideResidue()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile : findJavaSources(repoRoot.resolve(ADAPTER_FCP_MAIN_JAVA))) {
+      Path relativePath = repoRoot.relativize(sourceFile);
+      if (CLIENT_CONTEXT_RESIDUE_ALLOWLIST.contains(relativePath)) {
+        continue;
+      }
+      String source = Files.readString(sourceFile);
+      if (source.contains("network.crypta.client.async.ClientContext")
+          || source.contains("ClientContext")) {
+        violations.add(relativePath.toString());
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        ":adapter-fcp main sources must not import or reference ClientContext outside the"
+            + " legacy BaseClientPutter/ClientPutCallback residue."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
   void adapterFcpMain_whenCheckingGetRuntimeSeam_expectNoLiveFetchTypeImports() throws IOException {
     Path repoRoot = repoRoot();
     List<String> violations = new ArrayList<>();
@@ -813,9 +842,8 @@ class AdapterFcpBoundaryTest {
         violations,
         CLIENT_REQUEST_SOURCE,
         clientRequestSource,
-        "public final boolean restart(PersistentRequestRuntimeContext context, boolean"
-            + " disableFilterData)",
-        "must expose detached restart wrapper");
+        "public abstract boolean restart(",
+        "must expose detached restart signature");
     requireAbsent(
         violations,
         CLIENT_REQUEST_SOURCE,
@@ -847,6 +875,12 @@ class AdapterFcpBoundaryTest {
         runtimeSupportSource,
         "void setCheckpointASAP();",
         "must expose detached checkpoint signaling");
+    requireAbsent(
+        violations,
+        FCP_SERVER_RUNTIME_SUPPORT_SOURCE,
+        runtimeSupportSource,
+        "ClientContext",
+        "must not expose live ClientContext");
 
     assertTrue(
         violations.isEmpty(),

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpFetchRuntimeSupport.java
@@ -30,6 +30,7 @@ import network.crypta.clients.fcp.ClientGetExecution;
 import network.crypta.clients.fcp.ClientGetExecutionSpec;
 import network.crypta.clients.fcp.ClientGetFetchConfig;
 import network.crypta.clients.fcp.FcpFetchRuntimeSupport;
+import network.crypta.clients.fcp.FcpRequestRuntimeContext;
 import network.crypta.clients.fcp.FcpRequesterHandle;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.crypt.ChecksumFailedException;
@@ -223,6 +224,18 @@ record CoreFcpFetchRuntimeSupport(
     return allowedMimeTypes == null ? null : new HashSet<>(allowedMimeTypes);
   }
 
+  private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {
+    if (context instanceof FcpRequestRuntimeContext requestContext) {
+      return requireClientContext(requestContext.persistentRequestRuntimeContext());
+    }
+    if (context instanceof ClientContext clientContext) {
+      return clientContext;
+    }
+    String contextType = context == null ? "null" : context.getClass().getName();
+    throw new IllegalArgumentException(
+        "FCP GET execution resume requires ClientContext but got " + contextType);
+  }
+
   private static final class CoreClientGetExecution implements ClientGetExecution {
     @Serial private static final long serialVersionUID = 1L;
 
@@ -314,15 +327,6 @@ record CoreFcpFetchRuntimeSupport(
       if (requesterHandle == null) {
         requesterHandle = new CoreRequesterHandle(getter);
       }
-    }
-
-    private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {
-      if (context instanceof ClientContext clientContext) {
-        return clientContext;
-      }
-      String contextType = context == null ? "null" : context.getClass().getName();
-      throw new IllegalArgumentException(
-          "FCP GET execution resume requires ClientContext but got " + contextType);
     }
 
     private ClientGetterOptions createOptions(
@@ -471,13 +475,13 @@ record CoreFcpFetchRuntimeSupport(
     }
 
     @Override
-    public void cancel(ClientContext context) {
-      requester.cancel(context);
+    public void cancel(PersistentRequestRuntimeContext context) {
+      requester.cancel(requireClientContext(context));
     }
 
     @Override
-    public void setPriorityClass(short priorityClass, ClientContext context) {
-      requester.setPriorityClass(priorityClass, context);
+    public void setPriorityClass(short priorityClass, PersistentRequestRuntimeContext context) {
+      requester.setPriorityClass(priorityClass, requireClientContext(context));
     }
 
     @Override
@@ -486,13 +490,13 @@ record CoreFcpFetchRuntimeSupport(
     }
 
     @Override
-    public void onResume(ClientContext context) throws ResumeFailedException {
-      requester.onResume(context);
+    public void onResume(PersistentRequestRuntimeContext context) throws ResumeFailedException {
+      requester.onResume(requireClientContext(context));
     }
 
     @Override
-    public void onShutdown(ClientContext context) {
-      requester.onShutdown(context);
+    public void onShutdown(PersistentRequestRuntimeContext context) {
+      requester.onShutdown(requireClientContext(context));
     }
 
     @Override

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupport.java
@@ -36,6 +36,7 @@ import network.crypta.client.async.USKCallback;
 import network.crypta.client.async.USKFoundEdition;
 import network.crypta.client.async.USKManager;
 import network.crypta.client.async.USKProgressCallback;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientPutDirExecution;
 import network.crypta.clients.fcp.ClientPutDirExecutionSpec;
 import network.crypta.clients.fcp.ClientPutExecution;
@@ -53,12 +54,15 @@ import network.crypta.clients.fcp.FcpInsertContextLimits;
 import network.crypta.clients.fcp.FcpInsertOptions;
 import network.crypta.clients.fcp.FcpInsertRuntimeSupport;
 import network.crypta.clients.fcp.FcpInsertTuningOptions;
+import network.crypta.clients.fcp.FcpRequestRuntimeContext;
 import network.crypta.clients.fcp.FcpRequesterHandle;
 import network.crypta.clients.fcp.PersistentPutDirEntrySnapshot;
 import network.crypta.clients.fcp.SubscribeUSKCallbacks;
 import network.crypta.clients.fcp.SubscribeUSKMessage;
 import network.crypta.clients.fcp.UskSubscriptionHandle;
 import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.CryptoResumeContext;
+import network.crypta.crypt.MasterSecret;
 import network.crypta.keys.FreenetURI;
 import network.crypta.keys.InsertableClientSSK;
 import network.crypta.keys.USK;
@@ -183,6 +187,18 @@ record CoreFcpInsertRuntimeSupport(
 
   private ClientContext clientContext() {
     return Objects.requireNonNull(core.getClientContext());
+  }
+
+  private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {
+    if (context instanceof FcpRequestRuntimeContext requestContext) {
+      return requireClientContext(requestContext.persistentRequestRuntimeContext());
+    }
+    if (context instanceof ClientContext clientContext) {
+      return clientContext;
+    }
+    String contextType = context == null ? "null" : context.getClass().getName();
+    throw new IllegalArgumentException(
+        "FCP insert runtime requires ClientContext but got " + contextType);
   }
 
   private static FcpInsertContextHandle toInsertContextHandle(InsertContext context) {
@@ -346,8 +362,8 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public void start(ClientContext context) throws InsertException {
-      putter.start(context);
+    public void start(PersistentRequestRuntimeContext context) throws InsertException {
+      putter.start(requireClientContext(context));
     }
 
     @Override
@@ -356,8 +372,8 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public boolean restart(ClientContext context) throws InsertException {
-      return putter.restart(context);
+    public boolean restart(PersistentRequestRuntimeContext context) throws InsertException {
+      return putter.restart(requireClientContext(context));
     }
 
     @Override
@@ -388,8 +404,8 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public void start(ClientContext context) throws InsertException {
-      putter.start(context);
+    public void start(PersistentRequestRuntimeContext context) throws InsertException {
+      putter.start(requireClientContext(context));
     }
 
     @Override
@@ -398,13 +414,14 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public boolean restart(ClientContext context) throws InsertException {
+    public boolean restart(PersistentRequestRuntimeContext context) throws InsertException {
+      ClientContext clientContext = requireClientContext(context);
       try {
-        putter = createManifestPutter(spec, context);
+        putter = createManifestPutter(spec, clientContext);
       } catch (TooManyFilesInsertException e) {
         throw new InsertException(InsertException.InsertExceptionMode.TOO_MANY_FILES, e, null);
       }
-      putter.start(context);
+      putter.start(clientContext);
       return true;
     }
 
@@ -429,9 +446,10 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public void resumeMetadata(Map<String, Object> manifestElements, ClientContext context)
+    public void resumeMetadata(
+        Map<String, Object> manifestElements, FcpRequestRuntimeContext context)
         throws ResumeFailedException {
-      ContainerInserter.resumeMetadata(manifestElements, context);
+      ContainerInserter.resumeMetadata(manifestElements, requireClientContext(context));
     }
   }
 
@@ -463,13 +481,13 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public void cancel(ClientContext context) {
-      requester.cancel(context);
+    public void cancel(PersistentRequestRuntimeContext context) {
+      requester.cancel(requireClientContext(context));
     }
 
     @Override
-    public void setPriorityClass(short priorityClass, ClientContext context) {
-      requester.setPriorityClass(priorityClass, context);
+    public void setPriorityClass(short priorityClass, PersistentRequestRuntimeContext context) {
+      requester.setPriorityClass(priorityClass, requireClientContext(context));
     }
 
     @Override
@@ -478,13 +496,13 @@ record CoreFcpInsertRuntimeSupport(
     }
 
     @Override
-    public void onResume(ClientContext context) throws ResumeFailedException {
-      requester.onResume(context);
+    public void onResume(PersistentRequestRuntimeContext context) throws ResumeFailedException {
+      requester.onResume(requireClientContext(context));
     }
 
     @Override
-    public void onShutdown(ClientContext context) {
-      requester.onShutdown(context);
+    public void onShutdown(PersistentRequestRuntimeContext context) {
+      requester.onShutdown(requireClientContext(context));
     }
 
     @Override
@@ -531,7 +549,7 @@ record CoreFcpInsertRuntimeSupport(
 
     @Override
     public void onResume(ClientContext context) throws ResumeFailedException {
-      callback.onResume(context);
+      callback.onResume(toRequestRuntimeContext(context));
     }
 
     @Override
@@ -546,6 +564,10 @@ record CoreFcpInsertRuntimeSupport(
 
     private static FcpInsertCallbackState wrapState(BaseClientPutter state) {
       return state == null ? null : new CoreInsertCallbackState(state);
+    }
+
+    private static FcpRequestRuntimeContext toRequestRuntimeContext(ClientContext context) {
+      return new CoreFcpRequestRuntimeContext(Objects.requireNonNull(context));
     }
   }
 
@@ -653,6 +675,35 @@ record CoreFcpInsertRuntimeSupport(
       public void onRoundFinished(ClientContext context) {
         callbacks.onRoundFinished();
       }
+    }
+  }
+
+  private record CoreFcpRequestRuntimeContext(ClientContext clientContext)
+      implements FcpRequestRuntimeContext, CryptoResumeContext {
+
+    @Override
+    public java.util.Random fastWeakRandom() {
+      return clientContext.fastWeakRandom();
+    }
+
+    @Override
+    public network.crypta.support.io.PersistentFilenameGenerator getPersistentFilenameGenerator() {
+      return clientContext.getPersistentFilenameGenerator();
+    }
+
+    @Override
+    public network.crypta.support.io.PersistentFileTracker getPersistentFileTracker() {
+      return clientContext.getPersistentFileTracker();
+    }
+
+    @Override
+    public MasterSecret getPersistentMasterSecret() {
+      return clientContext.getPersistentMasterSecret();
+    }
+
+    @Override
+    public PersistentRequestRuntimeContext persistentRequestRuntimeContext() {
+      return clientContext;
     }
   }
 }

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupport.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupport.java
@@ -45,11 +45,6 @@ record CoreFcpServerRuntimeSupport(NodeClientCore core) implements FcpServerRunt
     this.core = Objects.requireNonNull(core);
   }
 
-  @Override
-  public ClientContext clientContext() {
-    return core.getClientContext();
-  }
-
   /**
    * Returns the detached persistence-runtime context for server-side bridge helpers.
    *
@@ -78,8 +73,7 @@ record CoreFcpServerRuntimeSupport(NodeClientCore core) implements FcpServerRunt
   @Override
   public void queuePersistentJob(FcpPersistentJob job, int threadPriority)
       throws PersistenceDisabledException {
-    ClientContext clientContext = clientContext();
-    clientContext.jobRunner.queue(new CorePersistentJob(job), threadPriority);
+    clientContext().jobRunner.queue(new CorePersistentJob(job), threadPriority);
   }
 
   /**
@@ -111,6 +105,10 @@ record CoreFcpServerRuntimeSupport(NodeClientCore core) implements FcpServerRunt
   @Override
   public void fillSecureRandom(byte[] bytes) {
     core.getRandom().nextBytes(bytes);
+  }
+
+  private network.crypta.client.async.ClientContext clientContext() {
+    return Objects.requireNonNull(core.getClientContext());
   }
 
   @SuppressWarnings("ClassCanBeRecord")

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/FcpPersistentRequestRecoveryCodec.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/FcpPersistentRequestRecoveryCodec.java
@@ -8,6 +8,7 @@ import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 import network.crypta.client.async.persistence.PersistentRequestRecoveryCodec;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientRequest;
+import network.crypta.clients.fcp.FcpRequestRuntimeContext;
 import network.crypta.clients.fcp.RequestIdentifier;
 import network.crypta.crypt.ChecksumChecker;
 import network.crypta.support.io.ResumeFailedException;
@@ -20,9 +21,9 @@ import network.crypta.support.io.StorageFormatException;
  * It converts the client-owned durable identifier into the legacy FCP identifier type, narrows the
  * runtime-context seam back to {@link ClientContext} at the bridge boundary, and then delegates
  * reconstruction to {@link ClientRequest#restartFrom(DataInputStream, RequestIdentifier,
- * network.crypta.clients.fcp.FcpFetchRuntimeSupport, ClientContext, ChecksumChecker)}. The adapter
- * stays stateless, so startup wiring can reuse a single instance without coordinating additional
- * caches or configuration.
+ * network.crypta.clients.fcp.FcpFetchRuntimeSupport, PersistentRequestRuntimeContext,
+ * ChecksumChecker)}. The adapter stays stateless, so startup wiring can reuse a single instance
+ * without coordinating additional caches or configuration.
  */
 public final class FcpPersistentRequestRecoveryCodec implements PersistentRequestRecoveryCodec {
 
@@ -46,21 +47,23 @@ public final class FcpPersistentRequestRecoveryCodec implements PersistentReques
       throws StorageFormatException, IOException, ResumeFailedException {
     RequestIdentifier requestIdentifier =
         RequestIdentifier.fromPersistentRequestIdentifier(identifier);
-    ClientContext clientContext = requireClientContext(context);
     return ClientRequest.restartFrom(
         dis,
         requestIdentifier,
         new CoreFcpFetchRuntimeSupport(
-            clientContext,
+            requireClientContext(context),
             () -> {
               throw new UnsupportedOperationException(
                   "transferAccess is unavailable during persistent request recovery");
             }),
-        clientContext,
+        context,
         checker);
   }
 
   private static ClientContext requireClientContext(PersistentRequestRuntimeContext context) {
+    if (context instanceof FcpRequestRuntimeContext requestContext) {
+      return requireClientContext(requestContext.persistentRequestRuntimeContext());
+    }
     if (context instanceof ClientContext clientContext) {
       return clientContext;
     }

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpInsertRuntimeSupportTest.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertContext;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.CompatibilityAnalyser;
 import network.crypta.client.async.ManifestPutter;
@@ -41,7 +42,10 @@ import network.crypta.clients.fcp.FcpInsertContextHandle;
 import network.crypta.clients.fcp.FcpInsertContextLimits;
 import network.crypta.clients.fcp.FcpInsertOptions;
 import network.crypta.clients.fcp.FcpInsertTuningOptions;
+import network.crypta.clients.fcp.FcpRequestRuntimeContext;
 import network.crypta.clients.fcp.PersistentPutDirEntrySnapshot;
+import network.crypta.crypt.CryptoResumeContext;
+import network.crypta.crypt.MasterSecret;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestClient;
@@ -57,6 +61,7 @@ import network.crypta.support.io.PersistentTempBucketFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -458,6 +463,24 @@ class CoreFcpInsertRuntimeSupportTest {
     assertTrue(serialized.length > 0);
   }
 
+  @Test
+  void insertCallbackAdapter_onResume_preservesCryptoResumeContext() throws Exception {
+    FcpInsertCallback callback = mock(FcpInsertCallback.class);
+    ClientPutCallback adapter = instantiateInsertCallbackAdapter(callback);
+    MasterSecret secret = mock(MasterSecret.class);
+    when(clientContext.getPersistentMasterSecret()).thenReturn(secret);
+
+    adapter.onResume(clientContext);
+
+    ArgumentCaptor<FcpRequestRuntimeContext> captor =
+        ArgumentCaptor.forClass(FcpRequestRuntimeContext.class);
+    verify(callback).onResume(captor.capture());
+    FcpRequestRuntimeContext requestContext = captor.getValue();
+    CryptoResumeContext cryptoContext = assertInstanceOf(CryptoResumeContext.class, requestContext);
+    assertSame(secret, cryptoContext.getPersistentMasterSecret());
+    assertSame(clientContext, requestContext.persistentRequestRuntimeContext());
+  }
+
   private static ClientPutDirExecution instantiateDirectoryExecution(
       ClientPutDirExecutionSpec executionSpec, ManifestPutter putter)
       throws InvalidObjectException {
@@ -505,6 +528,23 @@ class CoreFcpInsertRuntimeSupportTest {
       objectOutput.writeObject(value);
       objectOutput.flush();
       return output.toByteArray();
+    }
+  }
+
+  private static ClientPutCallback instantiateInsertCallbackAdapter(FcpInsertCallback callback) {
+    try {
+      Class<?> adapterClass =
+          Class.forName(
+              "network.crypta.clients.fcp.bridge.CoreFcpInsertRuntimeSupport$CoreInsertCallbackAdapter");
+      MethodHandle constructor =
+          MethodHandles.privateLookupIn(adapterClass, MethodHandles.lookup())
+              .findConstructor(
+                  adapterClass, MethodType.methodType(void.class, FcpInsertCallback.class));
+      return (ClientPutCallback) constructor.invoke(callback);
+    } catch (RuntimeException | Error e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new IllegalStateException(t);
     }
   }
 

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupportTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/CoreFcpServerRuntimeSupportTest.java
@@ -65,16 +65,6 @@ class CoreFcpServerRuntimeSupportTest {
   }
 
   @Test
-  void clientContext_whenQueried_returnsCoreClientContext() {
-    ClientContext clientContext = createClientContext(jobRunner);
-    when(core.getClientContext()).thenReturn(clientContext);
-
-    CoreFcpServerRuntimeSupport support = new CoreFcpServerRuntimeSupport(core);
-
-    assertSame(clientContext, support.clientContext());
-  }
-
-  @Test
   void persistentRequestRuntimeContext_whenQueried_returnsCoreClientContext() {
     ClientContext clientContext = createClientContext(jobRunner);
     when(core.getClientContext()).thenReturn(clientContext);

--- a/kernel-content/src/main/java/network/crypta/client/async/persistence/PersistentRequestCoordinatorContext.java
+++ b/kernel-content/src/main/java/network/crypta/client/async/persistence/PersistentRequestCoordinatorContext.java
@@ -1,0 +1,32 @@
+package network.crypta.client.async.persistence;
+
+/**
+ * Narrow runtime-context seam that exposes the persistent-request coordinator.
+ *
+ * <p>Persistent request implementations sometimes need more than the bare {@link
+ * PersistentRequestRuntimeContext} marker during restart and resume. In particular, they may need
+ * to recover the owning persistent client or re-register themselves with the persistent-request
+ * coordinator. This interface exposes just that coordinator dependency without forcing higher
+ * layers to depend on a larger live runtime type.
+ *
+ * <p>Concrete runtimes may implement this directly on their live execution context, or they may
+ * wrap another runtime token and forward the coordinator call. Callers should treat the returned
+ * coordinator as a persistence-only collaborator rather than as a general runtime service locator.
+ * The seam exists specifically so restart and replay code can recover persistent ownership without
+ * reintroducing compile-time coupling to larger runtime types such as the daemon's full client
+ * context.
+ */
+public interface PersistentRequestCoordinatorContext extends PersistentRequestRuntimeContext {
+
+  /**
+   * Returns the persistent-request coordinator for the current runtime.
+   *
+   * <p>Callers use the coordinator to recover persistent request clients, re-register durable
+   * requests after deserialization, and keep queue ownership consistent across restarts. The
+   * returned coordinator should be treated as stable for the lifetime of the surrounding runtime
+   * context, but not as a general-purpose access path to unrelated node services.
+   *
+   * @return persistence coordinator used to recover clients and resume durable requests
+   */
+  PersistentRequestCoordinator persistentRequestCoordinator();
+}

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientContext.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientContext.java
@@ -9,6 +9,7 @@ import network.crypta.client.InsertException;
 import network.crypta.client.async.alerts.ClientAlert;
 import network.crypta.client.async.alerts.ClientAlertSink;
 import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestCoordinatorContext;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.client.events.ClientEventDispatchContext;
 import network.crypta.client.events.ClientEventPersistentTask;
@@ -68,7 +69,10 @@ import network.crypta.support.io.TempBucketFactory;
  * @see RequestScheduler
  */
 public class ClientContext
-    implements CryptoResumeContext, PersistentRequestRuntimeContext, ClientEventDispatchContext {
+    implements CryptoResumeContext,
+        PersistentRequestCoordinatorContext,
+        PersistentRequestRuntimeContext,
+        ClientEventDispatchContext {
 
   private ClientRequestScheduler sskFetchSchedulerBulk;
   private ClientRequestScheduler chkFetchSchedulerBulk;
@@ -174,7 +178,7 @@ public class ClientContext
   public final MemoryLimitedJobRunner memoryLimitedJobRunner;
 
   /** Coordinator for persistent request ownership, including recovery across restarts. */
-  public final PersistentRequestCoordinator persistentRequestCoordinator;
+  public final PersistentRequestCoordinator persistentRequestCoordinatorRef;
 
   private final FetchContext defaultPersistentFetchContext;
   private final InsertContext defaultPersistentInsertContext;
@@ -239,12 +243,17 @@ public class ClientContext
     this.linkFilterExceptionProvider = services.linkFilterExceptionProvider();
     this.memoryLimitedJobRunner = runtime.memoryLimitedJobRunner();
     this.tempRAFFactory = rafFactories.tempRAFFactory();
-    this.persistentRequestCoordinator = services.persistentRequestCoordinator();
+    this.persistentRequestCoordinatorRef = services.persistentRequestCoordinator();
     this.dummyJobRunner = new DummyJobRunner(mainExecutorInternal, this);
     this.defaultPersistentFetchContext = defaults.defaultPersistentFetchContext();
     this.defaultPersistentInsertContext = defaults.defaultPersistentInsertContext();
     this.cryptoSecretTransient = runtime.cryptoSecretTransient();
     this.config = defaults.config();
+  }
+
+  @Override
+  public PersistentRequestCoordinator persistentRequestCoordinator() {
+    return persistentRequestCoordinatorRef;
   }
 
   /**

--- a/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetFactoryTest.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Path;
 import java.util.Arrays;
-import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.keys.FreenetURI;
@@ -442,7 +442,7 @@ class ClientGetFactoryTest {
     }
 
     @Override
-    public void onLostConnection(ClientContext context) {
+    public void onLostConnection(PersistentRequestRuntimeContext context) {
       // No-op for this focused registration stub.
     }
 
@@ -511,7 +511,7 @@ class ClientGetFactoryTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       // Start semantics are irrelevant to identifier collision coverage.
     }
 
@@ -526,7 +526,7 @@ class ClientGetFactoryTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       return false;
     }
 
@@ -536,7 +536,7 @@ class ClientGetFactoryTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       // Resume is intentionally unsupported for this lightweight test double.
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetLifecycleTest.java
@@ -6,28 +6,78 @@ import network.crypta.client.ClientMetadata;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientGet.ReturnType;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.support.api.Bucket;
 import network.crypta.support.io.ResumeFailedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class ClientGetLifecycleTest {
+
+  @Test
+  void register_whenPersistentAndTagsEnabled_expectRegisterAndQueueTag() throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.DIRECT, false);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    FCPMessage tagMessage = Mockito.mock(FCPMessage.class);
+    setField(request, "client", client);
+    setField(request, "persistence", Persistence.REBOOT);
+    doReturn(tagMessage).when(request).persistentTagMessage();
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.register(false);
+
+    verify(client).register(request);
+    verify(client).queueClientRequestMessage(tagMessage, 0);
+  }
+
+  @Test
+  void register_whenNoTags_expectRegisterWithoutQueueingTag() throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.DIRECT, false);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    setField(request, "client", client);
+    setField(request, "persistence", Persistence.REBOOT);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.register(true);
+
+    verify(client).register(request);
+    verify(client, never()).queueClientRequestMessage(any(FCPMessage.class), eq(0));
+  }
+
+  @Test
+  void register_whenConnectionPersistence_expectNoRegistration() throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.DIRECT, false);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    setField(request, "client", client);
+    setField(request, "persistence", Persistence.CONNECTION);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.register(false);
+
+    verify(client, never()).register(any(ClientRequest.class));
+    verify(client, never()).queueClientRequestMessage(any(FCPMessage.class), eq(0));
+  }
 
   @Test
   void onSuccess_whenDirectReturn_expectStateUpdatedAndNotifications() throws Exception {
@@ -134,6 +184,89 @@ class ClientGetLifecycleTest {
     verify(request).trySendDataFoundOrGetFailed(null, null);
     verify(request).finish();
     verify(client).notifyFailure(request);
+  }
+
+  @Test
+  void start_whenExecutionSucceeds_expectStartedCacheUpdateAndPersistentTag() throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.NONE, false);
+    ClientGetExecution execution = Mockito.mock(ClientGetExecution.class);
+    PersistentRequestClient client = Mockito.mock(PersistentRequestClient.class);
+    RequestStatusCache cache = Mockito.mock(RequestStatusCache.class);
+    FCPMessage tagMessage = Mockito.mock(FCPMessage.class);
+    request.setExecution(execution);
+    setField(request, "client", client);
+    setField(request, "persistence", Persistence.REBOOT);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    doReturn(tagMessage).when(request).persistentTagMessage();
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.start();
+
+    verify(execution).start();
+    verify(client).queueClientRequestMessage(tagMessage, 0);
+    verify(cache).updateStarted("req-1", true);
+    assertTrue(getBooleanField(request, "started"));
+  }
+
+  @Test
+  void start_whenExecutionThrowsFetchException_expectStartedAndFailureDelegation()
+      throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.NONE, false);
+    ClientGetExecution execution = Mockito.mock(ClientGetExecution.class);
+    FetchException failure = new FetchException(FetchExceptionMode.INTERNAL_ERROR, "boom");
+    request.setExecution(execution);
+    doThrow(failure).when(execution).start();
+    doNothing().when(request).onFailure(failure);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.start();
+
+    verify(request).onFailure(failure);
+    assertTrue(getBooleanField(request, "started"));
+  }
+
+  @Test
+  void start_whenExecutionThrowsRuntimeException_expectInternalErrorFailure() throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.NONE, false);
+    ClientGetExecution execution = Mockito.mock(ClientGetExecution.class);
+    RuntimeException failure = new RuntimeException("boom");
+    request.setExecution(execution);
+    doThrow(failure).when(execution).start();
+    doNothing().when(request).onFailure(any(FetchException.class));
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.start();
+
+    ArgumentCaptor<FetchException> captor = ArgumentCaptor.forClass(FetchException.class);
+    verify(request).onFailure(captor.capture());
+    assertEquals(FetchExceptionMode.INTERNAL_ERROR, captor.getValue().getMode());
+    assertSame(failure, captor.getValue().getCause());
+    assertTrue(getBooleanField(request, "started"));
+  }
+
+  @Test
+  void onLostConnection_whenConnectionPersistence_expectCancel() throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.NONE, false);
+    PersistentRequestRuntimeContext context = Mockito.mock(PersistentRequestRuntimeContext.class);
+    setField(request, "persistence", Persistence.CONNECTION);
+    doNothing().when(request).cancel(context);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.onLostConnection(context);
+
+    verify(request).cancel(context);
+  }
+
+  @Test
+  void onLostConnection_whenPersistent_expectNoCancellation() throws Exception {
+    ClientGet request = newSpyRequest(ReturnType.NONE, false);
+    PersistentRequestRuntimeContext context = Mockito.mock(PersistentRequestRuntimeContext.class);
+    setField(request, "persistence", Persistence.REBOOT);
+    ClientGetLifecycle lifecycle = new ClientGetLifecycle(request);
+
+    lifecycle.onLostConnection(context);
+
+    verify(request, never()).cancel(any(PersistentRequestRuntimeContext.class));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceCodecTest.java
@@ -424,7 +424,7 @@ class ClientGetPersistenceCodecTest {
 
     import java.io.File;
     import java.io.Serial;
-    import network.crypta.client.async.ClientContext;
+    import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
     import network.crypta.support.api.Bucket;
     import network.crypta.support.io.ResumeFailedException;
 
@@ -458,7 +458,7 @@ class ClientGetPersistenceCodecTest {
       }
 
       @Override
-      public void onLostConnection(ClientContext context) {}
+      public void onLostConnection(PersistentRequestRuntimeContext context) {}
 
       @Override
       public void sendPendingMessages(
@@ -471,7 +471,7 @@ class ClientGetPersistenceCodecTest {
       void register(boolean noTags) {}
 
       @Override
-      public void start(ClientContext context) {}
+      public void start(PersistentRequestRuntimeContext context) {}
 
       @Override
       protected FcpRequesterHandle getClientRequest() {
@@ -528,11 +528,12 @@ class ClientGetPersistenceCodecTest {
 
       @Override
       public boolean canRestart() {
-        return false;
-      }
+          return false;
+        }
 
           @Override
-          public boolean restart(ClientContext context, boolean disableFilterData) {
+          public boolean restart(
+              PersistentRequestRuntimeContext context, boolean disableFilterData) {
             return false;
           }
 
@@ -547,7 +548,7 @@ class ClientGetPersistenceCodecTest {
           }
 
       @Override
-      protected void innerResume(ClientContext context) throws ResumeFailedException {}
+      protected void innerResume(FcpRequestRuntimeContext context) throws ResumeFailedException {}
 
       @Override
       RequestIdentifier.RequestType getType() {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetPersistenceIOTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -209,6 +210,54 @@ class ClientGetPersistenceIOTest {
         input, fetchRuntimeSupport, checker, execution, request);
 
     verifyNoInteractions(execution, request);
+  }
+
+  @Test
+  void resume_whenExecutionPresent_resumesBucketsAndBackfillsMissingState()
+      throws ResumeFailedException {
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    Bucket returnBucket = mock(Bucket.class);
+    Bucket initialMetadata = mock(Bucket.class);
+    FcpRequestRuntimeContext context = mock(FcpRequestRuntimeContext.class);
+    ClientGet request = newRequestWithState();
+    request.setExecution(execution);
+    request.state().setReturnBucketDirect(returnBucket);
+    request.setRequestProfile(request.requestProfile().withInitialMetadata(initialMetadata));
+    request.state().setFoundDataLength(0L);
+    request.state().setFoundDataMimeType(null);
+    when(execution.expectedSize()).thenReturn(42L);
+    when(execution.expectedMime()).thenReturn("text/plain");
+
+    ClientGetPersistenceIO.resume(request, context);
+
+    verify(execution).onResume(context);
+    verify(returnBucket).onResume(context);
+    verify(initialMetadata).onResume(context);
+    assertEquals(42L, request.state().getFoundDataLength());
+    assertEquals("text/plain", request.state().getFoundDataMimeType());
+  }
+
+  @Test
+  void resume_whenStateAlreadyPopulated_keepsExistingLengthAndMime() throws ResumeFailedException {
+    ClientGetExecution execution = mock(ClientGetExecution.class);
+    Bucket returnBucket = mock(Bucket.class);
+    Bucket initialMetadata = mock(Bucket.class);
+    FcpRequestRuntimeContext context = mock(FcpRequestRuntimeContext.class);
+    ClientGet request = newRequestWithState();
+    request.setExecution(execution);
+    request.state().setReturnBucketDirect(returnBucket);
+    request.setRequestProfile(request.requestProfile().withInitialMetadata(initialMetadata));
+    request.state().setFoundDataLength(7L);
+    request.state().setFoundDataMimeType("existing/type");
+
+    ClientGetPersistenceIO.resume(request, context);
+
+    verify(execution).onResume(context);
+    verify(returnBucket).onResume(context);
+    verify(initialMetadata).onResume(context);
+    assertEquals(7L, request.state().getFoundDataLength());
+    assertEquals("existing/type", request.state().getFoundDataMimeType());
+    verifyNoMoreInteractions(execution);
   }
 
   private static StorageFormatException storageFormatExceptionWithChecksumFailure() {

--- a/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientGetTest.java
@@ -305,16 +305,9 @@ class ClientGetTest {
     throw new IllegalArgumentException("Field not found: " + fieldName);
   }
 
-  @SuppressWarnings("java:S3011")
   private static ClientContext newContextWithCoordinator(PersistentRequestCoordinator coordinator) {
     ClientContext context = mock(ClientContext.class);
-    try {
-      Field field = ClientContext.class.getDeclaredField("persistentRequestCoordinator");
-      field.setAccessible(true);
-      field.set(context, coordinator);
-      return context;
-    } catch (ReflectiveOperationException e) {
-      throw new LinkageError("Failed to set ClientContext.persistentRequestCoordinator", e);
-    }
+    when(context.persistentRequestCoordinator()).thenReturn(coordinator);
+    return context;
   }
 }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
@@ -8,6 +8,7 @@ import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.BaseClientPutter;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.client.events.ExpectedHashesEvent;
 import network.crypta.client.events.FinishedCompressionEvent;
 import network.crypta.client.events.SimpleEventProducer;
@@ -378,7 +379,7 @@ class ClientPutBaseTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       // The test double never schedules real network work.
     }
 
@@ -393,7 +394,7 @@ class ClientPutBaseTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       return false;
     }
 
@@ -403,7 +404,7 @@ class ClientPutBaseTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       // No-op for test double.
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutDirTest.java
@@ -205,7 +205,7 @@ class ClientPutDirTest {
     ClientPutDirExecution putter = mock(ClientPutDirExecution.class);
     setField(ClientPutDir.class, putDir, "manifestElements", manifest);
     setField(ClientPutDir.class, putDir, "putter", putter);
-    ClientContext context = mock(ClientContext.class);
+    FcpRequestRuntimeContext context = mock(FcpRequestRuntimeContext.class);
 
     putDir.innerResume(context);
 

--- a/src/test/java/network/crypta/clients/fcp/ClientPutLifecycleTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutLifecycleTest.java
@@ -1,0 +1,209 @@
+package network.crypta.clients.fcp;
+
+import java.lang.reflect.Field;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.InsertException.InsertExceptionMode;
+import network.crypta.client.InsertException;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
+import network.crypta.client.events.SimpleEventProducer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class ClientPutLifecycleTest {
+
+  private ClientPut clientPut;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    clientPut = new ClientPut();
+    setField(
+        ClientPutBase.class,
+        clientPut,
+        "ctx",
+        new DefaultFcpInsertContextHandle(
+            new SimpleEventProducer(),
+            new FcpInsertContextLimits(0, 1, 1),
+            new FcpInsertOptions(
+                new FcpInsertBehaviorOptions(false, false, false, 1, false, false, false),
+                new FcpInsertTuningOptions(
+                    true, false, null, 0, 0, FcpCompatibilityMode.COMPAT_CURRENT),
+                null)));
+    setField(ClientPut.class, clientPut, "clientMetadata", new ClientMetadata("text/plain"));
+    setField(ClientRequest.class, clientPut, "identifier", "test-id");
+    setField(ClientRequest.class, clientPut, "persistence", ClientRequest.Persistence.FOREVER);
+  }
+
+  @Test
+  void register_whenPersistentAndTagsRequested_registersAndQueuesTagMessage() throws Exception {
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    FCPMessage tagMessage = mock(FCPMessage.class);
+    ClientPut request = spy(clientPut);
+    setField(ClientRequest.class, request, "client", client);
+    doReturn(tagMessage).when(request).persistentTagMessage();
+
+    new ClientPutLifecycle(request).register(false);
+
+    verify(client).register(request);
+    verify(client).queueClientRequestMessage(tagMessage, 0);
+  }
+
+  @Test
+  void start_whenPersistentRequestStarts_updatesCacheAndQueuesTag() throws Exception {
+    ClientPutExecution putter = mock(ClientPutExecution.class);
+    PersistentRequestRuntimeContext context = mock(PersistentRequestRuntimeContext.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    FCPMessage tagMessage = mock(FCPMessage.class);
+    ClientPut request = spy(clientPut);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(ClientPut.class, request, "putter", putter);
+    setField(ClientRequest.class, request, "identifier", "start-id");
+    setField(ClientRequest.class, request, "persistence", ClientRequest.Persistence.REBOOT);
+    setField(ClientRequest.class, request, "client", client);
+    doReturn(tagMessage).when(request).persistentTagMessage();
+
+    new ClientPutLifecycle(request).start(context);
+
+    verify(putter).start(context);
+    verify(client).queueClientRequestMessage(tagMessage, 0);
+    verify(cache).updateStarted("start-id", true);
+    assertTrue((boolean) getField(ClientRequest.class, request, "started"));
+  }
+
+  @Test
+  void start_whenPutterThrowsInsertException_invokesOnFailure() throws Exception {
+    ClientPutExecution putter = mock(ClientPutExecution.class);
+    PersistentRequestRuntimeContext context = mock(PersistentRequestRuntimeContext.class);
+    InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
+    ClientPut request = spy(clientPut);
+    setField(ClientPut.class, request, "putter", putter);
+    doThrow(failure).when(putter).start(context);
+    doNothing().when(request).onFailure(failure, (FcpInsertCallbackState) null);
+
+    new ClientPutLifecycle(request).start(context);
+
+    verify(request).onFailure(failure, (FcpInsertCallbackState) null);
+  }
+
+  @Test
+  void restart_whenDelegateSucceeds_updatesCacheAndState() throws Exception {
+    ClientPutExecution putter = mock(ClientPutExecution.class);
+    PersistentRequestRuntimeContext context = mock(PersistentRequestRuntimeContext.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    when(putter.canRestart()).thenReturn(true);
+    when(putter.restart(context)).thenReturn(true);
+    setField(ClientPut.class, clientPut, "putter", putter);
+    setField(ClientRequest.class, clientPut, "finished", true);
+    setField(ClientPutBase.class, clientPut, "succeeded", false);
+    setField(
+        ClientPutBase.class, clientPut, "generatedURI", mock(network.crypta.keys.FreenetURI.class));
+    setField(ClientRequest.class, clientPut, "client", client);
+
+    boolean restarted = new ClientPutLifecycle(clientPut).restart(context);
+
+    assertTrue(restarted);
+    assertNull(getField(ClientPutBase.class, clientPut, "generatedURI"));
+    assertTrue((boolean) getField(ClientRequest.class, clientPut, "started"));
+    InOrder order = inOrder(cache);
+    order.verify(cache).updateStarted("test-id", false);
+    order.verify(cache).updateStarted("test-id", true);
+  }
+
+  @Test
+  void restart_whenDelegateThrowsInsertException_invokesOnFailure() throws Exception {
+    ClientPutExecution putter = mock(ClientPutExecution.class);
+    PersistentRequestRuntimeContext context = mock(PersistentRequestRuntimeContext.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    InsertException failure = new InsertException(InsertExceptionMode.INTERNAL_ERROR, "boom", null);
+    ClientPut request = spy(clientPut);
+    setField(ClientPut.class, request, "putter", putter);
+    setField(ClientRequest.class, request, "finished", true);
+    setField(ClientPutBase.class, request, "succeeded", false);
+    setField(ClientRequest.class, request, "client", client);
+    when(putter.canRestart()).thenReturn(true);
+    when(putter.restart(context)).thenThrow(failure);
+    doNothing().when(request).onFailure(failure, (FcpInsertCallbackState) null);
+
+    boolean restarted = new ClientPutLifecycle(request).restart(context);
+
+    assertFalse(restarted);
+    verify(request).onFailure(failure, (FcpInsertCallbackState) null);
+  }
+
+  @Test
+  void onStartCompressing_whenClientHasCache_updatesCache() throws Exception {
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(ClientRequest.class, clientPut, "client", client);
+
+    new ClientPutLifecycle(clientPut).onStartCompressing();
+
+    verify(cache).updateCompressionStatus("test-id", ClientPut.COMPRESS_STATE.COMPRESSING);
+  }
+
+  @Test
+  void onStopCompressing_whenClientHasCache_updatesCacheAndState() throws Exception {
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    RequestStatusCache cache = mock(RequestStatusCache.class);
+    when(client.getRequestStatusCache()).thenReturn(cache);
+    setField(ClientRequest.class, clientPut, "client", client);
+
+    new ClientPutLifecycle(clientPut).onStopCompressing();
+
+    verify(cache).updateCompressionStatus("test-id", ClientPut.COMPRESS_STATE.WORKING);
+    assertTrue((boolean) getField(ClientPut.class, clientPut, "compressed"));
+  }
+
+  @Test
+  void requestWasRemoved_whenForeverPersistence_clearsPutter() throws Exception {
+    ClientPutExecution putter = mock(ClientPutExecution.class);
+    PersistentRequestClient client = mock(PersistentRequestClient.class);
+    ClientPut request = spy(clientPut);
+    setField(ClientPut.class, request, "putter", putter);
+    setField(ClientRequest.class, request, "client", client);
+    setField(ClientRequest.class, request, "finished", true);
+    doNothing().when(request).requestWasRemovedBase(any());
+
+    new ClientPutLifecycle(request).requestWasRemoved(mock(PersistentRequestRuntimeContext.class));
+
+    assertNull(getField(ClientPut.class, request, "putter"));
+    verify(request).requestWasRemovedBase(any());
+    verifyNoInteractions(putter);
+  }
+
+  private static void setField(Class<?> owner, Object target, String name, Object value)
+      throws ReflectiveOperationException {
+    Field field = owner.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Object getField(Class<?> owner, Object target, String name)
+      throws ReflectiveOperationException {
+    Field field = owner.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+}

--- a/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
@@ -254,7 +254,7 @@ class ClientPutTest {
   void innerResume_whenBucketPresent_delegatesToBucket() throws Exception {
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     setField(ClientPut.class, clientPut, "data", bucket);
-    ClientContext context = mock(ClientContext.class);
+    FcpRequestRuntimeContext context = mock(FcpRequestRuntimeContext.class);
 
     clientPut.innerResume(context);
 
@@ -266,7 +266,7 @@ class ClientPutTest {
     FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     ClientPutExecution putter = createExecution(requester);
     setField(ClientPut.class, clientPut, "putter", putter);
-    ClientContext context = mock(ClientContext.class);
+    FcpRequestRuntimeContext context = mock(FcpRequestRuntimeContext.class);
 
     clientPut.innerResume(context);
 
@@ -277,7 +277,7 @@ class ClientPutTest {
   void innerResume_whenBucketThrows_propagatesException() throws Exception {
     RandomAccessBucket bucket = mock(RandomAccessBucket.class);
     setField(ClientPut.class, clientPut, "data", bucket);
-    ClientContext context = mock(ClientContext.class);
+    FcpRequestRuntimeContext context = mock(FcpRequestRuntimeContext.class);
     ResumeFailedException failure = new ResumeFailedException("boom");
     doThrow(failure).when(bucket).onResume(context);
 

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestModifyRequestTest.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.fcp;
 
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ class ClientRequestModifyRequestTest {
   void modifyRequest_whenPriorityAndTokenChange_updatesRequesterCacheAndQueuesMessage() {
     ClientContext context = mock(ClientContext.class);
     FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
-    when(runtimeSupport.clientContext()).thenReturn(context);
+    when(runtimeSupport.persistentRequestRuntimeContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
     FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
@@ -58,7 +59,7 @@ class ClientRequestModifyRequestTest {
   void modifyRequest_whenNothingChanges_skipsCheckpointRequesterAndMessageQueue() {
     ClientContext context = mock(ClientContext.class);
     FcpServerRuntimeSupport runtimeSupport = mock(FcpServerRuntimeSupport.class);
-    when(runtimeSupport.clientContext()).thenReturn(context);
+    when(runtimeSupport.persistentRequestRuntimeContext()).thenReturn(context);
     FCPServer server = mock(FCPServer.class);
     when(server.serverRuntimeSupport()).thenReturn(runtimeSupport);
     FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
@@ -72,7 +73,8 @@ class ClientRequestModifyRequestTest {
     request.modifyRequest("same-token", (short) 2, server);
 
     verify(runtimeSupport, never()).setCheckpointASAP();
-    verify(requester, never()).setPriorityClass(any(short.class), any(ClientContext.class));
+    verify(requester, never())
+        .setPriorityClass(any(short.class), any(PersistentRequestRuntimeContext.class));
     verify(client, never()).queueClientRequestMessage(any(FCPMessage.class), eq(0));
   }
 
@@ -133,7 +135,7 @@ class ClientRequestModifyRequestTest {
     }
 
     @Override
-    public void onLostConnection(ClientContext context) {
+    public void onLostConnection(PersistentRequestRuntimeContext context) {
       // No-op for focused modifyRequest() testing.
     }
 
@@ -202,7 +204,7 @@ class ClientRequestModifyRequestTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       // No-op for focused modifyRequest() testing.
     }
 
@@ -217,7 +219,7 @@ class ClientRequestModifyRequestTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       return false;
     }
 
@@ -227,7 +229,7 @@ class ClientRequestModifyRequestTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       // No-op for focused modifyRequest() testing.
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestRestartAsyncTest.java
@@ -2,6 +2,7 @@ package network.crypta.clients.fcp;
 
 import java.io.Serial;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.node.PrioRunnable;
 import network.crypta.runtime.spi.ExecutionPort;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -98,7 +99,7 @@ class ClientRequestRestartAsyncTest {
   private static final class TestClientRequest extends ClientRequest {
     @Serial private static final long serialVersionUID = 1L;
 
-    private transient ClientContext lastRestartContext;
+    private transient PersistentRequestRuntimeContext lastRestartContext;
     private boolean lastDisableFilterData;
     private int restartCalls;
 
@@ -137,7 +138,7 @@ class ClientRequestRestartAsyncTest {
     }
 
     @Override
-    public void onLostConnection(ClientContext context) {
+    public void onLostConnection(PersistentRequestRuntimeContext context) {
       // This test double only exercises restart scheduling and does not simulate connection loss.
     }
 
@@ -206,7 +207,7 @@ class ClientRequestRestartAsyncTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       // Starting the request is outside this test's scope; only restart dispatch is validated.
     }
 
@@ -221,7 +222,7 @@ class ClientRequestRestartAsyncTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       restartCalls++;
       lastRestartContext = context;
       lastDisableFilterData = disableFilterData;
@@ -234,7 +235,7 @@ class ClientRequestRestartAsyncTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       // This focused test covers restartAsync() only and does not model resume behavior.
     }
 

--- a/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientRequestTest.java
@@ -6,14 +6,20 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serial;
-import java.lang.reflect.Field;
+import java.util.Random;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.client.async.persistence.PersistentRequestCoordinator;
+import network.crypta.client.async.persistence.PersistentRequestCoordinatorContext;
 import network.crypta.client.async.persistence.PersistentRequestIdentifier;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.crypt.ChecksumChecker;
+import network.crypta.crypt.CryptoResumeContext;
+import network.crypta.crypt.MasterSecret;
 import network.crypta.node.RequestClient;
+import network.crypta.support.api.ResumeContext;
+import network.crypta.support.io.PersistentFileTracker;
+import network.crypta.support.io.PersistentFilenameGenerator;
 import network.crypta.support.io.ResumeFailedException;
 import network.crypta.support.io.StorageFormatException;
 import org.junit.jupiter.api.Test;
@@ -21,6 +27,7 @@ import org.mockito.InOrder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -162,6 +169,7 @@ class ClientRequestTest {
     // Arrange
     FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     ClientContext context = mock(ClientContext.class);
+    //noinspection UnnecessaryLocalVariable
     PersistentRequestRuntimeContext runtimeContext = context;
     PersistentRequestRoot root = new PersistentRequestRoot();
     TestClientRequest request =
@@ -188,6 +196,7 @@ class ClientRequestTest {
     // Arrange
     FcpRequesterHandle requester = mock(FcpRequesterHandle.class);
     ClientContext context = mock(ClientContext.class);
+    //noinspection UnnecessaryLocalVariable
     PersistentRequestRuntimeContext runtimeContext = context;
     PersistentRequestRoot root = new PersistentRequestRoot();
     TestClientRequest request =
@@ -212,6 +221,7 @@ class ClientRequestTest {
   void start_whenRuntimeContextUsesClientContext_expectDelegatesToTypedOverload() {
     // Arrange
     ClientContext context = mock(ClientContext.class);
+    //noinspection UnnecessaryLocalVariable
     PersistentRequestRuntimeContext runtimeContext = context;
     PersistentRequestRoot root = new PersistentRequestRoot();
     TestClientRequest request =
@@ -394,6 +404,7 @@ class ClientRequestTest {
     when(coordinator.resumePersistentRequest(request, false, "resume-client"))
         .thenReturn(resumedClient);
     ClientContext context = newContextWithCoordinator(coordinator);
+    //noinspection UnnecessaryLocalVariable
     PersistentRequestRuntimeContext runtimeContext = context;
 
     // Act
@@ -404,13 +415,84 @@ class ClientRequestTest {
     inOrder.verify(coordinator).getOrCreateClientHandle(false, "resume-client");
     inOrder.verify(requester).onResume(context);
     inOrder.verify(coordinator).resumePersistentRequest(request, false, "resume-client");
-    assertSame(context, request.innerResumeContext());
+    assertSame(context, request.innerResumeContext().persistentRequestRuntimeContext());
     assertSame(resumedClient, request.getClient());
     assertSame(resumedClient.lowLevelClient(false), request.getRequestClient());
   }
 
   @Test
-  void onResume_whenRuntimeContextIsNotClientContext_expectIllegalArgumentException() {
+  void onResume_whenRuntimeContextIsCryptoResumeCapable_preservesCryptoResumeContext()
+      throws ResumeFailedException {
+    PersistentRequestRoot originalRoot = new PersistentRequestRoot();
+    TestClientRequest request =
+        TestClientRequest.forever(
+            "resume-crypto",
+            0,
+            (short) 1,
+            null,
+            false,
+            false,
+            originalRoot.registerForeverClient("resume-crypto-client", null),
+            null);
+    PersistentRequestRoot resumedRoot = new PersistentRequestRoot();
+    PersistentRequestClient resumedClient =
+        resumedRoot.registerForeverClient("resume-crypto-client", null);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "resume-crypto-client"))
+        .thenReturn(resumedClient);
+    when(coordinator.resumePersistentRequest(request, false, "resume-crypto-client"))
+        .thenReturn(resumedClient);
+    MasterSecret secret = mock(MasterSecret.class);
+    ClientContext context = newContextWithCoordinator(coordinator);
+    when(context.getPersistentMasterSecret()).thenReturn(secret);
+
+    request.onResume((PersistentRequestRuntimeContext) context);
+
+    CryptoResumeContext cryptoContext =
+        assertInstanceOf(CryptoResumeContext.class, request.innerResumeContext());
+    assertSame(secret, cryptoContext.getPersistentMasterSecret());
+    assertSame(context, request.innerResumeContext().persistentRequestRuntimeContext());
+  }
+
+  @Test
+  void onResume_whenRuntimeContextIsResumeCapableOnly_wrapsResumeContextWithoutCrypto()
+      throws ResumeFailedException {
+    PersistentRequestRoot originalRoot = new PersistentRequestRoot();
+    TestClientRequest request =
+        TestClientRequest.forever(
+            "resume-resume-only",
+            0,
+            (short) 1,
+            null,
+            false,
+            false,
+            originalRoot.registerForeverClient("resume-only-client", null),
+            null);
+    PersistentRequestRoot resumedRoot = new PersistentRequestRoot();
+    PersistentRequestClient resumedClient =
+        resumedRoot.registerForeverClient("resume-only-client", null);
+    PersistentRequestCoordinator coordinator = mock(PersistentRequestCoordinator.class);
+    when(coordinator.getOrCreateClientHandle(false, "resume-only-client"))
+        .thenReturn(resumedClient);
+    when(coordinator.resumePersistentRequest(request, false, "resume-only-client"))
+        .thenReturn(resumedClient);
+    Random fastWeakRandom = mock(Random.class);
+    PersistentFilenameGenerator filenameGenerator = mock(PersistentFilenameGenerator.class);
+    PersistentFileTracker fileTracker = mock(PersistentFileTracker.class);
+    ResumeOnlyRuntimeContext runtimeContext =
+        new ResumeOnlyRuntimeContext(coordinator, fastWeakRandom, filenameGenerator, fileTracker);
+
+    request.onResume(runtimeContext);
+
+    assertFalse(request.innerResumeContext() instanceof CryptoResumeContext);
+    assertSame(runtimeContext, request.innerResumeContext().persistentRequestRuntimeContext());
+    assertSame(fastWeakRandom, request.innerResumeContext().fastWeakRandom());
+    assertSame(filenameGenerator, request.innerResumeContext().getPersistentFilenameGenerator());
+    assertSame(fileTracker, request.innerResumeContext().getPersistentFileTracker());
+  }
+
+  @Test
+  void onResume_whenRuntimeContextIsNotResumeCapable_expectIllegalArgumentException() {
     // Arrange
     PersistentRequestRoot root = new PersistentRequestRoot();
     TestClientRequest request =
@@ -431,7 +513,7 @@ class ClientRequestTest {
 
     // Assert
     assertEquals(
-        "FCP persistent request resume requires ClientContext but got "
+        "FCP persistent request resume requires a resume-capable runtime context but got "
             + runtimeContext.getClass().getName(),
         ex.getMessage());
   }
@@ -466,29 +548,50 @@ class ClientRequestTest {
     }
   }
 
-  @SuppressWarnings("java:S3011")
   private static ClientContext newContextWithCoordinator(PersistentRequestCoordinator coordinator) {
     ClientContext context = mock(ClientContext.class);
-    try {
-      Field field = ClientContext.class.getDeclaredField("persistentRequestCoordinator");
-      field.setAccessible(true);
-      field.set(context, coordinator);
-      return context;
-    } catch (ReflectiveOperationException e) {
-      throw new LinkageError("Failed to set ClientContext.persistentRequestCoordinator", e);
-    }
+    when(context.persistentRequestCoordinator()).thenReturn(coordinator);
+    return context;
   }
 
   private static final class OpaqueHandle implements PersistentRequestClientHandle {}
 
   private static final class OpaqueRuntimeContext implements PersistentRequestRuntimeContext {}
 
+  private record ResumeOnlyRuntimeContext(
+      PersistentRequestCoordinator persistentRequestCoordinator,
+      Random fastWeakRandom,
+      PersistentFilenameGenerator persistentFilenameGenerator,
+      PersistentFileTracker persistentFileTracker)
+      implements PersistentRequestCoordinatorContext, ResumeContext {
+
+    @Override
+    public PersistentRequestCoordinator persistentRequestCoordinator() {
+      return persistentRequestCoordinator;
+    }
+
+    @Override
+    public Random fastWeakRandom() {
+      return fastWeakRandom;
+    }
+
+    @Override
+    public PersistentFilenameGenerator getPersistentFilenameGenerator() {
+      return persistentFilenameGenerator;
+    }
+
+    @Override
+    public PersistentFileTracker getPersistentFileTracker() {
+      return persistentFileTracker;
+    }
+  }
+
   private static final class TestClientRequest extends ClientRequest {
     @Serial private static final long serialVersionUID = 1L;
 
     private final FcpRequesterHandle requester;
-    private transient ClientContext innerResumeContext;
-    private transient ClientContext startContext;
+    private transient FcpRequestRuntimeContext innerResumeContext;
+    private transient PersistentRequestRuntimeContext startContext;
     private int freeDataCalls;
 
     private TestClientRequest(ConstructorInit init, FcpRequesterHandle requester) {
@@ -543,11 +646,11 @@ class ClientRequestTest {
       return freeDataCalls;
     }
 
-    ClientContext innerResumeContext() {
+    FcpRequestRuntimeContext innerResumeContext() {
       return innerResumeContext;
     }
 
-    ClientContext startContext() {
+    PersistentRequestRuntimeContext startContext() {
       return startContext;
     }
 
@@ -564,7 +667,7 @@ class ClientRequestTest {
     }
 
     @Override
-    public void onLostConnection(ClientContext context) {
+    public void onLostConnection(PersistentRequestRuntimeContext context) {
       // No-op for focused ClientRequest base-class tests.
     }
 
@@ -633,7 +736,7 @@ class ClientRequestTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       startContext = context;
     }
 
@@ -648,7 +751,7 @@ class ClientRequestTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       return false;
     }
 
@@ -658,7 +761,7 @@ class ClientRequestTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       innerResumeContext = context;
     }
 

--- a/src/test/java/network/crypta/clients/fcp/CoreFcpPersistentRequestCatalogTest.java
+++ b/src/test/java/network/crypta/clients/fcp/CoreFcpPersistentRequestCatalogTest.java
@@ -1,8 +1,8 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
 import network.crypta.client.async.persistence.PersistentRequestIdentifier;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.bridge.CoreFcpPersistentRequestCatalog;
 import org.junit.jupiter.api.Test;
 
@@ -87,7 +87,7 @@ class CoreFcpPersistentRequestCatalogTest {
     }
 
     @Override
-    public void onLostConnection(ClientContext context) {
+    public void onLostConnection(PersistentRequestRuntimeContext context) {
       // No-op: connection lifecycle is irrelevant for this adapter test.
     }
 
@@ -156,7 +156,7 @@ class CoreFcpPersistentRequestCatalogTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       // No-op: startup mechanics are not part of catalog behavior.
     }
 
@@ -171,7 +171,7 @@ class CoreFcpPersistentRequestCatalogTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       return false;
     }
 
@@ -181,7 +181,7 @@ class CoreFcpPersistentRequestCatalogTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       // No-op: runtime reattachment is not exercised here.
     }
 

--- a/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPConnectionHandlerTest.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.crypt.EntropySource;
 import network.crypta.crypt.RandomSource;
 import network.crypta.node.RequestClient;
@@ -58,7 +57,6 @@ class FCPConnectionHandlerTest {
     Random fastRandom = new Random(5678L);
 
     lenient().when(server.serverRuntimeSupport()).thenReturn(serverRuntimeSupport);
-    lenient().when(serverRuntimeSupport.clientContext()).thenReturn(clientContext);
     lenient()
         .when(serverRuntimeSupport.persistentRequestRuntimeContext())
         .thenReturn(clientContext);
@@ -130,8 +128,8 @@ class FCPConnectionHandlerTest {
     ClientRequest removed = handler.removeRequestByIdentifier("id", true);
 
     assertSame(request, removed);
-    verify(request).cancel((PersistentRequestRuntimeContext) clientContext);
-    verify(request).requestWasRemoved((PersistentRequestRuntimeContext) clientContext);
+    verify(request).cancel(clientContext);
+    verify(request).requestWasRemoved(clientContext);
     verifyNoMoreInteractions(request);
   }
 
@@ -143,7 +141,7 @@ class FCPConnectionHandlerTest {
     ClientRequest removed = handler.removeRequestByIdentifier("id", false);
 
     assertSame(request, removed);
-    verify(request).requestWasRemoved((PersistentRequestRuntimeContext) clientContext);
+    verify(request).requestWasRemoved(clientContext);
     verifyNoMoreInteractions(request);
   }
 
@@ -272,7 +270,7 @@ class FCPConnectionHandlerTest {
       handler.startClientPut(message);
 
       ClientPut request = ignored.constructed().getFirst();
-      verify(request).start((PersistentRequestRuntimeContext) clientContext);
+      verify(request).start(clientContext);
     }
   }
 
@@ -285,7 +283,7 @@ class FCPConnectionHandlerTest {
 
       ClientPut request = ignored.constructed().getFirst();
       verify(request).register(false);
-      verify(request).start((PersistentRequestRuntimeContext) clientContext);
+      verify(request).start(clientContext);
     }
   }
 
@@ -299,7 +297,7 @@ class FCPConnectionHandlerTest {
       handler.startClientPutDir(message, buckets, true);
 
       ClientPutDir request = ignored.constructed().getFirst();
-      verify(request).start((PersistentRequestRuntimeContext) clientContext);
+      verify(request).start(clientContext);
     }
   }
 
@@ -314,7 +312,7 @@ class FCPConnectionHandlerTest {
 
       ClientPutDir request = ignored.constructed().getFirst();
       verify(request).register(false);
-      verify(request).start((PersistentRequestRuntimeContext) clientContext);
+      verify(request).start(clientContext);
     }
   }
 

--- a/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FCPServerTest.java
@@ -208,7 +208,7 @@ class FCPServerTest {
 
     FcpServerRuntimeSupport support = server.serverRuntimeSupport();
 
-    assertSame(clientContext, support.clientContext());
+    assertSame(clientContext, support.persistentRequestRuntimeContext());
     assertTrue(support.persistenceDisabled());
     assertSame(tempBucketFactory, support.tempBucketFactory());
     assertSame(persistentTempBucketFactory, support.persistentTempBucketFactory());

--- a/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
+++ b/src/test/java/network/crypta/clients/fcp/FcpServerPersistentOpsTest.java
@@ -681,11 +681,6 @@ class FcpServerPersistentOpsTest {
       }
 
       @Override
-      public ClientContext clientContext() {
-        return clientContextSupplier.get();
-      }
-
-      @Override
       public boolean persistenceDisabled() {
         return persistenceDisabledSupplier.getAsBoolean();
       }

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestClientTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestClientTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import network.crypta.client.FetchException.FetchExceptionMode;
 import network.crypta.client.FetchException;
 import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.ClientRequest.Persistence;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import network.crypta.keys.FreenetURI;
@@ -174,7 +175,7 @@ class PersistentRequestClientTest {
     PersistentRequestClient client =
         new PersistentRequestClient(
             "client", mock(FCPConnectionHandler.class), true, null, Persistence.REBOOT, null);
-    ClientGet download = newPersistentClientGet("download-1", Persistence.REBOOT);
+    ClientGet download = newPersistentClientGet();
     client.register(download);
     GetFailedMessage failureMessage =
         new GetFailedMessage(
@@ -189,7 +190,8 @@ class PersistentRequestClientTest {
     assertNotNull(cache);
     List<RequestStatus> statuses = new ArrayList<>();
     cache.addTo(statuses);
-    DownloadRequestStatus status = assertInstanceOf(DownloadRequestStatus.class, statuses.get(0));
+    DownloadRequestStatus status =
+        assertInstanceOf(DownloadRequestStatus.class, statuses.getFirst());
     assertEquals(failureMessage.getShortFailedMessage(), status.getFailureReason(false));
     assertEquals(failureMessage.getLongFailedMessage(), status.getFailureReason(true));
   }
@@ -210,7 +212,7 @@ class PersistentRequestClientTest {
     }
 
     @Override
-    public void onLostConnection(ClientContext context) {
+    public void onLostConnection(PersistentRequestRuntimeContext context) {
       // Deliberately no-op: test stub does not model connection loss behavior.
     }
 
@@ -279,7 +281,7 @@ class PersistentRequestClientTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       // Deliberately no-op: start logic exercised via pending message counting only.
     }
 
@@ -294,7 +296,7 @@ class PersistentRequestClientTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       return false;
     }
 
@@ -304,7 +306,7 @@ class PersistentRequestClientTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       // Deliberately no-op: resumption mechanics not needed for these tests.
     }
 
@@ -319,30 +321,30 @@ class PersistentRequestClientTest {
     }
 
     @Override
-    public void cancel(ClientContext context) {
+    public void cancel(PersistentRequestRuntimeContext context) {
       cancelCalls++;
     }
 
     @Override
-    public void requestWasRemoved(ClientContext context) {
+    public void requestWasRemoved(PersistentRequestRuntimeContext context) {
       requestRemovedCalls++;
     }
   }
 
-  private static ClientGet newPersistentClientGet(String identifier, Persistence persistence)
-      throws Exception {
+  private static ClientGet newPersistentClientGet() throws Exception {
+    String identifier = "download-1";
     ClientGet request = new ClientGet();
     ClientGetTestProfiles.setFetchConfig(request, new ClientGetFetchConfig());
     ClientGetTestProfiles.setReturnType(request, ClientGet.ReturnType.NONE);
-    setField(ClientRequest.class, request, "identifier", identifier);
-    setField(ClientRequest.class, request, "persistence", persistence);
-    setField(ClientRequest.class, request, "uri", new FreenetURI("KSK@" + identifier));
+    setField(request, "identifier", identifier);
+    setField(request, "persistence", Persistence.REBOOT);
+    setField(request, "uri", new FreenetURI("KSK@" + identifier));
     return request;
   }
 
-  private static void setField(Class<?> owner, Object target, String name, Object value)
+  private static void setField(Object target, String name, Object value)
       throws ReflectiveOperationException {
-    Field field = owner.getDeclaredField(name);
+    Field field = ClientRequest.class.getDeclaredField(name);
     field.setAccessible(true);
     field.set(target, value);
   }

--- a/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
+++ b/src/test/java/network/crypta/clients/fcp/PersistentRequestRootTest.java
@@ -1,8 +1,8 @@
 package network.crypta.clients.fcp;
 
-import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.persistence.PersistentRequestClientHandle;
 import network.crypta.client.async.persistence.PersistentRequestHandle;
+import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.clients.fcp.RequestIdentifier.RequestType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -215,7 +215,7 @@ class PersistentRequestRootTest {
     }
 
     @Override
-    public void onLostConnection(ClientContext context) {
+    public void onLostConnection(PersistentRequestRuntimeContext context) {
       // No-op: connection lifecycle is irrelevant for this stubbed request.
     }
 
@@ -284,7 +284,7 @@ class PersistentRequestRootTest {
     }
 
     @Override
-    public void start(ClientContext context) {
+    public void start(PersistentRequestRuntimeContext context) {
       // No-op: a start lifecycle isn't needed in these tests.
     }
 
@@ -299,7 +299,7 @@ class PersistentRequestRootTest {
     }
 
     @Override
-    public boolean restart(ClientContext context, boolean disableFilterData) {
+    public boolean restart(PersistentRequestRuntimeContext context, boolean disableFilterData) {
       return false;
     }
 
@@ -309,7 +309,7 @@ class PersistentRequestRootTest {
     }
 
     @Override
-    protected void innerResume(ClientContext context) {
+    protected void innerResume(FcpRequestRuntimeContext context) {
       // No-op: resume side effects are unnecessary for the stub.
     }
 

--- a/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
+++ b/src/test/java/network/crypta/runtime/endpoints/NodeClientPersistenceTest.java
@@ -580,7 +580,7 @@ class NodeClientPersistenceTest {
 
     // Assert
     assertAll(
-        () -> assertSame(coordinator, context.persistentRequestCoordinator),
+        () -> assertSame(coordinator, context.persistentRequestCoordinator()),
         () -> assertSame(persistentRequests, persistence.getPersistentRequests()));
     verify(servicesFactory).create();
     verify(clientLayerPersister).configurePersistenceAdapters(catalog, recoveryCodec);
@@ -638,7 +638,7 @@ class NodeClientPersistenceTest {
     ClientRequest request = mock(ClientRequest.class);
     when(request.hasFinished()).thenReturn(false);
     when(request.isPersistentForever()).thenReturn(true);
-    context.persistentRequestCoordinator.resumePersistentRequest(request, true, "client");
+    context.persistentRequestCoordinator().resumePersistentRequest(request, true, "client");
 
     // Act
     PersistentRequestHandle[] requests = persistence.getPersistentRequests();


### PR DESCRIPTION
## Summary

This PR detaches the remaining adapter-owned FCP request lifecycle surface from the live `ClientContext` type while preserving existing FCP behavior.

It:
- introduces `FcpRequestRuntimeContext` as the adapter-owned detached seam for resume paths that need both persistent-request runtime state and bucket reattachment
- migrates `ClientRequest`, `ClientGet`, `ClientPut`, `ClientPutDir`, `FcpRequesterHandle`, `FcpInsertCallback`, and related lifecycle interfaces away from direct `ClientContext` exposure in `:adapter-fcp`
- moves runtime narrowing back into `:bridge-fcp-runtime`, including the fetch/insert runtime adapters and persistent recovery codec
- extracts `ClientGetLifecycle`, `ClientGetRestoreInput`, `ClientPutConstructorSupport`, and `ClientPutLifecycle` to keep the request classes smaller while preserving behavior
- tightens `AdapterFcpBoundaryTest` so `:adapter-fcp` main only allows the intentionally preserved `ClientPutBase` / `ClientPutCallback` residue
- adds focused regression coverage for detached resume wrapping, crypto-capable resume contexts, and `ClientGetPersistenceIO.resume(...)`
- improves Javadoc for the newly added non-test Java seam/helper files

Out of scope and still intentionally preserved:
- the remaining `BaseClientPutter` / `ClientPutCallback` cleanup in `ClientPutBase`
- removal of the `:adapter-fcp -> :runtime-node` dependency

## How to test

Run the focused validation used while developing the change:

```bash
./gradlew :adapter-fcp:compileJava :bridge-fcp-runtime:compileJava compileTestJava
./gradlew :test --tests network.crypta.clients.fcp.ClientRequestTest --tests network.crypta.clients.fcp.ClientGetTest --tests network.crypta.clients.fcp.ClientGetPersistenceIOTest --tests network.crypta.clients.fcp.ClientPutTest --tests network.crypta.clients.fcp.ClientPutDirTest --tests network.crypta.clients.fcp.FCPConnectionHandlerTest --tests network.crypta.clients.fcp.FcpServerPersistentOpsTest
./gradlew :bridge-fcp-runtime:test --tests network.crypta.clients.fcp.bridge.CoreFcpServerRuntimeSupportTest --tests network.crypta.clients.fcp.bridge.CoreFcpFetchRuntimeSupportTest --tests network.crypta.clients.fcp.bridge.CoreFcpInsertRuntimeSupportTest
./gradlew :adapter-fcp:test --tests network.crypta.clients.fcp.AdapterFcpBoundaryTest
./gradlew test
```

## Notes

- `origin/develop` was used as the base branch.
- The branch was created from `develop` before formatting and committing to avoid committing directly on a base branch.
