### PR TITLE
refactor(adapter-fcp): Detach insert callbacks from runtime-node

### DIFF
--- a/adapter-fcp/build.gradle.kts
+++ b/adapter-fcp/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
   implementation(project(":kernel-transport"))
   implementation(project(":kernel-routing"))
   implementation(project(":runtime-spi"))
-  implementation(project(":runtime-node"))
 
   implementation(libs.slf4jApi)
   implementation(files(rootProject.file("libs/wrapper.jar")))

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/ClientPutBase.java
@@ -22,7 +22,6 @@ import network.crypta.client.events.SplitfileProgressEvent;
 import network.crypta.client.events.StartedCompressionEvent;
 import network.crypta.keys.FreenetURI;
 import network.crypta.support.api.Bucket;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,9 +52,7 @@ import org.slf4j.LoggerFactory;
  * @see ClientPutDir
  */
 public abstract class ClientPutBase extends ClientRequest
-    implements FcpInsertCallback,
-        ClientEventListener,
-        network.crypta.client.async.ClientPutCallback {
+    implements FcpInsertCallback, ClientEventListener {
   private static final Logger LOG = LoggerFactory.getLogger(ClientPutBase.class);
   private static final String LEGACY_INSERT_CONTEXT_TYPE = "network.crypta.client.InsertContext";
   private static final String FIELD_SUCCEEDED = "succeeded";
@@ -338,12 +335,6 @@ public abstract class ClientPutBase extends ClientRequest
     // otherwise ignore
   }
 
-  @Override
-  public final void onResume(network.crypta.client.async.ClientContext context)
-      throws network.crypta.support.io.ResumeFailedException {
-    super.onResume(context);
-  }
-
   /**
    * Finalizes a successful insert by freezing timing statistics, cleaning up transient buckets, and
    * emitting the appropriate {@code PutSuccessful} message.
@@ -374,11 +365,6 @@ public abstract class ClientPutBase extends ClientRequest
     finish();
     trySendFinalMessage(null, null);
     if (client != null) client.notifySuccess(this);
-  }
-
-  @Override
-  public final void onSuccess(network.crypta.client.async.BaseClientPutter state) {
-    onSuccess(legacyState(state));
   }
 
   private FreenetURI generatedUriOrFallback(FcpInsertCallbackState state) {
@@ -428,12 +414,6 @@ public abstract class ClientPutBase extends ClientRequest
     if (client != null) client.notifyFailure(this);
   }
 
-  @Override
-  public final void onFailure(
-      InsertException e, network.crypta.client.async.BaseClientPutter state) {
-    onFailure(e, legacyState(state));
-  }
-
   /**
    * Accepts the newly derived final URI from the inserter and propagates it to listeners and caches
    * exactly once.
@@ -466,12 +446,6 @@ public abstract class ClientPutBase extends ClientRequest
         cache.gotFinalURI(identifier, uri);
       }
     }
-  }
-
-  @Override
-  public final void onGeneratedURI(
-      FreenetURI uri, network.crypta.client.async.BaseClientPutter state) {
-    onGeneratedURI(uri, legacyState(state));
   }
 
   /**
@@ -516,12 +490,6 @@ public abstract class ClientPutBase extends ClientRequest
     } else {
       trySendGeneratedMetadataMessage(metadata, null, null);
     }
-  }
-
-  @Override
-  public final void onGeneratedMetadata(
-      Bucket metadata, network.crypta.client.async.BaseClientPutter state) {
-    onGeneratedMetadata(metadata, legacyState(state));
   }
 
   /**
@@ -676,29 +644,6 @@ public abstract class ClientPutBase extends ClientRequest
       }
       PutFetchableMessage msg = new PutFetchableMessage(identifier, global, temp);
       trySendProgressMessage(msg, VERBOSITY_PUT_FETCHABLE, null);
-    }
-  }
-
-  @Override
-  public final void onFetchable(network.crypta.client.async.BaseClientPutter state) {
-    onFetchable(legacyState(state));
-  }
-
-  private static FcpInsertCallbackState legacyState(
-      network.crypta.client.async.BaseClientPutter state) {
-    return state == null ? null : new LegacyInsertCallbackState(state);
-  }
-
-  private record LegacyInsertCallbackState(network.crypta.client.async.BaseClientPutter putter)
-      implements FcpInsertCallbackState {
-    @Override
-    public FreenetURI getURI() {
-      return putter.getURI();
-    }
-
-    @Override
-    public @NotNull String toString() {
-      return putter.toString();
     }
   }
 

--- a/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallback.java
+++ b/adapter-fcp/src/main/java/network/crypta/clients/fcp/FcpInsertCallback.java
@@ -14,9 +14,9 @@ import network.crypta.support.io.ResumeFailedException;
 /**
  * Adapter-owned callback contract for live insert lifecycle events.
  *
- * <p>This interface is the adapter-side replacement for the runtime {@code ClientPutCallback}. The
- * bridge runtime owns the concrete daemon inserter and adapts that inserter back to this detached
- * surface, which lets {@code :adapter-fcp} react to insert progress without importing the
+ * <p>This interface is the adapter-side replacement for the live runtime insert callback contract.
+ * The bridge runtime owns the concrete daemon inserter and adapts that inserter back to this
+ * detached surface, which lets {@code :adapter-fcp} react to insert progress without importing the
  * runtime-owned callback or putter classes directly. In practice, implementations are long-lived
  * request objects such as {@link ClientPutBase} descendants that need to survive reconnections,
  * Java serialization, and persistent-request resume.
@@ -36,7 +36,7 @@ import network.crypta.support.io.ResumeFailedException;
  * <ul>
  *   <li>Receives user-visible insert lifecycle notifications from the bridge runtime.
  *   <li>Provides persistent-request resume and serialization hooks for the owning request.
- *   <li>Hides the concrete runtime {@code ClientPutCallback} and putter types from the adapter.
+ *   <li>Hides the concrete runtime callback and putter types from the adapter.
  * </ul>
  */
 public interface FcpInsertCallback extends Serializable {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -82,8 +82,7 @@ class AdapterFcpBoundaryTest {
   private static final Path FCP_MESSAGE_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("FCPMessage.java");
   private static final Path CLIENT_PUT_COMPLEX_DIR_MESSAGE_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutComplexDirMessage.java");
-  private static final Path CLIENT_PUT_BASE_SOURCE =
-      ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutBase.java");
+  private static final Path CLIENT_PUT_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("ClientPut.java");
   private static final Path CLIENT_PUT_DIR_SOURCE =
       ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutDir.java");
   private static final Path CLIENT_PUT_PREPARED_DATA_FACTORY_SOURCE =
@@ -111,7 +110,7 @@ class AdapterFcpBoundaryTest {
   private static final Set<Path> INSERT_FAMILY_SEAM_SOURCES =
       Set.of(
           ADAPTER_FCP_MAIN_JAVA.resolve("FcpInsertRuntimeSupport.java"),
-          ADAPTER_FCP_MAIN_JAVA.resolve("ClientPut.java"),
+          CLIENT_PUT_SOURCE,
           CLIENT_PUT_DIR_SOURCE,
           CLIENT_PUT_PREPARED_DATA_FACTORY_SOURCE,
           ADAPTER_FCP_MAIN_JAVA.resolve("ClientPutPutterFactory.java"),
@@ -147,7 +146,6 @@ class AdapterFcpBoundaryTest {
           ADAPTER_FCP_MAIN_JAVA.resolve("ClientGetMessage.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("UnsupportedPluginMessage.java"),
           ADAPTER_FCP_MAIN_JAVA.resolve("TestDdaCompleteMessage.java"));
-  private static final Set<Path> CLIENT_CONTEXT_RESIDUE_ALLOWLIST = Set.of(CLIENT_PUT_BASE_SOURCE);
   private static final Path BRIDGE_FCP_RUNTIME_MAIN_JAVA =
       Path.of(
           "bridge-fcp-runtime",
@@ -207,11 +205,10 @@ class AdapterFcpBoundaryTest {
           "network.crypta.client.async.USKFoundEdition",
           "network.crypta.client.async.USKManager",
           "network.crypta.client.async.USKProgressCallback");
-  private static final Set<String> FORBIDDEN_REQUESTER_CALLBACK_IMPORTS =
-      Set.of(
-          "network.crypta.client.async.BaseClientPutter",
-          "network.crypta.client.async.ClientPutCallback",
-          "network.crypta.client.async.ClientRequester");
+  private static final Set<String> FORBIDDEN_RUNTIME_TYPE_REFERENCES =
+      Set.of("BaseClientPutter", "ClientContext", "ClientPutCallback");
+  private static final Set<String> FORBIDDEN_REQUESTER_IMPORTS =
+      Set.of("network.crypta.client.async.ClientRequester");
   private static final Set<String> FORBIDDEN_SERVER_INFRA_RUNTIME_TYPES =
       Set.of(
           "network.crypta.client.async.ClientContext",
@@ -594,27 +591,30 @@ class AdapterFcpBoundaryTest {
   }
 
   @Test
-  void adapterFcpMain_whenCheckingClientContextBoundary_expectNoLiveClientContextOutsideResidue()
-      throws IOException {
+  void
+      adapterFcpMain_whenCheckingLegacyRuntimeTypeBoundary_expectNoClientContextOrInsertCallbackReferences()
+          throws IOException {
     Path repoRoot = repoRoot();
     List<String> violations = new ArrayList<>();
 
     for (Path sourceFile : findJavaSources(repoRoot.resolve(ADAPTER_FCP_MAIN_JAVA))) {
       Path relativePath = repoRoot.relativize(sourceFile);
-      if (CLIENT_CONTEXT_RESIDUE_ALLOWLIST.contains(relativePath)) {
-        continue;
-      }
       String source = Files.readString(sourceFile);
-      if (source.contains("network.crypta.client.async.ClientContext")
-          || source.contains("ClientContext")) {
-        violations.add(relativePath.toString());
+      Set<String> forbiddenReferences = new TreeSet<>();
+      for (String forbiddenReference : FORBIDDEN_RUNTIME_TYPE_REFERENCES) {
+        if (source.contains(forbiddenReference)) {
+          forbiddenReferences.add(forbiddenReference);
+        }
+      }
+      if (!forbiddenReferences.isEmpty()) {
+        violations.add(relativePath + " -> " + String.join(", ", forbiddenReferences));
       }
     }
 
     assertTrue(
         violations.isEmpty(),
-        ":adapter-fcp main sources must not import or reference ClientContext outside the"
-            + " legacy BaseClientPutter/ClientPutCallback residue."
+        ":adapter-fcp main sources must not reference ClientContext, BaseClientPutter, or "
+            + "ClientPutCallback."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
   }
@@ -689,7 +689,7 @@ class AdapterFcpBoundaryTest {
   }
 
   @Test
-  void adapterFcpMain_whenScanningRequesterCallbackImports_expectNoLiveRequesterOrCallbackLeaks()
+  void adapterFcpMain_whenScanningRequesterImports_expectNoLiveClientRequesterLeak()
       throws IOException {
     Path repoRoot = repoRoot();
     List<String> violations = new ArrayList<>();
@@ -698,7 +698,7 @@ class AdapterFcpBoundaryTest {
     for (Path sourceFile : findJavaSources(adapterFcpMain)) {
       Set<String> imports = readImports(sourceFile);
       Set<String> forbiddenImports = new TreeSet<>(imports);
-      forbiddenImports.retainAll(FORBIDDEN_REQUESTER_CALLBACK_IMPORTS);
+      forbiddenImports.retainAll(FORBIDDEN_REQUESTER_IMPORTS);
       if (!forbiddenImports.isEmpty()) {
         violations.add(
             repoRoot.relativize(sourceFile) + " -> " + String.join(", ", forbiddenImports));
@@ -707,8 +707,7 @@ class AdapterFcpBoundaryTest {
 
     assertTrue(
         violations.isEmpty(),
-        ":adapter-fcp main sources must not import live requester or insert-callback runtime "
-            + "types."
+        ":adapter-fcp main sources must not import ClientRequester."
             + System.lineSeparator()
             + String.join(System.lineSeparator(), violations));
   }

--- a/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutBaseTest.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Field;
 import java.time.Instant;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
-import network.crypta.client.async.BaseClientPutter;
 import network.crypta.client.async.ClientContext;
 import network.crypta.client.async.persistence.PersistentRequestRuntimeContext;
 import network.crypta.client.events.ExpectedHashesEvent;
@@ -146,29 +145,6 @@ class ClientPutBaseTest {
     FcpInsertCallbackState state = mock(FcpInsertCallbackState.class);
     FreenetURI generatedUri = new FreenetURI("KSK", "fallback-uri");
     setField(ClientRequest.class, request, "identifier", "fallback-id");
-    setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
-    setField(ClientRequest.class, request, "origHandler", handler);
-    setField(ClientRequest.class, request, "client", client);
-    when(state.getURI()).thenReturn(generatedUri);
-
-    request.onSuccess(state);
-
-    ArgumentCaptor<PutSuccessfulMessage> successCaptor =
-        ArgumentCaptor.forClass(PutSuccessfulMessage.class);
-    verify(handler).send(successCaptor.capture());
-    assertSame(generatedUri, request.getGeneratedURI());
-    assertSame(generatedUri, successCaptor.getValue().uri);
-    verify(client).notifySuccess(request);
-  }
-
-  @Test
-  void onSuccess_whenLegacyBaseClientPutterProvided_usesStateUriForPutSuccessfulAndStatus()
-      throws Exception {
-    TestClientPutBase request = new TestClientPutBase();
-    PersistentRequestClient client = mock(PersistentRequestClient.class);
-    BaseClientPutter state = mock(BaseClientPutter.class);
-    FreenetURI generatedUri = new FreenetURI("KSK", "legacy-fallback-uri");
-    setField(ClientRequest.class, request, "identifier", "legacy-fallback-id");
     setField(ClientRequest.class, request, "persistence", Persistence.CONNECTION);
     setField(ClientRequest.class, request, "origHandler", handler);
     setField(ClientRequest.class, request, "client", client);

--- a/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
+++ b/src/test/java/network/crypta/clients/fcp/ClientPutTest.java
@@ -7,14 +7,11 @@ import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
-import java.io.Serial;
-import java.io.Serializable;
 import java.lang.reflect.Field;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.InsertException.InsertExceptionMode;
 import network.crypta.client.InsertException;
 import network.crypta.client.async.ClientContext;
-import network.crypta.client.async.ClientPutCallback;
 import network.crypta.client.async.ClientPutter;
 import network.crypta.client.async.ClientRequester;
 import network.crypta.client.events.SimpleEventProducer;
@@ -437,15 +434,6 @@ class ClientPutTest {
   }
 
   @Test
-  void legacyClientPutCallbackField_whenRoundTripped_acceptsClientPutInstance() throws Exception {
-    LegacyClientPutCallbackHolder restored =
-        roundTripObject(
-            new LegacyClientPutCallbackHolder(clientPut), LegacyClientPutCallbackHolder.class);
-
-    assertInstanceOf(ClientPut.class, restored.callback);
-  }
-
-  @Test
   void serialization_whenRoundTripped_restoresExecutionFromLegacyClientPutter() throws Exception {
     ClientPutter legacyPutter = mock(ClientPutter.class, withSettings().serializable());
     ClientPutExecution execution = createExecution(legacyPutter);
@@ -518,17 +506,6 @@ class ClientPutTest {
     try (ObjectInputStream objectInput =
         new ObjectInputStream(new ByteArrayInputStream(serialized))) {
       return type.cast(objectInput.readObject());
-    }
-  }
-
-  @SuppressWarnings("ClassCanBeRecord")
-  private static final class LegacyClientPutCallbackHolder implements Serializable {
-    @Serial private static final long serialVersionUID = 1L;
-
-    private final ClientPutCallback callback;
-
-    private LegacyClientPutCallbackHolder(ClientPutCallback callback) {
-      this.callback = callback;
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove the remaining `ClientPutCallback` / `BaseClientPutter` / `ClientContext` residue from `ClientPutBase`
- tighten `AdapterFcpBoundaryTest` so `:adapter-fcp` main sources reject those live runtime callback/context references
- drop the main `:adapter-fcp` dependency on `:runtime-node` and confirm it is absent from the main compile classpath

## Testing
- `./gradlew :adapter-fcp:compileJava :adapter-fcp:test --tests network.crypta.clients.fcp.AdapterFcpBoundaryTest`
- `./gradlew :adapter-fcp:test`
- `./gradlew :bridge-fcp-runtime:test --tests '*CoreFcpInsertRuntimeSupport*'`
- `./gradlew :adapter-fcp:dependencies --configuration compileClasspath`
