### PR TITLE
feat(queue): Add Platform API queue control plane

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.api.PlatformApiPaths;
 import network.crypta.platform.api.PlatformApiRequest;
 import network.crypta.platform.api.PlatformApiResponse;
@@ -42,6 +43,9 @@ public final class PlatformApiToadlet extends Toadlet {
 
   /** JSON media type advertised for every Platform API response emitted through the bridge. */
   private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
+
+  /** Legacy maximum accepted size for one URL-encoded request body. */
+  private static final long MAX_URL_ENCODED_BODY_LENGTH = 1024L * 1024L;
 
   private static final String URL_ENCODED_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
@@ -273,6 +277,8 @@ public final class PlatformApiToadlet extends Toadlet {
       response =
           PlatformApiResponse.error(
               400, "invalid_path", "Request path contains malformed percent-encoding.");
+    } catch (PlatformApiException e) {
+      response = PlatformApiResponse.error(e.statusCode(), e.errorCode(), e.getMessage());
     } catch (RuntimeException e) {
       LOG.error("Platform API request failed for path {}", requestPath(uri), e);
       response =
@@ -443,6 +449,10 @@ public final class PlatformApiToadlet extends Toadlet {
 
   private static void mergeUrlEncodedBodyParameters(
       Bucket rawData, Map<String, List<String>> queryParameters) {
+    if (rawData.size() > MAX_URL_ENCODED_BODY_LENGTH) {
+      throw new PlatformApiException(
+          400, "invalid_request_body", "URL-encoded request body exceeds the 1048576 byte limit.");
+    }
     Map<String, List<String>> bodyParameters;
     try (var input = rawData.getInputStream()) {
       if (input == null) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -17,6 +17,7 @@ import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.URLDecoder;
 import network.crypta.support.URLEncodedFormatException;
+import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,10 +43,12 @@ public final class PlatformApiToadlet extends Toadlet {
   /** JSON media type advertised for every Platform API response emitted through the bridge. */
   private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
+  private static final String URL_ENCODED_CONTENT_TYPE = "application/x-www-form-urlencoded";
+
   private static final String DELETE_METHOD = "DELETE";
   private static final String FORM_PASSWORD_PARAMETER = "formPassword";
-  private static final String STAGED_DIR_PARAMETER = "stagedDir";
-  private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = 4096;
+  private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = QueueToadlet.MAX_KEY_LENGTH;
+  private static final String QUEUE_SEGMENT = "queue";
 
   /**
    * Transport-neutral router that owns endpoint selection, validation, and JSON payload creation.
@@ -303,7 +306,7 @@ public final class PlatformApiToadlet extends Toadlet {
     }
 
     if (pathSegments.isEmpty() || !"apps".equals(pathSegments.getFirst())) {
-      return false;
+      return requiresQueueFormPassword(method, pathSegments);
     }
     if (DELETE_METHOD.equals(method)) {
       return pathSegments.size() == 2;
@@ -315,6 +318,34 @@ public final class PlatformApiToadlet extends Toadlet {
         && ("start".equals(pathSegments.get(2))
             || "stop".equals(pathSegments.get(2))
             || "update".equals(pathSegments.get(2)));
+  }
+
+  /**
+   * Returns whether the current request targets one of the mutating queue routes.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresQueueFormPassword(String method, List<String> pathSegments) {
+    if (!"POST".equals(method)
+        || pathSegments.isEmpty()
+        || !QUEUE_SEGMENT.equals(pathSegments.getFirst())) {
+      return false;
+    }
+    if (pathSegments.size() == 2 && "downloads".equals(pathSegments.get(1))) {
+      return true;
+    }
+    if (pathSegments.size() != 3) {
+      return false;
+    }
+    if ("requests".equals(pathSegments.get(1))) {
+      return "remove".equals(pathSegments.get(2))
+          || "restart".equals(pathSegments.get(2))
+          || "priority".equals(pathSegments.get(2));
+    }
+    return "cleanup".equals(pathSegments.get(1))
+        && ("uploads".equals(pathSegments.get(2)) || "downloads".equals(pathSegments.get(2)));
   }
 
   /**
@@ -351,9 +382,11 @@ public final class PlatformApiToadlet extends Toadlet {
    *
    * <p>Query parameters preserve encounter order and repeated values so the router can apply its
    * own validation without depending on the legacy HTTP request type. The bridge excludes the
-   * legacy admin {@code formPassword} from that map. It also lifts the small set of scalar form
-   * fields currently needed by Platform API v1 into the same map. The transport-neutral request
-   * model intentionally does not define a separate body contract yet.
+   * legacy admin {@code formPassword} from that map. It also lifts scalar form fields from request
+   * parts into the same map so the transport-neutral router can handle urlencoded and multipart
+   * admin submissions without learning legacy HTTP request details. Uploaded-file bodies stay out
+   * of that map because Platform API v1 still treats file transfer payloads as adapter-local
+   * concerns.
    *
    * @param method HTTP method name forwarded into the router
    * @param uri request target supplied by the legacy HTTP shell
@@ -371,29 +404,79 @@ public final class PlatformApiToadlet extends Toadlet {
       }
       queryParameters.put(parameterName, List.of(request.getMultipleParam(parameterName)));
     }
-    copyStagedDirPartIfPresent(request, queryParameters);
+    copyBodyParametersIfPresent(request, queryParameters);
     return new PlatformApiRequest(method, relativeApiPath(requestPath(uri)), queryParameters);
   }
 
   /**
-   * Copies the staged-directory form part into the query-like parameter map when present.
+   * Copies body-backed form values into the query-like parameter map when present.
    *
    * <p>This keeps the bridge compatible with legacy-authenticated form submissions while preserving
-   * the transport-neutral request model expected by the Platform API router.
+   * the transport-neutral request model expected by the Platform API router. Existing query-string
+   * values win when the same name appears in both places. Urlencoded bodies are reparsed from the
+   * raw payload so repeated values survive intact; multipart uploads continue to use scalar parts,
+   * with uploaded-file bodies skipped because the Platform API request model is still text-only in
+   * this phase.
    *
    * @param request decoded legacy HTTP request wrapper
    * @param queryParameters query-like parameter map being assembled for the router
    */
-  private static void copyStagedDirPartIfPresent(
+  private static void copyBodyParametersIfPresent(
       HTTPRequest request, Map<String, List<String>> queryParameters) {
-    if (queryParameters.containsKey(STAGED_DIR_PARAMETER)
-        || !request.isPartSet(STAGED_DIR_PARAMETER)) {
+    Bucket rawData = request.getRawData();
+    if (rawData == null) {
       return;
     }
-    String value =
-        request.getPartAsStringFailsafe(STAGED_DIR_PARAMETER, MAX_PLATFORM_API_FORM_FIELD_LENGTH);
-    if (!value.isEmpty()) {
-      queryParameters.put(STAGED_DIR_PARAMETER, List.of(value));
+    if (isUrlEncodedBodyRequest(request)) {
+      mergeUrlEncodedBodyParameters(rawData, queryParameters);
+      return;
+    }
+    copyScalarFormPartsIfPresent(request, queryParameters);
+  }
+
+  private static boolean isUrlEncodedBodyRequest(HTTPRequest request) {
+    String contentType = request.getHeader("content-type");
+    return contentType != null
+        && contentType.regionMatches(
+            true, 0, URL_ENCODED_CONTENT_TYPE, 0, URL_ENCODED_CONTENT_TYPE.length());
+  }
+
+  private static void mergeUrlEncodedBodyParameters(
+      Bucket rawData, Map<String, List<String>> queryParameters) {
+    Map<String, List<String>> bodyParameters;
+    try (var input = rawData.getInputStream()) {
+      if (input == null) {
+        return;
+      }
+      String body = new String(input.readAllBytes(), StandardCharsets.US_ASCII);
+      bodyParameters = HTTPRequestImpl.parseUriParameters(body, true);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read Platform API form body.", e);
+    }
+    for (Map.Entry<String, List<String>> entry : bodyParameters.entrySet()) {
+      if (FORM_PASSWORD_PARAMETER.equals(entry.getKey())
+          || queryParameters.containsKey(entry.getKey())) {
+        continue;
+      }
+      queryParameters.put(entry.getKey(), List.copyOf(entry.getValue()));
+    }
+  }
+
+  private static void copyScalarFormPartsIfPresent(
+      HTTPRequest request, Map<String, List<String>> queryParameters) {
+    String[] partNames = request.getParts();
+    if (partNames == null) {
+      return;
+    }
+    for (String partName : partNames) {
+      if (FORM_PASSWORD_PARAMETER.equals(partName)
+          || queryParameters.containsKey(partName)
+          || request.getUploadedFile(partName) != null) {
+        continue;
+      }
+      queryParameters.put(
+          partName,
+          List.of(request.getPartAsStringFailsafe(partName, MAX_PLATFORM_API_FORM_FIELD_LENGTH)));
     }
   }
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
@@ -23,8 +23,9 @@ import network.crypta.support.api.HTTPRequest;
  * <p>This toadlet keeps HTTP-specific routing and access control inside the legacy admin adapter
  * while reusing the shell-owned browser contract from {@code :platform-web-shell}. It serves the
  * shell index page at {@value WebShellPaths#SHELL_ROOT}, serves the shell-owned static assets
- * beneath {@value WebShellPaths#ASSET_ROOT}, and injects only the small read-only bootstrap payload
- * needed by the browser-side script.
+ * beneath {@value WebShellPaths#ASSET_ROOT}, and injects the small bootstrap payload needed by the
+ * browser-side script, including the legacy mutation token required by the current Platform API
+ * bridge.
  */
 public final class WebShellToadlet extends Toadlet {
   /** Content type used for the shell document returned from the main route. */
@@ -83,7 +84,7 @@ public final class WebShellToadlet extends Toadlet {
       writeReply(
           ctx,
           ReplyHeaders.of(200, "OK", HTML_CONTENT_TYPE),
-          WebShellPageRenderer.render(bootstrap));
+          WebShellPageRenderer.render(bootstrap.withFormPassword(ctx.getFormPassword())));
       return;
     }
 

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -9,6 +9,8 @@ version = rootProject.version
 val mainSourceSet = sourceSets.named("main")
 
 dependencies {
+  implementation(project(":foundation-crypto-keys"))
+
   api(project(":runtime-spi"))
   api(project(":platform-apphost"))
 

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -8,6 +8,7 @@ import network.crypta.platform.api.config.ConfigApiHandler;
 import network.crypta.platform.api.connectivity.ConnectivityApiHandler;
 import network.crypta.platform.api.node.NodeApiHandler;
 import network.crypta.platform.api.peers.PeersApiHandler;
+import network.crypta.platform.api.queue.QueueApiHandler;
 import network.crypta.platform.api.security.SecurityLevelsApiHandler;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -24,6 +25,12 @@ public final class PlatformApiRouter {
   /** Logger used for unexpected failures that escape endpoint-specific validation. */
   private static final System.Logger LOG = System.getLogger(PlatformApiRouter.class.getName());
 
+  /** Shared 405 message for routes that only support GET. */
+  private static final String GET_ONLY_MESSAGE = "Platform API v1 supports GET requests only.";
+
+  /** Shared 405 message for routes that only support POST. */
+  private static final String POST_ONLY_MESSAGE = "Platform API v1 supports POST requests only.";
+
   /** Handler for the {@code /node/...} endpoint family. */
   private final NodeApiHandler nodeApiHandler;
 
@@ -38,6 +45,9 @@ public final class PlatformApiRouter {
 
   /** Handler for the {@code /security-levels} endpoint. */
   private final SecurityLevelsApiHandler securityLevelsApiHandler;
+
+  /** Handler for the {@code /queue/...} endpoint family. */
+  private final QueueApiHandler queueApiHandler;
 
   /** Handler for the {@code /apps/...} endpoint family, when AppHost support is available. */
   private final AppsApiHandler appsApiHandler;
@@ -66,6 +76,13 @@ public final class PlatformApiRouter {
     configApiHandler = new ConfigApiHandler(runtimePorts.config());
     connectivityApiHandler = new ConnectivityApiHandler(runtimePorts.connectivity());
     securityLevelsApiHandler = new SecurityLevelsApiHandler(runtimePorts.securityLevels());
+    queueApiHandler =
+        new QueueApiHandler(
+            runtimePorts.queuePage(),
+            runtimePorts.queueMutation(),
+            runtimePorts.queueDownload(),
+            runtimePorts.queueSupport(),
+            runtimePorts.queueCompletion());
     appsApiHandler = appHost == null ? null : new AppsApiHandler(appHost);
   }
 
@@ -106,13 +123,13 @@ public final class PlatformApiRouter {
     if ("apps".equals(firstSegment)) {
       return routeAppsRequest(segments, request);
     }
+    if ("queue".equals(firstSegment)) {
+      return routeQueueRequest(segments, request);
+    }
 
     if (!"GET".equals(request.method())) {
       return PlatformApiResponse.error(
-          405,
-          Map.of("Allow", "GET"),
-          "method_not_allowed",
-          "Platform API v1 supports GET requests only.");
+          405, Map.of("Allow", "GET"), "method_not_allowed", GET_ONLY_MESSAGE);
     }
 
     if ("node".equals(firstSegment)) {
@@ -163,7 +180,7 @@ public final class PlatformApiRouter {
    */
   private PlatformApiResponse routeAppsCollection(String method) {
     if (!"GET".equals(method)) {
-      return methodNotAllowed("GET", "Platform API v1 supports GET requests only.");
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
     }
     return PlatformApiResponse.ok(envelope("apps", appsApiHandler.list()));
   }
@@ -191,7 +208,7 @@ public final class PlatformApiRouter {
    */
   private PlatformApiResponse routeAppsInstall(PlatformApiRequest request) {
     if (!"POST".equals(request.method())) {
-      return methodNotAllowed("POST", "Platform API v1 supports POST requests only.");
+      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
     }
     return PlatformApiResponse.created(
         envelope("app", appsApiHandler.install(request.queryParameters())));
@@ -242,7 +259,7 @@ public final class PlatformApiRouter {
       String appId, String action, PlatformApiRequest request) {
     String method = request.method();
     if (!"POST".equals(method)) {
-      return methodNotAllowed("POST", "Platform API v1 supports POST requests only.");
+      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
     }
     return switch (action) {
       case "start" -> PlatformApiResponse.ok(envelope("app", appsApiHandler.start(appId)));
@@ -252,6 +269,129 @@ public final class PlatformApiRouter {
               envelope("app", appsApiHandler.update(appId, request.queryParameters())));
       default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
     };
+  }
+
+  /**
+   * Routes requests beneath the {@code /queue} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected queue endpoint
+   */
+  private PlatformApiResponse routeQueueRequest(List<String> segments, PlatformApiRequest request) {
+    return switch (segments.size()) {
+      case 1 -> routeQueueRoot(request);
+      case 2 -> routeQueueResource(segments.get(1), request);
+      case 3 -> routeQueueAction(segments.get(1), segments.get(2), request);
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  /**
+   * Routes the queue snapshot endpoint at {@code /queue}.
+   *
+   * @param request full request metadata, including query parameters
+   * @return JSON response containing one detached queue snapshot
+   */
+  private PlatformApiResponse routeQueueRoot(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(queueApiHandler.snapshot(request.queryParameters()));
+  }
+
+  /**
+   * Routes queue resources such as count, keys, and direct-download creation.
+   *
+   * @param resource second path segment beneath {@code /queue}
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected queue resource
+   */
+  private PlatformApiResponse routeQueueResource(String resource, PlatformApiRequest request) {
+    return switch (resource) {
+      case "count" -> routeQueueCount(request);
+      case "keys" -> routeQueueKeys(request);
+      case "downloads" -> routeQueueDownloads(request);
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  /**
+   * Routes queue snapshot count requests.
+   *
+   * @param request full request metadata, including query parameters
+   * @return JSON response containing one detached count snapshot
+   */
+  private PlatformApiResponse routeQueueCount(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(queueApiHandler.count(request.queryParameters()));
+  }
+
+  /**
+   * Routes queue key-export requests.
+   *
+   * @param request full request metadata, including query parameters
+   * @return JSON response containing the detached queue key export
+   */
+  private PlatformApiResponse routeQueueKeys(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(queueApiHandler.keys(request.queryParameters()));
+  }
+
+  /**
+   * Routes direct-download creation requests.
+   *
+   * @param request full request metadata, including query parameters
+   * @return JSON response describing the newly queued direct download
+   */
+  private PlatformApiResponse routeQueueDownloads(PlatformApiRequest request) {
+    if (!"POST".equals(request.method())) {
+      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.created(
+        queueApiHandler.createDirectDownload(request.queryParameters()));
+  }
+
+  /**
+   * Routes queue mutation actions beneath {@code /queue/...}.
+   *
+   * @param resource second path segment beneath {@code /queue}
+   * @param action queue action segment
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected queue mutation
+   */
+  private PlatformApiResponse routeQueueAction(
+      String resource, String action, PlatformApiRequest request) {
+    if (!"POST".equals(request.method())) {
+      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+    }
+    if ("requests".equals(resource)) {
+      return switch (action) {
+        case "remove" ->
+            PlatformApiResponse.ok(queueApiHandler.removeRequests(request.queryParameters()));
+        case "restart" ->
+            PlatformApiResponse.ok(queueApiHandler.restartRequests(request.queryParameters()));
+        case "priority" ->
+            PlatformApiResponse.ok(queueApiHandler.changePriority(request.queryParameters()));
+        default ->
+            throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+      };
+    }
+    if ("cleanup".equals(resource)) {
+      return switch (action) {
+        case "uploads" ->
+            PlatformApiResponse.ok(queueApiHandler.cleanupUploads(request.queryParameters()));
+        case "downloads" ->
+            PlatformApiResponse.ok(queueApiHandler.cleanupDownloads(request.queryParameters()));
+        default ->
+            throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+      };
+    }
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
   }
 
   /**

--- a/platform-api/src/main/java/network/crypta/platform/api/queue/QueueApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/queue/QueueApiHandler.java
@@ -1,0 +1,617 @@
+package network.crypta.platform.api.queue;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.keys.FreenetURI;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueDownloadRejectedException;
+import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueMutationPort;
+import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueuePageRequest;
+import network.crypta.runtime.spi.QueuePageSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
+import network.crypta.runtime.spi.RequestQueueUnavailableException;
+
+/**
+ * Serves the Platform API v1 queue control-plane surface.
+ *
+ * <p>This handler turns the detached queue runtime ports into one transport-neutral JSON API for
+ * the Web Shell and any other local callers that need queue visibility or queue mutation access.
+ * Reads still originate from the legacy page-oriented {@link QueuePagePort}, so the current read
+ * model remains intentionally transitional: the handler wraps detached HTML snapshots in stable
+ * JSON envelopes, strips request-local placeholders that belong only to the legacy HTTP shell, and
+ * leaves the runtime traversal logic behind the existing SPI boundary.
+ *
+ * <p>Mutation requests already cross the detached ports more directly. This type validates the
+ * supported request parameters, normalizes legacy queue form conventions such as repeated
+ * identifiers and checkbox values, and preserves the established queue-backend error mapping.
+ *
+ * <p>It also keeps direct-download creation deliberately narrow. That leaves later queue phases
+ * free to add richer insert flows without reworking the basic control-plane contract.
+ */
+public final class QueueApiHandler {
+  private static final String ALERT_SUMMARY_PLACEHOLDER = "<!--CRYPTA_ALERT_SUMMARY-->";
+  private static final String FORM_PASSWORD_PLACEHOLDER = "<!--CRYPTA_QUEUE_FORM_PASSWORD-->";
+  private static final String PANIC_BOX_PLACEHOLDER = "<!--CRYPTA_QUEUE_PANIC_BOX-->";
+  private static final String FIELD_OPERATION = "operation";
+  private static final String FIELD_IDENTIFIER_COUNT = "identifierCount";
+  private static final String IDENTIFIER_PARAMETER_PREFIX = "identifier-";
+  private static final String PARAMETER_DISABLE_FILTER_DATA = "disableFilterData";
+  private static final String PARAMETER_FETCH_URI = "fetchUri";
+  private static final String PARAMETER_FILTER_DATA = "filterData";
+  private static final String PARAMETER_PAGE = "page";
+  private static final String PARAMETER_PRIORITY = "priority";
+  private static final short MINIMUM_PRIORITY_CLASS = 0;
+  private static final short MAXIMUM_PRIORITY_CLASS = 6;
+  private static final String QUERY_PARAMETER_PREFIX = "Query parameter '";
+  private static final String QUEUE_PAGE_DOWNLOADS = "downloads";
+  private static final String QUEUE_PAGE_UPLOADS = "uploads";
+
+  /** Detached queue snapshot read port. */
+  private final QueuePagePort queuePagePort;
+
+  /** Detached queue mutation port for already-existing requests. */
+  private final QueueMutationPort queueMutationPort;
+
+  /** Detached download-creation port for new direct downloads. */
+  private final QueueDownloadPort queueDownloadPort;
+
+  /** Detached queue support port used for availability checks. */
+  private final QueueSupportPort queueSupportPort;
+
+  /** Detached completion tracker startup hook used when a queue side is rendered. */
+  private final QueueCompletionPort queueCompletionPort;
+
+  /**
+   * Creates a queue API handler backed by the existing queue runtime ports.
+   *
+   * <p>All ports are required because even the small initial queue surface spans detached reads,
+   * existing-request mutations, direct-download creation, backend availability checks, and
+   * completion-tracker startup for rendered queue sides.
+   *
+   * @param queuePagePort detached queue snapshot read port used for queue pages and count views
+   * @param queueMutationPort detached mutation port for already-existing queue requests
+   * @param queueDownloadPort detached direct-download creation port for new download requests
+   * @param queueSupportPort detached queue support port used for backend availability checks
+   * @param queueCompletionPort detached completion-tracker startup hook for rendered queue sides
+   * @throws NullPointerException if any required detached runtime port reference is {@code null}
+   */
+  public QueueApiHandler(
+      QueuePagePort queuePagePort,
+      QueueMutationPort queueMutationPort,
+      QueueDownloadPort queueDownloadPort,
+      QueueSupportPort queueSupportPort,
+      QueueCompletionPort queueCompletionPort) {
+    this.queuePagePort = Objects.requireNonNull(queuePagePort, "queuePagePort");
+    this.queueMutationPort = Objects.requireNonNull(queueMutationPort, "queueMutationPort");
+    this.queueDownloadPort = Objects.requireNonNull(queueDownloadPort, "queueDownloadPort");
+    this.queueSupportPort = Objects.requireNonNull(queueSupportPort, "queueSupportPort");
+    this.queueCompletionPort = Objects.requireNonNull(queueCompletionPort, "queueCompletionPort");
+  }
+
+  /**
+   * Returns one detached queue page snapshot as a JSON-compatible object.
+   *
+   * <p>The caller selects one queue side with {@code page} and may opt into the same advanced-mode
+   * and sorting controls that the legacy queue page already understands. Successful reads also
+   * ensure that the detached completion tracker is started for the rendered side so the shell sees
+   * the same completion-aware runtime behavior as the legacy operator path.
+   *
+   * @param queryParameters decoded request parameters for the current API call, including page
+   *     selection and optional advanced-mode or sorting fields
+   * @return JSON-compatible queue page snapshot containing the selected side, detached title, and
+   *     placeholder-free HTML fragment for shell rendering
+   * @throws PlatformApiException if required parameters are missing, malformed, or the queue
+   *     backend is currently unavailable
+   */
+  public Map<String, Object> snapshot(Map<String, List<String>> queryParameters) {
+    QueueSide page = requireQueueSide(queryParameters);
+    boolean advancedMode =
+        PlatformApiParameters.readBoolean(queryParameters, "advancedMode", false);
+    String sortBy = optionalString(queryParameters, "sortBy");
+    boolean reversed = PlatformApiParameters.readBoolean(queryParameters, "reversed", false);
+    ensureQueueReadable(page.uploads());
+
+    QueuePageSnapshot snapshot =
+        readQueuePage(
+            () ->
+                queuePagePort.renderPage(
+                    new QueuePageRequest(page.uploads(), advancedMode, sortBy, reversed)));
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(6);
+    json.put("page", page.apiValue());
+    json.put("pageTitle", snapshot.pageTitle());
+    json.put("contentHtml", stripRuntimePlaceholders(snapshot.contentHtmlTemplate()));
+    json.put("advancedMode", advancedMode);
+    json.put("sortBy", sortBy);
+    json.put("reversed", reversed);
+    return json;
+  }
+
+  /**
+   * Returns the detached queue count snapshot for one queue side.
+   *
+   * <p>The underlying runtime currently exposes only the download-side count view. This method
+   * therefore rejects {@code page=uploads} instead of returning mislabeled data. When the count is
+   * available, it is wrapped in the same small JSON envelope shape used by the other queue reads so
+   * the shell can treat it as an auxiliary panel.
+   *
+   * @param queryParameters decoded request parameters for the current API call, including the
+   *     required queue-side selector
+   * @return JSON-compatible count snapshot for the download queue side
+   * @throws PlatformApiException if the page selector is missing, unsupported, or the queue backend
+   *     is currently unavailable
+   */
+  public Map<String, Object> count(Map<String, List<String>> queryParameters) {
+    QueueSide page = requireQueueSide(queryParameters);
+    if (page.uploads()) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_PAGE) + " must be 'downloads' for this endpoint.");
+    }
+    ensureQueueReadable(false);
+
+    QueuePageSnapshot snapshot = readQueuePage(() -> queuePagePort.renderCountPage(false));
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put("page", page.apiValue());
+    json.put("pageTitle", snapshot.pageTitle());
+    json.put("contentHtml", stripRuntimePlaceholders(snapshot.contentHtmlTemplate()));
+    return json;
+  }
+
+  /**
+   * Returns the detached queue key export as a JSON list.
+   *
+   * <p>The runtime port still emits the key list as newline-delimited text. This method trims that
+   * output into a stable JSON array, preserving the legacy queue-side split while giving the shell
+   * and other callers a transport-neutral export shape that is easier to render or download.
+   *
+   * @param queryParameters decoded request parameters for the current API call, including the
+   *     required queue-side selector
+   * @return JSON-compatible queue key export containing the selected side, key count, and trimmed
+   *     key list entries
+   * @throws PlatformApiException if the page selector is missing, invalid, or the queue backend is
+   *     currently unavailable
+   */
+  public Map<String, Object> keys(Map<String, List<String>> queryParameters) {
+    QueueSide page = requireQueueSide(queryParameters);
+    ensureQueueReadable(page.uploads());
+
+    String rawKeyList = readKeyList(page.uploads());
+    List<String> keys =
+        rawKeyList.lines().map(String::trim).filter(line -> !line.isEmpty()).toList();
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put("page", page.apiValue());
+    json.put("keyCount", keys.size());
+    json.put("keys", keys);
+    return json;
+  }
+
+  /**
+   * Removes already-existing queue requests.
+   *
+   * <p>The request may identify selections either through repeated {@code identifier} parameters or
+   * the numbered {@code identifier-*} fields emitted by the legacy queue tables. The handler
+   * preserves the caller's row order before invoking the detached mutation port so downstream
+   * partial-failure behavior stays aligned with the user's selection order.
+   *
+   * @param queryParameters decoded request parameters for the current API call, including one or
+   *     more queue request identifiers
+   * @return JSON-compatible mutation summary reporting the remove operation and identifier count
+   * @throws PlatformApiException if no identifiers are supplied, if any identifier field is
+   *     malformed, or if the queue backend is unavailable
+   */
+  public Map<String, Object> removeRequests(Map<String, List<String>> queryParameters) {
+    List<String> identifiers = requireIdentifiers(queryParameters);
+    ensureQueueBackendEnabled();
+    mutateQueue(() -> queueMutationPort.removeRequests(identifiers));
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put(FIELD_OPERATION, "remove");
+    json.put(FIELD_IDENTIFIER_COUNT, identifiers.size());
+    return json;
+  }
+
+  /**
+   * Restarts already-existing queue requests.
+   *
+   * <p>This endpoint accepts the legacy restart checkbox conventions as well as normalized boolean
+   * values. That keeps Web Shell submissions and transplanted legacy form payloads compatible while
+   * still returning one explicit JSON summary that states whether filter bypass was requested.
+   *
+   * @param queryParameters decoded request parameters for the current API call, including one or
+   *     more queue request identifiers and the optional disable-filter checkbox value
+   * @return JSON-compatible mutation summary reporting the restart operation, identifier count, and
+   *     normalized filter-bypass flag
+   * @throws PlatformApiException if the identifiers are missing or malformed, if the checkbox value
+   *     cannot be interpreted, or if the queue backend is unavailable
+   */
+  public Map<String, Object> restartRequests(Map<String, List<String>> queryParameters) {
+    List<String> identifiers = requireIdentifiers(queryParameters);
+    boolean disableFilterData = readCheckboxBoolean(queryParameters, PARAMETER_DISABLE_FILTER_DATA);
+    ensureQueueBackendEnabled();
+    mutateQueue(() -> queueMutationPort.restartRequests(identifiers, disableFilterData));
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put(FIELD_OPERATION, "restart");
+    json.put(FIELD_IDENTIFIER_COUNT, identifiers.size());
+    json.put(PARAMETER_DISABLE_FILTER_DATA, disableFilterData);
+    return json;
+  }
+
+  /**
+   * Changes the priority class of already-existing queue requests.
+   *
+   * <p>The handler validates the detached priority value before it reaches the runtime port. That
+   * keeps malformed or out-of-range API calls from becoming misleading no-ops or backend failures
+   * when the queue tries to re-register the affected requests with the scheduler.
+   *
+   * @param queryParameters decoded request parameters for the current API call, including one or
+   *     more queue request identifiers and the requested detached priority class
+   * @return JSON-compatible mutation summary reporting the change-priority operation, identifier
+   *     count, and accepted priority class
+   * @throws PlatformApiException if the identifiers are missing, if the priority is malformed or
+   *     out of the supported range, or if the queue backend is unavailable
+   */
+  public Map<String, Object> changePriority(Map<String, List<String>> queryParameters) {
+    List<String> identifiers = requireIdentifiers(queryParameters);
+    short priority = requirePriority(queryParameters);
+    ensureQueueBackendEnabled();
+    mutateQueue(() -> queueMutationPort.changePriority(identifiers, priority));
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put(FIELD_OPERATION, "change_priority");
+    json.put(FIELD_IDENTIFIER_COUNT, identifiers.size());
+    json.put(PARAMETER_PRIORITY, priority);
+    return json;
+  }
+
+  /**
+   * Removes completed upload requests using the legacy cleanup semantics.
+   *
+   * <p>The current cleanup endpoints do not accept additional knobs. The query-parameter map is
+   * still required, so this method shares the same transport-neutral entry shape as the other queue
+   * mutations and can grow later without changing the router contract.
+   *
+   * @param queryParameters decoded request parameters for the current API call; currently present
+   *     only to preserve the shared queue mutation shape
+   * @return JSON-compatible cleanup summary identifying the legacy cleanup operation and upload
+   *     target side
+   * @throws NullPointerException if {@code queryParameters} is {@code null}
+   * @throws PlatformApiException if the queue backend is unavailable when the cleanup runs
+   */
+  public Map<String, Object> cleanupUploads(Map<String, List<String>> queryParameters) {
+    Objects.requireNonNull(queryParameters, "queryParameters");
+    ensureQueueBackendEnabled();
+    mutateQueue(queueMutationPort::removeFinishedUploads);
+    return cleanupResult(QUEUE_PAGE_UPLOADS);
+  }
+
+  /**
+   * Removes completed download requests using the legacy cleanup semantics.
+   *
+   * <p>This endpoint mirrors the legacy finished-download cleanup action and deliberately keeps the
+   * detached JSON response small. Callers get a stable operation and target summary while the
+   * runtime port retains the authoritative definition of what counts as a finished download entry.
+   *
+   * @param queryParameters decoded request parameters for the current API call; currently present
+   *     only to preserve the shared queue mutation shape
+   * @return JSON-compatible cleanup summary identifying the legacy cleanup operation and download
+   *     target side
+   * @throws NullPointerException if {@code queryParameters} is {@code null}
+   * @throws PlatformApiException if the queue backend is unavailable when the cleanup runs
+   */
+  public Map<String, Object> cleanupDownloads(Map<String, List<String>> queryParameters) {
+    Objects.requireNonNull(queryParameters, "queryParameters");
+    ensureQueueBackendEnabled();
+    mutateQueue(queueMutationPort::removeFinishedDownloads);
+    return cleanupResult(QUEUE_PAGE_DOWNLOADS);
+  }
+
+  /**
+   * Queues one new direct download using the existing detached download SPI.
+   *
+   * <p>This initial Platform API surface keeps direct-download creation intentionally narrow. It
+   * always creates a persistent direct-return download and leaves browser uploads and local file or
+   * directory insert flows on the legacy queue pages for now.
+   *
+   * <p>The caller may provide either {@code fetchUri} or the legacy {@code key} alias and may
+   * optionally supply a MIME hint. The handler validates the URI syntax up front, normalizes the
+   * filter checkbox, and then delegates to the detached runtime port with the fixed persistent
+   * direct-return contract for this phase.
+   *
+   * @param queryParameters decoded request parameters for the current API call, including the
+   *     required fetch URI and optional filter or MIME fields
+   * @return JSON-compatible creation summary describing the queued direct download request
+   * @throws PlatformApiException if the URI is missing or invalid, if the queue backend is
+   *     unavailable, or if the runtime port rejects or fails the request
+   */
+  public Map<String, Object> createDirectDownload(Map<String, List<String>> queryParameters) {
+    String fetchUri = requireFetchUri(queryParameters);
+    boolean filterData = readCheckboxBoolean(queryParameters, PARAMETER_FILTER_DATA);
+    String expectedMimeType = optionalString(queryParameters, "expectedMimeType");
+    ensureQueueBackendEnabled();
+
+    try {
+      queueDownloadPort.enqueueDownload(
+          new QueueDownloadRequest(
+              fetchUri, filterData, expectedMimeType, "forever", "direct", null));
+    } catch (QueueDownloadRejectedException _) {
+      throw new PlatformApiException(
+          409, "queue_download_rejected", "Direct download rejected by the queue backend.");
+    } catch (RequestQueueUnavailableException _) {
+      throw queueUnavailable();
+    } catch (IOException _) {
+      throw new PlatformApiException(500, "internal_error", "Failed to enqueue direct download.");
+    }
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(5);
+    json.put(FIELD_OPERATION, "create_direct_download");
+    json.put(PARAMETER_FETCH_URI, fetchUri);
+    json.put(PARAMETER_FILTER_DATA, filterData);
+    json.put("expectedMimeType", expectedMimeType);
+    json.put("returnType", "direct");
+    return json;
+  }
+
+  private void ensureQueueReadable(boolean uploads) {
+    ensureQueueBackendEnabled();
+    queueCompletionPort.ensureTrackingStarted(uploads);
+  }
+
+  private void ensureQueueBackendEnabled() {
+    if (!queueSupportPort.isQueueBackendEnabled()) {
+      throw new PlatformApiException(
+          409, "queue_backend_disabled", "Queue backend is currently disabled.");
+    }
+  }
+
+  private QueuePageSnapshot readQueuePage(QueuePageReadOperation operation) {
+    try {
+      return operation.read();
+    } catch (RequestQueueUnavailableException _) {
+      throw queueUnavailable();
+    }
+  }
+
+  private String readKeyList(boolean uploads) {
+    try {
+      return queuePagePort.renderKeyList(uploads);
+    } catch (RequestQueueUnavailableException _) {
+      throw queueUnavailable();
+    }
+  }
+
+  private void mutateQueue(QueueMutationOperation operation) {
+    try {
+      operation.apply();
+    } catch (RequestQueueUnavailableException _) {
+      throw queueUnavailable();
+    }
+  }
+
+  private static Map<String, Object> cleanupResult(String target) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put(FIELD_OPERATION, "cleanup");
+    json.put("target", target);
+    return json;
+  }
+
+  private static QueueSide requireQueueSide(Map<String, List<String>> queryParameters) {
+    String raw = PlatformApiParameters.requireString(queryParameters, PARAMETER_PAGE);
+    return switch (raw) {
+      case QUEUE_PAGE_DOWNLOADS -> QueueSide.DOWNLOADS;
+      case QUEUE_PAGE_UPLOADS -> QueueSide.UPLOADS;
+      default ->
+          throw invalidQuery(
+              queryParameter(PARAMETER_PAGE)
+                  + " must be either '"
+                  + QUEUE_PAGE_DOWNLOADS
+                  + "' or '"
+                  + QUEUE_PAGE_UPLOADS
+                  + "'.");
+    };
+  }
+
+  private static String requireFetchUri(Map<String, List<String>> queryParameters) {
+    String fetchUri = optionalString(queryParameters, PARAMETER_FETCH_URI);
+    if (fetchUri == null) {
+      fetchUri = optionalString(queryParameters, "key");
+    }
+    if (fetchUri == null || fetchUri.isBlank()) {
+      throw invalidQuery("Missing required query parameter '" + PARAMETER_FETCH_URI + "'.");
+    }
+    try {
+      new FreenetURI(fetchUri);
+    } catch (MalformedURLException _) {
+      throw invalidQuery(queryParameter(PARAMETER_FETCH_URI) + " must be a valid fetch URI.");
+    }
+    return fetchUri;
+  }
+
+  private static List<String> requireIdentifiers(Map<String, List<String>> queryParameters) {
+    ArrayList<String> identifiers = new ArrayList<>();
+    List<String> repeatedIdentifiers = queryParameters.get("identifier");
+    if (repeatedIdentifiers != null) {
+      for (String identifier : repeatedIdentifiers) {
+        addIdentifier(identifiers, identifier);
+      }
+    }
+
+    // Legacy queue pages emit numbered identifier-* fields; sort by suffix so HashMap-backed
+    // request parsing does not scramble the caller's row order before the mutation port sees it.
+    for (Map.Entry<String, List<String>> entry : sortedIdentifierEntries(queryParameters)) {
+      if (entry.getValue().size() != 1) {
+        throw invalidQuery(queryParameter(entry.getKey()) + " must not be repeated.");
+      }
+      addIdentifier(identifiers, entry.getValue().getFirst());
+    }
+
+    if (identifiers.isEmpty()) {
+      throw invalidQuery("At least one queue request identifier must be selected.");
+    }
+    return List.copyOf(identifiers);
+  }
+
+  private static List<Map.Entry<String, List<String>>> sortedIdentifierEntries(
+      Map<String, List<String>> queryParameters) {
+    return queryParameters.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(IDENTIFIER_PARAMETER_PREFIX))
+        .sorted(Map.Entry.comparingByKey(QueueApiHandler::compareIdentifierKeys))
+        .toList();
+  }
+
+  private static int compareIdentifierKeys(String firstKey, String secondKey) {
+    String firstSuffix = firstKey.substring(IDENTIFIER_PARAMETER_PREFIX.length());
+    String secondSuffix = secondKey.substring(IDENTIFIER_PARAMETER_PREFIX.length());
+    if (isDigitsOnly(firstSuffix) && isDigitsOnly(secondSuffix)) {
+      int byLength = Integer.compare(firstSuffix.length(), secondSuffix.length());
+      return byLength != 0 ? byLength : firstSuffix.compareTo(secondSuffix);
+    }
+    return firstSuffix.compareTo(secondSuffix);
+  }
+
+  private static boolean isDigitsOnly(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      if (!Character.isDigit(value.charAt(i))) {
+        return false;
+      }
+    }
+    return !value.isEmpty();
+  }
+
+  private static void addIdentifier(List<String> identifiers, String identifier) {
+    if (identifier == null || identifier.isBlank()) {
+      throw invalidQuery("Queue request identifiers must not be blank.");
+    }
+    identifiers.add(identifier);
+  }
+
+  private static short requirePriority(Map<String, List<String>> queryParameters) {
+    String raw = PlatformApiParameters.requireString(queryParameters, PARAMETER_PRIORITY);
+    short priority;
+    try {
+      priority = Short.parseShort(raw);
+    } catch (NumberFormatException _) {
+      throw invalidQuery(queryParameter(PARAMETER_PRIORITY) + " must be a valid short integer.");
+    }
+    if (priority < MINIMUM_PRIORITY_CLASS || priority > MAXIMUM_PRIORITY_CLASS) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_PRIORITY)
+              + " must be between "
+              + MINIMUM_PRIORITY_CLASS
+              + " and "
+              + MAXIMUM_PRIORITY_CLASS
+              + ".");
+    }
+    return priority;
+  }
+
+  private static boolean readCheckboxBoolean(
+      Map<String, List<String>> queryParameters, String name) {
+    List<String> values = queryParameters.get(name);
+    if (values == null || values.isEmpty()) {
+      return false;
+    }
+    boolean anyTruthy = false;
+    for (String raw : values) {
+      if (raw == null || isTruthyCheckboxValue(raw, name)) {
+        anyTruthy = true;
+      } else if (!isFalseyCheckboxValue(raw)) {
+        throw invalidQuery(
+            queryParameter(name)
+                + " must be a checkbox value or one of 'true', 'false', 'on', or 'off'.");
+      }
+    }
+    return anyTruthy;
+  }
+
+  private static boolean isTruthyCheckboxValue(String raw, String name) {
+    return raw.isBlank()
+        || "true".equalsIgnoreCase(raw)
+        || "on".equalsIgnoreCase(raw)
+        || name.equals(raw);
+  }
+
+  private static boolean isFalseyCheckboxValue(String raw) {
+    return "false".equalsIgnoreCase(raw) || "off".equalsIgnoreCase(raw);
+  }
+
+  private static String optionalString(Map<String, List<String>> queryParameters, String name) {
+    String value = readSingleValue(queryParameters, name);
+    if (value == null) {
+      return null;
+    }
+    return value.isBlank() ? null : value;
+  }
+
+  private static String readSingleValue(Map<String, List<String>> queryParameters, String name) {
+    List<String> values = queryParameters.get(name);
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    if (values.size() > 1) {
+      throw invalidQuery(queryParameter(name) + " must not be repeated.");
+    }
+    return values.getFirst();
+  }
+
+  private static String queryParameter(String name) {
+    return QUERY_PARAMETER_PREFIX + name + "'";
+  }
+
+  private static String stripRuntimePlaceholders(String contentHtmlTemplate) {
+    return contentHtmlTemplate
+        .replace(ALERT_SUMMARY_PLACEHOLDER, "")
+        .replace(FORM_PASSWORD_PLACEHOLDER, "")
+        .replace(PANIC_BOX_PLACEHOLDER, "");
+  }
+
+  private static PlatformApiException queueUnavailable() {
+    return new PlatformApiException(
+        409, "queue_unavailable", "Persistent request queue is currently unavailable.");
+  }
+
+  private static PlatformApiException invalidQuery(String message) {
+    return new PlatformApiException(400, "invalid_query_parameter", message);
+  }
+
+  private enum QueueSide {
+    DOWNLOADS(QUEUE_PAGE_DOWNLOADS, false),
+    UPLOADS(QUEUE_PAGE_UPLOADS, true);
+
+    private final String apiValue;
+    private final boolean uploads;
+
+    QueueSide(String apiValue, boolean uploads) {
+      this.apiValue = apiValue;
+      this.uploads = uploads;
+    }
+
+    private String apiValue() {
+      return apiValue;
+    }
+
+    private boolean uploads() {
+      return uploads;
+    }
+  }
+
+  @FunctionalInterface
+  private interface QueuePageReadOperation {
+    QueuePageSnapshot read() throws RequestQueueUnavailableException;
+  }
+
+  @FunctionalInterface
+  private interface QueueMutationOperation {
+    void apply() throws RequestQueueUnavailableException;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/queue/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/queue/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Queue control-plane endpoints for Platform API v1.
+ *
+ * <p>This package owns the transport-neutral queue surface that sits between the legacy HTTP bridge
+ * and the detached queue runtime ports. It exists to make queue operations first-class Platform API
+ * features instead of requiring the Web Shell to call the legacy queue toadlet directly for routine
+ * operator actions.
+ *
+ * <p>The current read model remains intentionally transitional. Queue reads still originate from
+ * detached HTML snapshots produced by the existing runtime page port, then leave this package as
+ * stable JSON envelopes after request-local placeholders are stripped. Mutations and direct
+ * download creation already cross the SPI more directly, which keeps later queue phases free to
+ * replace the transitional read model without reworking the basic control-plane routing contract.
+ */
+package network.crypta.platform.api.queue;

--- a/platform-api/src/test/java/network/crypta/platform/api/queue/QueueApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/queue/QueueApiHandlerTest.java
@@ -1,0 +1,452 @@
+package network.crypta.platform.api.queue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueMutationPort;
+import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueuePageRequest;
+import network.crypta.runtime.spi.QueuePageSnapshot;
+import network.crypta.runtime.spi.QueuePersistenceStatusSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class QueueApiHandlerTest {
+  @Test
+  void snapshot_whenRequested_expectDetachedHtmlWithoutLegacyRuntimePlaceholders() {
+    RecordingQueuePagePort queuePagePort = new RecordingQueuePagePort();
+    queuePagePort.pageSnapshot =
+        new QueuePageSnapshot(
+            "Downloads",
+            "<div>before<!--CRYPTA_ALERT_SUMMARY--><!--CRYPTA_QUEUE_FORM_PASSWORD-->"
+                + "<!--CRYPTA_QUEUE_PANIC_BOX-->after</div>");
+    RecordingQueueCompletionPort queueCompletionPort = new RecordingQueueCompletionPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            queuePagePort,
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            queueCompletionPort);
+
+    Map<String, Object> snapshot =
+        handler.snapshot(
+            orderedParameters(
+                Map.entry("page", List.of("downloads")),
+                Map.entry("advancedMode", List.of("true")),
+                Map.entry("sortBy", List.of("priority")),
+                Map.entry("reversed", List.of("true"))));
+
+    assertEquals(
+        new QueuePageRequest(false, true, "priority", true), queuePagePort.lastPageRequest);
+    assertEquals(List.of(false), queueCompletionPort.startedSides);
+    assertEquals("downloads", snapshot.get("page"));
+    assertEquals("Downloads", snapshot.get("pageTitle"));
+    assertEquals("<div>beforeafter</div>", snapshot.get("contentHtml"));
+    assertEquals(Boolean.TRUE, snapshot.get("advancedMode"));
+    assertEquals("priority", snapshot.get("sortBy"));
+    assertEquals(Boolean.TRUE, snapshot.get("reversed"));
+  }
+
+  @Test
+  void count_whenUploadsRequested_expectBadRequest() {
+    RecordingQueuePagePort queuePagePort = new RecordingQueuePagePort();
+    RecordingQueueCompletionPort queueCompletionPort = new RecordingQueueCompletionPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            queuePagePort,
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            queueCompletionPort);
+    Map<String, List<String>> parameters = orderedParameters(Map.entry("page", List.of("uploads")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.count(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals(
+        "Query parameter 'page' must be 'downloads' for this endpoint.", error.getMessage());
+    assertEquals(0, queuePagePort.countPageRequests);
+    assertEquals(List.of(), queueCompletionPort.startedSides);
+  }
+
+  @Test
+  void removeRequests_whenLegacyIdentifierParametersProvided_expectSelectionOrderPreserved() {
+    RecordingQueueMutationPort queueMutationPort = new RecordingQueueMutationPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            queueMutationPort,
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.removeRequests(
+            orderedParameters(
+                Map.entry("identifier-0", List.of("download-1")),
+                Map.entry("identifier-1", List.of("download-2"))));
+
+    assertEquals(List.of("download-1", "download-2"), queueMutationPort.lastIdentifiers);
+    assertEquals("remove", result.get("operation"));
+    assertEquals(2, result.get("identifierCount"));
+  }
+
+  @Test
+  void removeRequests_whenIdentifierFieldsOutOfOrder_expectSuffixOrderPreserved() {
+    RecordingQueueMutationPort queueMutationPort = new RecordingQueueMutationPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            queueMutationPort,
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.removeRequests(
+            orderedParameters(
+                Map.entry("identifier-10", List.of("download-10")),
+                Map.entry("identifier-2", List.of("download-2")),
+                Map.entry("identifier-1", List.of("download-1"))));
+
+    assertEquals(
+        List.of("download-1", "download-2", "download-10"), queueMutationPort.lastIdentifiers);
+    assertEquals("remove", result.get("operation"));
+    assertEquals(3, result.get("identifierCount"));
+  }
+
+  @Test
+  void removeRequests_whenRepeatedIdentifierParameterProvided_expectAllIdentifiersPreserved() {
+    RecordingQueueMutationPort queueMutationPort = new RecordingQueueMutationPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            queueMutationPort,
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.removeRequests(
+            orderedParameters(Map.entry("identifier", List.of("download-1", "download-2"))));
+
+    assertEquals(List.of("download-1", "download-2"), queueMutationPort.lastIdentifiers);
+    assertEquals("remove", result.get("operation"));
+    assertEquals(2, result.get("identifierCount"));
+  }
+
+  @Test
+  void createDirectDownload_whenRequested_expectDirectForeverQueueRequest() {
+    RecordingQueueDownloadPort queueDownloadPort = new RecordingQueueDownloadPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            queueDownloadPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.createDirectDownload(
+            orderedParameters(
+                Map.entry("fetchUri", List.of("KSK@direct-download")),
+                Map.entry("filterData", List.of("true")),
+                Map.entry("expectedMimeType", List.of("text/plain"))));
+
+    assertEquals(
+        new QueueDownloadRequest(
+            "KSK@direct-download", true, "text/plain", "forever", "direct", null),
+        queueDownloadPort.lastRequest);
+    assertEquals("create_direct_download", result.get("operation"));
+    assertEquals("KSK@direct-download", result.get("fetchUri"));
+    assertEquals(Boolean.TRUE, result.get("filterData"));
+    assertEquals("text/plain", result.get("expectedMimeType"));
+    assertEquals("direct", result.get("returnType"));
+  }
+
+  @Test
+  void createDirectDownload_whenFilterDataCheckboxValuePresent_expectTrue() {
+    RecordingQueueDownloadPort queueDownloadPort = new RecordingQueueDownloadPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            queueDownloadPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.createDirectDownload(
+            orderedParameters(
+                Map.entry("fetchUri", List.of("KSK@direct-download")),
+                Map.entry("filterData", List.of("on"))));
+
+    assertEquals(Boolean.TRUE, result.get("filterData"));
+    assertEquals(Boolean.TRUE, queueDownloadPort.lastRequest.filterData());
+  }
+
+  @Test
+  void createDirectDownload_whenFetchUriMalformed_expectBadRequest() {
+    RecordingQueueDownloadPort queueDownloadPort = new RecordingQueueDownloadPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            queueDownloadPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(Map.entry("fetchUri", List.of("http://example.com/")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.createDirectDownload(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals("Query parameter 'fetchUri' must be a valid fetch URI.", error.getMessage());
+    assertNull(queueDownloadPort.lastRequest);
+  }
+
+  @Test
+  void changePriority_whenPriorityMalformed_expectBadRequest() {
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("identifier-0", List.of("download-1")),
+            Map.entry("priority", List.of("fast")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.changePriority(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+  }
+
+  @Test
+  void changePriority_whenPriorityWithinSupportedRange_expectMutationSummary() {
+    RecordingQueueMutationPort queueMutationPort = new RecordingQueueMutationPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            queueMutationPort,
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("identifier-0", List.of("download-1")),
+            Map.entry("identifier-1", List.of("download-2")),
+            Map.entry("priority", List.of("3")));
+
+    Map<String, Object> result = handler.changePriority(parameters);
+
+    assertEquals(List.of("download-1", "download-2"), queueMutationPort.lastIdentifiers);
+    assertEquals((short) 3, queueMutationPort.lastPriorityClass);
+    assertEquals("change_priority", result.get("operation"));
+    assertEquals(2, result.get("identifierCount"));
+    assertEquals((short) 3, result.get("priority"));
+  }
+
+  @Test
+  void changePriority_whenPriorityOutsideSupportedRange_expectBadRequest() {
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("identifier-0", List.of("download-1")), Map.entry("priority", List.of("99")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.changePriority(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals("Query parameter 'priority' must be between 0 and 6.", error.getMessage());
+  }
+
+  @Test
+  void restartRequests_whenDisableFilterCheckboxValuePresent_expectTrue() {
+    RecordingQueueMutationPort queueMutationPort = new RecordingQueueMutationPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            queueMutationPort,
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.restartRequests(
+            orderedParameters(
+                Map.entry("identifier-0", List.of("download-1")),
+                Map.entry("disableFilterData", List.of("disableFilterData"))));
+
+    assertEquals("restart", result.get("operation"));
+    assertEquals(Boolean.TRUE, result.get("disableFilterData"));
+    assertEquals(Boolean.TRUE, queueMutationPort.lastDisableFilterData);
+  }
+
+  @Test
+  void restartRequests_whenDisableFilterCheckboxRepeated_expectTrue() {
+    RecordingQueueMutationPort queueMutationPort = new RecordingQueueMutationPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            queueMutationPort,
+            new RecordingQueueDownloadPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.restartRequests(
+            orderedParameters(
+                Map.entry("identifier-0", List.of("download-1")),
+                Map.entry("disableFilterData", List.of("disableFilterData", "disableFilterData"))));
+
+    assertEquals("restart", result.get("operation"));
+    assertEquals(Boolean.TRUE, result.get("disableFilterData"));
+    assertEquals(Boolean.TRUE, queueMutationPort.lastDisableFilterData);
+  }
+
+  @SafeVarargs
+  private static Map<String, List<String>> orderedParameters(
+      Map.Entry<String, List<String>>... entries) {
+    LinkedHashMap<String, List<String>> parameters = LinkedHashMap.newLinkedHashMap(entries.length);
+    for (Map.Entry<String, List<String>> entry : entries) {
+      parameters.put(entry.getKey(), entry.getValue());
+    }
+    return parameters;
+  }
+
+  private static final class RecordingQueuePagePort implements QueuePagePort {
+    private QueuePageSnapshot pageSnapshot = new QueuePageSnapshot("Queue", "<div></div>");
+    private QueuePageRequest lastPageRequest;
+    private int countPageRequests;
+
+    @Override
+    public QueuePageSnapshot renderPage(QueuePageRequest request) {
+      lastPageRequest = request;
+      return pageSnapshot;
+    }
+
+    @Override
+    public QueuePageSnapshot renderCountPage(boolean uploads) {
+      countPageRequests++;
+      return new QueuePageSnapshot("Count", "<div>count</div>");
+    }
+
+    @Override
+    public String renderKeyList(boolean uploads) {
+      return "CHK@alpha\nCHK@beta\n";
+    }
+  }
+
+  private static final class RecordingQueueMutationPort implements QueueMutationPort {
+    private List<String> lastIdentifiers = List.of();
+    private boolean lastDisableFilterData;
+    private short lastPriorityClass;
+
+    @Override
+    public void removeRequests(List<String> identifiers) {
+      lastIdentifiers = identifiers;
+    }
+
+    @Override
+    public void restartRequests(List<String> identifiers, boolean disableFilterData) {
+      lastIdentifiers = identifiers;
+      lastDisableFilterData = disableFilterData;
+    }
+
+    @Override
+    public void changePriority(List<String> identifiers, short newPriorityClass) {
+      lastIdentifiers = identifiers;
+      lastPriorityClass = newPriorityClass;
+    }
+
+    @Override
+    public void removeFinishedUploads() {
+      throw new UnsupportedOperationException(
+          "Queue cleanup is not exercised by this test double.");
+    }
+
+    @Override
+    public void removeFinishedDownloads() {
+      throw new UnsupportedOperationException(
+          "Queue cleanup is not exercised by this test double.");
+    }
+  }
+
+  private static final class RecordingQueueDownloadPort implements QueueDownloadPort {
+    private QueueDownloadRequest lastRequest;
+
+    @Override
+    public boolean isDiskDownloadDisabled() {
+      return false;
+    }
+
+    @Override
+    public void enqueueDownload(QueueDownloadRequest request) {
+      lastRequest = request;
+    }
+  }
+
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class FixedQueueSupportPort implements QueueSupportPort {
+    private final boolean enabled;
+
+    private FixedQueueSupportPort(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    @Override
+    public boolean isQueueBackendEnabled() {
+      return enabled;
+    }
+
+    @Override
+    public QueuePersistenceStatusSnapshot persistenceStatus() {
+      return new QueuePersistenceStatusSnapshot(false, false, null, null);
+    }
+
+    @Override
+    public void beginPanic() {
+      throw new UnsupportedOperationException("Panic flows are not exercised by this test double.");
+    }
+
+    @Override
+    public void finishPanic() {
+      throw new UnsupportedOperationException("Panic flows are not exercised by this test double.");
+    }
+  }
+
+  private static final class RecordingQueueCompletionPort implements QueueCompletionPort {
+    private final List<Boolean> startedSides = new java.util.ArrayList<>();
+
+    @Override
+    public void ensureTrackingStarted(boolean uploads) {
+      startedSides.add(uploads);
+    }
+  }
+}

--- a/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
+++ b/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
@@ -19,6 +19,8 @@ import network.crypta.platform.webshell.routes.WebShellPaths;
  * @param shellRoot canonical mount path for the shell page
  * @param assetRoot canonical mount path for shell-owned static assets
  * @param platformApiRoot Platform API v1 root used by the browser-side fetches
+ * @param formPassword legacy mutation token used by the current Platform API bridge, or {@code
+ *     null} when the shell should stay read-only
  * @param legacyRoot legacy HTTP root used for deep links back to existing pages
  * @param legacyLinks user-visible deep links back to the legacy admin pages
  */
@@ -28,6 +30,7 @@ public record WebShellBootstrap(
     String shellRoot,
     String assetRoot,
     String platformApiRoot,
+    String formPassword,
     String legacyRoot,
     List<LegacyLink> legacyLinks) {
   /** Default shell title used by the node-management UI. */
@@ -35,7 +38,7 @@ public record WebShellBootstrap(
 
   /** Default shell description used by the node-management UI. */
   public static final String DEFAULT_SHELL_DESCRIPTION =
-      "Read-only node management powered by Platform API v1.";
+      "Node management and queue control powered by Platform API v1.";
 
   /** Default Platform API v1 root used by the shell bootstrap payload. */
   public static final String DEFAULT_PLATFORM_API_ROOT = "/api/v1/";
@@ -56,7 +59,28 @@ public record WebShellBootstrap(
         WebShellPaths.SHELL_ROOT,
         WebShellPaths.ASSET_ROOT,
         DEFAULT_PLATFORM_API_ROOT,
+        null,
         DEFAULT_LEGACY_ROOT,
+        legacyLinks);
+  }
+
+  /**
+   * Returns a copy of this bootstrap payload with one explicit mutation token.
+   *
+   * @param formPassword legacy mutation token injected by the serving bridge
+   * @return bootstrap payload carrying the supplied mutation token
+   */
+  public WebShellBootstrap withFormPassword(String formPassword) {
+    String normalizedFormPassword =
+        formPassword == null || formPassword.isBlank() ? null : formPassword;
+    return new WebShellBootstrap(
+        shellTitle,
+        shellDescription,
+        shellRoot,
+        assetRoot,
+        platformApiRoot,
+        normalizedFormPassword,
+        legacyRoot,
         legacyLinks);
   }
 
@@ -119,6 +143,9 @@ public record WebShellBootstrap(
     requireRootPath(shellRoot, "shellRoot");
     requireRootPath(assetRoot, "assetRoot");
     requireRootPath(platformApiRoot, "platformApiRoot");
+    if (formPassword != null) {
+      requireText(formPassword, "formPassword");
+    }
     requireRootPath(legacyRoot, "legacyRoot");
     legacyLinks = List.copyOf(Objects.requireNonNull(legacyLinks, "legacyLinks"));
     if (legacyLinks.isEmpty()) {

--- a/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrapJson.java
+++ b/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrapJson.java
@@ -20,12 +20,13 @@ public final class WebShellBootstrapJson {
    * @return JSON representation suitable for browser bootstrap
    */
   public static String serialize(WebShellBootstrap bootstrap) {
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(8);
     json.put("shellTitle", bootstrap.shellTitle());
     json.put("shellDescription", bootstrap.shellDescription());
     json.put("shellRoot", bootstrap.shellRoot());
     json.put("assetRoot", bootstrap.assetRoot());
     json.put("platformApiRoot", bootstrap.platformApiRoot());
+    json.put("formPassword", bootstrap.formPassword());
     json.put("legacyRoot", bootstrap.legacyRoot());
     json.put(
         "legacyLinks",

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -15,7 +15,8 @@
         <p class="eyebrow">Cryptad node management</p>
         <h1>Web Shell v1</h1>
         <p class="lede">
-          Read-only status, snapshot views, and legacy deep links powered by Platform API v1.
+          Snapshot views, queue control, and selective legacy deep links powered by Platform API
+          v1.
         </p>
         <div class="hero-actions">
           <a class="button button-primary" href="/api/v1/node/greeting">Node greeting JSON</a>
@@ -65,14 +66,69 @@
         </article>
       </section>
 
+      <section class="panel panel-wide" id="queue-panel">
+        <div class="panel-header">
+          <p class="panel-kicker">Queue</p>
+          <h2>Queue control plane</h2>
+        </div>
+        <p class="panel-description">
+          Detached queue snapshots come from Platform API v1. Supported queue actions stay in the
+          shell and unsupported legacy-only controls can still fall back to the historical pages.
+        </p>
+        <div class="queue-toolbar">
+          <div class="toggle-group" aria-label="Queue page">
+            <button class="toggle-button is-active" id="queue-downloads-button" type="button">
+              Downloads
+            </button>
+            <button class="toggle-button" id="queue-uploads-button" type="button">
+              Uploads
+            </button>
+          </div>
+          <label class="checkbox-inline" for="queue-advanced-toggle">
+            <input id="queue-advanced-toggle" type="checkbox">
+            <span>Advanced mode</span>
+          </label>
+          <button class="button button-secondary" id="queue-refresh-button" type="button">
+            Refresh queue
+          </button>
+          <button class="button button-secondary" id="queue-keys-button" type="button">
+            Show keys
+          </button>
+        </div>
+        <div class="queue-status" id="queue-status" aria-live="polite"></div>
+        <div class="queue-count" id="queue-count"></div>
+        <form class="queue-create-form" hidden id="queue-create-form">
+          <div class="queue-create-copy">
+            <p class="panel-kicker">Direct download</p>
+            <p class="queue-create-description">
+              Queue one persistent direct-return download through the Platform API.
+            </p>
+          </div>
+          <label class="queue-field" for="queue-download-uri">
+            <span>Fetch URI</span>
+            <input id="queue-download-uri" name="fetchUri" type="text" autocomplete="off">
+          </label>
+          <label class="checkbox-inline" for="queue-download-filter">
+            <input id="queue-download-filter" name="filterData" type="checkbox" checked>
+            <span>Filter data</span>
+          </label>
+          <button class="button button-primary" id="queue-download-submit" type="submit">
+            Queue direct download
+          </button>
+        </form>
+        <div class="queue-key-export" hidden id="queue-key-export"></div>
+        <div class="panel-body" id="queue-body">
+          <p class="loading">Loading queue snapshot...</p>
+        </div>
+      </section>
+
       <section class="panel panel-wide" id="legacy-panel">
         <div class="panel-header">
           <p class="panel-kicker">Legacy tools</p>
           <h2>Deep links back to existing admin pages</h2>
         </div>
         <p class="panel-description">
-          Actions that still belong to the legacy UI remain reachable here while the shell stays
-          read-only.
+          Remaining legacy-only pages stay reachable here while queue control moves into the shell.
         </p>
         <ul class="legacy-links" id="legacy-links"></ul>
       </section>

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -273,6 +273,201 @@ a {
   color: var(--shell-accent);
 }
 
+.queue-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.toggle-group {
+  display: inline-flex;
+  padding: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.toggle-button {
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--shell-muted);
+  font: inherit;
+  font-weight: 700;
+  padding: 10px 16px;
+  cursor: pointer;
+}
+
+.toggle-button.is-active {
+  color: #03101b;
+  background: linear-gradient(135deg, var(--shell-accent) 0%, var(--shell-accent-2) 100%);
+}
+
+.checkbox-inline {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 44px;
+  color: var(--shell-muted);
+}
+
+.queue-status {
+  min-height: 24px;
+}
+
+.status-message {
+  margin: 0;
+  padding: 10px 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--shell-muted);
+}
+
+.status-message.is-success {
+  color: #d6ffe6;
+  background: rgba(142, 240, 181, 0.12);
+}
+
+.status-message.is-error {
+  color: #ffd4d4;
+  background: rgba(255, 143, 143, 0.12);
+}
+
+.queue-create-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(140px, auto) auto;
+  gap: 14px;
+  align-items: end;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.queue-create-copy,
+.queue-create-description {
+  margin: 0;
+}
+
+.queue-field {
+  display: grid;
+  gap: 6px;
+}
+
+.queue-field span {
+  color: var(--shell-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.queue-field input,
+.queue-key-text,
+.queue-html input[type="text"],
+.queue-html textarea,
+.queue-html select {
+  width: 100%;
+  min-height: 42px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  background: rgba(4, 8, 16, 0.48);
+  color: var(--shell-text);
+  font: inherit;
+}
+
+.queue-key-export {
+  display: grid;
+  gap: 10px;
+}
+
+.queue-key-text {
+  min-height: 220px;
+  resize: vertical;
+}
+
+.queue-html {
+  display: grid;
+  gap: 16px;
+}
+
+.queue-html .infobox,
+.queue-html .infobox-content,
+.queue-html .queue-empty,
+.queue-html .queue-downloads {
+  color: inherit;
+}
+
+.queue-html .infobox {
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.queue-html .infobox-header,
+.queue-html .infobox-title,
+.queue-html h1,
+.queue-html h2,
+.queue-html h3,
+.queue-html h4 {
+  margin-top: 0;
+}
+
+.queue-html table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.queue-html th,
+.queue-html td {
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.queue-html th {
+  color: var(--shell-muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.queue-html td {
+  overflow-wrap: anywhere;
+}
+
+.queue-html a {
+  color: var(--shell-accent);
+}
+
+.queue-html form {
+  display: grid;
+  gap: 10px;
+}
+
+.queue-html input[type="submit"],
+.queue-html button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 14px;
+  border: 1px solid var(--shell-panel-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--shell-text);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.queue-html input[type="checkbox"] {
+  accent-color: var(--shell-accent);
+}
+
 .peer-table {
   width: 100%;
   border-collapse: collapse;
@@ -324,6 +519,10 @@ a {
   .hero,
   .panel {
     border-radius: 22px;
+  }
+
+  .queue-create-form {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -7,14 +7,40 @@
     : {};
 
   const apiRoot = typeof bootstrap.platformApiRoot === "string" ? bootstrap.platformApiRoot : "/api/v1/";
+  const shellRoot = typeof bootstrap.shellRoot === "string" ? bootstrap.shellRoot : "/app/node/";
+  let formPassword = typeof bootstrap.formPassword === "string" ? bootstrap.formPassword : "";
   const legacyLinks = Array.isArray(bootstrap.legacyLinks) ? bootstrap.legacyLinks : [];
+  const directDownloadOperation = "create_direct_download";
+  const queueState = {
+    page: "downloads",
+    advancedMode: false,
+    sortBy: null,
+    reversed: false,
+    keysVisible: false,
+  };
+  let queueLoadGeneration = 0;
+  const nativeQueueSubmitBypass = new WeakSet();
 
   const sections = {
     overview: document.getElementById("overview-body"),
     connectivity: document.getElementById("connectivity-body"),
     security: document.getElementById("security-body"),
     peers: document.getElementById("peers-body"),
+    queue: document.getElementById("queue-body"),
+    queueCount: document.getElementById("queue-count"),
+    queueStatus: document.getElementById("queue-status"),
+    queueKeys: document.getElementById("queue-key-export"),
     legacy: document.getElementById("legacy-links"),
+  };
+  const queueControls = {
+    downloadsButton: document.getElementById("queue-downloads-button"),
+    uploadsButton: document.getElementById("queue-uploads-button"),
+    advancedToggle: document.getElementById("queue-advanced-toggle"),
+    refreshButton: document.getElementById("queue-refresh-button"),
+    keysButton: document.getElementById("queue-keys-button"),
+    createForm: document.getElementById("queue-create-form"),
+    createSubmit: document.getElementById("queue-download-submit"),
+    createUri: document.getElementById("queue-download-uri"),
   };
 
   function apiUrl(path) {
@@ -35,8 +61,15 @@
   }
 
   function createPill(value, tone) {
-    const pill = text("span", "status-pill" + (tone ? " " + tone : ""), value);
-    return pill;
+    return text("span", "status-pill" + (tone ? " " + tone : ""), value);
+  }
+
+  function setStatus(message, tone) {
+    clear(sections.queueStatus);
+    if (!message) {
+      return;
+    }
+    sections.queueStatus.append(text("p", tone ? `status-message ${tone}` : "status-message", message));
   }
 
   function definitionList(entries) {
@@ -220,6 +253,181 @@
     sections.peers.append(table);
   }
 
+  function updateQueueToolbar() {
+    queueControls.downloadsButton.classList.toggle("is-active", queueState.page === "downloads");
+    queueControls.uploadsButton.classList.toggle("is-active", queueState.page === "uploads");
+    queueControls.advancedToggle.checked = queueState.advancedMode;
+    queueControls.keysButton.textContent = queueState.keysVisible ? "Hide keys" : "Show keys";
+    queueControls.createForm.hidden = queueState.page !== "downloads" || !formPassword;
+  }
+
+  function queueQueryString() {
+    const params = new URLSearchParams();
+    params.set("page", queueState.page);
+    params.set("advancedMode", String(queueState.advancedMode));
+    if (queueState.sortBy) {
+      params.set("sortBy", queueState.sortBy);
+    }
+    if (queueState.reversed) {
+      params.set("reversed", "true");
+    }
+    return params.toString();
+  }
+
+  function queuePageUrl() {
+    return apiUrl(`queue?${queueQueryString()}`);
+  }
+
+  function queueCountUrl() {
+    return apiUrl(`queue/count?page=${encodeURIComponent(queueState.page)}`);
+  }
+
+  function queueKeysUrl() {
+    return apiUrl(`queue/keys?page=${encodeURIComponent(queueState.page)}`);
+  }
+
+  function formsWithin(root) {
+    if (root instanceof HTMLFormElement) {
+      return [root];
+    }
+    return Array.from(root.querySelectorAll("form"));
+  }
+
+  function injectFormPassword(root) {
+    formsWithin(root).forEach((form) => {
+      let field = form.querySelector('input[name="formPassword"]');
+      if (!formPassword) {
+        if (field) {
+          field.remove();
+        }
+        return;
+      }
+      if (!field) {
+        field = document.createElement("input");
+        field.type = "hidden";
+        field.name = "formPassword";
+        form.append(field);
+      }
+      field.value = formPassword;
+    });
+  }
+
+  function normalizeQueueBasePath(rawPath) {
+    if (typeof rawPath !== "string" || !rawPath.startsWith("/")) {
+      return `/${queueState.page}/`;
+    }
+    return rawPath.endsWith("/") ? rawPath : `${rawPath}/`;
+  }
+
+  function rewriteQueueRelativeLinks(root) {
+    const actionForm = formsWithin(root).find((form) => typeof form.getAttribute("action") === "string");
+    const queueBasePath = normalizeQueueBasePath(actionForm && actionForm.getAttribute("action"));
+
+    root.querySelectorAll("a[href]").forEach((anchor) => {
+      const href = anchor.getAttribute("href");
+      if (typeof href !== "string" || href.length === 0) {
+        return;
+      }
+      if (href.startsWith("?")) {
+        anchor.dataset.shellHref = href;
+        anchor.setAttribute("href", `${queueBasePath}${href}`);
+        return;
+      }
+      if (href === "listKeys.txt") {
+        anchor.dataset.shellHref = href;
+        anchor.setAttribute("href", `${queueBasePath}listKeys.txt`);
+      }
+    });
+  }
+
+  function stripReadOnlyQueueForms(root) {
+    const forms = formsWithin(root);
+    if (forms.length === 0) {
+      return;
+    }
+    root.prepend(text("p", "status-message is-warning", "Queue mutations unavailable in read-only mode."));
+    forms.forEach((form) => {
+      form
+        .querySelectorAll('input:not([type="hidden"]), button, select, textarea')
+        .forEach((control) => {
+          control.disabled = true;
+          control.hidden = true;
+        });
+    });
+  }
+
+  async function refreshFormPassword() {
+    const response = await fetch(shellRoot, {
+      headers: { Accept: "text/html" },
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+    const html = await response.text();
+    const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+    const nextBootstrapElement = parsedDocument.getElementById("web-shell-bootstrap");
+    if (!(nextBootstrapElement instanceof HTMLScriptElement)) {
+      throw new Error("Web Shell bootstrap unavailable.");
+    }
+    const nextBootstrap = JSON.parse(nextBootstrapElement.textContent || "{}");
+    formPassword = typeof nextBootstrap.formPassword === "string" ? nextBootstrap.formPassword : "";
+    return formPassword;
+  }
+
+  function renderQueue(snapshot, countSnapshot, keysPayload) {
+    clear(sections.queue);
+    clear(sections.queueCount);
+    clear(sections.queueKeys);
+
+    updateQueueToolbar();
+
+    if (countSnapshot && typeof countSnapshot.contentHtml === "string" && countSnapshot.contentHtml) {
+      const countNode = document.createElement("div");
+      countNode.className = "queue-html queue-count-html";
+      countNode.innerHTML = countSnapshot.contentHtml;
+      rewriteQueueRelativeLinks(countNode);
+      injectFormPassword(countNode);
+      if (!formPassword) {
+        stripReadOnlyQueueForms(countNode);
+      }
+      sections.queueCount.append(countNode);
+    }
+
+    if (snapshot && typeof snapshot.contentHtml === "string") {
+      const contentNode = document.createElement("div");
+      contentNode.className = "queue-html";
+      contentNode.innerHTML = snapshot.contentHtml;
+      rewriteQueueRelativeLinks(contentNode);
+      injectFormPassword(contentNode);
+      if (!formPassword) {
+        stripReadOnlyQueueForms(contentNode);
+      }
+      sections.queue.append(contentNode);
+    } else {
+      sections.queue.append(text("p", "empty-state", "No queue snapshot was returned."));
+    }
+
+    if (queueState.keysVisible && keysPayload && Array.isArray(keysPayload.keys)) {
+      sections.queueKeys.hidden = false;
+      const label = text("p", "panel-kicker", `${keysPayload.keyCount} exported keys`);
+      const exportField = document.createElement("textarea");
+      exportField.className = "queue-key-text";
+      exportField.readOnly = true;
+      exportField.value = keysPayload.keys.join("\n");
+      sections.queueKeys.append(label, exportField);
+    } else {
+      sections.queueKeys.hidden = true;
+    }
+  }
+
+  function extractApiError(data, response) {
+    if (data && data.error && typeof data.error.message === "string") {
+      return data.error.message;
+    }
+    return `${response.status} ${response.statusText}`;
+  }
+
   function renderError(node, label, error) {
     clear(node);
     const message =
@@ -229,10 +437,289 @@
 
   async function loadJson(url) {
     const response = await fetch(url, { headers: { Accept: "application/json" } });
+    const data = await response.json().catch(() => ({}));
     if (!response.ok) {
-      throw new Error(`${response.status} ${response.statusText}`);
+      throw new Error(extractApiError(data, response));
     }
-    return response.json();
+    return data;
+  }
+
+  async function loadOptionalJson(url) {
+    try {
+      return await loadJson(url);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  async function postForm(path, formData) {
+    const currentFormPassword = await refreshFormPassword();
+    if (!currentFormPassword) {
+      throw new Error("Queue mutations unavailable in read-only mode.");
+    }
+    const body = new URLSearchParams();
+    for (const [key, value] of formData.entries()) {
+      if (typeof value === "string") {
+        body.append(key, value);
+      }
+    }
+    if (currentFormPassword) {
+      body.set("formPassword", currentFormPassword);
+    }
+
+    const response = await fetch(apiUrl(path), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+      body: body.toString(),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(extractApiError(data, response));
+    }
+    return data;
+  }
+
+  function queueMutationPath(submitterName) {
+    switch (submitterName) {
+      case "remove_request":
+        return "queue/requests/remove";
+      case "restart_request":
+        return "queue/requests/restart";
+      case "remove_finished_uploads_request":
+        return "queue/cleanup/uploads";
+      case "remove_finished_downloads_request":
+        return "queue/cleanup/downloads";
+      default:
+        if (submitterName && submitterName.indexOf("change_priority") === 0) {
+          return "queue/requests/priority";
+        }
+        return null;
+    }
+  }
+
+  function updateQueueSort(rawHref) {
+    const href = typeof rawHref === "string" ? rawHref : "";
+    if (!href.startsWith("?")) {
+      return false;
+    }
+    const params = new URLSearchParams(href.slice(1));
+    queueState.sortBy = params.get("sortBy");
+    queueState.reversed = params.get("reversed") === "true" || params.has("reversed");
+    setStatus(`Sorted ${queueState.page} queue${queueState.sortBy ? ` by ${queueState.sortBy}` : ""}.`);
+    loadQueueSection();
+    return true;
+  }
+
+  async function loadQueueSection() {
+    const loadGeneration = ++queueLoadGeneration;
+    updateQueueToolbar();
+    clear(sections.queue);
+    sections.queue.append(text("p", "loading", "Loading queue snapshot..."));
+    clear(sections.queueCount);
+    if (queueState.keysVisible) {
+      clear(sections.queueKeys);
+    }
+
+    const snapshotRequest = loadJson(queuePageUrl());
+    const countRequest =
+      queueState.page === "downloads" ? loadOptionalJson(queueCountUrl()) : Promise.resolve(null);
+    const keysRequest = queueState.keysVisible ? loadOptionalJson(queueKeysUrl()) : Promise.resolve(null);
+
+    try {
+      const snapshot = await snapshotRequest;
+      const [countSnapshot, keysPayload] = await Promise.all([countRequest, keysRequest]);
+      if (loadGeneration !== queueLoadGeneration) {
+        return;
+      }
+      renderQueue(snapshot, countSnapshot, keysPayload);
+    } catch (error) {
+      if (loadGeneration !== queueLoadGeneration) {
+        return;
+      }
+      renderError(sections.queue, "queue", error);
+      clear(sections.queueCount);
+      clear(sections.queueKeys);
+    }
+  }
+
+  function queuePriorityFieldName(submitterName) {
+    switch (submitterName) {
+      case "change_priority_top":
+        return "priority_top";
+      case "change_priority_bottom":
+        return "priority_bottom";
+      default:
+        return null;
+    }
+  }
+
+  function buildQueueMutationFormData(form, submitter, path) {
+    const source = new FormData(form, submitter);
+    const filtered = new FormData();
+
+    for (const [key, value] of source.entries()) {
+      if (typeof value !== "string") {
+        continue;
+      }
+      if (key === "identifier" || key.indexOf("identifier-") === 0) {
+        filtered.append(key, value);
+      }
+    }
+
+    if (path === "queue/requests/restart" && source.has("disableFilterData")) {
+      filtered.append("disableFilterData", "disableFilterData");
+    }
+
+    if (path === "queue/requests/priority") {
+      const priorityField = queuePriorityFieldName(submitter && submitter.name);
+      if (priorityField) {
+        const priorityValue = source.get(priorityField);
+        if (typeof priorityValue === "string") {
+          filtered.set("priority", priorityValue);
+        }
+      }
+    }
+
+    return filtered;
+  }
+
+  async function submitQueueMutation(form, submitter, path) {
+    const formData = buildQueueMutationFormData(form, submitter, path);
+
+    try {
+      const data = await postForm(path, formData);
+      const operation = data.operation || submitter.name;
+      setStatus(`Queue action completed: ${operation.replaceAll("_", " ")}.`, "is-success");
+      await loadQueueSection();
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  async function submitDirectDownload(event) {
+    event.preventDefault();
+    const formData = new FormData(queueControls.createForm);
+    try {
+      const data = await postForm("queue/downloads", formData);
+      if (data.operation === directDownloadOperation) {
+        queueControls.createForm.reset();
+      }
+      setStatus("Direct download queued.", "is-success");
+      await loadQueueSection();
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  function submitLegacyQueueForm(form, submitter) {
+    if (
+      typeof form.requestSubmit === "function" &&
+      (submitter instanceof HTMLButtonElement || submitter instanceof HTMLInputElement)
+    ) {
+      nativeQueueSubmitBypass.add(form);
+      form.requestSubmit(submitter);
+      return;
+    }
+
+    let transientSubmitter = null;
+    if (
+      (submitter instanceof HTMLButtonElement || submitter instanceof HTMLInputElement) &&
+      submitter.name
+    ) {
+      transientSubmitter = document.createElement("input");
+      transientSubmitter.type = "hidden";
+      transientSubmitter.name = submitter.name;
+      transientSubmitter.value = submitter.value;
+      form.append(transientSubmitter);
+    }
+    form.submit();
+    if (transientSubmitter) {
+      transientSubmitter.remove();
+    }
+  }
+
+  function bindQueueInteractions() {
+    queueControls.downloadsButton.addEventListener("click", () => {
+      queueState.page = "downloads";
+      queueState.sortBy = null;
+      queueState.reversed = false;
+      setStatus("Showing download queue.");
+      loadQueueSection();
+    });
+    queueControls.uploadsButton.addEventListener("click", () => {
+      queueState.page = "uploads";
+      queueState.sortBy = null;
+      queueState.reversed = false;
+      setStatus("Showing upload queue.");
+      loadQueueSection();
+    });
+    queueControls.advancedToggle.addEventListener("change", () => {
+      queueState.advancedMode = queueControls.advancedToggle.checked;
+      loadQueueSection();
+    });
+    queueControls.refreshButton.addEventListener("click", () => {
+      setStatus(`Refreshing ${queueState.page} queue.`);
+      loadQueueSection();
+    });
+    queueControls.keysButton.addEventListener("click", () => {
+      queueState.keysVisible = !queueState.keysVisible;
+      loadQueueSection();
+    });
+    queueControls.createForm.addEventListener("submit", submitDirectDownload);
+
+    sections.queue.addEventListener("submit", async (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+      if (nativeQueueSubmitBypass.has(form)) {
+        nativeQueueSubmitBypass.delete(form);
+        return;
+      }
+      const submitter = event.submitter;
+      if (!(submitter instanceof HTMLElement)) {
+        return;
+      }
+      const path = queueMutationPath(submitter.name);
+      event.preventDefault();
+      if (path) {
+        await submitQueueMutation(form, submitter, path);
+        return;
+      }
+      try {
+        await refreshFormPassword();
+        if (!formPassword) {
+          setStatus("Queue mutations unavailable in read-only mode.", "is-error");
+          return;
+        }
+        injectFormPassword(form);
+        submitLegacyQueueForm(form, submitter);
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : String(error), "is-error");
+      }
+    });
+
+    sections.queue.addEventListener("click", (event) => {
+      const anchor = event.target instanceof Element ? event.target.closest("a") : null;
+      if (!(anchor instanceof HTMLAnchorElement)) {
+        return;
+      }
+      const shellHref = anchor.dataset.shellHref || anchor.getAttribute("href") || "";
+      if (shellHref === "listKeys.txt") {
+        event.preventDefault();
+        if (!queueState.keysVisible) {
+          queueState.keysVisible = true;
+        }
+        loadQueueSection();
+        return;
+      }
+      if (updateQueueSort(shellHref)) {
+        event.preventDefault();
+      }
+    });
   }
 
   async function loadShellData() {
@@ -270,7 +757,12 @@
   }
 
   renderLegacyLinks();
+  bindQueueInteractions();
+  updateQueueToolbar();
   loadShellData().catch((error) => {
     renderError(sections.overview, "Shell", error);
+  });
+  loadQueueSection().catch((error) => {
+    renderError(sections.queue, "queue", error);
   });
 })();

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBootstrapTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBootstrapTest.java
@@ -7,6 +7,7 @@ import network.crypta.platform.webshell.routes.WebShellPaths;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,6 +25,7 @@ class WebShellBootstrapTest {
     assertEquals(WebShellPaths.SHELL_ROOT, bootstrap.shellRoot());
     assertEquals(WebShellPaths.ASSET_ROOT, bootstrap.assetRoot());
     assertEquals(WebShellBootstrap.DEFAULT_PLATFORM_API_ROOT, bootstrap.platformApiRoot());
+    assertNull(bootstrap.formPassword());
     assertEquals(WebShellBootstrap.DEFAULT_LEGACY_ROOT, bootstrap.legacyRoot());
     assertEquals(legacyLinks, bootstrap.legacyLinks());
   }
@@ -33,22 +35,34 @@ class WebShellBootstrapTest {
     WebShellBootstrap bootstrap =
         new WebShellBootstrap(
             "A \"shell\" <node> & more",
-            "Read-only shell",
+            "Queue-aware shell",
             "/app/node/",
             "/app/node/static/",
             "/api/v1/",
+            "secret<token>",
             "/",
             List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends & Allies")));
 
     assertEquals(
         "{\"shellTitle\":\"A \\\"shell\\\" \\u003cnode\\u003e \\u0026 more\","
-            + "\"shellDescription\":\"Read-only shell\","
+            + "\"shellDescription\":\"Queue-aware shell\","
             + "\"shellRoot\":\"/app/node/\","
             + "\"assetRoot\":\"/app/node/static/\","
             + "\"platformApiRoot\":\"/api/v1/\","
+            + "\"formPassword\":\"secret\\u003ctoken\\u003e\","
             + "\"legacyRoot\":\"/\","
             + "\"legacyLinks\":[{\"path\":\"/friends/\",\"label\":\"Friends \\u0026 Allies\"}]}",
         WebShellBootstrapJson.serialize(bootstrap));
+  }
+
+  @Test
+  void withFormPassword_whenBlank_expectMutationTokenCleared() {
+    WebShellBootstrap bootstrap =
+        WebShellBootstrap.nodeManagement(
+                List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends")))
+            .withFormPassword("");
+
+    assertNull(bootstrap.formPassword());
   }
 
   @Test

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -12,6 +12,121 @@ class WebShellResourcesTest {
     String html = WebShellResources.readText(WebShellPaths.INDEX_RESOURCE_PATH);
 
     assertTrue(html.contains("Web Shell v1"));
+    assertTrue(html.contains("Queue control plane"));
     assertTrue(html.contains("__BOOTSTRAP_JSON__"));
+    assertTrue(html.contains("name=\"filterData\" type=\"checkbox\" checked"));
+    assertTrue(html.contains("queue-create-form\" hidden"));
+  }
+
+  @Test
+  void readText_whenScriptResourceRequested_expectQueueMutationSafeguardsPresent() {
+    String script =
+        WebShellResources.readText(WebShellPaths.resourcePath(WebShellPaths.SCRIPT_PATH));
+
+    assertQueueMutationMarkersPresent(script);
+    assertQueueMutationSubmissionOrder(script);
+    assertQueueLoadSequencing(script);
+    assertQueueLinkRewriting(script);
+    assertReadOnlyQueueHandling(script);
+  }
+
+  private static void assertQueueMutationMarkersPresent(String script) {
+    assertTrue(script.contains("function queuePriorityFieldName(submitterName)"));
+    assertTrue(script.contains("case \"change_priority_top\":"));
+    assertTrue(script.contains("case \"change_priority_bottom\":"));
+    assertTrue(script.contains("let queueLoadGeneration = 0;"));
+    assertTrue(script.contains("let formPassword ="));
+    assertTrue(
+        script.contains("throw new Error(\"Queue mutations unavailable in read-only mode.\");"));
+    assertTrue(
+        script.contains(
+            "queueControls.createForm.hidden = queueState.page !== \"downloads\" ||"
+                + " !formPassword;"));
+  }
+
+  private static void assertQueueMutationSubmissionOrder(String script) {
+    int submitHandlerIndex = script.indexOf("const path = queueMutationPath(submitter.name);");
+    int preventDefaultIndex = script.indexOf("event.preventDefault();", submitHandlerIndex);
+    int awaitMutationIndex =
+        script.indexOf("await submitQueueMutation(form, submitter, path);", submitHandlerIndex);
+    int refreshFormPasswordIndex =
+        script.indexOf("await refreshFormPassword();", submitHandlerIndex);
+    int legacySubmitIndex =
+        script.indexOf("submitLegacyQueueForm(form, submitter);", submitHandlerIndex);
+
+    assertTrue(submitHandlerIndex >= 0);
+    assertTrue(preventDefaultIndex > submitHandlerIndex);
+    assertTrue(awaitMutationIndex > preventDefaultIndex);
+    assertTrue(refreshFormPasswordIndex > submitHandlerIndex);
+    assertTrue(legacySubmitIndex > refreshFormPasswordIndex);
+  }
+
+  private static void assertQueueLoadSequencing(String script) {
+    int queueLoadIndex = script.indexOf("const loadGeneration = ++queueLoadGeneration;");
+    int successGuardIndex =
+        script.indexOf("if (loadGeneration !== queueLoadGeneration) {", queueLoadIndex);
+    int renderQueueIndex =
+        script.indexOf("renderQueue(snapshot, countSnapshot, keysPayload);", queueLoadIndex);
+    int errorGuardIndex =
+        script.indexOf("if (loadGeneration !== queueLoadGeneration) {", successGuardIndex + 1);
+    int renderErrorIndex =
+        script.indexOf("renderError(sections.queue, \"queue\", error);", queueLoadIndex);
+    int queueCountLoadIndex =
+        script.indexOf(
+            "queueState.page === \"downloads\" ? loadOptionalJson(queueCountUrl()) :"
+                + " Promise.resolve(null);");
+    int loadOptionalJsonIndex = script.indexOf("async function loadOptionalJson(url)");
+    int snapshotAwaitIndex =
+        script.indexOf("const snapshot = await snapshotRequest;", queueLoadIndex);
+    int optionalAwaitIndex =
+        script.indexOf(
+            "const [countSnapshot, keysPayload] = await Promise.all([countRequest, keysRequest]);");
+
+    assertTrue(queueLoadIndex >= 0);
+    assertTrue(successGuardIndex > queueLoadIndex);
+    assertTrue(renderQueueIndex > successGuardIndex);
+    assertTrue(errorGuardIndex > renderQueueIndex);
+    assertTrue(renderErrorIndex > errorGuardIndex);
+    assertTrue(queueCountLoadIndex >= 0);
+    assertTrue(loadOptionalJsonIndex >= 0);
+    assertTrue(snapshotAwaitIndex > queueLoadIndex);
+    assertTrue(optionalAwaitIndex > snapshotAwaitIndex);
+  }
+
+  private static void assertQueueLinkRewriting(String script) {
+    int rewriteQueueLinksIndex = script.indexOf("function rewriteQueueRelativeLinks(root)");
+    int rewriteCountLinksIndex = script.indexOf("rewriteQueueRelativeLinks(countNode);");
+    int rewriteContentLinksIndex = script.indexOf("rewriteQueueRelativeLinks(contentNode);");
+    int shellHrefDatasetIndex = script.indexOf("anchor.dataset.shellHref = href;");
+    int shellHrefLookupIndex =
+        script.indexOf(
+            "const shellHref = anchor.dataset.shellHref || anchor.getAttribute(\"href\") || \"\";");
+
+    assertTrue(rewriteQueueLinksIndex >= 0);
+    assertTrue(rewriteCountLinksIndex > rewriteQueueLinksIndex);
+    assertTrue(rewriteContentLinksIndex > rewriteQueueLinksIndex);
+    assertTrue(shellHrefDatasetIndex > rewriteQueueLinksIndex);
+    assertTrue(shellHrefLookupIndex > rewriteQueueLinksIndex);
+  }
+
+  private static void assertReadOnlyQueueHandling(String script) {
+    int stripReadOnlyFormsIndex = script.indexOf("function stripReadOnlyQueueForms(root)");
+    int countReadOnlyStripIndex = script.indexOf("stripReadOnlyQueueForms(countNode);");
+    int contentReadOnlyStripIndex = script.indexOf("stripReadOnlyQueueForms(contentNode);");
+    int buildMutationFormDataIndex =
+        script.indexOf("function buildQueueMutationFormData(form, submitter, path)");
+    int filteredMutationFormDataIndex =
+        script.indexOf("const formData = buildQueueMutationFormData(form, submitter, path);");
+    int refreshFormPasswordIndex = script.indexOf("async function refreshFormPassword()");
+    int postRefreshIndex =
+        script.indexOf("const currentFormPassword = await refreshFormPassword();");
+
+    assertTrue(stripReadOnlyFormsIndex >= 0);
+    assertTrue(countReadOnlyStripIndex > stripReadOnlyFormsIndex);
+    assertTrue(contentReadOnlyStripIndex > stripReadOnlyFormsIndex);
+    assertTrue(buildMutationFormDataIndex >= 0);
+    assertTrue(filteredMutationFormDataIndex > buildMutationFormDataIndex);
+    assertTrue(refreshFormPasswordIndex >= 0);
+    assertTrue(postRefreshIndex > refreshFormPasswordIndex);
   }
 }

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -243,6 +243,32 @@ class PlatformApiToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenUrlEncodedBodyExceedsLegacyLimit_expectJson400WithoutRouting()
+      throws Exception {
+    byte[] oversizedBody = new byte[1024 * 1024 + 1];
+    Arrays.fill(oversizedBody, (byte) 'a');
+
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(request.getHeader("content-type")).thenReturn("application/x-www-form-urlencoded");
+    when(request.getRawData()).thenReturn(new SimpleReadOnlyArrayBucket(oversizedBody));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/queue/downloads"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(400, replyHeaders.statusCode());
+    assertEquals("Bad Request", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_request_body\",\"message\":\"URL-encoded request body"
+            + " exceeds the 1048576 byte limit.\"}}",
+        bodyWrite.bodyText());
+  }
+
+  @Test
   void handleMethodPOST_whenQueueDownloadUsesFormParts_routesDecodedCreationRequest()
       throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -10,6 +10,8 @@ import network.crypta.platform.api.PlatformApiRequest;
 import network.crypta.platform.api.PlatformApiResponse;
 import network.crypta.platform.api.PlatformApiRouter;
 import network.crypta.support.MultiValueTable;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
+import network.crypta.support.api.Bucket;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,7 @@ class PlatformApiToadletTest {
   @Mock private PlatformApiRouter router;
   @Mock private ToadletContext ctx;
   @Mock private HTTPRequest request;
+  @Mock private Bucket requestBody;
 
   private PlatformApiToadlet toadlet;
 
@@ -55,6 +58,7 @@ class PlatformApiToadletTest {
     assertEquals("GET", captor.getValue().method());
     assertEquals(List.of("peers", "alice/bob"), captor.getValue().pathSegments());
     assertEquals(Map.of(), captor.getValue().queryParameters());
+    verify(request, never()).getParts();
   }
 
   @Test
@@ -78,8 +82,10 @@ class PlatformApiToadletTest {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     when(ctx.hasFormPassword(request)).thenReturn(true);
     when(request.getParameterNames()).thenReturn(List.of());
-    when(request.isPartSet("stagedDir")).thenReturn(true);
-    when(request.getPartAsStringFailsafe("stagedDir", 4096)).thenReturn("/tmp/staged");
+    when(request.getRawData()).thenReturn(requestBody);
+    when(request.getParts()).thenReturn(new String[] {"stagedDir"});
+    when(request.getPartAsStringFailsafe("stagedDir", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("/tmp/staged");
     when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
 
     toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/install"), request, ctx);
@@ -113,8 +119,10 @@ class PlatformApiToadletTest {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     when(ctx.hasFormPassword(request)).thenReturn(true);
     when(request.getParameterNames()).thenReturn(List.of());
-    when(request.isPartSet("stagedDir")).thenReturn(true);
-    when(request.getPartAsStringFailsafe("stagedDir", 4096)).thenReturn("/tmp/staged");
+    when(request.getRawData()).thenReturn(requestBody);
+    when(request.getParts()).thenReturn(new String[] {"stagedDir"});
+    when(request.getPartAsStringFailsafe("stagedDir", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("/tmp/staged");
     when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
 
     toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/apps/alpha/update"), request, ctx);
@@ -125,6 +133,164 @@ class PlatformApiToadletTest {
                 "POST",
                 List.of("apps", "alpha", "update"),
                 Map.of("stagedDir", List.of("/tmp/staged"))));
+  }
+
+  @Test
+  void handleMethodPOST_whenQueueRemoveRequested_routesDecodedMutationRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of("identifier-0", "identifier-1"));
+    when(request.getMultipleParam("identifier-0")).thenReturn(new String[] {"download-1"});
+    when(request.getMultipleParam("identifier-1")).thenReturn(new String[] {"download-2"});
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/queue/requests/remove"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("queue", "requests", "remove"),
+                Map.of(
+                    "identifier-0", List.of("download-1"),
+                    "identifier-1", List.of("download-2"))));
+  }
+
+  @Test
+  void handleMethodPOST_whenQueueRemoveUsesFormParts_routesDecodedMutationRequest()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(request.getRawData()).thenReturn(requestBody);
+    when(request.getParts()).thenReturn(new String[] {"identifier-0", "identifier-1"});
+    when(request.getPartAsStringFailsafe("identifier-0", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("download-1");
+    when(request.getPartAsStringFailsafe("identifier-1", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("download-2");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/queue/requests/remove"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("queue", "requests", "remove"),
+                Map.of(
+                    "identifier-0", List.of("download-1"),
+                    "identifier-1", List.of("download-2"))));
+    verify(request).getPartAsStringFailsafe("identifier-0", QueueToadlet.MAX_KEY_LENGTH);
+    verify(request).getPartAsStringFailsafe("identifier-1", QueueToadlet.MAX_KEY_LENGTH);
+  }
+
+  @Test
+  void handleMethodPOST_whenQueueRemoveUsesRepeatedUrlEncodedBody_routesAllIdentifiers()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(request.getHeader("content-type")).thenReturn("application/x-www-form-urlencoded");
+    when(request.getRawData())
+        .thenReturn(
+            new SimpleReadOnlyArrayBucket(
+                "identifier=download-1&identifier=download-2".getBytes(StandardCharsets.US_ASCII)));
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/queue/requests/remove"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("queue", "requests", "remove"),
+                Map.of("identifier", List.of("download-1", "download-2"))));
+    verify(request, never()).getParts();
+  }
+
+  @Test
+  void handleMethodPOST_whenUrlEncodedBodyOverlapsQuery_expectQueryValuesPreserved()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of("expectedMimeType"));
+    when(request.getMultipleParam("expectedMimeType")).thenReturn(new String[] {"text/html"});
+    when(request.getHeader("content-type"))
+        .thenReturn("application/x-www-form-urlencoded; charset=UTF-8");
+    when(request.getRawData())
+        .thenReturn(
+            new SimpleReadOnlyArrayBucket(
+                ("fetchUri=KSK@direct-download&expectedMimeType=text/plain&filterData=on"
+                        + "&formPassword=secret")
+                    .getBytes(StandardCharsets.US_ASCII)));
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/queue/downloads"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("queue", "downloads"),
+                Map.of(
+                    "expectedMimeType", List.of("text/html"),
+                    "fetchUri", List.of("KSK@direct-download"),
+                    "filterData", List.of("on"))));
+    verify(request, never()).getParts();
+  }
+
+  @Test
+  void handleMethodPOST_whenQueueDownloadUsesFormParts_routesDecodedCreationRequest()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(request.getRawData()).thenReturn(requestBody);
+    when(request.getParts())
+        .thenReturn(new String[] {"fetchUri", "filterData", "expectedMimeType"});
+    when(request.getPartAsStringFailsafe("fetchUri", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("KSK@direct-download");
+    when(request.getPartAsStringFailsafe("filterData", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("on");
+    when(request.getPartAsStringFailsafe("expectedMimeType", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("text/plain");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/queue/downloads"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("queue", "downloads"),
+                Map.of(
+                    "fetchUri", List.of("KSK@direct-download"),
+                    "filterData", List.of("on"),
+                    "expectedMimeType", List.of("text/plain"))));
+    verify(request).getPartAsStringFailsafe("fetchUri", QueueToadlet.MAX_KEY_LENGTH);
+  }
+
+  @Test
+  void handleMethodPOST_whenQueueMutationPasswordMissing_expectJson403WithoutRouting()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(false);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/queue/requests/remove"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals("Forbidden", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"forbidden\",\"message\":\"Valid form password is required.\"}}",
+        bodyWrite.bodyText());
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/WebShellToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/WebShellToadletTest.java
@@ -55,6 +55,7 @@ class WebShellToadletTest {
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     when(ctx.getContainer()).thenReturn(container);
     when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(ctx.getFormPassword()).thenReturn("secret-form-password");
 
     toadlet.handleMethodGET(URI.create("http://localhost/app/node/"), request, ctx);
 
@@ -67,6 +68,26 @@ class WebShellToadletTest {
     assertTrue(bodyWrite.bodyText().contains(WebShellPaths.BOOTSTRAP_ELEMENT_ID));
     assertTrue(bodyWrite.bodyText().contains("\"shellRoot\":\"/app/node/\""));
     assertTrue(bodyWrite.bodyText().contains("\"platformApiRoot\":\"/api/v1/\""));
+    assertTrue(bodyWrite.bodyText().contains("\"formPassword\":\"secret-form-password\""));
+  }
+
+  @Test
+  void handleMethodGET_whenFormPasswordBlank_expectRenderedHtmlBootstrapWithoutMutationToken()
+      throws Exception {
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    when(ctx.getContainer()).thenReturn(container);
+    when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(ctx.getFormPassword()).thenReturn("");
+
+    toadlet.handleMethodGET(URI.create("http://localhost/app/node/"), request, ctx);
+
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(200, replyHeaders.statusCode());
+    assertEquals("OK", replyHeaders.reasonPhrase());
+    assertEquals("text/html; charset=UTF-8", replyHeaders.mimeType());
+
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertTrue(bodyWrite.bodyText().contains("\"formPassword\":null"));
   }
 
   @Test

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -37,6 +37,14 @@ import network.crypta.runtime.spi.NodeReferenceView;
 import network.crypta.runtime.spi.PeerFieldSet;
 import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.QueueCompletionPort;
+import network.crypta.runtime.spi.QueueDownloadPort;
+import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueMutationPort;
+import network.crypta.runtime.spi.QueuePagePort;
+import network.crypta.runtime.spi.QueuePageRequest;
+import network.crypta.runtime.spi.QueuePageSnapshot;
+import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.SecurityLevelsSnapshot;
@@ -75,6 +83,11 @@ class PlatformApiRouterTest {
   @Mock private ConfigPort configPort;
   @Mock private ConnectivityPort connectivityPort;
   @Mock private SecurityLevelsPort securityLevelsPort;
+  @Mock private QueuePagePort queuePagePort;
+  @Mock private QueueMutationPort queueMutationPort;
+  @Mock private QueueDownloadPort queueDownloadPort;
+  @Mock private QueueSupportPort queueSupportPort;
+  @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private AppHost appHost;
 
   @TempDir private Path tempDir;
@@ -88,6 +101,11 @@ class PlatformApiRouterTest {
     when(runtimePorts.config()).thenReturn(configPort);
     when(runtimePorts.connectivity()).thenReturn(connectivityPort);
     when(runtimePorts.securityLevels()).thenReturn(securityLevelsPort);
+    when(runtimePorts.queuePage()).thenReturn(queuePagePort);
+    when(runtimePorts.queueMutation()).thenReturn(queueMutationPort);
+    when(runtimePorts.queueDownload()).thenReturn(queueDownloadPort);
+    when(runtimePorts.queueSupport()).thenReturn(queueSupportPort);
+    when(runtimePorts.queueCompletion()).thenReturn(queueCompletionPort);
     router = new PlatformApiRouter(runtimePorts, appHost);
   }
 
@@ -351,6 +369,159 @@ class PlatformApiRouterTest {
     assertEquals(200, response.statusCode());
     assertEquals(
         "{\"CURRENT\":{\"enabled\":\"true\",\"node\":{\"name\":\"alpha\"}}}", response.body());
+  }
+
+  @Test
+  void route_whenQueueSnapshotRequested_expectDetachedQueueJson() throws Exception {
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queuePagePort.renderPage(new QueuePageRequest(false, true, "priority", true)))
+        .thenReturn(
+            new QueuePageSnapshot(
+                "Downloads",
+                "<div>before<!--CRYPTA_ALERT_SUMMARY--><!--CRYPTA_QUEUE_FORM_PASSWORD-->"
+                    + "after</div>"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "GET",
+                List.of("queue"),
+                Map.of(
+                    "page", List.of("downloads"),
+                    "advancedMode", List.of("true"),
+                    "sortBy", List.of("priority"),
+                    "reversed", List.of("true"))));
+
+    verify(queueCompletionPort).ensureTrackingStarted(false);
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(
+                Map.entry("page", "downloads"),
+                Map.entry("pageTitle", "Downloads"),
+                Map.entry("contentHtml", "<div>beforeafter</div>"),
+                Map.entry("advancedMode", true),
+                Map.entry("sortBy", "priority"),
+                Map.entry("reversed", true))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueuePageMissing_expectBadRequestJson() {
+    PlatformApiResponse response = router.route(request("GET", List.of("queue"), Map.of()));
+
+    assertEquals(400, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_query_parameter\",\"message\":\"Missing required query"
+            + " parameter 'page'.\"}}",
+        response.body());
+    verify(queueSupportPort, never()).isQueueBackendEnabled();
+  }
+
+  @Test
+  void route_whenQueueKeysRequested_expectJsonArrayExport() throws Exception {
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queuePagePort.renderKeyList(true)).thenReturn("USK@alpha\nUSK@beta\n");
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("queue", "keys"), Map.of("page", List.of("uploads"))));
+
+    verify(queueCompletionPort).ensureTrackingStarted(true);
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(
+                Map.entry("page", "uploads"),
+                Map.entry("keyCount", 2),
+                Map.entry("keys", List.of("USK@alpha", "USK@beta")))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueCountRequested_expectDetachedCountJson() throws Exception {
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    when(queuePagePort.renderCountPage(false))
+        .thenReturn(
+            new QueuePageSnapshot(
+                "Downloads Count", "<div>count<!--CRYPTA_QUEUE_FORM_PASSWORD--></div>"));
+
+    PlatformApiResponse response =
+        router.route(
+            request("GET", List.of("queue", "count"), Map.of("page", List.of("downloads"))));
+
+    verify(queueCompletionPort).ensureTrackingStarted(false);
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(
+                Map.entry("page", "downloads"),
+                Map.entry("pageTitle", "Downloads Count"),
+                Map.entry("contentHtml", "<div>count</div>"))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueRemoveRequested_expectMutationJsonAndIdentifiersPassedThrough()
+      throws Exception {
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("queue", "requests", "remove"),
+                orderedStringParameters(
+                    Map.entry("identifier-0", List.of("download-1")),
+                    Map.entry("identifier-1", List.of("download-2")))));
+
+    verify(queueMutationPort).removeRequests(List.of("download-1", "download-2"));
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(Map.entry("operation", "remove"), Map.entry("identifierCount", 2))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueCleanupDownloadsRequested_expectCleanupJson() throws Exception {
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("queue", "cleanup", "downloads"), Map.of()));
+
+    verify(queueMutationPort).removeFinishedDownloads();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(Map.entry("operation", "cleanup"), Map.entry("target", "downloads"))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueDirectDownloadRequested_expectCreatedJsonAndDirectRequest() throws Exception {
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("queue", "downloads"),
+                Map.of(
+                    "fetchUri", List.of("KSK@queued"),
+                    "filterData", List.of("true"),
+                    "expectedMimeType", List.of("text/plain"))));
+
+    verify(queueDownloadPort)
+        .enqueueDownload(
+            new QueueDownloadRequest("KSK@queued", true, "text/plain", "forever", "direct", null));
+    assertEquals(201, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(
+                Map.entry("operation", "create_direct_download"),
+                Map.entry("fetchUri", "KSK@queued"),
+                Map.entry("filterData", true),
+                Map.entry("expectedMimeType", "text/plain"),
+                Map.entry("returnType", "direct"))),
+        response.body());
   }
 
   @Test
@@ -916,6 +1087,25 @@ class PlatformApiRouterTest {
   private static PlatformApiRequest request(
       String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
     return new PlatformApiRequest(method, pathSegments, queryParameters);
+  }
+
+  @SafeVarargs
+  private static Map<String, Object> orderedJson(Map.Entry<String, Object>... entries) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(entries.length);
+    for (Map.Entry<String, Object> entry : entries) {
+      json.put(entry.getKey(), entry.getValue());
+    }
+    return json;
+  }
+
+  @SafeVarargs
+  private static Map<String, List<String>> orderedStringParameters(
+      Map.Entry<String, List<String>>... entries) {
+    LinkedHashMap<String, List<String>> parameters = LinkedHashMap.newLinkedHashMap(entries.length);
+    for (Map.Entry<String, List<String>> entry : entries) {
+      parameters.put(entry.getKey(), entry.getValue());
+    }
+    return parameters;
   }
 
   private InstalledAppSnapshot installedSnapshot() {


### PR DESCRIPTION
## Summary
- add a dedicated `/api/v1/queue` Platform API surface backed by the detached queue SPI
- bridge queue form-password and body handling through the legacy admin adapter, and extend the Web Shell with queue snapshots, mutations, and direct downloads
- add focused router, handler, bridge, bootstrap, and shell regression tests for the new queue control-plane flows

## Deferred
- browser-upload insert flows
- local file insert flows
- local directory insert flows

## How to test
- `./gradlew :platform-api:test --tests '*QueueApiHandlerTest'`
- `./gradlew :platform-web-shell:test --tests '*WebShellResourcesTest'`
- `./gradlew :platform-api:test --tests '*QueueApiHandlerTest' :test --tests '*PlatformApiRouterTest' --tests '*PlatformApiToadletTest'`
- `./gradlew test`