### PR TITLE
test(boundaries): Freeze phase 2 adapter-runtime split

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -25,12 +25,16 @@ Use this skill when you need to:
     `network.crypta.support.transport.ip`, and `network.crypta.support.http`, plus
     `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
     `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`,
-    `network.crypta.node.SemiOrderedShutdownHook`, and `network.crypta.support.IllegalValueException`
+    `network.crypta.node.PrioRunnable`, `network.crypta.node.SemiOrderedShutdownHook`,
+    `network.crypta.support.IllegalValueException`, `network.crypta.support.JVMVersion`, the
+    generic `HTTPRequest` / `HTTPUploadedFile` / `MultiValueTable` / `SizeUtil` support surface,
+    generic helpers such as `URIPreEncoder`, `IOUtils`, and `LegacyFileSupport`, and the
+    cycle-safe file-backed support I/O slice
   - `:foundation-store-contracts` → neutral `network.crypta.store` contracts
     `BlockMetadata`, `GetPubkey`, `StorableBlock`, plus the `network.crypta.store.alerts` seam
     (`StoreAlertSink`, `StoreMaintenanceAlertKind`, `StoreMaintenanceAlertSource`)
   - `:foundation-crypto-keys` → `network.crypta.crypt`, `network.crypta.keys`, plus
-    `network.crypta.support.io.BucketTools` and
+    `network.crypta.support.io.BucketTools`, `network.crypta.support.io.NoFreeBucket`, and
     `network.crypta.support.io.PrependLengthOutputStream`
   - `:foundation-store` → reusable `network.crypta.store` implementations plus
     `network.crypta.store.caching` and `network.crypta.store.saltedhash`
@@ -46,12 +50,14 @@ Use this skill when you need to:
     `network.crypta.compat.bandwidth`
   - `:kernel-content` → the compile-neutral phase-1 content slice across selected
     `network.crypta.client`, `network.crypta.client.events`,
-    `network.crypta.client.filter`, `network.crypta.client.async.alerts`, and
+    `network.crypta.client.filter`, `network.crypta.client.async.alerts`,
+    `network.crypta.client.async.persistence`, selected filter policy/helper types such as
+    `HTMLFilterPolicy`, selected event/helper types such as `SplitfileCompatibilityMode*`, and
     `network.crypta.support.MediaType`
   - `:kernel-transport` → the compile-neutral phase-1 transport slice across selected
     `network.crypta.io`, `network.crypta.io.comm`, and `network.crypta.io.xfer` helpers such as
-    address matchers, allow-list parsing, listener abstractions, I/O statistics collection,
-    throttling, and partially received block assembly
+    address matchers, allow-list parsing, listener abstractions, `SSLNetworkInterface`,
+    I/O statistics collection, throttling, and partially received block assembly
   - `:kernel-routing` → the compile-neutral phase-1 routing/helper slice across selected
     `network.crypta.node` value, exception, callback, and request-item helper types such as
     `BaseRequestThrottle`, `LowLevelGetException`, `LowLevelPutException`, `RequestClient`,
@@ -68,11 +74,11 @@ Use this skill when you need to:
     `network.crypta.node` / `network.crypta.runtime.*` slices, the retained node-coupled
     transport/message execution code in `network.crypta.io*`, and the remaining daemon-coupled
     `network.crypta.support` / `network.crypta.support.io` / `network.crypta.support.api` subset
-  - `:adapter-fcp` → the protocol-side `network.crypta.clients.fcp` package tree
+  - `:adapter-fcp` → the detached protocol-side `network.crypta.clients.fcp` package tree
   - `:bridge-fcp-runtime` → the concrete runtime-binding FCP bridge package
     `network.crypta.clients.fcp.bridge`
-  - `:adapter-http-legacy-admin` → the shared legacy `network.crypta.clients.http` shell, admin
-    toadlets, `/api/v1/` and `/app/node/` bridge entrypoints, and matching
+  - `:adapter-http-legacy-admin` → the detached shared legacy `network.crypta.clients.http`
+    shell, admin toadlets, `/api/v1/` and `/app/node/` bridge entrypoints, and matching
     `network/crypta/clients/http/**` main resources
   - `:adapter-http-legacy-browse` → the concrete legacy browse/FProxy routes, toadlets, helper
     models, and browse-only packages under `network.crypta.clients.http`
@@ -119,11 +125,14 @@ Use this skill when you need to:
 - The wire split is intentionally narrow:
   `:interop-wire` owns the message/schema nucleus, `:kernel-transport` owns the compile-neutral
   transport helper slice (`AllowedHosts`, `NetworkInterface`, `IOStatisticCollector`,
-  `SocketHandler`, `PacketThrottle`, `PartiallyReceivedBlock`, etc.), while `:runtime-node` keeps
-  `MessageCore`, `MessageFilter`, `AsyncMessageFilterCallback`, `SlowAsyncMessageFilterCallback`,
-  `PeerContext`, incoming-packet filters, active socket handlers, and transfer send/receive code.
+  `SSLNetworkInterface`, `SocketHandler`, `PacketThrottle`, `PartiallyReceivedBlock`, etc.),
+  while `:runtime-node` keeps `MessageCore`, `MessageFilter`, `AsyncMessageFilterCallback`,
+  `SlowAsyncMessageFilterCallback`, `PeerContext`, incoming-packet filters, active socket
+  handlers, and transfer send/receive code.
   `network.crypta.io.comm.Message` now depends on the minimal `MessageSource` seam instead of
   directly on `PeerContext`.
+- For the detached adapter/runtime boundary details, prefer the maintenance docs in
+  `docs/fcp-boundary.md` and `docs/legacy-http-boundary.md` over older migration narratives.
 - `:foundation-config` is the current home for all main `network.crypta.config` and
   `network.crypta.l10n` sources. Their unit tests still live in the root test tree and are run by
   the root project.
@@ -210,8 +219,12 @@ Use this skill when you need to:
 ### Client APIs
 - High-level client: `network.crypta.client`
   - `:kernel-content` now owns the compile-neutral phase-1 content slice: selected
-    archive/value/helper classes, immutable event values, a conservative subset of filter
-    helper/parser types, the full `network.crypta.client.async.alerts` seam, and
+    archive/value/helper classes, immutable event values, the full
+    `network.crypta.client.async.alerts` seam, client-local seams under
+    `network.crypta.client.async.persistence`, a conservative subset of filter helper/parser
+    types plus policy holders such as `HTMLFilterPolicy`, event/helper types such as
+    `ClientEventProducer` and `SplitfileCompatibilityMode*`, utility/value types such as
+    `ClientGetterOptions` and `ClientPutterOptions`, `InsertUriChecks`, and
     `network.crypta.support.MediaType`.
   - `:runtime-node` still owns the cyclic async scheduler/request engine, high-level client APIs,
     and the remaining filter/archive surfaces that still depend on request scheduling or node
@@ -358,8 +371,11 @@ Use this skill when you need to:
   `network.crypta.support.transport.ip`, and `network.crypta.support.http`.
 - `:foundation-support` also owns `network.crypta.io.AddressIdentifier`,
   `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FastRunnable`,
-  `network.crypta.node.SemiOrderedShutdownHook`, `network.crypta.support.IllegalValueException`,
-  and `network.crypta.support.SerializationLimits`.
+  `network.crypta.node.PrioRunnable`, `network.crypta.node.SemiOrderedShutdownHook`,
+  `network.crypta.support.IllegalValueException`, `network.crypta.support.JVMVersion`, the
+  generic HTTP request/upload and multimap/size-formatting surface, generic helpers such as
+  `URIPreEncoder`, `IOUtils`, and `LegacyFileSupport`, the cycle-safe file-backed support I/O
+  slice, and `network.crypta.support.SerializationLimits`.
 - The root project still owns daemon-coupled support code and higher-level wiring that is not yet
   stable enough to extract cleanly.
 
@@ -372,11 +388,16 @@ Use this skill when you need to:
 - `:foundation-support`: stable generic `network.crypta.support*` subset plus
   `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
   `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`,
-  `network.crypta.node.SemiOrderedShutdownHook`, `network.crypta.support.http`, and
-  `network.crypta.support.IllegalValueException`
+  `network.crypta.node.PrioRunnable`, `network.crypta.node.SemiOrderedShutdownHook`,
+  `network.crypta.support.http`, `network.crypta.support.IllegalValueException`,
+  `network.crypta.support.JVMVersion`, the generic `HTTPRequest` / `HTTPUploadedFile` /
+  `MultiValueTable` / `SizeUtil` surface, generic helpers such as `URIPreEncoder`, `IOUtils`,
+  and `LegacyFileSupport`, and the cycle-safe file-backed support I/O slice
 - `:foundation-store-contracts`: neutral `network.crypta.store` contracts plus
   `network.crypta.store.alerts`
-- `:foundation-crypto-keys`: `network.crypta.crypt`, `network.crypta.keys`
+- `:foundation-crypto-keys`: `network.crypta.crypt`, `network.crypta.keys`, plus adjacent
+  support-IO helpers such as `BucketTools`, `NoFreeBucket`, and
+  `PrependLengthOutputStream`
 - `:foundation-store`: reusable `network.crypta.store` implementations
 - `:interop-wire`: wire/message/schema/version/probe nucleus
 - `:foundation-config`: `network.crypta.config`, `network.crypta.l10n`,
@@ -384,9 +405,11 @@ Use this skill when you need to:
 - `:foundation-fs`: `network.crypta.fs`
 - `:foundation-compat`: `network.crypta.compat`, `network.crypta.compat.bandwidth`
 - `:kernel-content`: compile-neutral phase-1 content slice across selected `network.crypta.client*`
-  classes plus `network.crypta.support.MediaType`
+  classes, `network.crypta.client.async.persistence`, event/helper types such as
+  `SplitfileCompatibilityMode*`, filter policy/helper types such as `HTMLFilterPolicy`,
+  `InsertUriChecks`, and `network.crypta.support.MediaType`
 - `:kernel-transport`: compile-neutral phase-1 transport slice across selected
-  `network.crypta.io*` helpers
+  `network.crypta.io*` helpers including `SSLNetworkInterface`
 - `:kernel-routing`: compile-neutral phase-1 routing/helper slice across selected
   `network.crypta.node` helper/value types
 - `:runtime-spi`: `network.crypta.runtime.spi`

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -32,13 +32,16 @@ Use this skill when you need to:
   `network.crypta.support*`, `network.crypta.support.transport.ip`,
   `network.crypta.support.http`, `network.crypta.io.AddressIdentifier`,
   `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FSParseException`,
-  `network.crypta.node.FastRunnable`, `network.crypta.node.SemiOrderedShutdownHook`, and
-  `network.crypta.support.IllegalValueException`.
+  `network.crypta.node.FastRunnable`, `network.crypta.node.PrioRunnable`,
+  `network.crypta.node.SemiOrderedShutdownHook`, `network.crypta.support.IllegalValueException`,
+  `network.crypta.support.JVMVersion`, the generic `HTTPRequest` / `HTTPUploadedFile` /
+  `MultiValueTable` / `SizeUtil` surface, generic helpers such as `URIPreEncoder`, `IOUtils`,
+  and `LegacyFileSupport`, plus the cycle-safe file-backed support I/O slice.
 - `:foundation-store-contracts` owns the neutral `network.crypta.store` contracts
   `BlockMetadata`, `GetPubkey`, and `StorableBlock`, plus the `network.crypta.store.alerts`
   seam.
 - `:foundation-crypto-keys` owns `network.crypta.crypt`, `network.crypta.keys`, and the adjacent
-  `BucketTools` / `PrependLengthOutputStream` helpers.
+  `BucketTools` / `NoFreeBucket` / `PrependLengthOutputStream` helpers.
 - `:foundation-store` owns reusable `network.crypta.store` implementations plus
   `network.crypta.store.caching` and `network.crypta.store.saltedhash`.
 - `:interop-wire` owns the narrow wire/message/schema/version/probe nucleus:
@@ -52,11 +55,13 @@ Use this skill when you need to:
   `network.crypta.compat.bandwidth`.
 - `:kernel-content` owns the compile-neutral phase-1 content slice across selected
   `network.crypta.client`, `network.crypta.client.events`, `network.crypta.client.filter`,
-  `network.crypta.client.async.alerts`, and `network.crypta.support.MediaType`.
+  `network.crypta.client.async.alerts`, `network.crypta.client.async.persistence`,
+  event/helper types such as `SplitfileCompatibilityMode*`, filter policy/helper types such as
+  `HTMLFilterPolicy`, `InsertUriChecks`, and `network.crypta.support.MediaType`.
 - `:kernel-transport` owns the compile-neutral phase-1 transport slice across selected
   `network.crypta.io`, `network.crypta.io.comm`, and `network.crypta.io.xfer` helpers such as
-  allow-list parsing, listener abstraction, I/O statistics collection, throttling, and partially
-  received block assembly.
+  allow-list parsing, listener abstraction, `SSLNetworkInterface`, I/O statistics collection,
+  throttling, and partially received block assembly.
 - `:kernel-routing` owns the compile-neutral phase-1 routing/helper slice across selected
   `network.crypta.node` value, exception, callback, and request-item helper types such as
   `BaseRequestThrottle`, `LowLevelGetException`, `LowLevelPutException`, `RequestClient`,
@@ -91,14 +96,16 @@ Use this skill when you need to:
   `network.crypta.node`, the retained node-coupled transport/message execution code in
   `network.crypta.io*`, `network.crypta.runtime.*`, and the remaining daemon-coupled support
   helpers.
-- `:adapter-fcp` owns the protocol-side `network.crypta.clients.fcp` tree.
-- `:bridge-fcp-runtime` owns the concrete runtime-binding `network.crypta.clients.fcp.bridge`
-  implementations and its focused leaf tests under `bridge-fcp-runtime/src/test/java`.
+- `:adapter-fcp` owns the detached protocol-side `network.crypta.clients.fcp` tree.
+- `:bridge-fcp-runtime` owns the concrete runtime-binding
+  `network.crypta.clients.fcp.bridge` implementations, remains the only FCP leaf with the direct
+  `:runtime-node` binding, and keeps its focused leaf tests under
+  `bridge-fcp-runtime/src/test/java`.
 - `:bridge-http-runtime` owns the concrete `network.crypta.clients.http.bridge` runtime-binding
   implementations plus the legacy HTTP `network.crypta.clients.http.geoip` helper package, with
   focused leaf tests under `bridge-http-runtime/src/test/java`.
-- `:adapter-http-legacy-admin` owns the shared legacy `network.crypta.clients.http` shell, admin
-  toadlets, `/api/v1/` and `/app/node/` bridge entrypoints, and the matching
+- `:adapter-http-legacy-admin` owns the detached shared legacy `network.crypta.clients.http`
+  shell, admin toadlets, `/api/v1/` and `/app/node/` bridge entrypoints, and the matching
   `network/crypta/clients/http/**` main resources.
 - `:adapter-http-legacy-browse` owns the concrete browse/FProxy routes, toadlets, and helper
   models under `network.crypta.clients.http`, with focused leaf tests under
@@ -155,9 +162,13 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew compileJava`
 - Compile the support leaf when you touched extracted generic support classes:
   - `./gradlew :foundation-support:classes`
+  - Representative moved types: `URIPreEncoder`, `IOUtils`, `LegacyFileSupport`, file-backed
+    buckets, generic HTTP request/upload helpers.
 - Compile the crypto/keys leaf when you touched `network.crypta.crypt`, `network.crypta.keys`,
   or the moved bucket/length helpers:
   - `./gradlew :foundation-crypto-keys:classes`
+  - Representative moved types: `NoFreeBucket`, `BucketTools`,
+    `PrependLengthOutputStream`.
 - Compile the reusable store leaf when you touched extracted `network.crypta.store`,
   `network.crypta.store.caching`, or `network.crypta.store.saltedhash` code:
   - `./gradlew :foundation-store:compileJava`
@@ -174,9 +185,14 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
 - Compile the phase-1 kernel-content leaf when you touched extracted compile-neutral client/content
   classes:
   - `./gradlew :kernel-content:compileJava`
+  - Representative moved types: `ClientEventProducer`, `SplitfileCompatibilityMode*`,
+    `HTMLFilterPolicy`, `InsertUriChecks`, `PersistentRequestCoordinatorContext`,
+    `ClientGetterOptions`.
 - Compile the phase-1 kernel-transport leaf when you touched extracted compile-neutral transport
   helpers:
   - `./gradlew :kernel-transport:compileJava`
+  - Representative moved types: `SSLNetworkInterface`, `NetworkInterface`,
+    `AllowedHosts`, `SocketHandler`.
 - Compile the phase-1 kernel-routing leaf when you touched extracted compile-neutral routing/helper
   classes:
   - `./gradlew :kernel-routing:compileJava`

--- a/README.md
+++ b/README.md
@@ -178,14 +178,17 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.node.PrioRunnable`, `network.crypta.node.SemiOrderedShutdownHook`,
   `network.crypta.support.IllegalValueException`, `network.crypta.support.JVMVersion`, the generic
   `HTTPRequest` / `HTTPUploadedFile` / `MultiValueTable` / `SizeUtil` support surface, and the
-  cycle-safe file-backed support I/O slice (`BaseFileBucket`, `FileBucket`,
-  `FileRandomAccessBuffer`, `PersistentTempFileBucket`, `PooledFileRandomAccessBuffer`,
-  `TempFileBucket`, and their related exceptions/factories).
+  generic utility/file-helper surface around `URIPreEncoder`, `IOUtils`, and
+  `LegacyFileSupport`, plus the cycle-safe file-backed support I/O slice (`BaseFileBucket`,
+  `FileBucket`, `FileRandomAccessBuffer`, `PersistentTempFileBucket`,
+  `PooledFileRandomAccessBuffer`, `TempFileBucket`, and their related
+  exceptions/factories).
 - `:foundation-store-contracts` owns the neutral `network.crypta.store` contracts
   `BlockMetadata`, `GetPubkey`, and `StorableBlock`, plus the store-maintenance alert seam under
   `network.crypta.store.alerts`.
 - `:foundation-crypto-keys` owns `network.crypta.crypt`, `network.crypta.keys`, and the
-  crypto-adjacent `network.crypta.support.io.BucketTools` and
+  crypto-adjacent `network.crypta.support.io.BucketTools`,
+  `network.crypta.support.io.NoFreeBucket`, and
   `network.crypta.support.io.PrependLengthOutputStream` helpers.
 - `:foundation-store` owns the reusable `network.crypta.store` implementations plus
   `network.crypta.store.caching` and `network.crypta.store.saltedhash`.
@@ -209,25 +212,26 @@ Cryptad now uses a partial multi-project Gradle build.
   leaf-safe `network.crypta.client.async` utility/value subset (`BlockSet`, `BinaryBlob`,
   `BinaryBlobFormatException`, `BinaryBlobWriter`, `CacheFetchResult`, `ClientGetterOptions`,
   `ClientPutterOptions`, `PersistenceDisabledException`, `TooManyFilesInsertException`), the
-  client failure/filter exception subset, the MIME helper `network.crypta.support.MediaType`, and
-  the small manifest/model helper subset under `network.crypta.support.*` (`ManifestElement` and
-  `ContainerSizeEstimator`) that stay free of `:runtime-node`, adapter, and root-composition
-  dependencies.
+  client failure/filter exception subset, selected filter policy/helper types such as
+  `HTMLFilterPolicy`, the MIME helper `network.crypta.support.MediaType`, and the small
+  manifest/model helper subset under `network.crypta.support.*` (`ManifestElement`,
+  `ContainerSizeEstimator`) plus `InsertUriChecks` that stay free of `:runtime-node`, adapter,
+  and root-composition dependencies.
 - `:kernel-transport` owns the compile-neutral phase-1 transport slice across selected
   `network.crypta.io`, `network.crypta.io.comm`, and `network.crypta.io.xfer` helpers such as
-  address matching, allowlist parsing, listener abstraction, I/O statistics collection, transfer
-  throttling, and partially received block assembly that stay free of `:runtime-node`, adapters,
-  and root-composition dependencies.
+  address matching, allowlist parsing, listener abstraction, `SSLNetworkInterface`,
+  I/O statistics collection, transfer throttling, and partially received block assembly that stay
+  free of `:runtime-node`, adapters, and root-composition dependencies.
 - `:kernel-routing` owns the compile-neutral phase-1 routing/helper slice across selected
   `network.crypta.node` value, exception, callback, and request-item helper types such as
   `BaseRequestThrottle`, `LowLevelGetException`, `LowLevelPutException`, `RequestClient`,
   `PeerStatusCounts`, and `SendableRequestItem*` that stay free of `:runtime-node`, adapters, and
   root-composition dependencies.
 - `:runtime-spi` owns `network.crypta.runtime.spi` and the JDK-only runtime/config boundary used
-  by higher layers, including detached FCP peer management plus the admin-HTTP config,
-  connectivity, connections, queue, security-levels, shared page-chrome, core-update action,
-  first-time-wizard, symlinker, and welcome-page slices plus shared path constants such as
-  `ConnectivityPagePaths` and `UpdaterPaths`.
+  by higher layers, including the admin-HTTP config, connectivity, connections, queue,
+  security-levels, shared page-chrome, core-update action, first-time-wizard, symlinker, and
+  welcome-page slices plus shared path constants such as `ConnectivityPagePaths` and
+  `UpdaterPaths`.
 - `:platform-api` owns the transport-neutral Platform API v1 under
   `network.crypta.platform.api`. It sits above `:runtime-spi`, exposes detached runtime snapshots
   and the minimal local AppHost control surface as JSON-oriented responses, and is currently
@@ -258,17 +262,20 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.support` / `network.crypta.support.io` / `network.crypta.support.api` subset
   after the generic HTTP, multimap, size-formatting, and file-backed bucket slice moved into
   `:foundation-support` and the manifest/model helper subset moved into `:kernel-content`.
-- `:adapter-fcp` owns the protocol-side `network.crypta.clients.fcp` package tree and its
-  protocol-side persistent-bucket/filter seams.
+- `:adapter-fcp` owns the detached protocol-side `network.crypta.clients.fcp` package tree and
+  its protocol-side persistent-bucket/filter seams. It does not depend directly on
+  `:runtime-node`. See [docs/fcp-boundary.md](docs/fcp-boundary.md) for the explicit maintenance
+  boundary.
 - `:bridge-fcp-runtime` owns the concrete runtime-binding bridge package
   `network.crypta.clients.fcp.bridge`, including the live persistent-bucket and content-filter
-  bindings.
+  bindings, and remains the only FCP leaf that depends directly on `:runtime-node`.
 - `:adapter-http-legacy-admin` owns the shared legacy `network.crypta.clients.http` shell, the
   admin toadlets, the `/api/v1/` and `/app/node/` bridge entrypoints, and the matching
   `network/crypta/clients/http/**` main resources such as `staticfiles/**` and `templates/**`.
-  It keeps the browse-neutral shell and seam types, but no longer owns the concrete browse/FProxy
-  implementations. See [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the
-  explicit maintenance boundary.
+  It is detached from `:runtime-node`, keeps the browse-neutral shell and seam types, and no
+  longer owns the concrete browse/FProxy implementations. See
+  [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
+  boundary.
 - `:adapter-http-legacy-browse` owns the concrete legacy browse/FProxy routes, toadlets, helper
   models, and browse-only packages under `network.crypta.clients.http`.
 - `:bridge-http-runtime` owns the concrete `network.crypta.clients.http.bridge` runtime-binding
@@ -613,14 +620,16 @@ Root build also includes:
 - `:foundation-support`: extracted stable support/api/io/compress/math/transport subset plus
   `network.crypta.support.http`, `network.crypta.io.AddressIdentifier`,
   `network.crypta.io.WritableToDataOutputStream`, `network.crypta.node.FSParseException`,
-  `network.crypta.node.FastRunnable`, `network.crypta.node.SemiOrderedShutdownHook`, and
-  `network.crypta.support.IllegalValueException`, including the generic `HTTPRequest` /
-  `HTTPUploadedFile` / `MultiValueTable` / `SizeUtil` surface and the cycle-safe file-backed
-  support I/O slice.
+  `network.crypta.node.FastRunnable`, `network.crypta.node.PrioRunnable`,
+  `network.crypta.node.SemiOrderedShutdownHook`, `network.crypta.support.IllegalValueException`,
+  and `network.crypta.support.JVMVersion`, including the generic `HTTPRequest` /
+  `HTTPUploadedFile` / `MultiValueTable` / `SizeUtil` surface, generic helpers such as
+  `URIPreEncoder`, `IOUtils`, and `LegacyFileSupport`, and the cycle-safe file-backed support
+  I/O slice.
 - `:foundation-store-contracts`: neutral store contracts plus the store-maintenance alert seam
   shared by store code and root runtime/UI adapters.
 - `:foundation-crypto-keys`: extracted `network.crypta.crypt`, `network.crypta.keys`, and the
-  adjacent `BucketTools` / `PrependLengthOutputStream` helpers.
+  adjacent `BucketTools` / `NoFreeBucket` / `PrependLengthOutputStream` helpers.
 - `:foundation-store`: extracted reusable `network.crypta.store` implementations, caching, and
   salted-hash storage code.
 - `:interop-wire`: extracted wire/message/schema/address/version/probe nucleus plus
@@ -638,19 +647,19 @@ Root build also includes:
   `ClientEventProducer`, `SimpleEventProducer`, `EventLogger`, `EventDumper`,
   `SplitfileProgressEvent`, `SplitfileCompatibilityModeEvent`, `SplitfileCompatibilityMode`), the
   leaf-safe `network.crypta.client.async` utility/value subset, the leaf-safe client
-  failure/filter exception subset, `network.crypta.support.MediaType`, and the small manifest/model
-  helper subset under `network.crypta.support.*`.
+  failure/filter exception subset, selected filter policy/helper types such as
+  `HTMLFilterPolicy`, `network.crypta.support.MediaType`, `InsertUriChecks`, and the small
+  manifest/model helper subset under `network.crypta.support.*`.
 - `:kernel-transport`: compile-neutral phase-1 transport leaf spanning selected
   `network.crypta.io`, `network.crypta.io.comm`, and `network.crypta.io.xfer` helpers such as
-  allowlist parsing, listener abstraction, statistics collection, throttling, and partially
-  received block assembly.
+  allowlist parsing, listener abstraction, `SSLNetworkInterface`, statistics collection,
+  throttling, and partially received block assembly.
 - `:kernel-routing`: compile-neutral phase-1 routing/helper leaf spanning selected
   `network.crypta.node` value, exception, callback, and request-item helper types such as
   `BaseRequestThrottle`, `LowLevelGetException`, `LowLevelPutException`, `RequestClient`,
   `PeerStatusCounts`, and `SendableRequestItem*`.
-- `:runtime-spi`: JDK-only runtime ports plus immutable config snapshot/value types used by FCP
-  and other infrastructure code, including shared path constants such as `ConnectivityPagePaths`
-  and `UpdaterPaths`.
+- `:runtime-spi`: JDK-only runtime ports plus immutable config snapshot/value types and shared
+  path constants such as `ConnectivityPagePaths` and `UpdaterPaths`.
 - `:platform-api`: transport-neutral Platform API v1 built on top of `:runtime-spi` and
   `:platform-apphost`, currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
 - `:platform-apphost`: transport-neutral out-of-process AppHost v1 core for installed local apps.
@@ -666,15 +675,16 @@ Root build also includes:
   support helpers after the generic HTTP, multimap, size-formatting, and file-backed bucket slice
   moved into `:foundation-support` and the manifest/model helper subset moved into
   `:kernel-content`.
-- `:adapter-fcp`: extracted `network.crypta.clients.fcp` protocol leaf.
+- `:adapter-fcp`: detached `network.crypta.clients.fcp` protocol leaf. See
+  [docs/fcp-boundary.md](docs/fcp-boundary.md) for the explicit maintenance boundary.
 - `:bridge-fcp-runtime`: extracted concrete `network.crypta.clients.fcp.bridge` runtime-binding
-  leaf.
+  leaf and the only FCP leaf that depends directly on `:runtime-node`.
 - `:adapter-http-legacy-admin`: extracted shared legacy `network.crypta.clients.http` shell plus
   `network/crypta/clients/http/**` main resources. The root project no longer owns that main
   HTTP source/resource tree, and the browse/FProxy implementation now lives in
   `:adapter-http-legacy-browse`. The shared shell uses browse-neutral bookmark, push, client-side
   localization, and route-registration seams instead of importing or instantiating the concrete
-  browse-owned collaborators directly. It still hosts the temporary `/api/v1/` bridge for
+  browse-owned collaborators directly. It still hosts the current `/api/v1/` bridge for
   `:platform-api` and the `/app/node/` bridge for `:platform-web-shell`. See
   [docs/legacy-http-boundary.md](docs/legacy-http-boundary.md) for the explicit maintenance
   boundary.
@@ -800,7 +810,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   concrete runtime, while runtime-owned FCP seam types now live under `network.crypta.runtime.fcp`
   and `network.crypta.runtime.endpoints.fcp`. Concrete persistent-request services, queue
   adapters, alert-feed adapters, persistent-bucket bindings, filter bindings, and endpoint-handle
-  wrappers now live under `network.crypta.clients.fcp.bridge` in `:bridge-fcp-runtime`.
+  wrappers now live under `network.crypta.clients.fcp.bridge` in `:bridge-fcp-runtime`. See
+  [docs/fcp-boundary.md](docs/fcp-boundary.md) for the maintained protocol/bridge split.
   `network.crypta.clients.http` now lives in `:adapter-http-legacy-admin` together with its
   `staticfiles/**` and `templates/**` resources, excluding `network.crypta.clients.http.bridge`
   and `network.crypta.clients.http.geoip`. The legacy HTTP surface now has a physical browse leaf:
@@ -853,7 +864,10 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `network.crypta.io.AddressIdentifier`, `network.crypta.io.WritableToDataOutputStream`,
   `network.crypta.node.FSParseException`, `network.crypta.node.FastRunnable`,
   `network.crypta.node.PrioRunnable`, `network.crypta.node.SemiOrderedShutdownHook`, and
-  `network.crypta.support.IllegalValueException`, plus `network.crypta.support.JVMVersion`.
+  `network.crypta.support.IllegalValueException`, plus `network.crypta.support.JVMVersion`, the
+  generic `HTTPRequest` / `HTTPUploadedFile` / `MultiValueTable` / `SizeUtil` surface, generic
+  helpers such as `URIPreEncoder`, `IOUtils`, and `LegacyFileSupport`, and the cycle-safe
+  file-backed support I/O slice.
 - Support (`network.crypta.support`): logging, data structures, threading, and helpers are now
   split between `:foundation-support` and the root project. Keep generic reusable utilities in the
   foundation leaf; daemon-coupled support code still remains in the root.
@@ -861,7 +875,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `com.jthemedetecor`, launcher resources, and desktop-theme integration.
 - Extracted foundations: `:foundation-support` provides the stable generic support subset,
   `:foundation-store-contracts` provides neutral store contracts and alert seams,
-  `:foundation-crypto-keys` provides `network.crypta.crypt` and `network.crypta.keys`,
+  `:foundation-crypto-keys` provides `network.crypta.crypt`, `network.crypta.keys`, and adjacent
+  support-IO helpers such as `BucketTools`, `NoFreeBucket`, and
+  `PrependLengthOutputStream`,
   `:foundation-store` provides reusable store implementations, `:interop-wire` provides the
   wire/version/probe nucleus, `:foundation-config` provides config/l10n plus datastore-sizing
   helpers,
@@ -871,13 +887,15 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 - Runtime boundary leaves: `:kernel-content` provides the compile-neutral phase-1 content slice
   across selected `network.crypta.client*` classes, the leaf-safe client failure/filter
   exception subset, the `network.crypta.client.async.persistence` seam, the leaf-safe
-  `network.crypta.client.async` utility/value subset, plus
-  `network.crypta.support.MediaType` and the small manifest/model helper subset under
-  `network.crypta.support.*`;
+  `network.crypta.client.async` utility/value subset, event/helper types such as
+  `SplitfileCompatibilityMode*`, selected filter policy/helper types such as `HTMLFilterPolicy`,
+  plus `network.crypta.support.MediaType`, `InsertUriChecks`, and the small manifest/model helper
+  subset under `network.crypta.support.*`;
   `:kernel-transport` provides the compile-neutral phase-1 transport slice across selected
-  `network.crypta.io*` helpers; `:kernel-routing` provides the compile-neutral phase-1
-  `network.crypta.node` helper slice across selected request/routing value, exception, callback,
-  and request-item types; `:runtime-spi` provides `network.crypta.runtime.spi`;
+  `network.crypta.io*` helpers including `SSLNetworkInterface`; `:kernel-routing` provides the
+  compile-neutral phase-1 `network.crypta.node` helper slice across selected request/routing
+  value, exception, callback, and request-item types; `:runtime-spi` provides
+  `network.crypta.runtime.spi`;
   `:runtime-alerts` provides the extracted leaf-safe `network.crypta.runtime.alerts`
   feed/model subset plus the detached `UserAlertSurface`;
   `:platform-api` provides the transport-neutral Platform API v1 plus the minimal AppHost

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -972,8 +972,7 @@ class AdapterFcpBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
-    String uncommentedScript =
-        buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
+    String uncommentedScript = stripCommentsPreservingStrings(buildScript);
     for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
       Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
 
@@ -1061,7 +1060,10 @@ class AdapterFcpBoundaryTest {
     }
 
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
-      return trimmedExpression.substring(1, trimmedExpression.length() - 1);
+      return resolveKotlinStringLiteral(
+          trimmedExpression.substring(1, trimmedExpression.length() - 1),
+          script,
+          visitedIdentifiers);
     }
 
     List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
@@ -1086,6 +1088,63 @@ class AdapterFcpBoundaryTest {
     }
 
     return null;
+  }
+
+  private static String resolveKotlinStringLiteral(
+      String literalBody, String script, Set<String> visitedIdentifiers) {
+    StringBuilder resolved = new StringBuilder();
+
+    for (int index = 0; index < literalBody.length(); index++) {
+      char current = literalBody.charAt(index);
+      char previous = index > 0 ? literalBody.charAt(index - 1) : 0;
+
+      if (current != '$' || previous == '\\') {
+        resolved.append(current);
+        continue;
+      }
+
+      if (index + 1 >= literalBody.length()) {
+        resolved.append(current);
+        continue;
+      }
+
+      char next = literalBody.charAt(index + 1);
+      if (next == '{') {
+        int templateEnd = findMatchingTemplateBrace(literalBody, index + 1);
+        if (templateEnd == -1) {
+          return null;
+        }
+        String templateExpression = literalBody.substring(index + 2, templateEnd);
+        String resolvedTemplate =
+            resolveStringExpression(templateExpression, script, visitedIdentifiers);
+        if (resolvedTemplate == null) {
+          return null;
+        }
+        resolved.append(resolvedTemplate);
+        index = templateEnd;
+        continue;
+      }
+
+      if (Character.isJavaIdentifierStart(next)) {
+        int identifierEnd = index + 2;
+        while (identifierEnd < literalBody.length()
+            && Character.isJavaIdentifierPart(literalBody.charAt(identifierEnd))) {
+          identifierEnd++;
+        }
+        String identifier = literalBody.substring(index + 1, identifierEnd);
+        String resolvedIdentifier = resolveStringExpression(identifier, script, visitedIdentifiers);
+        if (resolvedIdentifier == null) {
+          return null;
+        }
+        resolved.append(resolvedIdentifier);
+        index = identifierEnd - 1;
+        continue;
+      }
+
+      resolved.append(current);
+    }
+
+    return resolved.toString();
   }
 
   private static String resolveIdentifierAssignment(String identifier, String script) {
@@ -1150,6 +1209,41 @@ class AdapterFcpBoundaryTest {
     return text.length();
   }
 
+  private static int findMatchingTemplateBrace(String text, int openBrace) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openBrace; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '{') {
+        depth++;
+      } else if (current == '}') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
+  }
+
   private static int findMatchingBrace(String text, int openBrace) {
     int depth = 0;
     boolean inString = false;
@@ -1183,6 +1277,61 @@ class AdapterFcpBoundaryTest {
     }
 
     return -1;
+  }
+
+  private static String stripCommentsPreservingStrings(String text) {
+    StringBuilder stripped = new StringBuilder(text.length());
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char next = index + 1 < text.length() ? text.charAt(index + 1) : 0;
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        stripped.append(current);
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        stripped.append(current);
+        continue;
+      }
+
+      if (current == '/' && next == '/') {
+        index += 2;
+        while (index < text.length() && text.charAt(index) != '\n') {
+          index++;
+        }
+        if (index < text.length()) {
+          stripped.append('\n');
+        }
+        continue;
+      }
+
+      if (current == '/' && next == '*') {
+        index += 2;
+        while (index + 1 < text.length()
+            && !(text.charAt(index) == '*' && text.charAt(index + 1) == '/')) {
+          if (text.charAt(index) == '\n') {
+            stripped.append('\n');
+          }
+          index++;
+        }
+        index++;
+        continue;
+      }
+
+      stripped.append(current);
+    }
+
+    return stripped.toString();
   }
 
   private static boolean continuesExpression(String expressionSoFar) {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -280,7 +280,7 @@ class AdapterFcpBoundaryTest {
         Files.exists(repoRoot.resolve(ROOT_FCP_BRIDGE_MAIN_JAVA)),
         "Root project must not re-own network/crypta/clients/fcp/bridge main sources");
     assertFalse(
-        hasJavaSources(repoRoot.resolve(ADAPTER_FCP_BRIDGE_MAIN_JAVA)),
+        Files.exists(repoRoot.resolve(ADAPTER_FCP_BRIDGE_MAIN_JAVA)),
         ":adapter-fcp must not own network/crypta/clients/fcp/bridge main sources");
   }
 
@@ -974,19 +974,55 @@ class AdapterFcpBoundaryTest {
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript =
         buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
-    Pattern dependencyPattern =
-        Pattern.compile("\\bproject\\(\\s*\"" + Pattern.quote(modulePath) + "\"\\s*\\)");
-    return dependencyPattern.matcher(uncommentedScript).find();
+    Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(uncommentedScript);
+
+    while (invocationMatcher.find()) {
+      int openParen = uncommentedScript.indexOf('(', invocationMatcher.start());
+      int closeParen = findMatchingParenthesis(uncommentedScript, openParen);
+      if (closeParen == -1) {
+        continue;
+      }
+      String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
+      if (invocationArgs.contains("\"" + modulePath + "\"")) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  private static boolean hasJavaSources(Path root) throws IOException {
-    if (!Files.exists(root)) {
-      return false;
+  private static int findMatchingParenthesis(String text, int openParen) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openParen; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
     }
-    try (Stream<Path> walk = Files.walk(root)) {
-      return walk.filter(Files::isRegularFile)
-          .anyMatch(AdapterFcpBoundaryTest::isTrackedJavaSource);
-    }
+
+    return -1;
   }
 
   private static void collectForbiddenRuntimeInfraImportViolations(

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -974,29 +974,47 @@ class AdapterFcpBoundaryTest {
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript =
         buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
-    Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(uncommentedScript);
+    for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
+      Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
 
-    while (invocationMatcher.find()) {
-      int openParen = uncommentedScript.indexOf('(', invocationMatcher.start());
-      int closeParen = findMatchingParenthesis(uncommentedScript, openParen);
-      if (closeParen == -1) {
-        continue;
-      }
-      String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
-      String pathExpression = extractProjectPathExpression(invocationArgs);
-      if (pathExpression == null) {
-        continue;
-      }
-      String resolvedPath =
-          resolveStringExpression(
-              stripEnclosingParentheses(pathExpression),
-              uncommentedScript,
-              new java.util.HashSet<>());
-      if (modulePath.equals(resolvedPath)) {
-        return true;
+      while (invocationMatcher.find()) {
+        int openParen = dependencyBlock.indexOf('(', invocationMatcher.start());
+        int closeParen = findMatchingParenthesis(dependencyBlock, openParen);
+        if (closeParen == -1) {
+          continue;
+        }
+        String invocationArgs = dependencyBlock.substring(openParen + 1, closeParen);
+        String pathExpression = extractProjectPathExpression(invocationArgs);
+        if (pathExpression == null) {
+          continue;
+        }
+        String resolvedPath =
+            resolveStringExpression(
+                stripEnclosingParentheses(pathExpression),
+                uncommentedScript,
+                new java.util.HashSet<>());
+        if (modulePath.equals(resolvedPath)) {
+          return true;
+        }
       }
     }
     return false;
+  }
+
+  private static List<String> extractDependencyBlocks(String script) {
+    List<String> blocks = new ArrayList<>();
+    Matcher dependenciesMatcher = Pattern.compile("\\bdependencies\\s*\\{").matcher(script);
+
+    while (dependenciesMatcher.find()) {
+      int openBrace = script.indexOf('{', dependenciesMatcher.start());
+      int closeBrace = findMatchingBrace(script, openBrace);
+      if (closeBrace == -1) {
+        continue;
+      }
+      blocks.add(script.substring(openBrace + 1, closeBrace));
+    }
+
+    return blocks;
   }
 
   private static String extractProjectPathExpression(String invocationArgs) {
@@ -1130,6 +1148,41 @@ class AdapterFcpBoundaryTest {
     }
 
     return text.length();
+  }
+
+  private static int findMatchingBrace(String text, int openBrace) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openBrace; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '{') {
+        depth++;
+      } else if (current == '}') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
   }
 
   private static boolean continuesExpression(String expressionSoFar) {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -973,24 +973,27 @@ class AdapterFcpBoundaryTest {
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript = stripCommentsPreservingStrings(buildScript);
-    for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
-      Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
+    for (DependencyBlock dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
+      Matcher invocationMatcher =
+          Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock.content());
 
       while (invocationMatcher.find()) {
-        int openParen = dependencyBlock.indexOf('(', invocationMatcher.start());
-        int closeParen = findMatchingParenthesis(dependencyBlock, openParen);
+        int openParen = dependencyBlock.content().indexOf('(', invocationMatcher.start());
+        int closeParen = findMatchingParenthesis(dependencyBlock.content(), openParen);
         if (closeParen == -1) {
           continue;
         }
-        String invocationArgs = dependencyBlock.substring(openParen + 1, closeParen);
+        String invocationArgs = dependencyBlock.content().substring(openParen + 1, closeParen);
         String pathExpression = extractProjectPathExpression(invocationArgs);
         if (pathExpression == null) {
           continue;
         }
+        int invocationStartInScript = dependencyBlock.bodyStartIndex() + invocationMatcher.start();
         String resolvedPath =
             resolveStringExpression(
                 stripEnclosingParentheses(pathExpression),
-                uncommentedScript,
+                uncommentedScript.substring(0, invocationStartInScript),
+                dependencyBlock.content().substring(0, invocationMatcher.start()),
                 new java.util.HashSet<>());
         if (modulePath.equals(resolvedPath)) {
           return true;
@@ -1000,8 +1003,10 @@ class AdapterFcpBoundaryTest {
     return false;
   }
 
-  private static List<String> extractDependencyBlocks(String script) {
-    List<String> blocks = new ArrayList<>();
+  private record DependencyBlock(String content, int bodyStartIndex) {}
+
+  private static List<DependencyBlock> extractDependencyBlocks(String script) {
+    List<DependencyBlock> blocks = new ArrayList<>();
     Matcher dependenciesMatcher = Pattern.compile("\\bdependencies\\s*\\{").matcher(script);
 
     while (dependenciesMatcher.find()) {
@@ -1010,7 +1015,7 @@ class AdapterFcpBoundaryTest {
       if (closeBrace == -1) {
         continue;
       }
-      blocks.add(script.substring(openBrace + 1, closeBrace));
+      blocks.add(new DependencyBlock(script.substring(openBrace + 1, closeBrace), openBrace + 1));
     }
 
     return blocks;
@@ -1053,7 +1058,10 @@ class AdapterFcpBoundaryTest {
   }
 
   private static String resolveStringExpression(
-      String expression, String script, Set<String> visitedIdentifiers) {
+      String expression,
+      String scriptPrefix,
+      String dependencyScopePrefix,
+      Set<String> visitedIdentifiers) {
     String trimmedExpression = stripEnclosingParentheses(expression.trim());
     if (trimmedExpression.isEmpty()) {
       return null;
@@ -1062,7 +1070,8 @@ class AdapterFcpBoundaryTest {
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
       return resolveKotlinStringLiteral(
           trimmedExpression.substring(1, trimmedExpression.length() - 1),
-          script,
+          scriptPrefix,
+          dependencyScopePrefix,
           visitedIdentifiers);
     }
 
@@ -1070,7 +1079,8 @@ class AdapterFcpBoundaryTest {
     if (concatenatedParts.size() > 1) {
       StringBuilder resolved = new StringBuilder();
       for (String part : concatenatedParts) {
-        String resolvedPart = resolveStringExpression(part, script, visitedIdentifiers);
+        String resolvedPart =
+            resolveStringExpression(part, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedPart == null) {
           return null;
         }
@@ -1081,9 +1091,11 @@ class AdapterFcpBoundaryTest {
 
     if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
         && visitedIdentifiers.add(trimmedExpression)) {
-      String assignedExpression = resolveIdentifierAssignment(trimmedExpression, script);
+      String assignedExpression =
+          resolveIdentifierAssignment(trimmedExpression, dependencyScopePrefix, scriptPrefix);
       if (assignedExpression != null) {
-        return resolveStringExpression(assignedExpression, script, visitedIdentifiers);
+        return resolveStringExpression(
+            assignedExpression, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
       }
     }
 
@@ -1091,7 +1103,10 @@ class AdapterFcpBoundaryTest {
   }
 
   private static String resolveKotlinStringLiteral(
-      String literalBody, String script, Set<String> visitedIdentifiers) {
+      String literalBody,
+      String scriptPrefix,
+      String dependencyScopePrefix,
+      Set<String> visitedIdentifiers) {
     StringBuilder resolved = new StringBuilder();
 
     for (int index = 0; index < literalBody.length(); index++) {
@@ -1116,7 +1131,8 @@ class AdapterFcpBoundaryTest {
         }
         String templateExpression = literalBody.substring(index + 2, templateEnd);
         String resolvedTemplate =
-            resolveStringExpression(templateExpression, script, visitedIdentifiers);
+            resolveStringExpression(
+                templateExpression, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedTemplate == null) {
           return null;
         }
@@ -1132,7 +1148,9 @@ class AdapterFcpBoundaryTest {
           identifierEnd++;
         }
         String identifier = literalBody.substring(index + 1, identifierEnd);
-        String resolvedIdentifier = resolveStringExpression(identifier, script, visitedIdentifiers);
+        String resolvedIdentifier =
+            resolveStringExpression(
+                identifier, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedIdentifier == null) {
           return null;
         }
@@ -1147,20 +1165,79 @@ class AdapterFcpBoundaryTest {
     return resolved.toString();
   }
 
-  private static String resolveIdentifierAssignment(String identifier, String script) {
+  private static String resolveIdentifierAssignment(
+      String identifier, String dependencyScopePrefix, String scriptPrefix) {
+    String localAssignment = findLastAssignmentInScope(identifier, dependencyScopePrefix);
+    if (localAssignment != null) {
+      return localAssignment;
+    }
+    return findLastAssignmentInScope(identifier, extractTopLevelScopePrefix(scriptPrefix));
+  }
+
+  private static String findLastAssignmentInScope(String identifier, String scopePrefix) {
     Matcher declarationMatcher =
         Pattern.compile(
                 "(?m)^\\s*(?:val|var)\\s+"
                     + Pattern.quote(identifier)
                     + "(?:\\s*:\\s*[^=\\n]+)?\\s*=")
-            .matcher(script);
-    if (!declarationMatcher.find()) {
+            .matcher(scopePrefix);
+    int lastExpressionStart = -1;
+    while (declarationMatcher.find()) {
+      lastExpressionStart = declarationMatcher.end();
+    }
+    if (lastExpressionStart == -1) {
       return null;
     }
 
-    int expressionStart = declarationMatcher.end();
-    int expressionEnd = findExpressionEnd(script, expressionStart);
-    return script.substring(expressionStart, expressionEnd).trim();
+    int expressionEnd = findExpressionEnd(scopePrefix, lastExpressionStart);
+    return scopePrefix.substring(lastExpressionStart, expressionEnd).trim();
+  }
+
+  private static String extractTopLevelScopePrefix(String text) {
+    StringBuilder scopeText = new StringBuilder(text.length());
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        scopeText.append(depth == 0 ? current : ' ');
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        scopeText.append(depth == 0 ? current : ' ');
+        continue;
+      }
+
+      if (current == '{') {
+        scopeText.append(depth == 0 ? ' ' : current == '\n' ? '\n' : ' ');
+        depth++;
+        continue;
+      }
+
+      if (current == '}') {
+        depth = Math.max(0, depth - 1);
+        scopeText.append(depth == 0 && current == '\n' ? '\n' : ' ');
+        continue;
+      }
+
+      if (depth == 0) {
+        scopeText.append(current);
+      } else {
+        scopeText.append(current == '\n' ? '\n' : ' ');
+      }
+    }
+
+    return scopeText.toString();
   }
 
   private static int findExpressionEnd(String text, int expressionStart) {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -1279,7 +1279,7 @@ class AdapterFcpBoundaryTest {
     for (int index = 0; index < text.length(); index++) {
       char current = text.charAt(index);
       char previous = index > 0 ? text.charAt(index - 1) : 0;
-      StringBuilder currentScope = visibleScopes.get(visibleScopes.size() - 1);
+      StringBuilder currentScope = visibleScopes.getLast();
 
       if (inString) {
         currentScope.append(current);
@@ -1304,9 +1304,9 @@ class AdapterFcpBoundaryTest {
 
       if (current == '}') {
         if (visibleScopes.size() > 1) {
-          visibleScopes.remove(visibleScopes.size() - 1);
+          visibleScopes.removeLast();
         }
-        visibleScopes.get(visibleScopes.size() - 1).append(' ');
+        visibleScopes.getLast().append(' ');
         continue;
       }
 

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -337,6 +337,24 @@ class AdapterFcpBoundaryTest {
   }
 
   @Test
+  void dependencyMatcher_whenClosedNestedScopeShadowsAlias_expectVisibleAliasWins() {
+    String buildScript =
+        """
+        dependencies {
+          constraints {
+            val runtimeNodePath = ":not-runtime-node"
+          }
+          val runtimeNodePath = ":runtime-node"
+          implementation(project(runtimeNodePath))
+        }
+        """;
+
+    assertTrue(
+        containsDirectProjectDependency(buildScript, ":runtime-node"),
+        "Direct dependency matcher must ignore aliases declared in closed nested scopes");
+  }
+
+  @Test
   void mainSources_whenScanningFcpImports_expectOnlyBootstrapAndToolBindingSitesOutsideAdapter()
       throws IOException {
     Path repoRoot = repoRoot();
@@ -1178,7 +1196,8 @@ class AdapterFcpBoundaryTest {
 
   private static String resolveIdentifierAssignment(
       String identifier, String dependencyScopePrefix, String scriptPrefix) {
-    String localAssignment = findLastAssignmentInScope(identifier, dependencyScopePrefix);
+    String localAssignment =
+        findLastAssignmentInScope(identifier, extractVisibleScopePrefix(dependencyScopePrefix));
     if (localAssignment != null) {
       return localAssignment;
     }
@@ -1249,6 +1268,56 @@ class AdapterFcpBoundaryTest {
     }
 
     return scopeText.toString();
+  }
+
+  private static String extractVisibleScopePrefix(String text) {
+    List<StringBuilder> visibleScopes = new ArrayList<>();
+    visibleScopes.add(new StringBuilder(text.length()));
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+      StringBuilder currentScope = visibleScopes.get(visibleScopes.size() - 1);
+
+      if (inString) {
+        currentScope.append(current);
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        currentScope.append(current);
+        continue;
+      }
+
+      if (current == '{') {
+        currentScope.append(' ');
+        visibleScopes.add(new StringBuilder());
+        continue;
+      }
+
+      if (current == '}') {
+        if (visibleScopes.size() > 1) {
+          visibleScopes.remove(visibleScopes.size() - 1);
+        }
+        visibleScopes.get(visibleScopes.size() - 1).append(' ');
+        continue;
+      }
+
+      currentScope.append(current);
+    }
+
+    StringBuilder visibleScopePrefix = new StringBuilder(text.length());
+    for (StringBuilder scope : visibleScopes) {
+      visibleScopePrefix.append(scope);
+    }
+    return visibleScopePrefix.toString();
   }
 
   private static int findExpressionEnd(String text, int expressionStart) {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -1021,11 +1021,14 @@ class AdapterFcpBoundaryTest {
       return null;
     }
 
-    int equalsIndex = findTopLevelChar(trimmedArgs, '=');
-    if (equalsIndex != -1) {
-      String leftSide = trimmedArgs.substring(0, equalsIndex).trim();
+    for (String argument : splitTopLevel(trimmedArgs, ',')) {
+      int equalsIndex = findTopLevelChar(argument, '=');
+      if (equalsIndex == -1) {
+        continue;
+      }
+      String leftSide = argument.substring(0, equalsIndex).trim();
       if (leftSide.equals("path")) {
-        return trimmedArgs.substring(equalsIndex + 1).trim();
+        return argument.substring(equalsIndex + 1).trim();
       }
     }
 

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -1044,7 +1044,7 @@ class AdapterFcpBoundaryTest {
     }
 
     for (String argument : splitTopLevel(trimmedArgs, ',')) {
-      int equalsIndex = findTopLevelChar(argument, '=');
+      int equalsIndex = findTopLevelEquals(argument);
       if (equalsIndex == -1) {
         continue;
       }
@@ -1067,12 +1067,22 @@ class AdapterFcpBoundaryTest {
       return null;
     }
 
+    if (trimmedExpression.startsWith("\"\"\"") && trimmedExpression.endsWith("\"\"\"")) {
+      return resolveKotlinStringLiteral(
+          trimmedExpression.substring(3, trimmedExpression.length() - 3),
+          scriptPrefix,
+          dependencyScopePrefix,
+          visitedIdentifiers,
+          true);
+    }
+
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
       return resolveKotlinStringLiteral(
           trimmedExpression.substring(1, trimmedExpression.length() - 1),
           scriptPrefix,
           dependencyScopePrefix,
-          visitedIdentifiers);
+          visitedIdentifiers,
+          false);
     }
 
     List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
@@ -1106,14 +1116,15 @@ class AdapterFcpBoundaryTest {
       String literalBody,
       String scriptPrefix,
       String dependencyScopePrefix,
-      Set<String> visitedIdentifiers) {
+      Set<String> visitedIdentifiers,
+      boolean rawString) {
     StringBuilder resolved = new StringBuilder();
 
     for (int index = 0; index < literalBody.length(); index++) {
       char current = literalBody.charAt(index);
       char previous = index > 0 ? literalBody.charAt(index - 1) : 0;
 
-      if (current != '$' || previous == '\\') {
+      if (current != '$' || (!rawString && previous == '\\')) {
         resolved.append(current);
         continue;
       }
@@ -1219,14 +1230,14 @@ class AdapterFcpBoundaryTest {
       }
 
       if (current == '{') {
-        scopeText.append(depth == 0 ? ' ' : current == '\n' ? '\n' : ' ');
+        scopeText.append(' ');
         depth++;
         continue;
       }
 
       if (current == '}') {
         depth = Math.max(0, depth - 1);
-        scopeText.append(depth == 0 && current == '\n' ? '\n' : ' ');
+        scopeText.append(' ');
         continue;
       }
 
@@ -1254,7 +1265,6 @@ class AdapterFcpBoundaryTest {
         if (current == stringDelimiter && previous != '\\') {
           inString = false;
         }
-        sawNonWhitespace = true;
         continue;
       }
 
@@ -1287,41 +1297,14 @@ class AdapterFcpBoundaryTest {
   }
 
   private static int findMatchingTemplateBrace(String text, int openBrace) {
-    int depth = 0;
-    boolean inString = false;
-    char stringDelimiter = 0;
-
-    for (int index = openBrace; index < text.length(); index++) {
-      char current = text.charAt(index);
-      char previous = index > 0 ? text.charAt(index - 1) : 0;
-
-      if (inString) {
-        if (current == stringDelimiter && previous != '\\') {
-          inString = false;
-        }
-        continue;
-      }
-
-      if (current == '"' || current == '\'') {
-        inString = true;
-        stringDelimiter = current;
-        continue;
-      }
-
-      if (current == '{') {
-        depth++;
-      } else if (current == '}') {
-        depth--;
-        if (depth == 0) {
-          return index;
-        }
-      }
-    }
-
-    return -1;
+    return findMatchingCurlyBrace(text, openBrace);
   }
 
   private static int findMatchingBrace(String text, int openBrace) {
+    return findMatchingCurlyBrace(text, openBrace);
+  }
+
+  private static int findMatchingCurlyBrace(String text, int openBrace) {
     int depth = 0;
     boolean inString = false;
     char stringDelimiter = 0;
@@ -1482,7 +1465,7 @@ class AdapterFcpBoundaryTest {
     return parts;
   }
 
-  private static int findTopLevelChar(String text, char target) {
+  private static int findTopLevelEquals(String text) {
     int depth = 0;
     boolean inString = false;
     char stringDelimiter = 0;
@@ -1508,7 +1491,7 @@ class AdapterFcpBoundaryTest {
         depth++;
       } else if (current == ')') {
         depth--;
-      } else if (current == target && depth == 0) {
+      } else if (current == '=' && depth == 0) {
         return index;
       }
     }

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -26,8 +26,12 @@ class AdapterFcpBoundaryTest {
       Path.of("src", "main", "java", "network", "crypta", "clients", "fcp");
   private static final Path ROOT_FCP_BRIDGE_MAIN_JAVA =
       Path.of("src", "main", "java", "network", "crypta", "clients", "fcp", "bridge");
+  private static final Path ADAPTER_FCP_BRIDGE_MAIN_JAVA =
+      Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "fcp", "bridge");
   private static final Path ADAPTER_FCP_MAIN_JAVA =
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "fcp");
+  private static final Path ADAPTER_BUILD_FILE = Path.of(MODULE_NAME, "build.gradle.kts");
+  private static final Path BRIDGE_BUILD_FILE = Path.of("bridge-fcp-runtime", "build.gradle.kts");
   private static final Path ADD_PEER_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("AddPeer.java");
   private static final Path CLIENT_GET_SOURCE = ADAPTER_FCP_MAIN_JAVA.resolve("ClientGet.java");
   private static final Path CLIENT_GET_EVENT_HANDLING_SOURCE =
@@ -275,6 +279,9 @@ class AdapterFcpBoundaryTest {
     assertFalse(
         Files.exists(repoRoot.resolve(ROOT_FCP_BRIDGE_MAIN_JAVA)),
         "Root project must not re-own network/crypta/clients/fcp/bridge main sources");
+    assertFalse(
+        hasJavaSources(repoRoot.resolve(ADAPTER_FCP_BRIDGE_MAIN_JAVA)),
+        ":adapter-fcp must not own network/crypta/clients/fcp/bridge main sources");
   }
 
   @Test
@@ -282,6 +289,8 @@ class AdapterFcpBoundaryTest {
     Path repoRoot = repoRoot();
     String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
     String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String adapterBuild = Files.readString(repoRoot.resolve(ADAPTER_BUILD_FILE));
+    String bridgeBuild = Files.readString(repoRoot.resolve(BRIDGE_BUILD_FILE));
     Set<String> metadataPatterns = readOwnershipPatterns(repoRoot.resolve(OWNERSHIP_METADATA));
     Set<String> bridgeMetadataPatterns =
         readOwnershipPatterns(repoRoot.resolve(BRIDGE_OWNERSHIP_METADATA));
@@ -294,6 +303,15 @@ class AdapterFcpBoundaryTest {
     assertTrue(settings.contains("\":bridge-fcp-runtime\""));
     assertTrue(build.contains("project(\":adapter-fcp\")"));
     assertTrue(build.contains("project(\":bridge-fcp-runtime\")"));
+    assertFalse(
+        adapterBuild.contains("implementation(project(\":runtime-node\"))"),
+        ":adapter-fcp must not depend on :runtime-node");
+    assertTrue(
+        bridgeBuild.contains("project(\":adapter-fcp\")"),
+        ":bridge-fcp-runtime must depend on :adapter-fcp");
+    assertTrue(
+        bridgeBuild.contains("implementation(project(\":runtime-node\"))"),
+        ":bridge-fcp-runtime must remain the concrete runtime-binding owner for FCP");
     assertTrue(metadataPatterns.contains("network/crypta/clients/fcp/*"));
     assertFalse(
         metadataPatterns.contains("network/crypta/clients/fcp/bridge/**"),
@@ -351,12 +369,11 @@ class AdapterFcpBoundaryTest {
     assertEquals(
         EXPECTED_DEFAULT_BRIDGE_FACTORIES_IMPORTS,
         bootstrapImports,
-        "DefaultNodeRuntimeBridgeFactories must remain the narrow bootstrap-owned FCP binding "
-            + "site");
+        "DefaultNodeRuntimeBridgeFactories must be the only bootstrap-owned FCP binding " + "site");
     assertEquals(
         EXPECTED_ADD_REF_IMPORTS,
         addRefImports,
-        "AddRef must remain the narrow tool-owned FCP exception");
+        "AddRef must be the only tool-owned FCP exception");
   }
 
   @Test
@@ -951,6 +968,16 @@ class AdapterFcpBoundaryTest {
           .filter(line -> !line.isEmpty())
           .filter(line -> !line.startsWith("#"))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static boolean hasJavaSources(Path root) throws IOException {
+    if (!Files.exists(root)) {
+      return false;
+    }
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile)
+          .anyMatch(AdapterFcpBoundaryTest::isTrackedJavaSource);
     }
   }
 

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -304,13 +304,13 @@ class AdapterFcpBoundaryTest {
     assertTrue(build.contains("project(\":adapter-fcp\")"));
     assertTrue(build.contains("project(\":bridge-fcp-runtime\")"));
     assertFalse(
-        adapterBuild.contains("implementation(project(\":runtime-node\"))"),
+        containsDirectProjectDependency(adapterBuild, ":runtime-node"),
         ":adapter-fcp must not depend on :runtime-node");
     assertTrue(
-        bridgeBuild.contains("project(\":adapter-fcp\")"),
+        containsDirectProjectDependency(bridgeBuild, ":adapter-fcp"),
         ":bridge-fcp-runtime must depend on :adapter-fcp");
     assertTrue(
-        bridgeBuild.contains("implementation(project(\":runtime-node\"))"),
+        containsDirectProjectDependency(bridgeBuild, ":runtime-node"),
         ":bridge-fcp-runtime must remain the concrete runtime-binding owner for FCP");
     assertTrue(metadataPatterns.contains("network/crypta/clients/fcp/*"));
     assertFalse(
@@ -969,6 +969,15 @@ class AdapterFcpBoundaryTest {
           .filter(line -> !line.startsWith("#"))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
+  }
+
+  private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
+    Pattern dependencyPattern =
+        Pattern.compile(
+            "(?m)^\\s*[A-Za-z][A-Za-z0-9_]*\\s*\\(\\s*project\\(\""
+                + Pattern.quote(modulePath)
+                + "\"\\)\\s*\\)");
+    return dependencyPattern.matcher(buildScript).find();
   }
 
   private static boolean hasJavaSources(Path root) throws IOException {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -983,11 +983,173 @@ class AdapterFcpBoundaryTest {
         continue;
       }
       String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
-      if (invocationArgs.contains("\"" + modulePath + "\"")) {
+      String pathExpression = extractProjectPathExpression(invocationArgs);
+      if (pathExpression == null) {
+        continue;
+      }
+      String resolvedPath =
+          resolveStringExpression(
+              stripEnclosingParentheses(pathExpression),
+              uncommentedScript,
+              new java.util.HashSet<>());
+      if (modulePath.equals(resolvedPath)) {
         return true;
       }
     }
     return false;
+  }
+
+  private static String extractProjectPathExpression(String invocationArgs) {
+    String trimmedArgs = stripEnclosingParentheses(invocationArgs.trim());
+    if (trimmedArgs.startsWith("mapOf")) {
+      int openParen = trimmedArgs.indexOf('(');
+      if (openParen == -1) {
+        return null;
+      }
+      int closeParen = findMatchingParenthesis(trimmedArgs, openParen);
+      if (closeParen == -1) {
+        return null;
+      }
+      String mapArgs = trimmedArgs.substring(openParen + 1, closeParen);
+      for (String entry : splitTopLevel(mapArgs, ',')) {
+        Matcher pathEntryMatcher =
+            Pattern.compile("^\\s*\"path\"\\s*to\\s*(.+)$", Pattern.DOTALL).matcher(entry);
+        if (pathEntryMatcher.matches()) {
+          return pathEntryMatcher.group(1).trim();
+        }
+      }
+      return null;
+    }
+
+    int equalsIndex = findTopLevelChar(trimmedArgs, '=');
+    if (equalsIndex != -1) {
+      String leftSide = trimmedArgs.substring(0, equalsIndex).trim();
+      if (leftSide.equals("path")) {
+        return trimmedArgs.substring(equalsIndex + 1).trim();
+      }
+    }
+
+    return trimmedArgs;
+  }
+
+  private static String resolveStringExpression(
+      String expression, String script, Set<String> visitedIdentifiers) {
+    String trimmedExpression = stripEnclosingParentheses(expression.trim());
+    if (trimmedExpression.isEmpty()) {
+      return null;
+    }
+
+    if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
+      return trimmedExpression.substring(1, trimmedExpression.length() - 1);
+    }
+
+    List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
+    if (concatenatedParts.size() > 1) {
+      StringBuilder resolved = new StringBuilder();
+      for (String part : concatenatedParts) {
+        String resolvedPart = resolveStringExpression(part, script, visitedIdentifiers);
+        if (resolvedPart == null) {
+          return null;
+        }
+        resolved.append(resolvedPart);
+      }
+      return resolved.toString();
+    }
+
+    if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
+        && visitedIdentifiers.add(trimmedExpression)) {
+      Matcher assignmentMatcher =
+          Pattern.compile(
+                  "(?m)^\\s*(?:val|var)\\s+" + Pattern.quote(trimmedExpression) + "\\s*=\\s*(.+)$")
+              .matcher(script);
+      if (assignmentMatcher.find()) {
+        return resolveStringExpression(assignmentMatcher.group(1), script, visitedIdentifiers);
+      }
+    }
+
+    return null;
+  }
+
+  private static String stripEnclosingParentheses(String expression) {
+    String trimmed = expression.trim();
+    while (trimmed.startsWith("(")
+        && trimmed.endsWith(")")
+        && findMatchingParenthesis(trimmed, 0) == trimmed.length() - 1) {
+      trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+    }
+    return trimmed;
+  }
+
+  private static List<String> splitTopLevel(String text, char delimiter) {
+    List<String> parts = new ArrayList<>();
+    int segmentStart = 0;
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+      } else if (current == delimiter && depth == 0) {
+        parts.add(text.substring(segmentStart, index).trim());
+        segmentStart = index + 1;
+      }
+    }
+
+    parts.add(text.substring(segmentStart).trim());
+    return parts;
+  }
+
+  private static int findTopLevelChar(String text, char target) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+      } else if (current == target && depth == 0) {
+        return index;
+      }
+    }
+
+    return -1;
   }
 
   private static int findMatchingParenthesis(String text, int openParen) {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -1058,16 +1058,98 @@ class AdapterFcpBoundaryTest {
 
     if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
         && visitedIdentifiers.add(trimmedExpression)) {
-      Matcher assignmentMatcher =
-          Pattern.compile(
-                  "(?m)^\\s*(?:val|var)\\s+" + Pattern.quote(trimmedExpression) + "\\s*=\\s*(.+)$")
-              .matcher(script);
-      if (assignmentMatcher.find()) {
-        return resolveStringExpression(assignmentMatcher.group(1), script, visitedIdentifiers);
+      String assignedExpression = resolveIdentifierAssignment(trimmedExpression, script);
+      if (assignedExpression != null) {
+        return resolveStringExpression(assignedExpression, script, visitedIdentifiers);
       }
     }
 
     return null;
+  }
+
+  private static String resolveIdentifierAssignment(String identifier, String script) {
+    Matcher declarationMatcher =
+        Pattern.compile(
+                "(?m)^\\s*(?:val|var)\\s+"
+                    + Pattern.quote(identifier)
+                    + "(?:\\s*:\\s*[^=\\n]+)?\\s*=")
+            .matcher(script);
+    if (!declarationMatcher.find()) {
+      return null;
+    }
+
+    int expressionStart = declarationMatcher.end();
+    int expressionEnd = findExpressionEnd(script, expressionStart);
+    return script.substring(expressionStart, expressionEnd).trim();
+  }
+
+  private static int findExpressionEnd(String text, int expressionStart) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+    boolean sawNonWhitespace = false;
+
+    for (int index = expressionStart; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > expressionStart ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        sawNonWhitespace = true;
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        sawNonWhitespace = true;
+        continue;
+      }
+
+      if (current == '(' || current == '[' || current == '{') {
+        depth++;
+      } else if (current == ')' || current == ']' || current == '}') {
+        depth--;
+      } else if (current == ';' && depth == 0 && sawNonWhitespace) {
+        return index;
+      } else if (current == '\n' && depth == 0 && sawNonWhitespace) {
+        String expressionSoFar = text.substring(expressionStart, index);
+        if (!continuesExpression(expressionSoFar)) {
+          return index;
+        }
+      }
+
+      if (!Character.isWhitespace(current)) {
+        sawNonWhitespace = true;
+      }
+    }
+
+    return text.length();
+  }
+
+  private static boolean continuesExpression(String expressionSoFar) {
+    String trimmed = expressionSoFar.trim();
+    if (trimmed.isEmpty()) {
+      return true;
+    }
+
+    return trimmed.endsWith("+")
+        || trimmed.endsWith("-")
+        || trimmed.endsWith("*")
+        || trimmed.endsWith("/")
+        || trimmed.endsWith("%")
+        || trimmed.endsWith("&&")
+        || trimmed.endsWith("||")
+        || trimmed.endsWith("?:")
+        || trimmed.endsWith("?.")
+        || trimmed.endsWith("..")
+        || trimmed.endsWith(",")
+        || trimmed.endsWith("(")
+        || trimmed.endsWith("[")
+        || trimmed.endsWith("{")
+        || trimmed.endsWith("to");
   }
 
   private static String stripEnclosingParentheses(String expression) {

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -972,9 +972,10 @@ class AdapterFcpBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
-    String uncommentedScript = buildScript.replaceAll("(?s)/\\*.*?\\*/", "");
+    String uncommentedScript =
+        buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
     Pattern dependencyPattern =
-        Pattern.compile("(?m)^(?!\\s*//).*\\bproject\\(\"" + Pattern.quote(modulePath) + "\"\\)");
+        Pattern.compile("\\bproject\\(\\s*\"" + Pattern.quote(modulePath) + "\"\\s*\\)");
     return dependencyPattern.matcher(uncommentedScript).find();
   }
 

--- a/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
+++ b/adapter-fcp/src/test/java/network/crypta/clients/fcp/AdapterFcpBoundaryTest.java
@@ -972,12 +972,10 @@ class AdapterFcpBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
+    String uncommentedScript = buildScript.replaceAll("(?s)/\\*.*?\\*/", "");
     Pattern dependencyPattern =
-        Pattern.compile(
-            "(?m)^\\s*[A-Za-z][A-Za-z0-9_]*\\s*\\(\\s*project\\(\""
-                + Pattern.quote(modulePath)
-                + "\"\\)\\s*\\)");
-    return dependencyPattern.matcher(buildScript).find();
+        Pattern.compile("(?m)^(?!\\s*//).*\\bproject\\(\"" + Pattern.quote(modulePath) + "\"\\)");
+    return dependencyPattern.matcher(uncommentedScript).find();
   }
 
   private static boolean hasJavaSources(Path root) throws IOException {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -844,11 +844,173 @@ class HttpLegacyAdminBoundaryTest {
         continue;
       }
       String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
-      if (invocationArgs.contains("\"" + modulePath + "\"")) {
+      String pathExpression = extractProjectPathExpression(invocationArgs);
+      if (pathExpression == null) {
+        continue;
+      }
+      String resolvedPath =
+          resolveStringExpression(
+              stripEnclosingParentheses(pathExpression),
+              uncommentedScript,
+              new java.util.HashSet<>());
+      if (modulePath.equals(resolvedPath)) {
         return true;
       }
     }
     return false;
+  }
+
+  private static String extractProjectPathExpression(String invocationArgs) {
+    String trimmedArgs = stripEnclosingParentheses(invocationArgs.trim());
+    if (trimmedArgs.startsWith("mapOf")) {
+      int openParen = trimmedArgs.indexOf('(');
+      if (openParen == -1) {
+        return null;
+      }
+      int closeParen = findMatchingParenthesis(trimmedArgs, openParen);
+      if (closeParen == -1) {
+        return null;
+      }
+      String mapArgs = trimmedArgs.substring(openParen + 1, closeParen);
+      for (String entry : splitTopLevel(mapArgs, ',')) {
+        Matcher pathEntryMatcher =
+            Pattern.compile("^\\s*\"path\"\\s*to\\s*(.+)$", Pattern.DOTALL).matcher(entry);
+        if (pathEntryMatcher.matches()) {
+          return pathEntryMatcher.group(1).trim();
+        }
+      }
+      return null;
+    }
+
+    int equalsIndex = findTopLevelChar(trimmedArgs, '=');
+    if (equalsIndex != -1) {
+      String leftSide = trimmedArgs.substring(0, equalsIndex).trim();
+      if (leftSide.equals("path")) {
+        return trimmedArgs.substring(equalsIndex + 1).trim();
+      }
+    }
+
+    return trimmedArgs;
+  }
+
+  private static String resolveStringExpression(
+      String expression, String script, Set<String> visitedIdentifiers) {
+    String trimmedExpression = stripEnclosingParentheses(expression.trim());
+    if (trimmedExpression.isEmpty()) {
+      return null;
+    }
+
+    if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
+      return trimmedExpression.substring(1, trimmedExpression.length() - 1);
+    }
+
+    List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
+    if (concatenatedParts.size() > 1) {
+      StringBuilder resolved = new StringBuilder();
+      for (String part : concatenatedParts) {
+        String resolvedPart = resolveStringExpression(part, script, visitedIdentifiers);
+        if (resolvedPart == null) {
+          return null;
+        }
+        resolved.append(resolvedPart);
+      }
+      return resolved.toString();
+    }
+
+    if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
+        && visitedIdentifiers.add(trimmedExpression)) {
+      Matcher assignmentMatcher =
+          Pattern.compile(
+                  "(?m)^\\s*(?:val|var)\\s+" + Pattern.quote(trimmedExpression) + "\\s*=\\s*(.+)$")
+              .matcher(script);
+      if (assignmentMatcher.find()) {
+        return resolveStringExpression(assignmentMatcher.group(1), script, visitedIdentifiers);
+      }
+    }
+
+    return null;
+  }
+
+  private static String stripEnclosingParentheses(String expression) {
+    String trimmed = expression.trim();
+    while (trimmed.startsWith("(")
+        && trimmed.endsWith(")")
+        && findMatchingParenthesis(trimmed, 0) == trimmed.length() - 1) {
+      trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+    }
+    return trimmed;
+  }
+
+  private static List<String> splitTopLevel(String text, char delimiter) {
+    List<String> parts = new ArrayList<>();
+    int segmentStart = 0;
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+      } else if (current == delimiter && depth == 0) {
+        parts.add(text.substring(segmentStart, index).trim());
+        segmentStart = index + 1;
+      }
+    }
+
+    parts.add(text.substring(segmentStart).trim());
+    return parts;
+  }
+
+  private static int findTopLevelChar(String text, char target) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+      } else if (current == target && depth == 0) {
+        return index;
+      }
+    }
+
+    return -1;
   }
 
   private static int findMatchingParenthesis(String text, int openParen) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -835,29 +835,47 @@ class HttpLegacyAdminBoundaryTest {
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript =
         buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
-    Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(uncommentedScript);
+    for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
+      Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
 
-    while (invocationMatcher.find()) {
-      int openParen = uncommentedScript.indexOf('(', invocationMatcher.start());
-      int closeParen = findMatchingParenthesis(uncommentedScript, openParen);
-      if (closeParen == -1) {
-        continue;
-      }
-      String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
-      String pathExpression = extractProjectPathExpression(invocationArgs);
-      if (pathExpression == null) {
-        continue;
-      }
-      String resolvedPath =
-          resolveStringExpression(
-              stripEnclosingParentheses(pathExpression),
-              uncommentedScript,
-              new java.util.HashSet<>());
-      if (modulePath.equals(resolvedPath)) {
-        return true;
+      while (invocationMatcher.find()) {
+        int openParen = dependencyBlock.indexOf('(', invocationMatcher.start());
+        int closeParen = findMatchingParenthesis(dependencyBlock, openParen);
+        if (closeParen == -1) {
+          continue;
+        }
+        String invocationArgs = dependencyBlock.substring(openParen + 1, closeParen);
+        String pathExpression = extractProjectPathExpression(invocationArgs);
+        if (pathExpression == null) {
+          continue;
+        }
+        String resolvedPath =
+            resolveStringExpression(
+                stripEnclosingParentheses(pathExpression),
+                uncommentedScript,
+                new java.util.HashSet<>());
+        if (modulePath.equals(resolvedPath)) {
+          return true;
+        }
       }
     }
     return false;
+  }
+
+  private static List<String> extractDependencyBlocks(String script) {
+    List<String> blocks = new ArrayList<>();
+    Matcher dependenciesMatcher = Pattern.compile("\\bdependencies\\s*\\{").matcher(script);
+
+    while (dependenciesMatcher.find()) {
+      int openBrace = script.indexOf('{', dependenciesMatcher.start());
+      int closeBrace = findMatchingBrace(script, openBrace);
+      if (closeBrace == -1) {
+        continue;
+      }
+      blocks.add(script.substring(openBrace + 1, closeBrace));
+    }
+
+    return blocks;
   }
 
   private static String extractProjectPathExpression(String invocationArgs) {
@@ -991,6 +1009,41 @@ class HttpLegacyAdminBoundaryTest {
     }
 
     return text.length();
+  }
+
+  private static int findMatchingBrace(String text, int openBrace) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openBrace; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '{') {
+        depth++;
+      } else if (current == '}') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
   }
 
   private static boolean continuesExpression(String expressionSoFar) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -1122,7 +1122,7 @@ class HttpLegacyAdminBoundaryTest {
     for (int index = 0; index < text.length(); index++) {
       char current = text.charAt(index);
       char previous = index > 0 ? text.charAt(index - 1) : 0;
-      StringBuilder currentScope = visibleScopes.get(visibleScopes.size() - 1);
+      StringBuilder currentScope = visibleScopes.getLast();
 
       if (inString) {
         currentScope.append(current);
@@ -1147,9 +1147,9 @@ class HttpLegacyAdminBoundaryTest {
 
       if (current == '}') {
         if (visibleScopes.size() > 1) {
-          visibleScopes.remove(visibleScopes.size() - 1);
+          visibleScopes.removeLast();
         }
-        visibleScopes.get(visibleScopes.size() - 1).append(' ');
+        visibleScopes.getLast().append(' ');
         continue;
       }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -317,7 +317,7 @@ class HttpLegacyAdminBoundaryTest {
         adapterBuild.contains("project(\":adapter-http-legacy-browse\")"),
         ":adapter-http-legacy-admin must not depend on :adapter-http-legacy-browse");
     assertFalse(
-        adapterBuild.contains("implementation(project(\":runtime-node\"))"),
+        containsDirectProjectDependency(adapterBuild, ":runtime-node"),
         ":adapter-http-legacy-admin must not depend on :runtime-node");
     assertTrue(
         Files.isRegularFile(repoRoot.resolve(BRIDGE_OWNERSHIP_METADATA)),
@@ -830,6 +830,15 @@ class HttpLegacyAdminBoundaryTest {
           .map(matcher -> matcher.group(1))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
+  }
+
+  private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
+    Pattern dependencyPattern =
+        Pattern.compile(
+            "(?m)^\\s*[A-Za-z][A-Za-z0-9_]*\\s*\\(\\s*project\\(\""
+                + Pattern.quote(modulePath)
+                + "\"\\)\\s*\\)");
+    return dependencyPattern.matcher(buildScript).find();
   }
 
   private static Set<String> readImports(Path file) throws IOException {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -833,8 +833,7 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
-    String uncommentedScript =
-        buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
+    String uncommentedScript = stripCommentsPreservingStrings(buildScript);
     for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
       Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
 
@@ -922,7 +921,10 @@ class HttpLegacyAdminBoundaryTest {
     }
 
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
-      return trimmedExpression.substring(1, trimmedExpression.length() - 1);
+      return resolveKotlinStringLiteral(
+          trimmedExpression.substring(1, trimmedExpression.length() - 1),
+          script,
+          visitedIdentifiers);
     }
 
     List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
@@ -947,6 +949,63 @@ class HttpLegacyAdminBoundaryTest {
     }
 
     return null;
+  }
+
+  private static String resolveKotlinStringLiteral(
+      String literalBody, String script, Set<String> visitedIdentifiers) {
+    StringBuilder resolved = new StringBuilder();
+
+    for (int index = 0; index < literalBody.length(); index++) {
+      char current = literalBody.charAt(index);
+      char previous = index > 0 ? literalBody.charAt(index - 1) : 0;
+
+      if (current != '$' || previous == '\\') {
+        resolved.append(current);
+        continue;
+      }
+
+      if (index + 1 >= literalBody.length()) {
+        resolved.append(current);
+        continue;
+      }
+
+      char next = literalBody.charAt(index + 1);
+      if (next == '{') {
+        int templateEnd = findMatchingTemplateBrace(literalBody, index + 1);
+        if (templateEnd == -1) {
+          return null;
+        }
+        String templateExpression = literalBody.substring(index + 2, templateEnd);
+        String resolvedTemplate =
+            resolveStringExpression(templateExpression, script, visitedIdentifiers);
+        if (resolvedTemplate == null) {
+          return null;
+        }
+        resolved.append(resolvedTemplate);
+        index = templateEnd;
+        continue;
+      }
+
+      if (Character.isJavaIdentifierStart(next)) {
+        int identifierEnd = index + 2;
+        while (identifierEnd < literalBody.length()
+            && Character.isJavaIdentifierPart(literalBody.charAt(identifierEnd))) {
+          identifierEnd++;
+        }
+        String identifier = literalBody.substring(index + 1, identifierEnd);
+        String resolvedIdentifier = resolveStringExpression(identifier, script, visitedIdentifiers);
+        if (resolvedIdentifier == null) {
+          return null;
+        }
+        resolved.append(resolvedIdentifier);
+        index = identifierEnd - 1;
+        continue;
+      }
+
+      resolved.append(current);
+    }
+
+    return resolved.toString();
   }
 
   private static String resolveIdentifierAssignment(String identifier, String script) {
@@ -1011,6 +1070,41 @@ class HttpLegacyAdminBoundaryTest {
     return text.length();
   }
 
+  private static int findMatchingTemplateBrace(String text, int openBrace) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openBrace; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '{') {
+        depth++;
+      } else if (current == '}') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
+  }
+
   private static int findMatchingBrace(String text, int openBrace) {
     int depth = 0;
     boolean inString = false;
@@ -1044,6 +1138,61 @@ class HttpLegacyAdminBoundaryTest {
     }
 
     return -1;
+  }
+
+  private static String stripCommentsPreservingStrings(String text) {
+    StringBuilder stripped = new StringBuilder(text.length());
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char next = index + 1 < text.length() ? text.charAt(index + 1) : 0;
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        stripped.append(current);
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        stripped.append(current);
+        continue;
+      }
+
+      if (current == '/' && next == '/') {
+        index += 2;
+        while (index < text.length() && text.charAt(index) != '\n') {
+          index++;
+        }
+        if (index < text.length()) {
+          stripped.append('\n');
+        }
+        continue;
+      }
+
+      if (current == '/' && next == '*') {
+        index += 2;
+        while (index + 1 < text.length()
+            && !(text.charAt(index) == '*' && text.charAt(index + 1) == '/')) {
+          if (text.charAt(index) == '\n') {
+            stripped.append('\n');
+          }
+          index++;
+        }
+        index++;
+        continue;
+      }
+
+      stripped.append(current);
+    }
+
+    return stripped.toString();
   }
 
   private static boolean continuesExpression(String expressionSoFar) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -919,16 +919,98 @@ class HttpLegacyAdminBoundaryTest {
 
     if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
         && visitedIdentifiers.add(trimmedExpression)) {
-      Matcher assignmentMatcher =
-          Pattern.compile(
-                  "(?m)^\\s*(?:val|var)\\s+" + Pattern.quote(trimmedExpression) + "\\s*=\\s*(.+)$")
-              .matcher(script);
-      if (assignmentMatcher.find()) {
-        return resolveStringExpression(assignmentMatcher.group(1), script, visitedIdentifiers);
+      String assignedExpression = resolveIdentifierAssignment(trimmedExpression, script);
+      if (assignedExpression != null) {
+        return resolveStringExpression(assignedExpression, script, visitedIdentifiers);
       }
     }
 
     return null;
+  }
+
+  private static String resolveIdentifierAssignment(String identifier, String script) {
+    Matcher declarationMatcher =
+        Pattern.compile(
+                "(?m)^\\s*(?:val|var)\\s+"
+                    + Pattern.quote(identifier)
+                    + "(?:\\s*:\\s*[^=\\n]+)?\\s*=")
+            .matcher(script);
+    if (!declarationMatcher.find()) {
+      return null;
+    }
+
+    int expressionStart = declarationMatcher.end();
+    int expressionEnd = findExpressionEnd(script, expressionStart);
+    return script.substring(expressionStart, expressionEnd).trim();
+  }
+
+  private static int findExpressionEnd(String text, int expressionStart) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+    boolean sawNonWhitespace = false;
+
+    for (int index = expressionStart; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > expressionStart ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        sawNonWhitespace = true;
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        sawNonWhitespace = true;
+        continue;
+      }
+
+      if (current == '(' || current == '[' || current == '{') {
+        depth++;
+      } else if (current == ')' || current == ']' || current == '}') {
+        depth--;
+      } else if (current == ';' && depth == 0 && sawNonWhitespace) {
+        return index;
+      } else if (current == '\n' && depth == 0 && sawNonWhitespace) {
+        String expressionSoFar = text.substring(expressionStart, index);
+        if (!continuesExpression(expressionSoFar)) {
+          return index;
+        }
+      }
+
+      if (!Character.isWhitespace(current)) {
+        sawNonWhitespace = true;
+      }
+    }
+
+    return text.length();
+  }
+
+  private static boolean continuesExpression(String expressionSoFar) {
+    String trimmed = expressionSoFar.trim();
+    if (trimmed.isEmpty()) {
+      return true;
+    }
+
+    return trimmed.endsWith("+")
+        || trimmed.endsWith("-")
+        || trimmed.endsWith("*")
+        || trimmed.endsWith("/")
+        || trimmed.endsWith("%")
+        || trimmed.endsWith("&&")
+        || trimmed.endsWith("||")
+        || trimmed.endsWith("?:")
+        || trimmed.endsWith("?.")
+        || trimmed.endsWith("..")
+        || trimmed.endsWith(",")
+        || trimmed.endsWith("(")
+        || trimmed.endsWith("[")
+        || trimmed.endsWith("{")
+        || trimmed.endsWith("to");
   }
 
   private static String stripEnclosingParentheses(String expression) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -882,11 +882,14 @@ class HttpLegacyAdminBoundaryTest {
       return null;
     }
 
-    int equalsIndex = findTopLevelChar(trimmedArgs, '=');
-    if (equalsIndex != -1) {
-      String leftSide = trimmedArgs.substring(0, equalsIndex).trim();
+    for (String argument : splitTopLevel(trimmedArgs, ',')) {
+      int equalsIndex = findTopLevelChar(argument, '=');
+      if (equalsIndex == -1) {
+        continue;
+      }
+      String leftSide = argument.substring(0, equalsIndex).trim();
       if (leftSide.equals("path")) {
-        return trimmedArgs.substring(equalsIndex + 1).trim();
+        return argument.substring(equalsIndex + 1).trim();
       }
     }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -833,12 +833,10 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
+    String uncommentedScript = buildScript.replaceAll("(?s)/\\*.*?\\*/", "");
     Pattern dependencyPattern =
-        Pattern.compile(
-            "(?m)^\\s*[A-Za-z][A-Za-z0-9_]*\\s*\\(\\s*project\\(\""
-                + Pattern.quote(modulePath)
-                + "\"\\)\\s*\\)");
-    return dependencyPattern.matcher(buildScript).find();
+        Pattern.compile("(?m)^(?!\\s*//).*\\bproject\\(\"" + Pattern.quote(modulePath) + "\"\\)");
+    return dependencyPattern.matcher(uncommentedScript).find();
   }
 
   private static Set<String> readImports(Path file) throws IOException {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -833,9 +833,10 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
-    String uncommentedScript = buildScript.replaceAll("(?s)/\\*.*?\\*/", "");
+    String uncommentedScript =
+        buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
     Pattern dependencyPattern =
-        Pattern.compile("(?m)^(?!\\s*//).*\\bproject\\(\"" + Pattern.quote(modulePath) + "\"\\)");
+        Pattern.compile("\\bproject\\(\\s*\"" + Pattern.quote(modulePath) + "\"\\s*\\)");
     return dependencyPattern.matcher(uncommentedScript).find();
   }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -317,7 +317,7 @@ class HttpLegacyAdminBoundaryTest {
         adapterBuild.contains("project(\":adapter-http-legacy-browse\")"),
         ":adapter-http-legacy-admin must not depend on :adapter-http-legacy-browse");
     assertFalse(
-        containsDirectProjectDependency(adapterBuild, ":runtime-node"),
+        containsDirectRuntimeNodeDependency(adapterBuild),
         ":adapter-http-legacy-admin must not depend on :runtime-node");
     assertTrue(
         Files.isRegularFile(repoRoot.resolve(BRIDGE_OWNERSHIP_METADATA)),
@@ -832,7 +832,7 @@ class HttpLegacyAdminBoundaryTest {
     }
   }
 
-  private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
+  private static boolean containsDirectRuntimeNodeDependency(String buildScript) {
     String uncommentedScript = stripCommentsPreservingStrings(buildScript);
     for (DependencyBlock dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
       Matcher invocationMatcher =
@@ -856,7 +856,7 @@ class HttpLegacyAdminBoundaryTest {
                 uncommentedScript.substring(0, invocationStartInScript),
                 dependencyBlock.content().substring(0, invocationMatcher.start()),
                 new java.util.HashSet<>());
-        if (modulePath.equals(resolvedPath)) {
+        if (":runtime-node".equals(resolvedPath)) {
           return true;
         }
       }
@@ -905,7 +905,7 @@ class HttpLegacyAdminBoundaryTest {
     }
 
     for (String argument : splitTopLevel(trimmedArgs, ',')) {
-      int equalsIndex = findTopLevelChar(argument, '=');
+      int equalsIndex = findTopLevelEquals(argument);
       if (equalsIndex == -1) {
         continue;
       }
@@ -928,12 +928,22 @@ class HttpLegacyAdminBoundaryTest {
       return null;
     }
 
+    if (trimmedExpression.startsWith("\"\"\"") && trimmedExpression.endsWith("\"\"\"")) {
+      return resolveKotlinStringLiteral(
+          trimmedExpression.substring(3, trimmedExpression.length() - 3),
+          scriptPrefix,
+          dependencyScopePrefix,
+          visitedIdentifiers,
+          true);
+    }
+
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
       return resolveKotlinStringLiteral(
           trimmedExpression.substring(1, trimmedExpression.length() - 1),
           scriptPrefix,
           dependencyScopePrefix,
-          visitedIdentifiers);
+          visitedIdentifiers,
+          false);
     }
 
     List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
@@ -967,14 +977,15 @@ class HttpLegacyAdminBoundaryTest {
       String literalBody,
       String scriptPrefix,
       String dependencyScopePrefix,
-      Set<String> visitedIdentifiers) {
+      Set<String> visitedIdentifiers,
+      boolean rawString) {
     StringBuilder resolved = new StringBuilder();
 
     for (int index = 0; index < literalBody.length(); index++) {
       char current = literalBody.charAt(index);
       char previous = index > 0 ? literalBody.charAt(index - 1) : 0;
 
-      if (current != '$' || previous == '\\') {
+      if (current != '$' || (!rawString && previous == '\\')) {
         resolved.append(current);
         continue;
       }
@@ -1080,14 +1091,14 @@ class HttpLegacyAdminBoundaryTest {
       }
 
       if (current == '{') {
-        scopeText.append(depth == 0 ? ' ' : current == '\n' ? '\n' : ' ');
+        scopeText.append(' ');
         depth++;
         continue;
       }
 
       if (current == '}') {
         depth = Math.max(0, depth - 1);
-        scopeText.append(depth == 0 && current == '\n' ? '\n' : ' ');
+        scopeText.append(' ');
         continue;
       }
 
@@ -1115,7 +1126,6 @@ class HttpLegacyAdminBoundaryTest {
         if (current == stringDelimiter && previous != '\\') {
           inString = false;
         }
-        sawNonWhitespace = true;
         continue;
       }
 
@@ -1148,41 +1158,14 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   private static int findMatchingTemplateBrace(String text, int openBrace) {
-    int depth = 0;
-    boolean inString = false;
-    char stringDelimiter = 0;
-
-    for (int index = openBrace; index < text.length(); index++) {
-      char current = text.charAt(index);
-      char previous = index > 0 ? text.charAt(index - 1) : 0;
-
-      if (inString) {
-        if (current == stringDelimiter && previous != '\\') {
-          inString = false;
-        }
-        continue;
-      }
-
-      if (current == '"' || current == '\'') {
-        inString = true;
-        stringDelimiter = current;
-        continue;
-      }
-
-      if (current == '{') {
-        depth++;
-      } else if (current == '}') {
-        depth--;
-        if (depth == 0) {
-          return index;
-        }
-      }
-    }
-
-    return -1;
+    return findMatchingCurlyBrace(text, openBrace);
   }
 
   private static int findMatchingBrace(String text, int openBrace) {
+    return findMatchingCurlyBrace(text, openBrace);
+  }
+
+  private static int findMatchingCurlyBrace(String text, int openBrace) {
     int depth = 0;
     boolean inString = false;
     char stringDelimiter = 0;
@@ -1343,7 +1326,7 @@ class HttpLegacyAdminBoundaryTest {
     return parts;
   }
 
-  private static int findTopLevelChar(String text, char target) {
+  private static int findTopLevelEquals(String text) {
     int depth = 0;
     boolean inString = false;
     char stringDelimiter = 0;
@@ -1369,7 +1352,7 @@ class HttpLegacyAdminBoundaryTest {
         depth++;
       } else if (current == ')') {
         depth--;
-      } else if (current == target && depth == 0) {
+      } else if (current == '=' && depth == 0) {
         return index;
       }
     }

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -834,24 +834,27 @@ class HttpLegacyAdminBoundaryTest {
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript = stripCommentsPreservingStrings(buildScript);
-    for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
-      Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
+    for (DependencyBlock dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
+      Matcher invocationMatcher =
+          Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock.content());
 
       while (invocationMatcher.find()) {
-        int openParen = dependencyBlock.indexOf('(', invocationMatcher.start());
-        int closeParen = findMatchingParenthesis(dependencyBlock, openParen);
+        int openParen = dependencyBlock.content().indexOf('(', invocationMatcher.start());
+        int closeParen = findMatchingParenthesis(dependencyBlock.content(), openParen);
         if (closeParen == -1) {
           continue;
         }
-        String invocationArgs = dependencyBlock.substring(openParen + 1, closeParen);
+        String invocationArgs = dependencyBlock.content().substring(openParen + 1, closeParen);
         String pathExpression = extractProjectPathExpression(invocationArgs);
         if (pathExpression == null) {
           continue;
         }
+        int invocationStartInScript = dependencyBlock.bodyStartIndex() + invocationMatcher.start();
         String resolvedPath =
             resolveStringExpression(
                 stripEnclosingParentheses(pathExpression),
-                uncommentedScript,
+                uncommentedScript.substring(0, invocationStartInScript),
+                dependencyBlock.content().substring(0, invocationMatcher.start()),
                 new java.util.HashSet<>());
         if (modulePath.equals(resolvedPath)) {
           return true;
@@ -861,8 +864,10 @@ class HttpLegacyAdminBoundaryTest {
     return false;
   }
 
-  private static List<String> extractDependencyBlocks(String script) {
-    List<String> blocks = new ArrayList<>();
+  private record DependencyBlock(String content, int bodyStartIndex) {}
+
+  private static List<DependencyBlock> extractDependencyBlocks(String script) {
+    List<DependencyBlock> blocks = new ArrayList<>();
     Matcher dependenciesMatcher = Pattern.compile("\\bdependencies\\s*\\{").matcher(script);
 
     while (dependenciesMatcher.find()) {
@@ -871,7 +876,7 @@ class HttpLegacyAdminBoundaryTest {
       if (closeBrace == -1) {
         continue;
       }
-      blocks.add(script.substring(openBrace + 1, closeBrace));
+      blocks.add(new DependencyBlock(script.substring(openBrace + 1, closeBrace), openBrace + 1));
     }
 
     return blocks;
@@ -914,7 +919,10 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   private static String resolveStringExpression(
-      String expression, String script, Set<String> visitedIdentifiers) {
+      String expression,
+      String scriptPrefix,
+      String dependencyScopePrefix,
+      Set<String> visitedIdentifiers) {
     String trimmedExpression = stripEnclosingParentheses(expression.trim());
     if (trimmedExpression.isEmpty()) {
       return null;
@@ -923,7 +931,8 @@ class HttpLegacyAdminBoundaryTest {
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
       return resolveKotlinStringLiteral(
           trimmedExpression.substring(1, trimmedExpression.length() - 1),
-          script,
+          scriptPrefix,
+          dependencyScopePrefix,
           visitedIdentifiers);
     }
 
@@ -931,7 +940,8 @@ class HttpLegacyAdminBoundaryTest {
     if (concatenatedParts.size() > 1) {
       StringBuilder resolved = new StringBuilder();
       for (String part : concatenatedParts) {
-        String resolvedPart = resolveStringExpression(part, script, visitedIdentifiers);
+        String resolvedPart =
+            resolveStringExpression(part, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedPart == null) {
           return null;
         }
@@ -942,9 +952,11 @@ class HttpLegacyAdminBoundaryTest {
 
     if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
         && visitedIdentifiers.add(trimmedExpression)) {
-      String assignedExpression = resolveIdentifierAssignment(trimmedExpression, script);
+      String assignedExpression =
+          resolveIdentifierAssignment(trimmedExpression, dependencyScopePrefix, scriptPrefix);
       if (assignedExpression != null) {
-        return resolveStringExpression(assignedExpression, script, visitedIdentifiers);
+        return resolveStringExpression(
+            assignedExpression, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
       }
     }
 
@@ -952,7 +964,10 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   private static String resolveKotlinStringLiteral(
-      String literalBody, String script, Set<String> visitedIdentifiers) {
+      String literalBody,
+      String scriptPrefix,
+      String dependencyScopePrefix,
+      Set<String> visitedIdentifiers) {
     StringBuilder resolved = new StringBuilder();
 
     for (int index = 0; index < literalBody.length(); index++) {
@@ -977,7 +992,8 @@ class HttpLegacyAdminBoundaryTest {
         }
         String templateExpression = literalBody.substring(index + 2, templateEnd);
         String resolvedTemplate =
-            resolveStringExpression(templateExpression, script, visitedIdentifiers);
+            resolveStringExpression(
+                templateExpression, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedTemplate == null) {
           return null;
         }
@@ -993,7 +1009,9 @@ class HttpLegacyAdminBoundaryTest {
           identifierEnd++;
         }
         String identifier = literalBody.substring(index + 1, identifierEnd);
-        String resolvedIdentifier = resolveStringExpression(identifier, script, visitedIdentifiers);
+        String resolvedIdentifier =
+            resolveStringExpression(
+                identifier, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedIdentifier == null) {
           return null;
         }
@@ -1008,20 +1026,79 @@ class HttpLegacyAdminBoundaryTest {
     return resolved.toString();
   }
 
-  private static String resolveIdentifierAssignment(String identifier, String script) {
+  private static String resolveIdentifierAssignment(
+      String identifier, String dependencyScopePrefix, String scriptPrefix) {
+    String localAssignment = findLastAssignmentInScope(identifier, dependencyScopePrefix);
+    if (localAssignment != null) {
+      return localAssignment;
+    }
+    return findLastAssignmentInScope(identifier, extractTopLevelScopePrefix(scriptPrefix));
+  }
+
+  private static String findLastAssignmentInScope(String identifier, String scopePrefix) {
     Matcher declarationMatcher =
         Pattern.compile(
                 "(?m)^\\s*(?:val|var)\\s+"
                     + Pattern.quote(identifier)
                     + "(?:\\s*:\\s*[^=\\n]+)?\\s*=")
-            .matcher(script);
-    if (!declarationMatcher.find()) {
+            .matcher(scopePrefix);
+    int lastExpressionStart = -1;
+    while (declarationMatcher.find()) {
+      lastExpressionStart = declarationMatcher.end();
+    }
+    if (lastExpressionStart == -1) {
       return null;
     }
 
-    int expressionStart = declarationMatcher.end();
-    int expressionEnd = findExpressionEnd(script, expressionStart);
-    return script.substring(expressionStart, expressionEnd).trim();
+    int expressionEnd = findExpressionEnd(scopePrefix, lastExpressionStart);
+    return scopePrefix.substring(lastExpressionStart, expressionEnd).trim();
+  }
+
+  private static String extractTopLevelScopePrefix(String text) {
+    StringBuilder scopeText = new StringBuilder(text.length());
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        scopeText.append(depth == 0 ? current : ' ');
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        scopeText.append(depth == 0 ? current : ' ');
+        continue;
+      }
+
+      if (current == '{') {
+        scopeText.append(depth == 0 ? ' ' : current == '\n' ? '\n' : ' ');
+        depth++;
+        continue;
+      }
+
+      if (current == '}') {
+        depth = Math.max(0, depth - 1);
+        scopeText.append(depth == 0 && current == '\n' ? '\n' : ' ');
+        continue;
+      }
+
+      if (depth == 0) {
+        scopeText.append(current);
+      } else {
+        scopeText.append(current == '\n' ? '\n' : ' ');
+      }
+    }
+
+    return scopeText.toString();
   }
 
   private static int findExpressionEnd(String text, int expressionStart) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -835,9 +835,55 @@ class HttpLegacyAdminBoundaryTest {
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript =
         buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
-    Pattern dependencyPattern =
-        Pattern.compile("\\bproject\\(\\s*\"" + Pattern.quote(modulePath) + "\"\\s*\\)");
-    return dependencyPattern.matcher(uncommentedScript).find();
+    Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(uncommentedScript);
+
+    while (invocationMatcher.find()) {
+      int openParen = uncommentedScript.indexOf('(', invocationMatcher.start());
+      int closeParen = findMatchingParenthesis(uncommentedScript, openParen);
+      if (closeParen == -1) {
+        continue;
+      }
+      String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
+      if (invocationArgs.contains("\"" + modulePath + "\"")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static int findMatchingParenthesis(String text, int openParen) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openParen; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
   }
 
   private static Set<String> readImports(Path file) throws IOException {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -288,7 +288,7 @@ class HttpLegacyAdminBoundaryTest {
   }
 
   @Test
-  void buildWiring_whenCheckingLeafMetadata_expectBridgeSplitDeclaredAndOwned() throws IOException {
+  void buildWiring_whenCheckingLeafMetadata_expectLeafDeclaredAndOwned() throws IOException {
     Path repoRoot = repoRoot();
     String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
     String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
@@ -368,7 +368,7 @@ class HttpLegacyAdminBoundaryTest {
     assertEquals(
         EXPECTED_DEFAULT_BRIDGE_FACTORIES_HTTP_IMPORTS,
         bootstrapHttpImports,
-        "DefaultNodeRuntimeBridgeFactories must remain the narrow bootstrap-owned HTTP binding "
+        "DefaultNodeRuntimeBridgeFactories must be the only bootstrap-owned HTTP binding "
             + "site");
   }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/runtime/bootstrap/HttpLegacyAdminBoundaryTest.java
@@ -1039,7 +1039,8 @@ class HttpLegacyAdminBoundaryTest {
 
   private static String resolveIdentifierAssignment(
       String identifier, String dependencyScopePrefix, String scriptPrefix) {
-    String localAssignment = findLastAssignmentInScope(identifier, dependencyScopePrefix);
+    String localAssignment =
+        findLastAssignmentInScope(identifier, extractVisibleScopePrefix(dependencyScopePrefix));
     if (localAssignment != null) {
       return localAssignment;
     }
@@ -1110,6 +1111,56 @@ class HttpLegacyAdminBoundaryTest {
     }
 
     return scopeText.toString();
+  }
+
+  private static String extractVisibleScopePrefix(String text) {
+    List<StringBuilder> visibleScopes = new ArrayList<>();
+    visibleScopes.add(new StringBuilder(text.length()));
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+      StringBuilder currentScope = visibleScopes.get(visibleScopes.size() - 1);
+
+      if (inString) {
+        currentScope.append(current);
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        currentScope.append(current);
+        continue;
+      }
+
+      if (current == '{') {
+        currentScope.append(' ');
+        visibleScopes.add(new StringBuilder());
+        continue;
+      }
+
+      if (current == '}') {
+        if (visibleScopes.size() > 1) {
+          visibleScopes.remove(visibleScopes.size() - 1);
+        }
+        visibleScopes.get(visibleScopes.size() - 1).append(' ');
+        continue;
+      }
+
+      currentScope.append(current);
+    }
+
+    StringBuilder visibleScopePrefix = new StringBuilder(text.length());
+    for (StringBuilder scope : visibleScopes) {
+      visibleScopePrefix.append(scope);
+    }
+    return visibleScopePrefix.toString();
   }
 
   private static int findExpressionEnd(String text, int expressionStart) {

--- a/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/package-info.java
+++ b/bridge-fcp-runtime/src/main/java/network/crypta/clients/fcp/bridge/package-info.java
@@ -14,11 +14,11 @@
  * production binding and then hands only seam types upstream. This package keeps the concrete
  * runtime-binding behavior behind that boundary, so the current FCP startup sequence,
  * persistent-request recovery path, queue semantics, and alert delivery behavior remain unchanged
- * while ownership is made explicit for later extraction work. It also owns the concrete mapping
- * between adapter-owned FCP peer/probe seam types and the live node peer/probe runtime classes,
- * plus the bridge-side translation between adapter-owned detached insert compatibility types and
- * the live {@code InsertContext}/{@code CompatibilityAnalyser} implementations. The AddPeer
- * noderef-loading bridge still requires live client and runtime loader access.
+ * while ownership stays explicit. It also owns the concrete mapping between adapter-owned FCP
+ * peer/probe seam types and the live node peer/probe runtime classes, plus the bridge-side
+ * translation between adapter-owned detached insert compatibility types and the live {@code
+ * InsertContext}/{@code CompatibilityAnalyser} implementations. The AddPeer noderef-loading bridge
+ * still requires live client and runtime loader access.
  *
  * <ul>
  *   <li>Owns the concrete persistent-request bundle and recovery adapters for FCP-backed state.

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ class BridgeFcpRuntimeBoundaryTest {
         Files.exists(repoRoot.resolve(ROOT_BRIDGE_MAIN_JAVA)),
         "Root project must not own network/crypta/clients/fcp/bridge main sources");
     assertFalse(
-        hasJavaSources(repoRoot.resolve(ADAPTER_BRIDGE_MAIN_JAVA)),
+        Files.exists(repoRoot.resolve(ADAPTER_BRIDGE_MAIN_JAVA)),
         ":adapter-fcp must not own network/crypta/clients/fcp/bridge main sources");
   }
 
@@ -141,19 +142,55 @@ class BridgeFcpRuntimeBoundaryTest {
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript =
         buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
-    Pattern dependencyPattern =
-        Pattern.compile("\\bproject\\(\\s*\"" + Pattern.quote(modulePath) + "\"\\s*\\)");
-    return dependencyPattern.matcher(uncommentedScript).find();
+    Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(uncommentedScript);
+
+    while (invocationMatcher.find()) {
+      int openParen = uncommentedScript.indexOf('(', invocationMatcher.start());
+      int closeParen = findMatchingParenthesis(uncommentedScript, openParen);
+      if (closeParen == -1) {
+        continue;
+      }
+      String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
+      if (invocationArgs.contains("\"" + modulePath + "\"")) {
+        return true;
+      }
+    }
+    return false;
   }
 
-  private static boolean hasJavaSources(Path root) throws IOException {
-    if (!Files.exists(root)) {
-      return false;
+  private static int findMatchingParenthesis(String text, int openParen) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openParen; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
     }
-    try (Stream<Path> walk = Files.walk(root)) {
-      return walk.filter(Files::isRegularFile)
-          .anyMatch(BridgeFcpRuntimeBoundaryTest::isTrackedJavaSource);
-    }
+
+    return -1;
   }
 
   private static Path parentOrThrow(Path path) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -346,7 +346,8 @@ class BridgeFcpRuntimeBoundaryTest {
 
   private static String resolveIdentifierAssignment(
       String identifier, String dependencyScopePrefix, String scriptPrefix) {
-    String localAssignment = findLastAssignmentInScope(identifier, dependencyScopePrefix);
+    String localAssignment =
+        findLastAssignmentInScope(identifier, extractVisibleScopePrefix(dependencyScopePrefix));
     if (localAssignment != null) {
       return localAssignment;
     }
@@ -417,6 +418,56 @@ class BridgeFcpRuntimeBoundaryTest {
     }
 
     return scopeText.toString();
+  }
+
+  private static String extractVisibleScopePrefix(String text) {
+    List<StringBuilder> visibleScopes = new ArrayList<>();
+    visibleScopes.add(new StringBuilder(text.length()));
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+      StringBuilder currentScope = visibleScopes.get(visibleScopes.size() - 1);
+
+      if (inString) {
+        currentScope.append(current);
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        currentScope.append(current);
+        continue;
+      }
+
+      if (current == '{') {
+        currentScope.append(' ');
+        visibleScopes.add(new StringBuilder());
+        continue;
+      }
+
+      if (current == '}') {
+        if (visibleScopes.size() > 1) {
+          visibleScopes.remove(visibleScopes.size() - 1);
+        }
+        visibleScopes.get(visibleScopes.size() - 1).append(' ');
+        continue;
+      }
+
+      currentScope.append(current);
+    }
+
+    StringBuilder visibleScopePrefix = new StringBuilder(text.length());
+    for (StringBuilder scope : visibleScopes) {
+      visibleScopePrefix.append(scope);
+    }
+    return visibleScopePrefix.toString();
   }
 
   private static int findExpressionEnd(String text, int expressionStart) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -139,12 +139,10 @@ class BridgeFcpRuntimeBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
+    String uncommentedScript = buildScript.replaceAll("(?s)/\\*.*?\\*/", "");
     Pattern dependencyPattern =
-        Pattern.compile(
-            "(?m)^\\s*[A-Za-z][A-Za-z0-9_]*\\s*\\(\\s*project\\(\""
-                + Pattern.quote(modulePath)
-                + "\"\\)\\s*\\)");
-    return dependencyPattern.matcher(buildScript).find();
+        Pattern.compile("(?m)^(?!\\s*//).*\\bproject\\(\"" + Pattern.quote(modulePath) + "\"\\)");
+    return dependencyPattern.matcher(uncommentedScript).find();
   }
 
   private static boolean hasJavaSources(Path root) throws IOException {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -139,9 +139,10 @@ class BridgeFcpRuntimeBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
-    String uncommentedScript = buildScript.replaceAll("(?s)/\\*.*?\\*/", "");
+    String uncommentedScript =
+        buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
     Pattern dependencyPattern =
-        Pattern.compile("(?m)^(?!\\s*//).*\\bproject\\(\"" + Pattern.quote(modulePath) + "\"\\)");
+        Pattern.compile("\\bproject\\(\\s*\"" + Pattern.quote(modulePath) + "\"\\s*\\)");
     return dependencyPattern.matcher(uncommentedScript).find();
   }
 

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -212,7 +212,7 @@ class BridgeFcpRuntimeBoundaryTest {
     }
 
     for (String argument : splitTopLevel(trimmedArgs, ',')) {
-      int equalsIndex = findTopLevelChar(argument, '=');
+      int equalsIndex = findTopLevelEquals(argument);
       if (equalsIndex == -1) {
         continue;
       }
@@ -235,12 +235,22 @@ class BridgeFcpRuntimeBoundaryTest {
       return null;
     }
 
+    if (trimmedExpression.startsWith("\"\"\"") && trimmedExpression.endsWith("\"\"\"")) {
+      return resolveKotlinStringLiteral(
+          trimmedExpression.substring(3, trimmedExpression.length() - 3),
+          scriptPrefix,
+          dependencyScopePrefix,
+          visitedIdentifiers,
+          true);
+    }
+
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
       return resolveKotlinStringLiteral(
           trimmedExpression.substring(1, trimmedExpression.length() - 1),
           scriptPrefix,
           dependencyScopePrefix,
-          visitedIdentifiers);
+          visitedIdentifiers,
+          false);
     }
 
     List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
@@ -274,14 +284,15 @@ class BridgeFcpRuntimeBoundaryTest {
       String literalBody,
       String scriptPrefix,
       String dependencyScopePrefix,
-      Set<String> visitedIdentifiers) {
+      Set<String> visitedIdentifiers,
+      boolean rawString) {
     StringBuilder resolved = new StringBuilder();
 
     for (int index = 0; index < literalBody.length(); index++) {
       char current = literalBody.charAt(index);
       char previous = index > 0 ? literalBody.charAt(index - 1) : 0;
 
-      if (current != '$' || previous == '\\') {
+      if (current != '$' || (!rawString && previous == '\\')) {
         resolved.append(current);
         continue;
       }
@@ -387,14 +398,14 @@ class BridgeFcpRuntimeBoundaryTest {
       }
 
       if (current == '{') {
-        scopeText.append(depth == 0 ? ' ' : current == '\n' ? '\n' : ' ');
+        scopeText.append(' ');
         depth++;
         continue;
       }
 
       if (current == '}') {
         depth = Math.max(0, depth - 1);
-        scopeText.append(depth == 0 && current == '\n' ? '\n' : ' ');
+        scopeText.append(' ');
         continue;
       }
 
@@ -422,7 +433,6 @@ class BridgeFcpRuntimeBoundaryTest {
         if (current == stringDelimiter && previous != '\\') {
           inString = false;
         }
-        sawNonWhitespace = true;
         continue;
       }
 
@@ -455,41 +465,14 @@ class BridgeFcpRuntimeBoundaryTest {
   }
 
   private static int findMatchingTemplateBrace(String text, int openBrace) {
-    int depth = 0;
-    boolean inString = false;
-    char stringDelimiter = 0;
-
-    for (int index = openBrace; index < text.length(); index++) {
-      char current = text.charAt(index);
-      char previous = index > 0 ? text.charAt(index - 1) : 0;
-
-      if (inString) {
-        if (current == stringDelimiter && previous != '\\') {
-          inString = false;
-        }
-        continue;
-      }
-
-      if (current == '"' || current == '\'') {
-        inString = true;
-        stringDelimiter = current;
-        continue;
-      }
-
-      if (current == '{') {
-        depth++;
-      } else if (current == '}') {
-        depth--;
-        if (depth == 0) {
-          return index;
-        }
-      }
-    }
-
-    return -1;
+    return findMatchingCurlyBrace(text, openBrace);
   }
 
   private static int findMatchingBrace(String text, int openBrace) {
+    return findMatchingCurlyBrace(text, openBrace);
+  }
+
+  private static int findMatchingCurlyBrace(String text, int openBrace) {
     int depth = 0;
     boolean inString = false;
     char stringDelimiter = 0;
@@ -650,7 +633,7 @@ class BridgeFcpRuntimeBoundaryTest {
     return parts;
   }
 
-  private static int findTopLevelChar(String text, char target) {
+  private static int findTopLevelEquals(String text) {
     int depth = 0;
     boolean inString = false;
     char stringDelimiter = 0;
@@ -676,7 +659,7 @@ class BridgeFcpRuntimeBoundaryTest {
         depth++;
       } else if (current == ')') {
         depth--;
-      } else if (current == target && depth == 0) {
+      } else if (current == '=' && depth == 0) {
         return index;
       }
     }

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -140,8 +140,7 @@ class BridgeFcpRuntimeBoundaryTest {
   }
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
-    String uncommentedScript =
-        buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
+    String uncommentedScript = stripCommentsPreservingStrings(buildScript);
     for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
       Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
 
@@ -229,7 +228,10 @@ class BridgeFcpRuntimeBoundaryTest {
     }
 
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
-      return trimmedExpression.substring(1, trimmedExpression.length() - 1);
+      return resolveKotlinStringLiteral(
+          trimmedExpression.substring(1, trimmedExpression.length() - 1),
+          script,
+          visitedIdentifiers);
     }
 
     List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
@@ -254,6 +256,63 @@ class BridgeFcpRuntimeBoundaryTest {
     }
 
     return null;
+  }
+
+  private static String resolveKotlinStringLiteral(
+      String literalBody, String script, Set<String> visitedIdentifiers) {
+    StringBuilder resolved = new StringBuilder();
+
+    for (int index = 0; index < literalBody.length(); index++) {
+      char current = literalBody.charAt(index);
+      char previous = index > 0 ? literalBody.charAt(index - 1) : 0;
+
+      if (current != '$' || previous == '\\') {
+        resolved.append(current);
+        continue;
+      }
+
+      if (index + 1 >= literalBody.length()) {
+        resolved.append(current);
+        continue;
+      }
+
+      char next = literalBody.charAt(index + 1);
+      if (next == '{') {
+        int templateEnd = findMatchingTemplateBrace(literalBody, index + 1);
+        if (templateEnd == -1) {
+          return null;
+        }
+        String templateExpression = literalBody.substring(index + 2, templateEnd);
+        String resolvedTemplate =
+            resolveStringExpression(templateExpression, script, visitedIdentifiers);
+        if (resolvedTemplate == null) {
+          return null;
+        }
+        resolved.append(resolvedTemplate);
+        index = templateEnd;
+        continue;
+      }
+
+      if (Character.isJavaIdentifierStart(next)) {
+        int identifierEnd = index + 2;
+        while (identifierEnd < literalBody.length()
+            && Character.isJavaIdentifierPart(literalBody.charAt(identifierEnd))) {
+          identifierEnd++;
+        }
+        String identifier = literalBody.substring(index + 1, identifierEnd);
+        String resolvedIdentifier = resolveStringExpression(identifier, script, visitedIdentifiers);
+        if (resolvedIdentifier == null) {
+          return null;
+        }
+        resolved.append(resolvedIdentifier);
+        index = identifierEnd - 1;
+        continue;
+      }
+
+      resolved.append(current);
+    }
+
+    return resolved.toString();
   }
 
   private static String resolveIdentifierAssignment(String identifier, String script) {
@@ -318,6 +377,41 @@ class BridgeFcpRuntimeBoundaryTest {
     return text.length();
   }
 
+  private static int findMatchingTemplateBrace(String text, int openBrace) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openBrace; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '{') {
+        depth++;
+      } else if (current == '}') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
+  }
+
   private static int findMatchingBrace(String text, int openBrace) {
     int depth = 0;
     boolean inString = false;
@@ -351,6 +445,61 @@ class BridgeFcpRuntimeBoundaryTest {
     }
 
     return -1;
+  }
+
+  private static String stripCommentsPreservingStrings(String text) {
+    StringBuilder stripped = new StringBuilder(text.length());
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char next = index + 1 < text.length() ? text.charAt(index + 1) : 0;
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        stripped.append(current);
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        stripped.append(current);
+        continue;
+      }
+
+      if (current == '/' && next == '/') {
+        index += 2;
+        while (index < text.length() && text.charAt(index) != '\n') {
+          index++;
+        }
+        if (index < text.length()) {
+          stripped.append('\n');
+        }
+        continue;
+      }
+
+      if (current == '/' && next == '*') {
+        index += 2;
+        while (index + 1 < text.length()
+            && !(text.charAt(index) == '*' && text.charAt(index + 1) == '/')) {
+          if (text.charAt(index) == '\n') {
+            stripped.append('\n');
+          }
+          index++;
+        }
+        index++;
+        continue;
+      }
+
+      stripped.append(current);
+    }
+
+    return stripped.toString();
   }
 
   private static boolean continuesExpression(String expressionSoFar) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -226,16 +226,98 @@ class BridgeFcpRuntimeBoundaryTest {
 
     if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
         && visitedIdentifiers.add(trimmedExpression)) {
-      Matcher assignmentMatcher =
-          Pattern.compile(
-                  "(?m)^\\s*(?:val|var)\\s+" + Pattern.quote(trimmedExpression) + "\\s*=\\s*(.+)$")
-              .matcher(script);
-      if (assignmentMatcher.find()) {
-        return resolveStringExpression(assignmentMatcher.group(1), script, visitedIdentifiers);
+      String assignedExpression = resolveIdentifierAssignment(trimmedExpression, script);
+      if (assignedExpression != null) {
+        return resolveStringExpression(assignedExpression, script, visitedIdentifiers);
       }
     }
 
     return null;
+  }
+
+  private static String resolveIdentifierAssignment(String identifier, String script) {
+    Matcher declarationMatcher =
+        Pattern.compile(
+                "(?m)^\\s*(?:val|var)\\s+"
+                    + Pattern.quote(identifier)
+                    + "(?:\\s*:\\s*[^=\\n]+)?\\s*=")
+            .matcher(script);
+    if (!declarationMatcher.find()) {
+      return null;
+    }
+
+    int expressionStart = declarationMatcher.end();
+    int expressionEnd = findExpressionEnd(script, expressionStart);
+    return script.substring(expressionStart, expressionEnd).trim();
+  }
+
+  private static int findExpressionEnd(String text, int expressionStart) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+    boolean sawNonWhitespace = false;
+
+    for (int index = expressionStart; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > expressionStart ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        sawNonWhitespace = true;
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        sawNonWhitespace = true;
+        continue;
+      }
+
+      if (current == '(' || current == '[' || current == '{') {
+        depth++;
+      } else if (current == ')' || current == ']' || current == '}') {
+        depth--;
+      } else if (current == ';' && depth == 0 && sawNonWhitespace) {
+        return index;
+      } else if (current == '\n' && depth == 0 && sawNonWhitespace) {
+        String expressionSoFar = text.substring(expressionStart, index);
+        if (!continuesExpression(expressionSoFar)) {
+          return index;
+        }
+      }
+
+      if (!Character.isWhitespace(current)) {
+        sawNonWhitespace = true;
+      }
+    }
+
+    return text.length();
+  }
+
+  private static boolean continuesExpression(String expressionSoFar) {
+    String trimmed = expressionSoFar.trim();
+    if (trimmed.isEmpty()) {
+      return true;
+    }
+
+    return trimmed.endsWith("+")
+        || trimmed.endsWith("-")
+        || trimmed.endsWith("*")
+        || trimmed.endsWith("/")
+        || trimmed.endsWith("%")
+        || trimmed.endsWith("&&")
+        || trimmed.endsWith("||")
+        || trimmed.endsWith("?:")
+        || trimmed.endsWith("?.")
+        || trimmed.endsWith("..")
+        || trimmed.endsWith(",")
+        || trimmed.endsWith("(")
+        || trimmed.endsWith("[")
+        || trimmed.endsWith("{")
+        || trimmed.endsWith("to");
   }
 
   private static String stripEnclosingParentheses(String expression) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -189,11 +189,14 @@ class BridgeFcpRuntimeBoundaryTest {
       return null;
     }
 
-    int equalsIndex = findTopLevelChar(trimmedArgs, '=');
-    if (equalsIndex != -1) {
-      String leftSide = trimmedArgs.substring(0, equalsIndex).trim();
+    for (String argument : splitTopLevel(trimmedArgs, ',')) {
+      int equalsIndex = findTopLevelChar(argument, '=');
+      if (equalsIndex == -1) {
+        continue;
+      }
+      String leftSide = argument.substring(0, equalsIndex).trim();
       if (leftSide.equals("path")) {
-        return trimmedArgs.substring(equalsIndex + 1).trim();
+        return argument.substring(equalsIndex + 1).trim();
       }
     }
 

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -141,24 +141,27 @@ class BridgeFcpRuntimeBoundaryTest {
 
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript = stripCommentsPreservingStrings(buildScript);
-    for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
-      Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
+    for (DependencyBlock dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
+      Matcher invocationMatcher =
+          Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock.content());
 
       while (invocationMatcher.find()) {
-        int openParen = dependencyBlock.indexOf('(', invocationMatcher.start());
-        int closeParen = findMatchingParenthesis(dependencyBlock, openParen);
+        int openParen = dependencyBlock.content().indexOf('(', invocationMatcher.start());
+        int closeParen = findMatchingParenthesis(dependencyBlock.content(), openParen);
         if (closeParen == -1) {
           continue;
         }
-        String invocationArgs = dependencyBlock.substring(openParen + 1, closeParen);
+        String invocationArgs = dependencyBlock.content().substring(openParen + 1, closeParen);
         String pathExpression = extractProjectPathExpression(invocationArgs);
         if (pathExpression == null) {
           continue;
         }
+        int invocationStartInScript = dependencyBlock.bodyStartIndex() + invocationMatcher.start();
         String resolvedPath =
             resolveStringExpression(
                 stripEnclosingParentheses(pathExpression),
-                uncommentedScript,
+                uncommentedScript.substring(0, invocationStartInScript),
+                dependencyBlock.content().substring(0, invocationMatcher.start()),
                 new java.util.HashSet<>());
         if (modulePath.equals(resolvedPath)) {
           return true;
@@ -168,8 +171,10 @@ class BridgeFcpRuntimeBoundaryTest {
     return false;
   }
 
-  private static List<String> extractDependencyBlocks(String script) {
-    List<String> blocks = new ArrayList<>();
+  private record DependencyBlock(String content, int bodyStartIndex) {}
+
+  private static List<DependencyBlock> extractDependencyBlocks(String script) {
+    List<DependencyBlock> blocks = new ArrayList<>();
     Matcher dependenciesMatcher = Pattern.compile("\\bdependencies\\s*\\{").matcher(script);
 
     while (dependenciesMatcher.find()) {
@@ -178,7 +183,7 @@ class BridgeFcpRuntimeBoundaryTest {
       if (closeBrace == -1) {
         continue;
       }
-      blocks.add(script.substring(openBrace + 1, closeBrace));
+      blocks.add(new DependencyBlock(script.substring(openBrace + 1, closeBrace), openBrace + 1));
     }
 
     return blocks;
@@ -221,7 +226,10 @@ class BridgeFcpRuntimeBoundaryTest {
   }
 
   private static String resolveStringExpression(
-      String expression, String script, Set<String> visitedIdentifiers) {
+      String expression,
+      String scriptPrefix,
+      String dependencyScopePrefix,
+      Set<String> visitedIdentifiers) {
     String trimmedExpression = stripEnclosingParentheses(expression.trim());
     if (trimmedExpression.isEmpty()) {
       return null;
@@ -230,7 +238,8 @@ class BridgeFcpRuntimeBoundaryTest {
     if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
       return resolveKotlinStringLiteral(
           trimmedExpression.substring(1, trimmedExpression.length() - 1),
-          script,
+          scriptPrefix,
+          dependencyScopePrefix,
           visitedIdentifiers);
     }
 
@@ -238,7 +247,8 @@ class BridgeFcpRuntimeBoundaryTest {
     if (concatenatedParts.size() > 1) {
       StringBuilder resolved = new StringBuilder();
       for (String part : concatenatedParts) {
-        String resolvedPart = resolveStringExpression(part, script, visitedIdentifiers);
+        String resolvedPart =
+            resolveStringExpression(part, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedPart == null) {
           return null;
         }
@@ -249,9 +259,11 @@ class BridgeFcpRuntimeBoundaryTest {
 
     if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
         && visitedIdentifiers.add(trimmedExpression)) {
-      String assignedExpression = resolveIdentifierAssignment(trimmedExpression, script);
+      String assignedExpression =
+          resolveIdentifierAssignment(trimmedExpression, dependencyScopePrefix, scriptPrefix);
       if (assignedExpression != null) {
-        return resolveStringExpression(assignedExpression, script, visitedIdentifiers);
+        return resolveStringExpression(
+            assignedExpression, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
       }
     }
 
@@ -259,7 +271,10 @@ class BridgeFcpRuntimeBoundaryTest {
   }
 
   private static String resolveKotlinStringLiteral(
-      String literalBody, String script, Set<String> visitedIdentifiers) {
+      String literalBody,
+      String scriptPrefix,
+      String dependencyScopePrefix,
+      Set<String> visitedIdentifiers) {
     StringBuilder resolved = new StringBuilder();
 
     for (int index = 0; index < literalBody.length(); index++) {
@@ -284,7 +299,8 @@ class BridgeFcpRuntimeBoundaryTest {
         }
         String templateExpression = literalBody.substring(index + 2, templateEnd);
         String resolvedTemplate =
-            resolveStringExpression(templateExpression, script, visitedIdentifiers);
+            resolveStringExpression(
+                templateExpression, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedTemplate == null) {
           return null;
         }
@@ -300,7 +316,9 @@ class BridgeFcpRuntimeBoundaryTest {
           identifierEnd++;
         }
         String identifier = literalBody.substring(index + 1, identifierEnd);
-        String resolvedIdentifier = resolveStringExpression(identifier, script, visitedIdentifiers);
+        String resolvedIdentifier =
+            resolveStringExpression(
+                identifier, scriptPrefix, dependencyScopePrefix, visitedIdentifiers);
         if (resolvedIdentifier == null) {
           return null;
         }
@@ -315,20 +333,79 @@ class BridgeFcpRuntimeBoundaryTest {
     return resolved.toString();
   }
 
-  private static String resolveIdentifierAssignment(String identifier, String script) {
+  private static String resolveIdentifierAssignment(
+      String identifier, String dependencyScopePrefix, String scriptPrefix) {
+    String localAssignment = findLastAssignmentInScope(identifier, dependencyScopePrefix);
+    if (localAssignment != null) {
+      return localAssignment;
+    }
+    return findLastAssignmentInScope(identifier, extractTopLevelScopePrefix(scriptPrefix));
+  }
+
+  private static String findLastAssignmentInScope(String identifier, String scopePrefix) {
     Matcher declarationMatcher =
         Pattern.compile(
                 "(?m)^\\s*(?:val|var)\\s+"
                     + Pattern.quote(identifier)
                     + "(?:\\s*:\\s*[^=\\n]+)?\\s*=")
-            .matcher(script);
-    if (!declarationMatcher.find()) {
+            .matcher(scopePrefix);
+    int lastExpressionStart = -1;
+    while (declarationMatcher.find()) {
+      lastExpressionStart = declarationMatcher.end();
+    }
+    if (lastExpressionStart == -1) {
       return null;
     }
 
-    int expressionStart = declarationMatcher.end();
-    int expressionEnd = findExpressionEnd(script, expressionStart);
-    return script.substring(expressionStart, expressionEnd).trim();
+    int expressionEnd = findExpressionEnd(scopePrefix, lastExpressionStart);
+    return scopePrefix.substring(lastExpressionStart, expressionEnd).trim();
+  }
+
+  private static String extractTopLevelScopePrefix(String text) {
+    StringBuilder scopeText = new StringBuilder(text.length());
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        scopeText.append(depth == 0 ? current : ' ');
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        scopeText.append(depth == 0 ? current : ' ');
+        continue;
+      }
+
+      if (current == '{') {
+        scopeText.append(depth == 0 ? ' ' : current == '\n' ? '\n' : ' ');
+        depth++;
+        continue;
+      }
+
+      if (current == '}') {
+        depth = Math.max(0, depth - 1);
+        scopeText.append(depth == 0 && current == '\n' ? '\n' : ' ');
+        continue;
+      }
+
+      if (depth == 0) {
+        scopeText.append(current);
+      } else {
+        scopeText.append(current == '\n' ? '\n' : ' ');
+      }
+    }
+
+    return scopeText.toString();
   }
 
   private static int findExpressionEnd(String text, int expressionStart) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -429,7 +429,7 @@ class BridgeFcpRuntimeBoundaryTest {
     for (int index = 0; index < text.length(); index++) {
       char current = text.charAt(index);
       char previous = index > 0 ? text.charAt(index - 1) : 0;
-      StringBuilder currentScope = visibleScopes.get(visibleScopes.size() - 1);
+      StringBuilder currentScope = visibleScopes.getLast();
 
       if (inString) {
         currentScope.append(current);
@@ -454,9 +454,9 @@ class BridgeFcpRuntimeBoundaryTest {
 
       if (current == '}') {
         if (visibleScopes.size() > 1) {
-          visibleScopes.remove(visibleScopes.size() - 1);
+          visibleScopes.removeLast();
         }
-        visibleScopes.get(visibleScopes.size() - 1).append(' ');
+        visibleScopes.getLast().append(' ');
         continue;
       }
 

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -151,11 +151,173 @@ class BridgeFcpRuntimeBoundaryTest {
         continue;
       }
       String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
-      if (invocationArgs.contains("\"" + modulePath + "\"")) {
+      String pathExpression = extractProjectPathExpression(invocationArgs);
+      if (pathExpression == null) {
+        continue;
+      }
+      String resolvedPath =
+          resolveStringExpression(
+              stripEnclosingParentheses(pathExpression),
+              uncommentedScript,
+              new java.util.HashSet<>());
+      if (modulePath.equals(resolvedPath)) {
         return true;
       }
     }
     return false;
+  }
+
+  private static String extractProjectPathExpression(String invocationArgs) {
+    String trimmedArgs = stripEnclosingParentheses(invocationArgs.trim());
+    if (trimmedArgs.startsWith("mapOf")) {
+      int openParen = trimmedArgs.indexOf('(');
+      if (openParen == -1) {
+        return null;
+      }
+      int closeParen = findMatchingParenthesis(trimmedArgs, openParen);
+      if (closeParen == -1) {
+        return null;
+      }
+      String mapArgs = trimmedArgs.substring(openParen + 1, closeParen);
+      for (String entry : splitTopLevel(mapArgs, ',')) {
+        Matcher pathEntryMatcher =
+            Pattern.compile("^\\s*\"path\"\\s*to\\s*(.+)$", Pattern.DOTALL).matcher(entry);
+        if (pathEntryMatcher.matches()) {
+          return pathEntryMatcher.group(1).trim();
+        }
+      }
+      return null;
+    }
+
+    int equalsIndex = findTopLevelChar(trimmedArgs, '=');
+    if (equalsIndex != -1) {
+      String leftSide = trimmedArgs.substring(0, equalsIndex).trim();
+      if (leftSide.equals("path")) {
+        return trimmedArgs.substring(equalsIndex + 1).trim();
+      }
+    }
+
+    return trimmedArgs;
+  }
+
+  private static String resolveStringExpression(
+      String expression, String script, Set<String> visitedIdentifiers) {
+    String trimmedExpression = stripEnclosingParentheses(expression.trim());
+    if (trimmedExpression.isEmpty()) {
+      return null;
+    }
+
+    if (trimmedExpression.startsWith("\"") && trimmedExpression.endsWith("\"")) {
+      return trimmedExpression.substring(1, trimmedExpression.length() - 1);
+    }
+
+    List<String> concatenatedParts = splitTopLevel(trimmedExpression, '+');
+    if (concatenatedParts.size() > 1) {
+      StringBuilder resolved = new StringBuilder();
+      for (String part : concatenatedParts) {
+        String resolvedPart = resolveStringExpression(part, script, visitedIdentifiers);
+        if (resolvedPart == null) {
+          return null;
+        }
+        resolved.append(resolvedPart);
+      }
+      return resolved.toString();
+    }
+
+    if (trimmedExpression.matches("[A-Za-z_][A-Za-z0-9_]*")
+        && visitedIdentifiers.add(trimmedExpression)) {
+      Matcher assignmentMatcher =
+          Pattern.compile(
+                  "(?m)^\\s*(?:val|var)\\s+" + Pattern.quote(trimmedExpression) + "\\s*=\\s*(.+)$")
+              .matcher(script);
+      if (assignmentMatcher.find()) {
+        return resolveStringExpression(assignmentMatcher.group(1), script, visitedIdentifiers);
+      }
+    }
+
+    return null;
+  }
+
+  private static String stripEnclosingParentheses(String expression) {
+    String trimmed = expression.trim();
+    while (trimmed.startsWith("(")
+        && trimmed.endsWith(")")
+        && findMatchingParenthesis(trimmed, 0) == trimmed.length() - 1) {
+      trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+    }
+    return trimmed;
+  }
+
+  private static List<String> splitTopLevel(String text, char delimiter) {
+    List<String> parts = new ArrayList<>();
+    int segmentStart = 0;
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+      } else if (current == delimiter && depth == 0) {
+        parts.add(text.substring(segmentStart, index).trim());
+        segmentStart = index + 1;
+      }
+    }
+
+    parts.add(text.substring(segmentStart).trim());
+    return parts;
+  }
+
+  private static int findTopLevelChar(String text, char target) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = 0; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '(') {
+        depth++;
+      } else if (current == ')') {
+        depth--;
+      } else if (current == target && depth == 0) {
+        return index;
+      }
+    }
+
+    return -1;
   }
 
   private static int findMatchingParenthesis(String text, int openParen) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -63,13 +64,13 @@ class BridgeFcpRuntimeBoundaryTest {
     assertTrue(build.contains("project(\":adapter-fcp\")"));
     assertTrue(build.contains("project(\":bridge-fcp-runtime\")"));
     assertTrue(
-        bridgeBuild.contains("project(\":adapter-fcp\")"),
+        containsDirectProjectDependency(bridgeBuild, ":adapter-fcp"),
         ":bridge-fcp-runtime must depend on :adapter-fcp");
     assertTrue(
-        bridgeBuild.contains("implementation(project(\":runtime-node\"))"),
+        containsDirectProjectDependency(bridgeBuild, ":runtime-node"),
         ":bridge-fcp-runtime must remain the concrete runtime-binding owner for FCP");
     assertFalse(
-        adapterBuild.contains("implementation(project(\":runtime-node\"))"),
+        containsDirectProjectDependency(adapterBuild, ":runtime-node"),
         ":adapter-fcp must not depend on :runtime-node");
     assertTrue(metadataPatterns.contains("network/crypta/clients/fcp/bridge/**"));
     assertTrue(
@@ -135,6 +136,15 @@ class BridgeFcpRuntimeBoundaryTest {
           .filter(line -> !line.startsWith("#"))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
     }
+  }
+
+  private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
+    Pattern dependencyPattern =
+        Pattern.compile(
+            "(?m)^\\s*[A-Za-z][A-Za-z0-9_]*\\s*\\(\\s*project\\(\""
+                + Pattern.quote(modulePath)
+                + "\"\\)\\s*\\)");
+    return dependencyPattern.matcher(buildScript).find();
   }
 
   private static boolean hasJavaSources(Path root) throws IOException {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -142,29 +142,47 @@ class BridgeFcpRuntimeBoundaryTest {
   private static boolean containsDirectProjectDependency(String buildScript, String modulePath) {
     String uncommentedScript =
         buildScript.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("(?m)//.*$", "");
-    Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(uncommentedScript);
+    for (String dependencyBlock : extractDependencyBlocks(uncommentedScript)) {
+      Matcher invocationMatcher = Pattern.compile("\\bproject\\s*\\(").matcher(dependencyBlock);
 
-    while (invocationMatcher.find()) {
-      int openParen = uncommentedScript.indexOf('(', invocationMatcher.start());
-      int closeParen = findMatchingParenthesis(uncommentedScript, openParen);
-      if (closeParen == -1) {
-        continue;
-      }
-      String invocationArgs = uncommentedScript.substring(openParen + 1, closeParen);
-      String pathExpression = extractProjectPathExpression(invocationArgs);
-      if (pathExpression == null) {
-        continue;
-      }
-      String resolvedPath =
-          resolveStringExpression(
-              stripEnclosingParentheses(pathExpression),
-              uncommentedScript,
-              new java.util.HashSet<>());
-      if (modulePath.equals(resolvedPath)) {
-        return true;
+      while (invocationMatcher.find()) {
+        int openParen = dependencyBlock.indexOf('(', invocationMatcher.start());
+        int closeParen = findMatchingParenthesis(dependencyBlock, openParen);
+        if (closeParen == -1) {
+          continue;
+        }
+        String invocationArgs = dependencyBlock.substring(openParen + 1, closeParen);
+        String pathExpression = extractProjectPathExpression(invocationArgs);
+        if (pathExpression == null) {
+          continue;
+        }
+        String resolvedPath =
+            resolveStringExpression(
+                stripEnclosingParentheses(pathExpression),
+                uncommentedScript,
+                new java.util.HashSet<>());
+        if (modulePath.equals(resolvedPath)) {
+          return true;
+        }
       }
     }
     return false;
+  }
+
+  private static List<String> extractDependencyBlocks(String script) {
+    List<String> blocks = new ArrayList<>();
+    Matcher dependenciesMatcher = Pattern.compile("\\bdependencies\\s*\\{").matcher(script);
+
+    while (dependenciesMatcher.find()) {
+      int openBrace = script.indexOf('{', dependenciesMatcher.start());
+      int closeBrace = findMatchingBrace(script, openBrace);
+      if (closeBrace == -1) {
+        continue;
+      }
+      blocks.add(script.substring(openBrace + 1, closeBrace));
+    }
+
+    return blocks;
   }
 
   private static String extractProjectPathExpression(String invocationArgs) {
@@ -298,6 +316,41 @@ class BridgeFcpRuntimeBoundaryTest {
     }
 
     return text.length();
+  }
+
+  private static int findMatchingBrace(String text, int openBrace) {
+    int depth = 0;
+    boolean inString = false;
+    char stringDelimiter = 0;
+
+    for (int index = openBrace; index < text.length(); index++) {
+      char current = text.charAt(index);
+      char previous = index > 0 ? text.charAt(index - 1) : 0;
+
+      if (inString) {
+        if (current == stringDelimiter && previous != '\\') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current == '"' || current == '\'') {
+        inString = true;
+        stringDelimiter = current;
+        continue;
+      }
+
+      if (current == '{') {
+        depth++;
+      } else if (current == '}') {
+        depth--;
+        if (depth == 0) {
+          return index;
+        }
+      }
+    }
+
+    return -1;
   }
 
   private static boolean continuesExpression(String expressionSoFar) {

--- a/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
+++ b/bridge-fcp-runtime/src/test/java/network/crypta/clients/fcp/bridge/BridgeFcpRuntimeBoundaryTest.java
@@ -25,6 +25,8 @@ class BridgeFcpRuntimeBoundaryTest {
           "adapter-fcp", "src", "main", "java", "network", "crypta", "clients", "fcp", "bridge");
   private static final Path BRIDGE_MAIN_JAVA =
       Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "clients", "fcp", "bridge");
+  private static final Path BRIDGE_BUILD_FILE = Path.of(MODULE_NAME, "build.gradle.kts");
+  private static final Path ADAPTER_BUILD_FILE = Path.of("adapter-fcp", "build.gradle.kts");
   private static final Path OWNERSHIP_METADATA =
       Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
   private static final Path ADAPTER_OWNERSHIP_METADATA =
@@ -41,7 +43,7 @@ class BridgeFcpRuntimeBoundaryTest {
         Files.exists(repoRoot.resolve(ROOT_BRIDGE_MAIN_JAVA)),
         "Root project must not own network/crypta/clients/fcp/bridge main sources");
     assertFalse(
-        Files.exists(repoRoot.resolve(ADAPTER_BRIDGE_MAIN_JAVA)),
+        hasJavaSources(repoRoot.resolve(ADAPTER_BRIDGE_MAIN_JAVA)),
         ":adapter-fcp must not own network/crypta/clients/fcp/bridge main sources");
   }
 
@@ -50,12 +52,25 @@ class BridgeFcpRuntimeBoundaryTest {
     Path repoRoot = repoRoot();
     String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
     String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String bridgeBuild = Files.readString(repoRoot.resolve(BRIDGE_BUILD_FILE));
+    String adapterBuild = Files.readString(repoRoot.resolve(ADAPTER_BUILD_FILE));
     Set<String> metadataPatterns = readOwnershipPatterns(repoRoot.resolve(OWNERSHIP_METADATA));
     Set<String> adapterMetadataPatterns =
         readOwnershipPatterns(repoRoot.resolve(ADAPTER_OWNERSHIP_METADATA));
 
+    assertTrue(settings.contains("\":adapter-fcp\""));
     assertTrue(settings.contains("\":bridge-fcp-runtime\""));
+    assertTrue(build.contains("project(\":adapter-fcp\")"));
     assertTrue(build.contains("project(\":bridge-fcp-runtime\")"));
+    assertTrue(
+        bridgeBuild.contains("project(\":adapter-fcp\")"),
+        ":bridge-fcp-runtime must depend on :adapter-fcp");
+    assertTrue(
+        bridgeBuild.contains("implementation(project(\":runtime-node\"))"),
+        ":bridge-fcp-runtime must remain the concrete runtime-binding owner for FCP");
+    assertFalse(
+        adapterBuild.contains("implementation(project(\":runtime-node\"))"),
+        ":adapter-fcp must not depend on :runtime-node");
     assertTrue(metadataPatterns.contains("network/crypta/clients/fcp/bridge/**"));
     assertTrue(
         Files.isRegularFile(repoRoot.resolve(OWNERSHIP_METADATA)),
@@ -119,6 +134,16 @@ class BridgeFcpRuntimeBoundaryTest {
           .filter(line -> !line.isEmpty())
           .filter(line -> !line.startsWith("#"))
           .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static boolean hasJavaSources(Path root) throws IOException {
+    if (!Files.exists(root)) {
+      return false;
+    }
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile)
+          .anyMatch(BridgeFcpRuntimeBoundaryTest::isTrackedJavaSource);
     }
   }
 

--- a/docs/fcp-boundary.md
+++ b/docs/fcp-boundary.md
@@ -1,0 +1,23 @@
+# FCP Boundary
+
+`:adapter-fcp` owns the detached protocol-side `network.crypta.clients.fcp` package tree together
+with the protocol-side persistent-bucket and filter seams. It must not depend directly on
+`:runtime-node`, and it must not claim `network.crypta.clients.fcp.bridge`.
+
+`:bridge-fcp-runtime` owns the concrete runtime-binding bridge package
+`network.crypta.clients.fcp.bridge`. It is the only FCP leaf allowed to carry direct bindings to
+daemon and client-engine types, including the live persistent-bucket, content-filter,
+persistent-request, queue, alert-feed, and endpoint-handle adapters used by the legacy FCP
+endpoint.
+
+The dependency direction is one way. `:bridge-fcp-runtime` depends on `:adapter-fcp` for the
+protocol-side seams, but `:adapter-fcp` must stay detached from the bridge and from
+`:runtime-node`.
+
+`:runtime-spi` stays detached and JDK-only. Shared runtime/config ports live there; concrete FCP
+runtime binding stays in `:bridge-fcp-runtime`.
+
+Default production binding still starts in
+`src/main/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactories.java`.
+
+Future browse/FProxy work is on the legacy HTTP side and is unrelated to this FCP boundary page.

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -3,7 +3,7 @@
 `:adapter-http-legacy-admin` owns the shared legacy `network.crypta.clients.http` shell, the
 admin toadlets, the `/api/v1/` and `/app/node/` bridge entrypoints, and the matching
 `network/crypta/clients/http/**` main resources. It does not own the concrete browse/FProxy
-implementation classes.
+implementation classes. The admin leaf is now detached from `:runtime-node`.
 
 `:adapter-http-legacy-browse` owns the concrete browse/FProxy routes, toadlets, helper models,
 and browse-only packages under `network.crypta.clients.http`.
@@ -22,8 +22,8 @@ HTTP/admin alert rendering now crosses the detached
 `network.crypta.runtime.alerts.UserAlertSurface` owned by `:runtime-alerts`. The concrete
 `UserAlertManager` remains runtime-node-owned, while `:adapter-http-legacy-admin` and
 `:bridge-http-runtime` consume the narrower alert surface instead of importing that concrete
-manager type directly. This is one focused step in the ongoing removal of
-`adapter-http-legacy-admin -> :runtime-node` coupling without widening `:runtime-spi`.
+manager type directly. This keeps `:adapter-http-legacy-admin` detached from `:runtime-node`
+without widening `:runtime-spi`.
 
 Admin config classification now also crosses a detached config-owned marker:
 `network.crypta.config.DirectorySelectionCallback` in `:foundation-config`. `ConfigToadlet`
@@ -42,5 +42,6 @@ Production code outside `:adapter-http-legacy-admin`, `:adapter-http-legacy-brow
 `src/main/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactories.java`, and the
 updater-action adapters remain in `:adapter-http-legacy-admin`.
 
-Future browse/FProxy decomposition or replacement is still deferred beyond the physical module
-split. This page documents the current admin/shared-shell, browse, and runtime boundary.
+Future browse/FProxy decomposition or replacement remains a separate concern. This page documents
+the current admin/shared-shell, browse, and runtime boundary, and the concrete browse leaf remains
+out of scope for this closeout.


### PR DESCRIPTION
## Summary
- tighten the Phase 2 FCP boundary tests so `:adapter-fcp` stays detached from `:runtime-node`, keeps ownership of the protocol tree only, and leaves `network.crypta.clients.fcp.bridge` to `:bridge-fcp-runtime`
- refresh the legacy HTTP boundary wording, add `docs/fcp-boundary.md`, and update the FCP bridge package docs so the current detached adapter / concrete bridge split is documented as the finished state
- sync `README.md` and the local `cryptad-architecture` / `cryptad-build-test` skills with the post-`c285f32` leaf layout, including the extracted support/content/transport details and representative moved classes

## How to test
- `./gradlew :adapter-fcp:test :bridge-fcp-runtime:test :adapter-http-legacy-admin:test :bridge-http-runtime:test`

## Notes
- no production Java classes moved
- no runtime behavior changes intended
- PR opened into `develop`
