### PR TITLE
feat(peers): Add peer control plane

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -52,6 +52,7 @@ public final class PlatformApiToadlet extends Toadlet {
   private static final String DELETE_METHOD = "DELETE";
   private static final String FORM_PASSWORD_PARAMETER = "formPassword";
   private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = QueueToadlet.MAX_KEY_LENGTH;
+  private static final String PEERS_SEGMENT = "peers";
   private static final String QUEUE_SEGMENT = "queue";
 
   /**
@@ -292,8 +293,8 @@ public final class PlatformApiToadlet extends Toadlet {
    *
    * <p>The legacy shell only auto-checks form passwords for POST before dispatch. The Platform API
    * bridge keeps full-access checks ahead of password checks and applies the same legacy password
-   * guard to DELETE so mutating app-management routes stay protected without changing their public
-   * route shape.
+   * guard to every currently supported Platform API mutation family. DELETE remains relevant only
+   * for installed-app removal, while queue and peer mutations currently use POST.
    *
    * @param method HTTP method name forwarded into the router
    * @param uri request target supplied by the legacy HTTP shell
@@ -311,19 +312,25 @@ public final class PlatformApiToadlet extends Toadlet {
       return false;
     }
 
-    if (pathSegments.isEmpty() || !"apps".equals(pathSegments.getFirst())) {
-      return requiresQueueFormPassword(method, pathSegments);
+    if (pathSegments.isEmpty()) {
+      return false;
     }
-    if (DELETE_METHOD.equals(method)) {
-      return pathSegments.size() == 2;
+    if ("apps".equals(pathSegments.getFirst())) {
+      if (DELETE_METHOD.equals(method)) {
+        return pathSegments.size() == 2;
+      }
+      if (pathSegments.size() == 2 && "install".equals(pathSegments.get(1))) {
+        return true;
+      }
+      return pathSegments.size() == 3
+          && ("start".equals(pathSegments.get(2))
+              || "stop".equals(pathSegments.get(2))
+              || "update".equals(pathSegments.get(2)));
     }
-    if (pathSegments.size() == 2 && "install".equals(pathSegments.get(1))) {
+    if (requiresQueueFormPassword(method, pathSegments)) {
       return true;
     }
-    return pathSegments.size() == 3
-        && ("start".equals(pathSegments.get(2))
-            || "stop".equals(pathSegments.get(2))
-            || "update".equals(pathSegments.get(2)));
+    return requiresPeersFormPassword(method, pathSegments);
   }
 
   /**
@@ -355,11 +362,32 @@ public final class PlatformApiToadlet extends Toadlet {
   }
 
   /**
+   * Returns whether the current request targets one of the mutating peer routes.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresPeersFormPassword(String method, List<String> pathSegments) {
+    if (!"POST".equals(method)
+        || pathSegments.isEmpty()
+        || !PEERS_SEGMENT.equals(pathSegments.getFirst())) {
+      return false;
+    }
+    if (pathSegments.size() == 2) {
+      return "add".equals(pathSegments.get(1));
+    }
+    return pathSegments.size() == 3
+        && ("settings".equals(pathSegments.get(2))
+            || "note".equals(pathSegments.get(2))
+            || "remove".equals(pathSegments.get(2)));
+  }
+
+  /**
    * Enforces the legacy form-password requirement for mutating requests.
    *
-   * <p>App-management mutations keep the legacy body-carried form password requirement, but the
-   * bridge handles failures itself so callers always receive structured JSON {@code 403} responses
-   * instead of legacy redirects.
+   * <p>The bridge handles failures itself so callers always receive structured JSON {@code 403}
+   * responses instead of legacy redirects.
    *
    * @param method HTTP method name forwarded into the router
    * @param uri request target supplied by the legacy HTTP shell

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -10,6 +10,7 @@ val mainSourceSet = sourceSets.named("main")
 
 dependencies {
   implementation(project(":foundation-crypto-keys"))
+  implementation(project(":foundation-support"))
 
   api(project(":runtime-spi"))
   api(project(":platform-apphost"))

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiParameters.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiParameters.java
@@ -5,6 +5,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Shared query-parameter parsing helpers for Platform API endpoints.
@@ -14,6 +15,8 @@ import java.util.Set;
  * request is malformed.
  */
 public final class PlatformApiParameters {
+  private static final String MISSING_REQUIRED_QUERY_PARAMETER_PREFIX =
+      "Missing required query parameter '";
   private static final String QUERY_PARAMETER_PREFIX = "Query parameter '";
 
   /** Prevents instantiation of this static helper type. */
@@ -43,6 +46,28 @@ public final class PlatformApiParameters {
   }
 
   /**
+   * Reads one optional boolean query parameter.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @return parsed boolean value, or {@code null} when the parameter is absent
+   */
+  public static @Nullable Boolean readOptionalBoolean(
+      Map<String, List<String>> queryParameters, String name) {
+    String raw = readSingle(queryParameters, name);
+    if (raw == null) {
+      return null;
+    }
+    if ("true".equalsIgnoreCase(raw)) {
+      return Boolean.TRUE;
+    }
+    if ("false".equalsIgnoreCase(raw)) {
+      return Boolean.FALSE;
+    }
+    throw invalidQuery(queryParameter(name) + " must be either 'true' or 'false'.");
+  }
+
+  /**
    * Reads one required string query parameter.
    *
    * @param queryParameters decoded query parameter map
@@ -52,9 +77,39 @@ public final class PlatformApiParameters {
   public static String requireString(Map<String, List<String>> queryParameters, String name) {
     String raw = readSingle(queryParameters, name);
     if (raw == null || raw.isBlank()) {
-      throw invalidQuery("Missing required query parameter '" + name + "'.");
+      throw invalidQuery(missingRequiredQueryParameter(name));
     }
     return raw;
+  }
+
+  /**
+   * Reads one required string query parameter while allowing an empty supplied value.
+   *
+   * <p>This variant is useful for mutation fields such as notes where the caller may explicitly
+   * clear the stored value by submitting an empty string.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @return supplied value, which may be empty
+   */
+  public static String requirePresentString(
+      Map<String, List<String>> queryParameters, String name) {
+    String raw = readSingle(queryParameters, name);
+    if (raw == null) {
+      throw invalidQuery(missingRequiredQueryParameter(name));
+    }
+    return raw;
+  }
+
+  /**
+   * Reads one optional string query parameter.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @return supplied value, or {@code null} when the parameter is absent
+   */
+  public static String readOptionalString(Map<String, List<String>> queryParameters, String name) {
+    return readSingle(queryParameters, name);
   }
 
   /**
@@ -70,7 +125,28 @@ public final class PlatformApiParameters {
       Map<String, List<String>> queryParameters, String name, Class<E> enumType) {
     String raw = readSingle(queryParameters, name);
     if (raw == null || raw.isBlank()) {
-      throw invalidQuery("Missing required query parameter '" + name + "'.");
+      throw invalidQuery(missingRequiredQueryParameter(name));
+    }
+    return parseEnum(name, raw, enumType);
+  }
+
+  /**
+   * Reads one optional enum query parameter using the enum's exact {@link Enum#name()} values.
+   *
+   * @param queryParameters decoded query parameter map
+   * @param name parameter name to read
+   * @param enumType target enum type
+   * @return parsed enum value, or {@code null} when the parameter is absent
+   * @param <E> enum type
+   */
+  public static <E extends Enum<E>> E readOptionalEnum(
+      Map<String, List<String>> queryParameters, String name, Class<E> enumType) {
+    String raw = readSingle(queryParameters, name);
+    if (raw == null) {
+      return null;
+    }
+    if (raw.isBlank()) {
+      throw invalidQuery(queryParameter(name) + " must not be empty.");
     }
     return parseEnum(name, raw, enumType);
   }
@@ -167,6 +243,10 @@ public final class PlatformApiParameters {
 
   private static String queryParameter(String name) {
     return QUERY_PARAMETER_PREFIX + name + "'";
+  }
+
+  private static String missingRequiredQueryParameter(String name) {
+    return MISSING_REQUIRED_QUERY_PARAMETER_PREFIX + name + "'.";
   }
 
   /**

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -72,7 +72,7 @@ public final class PlatformApiRouter {
   public PlatformApiRouter(RuntimePorts runtimePorts, AppHost appHost) {
     Objects.requireNonNull(runtimePorts, "runtimePorts");
     nodeApiHandler = new NodeApiHandler(runtimePorts.nodeInfo());
-    peersApiHandler = new PeersApiHandler(runtimePorts.peer());
+    peersApiHandler = new PeersApiHandler(runtimePorts.peer(), runtimePorts.darknetConnections());
     configApiHandler = new ConfigApiHandler(runtimePorts.config());
     connectivityApiHandler = new ConnectivityApiHandler(runtimePorts.connectivity());
     securityLevelsApiHandler = new SecurityLevelsApiHandler(runtimePorts.securityLevels());
@@ -126,6 +126,9 @@ public final class PlatformApiRouter {
     if ("queue".equals(firstSegment)) {
       return routeQueueRequest(segments, request);
     }
+    if ("peers".equals(firstSegment)) {
+      return routePeersRequest(segments, request);
+    }
 
     if (!"GET".equals(request.method())) {
       return PlatformApiResponse.error(
@@ -134,9 +137,6 @@ public final class PlatformApiRouter {
 
     if ("node".equals(firstSegment)) {
       return routeNodeRequest(segments, request);
-    }
-    if ("peers".equals(firstSegment)) {
-      return routePeersRequest(segments, request);
     }
     if ("config".equals(firstSegment) && segments.size() == 1) {
       return PlatformApiResponse.ok(configApiHandler.exportConfig(request.queryParameters()));
@@ -421,14 +421,77 @@ public final class PlatformApiRouter {
    * @throws PlatformApiException if the path does not identify a supported peers endpoint
    */
   private PlatformApiResponse routePeersRequest(List<String> segments, PlatformApiRequest request) {
-    if (segments.size() == 1) {
-      return PlatformApiResponse.ok(peersApiHandler.list(request.queryParameters()));
+    return switch (segments.size()) {
+      case 1 -> routePeersRoot(request);
+      case 2 -> routePeerResource(segments.get(1), request);
+      case 3 -> routePeerAction(segments.get(1), segments.get(2), request);
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  /**
+   * Routes the raw peer collection export at {@code /peers}.
+   *
+   * @param request full request metadata, including query parameters
+   * @return JSON response containing the raw peer export list
+   */
+  private PlatformApiResponse routePeersRoot(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
     }
-    if (segments.size() == 2) {
-      return PlatformApiResponse.ok(
-          peersApiHandler.get(segments.get(1), request.queryParameters()));
+    return PlatformApiResponse.ok(peersApiHandler.list(request.queryParameters()));
+  }
+
+  /**
+   * Routes either the shell-friendly roster view, the add-peer endpoint, or one raw peer resource.
+   *
+   * @param resource second path segment beneath {@code /peers}
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected peer endpoint
+   */
+  private PlatformApiResponse routePeerResource(String resource, PlatformApiRequest request) {
+    if ("roster".equals(resource)) {
+      if (!"GET".equals(request.method())) {
+        return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(peersApiHandler.roster());
     }
-    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    if ("add".equals(resource)) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.created(peersApiHandler.add(request.queryParameters()));
+    }
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(peersApiHandler.get(resource, request.queryParameters()));
+  }
+
+  /**
+   * Routes peer mutations beneath {@code /peers/{peerIdentity}/...}.
+   *
+   * @param peerIdentity exact peer identity segment
+   * @param action peer action segment
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected peer mutation
+   */
+  private PlatformApiResponse routePeerAction(
+      String peerIdentity, String action, PlatformApiRequest request) {
+    if (!"POST".equals(request.method())) {
+      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+    }
+    return switch (action) {
+      case "settings" ->
+          PlatformApiResponse.ok(
+              peersApiHandler.updateSettings(peerIdentity, request.queryParameters()));
+      case "note" ->
+          PlatformApiResponse.ok(
+              peersApiHandler.updateNote(peerIdentity, request.queryParameters()));
+      case "remove" ->
+          PlatformApiResponse.ok(peersApiHandler.remove(peerIdentity, request.queryParameters()));
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
   }
 
   /**

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -430,32 +430,34 @@ public final class PlatformApiRouter {
   }
 
   /**
-   * Routes the raw peer collection export at {@code /peers}.
+   * Routes either the raw peer collection export or the shell summary view at {@code /peers}.
    *
    * @param request full request metadata, including query parameters
-   * @return JSON response containing the raw peer export list
+   * @return JSON response containing the requested peer collection view
    */
   private PlatformApiResponse routePeersRoot(PlatformApiRequest request) {
     if (!"GET".equals(request.method())) {
       return methodNotAllowed("GET", GET_ONLY_MESSAGE);
     }
+    String view = PlatformApiParameters.readOptionalString(request.queryParameters(), "view");
+    if (view != null) {
+      if ("summary".equals(view)) {
+        return PlatformApiResponse.ok(peersApiHandler.roster());
+      }
+      throw new PlatformApiException(
+          400, "invalid_query_parameter", "Query parameter 'view' must be 'summary'.");
+    }
     return PlatformApiResponse.ok(peersApiHandler.list(request.queryParameters()));
   }
 
   /**
-   * Routes either the shell-friendly summary view, the add-peer endpoint, or one raw peer resource.
+   * Routes either the add-peer endpoint or one raw peer resource.
    *
    * @param resource second path segment beneath {@code /peers}
    * @param request full request metadata, including query parameters
    * @return JSON response for the selected peer endpoint
    */
   private PlatformApiResponse routePeerResource(String resource, PlatformApiRequest request) {
-    if ("summary".equals(resource)) {
-      if (!"GET".equals(request.method())) {
-        return methodNotAllowed("GET", GET_ONLY_MESSAGE);
-      }
-      return PlatformApiResponse.ok(peersApiHandler.roster());
-    }
     if ("add".equals(resource)) {
       if ("POST".equals(request.method())) {
         return PlatformApiResponse.created(peersApiHandler.add(request.queryParameters()));

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -443,24 +443,23 @@ public final class PlatformApiRouter {
   }
 
   /**
-   * Routes either the shell-friendly roster view, the add-peer endpoint, or one raw peer resource.
+   * Routes either the shell-friendly summary view, the add-peer endpoint, or one raw peer resource.
    *
    * @param resource second path segment beneath {@code /peers}
    * @param request full request metadata, including query parameters
    * @return JSON response for the selected peer endpoint
    */
   private PlatformApiResponse routePeerResource(String resource, PlatformApiRequest request) {
-    if ("roster".equals(resource)) {
+    if ("summary".equals(resource)) {
       if (!"GET".equals(request.method())) {
         return methodNotAllowed("GET", GET_ONLY_MESSAGE);
       }
       return PlatformApiResponse.ok(peersApiHandler.roster());
     }
     if ("add".equals(resource)) {
-      if (!"POST".equals(request.method())) {
-        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      if ("POST".equals(request.method())) {
+        return PlatformApiResponse.created(peersApiHandler.add(request.queryParameters()));
       }
-      return PlatformApiResponse.created(peersApiHandler.add(request.queryParameters()));
     }
     if (!"GET".equals(request.method())) {
       return methodNotAllowed("GET", GET_ONLY_MESSAGE);

--- a/platform-api/src/main/java/network/crypta/platform/api/peers/PeersApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/peers/PeersApiHandler.java
@@ -1,38 +1,86 @@
 package network.crypta.platform.api.peers;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.api.PlatformApiParameters;
 import network.crypta.platform.api.json.PlatformApiFieldSetJson;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetPeerRequiredException;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.PeerAddRejectedException;
+import network.crypta.runtime.spi.PeerFieldSet;
 import network.crypta.runtime.spi.PeerPort;
+import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
+import network.crypta.runtime.spi.RemovedPeerSnapshot;
 import network.crypta.runtime.spi.UnknownPeerException;
+import network.crypta.support.SimpleFieldSet;
 
 /**
- * Read-only peer endpoint family for Platform API v1.
+ * Peer endpoint family for Platform API v1.
  *
- * <p>The handler maps detached peer snapshots onto nested JSON objects and preserves the runtime
- * distinction between malformed requests and a peer lookup that simply does not resolve.
+ * <p>The handler preserves the existing raw peer export routes while also exposing a smaller,
+ * shell-friendly peer control plane. Reads continue to come from detached runtime snapshots. Peer
+ * mutations remain narrowly scoped to add, remove, darknet settings, and private note updates.
+ *
+ * <p>The handler keeps all request parsing transport-neutral. Callers provide one decoded parameter
+ * map plus any path-derived peer identity, and this type performs validation, converts pasted peer
+ * references into detached {@link PeerFieldSet} trees, delegates to the existing runtime SPI, and
+ * maps runtime failures onto stable Platform API error codes.
  */
 public final class PeersApiHandler {
-  /** Detached runtime port that supplies peer lists and individual peer snapshots. */
+  private static final System.Logger LOG = System.getLogger(PeersApiHandler.class.getName());
+
+  private static final String FIELD_IDENTITY = "identity";
+  private static final String FIELD_OPERATION = "operation";
+  private static final String FIELD_STATUS = "status";
+  private static final String FLAG_OPENNET = "opennet";
+  private static final String FLAG_DISABLE_ROUTING_HAS_BEEN_SET_LOCALLY =
+      "disableRoutingHasBeenSetLocally";
+  private static final String PARAMETER_ALLOW_LOCAL_ADDRESSES = "allowLocalAddresses";
+  private static final String PARAMETER_BURST_ONLY = "burstOnly";
+  private static final String PARAMETER_DISABLED = "disabled";
+  private static final String PARAMETER_FORCE_REMOVAL = "forceRemoval";
+  private static final String PARAMETER_IGNORE_SOURCE_PORT = "ignoreSourcePort";
+  private static final String PARAMETER_LISTEN_ONLY = "listenOnly";
+  private static final String PARAMETER_NOTE_TEXT = "noteText";
+  private static final String PARAMETER_PRIVATE_NOTE_TEXT = "privateNoteText";
+  private static final String PARAMETER_REFERENCE_TEXT = "referenceText";
+  private static final String PARAMETER_ROUTING_ENABLED = "routingEnabled";
+  private static final String PARAMETER_TRUST = "trust";
+  private static final String PARAMETER_VISIBILITY = "visibility";
+  private static final String STATUS_ROUTING_DISABLED = "ROUTING DISABLED";
+
+  /** Detached runtime port that supplies peer reads and mutations. */
   private final PeerPort peerPort;
 
+  /** Detached darknet companion port used for display names and private notes in roster views. */
+  private final DarknetConnectionsPort darknetConnectionsPort;
+
   /**
-   * Creates a peer API handler backed by the supplied runtime port.
+   * Creates a peer API handler backed by the supplied runtime ports.
    *
    * @param peerPort detached runtime peer port
+   * @param darknetConnectionsPort detached darknet peer companion port
    */
-  public PeersApiHandler(PeerPort peerPort) {
+  public PeersApiHandler(PeerPort peerPort, DarknetConnectionsPort darknetConnectionsPort) {
     this.peerPort = Objects.requireNonNull(peerPort, "peerPort");
+    this.darknetConnectionsPort =
+        Objects.requireNonNull(darknetConnectionsPort, "darknetConnectionsPort");
   }
 
   /**
    * Lists peers as JSON-compatible nested objects.
    *
    * <p>When the query parameters are omitted, both optional export flags default to {@code false}
-   * to keep the initial platform surface conservative and read-only.
+   * to keep the raw field-set export surface conservative.
    *
    * @param queryParameters decoded query parameters for the current request
    * @return peer list in encounter order
@@ -51,7 +99,7 @@ public final class PeersApiHandler {
    * Resolves one peer and returns it as a JSON-compatible nested object.
    *
    * <p>When the query parameters are omitted, both optional export flags default to {@code false}
-   * to keep the initial platform surface conservative and read-only.
+   * to keep the raw field-set export surface conservative.
    *
    * @param nodeIdentifier detached peer identifier extracted from the request path
    * @param queryParameters decoded query parameters for the current request
@@ -66,7 +114,452 @@ public final class PeersApiHandler {
       return PlatformApiFieldSetJson.toJson(
           peerPort.get(nodeIdentifier, includeMetadata, includeVolatile).root());
     } catch (UnknownPeerException _) {
-      throw new PlatformApiException(404, "unknown_peer", "Peer not found.");
+      throw unknownPeer();
     }
+  }
+
+  /**
+   * Returns a structured peer roster tailored for the Web Shell.
+   *
+   * <p>The roster is intentionally narrower than the raw field-set export. It surfaces only the
+   * fields the shell needs for overview and the currently supported control-plane actions, while
+   * still reusing detached runtime exports as the source of truth.
+   *
+   * @return JSON-compatible roster object containing the structured peer list
+   */
+  public Map<String, Object> roster() {
+    Map<String, DarknetConnectionPeerSnapshot> darknetPeersByIdentity = indexDarknetPeers();
+    List<Map<String, Object>> peers =
+        peerPort.list(true, true).stream()
+            .map(
+                snapshot ->
+                    toRosterEntry(snapshot, darknetPeersByIdentity.get(identity(snapshot.root()))))
+            .toList();
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put("peerCount", peers.size());
+    response.put("peers", peers);
+    return response;
+  }
+
+  /**
+   * Adds one peer from pasted peer-reference text.
+   *
+   * @param queryParameters decoded request parameters for the current request
+   * @return JSON-compatible mutation result
+   */
+  public Map<String, Object> add(Map<String, List<String>> queryParameters) {
+    PeerTrust requestedTrust =
+        PlatformApiParameters.readOptionalEnum(queryParameters, PARAMETER_TRUST, PeerTrust.class);
+    PeerVisibility requestedVisibility =
+        PlatformApiParameters.readOptionalEnum(
+            queryParameters, PARAMETER_VISIBILITY, PeerVisibility.class);
+    String referenceText =
+        PlatformApiParameters.requireString(queryParameters, PARAMETER_REFERENCE_TEXT);
+    String privateNoteText =
+        PlatformApiParameters.readOptionalString(queryParameters, PARAMETER_PRIVATE_NOTE_TEXT);
+    PeerFieldSet reference = parsePeerReference(referenceText);
+    validateAddOptions(reference, requestedTrust, requestedVisibility, privateNoteText);
+    PeerTrust trust = defaultEnum(requestedTrust, PeerTrust.NORMAL);
+    PeerVisibility visibility = defaultEnum(requestedVisibility, PeerVisibility.YES);
+
+    PeerSnapshot addedPeer;
+    try {
+      addedPeer = peerPort.add(reference, trust, visibility);
+    } catch (PeerAddRejectedException e) {
+      throw mapPeerAddRejected(e);
+    }
+
+    String addedPeerIdentity = directValue(addedPeer.root(), FIELD_IDENTITY);
+    boolean addedPeerIsOpennet = directFlag(addedPeer.root().directValues(), FLAG_OPENNET);
+    boolean privateNoteStored =
+        !addedPeerIsOpennet
+            && maybeWritePrivateDarknetCommentByIdentity(addedPeerIdentity, privateNoteText);
+
+    DarknetConnectionPeerSnapshot darknetPeer = lookupDarknetPeer(addedPeerIdentity);
+    if (darknetPeer != null && privateNoteStored) {
+      darknetPeer =
+          new DarknetConnectionPeerSnapshot(
+              darknetPeer.selectionToken(),
+              darknetPeer.nodeIdentifier(),
+              darknetPeer.displayName(),
+              privateNoteText,
+              darknetPeer.removableWithoutForce());
+    }
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put(FIELD_OPERATION, "add");
+    response.put("peer", toRosterEntry(addedPeer, darknetPeer));
+    return response;
+  }
+
+  /**
+   * Applies one exact-identity darknet settings update.
+   *
+   * @param peerIdentity exact peer identity extracted from the request path
+   * @param queryParameters decoded request parameters for the current request
+   * @return JSON-compatible mutation result
+   */
+  public Map<String, Object> updateSettings(
+      String peerIdentity, Map<String, List<String>> queryParameters) {
+    DarknetPeerSettingsUpdate update =
+        new DarknetPeerSettingsUpdate(
+            PlatformApiParameters.readOptionalBoolean(queryParameters, PARAMETER_DISABLED),
+            PlatformApiParameters.readOptionalBoolean(queryParameters, PARAMETER_LISTEN_ONLY),
+            PlatformApiParameters.readOptionalBoolean(queryParameters, PARAMETER_BURST_ONLY),
+            PlatformApiParameters.readOptionalBoolean(
+                queryParameters, PARAMETER_IGNORE_SOURCE_PORT),
+            PlatformApiParameters.readOptionalBoolean(
+                queryParameters, PARAMETER_ALLOW_LOCAL_ADDRESSES),
+            PlatformApiParameters.readOptionalBoolean(queryParameters, PARAMETER_ROUTING_ENABLED),
+            PlatformApiParameters.readOptionalEnum(
+                queryParameters, PARAMETER_TRUST, PeerTrust.class),
+            PlatformApiParameters.readOptionalEnum(
+                queryParameters, PARAMETER_VISIBILITY, PeerVisibility.class));
+    if (update.isEmpty()) {
+      throw invalidQuery("At least one peer setting parameter is required.");
+    }
+
+    try {
+      PeerSnapshot updatedPeer = peerPort.updateDarknetPeerByIdentity(peerIdentity, update);
+      LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+      response.put(FIELD_OPERATION, "update_settings");
+      response.put("peer", toRosterEntry(updatedPeer, lookupDarknetPeer(peerIdentity)));
+      return response;
+    } catch (UnknownPeerException _) {
+      throw unknownPeer();
+    } catch (DarknetPeerRequiredException e) {
+      throw darknetPeerRequired(e);
+    }
+  }
+
+  /**
+   * Writes the private darknet comment note for one exact-identity peer.
+   *
+   * @param peerIdentity exact peer identity extracted from the request path
+   * @param queryParameters decoded request parameters for the current request
+   * @return JSON-compatible mutation result
+   */
+  public Map<String, Object> updateNote(
+      String peerIdentity, Map<String, List<String>> queryParameters) {
+    String noteText =
+        PlatformApiParameters.requirePresentString(queryParameters, PARAMETER_NOTE_TEXT);
+    try {
+      String storedNote = peerPort.writePrivateDarknetCommentByIdentity(peerIdentity, noteText);
+      LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(3);
+      response.put(FIELD_OPERATION, "update_note");
+      response.put(FIELD_IDENTITY, peerIdentity);
+      response.put(PARAMETER_NOTE_TEXT, storedNote);
+      return response;
+    } catch (UnknownPeerException _) {
+      throw unknownPeer();
+    } catch (DarknetPeerRequiredException e) {
+      throw darknetPeerRequired(e);
+    }
+  }
+
+  /**
+   * Removes one peer using its exact detached identity.
+   *
+   * @param peerIdentity exact peer identity extracted from the request path
+   * @return JSON-compatible mutation result
+   */
+  public Map<String, Object> remove(
+      String peerIdentity, Map<String, List<String>> queryParameters) {
+    boolean forceRemoval =
+        Boolean.TRUE.equals(
+            PlatformApiParameters.readOptionalBoolean(queryParameters, PARAMETER_FORCE_REMOVAL));
+    DarknetConnectionPeerSnapshot darknetPeer = lookupDarknetPeer(peerIdentity);
+    if (darknetPeer != null && !darknetPeer.removableWithoutForce() && !forceRemoval) {
+      throw forceRemovalRequired();
+    }
+    try {
+      RemovedPeerSnapshot removedPeer = peerPort.removeByIdentity(peerIdentity);
+      LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(3);
+      response.put(FIELD_OPERATION, "remove");
+      response.put(FIELD_IDENTITY, removedPeer.identity());
+      response.put("nodeIdentifier", removedPeer.nodeIdentifier());
+      return response;
+    } catch (UnknownPeerException _) {
+      throw unknownPeer();
+    }
+  }
+
+  private Map<String, DarknetConnectionPeerSnapshot> indexDarknetPeers() {
+    List<DarknetConnectionPeerSnapshot> peers = darknetConnectionsPort.listPeers();
+    if (peers == null || peers.isEmpty()) {
+      return Map.of();
+    }
+    LinkedHashMap<String, DarknetConnectionPeerSnapshot> indexed = new LinkedHashMap<>();
+    for (DarknetConnectionPeerSnapshot peer : peers) {
+      indexed.put(peer.nodeIdentifier(), peer);
+    }
+    return indexed;
+  }
+
+  private DarknetConnectionPeerSnapshot lookupDarknetPeer(String peerIdentity) {
+    if (peerIdentity == null || peerIdentity.isBlank()) {
+      return null;
+    }
+    List<DarknetConnectionPeerSnapshot> peers = darknetConnectionsPort.listPeers();
+    if (peers == null) {
+      return null;
+    }
+    for (DarknetConnectionPeerSnapshot peer : peers) {
+      if (peerIdentity.equals(peer.nodeIdentifier())) {
+        return peer;
+      }
+    }
+    return null;
+  }
+
+  private static Map<String, Object> toRosterEntry(
+      PeerSnapshot snapshot, DarknetConnectionPeerSnapshot darknetPeer) {
+    PeerFieldSet root = snapshot.root();
+    PeerFieldSet metadata = root.directSubsets().get("metadata");
+    PeerFieldSet volatileState = root.directSubsets().get("volatile");
+    String identity = identity(root);
+    boolean opennet = directFlag(root.directValues(), FLAG_OPENNET);
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(14);
+    json.put(FIELD_IDENTITY, identity);
+    json.put("nodeIdentifier", darknetPeer == null ? identity : darknetPeer.nodeIdentifier());
+    json.put("displayName", displayName(root, darknetPeer));
+    json.put("family", opennet ? FLAG_OPENNET : "darknet");
+    json.put(FIELD_STATUS, directValue(volatileState, FIELD_STATUS));
+    json.put(PARAMETER_TRUST, directValue(metadata, "trustLevel"));
+    json.put(PARAMETER_VISIBILITY, directValue(metadata, "ourVisibility"));
+    json.put("theirVisibility", directValue(metadata, "theirVisibility"));
+    json.put(PARAMETER_DISABLED, directFlag(metadata, "isDisabled"));
+    json.put(PARAMETER_LISTEN_ONLY, directFlag(metadata, "isListenOnly"));
+    json.put(PARAMETER_BURST_ONLY, directFlag(metadata, "isBurstOnly"));
+    json.put(PARAMETER_ROUTING_ENABLED, routingEnabled(metadata, volatileState));
+    json.put(PARAMETER_IGNORE_SOURCE_PORT, directFlag(metadata, PARAMETER_IGNORE_SOURCE_PORT));
+    json.put(
+        PARAMETER_ALLOW_LOCAL_ADDRESSES, directFlag(metadata, PARAMETER_ALLOW_LOCAL_ADDRESSES));
+    json.put("hasPrivateNote", darknetPeer != null && !darknetPeer.privateNoteText().isBlank());
+    if (darknetPeer != null) {
+      json.put(PARAMETER_PRIVATE_NOTE_TEXT, darknetPeer.privateNoteText());
+      json.put("removableWithoutForce", darknetPeer.removableWithoutForce());
+    }
+    return json;
+  }
+
+  private static String displayName(PeerFieldSet root, DarknetConnectionPeerSnapshot darknetPeer) {
+    if (darknetPeer != null && !darknetPeer.displayName().isBlank()) {
+      return darknetPeer.displayName();
+    }
+    String name = root.directValues().get("myName");
+    if (name != null && !name.isBlank()) {
+      return name;
+    }
+    return identity(root);
+  }
+
+  private static String identity(PeerFieldSet root) {
+    String identity = root.directValues().get(FIELD_IDENTITY);
+    return identity == null || identity.isBlank() ? "<unknown-peer>" : identity;
+  }
+
+  private boolean maybeWritePrivateDarknetCommentByIdentity(String peerIdentity, String noteText) {
+    if (noteText == null || noteText.isBlank()) {
+      return false;
+    }
+    if (peerIdentity == null || peerIdentity.isBlank()) {
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "Added darknet peer without identity in snapshot; skipping private note write");
+      return false;
+    }
+
+    try {
+      peerPort.writePrivateDarknetCommentByIdentity(peerIdentity, noteText);
+      return true;
+    } catch (UnknownPeerException | DarknetPeerRequiredException | RuntimeException e) {
+      LOG.log(
+          System.Logger.Level.WARNING,
+          "Added darknet peer "
+              + peerIdentity
+              + " but failed to write private note; keeping peer addition",
+          e);
+      return false;
+    }
+  }
+
+  private static String directValue(PeerFieldSet fieldSet, String key) {
+    if (fieldSet == null) {
+      return null;
+    }
+    return fieldSet.directValues().get(key);
+  }
+
+  private static boolean directFlag(PeerFieldSet fieldSet, String key) {
+    return fieldSet != null && directFlag(fieldSet.directValues(), key);
+  }
+
+  private static boolean directFlag(Map<String, String> values, String key) {
+    String value = values.get(key);
+    return Boolean.parseBoolean(value);
+  }
+
+  private static boolean routingEnabled(PeerFieldSet metadata, PeerFieldSet volatileState) {
+    return !directFlag(metadata, FLAG_DISABLE_ROUTING_HAS_BEEN_SET_LOCALLY)
+        && !STATUS_ROUTING_DISABLED.equals(directValue(volatileState, FIELD_STATUS));
+  }
+
+  private static <E> E defaultEnum(E value, E defaultValue) {
+    return value == null ? defaultValue : value;
+  }
+
+  private static void validateAddOptions(
+      PeerFieldSet reference,
+      PeerTrust requestedTrust,
+      PeerVisibility requestedVisibility,
+      String privateNoteText) {
+    if (!directFlag(reference.directValues(), FLAG_OPENNET)) {
+      return;
+    }
+    if (!usesDarknetOnlyAddOptions(requestedTrust, requestedVisibility, privateNoteText)) {
+      return;
+    }
+    throw invalidQuery(
+        "Opennet peer references do not support trust, visibility, or privateNoteText add"
+            + " options.");
+  }
+
+  private static boolean usesDarknetOnlyAddOptions(
+      PeerTrust requestedTrust, PeerVisibility requestedVisibility, String privateNoteText) {
+    return (requestedTrust != null && requestedTrust != PeerTrust.NORMAL)
+        || (requestedVisibility != null && requestedVisibility != PeerVisibility.YES)
+        || (privateNoteText != null && !privateNoteText.isBlank());
+  }
+
+  private static PeerFieldSet parsePeerReference(String referenceText) {
+    List<String> references = extractReferenceBlocks(cleanReferenceText(referenceText));
+    if (references.isEmpty()) {
+      throw invalidPeerReference("Peer reference text is empty.");
+    }
+    if (references.size() != 1) {
+      throw invalidPeerReference("Exactly one peer reference is required.");
+    }
+
+    String candidate = references.getFirst().concat("\nEnd");
+    try {
+      SimpleFieldSet parsed = parseNoderefLiberally(candidate);
+      if (!parsed.getEndMarker().endsWith("End")) {
+        throw invalidPeerReference("Peer reference is missing a valid End marker.");
+      }
+      parsed.setEndMarker("End");
+      return toPeerFieldSet(parsed);
+    } catch (IOException e) {
+      throw invalidPeerReference("Peer reference could not be parsed: " + e.getMessage());
+    }
+  }
+
+  private static List<String> extractReferenceBlocks(String referenceText) {
+    String normalized = referenceText.replace("\r\n", "\n").replace('\r', '\n').trim();
+    if (normalized.isEmpty()) {
+      return List.of();
+    }
+
+    String[] rawReferences = normalized.split("\nEnd\n");
+    List<String> references = new ArrayList<>(rawReferences.length);
+    for (String rawReference : rawReferences) {
+      String normalizedReference = normalizeReferenceBlock(rawReference);
+      if (!normalizedReference.isBlank()) {
+        references.add(normalizedReference);
+      }
+    }
+    return List.copyOf(references);
+  }
+
+  private static String normalizeReferenceBlock(String rawReference) {
+    StringBuilder builder = new StringBuilder(rawReference.length());
+    boolean first = true;
+    for (String line : rawReference.split("\n")) {
+      String trimmed = line.trim();
+      if (!trimmed.isEmpty()) {
+        if ("End".equals(trimmed)) {
+          break;
+        }
+        if (trimmed.indexOf('=') >= 0 && !first) {
+          builder.append('\n');
+        }
+        builder.append(trimmed);
+        first = false;
+      }
+    }
+    return builder.toString();
+  }
+
+  private static String cleanReferenceText(String referenceText) {
+    StringBuilder builder = new StringBuilder(referenceText.length());
+    for (String line : referenceText.replace('\r', '\n').split("\n")) {
+      String trimmed = line.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      if (trimmed.indexOf('=') >= 0 || "End".equals(trimmed)) {
+        builder.append(trimmed).append('\n');
+      }
+    }
+    return builder.toString();
+  }
+
+  private static SimpleFieldSet parseNoderefLiberally(String nodeReference) throws IOException {
+    SimpleFieldSet parsed = new SimpleFieldSet(nodeReference, false, true, true);
+    if (parsed.directKeys().contains("lastGoodVersion")) {
+      return parsed;
+    }
+    return new SimpleFieldSet(nodeReference.replace(" ", "\n"), false, true, true);
+  }
+
+  private static PeerFieldSet toPeerFieldSet(SimpleFieldSet source) {
+    if (source.isEmpty()) {
+      return PeerFieldSet.empty();
+    }
+
+    LinkedHashMap<String, String> directValues = new LinkedHashMap<>(source.directKeyValues());
+    LinkedHashMap<String, PeerFieldSet> directSubsets = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleFieldSet> entry : source.directSubsets().entrySet()) {
+      PeerFieldSet subset = toPeerFieldSet(entry.getValue());
+      if (!subset.isEmpty()) {
+        directSubsets.put(entry.getKey(), subset);
+      }
+    }
+    return new PeerFieldSet(directValues, directSubsets);
+  }
+
+  private static PlatformApiException mapPeerAddRejected(PeerAddRejectedException e) {
+    return switch (e.reason()) {
+      case REF_PARSE_ERROR, REF_SIGNATURE_INVALID ->
+          new PlatformApiException(400, "invalid_peer_reference", e.getMessage());
+      case CANNOT_PEER_WITH_SELF ->
+          new PlatformApiException(409, "cannot_peer_with_self", e.getMessage());
+      case DUPLICATE_PEER_REF -> new PlatformApiException(409, "duplicate_peer", e.getMessage());
+      case OPENNET_DISABLED -> new PlatformApiException(409, "opennet_disabled", e.getMessage());
+    };
+  }
+
+  private static PlatformApiException unknownPeer() {
+    return new PlatformApiException(404, "unknown_peer", "Peer not found.");
+  }
+
+  private static PlatformApiException darknetPeerRequired(DarknetPeerRequiredException e) {
+    return new PlatformApiException(409, "darknet_peer_required", e.getMessage());
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private static PlatformApiException invalidQuery(String message) {
+    return new PlatformApiException(400, "invalid_query_parameter", message);
+  }
+
+  private static PlatformApiException invalidPeerReference(String message) {
+    return new PlatformApiException(400, "invalid_peer_reference", message);
+  }
+
+  private static PlatformApiException forceRemovalRequired() {
+    return new PlatformApiException(
+        409, "force_removal_required", "Peer removal requires forceRemoval=true.");
   }
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/peers/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/peers/package-info.java
@@ -1,7 +1,8 @@
 /**
  * Peer-oriented Platform API handlers.
  *
- * <p>This package owns the read-only peer list and peer detail endpoints for Platform API v1. The
- * handlers depend only on detached {@code runtime-spi} peer ports and immutable peer snapshots.
+ * <p>This package owns both the raw peer export endpoints and the structured peer control-plane
+ * routes for Platform API v1. The handlers depend only on detached {@code runtime-spi} peer ports,
+ * immutable peer snapshots, and narrow support helpers for pasted peer-reference parsing.
  */
 package network.crypta.platform.api.peers;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -55,13 +55,66 @@
           </div>
         </article>
 
-        <article class="panel" id="peers-panel">
+        <article class="panel panel-span-2" id="peers-panel">
           <div class="panel-header">
             <p class="panel-kicker">Peers</p>
-            <h2>Read-only roster</h2>
+            <h2>Peer control plane</h2>
           </div>
+          <p class="panel-description">
+            Detached roster data stays native to the shell, including add-peer, trust and
+            visibility updates, private notes, and peer removal.
+          </p>
+          <div class="queue-toolbar">
+            <button class="button button-secondary" id="peers-refresh-button" type="button">
+              Refresh peers
+            </button>
+          </div>
+          <div class="queue-status" id="peers-status" aria-live="polite"></div>
+          <p class="panel-description" hidden id="peers-readonly-hint">
+            Peer mutations are unavailable in read-only mode.
+          </p>
+          <form class="peer-create-form" hidden id="peer-create-form">
+            <div class="queue-create-copy">
+              <p class="panel-kicker">Add peer</p>
+              <p class="queue-create-description">
+                Paste a full peer reference to add a peer through the Platform API bridge.
+              </p>
+            </div>
+            <label class="queue-field peer-reference-field" for="peer-reference-text">
+              <span>Reference text</span>
+              <textarea
+                id="peer-reference-text"
+                name="referenceText"
+                rows="6"
+                spellcheck="false"
+              ></textarea>
+            </label>
+            <label class="queue-field" for="peer-trust">
+              <span>Trust</span>
+              <select id="peer-trust" name="trust">
+                <option value="HIGH">High</option>
+                <option value="NORMAL" selected>Normal</option>
+                <option value="LOW">Low</option>
+              </select>
+            </label>
+            <label class="queue-field" for="peer-visibility">
+              <span>Visibility</span>
+              <select id="peer-visibility" name="visibility">
+                <option value="YES" selected>Yes</option>
+                <option value="NAME_ONLY">Name only</option>
+                <option value="NO">No</option>
+              </select>
+            </label>
+            <label class="queue-field" for="peer-private-note">
+              <span>Private note</span>
+              <textarea id="peer-private-note" name="privateNoteText" rows="3"></textarea>
+            </label>
+            <button class="button button-primary" id="peer-create-submit" type="submit">
+              Add peer
+            </button>
+          </form>
           <div class="panel-body" id="peers-body">
-            <p class="loading">Loading peer snapshot...</p>
+            <p class="loading">Loading peer roster...</p>
           </div>
         </article>
       </section>

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -154,6 +154,10 @@ a {
   gap: 18px;
 }
 
+.panel-span-2 {
+  grid-column: span 2;
+}
+
 .panel {
   display: grid;
   gap: 18px;
@@ -312,7 +316,8 @@ a {
   color: var(--shell-muted);
 }
 
-.queue-status {
+.queue-status,
+.peer-status {
   min-height: 24px;
 }
 
@@ -334,7 +339,8 @@ a {
   background: rgba(255, 143, 143, 0.12);
 }
 
-.queue-create-form {
+.queue-create-form,
+.peer-create-form {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(140px, auto) auto;
   gap: 14px;
@@ -346,7 +352,9 @@ a {
 }
 
 .queue-create-copy,
-.queue-create-description {
+.queue-create-description,
+.peer-add-copy,
+.peer-add-description {
   margin: 0;
 }
 
@@ -362,6 +370,8 @@ a {
 }
 
 .queue-field input,
+.queue-field textarea,
+.queue-field select,
 .queue-key-text,
 .queue-html input[type="text"],
 .queue-html textarea,
@@ -374,6 +384,19 @@ a {
   background: rgba(4, 8, 16, 0.48);
   color: var(--shell-text);
   font: inherit;
+}
+
+.queue-field textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.peer-create-form {
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(140px, auto) minmax(140px, auto) auto;
+}
+
+.peer-reference-field {
+  grid-column: 1 / span 2;
 }
 
 .queue-key-export {
@@ -468,6 +491,72 @@ a {
   accent-color: var(--shell-accent);
 }
 
+.peer-card-list {
+  display: grid;
+  gap: 14px;
+}
+
+.peer-card {
+  display: grid;
+  gap: 14px;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.peer-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.peer-card-heading {
+  display: grid;
+  gap: 4px;
+}
+
+.peer-card-title,
+.peer-form-title {
+  margin: 0;
+}
+
+.peer-card-subtitle {
+  margin: 0;
+  color: var(--shell-muted);
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.peer-card-pills,
+.peer-card-links,
+.peer-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.peer-inline-form {
+  display: grid;
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.peer-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.peer-form-title {
+  color: var(--shell-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
 .peer-table {
   width: 100%;
   border-collapse: collapse;
@@ -516,12 +605,18 @@ a {
     grid-template-columns: 1fr;
   }
 
+  .panel-span-2 {
+    grid-column: auto;
+  }
+
   .hero,
   .panel {
     border-radius: 22px;
   }
 
-  .queue-create-form {
+  .queue-create-form,
+  .peer-create-form,
+  .peer-form-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -18,6 +18,7 @@
     reversed: false,
     keysVisible: false,
   };
+  let peerLoadGeneration = 0;
   let queueLoadGeneration = 0;
   const nativeQueueSubmitBypass = new WeakSet();
 
@@ -26,11 +27,19 @@
     connectivity: document.getElementById("connectivity-body"),
     security: document.getElementById("security-body"),
     peers: document.getElementById("peers-body"),
+    peersStatus: document.getElementById("peers-status"),
+    peersReadonlyHint: document.getElementById("peers-readonly-hint"),
     queue: document.getElementById("queue-body"),
     queueCount: document.getElementById("queue-count"),
     queueStatus: document.getElementById("queue-status"),
     queueKeys: document.getElementById("queue-key-export"),
     legacy: document.getElementById("legacy-links"),
+  };
+  const peerControls = {
+    refreshButton: document.getElementById("peers-refresh-button"),
+    createForm: document.getElementById("peer-create-form"),
+    createReference: document.getElementById("peer-reference-text"),
+    createSubmit: document.getElementById("peer-create-submit"),
   };
   const queueControls = {
     downloadsButton: document.getElementById("queue-downloads-button"),
@@ -70,6 +79,16 @@
       return;
     }
     sections.queueStatus.append(text("p", tone ? `status-message ${tone}` : "status-message", message));
+  }
+
+  function setPeerStatus(message, tone) {
+    clear(sections.peersStatus);
+    if (!message) {
+      return;
+    }
+    sections.peersStatus.append(
+      text("p", tone ? `status-message ${tone}` : "status-message", message),
+    );
   }
 
   function definitionList(entries) {
@@ -215,14 +234,219 @@
     );
   }
 
+  function updatePeerToolbar() {
+    peerControls.createForm.hidden = !formPassword;
+    if (sections.peersReadonlyHint) {
+      sections.peersReadonlyHint.hidden = !!formPassword;
+    }
+  }
+
+  function familyLabel(peer) {
+    return peer.family === "opennet" ? "Opennet" : "Darknet";
+  }
+
+  function peerDetailEntries(peer) {
+    const entries = [
+      ["Identity", peer.identity || "Unavailable"],
+      ["Family", familyLabel(peer)],
+      ["Status", peer.status || "Unavailable"],
+      ["Trust", peer.trust || "Unavailable"],
+      ["Visibility", peer.visibility || "Unavailable"],
+    ];
+    if (peer.family === "darknet") {
+      entries.push(["Their visibility", peer.theirVisibility || "Unavailable"]);
+      entries.push(["Disabled", scalar(peer.disabled)]);
+      entries.push(["Listen only", scalar(peer.listenOnly)]);
+      entries.push(["Burst only", scalar(peer.burstOnly)]);
+      entries.push(["Routing enabled", scalar(peer.routingEnabled)]);
+      entries.push(["Private note", peer.hasPrivateNote ? "Present" : "Empty"]);
+    }
+    return entries;
+  }
+
+  function buildPeerSelectField(id, name, label, currentValue, options) {
+    const wrapper = document.createElement("label");
+    wrapper.className = "queue-field peer-form-field";
+    wrapper.setAttribute("for", id);
+
+    wrapper.append(text("span", "", label));
+    const select = document.createElement("select");
+    select.id = id;
+    select.name = name;
+    for (const optionValue of options) {
+      const option = document.createElement("option");
+      option.value = optionValue;
+      option.textContent = optionValue.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+      if (optionValue === currentValue) {
+        option.selected = true;
+      }
+      select.append(option);
+    }
+    wrapper.append(select);
+    return wrapper;
+  }
+
+  function buildPeerSettingsForm(peer) {
+    if (peer.family !== "darknet" || !formPassword) {
+      return null;
+    }
+    const identityToken = encodeURIComponent(peer.identity || "peer");
+    const form = document.createElement("form");
+    form.className = "peer-inline-form";
+    form.dataset.peerAction = "settings";
+    form.dataset.peerIdentity = peer.identity || "";
+    form.dataset.peerDisplayName = peer.displayName || peer.identity || "peer";
+
+    form.append(text("p", "peer-form-title", "Trust and visibility"));
+    const fields = document.createElement("div");
+    fields.className = "peer-form-grid";
+    fields.append(
+      buildPeerSelectField(
+        `peer-trust-${identityToken}`,
+        "trust",
+        "Trust",
+        peer.trust || "NORMAL",
+        ["HIGH", "NORMAL", "LOW"],
+      ),
+      buildPeerSelectField(
+        `peer-visibility-${identityToken}`,
+        "visibility",
+        "Visibility",
+        peer.visibility || "YES",
+        ["YES", "NAME_ONLY", "NO"],
+      ),
+    );
+    form.append(fields);
+
+    const actions = document.createElement("div");
+    actions.className = "peer-form-actions";
+    const submit = document.createElement("button");
+    submit.className = "button button-secondary";
+    submit.type = "submit";
+    submit.textContent = "Save settings";
+    actions.append(submit);
+    form.append(actions);
+    return form;
+  }
+
+  function buildPeerNoteForm(peer) {
+    if (peer.family !== "darknet" || !formPassword) {
+      return null;
+    }
+    const identityToken = encodeURIComponent(peer.identity || "peer");
+    const form = document.createElement("form");
+    form.className = "peer-inline-form";
+    form.dataset.peerAction = "note";
+    form.dataset.peerIdentity = peer.identity || "";
+    form.dataset.peerDisplayName = peer.displayName || peer.identity || "peer";
+
+    form.append(text("p", "peer-form-title", "Private note"));
+    const label = document.createElement("label");
+    label.className = "queue-field peer-form-field";
+    label.setAttribute("for", `peer-note-${identityToken}`);
+    label.append(text("span", "", "Note text"));
+    const textarea = document.createElement("textarea");
+    textarea.id = `peer-note-${identityToken}`;
+    textarea.name = "noteText";
+    textarea.rows = 3;
+    textarea.maxLength = 250;
+    textarea.value = typeof peer.privateNoteText === "string" ? peer.privateNoteText : "";
+    label.append(textarea);
+    form.append(label);
+
+    const actions = document.createElement("div");
+    actions.className = "peer-form-actions";
+    const submit = document.createElement("button");
+    submit.className = "button button-secondary";
+    submit.type = "submit";
+    submit.textContent = "Save note";
+    actions.append(submit);
+    form.append(actions);
+    return form;
+  }
+
+  function buildPeerRemoveForm(peer) {
+    if (!formPassword) {
+      return null;
+    }
+    const form = document.createElement("form");
+    form.className = "peer-inline-form peer-remove-form";
+    form.dataset.peerAction = "remove";
+    form.dataset.peerIdentity = peer.identity || "";
+    form.dataset.peerDisplayName = peer.displayName || peer.identity || "peer";
+    form.dataset.peerRequiresForceRemoval = peer.removableWithoutForce === false ? "true" : "false";
+
+    const actions = document.createElement("div");
+    actions.className = "peer-form-actions";
+    const submit = document.createElement("button");
+    submit.className = "button button-secondary";
+    submit.type = "submit";
+    submit.textContent = "Remove peer";
+    actions.append(submit);
+    form.append(actions);
+    return form;
+  }
+
+  function renderPeerCard(peer) {
+    const card = document.createElement("article");
+    card.className = "peer-card";
+
+    const header = document.createElement("div");
+    header.className = "peer-card-header";
+    const heading = document.createElement("div");
+    heading.className = "peer-card-heading";
+    heading.append(
+      text("h3", "peer-card-title", peer.displayName || peer.identity || "Peer"),
+      text("p", "peer-card-subtitle", peer.identity || "Unavailable"),
+    );
+    const pills = document.createElement("div");
+    pills.className = "peer-card-pills";
+    pills.append(createPill(familyLabel(peer), peer.disabled ? "is-warning" : ""));
+    if (peer.status) {
+      pills.append(createPill(peer.status, peer.disabled ? "is-warning" : ""));
+    }
+    header.append(heading, pills);
+    card.append(header);
+
+    card.append(definitionList(peerDetailEntries(peer)));
+
+    const links = document.createElement("div");
+    links.className = "peer-card-links";
+    const rawLink = document.createElement("a");
+    rawLink.className = "button button-secondary";
+    rawLink.href = apiUrl(
+      `peers/${encodeURIComponent(peer.identity)}?includeMetadata=true&includeVolatile=true`,
+    );
+    rawLink.textContent = "Raw JSON";
+    links.append(rawLink);
+    card.append(links);
+
+    const settingsForm = buildPeerSettingsForm(peer);
+    if (settingsForm) {
+      card.append(settingsForm);
+    }
+    const noteForm = buildPeerNoteForm(peer);
+    if (noteForm) {
+      card.append(noteForm);
+    }
+    const removeForm = buildPeerRemoveForm(peer);
+    if (removeForm) {
+      card.append(removeForm);
+    }
+
+    return card;
+  }
+
   function renderPeers(data) {
-    const peers = Array.isArray(data) ? data : [];
+    const peers = data && Array.isArray(data.peers) ? data.peers : [];
+    const peerCount = data && typeof data.peerCount === "number" ? data.peerCount : peers.length;
     clear(sections.peers);
+    updatePeerToolbar();
 
     sections.peers.append(
       summaryCard("Roster", [
-        ["Peers exported", `${peers.length}`],
-        ["Scope", "Read-only"],
+        ["Peers exported", `${peerCount}`],
+        ["Scope", formPassword ? "Shell-native" : "Read-only"],
       ]),
     );
 
@@ -231,26 +455,12 @@
       return;
     }
 
-    const table = document.createElement("table");
-    table.className = "peer-table";
-    const head = document.createElement("thead");
-    head.innerHTML = "<tr><th>#</th><th>Snapshot</th></tr>";
-    table.append(head);
-
-    const body = document.createElement("tbody");
-    peers.slice(0, 5).forEach((peer, index) => {
-      const row = document.createElement("tr");
-      const indexCell = document.createElement("td");
-      indexCell.textContent = String(index + 1);
-
-      const summaryCell = document.createElement("td");
-      summaryCell.textContent = formatJson(peer);
-
-      row.append(indexCell, summaryCell);
-      body.append(row);
+    const list = document.createElement("div");
+    list.className = "peer-card-list";
+    peers.forEach((peer) => {
+      list.append(renderPeerCard(peer));
     });
-    table.append(body);
-    sections.peers.append(table);
+    sections.peers.append(list);
   }
 
   function updateQueueToolbar() {
@@ -452,10 +662,10 @@
     }
   }
 
-  async function postForm(path, formData) {
+  async function postForm(path, formData, unavailableMessage) {
     const currentFormPassword = await refreshFormPassword();
     if (!currentFormPassword) {
-      throw new Error("Queue mutations unavailable in read-only mode.");
+      throw new Error(unavailableMessage || "Queue mutations unavailable in read-only mode.");
     }
     const body = new URLSearchParams();
     for (const [key, value] of formData.entries()) {
@@ -480,6 +690,30 @@
       throw new Error(extractApiError(data, response));
     }
     return data;
+  }
+
+  function peerPath(peerIdentity, action) {
+    return `peers/${encodeURIComponent(peerIdentity)}/${action}`;
+  }
+
+  async function loadPeersSection() {
+    const loadGeneration = ++peerLoadGeneration;
+    updatePeerToolbar();
+    clear(sections.peers);
+    sections.peers.append(text("p", "loading", "Loading peer roster..."));
+
+    try {
+      const roster = await loadJson(apiUrl("peers/roster"));
+      if (loadGeneration !== peerLoadGeneration) {
+        return;
+      }
+      renderPeers(roster);
+    } catch (error) {
+      if (loadGeneration !== peerLoadGeneration) {
+        return;
+      }
+      renderError(sections.peers, "peers", error);
+    }
   }
 
   function queueMutationPath(submitterName) {
@@ -614,6 +848,47 @@
     }
   }
 
+  async function submitPeerCreate(event) {
+    event.preventDefault();
+    const formData = new FormData(peerControls.createForm);
+    try {
+      const data = await postForm(
+        "peers/add",
+        formData,
+        "Peer mutations unavailable in read-only mode.",
+      );
+      if (data.operation === "add") {
+        peerControls.createForm.reset();
+      }
+      setPeerStatus("Peer added.", "is-success");
+      await loadPeersSection();
+    } catch (error) {
+      setPeerStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  async function submitPeerMutation(form, action) {
+    const peerIdentity = form.dataset.peerIdentity || "";
+    const formData = new FormData(form);
+
+    try {
+      const data = await postForm(
+        peerPath(peerIdentity, action),
+        formData,
+        "Peer mutations unavailable in read-only mode.",
+      );
+      const operation = data.operation || action;
+      if (action === "remove") {
+        setPeerStatus("Peer removed.", "is-success");
+      } else {
+        setPeerStatus(`Peer action completed: ${operation.replaceAll("_", " ")}.`, "is-success");
+      }
+      await loadPeersSection();
+    } catch (error) {
+      setPeerStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
   function submitLegacyQueueForm(form, submitter) {
     if (
       typeof form.requestSubmit === "function" &&
@@ -722,6 +997,46 @@
     });
   }
 
+  function bindPeerInteractions() {
+    peerControls.refreshButton.addEventListener("click", () => {
+      setPeerStatus("Refreshing peer roster.");
+      loadPeersSection();
+    });
+    peerControls.createForm.addEventListener("submit", submitPeerCreate);
+    sections.peers.addEventListener("submit", async (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+      const action = form.dataset.peerAction;
+      if (!action) {
+        return;
+      }
+      event.preventDefault();
+      if (action === "remove") {
+        const displayName = form.dataset.peerDisplayName || "peer";
+        const requiresForceRemoval = form.dataset.peerRequiresForceRemoval === "true";
+        const confirmMessage = requiresForceRemoval
+          ? `Remove ${displayName}? This peer requires force removal.`
+          : `Remove ${displayName}?`;
+        if (!window.confirm(confirmMessage)) {
+          return;
+        }
+        if (requiresForceRemoval) {
+          let forceRemovalField = form.querySelector('input[name="forceRemoval"]');
+          if (!(forceRemovalField instanceof HTMLInputElement)) {
+            forceRemovalField = document.createElement("input");
+            forceRemovalField.type = "hidden";
+            forceRemovalField.name = "forceRemoval";
+            form.append(forceRemovalField);
+          }
+          forceRemovalField.value = "true";
+        }
+      }
+      await submitPeerMutation(form, action);
+    });
+  }
+
   async function loadShellData() {
     const requests = [
       loadJson(apiUrl("node/greeting"))
@@ -733,9 +1048,6 @@
       loadJson(apiUrl("security-levels"))
         .then((data) => ({ section: "security", data }))
         .catch((error) => ({ section: "security", error })),
-      loadJson(apiUrl("peers?includeMetadata=false&includeVolatile=false"))
-        .then((data) => ({ section: "peers", data }))
-        .catch((error) => ({ section: "peers", error })),
     ];
 
     const results = await Promise.all(requests);
@@ -750,17 +1062,20 @@
         renderConnectivity(result.data);
       } else if (result.section === "security") {
         renderSecurity(result.data);
-      } else if (result.section === "peers") {
-        renderPeers(result.data);
       }
     }
   }
 
   renderLegacyLinks();
+  bindPeerInteractions();
   bindQueueInteractions();
+  updatePeerToolbar();
   updateQueueToolbar();
   loadShellData().catch((error) => {
     renderError(sections.overview, "Shell", error);
+  });
+  loadPeersSection().catch((error) => {
+    renderError(sections.peers, "peers", error);
   });
   loadQueueSection().catch((error) => {
     renderError(sections.queue, "queue", error);

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -774,7 +774,7 @@
     sections.peers.append(text("p", "loading", "Loading peer roster..."));
 
     try {
-      const roster = await loadJson(apiUrl("peers/summary"));
+      const roster = await loadJson(apiUrl("peers?view=summary"));
       if (loadGeneration !== peerLoadGeneration) {
         return;
       }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -585,6 +585,61 @@
     return formPassword;
   }
 
+  function renderQueueHtmlFragment(html, className) {
+    const container = document.createElement("div");
+    container.className = className;
+    if (typeof html !== "string" || html.length === 0) {
+      return container;
+    }
+
+    const parsedDocument = new DOMParser().parseFromString(html, "text/html");
+    sanitizeQueueNode(parsedDocument.body);
+    container.replaceChildren(...Array.from(parsedDocument.body.childNodes));
+    return container;
+  }
+
+  function sanitizeQueueNode(root) {
+    root
+      .querySelectorAll("script, style, template, iframe, frame, frameset, object, embed, link, meta, base")
+      .forEach((node) => {
+        node.remove();
+      });
+
+    root.querySelectorAll("*").forEach((element) => {
+      Array.from(element.attributes).forEach((attribute) => {
+        const attributeName = attribute.name.toLowerCase();
+        if (attributeName.startsWith("on") || attributeName === "style" || attributeName === "srcdoc") {
+          element.removeAttribute(attribute.name);
+          return;
+        }
+        if (
+          (attributeName === "href" ||
+            attributeName === "src" ||
+            attributeName === "action" ||
+            attributeName === "formaction") &&
+          !isSafeQueueUrl(attribute.value)
+        ) {
+          element.removeAttribute(attribute.name);
+        }
+      });
+    });
+  }
+
+  function isSafeQueueUrl(rawValue) {
+    const value = typeof rawValue === "string" ? rawValue.trim() : "";
+    if (value.length === 0 || value.startsWith("//")) {
+      return value.length === 0;
+    }
+    try {
+      const url = new URL(value, window.location.href);
+      return (
+        (url.protocol === "http:" || url.protocol === "https:") && url.origin === window.location.origin
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
   function renderQueue(snapshot, countSnapshot, keysPayload) {
     clear(sections.queue);
     clear(sections.queueCount);
@@ -593,9 +648,10 @@
     updateQueueToolbar();
 
     if (countSnapshot && typeof countSnapshot.contentHtml === "string" && countSnapshot.contentHtml) {
-      const countNode = document.createElement("div");
-      countNode.className = "queue-html queue-count-html";
-      countNode.innerHTML = countSnapshot.contentHtml;
+      const countNode = renderQueueHtmlFragment(
+        countSnapshot.contentHtml,
+        "queue-html queue-count-html",
+      );
       rewriteQueueRelativeLinks(countNode);
       injectFormPassword(countNode);
       if (!formPassword) {
@@ -605,9 +661,7 @@
     }
 
     if (snapshot && typeof snapshot.contentHtml === "string") {
-      const contentNode = document.createElement("div");
-      contentNode.className = "queue-html";
-      contentNode.innerHTML = snapshot.contentHtml;
+      const contentNode = renderQueueHtmlFragment(snapshot.contentHtml, "queue-html");
       rewriteQueueRelativeLinks(contentNode);
       injectFormPassword(contentNode);
       if (!formPassword) {

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -6,8 +6,10 @@
     ? JSON.parse(bootstrapElement.textContent || "{}")
     : {};
 
-  const apiRoot = typeof bootstrap.platformApiRoot === "string" ? bootstrap.platformApiRoot : "/api/v1/";
-  const shellRoot = typeof bootstrap.shellRoot === "string" ? bootstrap.shellRoot : "/app/node/";
+  const apiRoot = normalizeLocalRootPath(bootstrap.platformApiRoot, "/api/v1/");
+  const shellRoot = normalizeLocalRootPath(bootstrap.shellRoot, "/app/node/");
+  const apiRootUrl = new URL(apiRoot, window.location.origin);
+  const shellRootUrl = new URL(shellRoot, window.location.origin);
   let formPassword = typeof bootstrap.formPassword === "string" ? bootstrap.formPassword : "";
   const legacyLinks = Array.isArray(bootstrap.legacyLinks) ? bootstrap.legacyLinks : [];
   const directDownloadOperation = "create_direct_download";
@@ -53,7 +55,22 @@
   };
 
   function apiUrl(path) {
-    return apiRoot + path;
+    return new URL(path, apiRootUrl).toString();
+  }
+
+  function normalizeLocalRootPath(value, fallback) {
+    if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+      return fallback;
+    }
+    try {
+      const url = new URL(value, window.location.origin);
+      if (url.origin !== window.location.origin || url.search !== "" || url.hash !== "") {
+        return fallback;
+      }
+      return url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+    } catch (error) {
+      return fallback;
+    }
   }
 
   function clear(node) {
@@ -567,7 +584,7 @@
   }
 
   async function refreshFormPassword() {
-    const response = await fetch(shellRoot, {
+    const response = await fetch(shellRootUrl.toString(), {
       headers: { Accept: "text/html" },
       cache: "no-store",
     });

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -774,7 +774,7 @@
     sections.peers.append(text("p", "loading", "Loading peer roster..."));
 
     try {
-      const roster = await loadJson(apiUrl("peers/roster"));
+      const roster = await loadJson(apiUrl("peers/summary"));
       if (loadGeneration !== peerLoadGeneration) {
         return;
       }

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -12,8 +12,12 @@ class WebShellResourcesTest {
     String html = WebShellResources.readText(WebShellPaths.INDEX_RESOURCE_PATH);
 
     assertTrue(html.contains("Web Shell v1"));
+    assertTrue(html.contains("Peer control plane"));
     assertTrue(html.contains("Queue control plane"));
     assertTrue(html.contains("__BOOTSTRAP_JSON__"));
+    assertTrue(html.contains("peer-create-form\" hidden"));
+    assertTrue(html.contains("name=\"referenceText\""));
+    assertTrue(html.contains("id=\"peers-status\""));
     assertTrue(html.contains("name=\"filterData\" type=\"checkbox\" checked"));
     assertTrue(html.contains("queue-create-form\" hidden"));
   }
@@ -28,6 +32,9 @@ class WebShellResourcesTest {
     assertQueueLoadSequencing(script);
     assertQueueLinkRewriting(script);
     assertReadOnlyQueueHandling(script);
+    assertPeerMutationMarkersPresent(script);
+    assertPeerMutationSubmissionOrder(script);
+    assertPeerLoadSequencing(script);
   }
 
   private static void assertQueueMutationMarkersPresent(String script) {
@@ -37,7 +44,9 @@ class WebShellResourcesTest {
     assertTrue(script.contains("let queueLoadGeneration = 0;"));
     assertTrue(script.contains("let formPassword ="));
     assertTrue(
-        script.contains("throw new Error(\"Queue mutations unavailable in read-only mode.\");"));
+        script.contains(
+            "throw new Error(unavailableMessage || \"Queue mutations unavailable in read-only"
+                + " mode.\");"));
     assertTrue(
         script.contains(
             "queueControls.createForm.hidden = queueState.page !== \"downloads\" ||"
@@ -128,5 +137,57 @@ class WebShellResourcesTest {
     assertTrue(filteredMutationFormDataIndex > buildMutationFormDataIndex);
     assertTrue(refreshFormPasswordIndex >= 0);
     assertTrue(postRefreshIndex > refreshFormPasswordIndex);
+  }
+
+  private static void assertPeerMutationMarkersPresent(String script) {
+    assertTrue(script.contains("let peerLoadGeneration = 0;"));
+    assertTrue(script.contains("function updatePeerToolbar()"));
+    assertTrue(script.contains("async function submitPeerCreate(event)"));
+    assertTrue(script.contains("async function submitPeerMutation(form, action)"));
+    assertTrue(script.contains("async function loadPeersSection()"));
+    assertTrue(script.contains("loadJson(apiUrl(\"peers/roster\"))"));
+    assertTrue(script.contains("peerControls.createForm.hidden = !formPassword;"));
+    assertTrue(script.contains("form.dataset.peerRequiresForceRemoval"));
+    assertTrue(script.contains("forceRemoval"));
+    assertTrue(script.contains("Peer mutations unavailable in read-only mode."));
+  }
+
+  private static void assertPeerMutationSubmissionOrder(String script) {
+    int bindPeersIndex = script.indexOf("function bindPeerInteractions()");
+    int actionLookupIndex =
+        script.indexOf("const action = form.dataset.peerAction;", bindPeersIndex);
+    int preventDefaultIndex = script.indexOf("event.preventDefault();", actionLookupIndex);
+    int requiresForceRemovalIndex =
+        script.indexOf(
+            "const requiresForceRemoval = form.dataset.peerRequiresForceRemoval === \"true\";",
+            bindPeersIndex);
+    int confirmIndex = script.indexOf("window.confirm(confirmMessage)", bindPeersIndex);
+    int mutationIndex = script.indexOf("await submitPeerMutation(form, action);", bindPeersIndex);
+
+    assertTrue(bindPeersIndex >= 0);
+    assertTrue(actionLookupIndex > bindPeersIndex);
+    assertTrue(preventDefaultIndex > actionLookupIndex);
+    assertTrue(requiresForceRemovalIndex > preventDefaultIndex);
+    assertTrue(confirmIndex > requiresForceRemovalIndex);
+    assertTrue(mutationIndex > confirmIndex);
+  }
+
+  private static void assertPeerLoadSequencing(String script) {
+    int loadPeersIndex = script.indexOf("const loadGeneration = ++peerLoadGeneration;");
+    int successGuardIndex =
+        script.indexOf("if (loadGeneration !== peerLoadGeneration) {", loadPeersIndex);
+    int renderPeersIndex = script.indexOf("renderPeers(roster);", loadPeersIndex);
+    int errorGuardIndex =
+        script.indexOf("if (loadGeneration !== peerLoadGeneration) {", successGuardIndex + 1);
+    int renderErrorIndex =
+        script.indexOf("renderError(sections.peers, \"peers\", error);", loadPeersIndex);
+    int loadPeersCatchIndex = script.indexOf("loadPeersSection().catch((error) => {");
+
+    assertTrue(loadPeersIndex >= 0);
+    assertTrue(successGuardIndex > loadPeersIndex);
+    assertTrue(renderPeersIndex > successGuardIndex);
+    assertTrue(errorGuardIndex > renderPeersIndex);
+    assertTrue(renderErrorIndex > errorGuardIndex);
+    assertTrue(loadPeersCatchIndex > renderErrorIndex);
   }
 }

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -171,7 +171,7 @@ class WebShellResourcesTest {
     assertTrue(script.contains("async function submitPeerCreate(event)"));
     assertTrue(script.contains("async function submitPeerMutation(form, action)"));
     assertTrue(script.contains("async function loadPeersSection()"));
-    assertTrue(script.contains("loadJson(apiUrl(\"peers/summary\"))"));
+    assertTrue(script.contains("loadJson(apiUrl(\"peers?view=summary\"))"));
     assertTrue(script.contains("peerControls.createForm.hidden = !formPassword;"));
     assertTrue(script.contains("form.dataset.peerRequiresForceRemoval"));
     assertTrue(script.contains("forceRemoval"));

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -39,6 +39,9 @@ class WebShellResourcesTest {
 
   private static void assertQueueMutationMarkersPresent(String script) {
     assertTrue(script.contains("function queuePriorityFieldName(submitterName)"));
+    assertTrue(script.contains("function renderQueueHtmlFragment(html, className)"));
+    assertTrue(script.contains("function sanitizeQueueNode(root)"));
+    assertTrue(script.contains("function isSafeQueueUrl(rawValue)"));
     assertTrue(script.contains("case \"change_priority_top\":"));
     assertTrue(script.contains("case \"change_priority_bottom\":"));
     assertTrue(script.contains("let queueLoadGeneration = 0;"));
@@ -120,8 +123,16 @@ class WebShellResourcesTest {
 
   private static void assertReadOnlyQueueHandling(String script) {
     int stripReadOnlyFormsIndex = script.indexOf("function stripReadOnlyQueueForms(root)");
+    int renderQueueHtmlFragmentIndex =
+        script.indexOf("function renderQueueHtmlFragment(html, className)");
     int countReadOnlyStripIndex = script.indexOf("stripReadOnlyQueueForms(countNode);");
     int contentReadOnlyStripIndex = script.indexOf("stripReadOnlyQueueForms(contentNode);");
+    int countRenderIndex =
+        script.indexOf("const countNode = renderQueueHtmlFragment(", renderQueueHtmlFragmentIndex);
+    int contentRenderIndex =
+        script.indexOf(
+            "const contentNode = renderQueueHtmlFragment(snapshot.contentHtml, \"queue-html\");",
+            renderQueueHtmlFragmentIndex);
     int buildMutationFormDataIndex =
         script.indexOf("function buildQueueMutationFormData(form, submitter, path)");
     int filteredMutationFormDataIndex =
@@ -131,6 +142,9 @@ class WebShellResourcesTest {
         script.indexOf("const currentFormPassword = await refreshFormPassword();");
 
     assertTrue(stripReadOnlyFormsIndex >= 0);
+    assertTrue(renderQueueHtmlFragmentIndex > stripReadOnlyFormsIndex);
+    assertTrue(countRenderIndex > renderQueueHtmlFragmentIndex);
+    assertTrue(contentRenderIndex > countRenderIndex);
     assertTrue(countReadOnlyStripIndex > stripReadOnlyFormsIndex);
     assertTrue(contentReadOnlyStripIndex > stripReadOnlyFormsIndex);
     assertTrue(buildMutationFormDataIndex >= 0);

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -171,7 +171,7 @@ class WebShellResourcesTest {
     assertTrue(script.contains("async function submitPeerCreate(event)"));
     assertTrue(script.contains("async function submitPeerMutation(form, action)"));
     assertTrue(script.contains("async function loadPeersSection()"));
-    assertTrue(script.contains("loadJson(apiUrl(\"peers/roster\"))"));
+    assertTrue(script.contains("loadJson(apiUrl(\"peers/summary\"))"));
     assertTrue(script.contains("peerControls.createForm.hidden = !formPassword;"));
     assertTrue(script.contains("form.dataset.peerRequiresForceRemoval"));
     assertTrue(script.contains("forceRemoval"));

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -38,6 +38,15 @@ class WebShellResourcesTest {
   }
 
   private static void assertQueueMutationMarkersPresent(String script) {
+    assertTrue(
+        script.contains(
+            "const apiRoot = normalizeLocalRootPath(bootstrap.platformApiRoot, \"/api/v1/\");"));
+    assertTrue(
+        script.contains(
+            "const shellRoot = normalizeLocalRootPath(bootstrap.shellRoot, \"/app/node/\");"));
+    assertTrue(script.contains("const apiRootUrl = new URL(apiRoot, window.location.origin);"));
+    assertTrue(script.contains("const shellRootUrl = new URL(shellRoot, window.location.origin);"));
+    assertTrue(script.contains("function normalizeLocalRootPath(value, fallback)"));
     assertTrue(script.contains("function queuePriorityFieldName(submitterName)"));
     assertTrue(script.contains("function renderQueueHtmlFragment(html, className)"));
     assertTrue(script.contains("function sanitizeQueueNode(root)"));
@@ -138,6 +147,8 @@ class WebShellResourcesTest {
     int filteredMutationFormDataIndex =
         script.indexOf("const formData = buildQueueMutationFormData(form, submitter, path);");
     int refreshFormPasswordIndex = script.indexOf("async function refreshFormPassword()");
+    int normalizedShellRootFetchIndex =
+        script.indexOf("const response = await fetch(shellRootUrl.toString(), {");
     int postRefreshIndex =
         script.indexOf("const currentFormPassword = await refreshFormPassword();");
 
@@ -150,6 +161,7 @@ class WebShellResourcesTest {
     assertTrue(buildMutationFormDataIndex >= 0);
     assertTrue(filteredMutationFormDataIndex > buildMutationFormDataIndex);
     assertTrue(refreshFormPasswordIndex >= 0);
+    assertTrue(normalizedShellRootFetchIndex > refreshFormPasswordIndex);
     assertTrue(postRefreshIndex > refreshFormPasswordIndex);
   }
 

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -300,6 +300,93 @@ class PlatformApiToadletTest {
   }
 
   @Test
+  void handleMethodPOST_whenPeerAddRequested_routesDecodedAddRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames())
+        .thenReturn(List.of("referenceText", "trust", "visibility", "privateNoteText"));
+    when(request.getMultipleParam("referenceText"))
+        .thenReturn(
+            new String[] {
+"""
+identity=peer-123
+lastGoodVersion=1
+myName=Alice
+physical.udp=127.0.0.1:9481
+End
+"""
+            });
+    when(request.getMultipleParam("trust")).thenReturn(new String[] {"NORMAL"});
+    when(request.getMultipleParam("visibility")).thenReturn(new String[] {"YES"});
+    when(request.getMultipleParam("privateNoteText")).thenReturn(new String[] {"friend note"});
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(URI.create("http://localhost/api/v1/peers/add"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("peers", "add"),
+                Map.of(
+                    "referenceText",
+                        List.of(
+                            """
+                            identity=peer-123
+                            lastGoodVersion=1
+                            myName=Alice
+                            physical.udp=127.0.0.1:9481
+                            End
+                            """),
+                    "trust", List.of("NORMAL"),
+                    "visibility", List.of("YES"),
+                    "privateNoteText", List.of("friend note"))));
+  }
+
+  @Test
+  void handleMethodPOST_whenPeerSettingsRequested_routesDecodedMutationRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of("trust", "visibility"));
+    when(request.getMultipleParam("trust")).thenReturn(new String[] {"HIGH"});
+    when(request.getMultipleParam("visibility")).thenReturn(new String[] {"NAME_ONLY"});
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/peers/peer%2F123/settings"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("peers", "peer/123", "settings"),
+                Map.of("trust", List.of("HIGH"), "visibility", List.of("NAME_ONLY"))));
+  }
+
+  @Test
+  void handleMethodPOST_whenPeerNoteUsesFormPart_routesDecodedMutationRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(request.getRawData()).thenReturn(requestBody);
+    when(request.getParts()).thenReturn(new String[] {"noteText"});
+    when(request.getPartAsStringFailsafe("noteText", QueueToadlet.MAX_KEY_LENGTH))
+        .thenReturn("updated note");
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/peers/peer-123/note"), request, ctx);
+
+    verify(router)
+        .route(
+            new PlatformApiRequest(
+                "POST",
+                List.of("peers", "peer-123", "note"),
+                Map.of("noteText", List.of("updated note"))));
+    verify(request).getPartAsStringFailsafe("noteText", QueueToadlet.MAX_KEY_LENGTH);
+  }
+
+  @Test
   void handleMethodPOST_whenQueueMutationPasswordMissing_expectJson403WithoutRouting()
       throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
@@ -307,6 +394,26 @@ class PlatformApiToadletTest {
 
     toadlet.handleMethodPOST(
         URI.create("http://localhost/api/v1/queue/requests/remove"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals("Forbidden", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"forbidden\",\"message\":\"Valid form password is required.\"}}",
+        bodyWrite.bodyText());
+  }
+
+  @Test
+  void handleMethodPOST_whenPeerMutationPasswordMissing_expectJson403WithoutRouting()
+      throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(false);
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/peers/peer-123/remove"), request, ctx);
 
     verifyNoInteractions(router);
     ReplyHeadersCapture replyHeaders = captureReplyHeaders();

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -244,7 +244,7 @@ class PlatformApiRouterTest {
   }
 
   @Test
-  void route_whenPeerRosterRequested_expectStructuredRosterJson() {
+  void route_whenPeerSummaryRequested_expectStructuredRosterJson() {
     LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(3);
     directValues.put("identity", "peer-1");
     directValues.put("myName", "Alice");
@@ -267,7 +267,7 @@ class PlatformApiRouterTest {
             List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", false)));
 
     PlatformApiResponse response =
-        router.route(request("GET", List.of("peers", "roster"), Map.of()));
+        router.route(request("GET", List.of("peers", "summary"), Map.of()));
 
     verify(peerPort).list(true, true);
     verify(darknetConnectionsPort).listPeers();
@@ -283,7 +283,7 @@ class PlatformApiRouterTest {
   }
 
   @Test
-  void route_whenPeerRosterStatusIsRoutingDisabled_expectEffectiveRoutingDisabledJson() {
+  void route_whenPeerSummaryStatusIsRoutingDisabled_expectEffectiveRoutingDisabledJson() {
     LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(3);
     directValues.put("identity", "peer-1");
     directValues.put("myName", "Alice");
@@ -300,10 +300,23 @@ class PlatformApiRouterTest {
             List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", true)));
 
     PlatformApiResponse response =
-        router.route(request("GET", List.of("peers", "roster"), Map.of()));
+        router.route(request("GET", List.of("peers", "summary"), Map.of()));
 
     assertEquals(200, response.statusCode());
     assertTrue(response.body().contains("\"routingEnabled\":false"));
+  }
+
+  @Test
+  void route_whenPeerNamedRosterRequested_expectRawPeerLookupStillUsed() throws Exception {
+    when(peerPort.get("roster", false, false))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(Map.of("identity", "roster"), Map.of())));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("peers", "roster"), Map.of()));
+
+    verify(peerPort).get("roster", false, false);
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"roster\""));
   }
 
   @Test
@@ -464,16 +477,15 @@ class PlatformApiRouterTest {
   }
 
   @Test
-  void route_whenPeerAddGetRequested_expectMethodNotAllowedWithAllowPost() {
+  void route_whenPeerNamedAddRequested_expectRawPeerLookupStillUsed() throws Exception {
+    when(peerPort.get("add", false, false))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(Map.of("identity", "add"), Map.of())));
+
     PlatformApiResponse response = router.route(request("GET", List.of("peers", "add"), Map.of()));
 
-    assertEquals(405, response.statusCode());
-    assertEquals("Method Not Allowed", response.reasonPhrase());
-    assertEquals(Map.of("Allow", "POST"), response.headers());
-    assertEquals(
-        "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Platform API v1 supports POST"
-            + " requests only.\"}}",
-        response.body());
+    verify(peerPort).get("add", false, false);
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"add\""));
   }
 
   @Test

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -29,14 +29,20 @@ import network.crypta.runtime.spi.ConnectivitySnapshot;
 import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
 import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
 import network.crypta.runtime.spi.ConnectivityTrafficInitiator;
+import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
+import network.crypta.runtime.spi.DarknetConnectionsPort;
+import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.runtime.spi.NodeInfoPort;
 import network.crypta.runtime.spi.NodeReferenceSnapshot;
 import network.crypta.runtime.spi.NodeReferenceView;
+import network.crypta.runtime.spi.PeerAddRejectedException;
 import network.crypta.runtime.spi.PeerFieldSet;
 import network.crypta.runtime.spi.PeerPort;
 import network.crypta.runtime.spi.PeerSnapshot;
+import network.crypta.runtime.spi.PeerTrust;
+import network.crypta.runtime.spi.PeerVisibility;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRequest;
@@ -45,6 +51,7 @@ import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
 import network.crypta.runtime.spi.QueueSupportPort;
+import network.crypta.runtime.spi.RemovedPeerSnapshot;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.SecurityLevelsSnapshot;
@@ -55,11 +62,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -80,6 +90,7 @@ class PlatformApiRouterTest {
   @Mock private RuntimePorts runtimePorts;
   @Mock private NodeInfoPort nodeInfoPort;
   @Mock private PeerPort peerPort;
+  @Mock private DarknetConnectionsPort darknetConnectionsPort;
   @Mock private ConfigPort configPort;
   @Mock private ConnectivityPort connectivityPort;
   @Mock private SecurityLevelsPort securityLevelsPort;
@@ -98,6 +109,7 @@ class PlatformApiRouterTest {
   void setUp() {
     when(runtimePorts.nodeInfo()).thenReturn(nodeInfoPort);
     when(runtimePorts.peer()).thenReturn(peerPort);
+    when(runtimePorts.darknetConnections()).thenReturn(darknetConnectionsPort);
     when(runtimePorts.config()).thenReturn(configPort);
     when(runtimePorts.connectivity()).thenReturn(connectivityPort);
     when(runtimePorts.securityLevels()).thenReturn(securityLevelsPort);
@@ -229,6 +241,327 @@ class PlatformApiRouterTest {
     assertEquals(
         "{\"nodeIdentifier\":\"peer-2\",\"status\":\"backed-off\",\"physical\":{\"address\":\"127.0.0.1\"}}",
         response.body());
+  }
+
+  @Test
+  void route_whenPeerRosterRequested_expectStructuredRosterJson() {
+    LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(3);
+    directValues.put("identity", "peer-1");
+    directValues.put("myName", "Alice");
+    directValues.put("opennet", "false");
+    LinkedHashMap<String, PeerFieldSet> directSubsets = LinkedHashMap.newLinkedHashMap(2);
+    directSubsets.put(
+        "metadata",
+        new PeerFieldSet(
+            Map.of(
+                "trustLevel", "HIGH",
+                "ourVisibility", "NAME_ONLY",
+                "isDisabled", "true",
+                "disableRoutingHasBeenSetLocally", "true"),
+            Map.of()));
+    directSubsets.put("volatile", new PeerFieldSet(Map.of("status", "CONNECTED"), Map.of()));
+    when(peerPort.list(true, true))
+        .thenReturn(List.of(new PeerSnapshot(new PeerFieldSet(directValues, directSubsets))));
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(
+            List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", false)));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("peers", "roster"), Map.of()));
+
+    verify(peerPort).list(true, true);
+    verify(darknetConnectionsPort).listPeers();
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"peer-1\""));
+    assertTrue(response.body().contains("\"displayName\":\"Alice\""));
+    assertTrue(response.body().contains("\"family\":\"darknet\""));
+    assertTrue(response.body().contains("\"trust\":\"HIGH\""));
+    assertTrue(response.body().contains("\"visibility\":\"NAME_ONLY\""));
+    assertTrue(response.body().contains("\"disabled\":true"));
+    assertTrue(response.body().contains("\"routingEnabled\":false"));
+    assertTrue(response.body().contains("\"privateNoteText\":\"trusted\""));
+  }
+
+  @Test
+  void route_whenPeerRosterStatusIsRoutingDisabled_expectEffectiveRoutingDisabledJson() {
+    LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(3);
+    directValues.put("identity", "peer-1");
+    directValues.put("myName", "Alice");
+    directValues.put("opennet", "false");
+    LinkedHashMap<String, PeerFieldSet> directSubsets = LinkedHashMap.newLinkedHashMap(2);
+    directSubsets.put(
+        "metadata",
+        new PeerFieldSet(Map.of("trustLevel", "HIGH", "ourVisibility", "YES"), Map.of()));
+    directSubsets.put("volatile", new PeerFieldSet(Map.of("status", "ROUTING DISABLED"), Map.of()));
+    when(peerPort.list(true, true))
+        .thenReturn(List.of(new PeerSnapshot(new PeerFieldSet(directValues, directSubsets))));
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(
+            List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", true)));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("peers", "roster"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"routingEnabled\":false"));
+  }
+
+  @Test
+  void route_whenPeerAddRequested_expectCreatedPeerFromParsedReference()
+      throws PeerAddRejectedException {
+    when(peerPort.add(any(PeerFieldSet.class), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES)))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(Map.of("identity", "peer-added"), Map.of())));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "add"),
+                Map.of(
+                    "referenceText",
+                    List.of(
+                        """
+                        identity=peer-added
+                        lastGoodVersion=1
+                        myName=Alice
+                        physical.udp=127.0.0.1:9481
+                        End
+                        """),
+                    "trust",
+                    List.of("NORMAL"),
+                    "visibility",
+                    List.of("YES"))));
+
+    ArgumentCaptor<PeerFieldSet> referenceCaptor = ArgumentCaptor.forClass(PeerFieldSet.class);
+    verify(peerPort).add(referenceCaptor.capture(), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES));
+    PeerFieldSet reference = referenceCaptor.getValue();
+    assertEquals("peer-added", reference.directValues().get("identity"));
+    assertEquals("1", reference.directValues().get("lastGoodVersion"));
+    assertEquals("Alice", reference.directValues().get("myName"));
+    assertEquals(
+        "127.0.0.1:9481", reference.directSubsets().get("physical").directValues().get("udp"));
+    assertEquals(201, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"peer-added\""));
+  }
+
+  @Test
+  void route_whenPeerAddNoteWriteFails_expectCreatedPeerResponseStillReturned() throws Exception {
+    when(peerPort.add(any(PeerFieldSet.class), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES)))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(Map.of("identity", "peer-added"), Map.of())));
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(List.of(new DarknetConnectionPeerSnapshot(7, "peer-added", "Alice", "", true)));
+    when(peerPort.writePrivateDarknetCommentByIdentity("peer-added", "trusted"))
+        .thenThrow(new UnknownPeerException("peer-added"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "add"),
+                Map.of(
+                    "referenceText",
+                    List.of(
+                        """
+                        identity=peer-added
+                        lastGoodVersion=1
+                        myName=Alice
+                        physical.udp=127.0.0.1:9481
+                        End
+                        """),
+                    "privateNoteText",
+                    List.of("trusted"))));
+
+    verify(peerPort).writePrivateDarknetCommentByIdentity("peer-added", "trusted");
+    assertEquals(201, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"peer-added\""));
+  }
+
+  @Test
+  void route_whenPeerAddBlankNoteRequested_expectCreatedPeerWithoutPersistingEmptyNote()
+      throws Exception {
+    when(peerPort.add(any(PeerFieldSet.class), eq(PeerTrust.NORMAL), eq(PeerVisibility.YES)))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(Map.of("identity", "peer-added"), Map.of())));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "add"),
+                Map.of(
+                    "referenceText",
+                    List.of(
+                        """
+                        identity=peer-added
+                        lastGoodVersion=1
+                        myName=Alice
+                        physical.udp=127.0.0.1:9481
+                        End
+                        """),
+                    "privateNoteText",
+                    List.of("   "))));
+
+    verify(peerPort, never()).writePrivateDarknetCommentByIdentity(any(), any());
+    assertEquals(201, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"peer-added\""));
+  }
+
+  @Test
+  void route_whenOpennetPeerAddRequestsDarknetOnlyOptions_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "add"),
+                Map.of(
+                    "referenceText",
+                    List.of(
+                        """
+                        identity=peer-added
+                        opennet=true
+                        lastGoodVersion=1
+                        physical.udp=127.0.0.1:9481
+                        End
+                        """),
+                    "trust",
+                    List.of("HIGH"))));
+
+    assertEquals(400, response.statusCode());
+    assertTrue(response.body().contains("\"code\":\"invalid_query_parameter\""));
+    assertTrue(response.body().contains("Opennet peer references do not support"));
+    verifyNoInteractions(peerPort);
+  }
+
+  @Test
+  void route_whenPeerSettingsRequested_expectExactIdentityMutation() throws Exception {
+    when(peerPort.updateDarknetPeerByIdentity(eq("peer-1"), any(DarknetPeerSettingsUpdate.class)))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(Map.of("identity", "peer-1"), Map.of())));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "peer-1", "settings"),
+                Map.of(
+                    "disabled",
+                    List.of("true"),
+                    "routingEnabled",
+                    List.of("false"),
+                    "trust",
+                    List.of("LOW"),
+                    "visibility",
+                    List.of("NO"))));
+
+    ArgumentCaptor<DarknetPeerSettingsUpdate> updateCaptor =
+        ArgumentCaptor.forClass(DarknetPeerSettingsUpdate.class);
+    verify(peerPort).updateDarknetPeerByIdentity(eq("peer-1"), updateCaptor.capture());
+    DarknetPeerSettingsUpdate update = updateCaptor.getValue();
+    assertEquals(Boolean.TRUE, update.disabled());
+    assertEquals(Boolean.FALSE, update.routingEnabled());
+    assertEquals(PeerTrust.LOW, update.trust());
+    assertEquals(PeerVisibility.NO, update.visibility());
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"peer-1\""));
+  }
+
+  @Test
+  void route_whenPeerAddGetRequested_expectMethodNotAllowedWithAllowPost() {
+    PlatformApiResponse response = router.route(request("GET", List.of("peers", "add"), Map.of()));
+
+    assertEquals(405, response.statusCode());
+    assertEquals("Method Not Allowed", response.reasonPhrase());
+    assertEquals(Map.of("Allow", "POST"), response.headers());
+    assertEquals(
+        "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Platform API v1 supports POST"
+            + " requests only.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenPeerNoteRequested_expectExactIdentityNoteWrite() throws Exception {
+    when(peerPort.writePrivateDarknetCommentByIdentity("peer-1", "updated note"))
+        .thenReturn("updated note");
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "peer-1", "note"),
+                Map.of("noteText", List.of("updated note"))));
+
+    verify(peerPort).writePrivateDarknetCommentByIdentity("peer-1", "updated note");
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"noteText\":\"updated note\""));
+  }
+
+  @Test
+  void route_whenPeerRemoveRequested_expectExactIdentityRemoval() throws Exception {
+    when(peerPort.removeByIdentity("peer-1"))
+        .thenReturn(new RemovedPeerSnapshot("peer-1", "peer-1"));
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("peers", "peer-1", "remove"), Map.of()));
+
+    verify(peerPort).removeByIdentity("peer-1");
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"peer-1\""));
+  }
+
+  @Test
+  void route_whenProtectedPeerRemoveRequestedWithoutForce_expectConflictJson() {
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(
+            List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", false)));
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("peers", "peer-1", "remove"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertTrue(response.body().contains("\"code\":\"force_removal_required\""));
+    verifyNoInteractions(peerPort);
+  }
+
+  @Test
+  void route_whenProtectedPeerRemoveRequestedWithForce_expectExactIdentityRemoval()
+      throws Exception {
+    when(darknetConnectionsPort.listPeers())
+        .thenReturn(
+            List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", false)));
+    when(peerPort.removeByIdentity("peer-1"))
+        .thenReturn(new RemovedPeerSnapshot("peer-1", "peer-1"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "peer-1", "remove"),
+                Map.of("forceRemoval", List.of("true"))));
+
+    verify(peerPort).removeByIdentity("peer-1");
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"peer-1\""));
+  }
+
+  @Test
+  void route_whenPeerSettingsRequestedWithoutChanges_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("peers", "peer-1", "settings"), Map.of()));
+
+    assertEquals(400, response.statusCode());
+    verifyNoInteractions(peerPort);
+  }
+
+  @Test
+  void route_whenPeerSettingsBooleanInvalid_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("peers", "peer-1", "settings"),
+                Map.of("disabled", List.of("sometimes"))));
+
+    assertEquals(400, response.statusCode());
+    assertTrue(response.body().contains("\"code\":\"invalid_query_parameter\""));
+    verifyNoInteractions(peerPort);
   }
 
   @Test

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -244,7 +244,7 @@ class PlatformApiRouterTest {
   }
 
   @Test
-  void route_whenPeerSummaryRequested_expectStructuredRosterJson() {
+  void route_whenPeerSummaryViewRequested_expectStructuredRosterJson() {
     LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(3);
     directValues.put("identity", "peer-1");
     directValues.put("myName", "Alice");
@@ -267,7 +267,7 @@ class PlatformApiRouterTest {
             List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", false)));
 
     PlatformApiResponse response =
-        router.route(request("GET", List.of("peers", "summary"), Map.of()));
+        router.route(request("GET", List.of("peers"), Map.of("view", List.of("summary"))));
 
     verify(peerPort).list(true, true);
     verify(darknetConnectionsPort).listPeers();
@@ -283,7 +283,7 @@ class PlatformApiRouterTest {
   }
 
   @Test
-  void route_whenPeerSummaryStatusIsRoutingDisabled_expectEffectiveRoutingDisabledJson() {
+  void route_whenPeerSummaryViewStatusIsRoutingDisabled_expectEffectiveRoutingDisabledJson() {
     LinkedHashMap<String, String> directValues = LinkedHashMap.newLinkedHashMap(3);
     directValues.put("identity", "peer-1");
     directValues.put("myName", "Alice");
@@ -300,10 +300,23 @@ class PlatformApiRouterTest {
             List.of(new DarknetConnectionPeerSnapshot(7, "peer-1", "Alice", "trusted", true)));
 
     PlatformApiResponse response =
-        router.route(request("GET", List.of("peers", "summary"), Map.of()));
+        router.route(request("GET", List.of("peers"), Map.of("view", List.of("summary"))));
 
     assertEquals(200, response.statusCode());
     assertTrue(response.body().contains("\"routingEnabled\":false"));
+  }
+
+  @Test
+  void route_whenPeerNamedSummaryRequested_expectRawPeerLookupStillUsed() throws Exception {
+    when(peerPort.get("summary", false, false))
+        .thenReturn(new PeerSnapshot(new PeerFieldSet(Map.of("identity", "summary"), Map.of())));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("peers", "summary"), Map.of()));
+
+    verify(peerPort).get("summary", false, false);
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"identity\":\"summary\""));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add Platform API peer control-plane support for peers, including a structured roster plus add, settings, note, and remove mutations backed by the detached runtime SPI ports
- enforce the existing admin full-access plus form-password path for peer mutations, preserve legacy safeguards such as force-removal confirmation semantics, and avoid false add failures when follow-up note writes race
- make the Web Shell peers panel operational with shell-native roster rendering, add-peer, trust/visibility updates, private-note editing, and peer removal while keeping legacy connections toadlets available as fallback
- extend router, toadlet, and Web Shell test coverage for the new peer-control-plane routes and edge cases, including force removal, blank note handling, opennet add validation, and effective routing-disabled reporting

## Testing
- ./gradlew :platform-api:test
- ./gradlew :platform-web-shell:test
- ./gradlew :adapter-http-legacy-admin:test
- ./gradlew :test --tests 'network.crypta.platform.api.PlatformApiRouterTest'
- ./gradlew :platform-web-shell:test
- ./gradlew test