### PR TITLE
feat(platform): Add shell-native node control plane

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -52,8 +52,12 @@ public final class PlatformApiToadlet extends Toadlet {
   private static final String DELETE_METHOD = "DELETE";
   private static final String FORM_PASSWORD_PARAMETER = "formPassword";
   private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = QueueToadlet.MAX_KEY_LENGTH;
+  private static final String CONFIG_SEGMENT = "config";
   private static final String PEERS_SEGMENT = "peers";
   private static final String QUEUE_SEGMENT = "queue";
+  private static final String SECURITY_LEVELS_SEGMENT = "security-levels";
+  private static final String UPDATES_SEGMENT = "updates";
+  private static final String WIZARD_SEGMENT = "wizard";
 
   /**
    * Transport-neutral router that owns endpoint selection, validation, and JSON payload creation.
@@ -294,43 +298,87 @@ public final class PlatformApiToadlet extends Toadlet {
    * <p>The legacy shell only auto-checks form passwords for POST before dispatch. The Platform API
    * bridge keeps full-access checks ahead of password checks and applies the same legacy password
    * guard to every currently supported Platform API mutation family. DELETE remains relevant only
-   * for installed-app removal, while queue and peer mutations currently use POST.
+   * for installed-app removal, while the current config, security-levels, updater, wizard, queue,
+   * peer, and app actions use POST.
    *
    * @param method HTTP method name forwarded into the router
    * @param uri request target supplied by the legacy HTTP shell
    * @return {@code true} when the request must present the legacy form password
    */
   private static boolean requiresFormPassword(String method, URI uri) {
-    if (!"POST".equals(method) && !DELETE_METHOD.equals(method)) {
+    if (!requiresFormPasswordEligibleMethod(method)) {
       return false;
     }
 
-    List<String> pathSegments;
-    try {
-      pathSegments = relativeApiPath(requestPath(uri));
-    } catch (URLEncodedFormatException _) {
-      return false;
-    }
-
+    List<String> pathSegments = decodeRelativeApiPath(uri);
     if (pathSegments.isEmpty()) {
       return false;
     }
     if ("apps".equals(pathSegments.getFirst())) {
-      if (DELETE_METHOD.equals(method)) {
-        return pathSegments.size() == 2;
-      }
-      if (pathSegments.size() == 2 && "install".equals(pathSegments.get(1))) {
-        return true;
-      }
-      return pathSegments.size() == 3
-          && ("start".equals(pathSegments.get(2))
-              || "stop".equals(pathSegments.get(2))
-              || "update".equals(pathSegments.get(2)));
+      return requiresAppsFormPassword(method, pathSegments);
     }
-    if (requiresQueueFormPassword(method, pathSegments)) {
+    return requiresNonAppFormPassword(method, pathSegments);
+  }
+
+  /**
+   * Returns whether the current request method participates in the legacy form-password guard.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @return {@code true} when the bridge should inspect the request path for a mutating route
+   */
+  private static boolean requiresFormPasswordEligibleMethod(String method) {
+    return "POST".equals(method) || DELETE_METHOD.equals(method);
+  }
+
+  /**
+   * Decodes one relative API path while treating malformed percent-encoding as a non-matching
+   * mutation route.
+   *
+   * @param uri request target supplied by the legacy HTTP shell
+   * @return decoded relative API path, or an empty list when decoding fails
+   */
+  private static List<String> decodeRelativeApiPath(URI uri) {
+    try {
+      return relativeApiPath(requestPath(uri));
+    } catch (URLEncodedFormatException _) {
+      return List.of();
+    }
+  }
+
+  /**
+   * Returns whether the current request targets one of the mutating app-management routes.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresAppsFormPassword(String method, List<String> pathSegments) {
+    if (DELETE_METHOD.equals(method)) {
+      return pathSegments.size() == 2;
+    }
+    if (pathSegments.size() == 2 && "install".equals(pathSegments.get(1))) {
       return true;
     }
-    return requiresPeersFormPassword(method, pathSegments);
+    return pathSegments.size() == 3
+        && ("start".equals(pathSegments.get(2))
+            || "stop".equals(pathSegments.get(2))
+            || "update".equals(pathSegments.get(2)));
+  }
+
+  /**
+   * Returns whether the current request targets one of the non-app mutating Platform API routes.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresNonAppFormPassword(String method, List<String> pathSegments) {
+    return requiresQueueFormPassword(method, pathSegments)
+        || requiresPeersFormPassword(method, pathSegments)
+        || requiresConfigFormPassword(method, pathSegments)
+        || requiresSecurityLevelsFormPassword(method, pathSegments)
+        || requiresUpdatesFormPassword(method, pathSegments)
+        || requiresWizardFormPassword(method, pathSegments);
   }
 
   /**
@@ -381,6 +429,65 @@ public final class PlatformApiToadlet extends Toadlet {
         && ("settings".equals(pathSegments.get(2))
             || "note".equals(pathSegments.get(2))
             || "remove".equals(pathSegments.get(2)));
+  }
+
+  /**
+   * Returns whether the current request targets one of the mutating config routes.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresConfigFormPassword(String method, List<String> pathSegments) {
+    return "POST".equals(method)
+        && pathSegments.size() == 2
+        && CONFIG_SEGMENT.equals(pathSegments.getFirst())
+        && ("overrides".equals(pathSegments.get(1)) || "persist".equals(pathSegments.get(1)));
+  }
+
+  /**
+   * Returns whether the current request targets one of the mutating security-level routes.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresSecurityLevelsFormPassword(
+      String method, List<String> pathSegments) {
+    return "POST".equals(method)
+        && pathSegments.size() == 2
+        && SECURITY_LEVELS_SEGMENT.equals(pathSegments.getFirst())
+        && ("network".equals(pathSegments.get(1)) || "physical".equals(pathSegments.get(1)));
+  }
+
+  /**
+   * Returns whether the current request targets the mutating updater download route.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresUpdatesFormPassword(String method, List<String> pathSegments) {
+    return "POST".equals(method)
+        && pathSegments.size() == 3
+        && UPDATES_SEGMENT.equals(pathSegments.getFirst())
+        && "core".equals(pathSegments.get(1))
+        && "download".equals(pathSegments.get(2));
+  }
+
+  /**
+   * Returns whether the current request targets the mutating first-time-wizard route.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresWizardFormPassword(String method, List<String> pathSegments) {
+    return "POST".equals(method)
+        && pathSegments.size() == 3
+        && WIZARD_SEGMENT.equals(pathSegments.getFirst())
+        && "first-time".equals(pathSegments.get(1))
+        && "apply".equals(pathSegments.get(2));
   }
 
   /**

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -10,6 +10,8 @@ import network.crypta.platform.api.node.NodeApiHandler;
 import network.crypta.platform.api.peers.PeersApiHandler;
 import network.crypta.platform.api.queue.QueueApiHandler;
 import network.crypta.platform.api.security.SecurityLevelsApiHandler;
+import network.crypta.platform.api.updates.UpdatesApiHandler;
+import network.crypta.platform.api.wizard.FirstTimeWizardApiHandler;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
@@ -46,6 +48,12 @@ public final class PlatformApiRouter {
   /** Handler for the {@code /security-levels} endpoint. */
   private final SecurityLevelsApiHandler securityLevelsApiHandler;
 
+  /** Handler for the {@code /updates/core} endpoint family. */
+  private final UpdatesApiHandler updatesApiHandler;
+
+  /** Handler for the {@code /wizard/first-time} endpoint family. */
+  private final FirstTimeWizardApiHandler firstTimeWizardApiHandler;
+
   /** Handler for the {@code /queue/...} endpoint family. */
   private final QueueApiHandler queueApiHandler;
 
@@ -75,7 +83,11 @@ public final class PlatformApiRouter {
     peersApiHandler = new PeersApiHandler(runtimePorts.peer(), runtimePorts.darknetConnections());
     configApiHandler = new ConfigApiHandler(runtimePorts.config());
     connectivityApiHandler = new ConnectivityApiHandler(runtimePorts.connectivity());
-    securityLevelsApiHandler = new SecurityLevelsApiHandler(runtimePorts.securityLevels());
+    securityLevelsApiHandler =
+        new SecurityLevelsApiHandler(
+            runtimePorts.securityLevels(), runtimePorts.config(), runtimePorts.firstTimeWizard());
+    updatesApiHandler = new UpdatesApiHandler(runtimePorts.coreUpdateAction());
+    firstTimeWizardApiHandler = new FirstTimeWizardApiHandler(runtimePorts.firstTimeWizard());
     queueApiHandler =
         new QueueApiHandler(
             runtimePorts.queuePage(),
@@ -129,6 +141,18 @@ public final class PlatformApiRouter {
     if ("peers".equals(firstSegment)) {
       return routePeersRequest(segments, request);
     }
+    if ("config".equals(firstSegment)) {
+      return routeConfigRequest(segments, request);
+    }
+    if ("security-levels".equals(firstSegment)) {
+      return routeSecurityLevelsRequest(segments, request);
+    }
+    if ("updates".equals(firstSegment)) {
+      return routeUpdatesRequest(segments, request);
+    }
+    if ("wizard".equals(firstSegment)) {
+      return routeWizardRequest(segments, request);
+    }
 
     if (!"GET".equals(request.method())) {
       return PlatformApiResponse.error(
@@ -138,16 +162,149 @@ public final class PlatformApiRouter {
     if ("node".equals(firstSegment)) {
       return routeNodeRequest(segments, request);
     }
-    if ("config".equals(firstSegment) && segments.size() == 1) {
-      return PlatformApiResponse.ok(configApiHandler.exportConfig(request.queryParameters()));
-    }
     if ("connectivity".equals(firstSegment) && segments.size() == 1) {
       return PlatformApiResponse.ok(connectivityApiHandler.snapshot(request.queryParameters()));
     }
-    if ("security-levels".equals(firstSegment) && segments.size() == 1) {
-      return PlatformApiResponse.ok(securityLevelsApiHandler.snapshot());
-    }
 
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /config} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected configuration endpoint
+   */
+  private PlatformApiResponse routeConfigRequest(
+      List<String> segments, PlatformApiRequest request) {
+    return switch (segments.size()) {
+      case 1 -> routeConfigRoot(request);
+      case 2 -> routeConfigAction(segments.get(1), request);
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  private PlatformApiResponse routeConfigRoot(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(configApiHandler.exportConfig(request.queryParameters()));
+  }
+
+  private PlatformApiResponse routeConfigAction(String action, PlatformApiRequest request) {
+    if ("overrides".equals(action)) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(configApiHandler.applyOverrides(request.queryParameters()));
+    }
+    if ("persist".equals(action)) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(configApiHandler.persist());
+    }
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /security-levels} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected security-levels endpoint
+   */
+  private PlatformApiResponse routeSecurityLevelsRequest(
+      List<String> segments, PlatformApiRequest request) {
+    return switch (segments.size()) {
+      case 1 -> routeSecurityLevelsRoot(request);
+      case 2 -> routeSecurityLevelsAction(segments.get(1), request);
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  private PlatformApiResponse routeSecurityLevelsRoot(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(securityLevelsApiHandler.snapshot());
+  }
+
+  private PlatformApiResponse routeSecurityLevelsAction(String action, PlatformApiRequest request) {
+    if ("network-warning".equals(action)) {
+      if (!"GET".equals(request.method())) {
+        return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(
+          securityLevelsApiHandler.networkThreatLevelWarning(request.queryParameters()));
+    }
+    if ("network".equals(action)) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(
+          securityLevelsApiHandler.setNetworkThreatLevel(request.queryParameters()));
+    }
+    if ("physical".equals(action)) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(
+          securityLevelsApiHandler.setPhysicalThreatLevel(request.queryParameters()));
+    }
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /updates} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected update endpoint
+   */
+  private PlatformApiResponse routeUpdatesRequest(
+      List<String> segments, PlatformApiRequest request) {
+    if (segments.size() == 2 && "core".equals(segments.get(1))) {
+      if (!"GET".equals(request.method())) {
+        return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(updatesApiHandler.coreSnapshot());
+    }
+    if (segments.size() == 3
+        && "core".equals(segments.get(1))
+        && "download".equals(segments.get(2))) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(updatesApiHandler.startCoreDownload());
+    }
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /wizard} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected wizard endpoint
+   */
+  private PlatformApiResponse routeWizardRequest(
+      List<String> segments, PlatformApiRequest request) {
+    if (segments.size() == 2 && "first-time".equals(segments.get(1))) {
+      if (!"GET".equals(request.method())) {
+        return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(firstTimeWizardApiHandler.snapshot());
+    }
+    if (segments.size() == 3
+        && "first-time".equals(segments.get(1))
+        && "apply".equals(segments.get(2))) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(firstTimeWizardApiHandler.apply(request.queryParameters()));
+    }
     throw new PlatformApiException(404, "not_found", "Platform API route not found.");
   }
 
@@ -458,11 +615,10 @@ public final class PlatformApiRouter {
    * @return JSON response for the selected peer endpoint
    */
   private PlatformApiResponse routePeerResource(String resource, PlatformApiRequest request) {
-    if ("add".equals(resource)) {
-      if ("POST".equals(request.method())) {
-        return PlatformApiResponse.created(peersApiHandler.add(request.queryParameters()));
-      }
+    if ("add".equals(resource) && "POST".equals(request.method())) {
+      return PlatformApiResponse.created(peersApiHandler.add(request.queryParameters()));
     }
+
     if (!"GET".equals(request.method())) {
       return methodNotAllowed("GET", GET_ONLY_MESSAGE);
     }

--- a/platform-api/src/main/java/network/crypta/platform/api/config/ConfigApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/config/ConfigApiHandler.java
@@ -1,28 +1,50 @@
 package network.crypta.platform.api.config;
 
+import java.net.MalformedURLException;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import network.crypta.keys.FreenetURI;
+import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.api.PlatformApiParameters;
 import network.crypta.platform.api.json.PlatformApiFieldSetJson;
+import network.crypta.runtime.spi.ConfigFieldSet;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConfigSection;
 import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.support.Fields;
+import network.crypta.support.TimeUtil;
+import network.crypta.support.URLDecoder;
+import network.crypta.support.URLEncodedFormatException;
+import network.crypta.support.URLEncoder;
 
 /**
- * Read-only configuration endpoint family for Platform API v1.
+ * Configuration endpoint family for Platform API v1.
  *
- * <p>The initial API keeps configuration export conservative: when callers omit the {@code
- * sections} query parameter, the handler exports only {@link ConfigSection#CURRENT}, which exposes
- * effective values without broadening the surface to descriptions, metadata, or write-oriented
- * flows.
+ * <p>The handler keeps reads and writes deliberately small. Configuration export defaults to the
+ * current effective values, while mutation support is limited to dotted-name override application
+ * plus explicit persistence through the existing runtime config port.
  */
 public final class ConfigApiHandler {
   /** Conservative default export scope used when callers omit the {@code sections} query. */
   private static final EnumSet<ConfigSection> DEFAULT_SECTIONS = EnumSet.of(ConfigSection.CURRENT);
+
+  private static final EnumSet<ConfigSection> VERIFICATION_SECTIONS =
+      EnumSet.of(ConfigSection.CURRENT, ConfigSection.DATA_TYPES);
+
+  private static final String FIELD_OPERATION = "operation";
+  private static final String FIELD_OVERRIDE_COUNT = "overrideCount";
+  private static final String TYPE_BOOLEAN = "boolean";
+  private static final String TYPE_NUMBER = "number";
+  private static final String TYPE_STRING_ARRAY = "stringArray";
+  private static final String UPDATE_URI_OPTION = "node.updater.URI";
+  private static final String REVOCATION_URI_OPTION = "node.updater.revocationURI";
+  private static final String LEGACY_UPDATE_URI_DOC_NAME = "jar";
+  private static final String REVOCATION_URI_DOC_NAME = "revoked";
+  private static final String UPDATE_URI_DOC_NAME = "info";
 
   /** Detached runtime port that exports configuration snapshots for the API layer. */
   private final ConfigPort configPort;
@@ -56,5 +78,338 @@ public final class ConfigApiHandler {
             (section, fieldSet) ->
                 sections.put(section.name(), PlatformApiFieldSetJson.toJson(fieldSet)));
     return sections;
+  }
+
+  /**
+   * Applies one or more dotted-name configuration overrides.
+   *
+   * <p>The Platform API keeps this mutation deliberately narrow. Every supplied parameter name is
+   * treated as one dotted config key and must carry exactly one value. The runtime port preserves
+   * the legacy behavior for unknown or invalid options, while this handler enforces only the
+   * transport-neutral shape of the request.
+   *
+   * @param queryParameters decoded request parameters containing dotted config overrides
+   * @return JSON-compatible mutation summary
+   */
+  public Map<String, Object> applyOverrides(Map<String, List<String>> queryParameters) {
+    Objects.requireNonNull(queryParameters, "queryParameters");
+    Map<String, String> overrides = toSingleValueOverrides(queryParameters);
+    if (overrides.isEmpty()) {
+      throw invalidQuery("At least one config override parameter is required.");
+    }
+
+    ConfigSnapshot beforeSnapshot = configPort.export(VERIFICATION_SECTIONS);
+    configPort.applyOverrides(overrides);
+    ConfigSnapshot afterSnapshot = configPort.export(VERIFICATION_SECTIONS);
+
+    Map<String, String> rejectedOverrides =
+        collectRejectedOverrides(beforeSnapshot, overrides, afterSnapshot);
+    if (!rejectedOverrides.isEmpty()) {
+      revertAcceptedOverrides(beforeSnapshot, afterSnapshot, overrides, rejectedOverrides.keySet());
+      throw new PlatformApiException(
+          400,
+          "config_override_rejected",
+          "Rejected config overrides: " + String.join(", ", rejectedOverrides.keySet()));
+    }
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put(FIELD_OPERATION, "apply_overrides");
+    response.put(FIELD_OVERRIDE_COUNT, overrides.size());
+    return response;
+  }
+
+  /**
+   * Persists the current configuration state through the runtime's existing storage path.
+   *
+   * @return JSON-compatible mutation summary
+   */
+  public Map<String, Object> persist() {
+    configPort.persist();
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(1);
+    response.put(FIELD_OPERATION, "persist");
+    return response;
+  }
+
+  private static Map<String, String> toSingleValueOverrides(
+      Map<String, List<String>> queryParameters) {
+    LinkedHashMap<String, String> overrides =
+        LinkedHashMap.newLinkedHashMap(queryParameters.size());
+    for (Map.Entry<String, List<String>> entry : queryParameters.entrySet()) {
+      String name = entry.getKey();
+      if (name == null || name.isBlank()) {
+        throw invalidQuery("Config override parameter names must not be blank.");
+      }
+
+      List<String> values = entry.getValue();
+      if (values == null || values.isEmpty()) {
+        throw invalidQuery("Config override parameter '" + name + "' must have one value.");
+      }
+      if (values.size() > 1) {
+        throw invalidQuery("Config override parameter '" + name + "' must not be repeated.");
+      }
+      overrides.put(name, values.getFirst());
+    }
+    return overrides;
+  }
+
+  private static PlatformApiException invalidQuery(String message) {
+    return new PlatformApiException(400, "invalid_query_parameter", message);
+  }
+
+  private void revertAcceptedOverrides(
+      ConfigSnapshot beforeSnapshot,
+      ConfigSnapshot afterSnapshot,
+      Map<String, String> requestedOverrides,
+      Set<String> rejectedOverrideNames) {
+    LinkedHashMap<String, String> revertOverrides =
+        LinkedHashMap.newLinkedHashMap(requestedOverrides.size());
+    for (Map.Entry<String, String> entry : requestedOverrides.entrySet()) {
+      String name = entry.getKey();
+      if (rejectedOverrideNames.contains(name)) {
+        continue;
+      }
+      String beforeValue = readCurrentValue(beforeSnapshot, name);
+      String afterValue = readCurrentValue(afterSnapshot, name);
+      if (beforeValue != null && !Objects.equals(beforeValue, afterValue)) {
+        revertOverrides.put(name, beforeValue);
+      }
+    }
+    if (!revertOverrides.isEmpty()) {
+      configPort.applyOverrides(revertOverrides);
+    }
+  }
+
+  private static Map<String, String> collectRejectedOverrides(
+      ConfigSnapshot beforeSnapshot,
+      Map<String, String> requestedOverrides,
+      ConfigSnapshot afterSnapshot) {
+    LinkedHashMap<String, String> rejectedOverrides =
+        LinkedHashMap.newLinkedHashMap(requestedOverrides.size());
+    for (Map.Entry<String, String> entry : requestedOverrides.entrySet()) {
+      String beforeValue = readCurrentValue(beforeSnapshot, entry.getKey());
+      String resultingValue = readCurrentValue(afterSnapshot, entry.getKey());
+      String dataType = readDataType(afterSnapshot, entry.getKey());
+      if (!valuesSemanticallyMatch(
+          entry.getKey(), beforeValue, entry.getValue(), resultingValue, dataType)) {
+        rejectedOverrides.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return rejectedOverrides;
+  }
+
+  private static String readDataType(ConfigSnapshot snapshot, String dottedName) {
+    Objects.requireNonNull(snapshot, "snapshot");
+    ConfigFieldSet dataTypes = snapshot.sections().get(ConfigSection.DATA_TYPES);
+    if (dataTypes == null || dottedName == null || dottedName.isBlank()) {
+      return null;
+    }
+    return readFieldValue(dataTypes, dottedName);
+  }
+
+  private static boolean valuesSemanticallyMatch(
+      String dottedName,
+      String beforeValue,
+      String requestedValue,
+      String resultingValue,
+      String dataType) {
+    if (Objects.equals(requestedValue, resultingValue)) {
+      return true;
+    }
+    if (requestedValue == null || resultingValue == null || dataType == null) {
+      return false;
+    }
+    try {
+      return switch (dataType) {
+        case TYPE_BOOLEAN -> parseBooleanValue(requestedValue) == parseBooleanValue(resultingValue);
+        case TYPE_NUMBER -> numericValuesSemanticallyMatch(requestedValue, resultingValue);
+        case TYPE_STRING_ARRAY ->
+            stringArrayValuesSemanticallyMatch(requestedValue, resultingValue);
+        default ->
+            canonicalizedStringValuesSemanticallyMatch(dottedName, requestedValue, resultingValue)
+                || (beforeValue != null && !Objects.equals(beforeValue, resultingValue));
+      };
+    } catch (RuntimeException _) {
+      return false;
+    }
+  }
+
+  private static boolean canonicalizedStringValuesSemanticallyMatch(
+      String dottedName, String requestedValue, String resultingValue) {
+    String canonicalRequested = canonicalizeKnownStringValue(dottedName, requestedValue);
+    return canonicalRequested != null && Objects.equals(canonicalRequested, resultingValue);
+  }
+
+  private static String canonicalizeKnownStringValue(String dottedName, String requestedValue) {
+    if (UPDATE_URI_OPTION.equals(dottedName)) {
+      return canonicalizeUpdateUriValue(requestedValue);
+    }
+    if (REVOCATION_URI_OPTION.equals(dottedName)) {
+      return canonicalizeRevocationUriValue(requestedValue);
+    }
+    return null;
+  }
+
+  private static String canonicalizeUpdateUriValue(String requestedValue) {
+    try {
+      FreenetURI parsed = new FreenetURI(requestedValue.trim());
+      if (parsed.isUSK()
+          && !parsed.hasMetaStrings()
+          && (UPDATE_URI_DOC_NAME.equals(parsed.getDocName())
+              || LEGACY_UPDATE_URI_DOC_NAME.equals(parsed.getDocName()))) {
+        return extractPublicKeyMaterial(parsed);
+      }
+    } catch (MalformedURLException | RuntimeException _) {
+      // Fall through to "unknown normalization".
+    }
+    return null;
+  }
+
+  private static String canonicalizeRevocationUriValue(String requestedValue) {
+    try {
+      FreenetURI parsed = new FreenetURI(requestedValue.trim());
+      if (parsed.isSSK()
+          && !parsed.hasMetaStrings()
+          && REVOCATION_URI_DOC_NAME.equals(parsed.getDocName())) {
+        return extractPublicKeyMaterial(parsed);
+      }
+    } catch (MalformedURLException | RuntimeException _) {
+      // Fall through to "unknown normalization".
+    }
+    return null;
+  }
+
+  private static String extractPublicKeyMaterial(FreenetURI uri) {
+    String uriString = uri.toString(false, false);
+    if (uriString == null) {
+      return "";
+    }
+    int prefixEnd = uriString.indexOf('@');
+    if (prefixEnd < 0 || prefixEnd + 1 >= uriString.length()) {
+      return uriString;
+    }
+    int pathStart = uriString.indexOf('/', prefixEnd + 1);
+    if (pathStart < 0) {
+      return uriString.substring(prefixEnd + 1);
+    }
+    return uriString.substring(prefixEnd + 1, pathStart);
+  }
+
+  private static boolean parseBooleanValue(String value) {
+    return Fields.stringToBool(value);
+  }
+
+  private static long parseNumericValue(String value) {
+    return Fields.parseLong(trimPerSecondSuffix(value));
+  }
+
+  private static boolean numericValuesSemanticallyMatch(
+      String requestedValue, String resultingValue) {
+    long resultingNumeric = parseNumericValue(resultingValue);
+    return matchesAnyRequestedNumericInterpretation(requestedValue, resultingNumeric);
+  }
+
+  private static boolean stringArrayValuesSemanticallyMatch(
+      String requestedValue, String resultingValue) {
+    try {
+      return Objects.equals(canonicalizeStringArrayValue(requestedValue), resultingValue);
+    } catch (URLEncodedFormatException _) {
+      return false;
+    }
+  }
+
+  private static String canonicalizeStringArrayValue(String value)
+      throws URLEncodedFormatException {
+    if (value.isEmpty()) {
+      return "";
+    }
+
+    List<String> tokens = splitStringArrayTokens(value);
+    StringBuilder canonical = new StringBuilder(value.length());
+    for (int i = 0; i < tokens.size(); i++) {
+      if (i > 0) {
+        canonical.append(';');
+      }
+      canonical.append(canonicalizeStringArrayToken(tokens.get(i)));
+    }
+    return canonical.toString();
+  }
+
+  private static List<String> splitStringArrayTokens(String value) {
+    java.util.ArrayList<String> tokens = new java.util.ArrayList<>();
+    int segmentStart = 0;
+    while (segmentStart <= value.length()) {
+      int delimiter = value.indexOf(';', segmentStart);
+      if (delimiter < 0) {
+        tokens.add(value.substring(segmentStart));
+        return tokens;
+      }
+      tokens.add(value.substring(segmentStart, delimiter));
+      segmentStart = delimiter + 1;
+    }
+    return tokens;
+  }
+
+  private static String canonicalizeStringArrayToken(String token)
+      throws URLEncodedFormatException {
+    if (":".equals(token)) {
+      return ":";
+    }
+    String decoded = URLDecoder.decode(token, true);
+    return decoded.isEmpty() ? ":" : URLEncoder.encode(decoded, false);
+  }
+
+  private static boolean matchesAnyRequestedNumericInterpretation(
+      String requestedValue, long resultingNumeric) {
+    try {
+      if (parseNumericValue(requestedValue) == resultingNumeric) {
+        return true;
+      }
+    } catch (RuntimeException _) {
+      // Try duration semantics next.
+    }
+    return TimeUtil.toMillis(requestedValue) == resultingNumeric;
+  }
+
+  private static String trimPerSecondSuffix(String value) {
+    String trimmed = value.trim();
+    String lower = trimmed.toLowerCase(java.util.Locale.ROOT);
+    for (String suffix : new String[] {"/s", "/sec", "/second", "ps"}) {
+      if (lower.endsWith(suffix)) {
+        return trimmed.substring(0, trimmed.length() - suffix.length());
+      }
+    }
+    return trimmed;
+  }
+
+  private static String readCurrentValue(ConfigSnapshot snapshot, String dottedName) {
+    Objects.requireNonNull(snapshot, "snapshot");
+    ConfigFieldSet current = snapshot.sections().get(ConfigSection.CURRENT);
+    if (current == null || dottedName == null || dottedName.isBlank()) {
+      return null;
+    }
+    return readFieldValue(current, dottedName);
+  }
+
+  private static String readFieldValue(ConfigFieldSet fieldSet, String dottedName) {
+    ConfigFieldSet current = fieldSet;
+    int segmentStart = 0;
+    while (segmentStart < dottedName.length()) {
+      int nextDot = dottedName.indexOf('.', segmentStart);
+      int segmentEnd = nextDot >= 0 ? nextDot : dottedName.length();
+      String segment = dottedName.substring(segmentStart, segmentEnd);
+      if (current.directSubsets().containsKey(segment)) {
+        current = current.directSubsets().get(segment);
+        segmentStart = segmentEnd + 1;
+        continue;
+      }
+
+      String remainingPath = dottedName.substring(segmentStart);
+      if (current.directValues().containsKey(remainingPath)) {
+        return current.directValues().get(remainingPath);
+      }
+      return null;
+    }
+    return null;
   }
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/config/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/config/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Configuration-oriented Platform API handlers.
  *
- * <p>This package owns the read-only configuration export endpoint for Platform API v1. It keeps
- * the default-section policy and section-name validation close to the runtime config port it
- * serves.
+ * <p>This package owns the detached configuration control-plane surface for Platform API v1. It
+ * keeps export defaults, dotted-name override parsing, and explicit persistence close to the
+ * runtime config port it serves.
  */
 package network.crypta.platform.api.config;

--- a/platform-api/src/main/java/network/crypta/platform/api/security/SecurityLevelsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/security/SecurityLevelsApiHandler.java
@@ -1,28 +1,61 @@
 package network.crypta.platform.api.security;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.SecurityLevelsPort;
 import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
 
 /**
- * Read-only security-level endpoint family for Platform API v1.
+ * Security-level endpoint family for Platform API v1.
  *
- * <p>The handler exposes the detached security-level page snapshot as JSON without bringing the
- * legacy mutation or confirmation-warning flows into the first platform API surface.
+ * <p>The handler exposes the detached security-level snapshot as JSON and adds narrowly scoped
+ * threat-level mutations. Legacy confirmation-warning HTML and master-password flows remain on the
+ * fallback page for this phase.
  */
 public final class SecurityLevelsApiHandler {
+  private static final String FIELD_OPERATION = "operation";
+  private static final String FIELD_CONFIRMATION_REQUIRED = "confirmationRequired";
+  private static final String FIELD_PHYSICAL_THREAT_LEVEL = "physicalThreatLevel";
+  private static final String FIELD_WARNING_HTML = "warningHtml";
+  private static final String OPERATION_SET_PHYSICAL_THREAT_LEVEL = "set_physical_threat_level";
+  private static final String PARAMETER_CONFIRMED = "confirmed";
+  private static final String PARAMETER_NEW_LEVEL = "newLevel";
+
   /** Detached runtime port that supplies security-level snapshots for the API layer. */
   private final SecurityLevelsPort securityLevelsPort;
+
+  /** Detached config port used to persist accepted threat-level changes. */
+  private final ConfigPort configPort;
+
+  /**
+   * Detached wizard port reused for the legacy physical-security path that reopens the database
+   * after leaving MAXIMUM.
+   */
+  private final FirstTimeWizardPort firstTimeWizardPort;
 
   /**
    * Creates a security-level API handler backed by the supplied runtime port.
    *
    * @param securityLevelsPort detached runtime security-level port
+   * @param configPort detached runtime config port used for persistence
+   * @param firstTimeWizardPort detached wizard port reused for MAXIMUM exit semantics
    */
-  public SecurityLevelsApiHandler(SecurityLevelsPort securityLevelsPort) {
+  public SecurityLevelsApiHandler(
+      SecurityLevelsPort securityLevelsPort,
+      ConfigPort configPort,
+      FirstTimeWizardPort firstTimeWizardPort) {
     this.securityLevelsPort = Objects.requireNonNull(securityLevelsPort, "securityLevelsPort");
+    this.configPort = Objects.requireNonNull(configPort, "configPort");
+    this.firstTimeWizardPort = Objects.requireNonNull(firstTimeWizardPort, "firstTimeWizardPort");
   }
 
   /**
@@ -34,10 +67,153 @@ public final class SecurityLevelsApiHandler {
     SecurityLevelsSnapshot snapshot = securityLevelsPort.snapshot();
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(5);
     json.put("networkThreatLevel", snapshot.networkThreatLevel().name());
-    json.put("physicalThreatLevel", snapshot.physicalThreatLevel().name());
+    json.put(FIELD_PHYSICAL_THREAT_LEVEL, snapshot.physicalThreatLevel().name());
     json.put("hasDatabase", snapshot.hasDatabase());
     json.put("masterPasswordFileExists", snapshot.masterPasswordFileExists());
     json.put("masterPasswordFilePath", snapshot.masterPasswordFilePath());
     return json;
+  }
+
+  /**
+   * Returns the current legacy confirmation warning for a prospective network-level change.
+   *
+   * <p>This keeps the legacy warning generation on the runtime side while letting shell clients
+   * preflight a change before sending the mutating request.
+   *
+   * @param queryParameters decoded request parameters for the current request
+   * @return JSON-compatible warning snapshot for the requested network level
+   */
+  public Map<String, Object> networkThreatLevelWarning(Map<String, List<String>> queryParameters) {
+    SecurityNetworkThreatLevel newLevel =
+        PlatformApiParameters.requireEnum(
+            queryParameters, PARAMETER_NEW_LEVEL, SecurityNetworkThreatLevel.class);
+    String warningHtml =
+        securityLevelsPort.networkThreatLevelConfirmWarningHtml(newLevel, PARAMETER_CONFIRMED);
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(3);
+    response.put(PARAMETER_NEW_LEVEL, newLevel.name());
+    response.put(FIELD_CONFIRMATION_REQUIRED, warningHtml != null);
+    response.put(FIELD_WARNING_HTML, warningHtml == null ? "" : warningHtml);
+    return response;
+  }
+
+  /**
+   * Applies a new network threat level and persists the updated config.
+   *
+   * @param queryParameters decoded request parameters for the current request
+   * @return JSON-compatible mutation summary
+   */
+  public Map<String, Object> setNetworkThreatLevel(Map<String, List<String>> queryParameters) {
+    SecurityNetworkThreatLevel newLevel =
+        PlatformApiParameters.requireEnum(
+            queryParameters, PARAMETER_NEW_LEVEL, SecurityNetworkThreatLevel.class);
+    boolean confirmed = readConfirmationFlag(queryParameters);
+    String warningHtml =
+        securityLevelsPort.networkThreatLevelConfirmWarningHtml(newLevel, PARAMETER_CONFIRMED);
+    if (warningHtml != null && !confirmed) {
+      throw new PlatformApiException(
+          409,
+          "network_threat_level_confirmation_required",
+          "This network threat-level change requires server-side confirmation. Retry after"
+              + " acknowledging the warning in the Web Shell or use the legacy security page.");
+    }
+
+    securityLevelsPort.setNetworkThreatLevel(newLevel);
+    configPort.persist();
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put(FIELD_OPERATION, "set_network_threat_level");
+    response.put("networkThreatLevel", newLevel.name());
+    return response;
+  }
+
+  /**
+   * Applies a new physical threat level and persists the updated config.
+   *
+   * @param queryParameters decoded request parameters for the current request
+   * @return JSON-compatible mutation summary
+   */
+  public Map<String, Object> setPhysicalThreatLevel(Map<String, List<String>> queryParameters) {
+    SecurityLevelsSnapshot snapshot = securityLevelsPort.snapshot();
+    SecurityPhysicalThreatLevel newLevel =
+        PlatformApiParameters.requireEnum(
+            queryParameters, PARAMETER_NEW_LEVEL, SecurityPhysicalThreatLevel.class);
+    boolean confirmed = readConfirmationFlag(queryParameters);
+    SecurityPhysicalThreatLevel currentLevel = snapshot.physicalThreatLevel();
+    if (newLevel == currentLevel) {
+      LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+      response.put(FIELD_OPERATION, OPERATION_SET_PHYSICAL_THREAT_LEVEL);
+      response.put(FIELD_PHYSICAL_THREAT_LEVEL, newLevel.name());
+      return response;
+    }
+    if (newLevel == SecurityPhysicalThreatLevel.HIGH
+        || (currentLevel == SecurityPhysicalThreatLevel.HIGH
+            && (newLevel == SecurityPhysicalThreatLevel.LOW
+                || newLevel == SecurityPhysicalThreatLevel.NORMAL))) {
+      throw new PlatformApiException(
+          409,
+          "physical_threat_level_password_required",
+          "Changing to or from physical HIGH still requires the legacy password flow."
+              + " Use the legacy security page for this transition.");
+    }
+    if (currentLevel == SecurityPhysicalThreatLevel.MAXIMUM) {
+      firstTimeWizardPort.setPhysicalThreatLevel(newLevel);
+
+      LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+      response.put(FIELD_OPERATION, OPERATION_SET_PHYSICAL_THREAT_LEVEL);
+      response.put(FIELD_PHYSICAL_THREAT_LEVEL, newLevel.name());
+      return response;
+    }
+    if (newLevel == SecurityPhysicalThreatLevel.MAXIMUM) {
+      if (snapshot.hasDatabase() && !confirmed) {
+        throw new PlatformApiException(
+            409,
+            "physical_threat_level_confirmation_required",
+            "Changing the physical threat level to MAXIMUM can delete queued work. Retry after"
+                + " acknowledging the confirmation.");
+      }
+      try {
+        securityLevelsPort.deleteMasterPasswordFile();
+      } catch (IOException _) {
+        throw new PlatformApiException(
+            409,
+            "physical_threat_level_master_password_cleanup_failed",
+            "Cannot switch to physical MAXIMUM because the master-password file could not be"
+                + " removed. Use the legacy security page for recovery.");
+      }
+    }
+
+    securityLevelsPort.setPhysicalThreatLevel(newLevel);
+    configPort.persist();
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put(FIELD_OPERATION, OPERATION_SET_PHYSICAL_THREAT_LEVEL);
+    response.put(FIELD_PHYSICAL_THREAT_LEVEL, newLevel.name());
+    return response;
+  }
+
+  private static boolean readConfirmationFlag(Map<String, List<String>> queryParameters) {
+    List<String> values = queryParameters.get(PARAMETER_CONFIRMED);
+    if (values == null || values.isEmpty()) {
+      return false;
+    }
+    boolean anyTruthy = false;
+    for (String raw : values) {
+      if (raw == null
+          || raw.isBlank()
+          || "true".equalsIgnoreCase(raw)
+          || "on".equalsIgnoreCase(raw)
+          || PARAMETER_CONFIRMED.equals(raw)) {
+        anyTruthy = true;
+      } else if (!"false".equalsIgnoreCase(raw) && !"off".equalsIgnoreCase(raw)) {
+        throw new PlatformApiException(
+            400,
+            "invalid_query_parameter",
+            "Query parameter '"
+                + PARAMETER_CONFIRMED
+                + "' must be a checkbox value or one of 'true', 'false', 'on', or 'off'.");
+      }
+    }
+    return anyTruthy;
   }
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/security/SecurityLevelsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/security/SecurityLevelsApiHandler.java
@@ -199,21 +199,25 @@ public final class SecurityLevelsApiHandler {
     }
     boolean anyTruthy = false;
     for (String raw : values) {
-      if (raw == null
-          || raw.isBlank()
-          || "true".equalsIgnoreCase(raw)
-          || "on".equalsIgnoreCase(raw)
-          || PARAMETER_CONFIRMED.equals(raw)) {
+      if (raw == null || isConfirmedCheckboxValue(raw)) {
         anyTruthy = true;
-      } else if (!"false".equalsIgnoreCase(raw) && !"off".equalsIgnoreCase(raw)) {
+      } else if (!"false".equalsIgnoreCase(raw)) {
         throw new PlatformApiException(
             400,
             "invalid_query_parameter",
             "Query parameter '"
                 + PARAMETER_CONFIRMED
-                + "' must be a checkbox value or one of 'true', 'false', 'on', or 'off'.");
+                + "' must be a legacy checkbox value or one of 'true' or 'false'.");
       }
     }
     return anyTruthy;
+  }
+
+  private static boolean isConfirmedCheckboxValue(String raw) {
+    return raw.isBlank()
+        || "true".equalsIgnoreCase(raw)
+        || "on".equalsIgnoreCase(raw)
+        || "off".equalsIgnoreCase(raw)
+        || PARAMETER_CONFIRMED.equals(raw);
   }
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/security/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/security/package-info.java
@@ -1,7 +1,8 @@
 /**
  * Security-level-oriented Platform API handlers.
  *
- * <p>This package owns the read-only security-level snapshot endpoint for Platform API v1. The
- * exported JSON is built from detached runtime snapshots and deliberately omits mutation flows.
+ * <p>This package owns the detached security-level snapshot and threat-level mutation endpoints for
+ * Platform API v1. It keeps the mutation surface small while preserving the legacy page as the
+ * fallback path for confirmation-heavy and password-management flows.
  */
 package network.crypta.platform.api.security;

--- a/platform-api/src/main/java/network/crypta/platform/api/updates/UpdatesApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/updates/UpdatesApiHandler.java
@@ -1,0 +1,110 @@
+package network.crypta.platform.api.updates;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
+
+/**
+ * Core-update control-plane endpoints for Platform API v1.
+ *
+ * <p>This handler is the transport-neutral bridge between the Platform API router and the daemon's
+ * detached updater SPI. It deliberately exposes only the smallest updater surface that the shell
+ * can use safely in Phase 3: one read-only snapshot that answers whether updater actions are wired
+ * and currently actionable, plus one mutation that mirrors the legacy "download from UI" control.
+ *
+ * <p>The class does not attempt to model installer launching, package-store handoff, progress
+ * rendering, or platform-specific recovery guidance. Those concerns still belong to the legacy HTTP
+ * updater pages and their runtime adapters. Callers should therefore treat this handler as a
+ * control-plane surface for availability and download triggering, not as a complete updater domain
+ * API.
+ *
+ * <ul>
+ *   <li>Reads are side-effect free and report only stable JSON fields.
+ *   <li>Mutations fail fast when the updater cannot actually honor the request.
+ *   <li>Legacy installer and store flows remain available as fallback/debug paths.
+ * </ul>
+ */
+public final class UpdatesApiHandler {
+  private static final String FIELD_OPERATION = "operation";
+
+  /**
+   * Detached runtime port that exposes the remaining updater actions needed by the control plane.
+   */
+  private final CoreUpdateActionPort coreUpdateActionPort;
+
+  /**
+   * Creates an updater API handler backed by the supplied runtime port.
+   *
+   * <p>The supplied port stays responsible for all daemon-bound updater decisions, including
+   * whether the updater service is present, whether a manual download is currently meaningful, and
+   * whether a requested UI-triggered download actually started. This handler only translates those
+   * outcomes into stable Platform API responses.
+   *
+   * @param coreUpdateActionPort detached updater action port used for availability checks and
+   *     UI-triggered download start
+   * @throws NullPointerException if {@code coreUpdateActionPort} is {@code null}
+   */
+  public UpdatesApiHandler(CoreUpdateActionPort coreUpdateActionPort) {
+    this.coreUpdateActionPort =
+        Objects.requireNonNull(coreUpdateActionPort, "coreUpdateActionPort");
+  }
+
+  /**
+   * Returns the current updater availability snapshot.
+   *
+   * <p>The response intentionally separates service presence from action readiness. {@code
+   * available} reports whether the legacy core-updater integration exists at all in the current
+   * runtime, while {@code downloadAllowed} narrows that to the smaller condition required for the
+   * shell-native "trigger download" button. Callers should not infer installer readiness or update
+   * progress from this snapshot alone.
+   *
+   * @return JSON-compatible updater snapshot containing stable booleans for updater presence and
+   *     current manual-download readiness
+   */
+  public Map<String, Object> coreSnapshot() {
+    boolean available = coreUpdateActionPort.isCoreUpdaterAvailable();
+    boolean downloadAllowed = available && coreUpdateActionPort.isCoreDownloadAvailable();
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put("available", available);
+    response.put("downloadAllowed", downloadAllowed);
+    return response;
+  }
+
+  /**
+   * Starts the current core-package download through the detached updater port.
+   *
+   * <p>This method preserves the legacy updater semantics that the shell can rely on: it refuses to
+   * report success when the updater service is absent, when no selectable package is currently
+   * downloadable, or when a race causes the underlying download start request to become a no-op.
+   * Callers should treat a successful response as "the daemon accepted the download start request
+   * now", not as proof that the package already finished downloading.
+   *
+   * @return JSON-compatible mutation summary describing the accepted download trigger
+   * @throws PlatformApiException if the updater service is absent, no downloadable package is
+   *     currently selected, or the runtime declines to start the download
+   */
+  public Map<String, Object> startCoreDownload() {
+    if (!coreUpdateActionPort.isCoreUpdaterAvailable()) {
+      throw new PlatformApiException(
+          409, "updater_unavailable", "Core updater is not currently available.");
+    }
+    if (!coreUpdateActionPort.isCoreDownloadAvailable()) {
+      throw new PlatformApiException(
+          409, "core_update_unavailable", "No selectable core update is currently available.");
+    }
+
+    if (!coreUpdateActionPort.startCoreDownloadFromUi()) {
+      throw new PlatformApiException(
+          409,
+          "core_download_not_started",
+          "The core download could not be started. Refresh updater state and retry.");
+    }
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put(FIELD_OPERATION, "start_core_download");
+    response.put("downloadTriggered", true);
+    return response;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/updates/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/updates/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Core-update Platform API handlers.
+ *
+ * <p>This package owns the deliberately small updater control-plane surface introduced for Platform
+ * API v1. The code here lets transport-neutral callers ask whether the daemon exposes the core
+ * updater and whether a shell-native manual download is currently actionable, then trigger the same
+ * download path that the legacy updater page already uses.
+ *
+ * <p>The package does not replace the full legacy updater experience. Platform-specific installer
+ * launching, package-store handoff, progress-oriented UI details, and recovery guidance still live
+ * on the legacy HTTP side. The classes here therefore focus on stable JSON contracts and detached
+ * runtime seams that make the shell more operational without broadening the updater API beyond the
+ * current Phase 3 scope.
+ */
+package network.crypta.platform.api.updates;

--- a/platform-api/src/main/java/network/crypta/platform/api/wizard/FirstTimeWizardApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/wizard/FirstTimeWizardApiHandler.java
@@ -1,0 +1,430 @@
+package network.crypta.platform.api.wizard;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+import network.crypta.support.Fields;
+
+/**
+ * First-time-wizard control-plane endpoints for Platform API v1.
+ *
+ * <p>This handler exposes the detached first-time-wizard snapshot and submission flow through the
+ * Platform API without inventing a second onboarding model. It reuses the runtime SPI snapshot and
+ * submission record directly, then performs transport-neutral validation that matches the current
+ * shell-native wizard fields. The result is a form-oriented API surface that stays close to the
+ * legacy workflow while remaining deterministic for JSON clients.
+ *
+ * <p>The handler is intentionally conservative about what it validates. It rejects malformed text
+ * values, impossible bandwidth/storage choices, and wizard mutations that would silently normalize
+ * unsupported live security states. It does not reimplement the daemon's full onboarding logic or
+ * master-password flows; instead, it validates the request shape, preserves the current shell
+ * contract, and delegates accepted submissions to the daemon-backed runtime port.
+ *
+ * <ul>
+ *   <li>Snapshot reads return detached wizard defaults and the current security context.
+ *   <li>Writes remain parameter-centric and mirror existing form semantics.
+ *   <li>Conflicts are surfaced as stable API errors before the daemon applies the submission.
+ * </ul>
+ */
+public final class FirstTimeWizardApiHandler {
+  private static final String GIB_UNIT_SUFFIX = " GiB.";
+  private static final String INVALID_GIB_VALUE_MESSAGE = "must be a valid GiB value.";
+  private static final String INVALID_KIB_VALUE_MESSAGE = "must be a valid KiB value.";
+  private static final long KIB = 1024L;
+  private static final String KIB_UNIT_SUFFIX = " KiB.";
+  private static final long MAX_INT_BACKED_BANDWIDTH_LIMIT_BYTES = Integer.MAX_VALUE;
+  private static final int MAX_PASSWORD_LENGTH = 1024;
+  private static final String MUST_BE_AT_LEAST = " must be at least ";
+  private static final String MUST_BE_AT_MOST = " must be at most ";
+  private static final String FIELD_OPERATION = "operation";
+  private static final String PARAMETER_BANDWIDTH_MONTHLY_LIMIT_GIB = "bandwidthMonthlyLimitGiB";
+  private static final String PARAMETER_CONNECT_TO_STRANGERS = "connectToStrangers";
+  private static final String PARAMETER_DOWNLOAD_LIMIT_KIB = "downloadLimitKiB";
+  private static final String PARAMETER_HAVE_MONTHLY_LIMIT = "haveMonthlyLimit";
+  private static final String PARAMETER_KNOW_SOMEONE = "knowSomeone";
+  private static final String PARAMETER_PASSWORD = "password";
+  private static final String PARAMETER_PRESERVE_BANDWIDTH_SETTINGS = "preserveBandwidthSettings";
+  private static final String PARAMETER_PRESERVE_CURRENT_NETWORK_THREAT_LEVEL =
+      "preserveCurrentNetworkThreatLevel";
+  private static final String PARAMETER_PRESERVE_CURRENT_PHYSICAL_THREAT_LEVEL =
+      "preserveCurrentPhysicalThreatLevel";
+  private static final String PARAMETER_SET_PASSWORD = "setPassword";
+  private static final String PARAMETER_STORAGE_LIMIT_GIB = "storageLimitGiB";
+  private static final String PARAMETER_UPLOAD_LIMIT_KIB = "uploadLimitKiB";
+
+  /** Detached runtime port that supplies wizard snapshots and applies validated submissions. */
+  private final FirstTimeWizardPort firstTimeWizardPort;
+
+  /**
+   * Creates a first-time-wizard API handler backed by the supplied runtime port.
+   *
+   * <p>The supplied port remains responsible for reading live wizard defaults, exposing the current
+   * detached security snapshot, and applying validated submissions with the daemon's existing
+   * onboarding semantics. This handler only adds request parsing, API-level validation, and stable
+   * error mapping for the Platform API surface.
+   *
+   * @param firstTimeWizardPort detached wizard runtime port used for snapshot reads and validated
+   *     submission application
+   * @throws NullPointerException if {@code firstTimeWizardPort} is {@code null}
+   */
+  public FirstTimeWizardApiHandler(FirstTimeWizardPort firstTimeWizardPort) {
+    this.firstTimeWizardPort = Objects.requireNonNull(firstTimeWizardPort, "firstTimeWizardPort");
+  }
+
+  /**
+   * Returns the current detached first-time-wizard snapshot.
+   *
+   * <p>The returned map combines wizard defaults with the current detached security state so the
+   * shell can render one coherent onboarding/reset panel. Fields such as bandwidth and storage
+   * limits come from the runtime wizard snapshot, while the current network and physical threat
+   * levels are read separately so callers can decide when the wizard should edit or preserve those
+   * states.
+   *
+   * @return JSON-compatible wizard snapshot containing detached limits, detected defaults, and the
+   *     current security-level context required by the shell
+   */
+  public Map<String, Object> snapshot() {
+    FirstTimeWizardSnapshot snapshot = firstTimeWizardPort.snapshot();
+    SecurityLevelsSnapshot securitySnapshot = firstTimeWizardPort.securitySnapshot();
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(15);
+    json.put("passwordAlreadySet", snapshot.passwordAlreadySet());
+    json.put("opennetEnabled", firstTimeWizardPort.isOpennetEnabled());
+    json.put("currentNetworkThreatLevel", securitySnapshot.networkThreatLevel().name());
+    json.put("currentPhysicalThreatLevel", securitySnapshot.physicalThreatLevel().name());
+    json.put("initialStorageLimitGiB", snapshot.initialStorageLimitGiB());
+    json.put("minStorageLimitGiB", snapshot.minStorageLimitGiB());
+    json.put("minStorageLimitBytes", snapshot.minStorageLimitBytes());
+    json.put("maxStorageLimitGiB", snapshot.maxStorageLimitGiB());
+    json.put("maxStorageLimitBytes", snapshot.maxStorageLimitBytes());
+    json.put("legacyMaxStorageLimitBytes", snapshot.legacyMaxStorageLimitBytes());
+    json.put("minBandwidthKiB", snapshot.minBandwidthKiB());
+    json.put("maxUploadLimitKiB", snapshot.maxUploadLimitKiB());
+    json.put("minBandwidthMonthlyLimitGiB", snapshot.minBandwidthMonthlyLimitGiB());
+    json.put("detectedDownloadLimitKiB", snapshot.detectedDownloadLimitKiB());
+    json.put("detectedUploadLimitKiB", snapshot.detectedUploadLimitKiB());
+    putCurrentBandwidthLimits(json, snapshot.currentBandwidthLimits());
+    json.put("autodetectedStorageLimitBytes", snapshot.autodetectedStorageLimitBytes());
+    return json;
+  }
+
+  /**
+   * Validates and applies one detached wizard submission.
+   *
+   * <p>The request stays parameter-oriented on purpose. Callers submit checkbox-style booleans and
+   * raw text fields that match the existing form controls, and this handler validates only the
+   * aspects that must be transport-neutral: required parameters, numeric ranges, password field
+   * shape, and preserve-flag combinations for unsupported live security states. Accepted
+   * submissions are then forwarded unchanged to the daemon-backed wizard port.
+   *
+   * @param queryParameters decoded request parameters for the current request
+   * @return JSON-compatible mutation summary describing the accepted wizard submission
+   * @throws PlatformApiException if the submission is malformed, conflicts with the current wizard
+   *     state, or attempts to edit unsupported live security settings without the required preserve
+   *     flags
+   */
+  public Map<String, Object> apply(Map<String, List<String>> queryParameters) {
+    FirstTimeWizardSnapshot snapshot = firstTimeWizardPort.snapshot();
+    SecurityLevelsSnapshot securitySnapshot = firstTimeWizardPort.securitySnapshot();
+    FirstTimeWizardSubmission submission = parseSubmission(queryParameters, snapshot);
+    validateCurrentSecurityState(securitySnapshot, submission);
+    firstTimeWizardPort.applySubmission(submission);
+
+    LinkedHashMap<String, Object> response = LinkedHashMap.newLinkedHashMap(2);
+    response.put(FIELD_OPERATION, "apply_submission");
+    response.put("wizardApplied", true);
+    return response;
+  }
+
+  private static void putCurrentBandwidthLimits(
+      Map<String, Object> json, FirstTimeWizardCurrentBandwidthLimits currentBandwidthLimits) {
+    if (currentBandwidthLimits == null) {
+      json.put("currentBandwidthLimits", null);
+      return;
+    }
+    LinkedHashMap<String, Object> currentBandwidthJson = LinkedHashMap.newLinkedHashMap(2);
+    currentBandwidthJson.put("downloadBytes", currentBandwidthLimits.downloadBytes());
+    currentBandwidthJson.put("uploadBytes", currentBandwidthLimits.uploadBytes());
+    json.put("currentBandwidthLimits", currentBandwidthJson);
+  }
+
+  private static FirstTimeWizardSubmission parseSubmission(
+      Map<String, List<String>> queryParameters, FirstTimeWizardSnapshot snapshot) {
+    boolean knowSomeone = readCheckboxBoolean(queryParameters, PARAMETER_KNOW_SOMEONE);
+    boolean connectToStrangers =
+        readCheckboxBoolean(queryParameters, PARAMETER_CONNECT_TO_STRANGERS);
+    boolean haveMonthlyLimit = readCheckboxBoolean(queryParameters, PARAMETER_HAVE_MONTHLY_LIMIT);
+    boolean preserveBandwidthSettings =
+        readCheckboxBoolean(queryParameters, PARAMETER_PRESERVE_BANDWIDTH_SETTINGS);
+    boolean preserveCurrentNetworkThreatLevel =
+        readCheckboxBoolean(queryParameters, PARAMETER_PRESERVE_CURRENT_NETWORK_THREAT_LEVEL);
+    boolean preserveCurrentPhysicalThreatLevel =
+        readCheckboxBoolean(queryParameters, PARAMETER_PRESERVE_CURRENT_PHYSICAL_THREAT_LEVEL);
+    boolean setPassword = readCheckboxBoolean(queryParameters, PARAMETER_SET_PASSWORD);
+
+    String downloadLimitKiB =
+        haveMonthlyLimit || preserveBandwidthSettings
+            ? optionalString(queryParameters, PARAMETER_DOWNLOAD_LIMIT_KIB)
+            : PlatformApiParameters.requireString(queryParameters, PARAMETER_DOWNLOAD_LIMIT_KIB);
+    String uploadLimitKiB =
+        haveMonthlyLimit || preserveBandwidthSettings
+            ? optionalString(queryParameters, PARAMETER_UPLOAD_LIMIT_KIB)
+            : PlatformApiParameters.requireString(queryParameters, PARAMETER_UPLOAD_LIMIT_KIB);
+    String bandwidthMonthlyLimitGiB =
+        haveMonthlyLimit && !preserveBandwidthSettings
+            ? PlatformApiParameters.requireString(
+                queryParameters, PARAMETER_BANDWIDTH_MONTHLY_LIMIT_GIB)
+            : optionalString(queryParameters, PARAMETER_BANDWIDTH_MONTHLY_LIMIT_GIB);
+    String storageLimitGiB =
+        PlatformApiParameters.requireString(queryParameters, PARAMETER_STORAGE_LIMIT_GIB);
+    String password =
+        setPassword
+            ? PlatformApiParameters.requirePresentString(queryParameters, PARAMETER_PASSWORD)
+            : optionalString(queryParameters, PARAMETER_PASSWORD);
+
+    FirstTimeWizardSubmission submission =
+        new FirstTimeWizardSubmission(
+            knowSomeone,
+            connectToStrangers,
+            haveMonthlyLimit,
+            preserveBandwidthSettings,
+            preserveCurrentNetworkThreatLevel,
+            preserveCurrentPhysicalThreatLevel,
+            downloadLimitKiB,
+            uploadLimitKiB,
+            bandwidthMonthlyLimitGiB,
+            storageLimitGiB,
+            setPassword,
+            password);
+    validateSubmission(snapshot, submission);
+    return submission;
+  }
+
+  private static void validateSubmission(
+      FirstTimeWizardSnapshot snapshot, FirstTimeWizardSubmission submission) {
+    validatePasswordFlowAvailability(snapshot, submission);
+    validateStorageLimit(snapshot, submission.storageLimitGiB());
+    if (submission.preserveBandwidthSettings()) {
+      validatePassword(submission.setPassword(), submission.password());
+      return;
+    }
+    if (submission.haveMonthlyLimit()) {
+      validateMonthlyLimit(snapshot, submission.bandwidthMonthlyLimitGiB());
+    } else {
+      validateDownloadLimit(snapshot, submission.downloadLimitKiB());
+      validateUploadLimit(snapshot, submission.uploadLimitKiB());
+    }
+    validatePassword(submission.setPassword(), submission.password());
+  }
+
+  private static void validateCurrentSecurityState(
+      SecurityLevelsSnapshot securitySnapshot, FirstTimeWizardSubmission submission) {
+    SecurityNetworkThreatLevel networkThreatLevel = securitySnapshot.networkThreatLevel();
+    SecurityPhysicalThreatLevel physicalThreatLevel = securitySnapshot.physicalThreatLevel();
+    if (!supportsWizardNetworkThreatLevel(networkThreatLevel)
+        && !submission.preserveCurrentNetworkThreatLevel()) {
+      throw new PlatformApiException(
+          409,
+          "wizard_current_security_unsupported",
+          "Current LOW or MAXIMUM network threat levels cannot be represented by the wizard"
+              + " controls. Retry with preserveCurrentNetworkThreatLevel=true or use the"
+              + " dedicated security controls.");
+    }
+    if (!supportsWizardPhysicalThreatLevel(physicalThreatLevel)
+        && !submission.preserveCurrentPhysicalThreatLevel()) {
+      throw new PlatformApiException(
+          409,
+          "wizard_current_security_unsupported",
+          "Current LOW or MAXIMUM physical threat levels cannot be represented by the wizard"
+              + " controls. Retry with preserveCurrentPhysicalThreatLevel=true or use the"
+              + " dedicated security controls.");
+    }
+  }
+
+  private static boolean supportsWizardNetworkThreatLevel(SecurityNetworkThreatLevel level) {
+    return level == SecurityNetworkThreatLevel.NORMAL || level == SecurityNetworkThreatLevel.HIGH;
+  }
+
+  private static boolean supportsWizardPhysicalThreatLevel(SecurityPhysicalThreatLevel level) {
+    return level == SecurityPhysicalThreatLevel.NORMAL || level == SecurityPhysicalThreatLevel.HIGH;
+  }
+
+  private static void validatePasswordFlowAvailability(
+      FirstTimeWizardSnapshot snapshot, FirstTimeWizardSubmission submission) {
+    if (snapshot.passwordAlreadySet() && submission.setPassword()) {
+      throw new PlatformApiException(
+          409,
+          "wizard_password_already_set",
+          "A startup password is already set. Use the dedicated security/password flow instead"
+              + " of the first-time wizard submission.");
+    }
+    if (submission.preserveCurrentPhysicalThreatLevel() && submission.setPassword()) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_SET_PASSWORD)
+              + " cannot be combined with "
+              + queryParameter(PARAMETER_PRESERVE_CURRENT_PHYSICAL_THREAT_LEVEL)
+              + ".");
+    }
+  }
+
+  private static void validateDownloadLimit(
+      FirstTimeWizardSnapshot snapshot, String downloadLimitKiB) {
+    long parsedDownloadLimitBytes =
+        parseSizedLong(
+            downloadLimitKiB, "KiB", PARAMETER_DOWNLOAD_LIMIT_KIB, INVALID_KIB_VALUE_MESSAGE);
+    if (parsedDownloadLimitBytes > MAX_INT_BACKED_BANDWIDTH_LIMIT_BYTES) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_DOWNLOAD_LIMIT_KIB)
+              + " exceeds the maximum supported bandwidth limit.");
+    }
+    if (parsedDownloadLimitBytes < snapshot.minBandwidthKiB() * KIB) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_DOWNLOAD_LIMIT_KIB)
+              + MUST_BE_AT_LEAST
+              + snapshot.minBandwidthKiB()
+              + KIB_UNIT_SUFFIX);
+    }
+  }
+
+  private static void validateUploadLimit(FirstTimeWizardSnapshot snapshot, String uploadLimitKiB) {
+    long parsedUploadLimitBytes =
+        parseSizedLong(
+            uploadLimitKiB, "KiB", PARAMETER_UPLOAD_LIMIT_KIB, INVALID_KIB_VALUE_MESSAGE);
+    if (parsedUploadLimitBytes < snapshot.minBandwidthKiB() * KIB) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_UPLOAD_LIMIT_KIB)
+              + MUST_BE_AT_LEAST
+              + snapshot.minBandwidthKiB()
+              + KIB_UNIT_SUFFIX);
+    }
+    if (parsedUploadLimitBytes > snapshot.maxUploadLimitKiB() * KIB) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_UPLOAD_LIMIT_KIB)
+              + MUST_BE_AT_MOST
+              + snapshot.maxUploadLimitKiB()
+              + KIB_UNIT_SUFFIX);
+    }
+  }
+
+  private static void validateMonthlyLimit(
+      FirstTimeWizardSnapshot snapshot, String bandwidthMonthlyLimitGiB) {
+    long requestedMonthlyLimitBytes =
+        parseSizedLong(
+            bandwidthMonthlyLimitGiB,
+            "GiB",
+            PARAMETER_BANDWIDTH_MONTHLY_LIMIT_GIB,
+            INVALID_GIB_VALUE_MESSAGE);
+    long minimumMonthlyLimitBytes =
+        parseSizedLong(
+            snapshot.minBandwidthMonthlyLimitGiB(),
+            "GiB",
+            PARAMETER_BANDWIDTH_MONTHLY_LIMIT_GIB,
+            INVALID_GIB_VALUE_MESSAGE);
+    if (requestedMonthlyLimitBytes < minimumMonthlyLimitBytes) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_BANDWIDTH_MONTHLY_LIMIT_GIB)
+              + MUST_BE_AT_LEAST
+              + snapshot.minBandwidthMonthlyLimitGiB()
+              + GIB_UNIT_SUFFIX);
+    }
+  }
+
+  private static void validateStorageLimit(
+      FirstTimeWizardSnapshot snapshot, String storageLimitGiB) {
+    long requestedStorageLimitBytes =
+        parseSizedLong(
+            storageLimitGiB, "GiB", PARAMETER_STORAGE_LIMIT_GIB, INVALID_GIB_VALUE_MESSAGE);
+    if (requestedStorageLimitBytes < snapshot.minStorageLimitBytes()) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_STORAGE_LIMIT_GIB)
+              + MUST_BE_AT_LEAST
+              + snapshot.minStorageLimitGiB()
+              + GIB_UNIT_SUFFIX);
+    }
+    if (requestedStorageLimitBytes > snapshot.maxStorageLimitBytes()) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_STORAGE_LIMIT_GIB)
+              + MUST_BE_AT_MOST
+              + snapshot.maxStorageLimitGiB()
+              + GIB_UNIT_SUFFIX);
+    }
+  }
+
+  private static void validatePassword(boolean setPassword, String password) {
+    if (!setPassword) {
+      return;
+    }
+    if (password.isEmpty()) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_PASSWORD) + " must not be empty when setPassword is enabled.");
+    }
+    if (password.length() > MAX_PASSWORD_LENGTH) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_PASSWORD)
+              + " must not exceed "
+              + MAX_PASSWORD_LENGTH
+              + " characters.");
+    }
+  }
+
+  private static long parseSizedLong(
+      String value, String suffix, String parameterName, String invalidMessage) {
+    try {
+      return Fields.parseLong(value + suffix);
+    } catch (NumberFormatException _) {
+      throw invalidQuery(queryParameter(parameterName) + " " + invalidMessage);
+    }
+  }
+
+  private static String optionalString(Map<String, List<String>> queryParameters, String name) {
+    String value = PlatformApiParameters.readOptionalString(queryParameters, name);
+    return value == null ? "" : value;
+  }
+
+  private static boolean readCheckboxBoolean(
+      Map<String, List<String>> queryParameters, String name) {
+    List<String> values = queryParameters.get(name);
+    if (values == null || values.isEmpty()) {
+      return false;
+    }
+    boolean anyTruthy = false;
+    for (String raw : values) {
+      if (raw == null || isTruthyCheckboxValue(raw, name)) {
+        anyTruthy = true;
+      } else if (!isFalseyCheckboxValue(raw)) {
+        throw invalidQuery(
+            queryParameter(name)
+                + " must be a checkbox value or one of 'true', 'false', 'on', or 'off'.");
+      }
+    }
+    return anyTruthy;
+  }
+
+  private static boolean isTruthyCheckboxValue(String raw, String name) {
+    return raw.isBlank()
+        || "true".equalsIgnoreCase(raw)
+        || "on".equalsIgnoreCase(raw)
+        || name.equals(raw);
+  }
+
+  private static boolean isFalseyCheckboxValue(String raw) {
+    return "false".equalsIgnoreCase(raw) || "off".equalsIgnoreCase(raw);
+  }
+
+  private static String queryParameter(String name) {
+    return "Query parameter '" + name + "'";
+  }
+
+  private static PlatformApiException invalidQuery(String message) {
+    return new PlatformApiException(400, "invalid_query_parameter", message);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/wizard/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/wizard/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * First-time-wizard Platform API handlers.
+ *
+ * <p>This package owns the detached wizard snapshot and submission endpoints introduced for
+ * Platform API v1. Its purpose is to make the most important onboarding and reset flows reachable
+ * from the Web Shell without redesigning the wizard domain model or bypassing the existing daemon
+ * seams.
+ *
+ * <p>The package keeps the request model intentionally close to the legacy form flow. Callers send
+ * checkbox-style booleans and raw text fields, the API layer validates only the transport-neutral
+ * contract, and the daemon-backed wizard port still owns the actual onboarding side effects. That
+ * split keeps the shell-native control plane practical while preserving the legacy wizard as a
+ * fallback for flows that remain more specialized or password-heavy.
+ */
+package network.crypta.platform.api.wizard;

--- a/platform-api/src/test/java/network/crypta/platform/api/config/ConfigApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/config/ConfigApiHandlerTest.java
@@ -1,0 +1,333 @@
+package network.crypta.platform.api.config;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.ConfigFieldSet;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class ConfigApiHandlerTest {
+  private static final String CANONICAL_UPDATE_URI =
+      "uQnFwn0aEFSAZihnSDduEHUd3GUmGg68ATn5R95MKJo,"
+          + "mcNiZqosfZ1F~PkZY8v1TuDKsY6noda-hGRXvu7uUFc,AQACAAE";
+  private static final String FULL_UPDATE_URI = "USK@" + CANONICAL_UPDATE_URI + "/info/1234";
+
+  @Test
+  void applyOverrides_whenOverridesProvided_expectDelegatesAndReturnsSummary() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("updater.enabled", "true");
+    configPort.currentValues.put("updater.autoupdate", "false");
+    configPort.dataTypes.put("updater.enabled", "boolean");
+    configPort.dataTypes.put("updater.autoupdate", "boolean");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+
+    Map<String, Object> response =
+        handler.applyOverrides(
+            orderedParameters(
+                Map.entry("node.updater.enabled", List.of("false")),
+                Map.entry("node.updater.autoupdate", List.of("true"))));
+
+    assertEquals(
+        Map.of("node.updater.enabled", "false", "node.updater.autoupdate", "true"),
+        configPort.lastOverrides);
+    assertEquals("apply_overrides", response.get("operation"));
+    assertEquals(2, response.get("overrideCount"));
+  }
+
+  @Test
+  void applyOverrides_whenCanonicalBooleanProvided_expectAccepted() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("updater.enabled", "false");
+    configPort.dataTypes.put("updater.enabled", "boolean");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+
+    Map<String, Object> response =
+        handler.applyOverrides(
+            orderedParameters(Map.entry("node.updater.enabled", List.of("YES"))));
+
+    assertEquals("true", configPort.currentValues.get("updater.enabled"));
+    assertEquals("apply_overrides", response.get("operation"));
+    assertEquals(1, response.get("overrideCount"));
+  }
+
+  @Test
+  void applyOverrides_whenCanonicalNumberProvided_expectAccepted() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("inputBandwidthLimit", "15360");
+    configPort.dataTypes.put("inputBandwidthLimit", "number");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+
+    Map<String, Object> response =
+        handler.applyOverrides(
+            orderedParameters(Map.entry("node.inputBandwidthLimit", List.of("15K"))));
+
+    assertEquals("15360", configPort.currentValues.get("inputBandwidthLimit"));
+    assertEquals("apply_overrides", response.get("operation"));
+    assertEquals(1, response.get("overrideCount"));
+  }
+
+  @Test
+  void applyOverrides_whenStringArrayProvidedAsDecodedValue_expectAccepted() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("downloadAllowedDirs", "");
+    configPort.dataTypes.put("downloadAllowedDirs", "stringArray");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+
+    Map<String, Object> response =
+        handler.applyOverrides(
+            orderedParameters(
+                Map.entry("node.downloadAllowedDirs", List.of("/home/alice/My Files"))));
+
+    assertEquals(
+        network.crypta.support.URLEncoder.encode("/home/alice/My Files", false),
+        configPort.currentValues.get("downloadAllowedDirs"));
+    assertEquals("apply_overrides", response.get("operation"));
+    assertEquals(1, response.get("overrideCount"));
+  }
+
+  @Test
+  void applyOverrides_whenStringOverrideIsNormalized_expectAccepted() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("updater.URI", "USK@old-key");
+    configPort.dataTypes.put("updater.URI", "string");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+
+    Map<String, Object> response =
+        handler.applyOverrides(
+            orderedParameters(Map.entry("node.updater.URI", List.of(FULL_UPDATE_URI))));
+
+    assertEquals(CANONICAL_UPDATE_URI, configPort.currentValues.get("updater.URI"));
+    assertEquals("apply_overrides", response.get("operation"));
+    assertEquals(1, response.get("overrideCount"));
+  }
+
+  @Test
+  void applyOverrides_whenNormalizedStringOverrideIsIdempotent_expectAccepted() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("updater.URI", CANONICAL_UPDATE_URI);
+    configPort.dataTypes.put("updater.URI", "string");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+
+    Map<String, Object> response =
+        handler.applyOverrides(
+            orderedParameters(Map.entry("node.updater.URI", List.of(FULL_UPDATE_URI))));
+
+    assertEquals(CANONICAL_UPDATE_URI, configPort.currentValues.get("updater.URI"));
+    assertEquals("apply_overrides", response.get("operation"));
+    assertEquals(1, response.get("overrideCount"));
+  }
+
+  @Test
+  void applyOverrides_whenOverrideRejected_expectConflictAndRollbackAcceptedChanges() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("updater.enabled", "true");
+    configPort.currentValues.put("updater.autoupdate", "false");
+    configPort.dataTypes.put("updater.enabled", "boolean");
+    configPort.dataTypes.put("updater.autoupdate", "boolean");
+    configPort.rejectNames.add("node.updater.autoupdate");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+    Map<String, List<String>> queryParameters =
+        orderedParameters(
+            Map.entry("node.updater.enabled", List.of("false")),
+            Map.entry("node.updater.autoupdate", List.of("true")));
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, () -> handler.applyOverrides(queryParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("config_override_rejected", exception.errorCode());
+    assertEquals("true", configPort.currentValues.get("updater.enabled"));
+    assertEquals("false", configPort.currentValues.get("updater.autoupdate"));
+    assertEquals(
+        List.of(
+            Map.of("node.updater.enabled", "false", "node.updater.autoupdate", "true"),
+            Map.of("node.updater.enabled", "true")),
+        configPort.applyCalls);
+  }
+
+  @Test
+  void applyOverrides_whenTypedOverrideMalformed_expectRejectedWithoutInternalError() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    configPort.currentValues.put("updater.enabled", "true");
+    configPort.dataTypes.put("updater.enabled", "boolean");
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+    Map<String, List<String>> queryParameters =
+        orderedParameters(Map.entry("node.updater.enabled", List.of("maybe")));
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, () -> handler.applyOverrides(queryParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("config_override_rejected", exception.errorCode());
+    assertEquals("true", configPort.currentValues.get("updater.enabled"));
+  }
+
+  @Test
+  void applyOverrides_whenNoParametersProvided_expectInvalidQueryException() {
+    ConfigApiHandler handler = new ConfigApiHandler(new RecordingConfigPort());
+    Map<String, List<String>> queryParameters = Map.of();
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, () -> handler.applyOverrides(queryParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_query_parameter", exception.errorCode());
+  }
+
+  @Test
+  void applyOverrides_whenParameterRepeated_expectInvalidQueryException() {
+    ConfigApiHandler handler = new ConfigApiHandler(new RecordingConfigPort());
+    Map<String, List<String>> queryParameters =
+        Map.of("node.updater.enabled", List.of("true", "false"));
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, () -> handler.applyOverrides(queryParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_query_parameter", exception.errorCode());
+  }
+
+  @Test
+  void persist_whenCalled_expectDelegatesAndReturnsSummary() {
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    ConfigApiHandler handler = new ConfigApiHandler(configPort);
+
+    Map<String, Object> response = handler.persist();
+
+    assertEquals(1, configPort.persistCalls);
+    assertEquals("persist", response.get("operation"));
+  }
+
+  @SafeVarargs
+  private static Map<String, List<String>> orderedParameters(
+      Map.Entry<String, List<String>>... entries) {
+    LinkedHashMap<String, List<String>> parameters = LinkedHashMap.newLinkedHashMap(entries.length);
+    for (Map.Entry<String, List<String>> entry : entries) {
+      parameters.put(entry.getKey(), entry.getValue());
+    }
+    return parameters;
+  }
+
+  private static final class RecordingConfigPort implements ConfigPort {
+    private Map<String, String> lastOverrides = Map.of();
+    private final LinkedHashMap<String, String> currentValues = LinkedHashMap.newLinkedHashMap(4);
+    private final LinkedHashMap<String, String> dataTypes = LinkedHashMap.newLinkedHashMap(4);
+    private final java.util.Set<String> rejectNames = new java.util.LinkedHashSet<>();
+    private final java.util.List<Map<String, String>> applyCalls = new java.util.ArrayList<>();
+    private int persistCalls;
+
+    @Override
+    public ConfigSnapshot export(Set<ConfigSection> sections) {
+      LinkedHashMap<ConfigSection, ConfigFieldSet> exported =
+          LinkedHashMap.newLinkedHashMap(sections.size());
+      if (sections.contains(ConfigSection.CURRENT)) {
+        exported.put(
+            ConfigSection.CURRENT,
+            new ConfigFieldSet(
+                Map.of(),
+                Map.of("node", new ConfigFieldSet(new LinkedHashMap<>(currentValues), Map.of()))));
+      }
+      if (sections.contains(ConfigSection.DATA_TYPES)) {
+        exported.put(
+            ConfigSection.DATA_TYPES,
+            new ConfigFieldSet(
+                Map.of(),
+                Map.of("node", new ConfigFieldSet(new LinkedHashMap<>(dataTypes), Map.of()))));
+      }
+      return new ConfigSnapshot(exported);
+    }
+
+    @Override
+    public void applyOverrides(Map<String, String> overrides) {
+      applyCalls.add(Map.copyOf(overrides));
+      lastOverrides = Map.copyOf(overrides);
+      overrides.forEach(
+          (name, value) -> {
+            if (!rejectNames.contains(name)) {
+              String nestedName =
+                  name.startsWith("node.") ? name.substring("node.".length()) : name;
+              try {
+                currentValues.put(nestedName, canonicalizeValue(nestedName, value));
+              } catch (RuntimeException _) {
+                // Mirror LegacyConfigPort: invalid values are ignored instead of bubbling out.
+              }
+            }
+          });
+    }
+
+    @Override
+    public void persist() {
+      persistCalls++;
+    }
+
+    private String canonicalizeValue(String nestedName, String value) {
+      String dataType = dataTypes.get(nestedName);
+      if ("updater.URI".equals(nestedName)) {
+        return CANONICAL_UPDATE_URI;
+      }
+      if ("boolean".equals(dataType)) {
+        return network.crypta.support.Fields.boolToString(
+            network.crypta.support.Fields.stringToBool(value));
+      }
+      if ("number".equals(dataType)) {
+        return Long.toString(network.crypta.support.Fields.parseLong(value));
+      }
+      if ("stringArray".equals(dataType)) {
+        return canonicalizeStringArrayValue(value);
+      }
+      return value;
+    }
+
+    private String canonicalizeStringArrayValue(String value) {
+      if (value.isEmpty()) {
+        return "";
+      }
+
+      java.util.List<String> tokens = splitStringArrayTokens(value);
+      StringBuilder canonical = new StringBuilder(value.length());
+      for (int i = 0; i < tokens.size(); i++) {
+        if (i > 0) {
+          canonical.append(';');
+        }
+        canonical.append(canonicalizeStringArrayToken(tokens.get(i)));
+      }
+      return canonical.toString();
+    }
+
+    private java.util.List<String> splitStringArrayTokens(String value) {
+      java.util.ArrayList<String> tokens = new java.util.ArrayList<>();
+      int segmentStart = 0;
+      while (segmentStart <= value.length()) {
+        int delimiter = value.indexOf(';', segmentStart);
+        if (delimiter < 0) {
+          tokens.add(value.substring(segmentStart));
+          return tokens;
+        }
+        tokens.add(value.substring(segmentStart, delimiter));
+        segmentStart = delimiter + 1;
+      }
+      return tokens;
+    }
+
+    private String canonicalizeStringArrayToken(String token) {
+      if (":".equals(token)) {
+        return ":";
+      }
+      try {
+        String decoded = network.crypta.support.URLDecoder.decode(token, true);
+        return decoded.isEmpty() ? ":" : network.crypta.support.URLEncoder.encode(decoded, false);
+      } catch (network.crypta.support.URLEncodedFormatException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/security/SecurityLevelsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/security/SecurityLevelsApiHandlerTest.java
@@ -112,6 +112,25 @@ class SecurityLevelsApiHandlerTest {
   }
 
   @Test
+  void
+      setNetworkThreatLevel_whenConfirmationPostedAsLegacyCheckboxValue_expectMutationAndPersist() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.networkWarningHtml = "<p>Needs confirmation</p>";
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    Map<String, Object> response =
+        handler.setNetworkThreatLevel(
+            Map.of("newLevel", List.of("LOW"), "confirmed", List.of("off")));
+
+    assertEquals(SecurityNetworkThreatLevel.LOW, securityLevelsPort.lastNetworkThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+    assertEquals("LOW", response.get("networkThreatLevel"));
+  }
+
+  @Test
   void setPhysicalThreatLevel_whenValidLevelProvided_expectMutationAndPersist() {
     RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
     RecordingConfigPort configPort = new RecordingConfigPort();

--- a/platform-api/src/test/java/network/crypta/platform/api/security/SecurityLevelsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/security/SecurityLevelsApiHandlerTest.java
@@ -1,0 +1,421 @@
+package network.crypta.platform.api.security;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.ConfigPort;
+import network.crypta.runtime.spi.ConfigSection;
+import network.crypta.runtime.spi.ConfigSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.runtime.spi.SecurityLevelsPort;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class SecurityLevelsApiHandlerTest {
+  @Test
+  void networkThreatLevelWarning_whenWarningRequired_expectWarningPayload() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.networkWarningHtml = "<p>Needs confirmation</p>";
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, new RecordingConfigPort(), new RecordingFirstTimeWizardPort());
+
+    Map<String, Object> response =
+        handler.networkThreatLevelWarning(Map.of("newLevel", List.of("LOW")));
+
+    assertEquals("LOW", response.get("newLevel"));
+    assertEquals(Boolean.TRUE, response.get("confirmationRequired"));
+    assertEquals("<p>Needs confirmation</p>", response.get("warningHtml"));
+  }
+
+  @Test
+  void setNetworkThreatLevel_whenValidLevelProvided_expectMutationAndPersist() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    Map<String, Object> response =
+        handler.setNetworkThreatLevel(Map.of("newLevel", List.of("HIGH")));
+
+    assertEquals(SecurityNetworkThreatLevel.HIGH, securityLevelsPort.lastNetworkThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+    assertEquals("set_network_threat_level", response.get("operation"));
+    assertEquals("HIGH", response.get("networkThreatLevel"));
+  }
+
+  @Test
+  void setNetworkThreatLevel_whenConfirmationRequiredWithoutAcknowledgement_expectConflict() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.networkWarningHtml = "<p>Needs confirmation</p>";
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+    Map<String, List<String>> queryParameters = Map.of("newLevel", List.of("LOW"));
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> handler.setNetworkThreatLevel(queryParameters));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("network_threat_level_confirmation_required", exception.errorCode());
+    assertEquals(0, configPort.persistCalls);
+  }
+
+  @Test
+  void setNetworkThreatLevel_whenConfirmationAcknowledged_expectMutationAndPersist() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.networkWarningHtml = "<p>Needs confirmation</p>";
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    Map<String, Object> response =
+        handler.setNetworkThreatLevel(
+            Map.of("newLevel", List.of("LOW"), "confirmed", List.of("true")));
+
+    assertEquals(SecurityNetworkThreatLevel.LOW, securityLevelsPort.lastNetworkThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+    assertEquals("LOW", response.get("networkThreatLevel"));
+  }
+
+  @Test
+  void setNetworkThreatLevel_whenConfirmationPostedAsCheckbox_expectMutationAndPersist() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.networkWarningHtml = "<p>Needs confirmation</p>";
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    Map<String, Object> response =
+        handler.setNetworkThreatLevel(
+            Map.of("newLevel", List.of("LOW"), "confirmed", List.of("on")));
+
+    assertEquals(SecurityNetworkThreatLevel.LOW, securityLevelsPort.lastNetworkThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+    assertEquals("LOW", response.get("networkThreatLevel"));
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenValidLevelProvided_expectMutationAndPersist() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    Map<String, Object> response =
+        handler.setPhysicalThreatLevel(Map.of("newLevel", List.of("MAXIMUM")));
+
+    assertEquals(SecurityPhysicalThreatLevel.MAXIMUM, securityLevelsPort.lastPhysicalThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+    assertEquals("set_physical_threat_level", response.get("operation"));
+    assertEquals("MAXIMUM", response.get("physicalThreatLevel"));
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenSettingMaximum_expectDeletesMasterPasswordFile() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    handler.setPhysicalThreatLevel(Map.of("newLevel", List.of("MAXIMUM")));
+
+    assertEquals(1, securityLevelsPort.deleteMasterPasswordFileCalls);
+    assertEquals(SecurityPhysicalThreatLevel.MAXIMUM, securityLevelsPort.lastPhysicalThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenMaximumNeedsConfirmation_expectConflict() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.hasDatabase = true;
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+    Map<String, List<String>> queryParameters = Map.of("newLevel", List.of("MAXIMUM"));
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> handler.setPhysicalThreatLevel(queryParameters));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("physical_threat_level_confirmation_required", exception.errorCode());
+    assertEquals(0, securityLevelsPort.deleteMasterPasswordFileCalls);
+    assertEquals(0, configPort.persistCalls);
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenMaximumConfirmed_expectDeletesMasterPasswordFile() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.hasDatabase = true;
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    handler.setPhysicalThreatLevel(
+        Map.of("newLevel", List.of("MAXIMUM"), "confirmed", List.of("true")));
+
+    assertEquals(1, securityLevelsPort.deleteMasterPasswordFileCalls);
+    assertEquals(SecurityPhysicalThreatLevel.MAXIMUM, securityLevelsPort.lastPhysicalThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenMaximumCleanupFails_expectConflict() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.deleteMasterPasswordFileException = new IOException("boom");
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+    Map<String, List<String>> queryParameters = Map.of("newLevel", List.of("MAXIMUM"));
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> handler.setPhysicalThreatLevel(queryParameters));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("physical_threat_level_master_password_cleanup_failed", exception.errorCode());
+    assertEquals(0, configPort.persistCalls);
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenTransitionRequiresPasswordFlow_expectConflict() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.currentPhysicalThreatLevel = SecurityPhysicalThreatLevel.NORMAL;
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+    Map<String, List<String>> queryParameters = Map.of("newLevel", List.of("HIGH"));
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> handler.setPhysicalThreatLevel(queryParameters));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("physical_threat_level_password_required", exception.errorCode());
+    assertEquals(0, configPort.persistCalls);
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenDowngradingFromHigh_expectConflict() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.currentPhysicalThreatLevel = SecurityPhysicalThreatLevel.HIGH;
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+    Map<String, List<String>> queryParameters = Map.of("newLevel", List.of("NORMAL"));
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> handler.setPhysicalThreatLevel(queryParameters));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("physical_threat_level_password_required", exception.errorCode());
+    assertEquals(0, configPort.persistCalls);
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenDowngradingFromHighToMaximum_expectMaximumApplied() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.currentPhysicalThreatLevel = SecurityPhysicalThreatLevel.HIGH;
+    securityLevelsPort.hasDatabase = true;
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            securityLevelsPort, configPort, new RecordingFirstTimeWizardPort());
+
+    Map<String, Object> response =
+        handler.setPhysicalThreatLevel(
+            Map.of("newLevel", List.of("MAXIMUM"), "confirmed", List.of("true")));
+
+    assertEquals(1, securityLevelsPort.deleteMasterPasswordFileCalls);
+    assertEquals(SecurityPhysicalThreatLevel.MAXIMUM, securityLevelsPort.lastPhysicalThreatLevel);
+    assertEquals(1, configPort.persistCalls);
+    assertEquals("set_physical_threat_level", response.get("operation"));
+    assertEquals("MAXIMUM", response.get("physicalThreatLevel"));
+  }
+
+  @Test
+  void setNetworkThreatLevel_whenLevelInvalid_expectInvalidQueryException() {
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(
+            new RecordingSecurityLevelsPort(),
+            new RecordingConfigPort(),
+            new RecordingFirstTimeWizardPort());
+    Map<String, List<String>> queryParameters = Map.of("newLevel", List.of("BOGUS"));
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> handler.setNetworkThreatLevel(queryParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_query_parameter", exception.errorCode());
+  }
+
+  @Test
+  void setPhysicalThreatLevel_whenLeavingMaximum_expectWizardSemantics() {
+    RecordingSecurityLevelsPort securityLevelsPort = new RecordingSecurityLevelsPort();
+    securityLevelsPort.currentPhysicalThreatLevel = SecurityPhysicalThreatLevel.MAXIMUM;
+    RecordingConfigPort configPort = new RecordingConfigPort();
+    RecordingFirstTimeWizardPort firstTimeWizardPort = new RecordingFirstTimeWizardPort();
+    SecurityLevelsApiHandler handler =
+        new SecurityLevelsApiHandler(securityLevelsPort, configPort, firstTimeWizardPort);
+
+    Map<String, Object> response =
+        handler.setPhysicalThreatLevel(Map.of("newLevel", List.of("NORMAL")));
+
+    assertEquals(SecurityPhysicalThreatLevel.NORMAL, firstTimeWizardPort.lastPhysicalThreatLevel);
+    assertNull(securityLevelsPort.lastPhysicalThreatLevel);
+    assertEquals(0, configPort.persistCalls);
+    assertEquals("set_physical_threat_level", response.get("operation"));
+    assertEquals("NORMAL", response.get("physicalThreatLevel"));
+  }
+
+  private static final class RecordingSecurityLevelsPort implements SecurityLevelsPort {
+    private String networkWarningHtml;
+    private final SecurityNetworkThreatLevel currentNetworkThreatLevel =
+        SecurityNetworkThreatLevel.NORMAL;
+    private SecurityPhysicalThreatLevel currentPhysicalThreatLevel =
+        SecurityPhysicalThreatLevel.NORMAL;
+    private boolean hasDatabase;
+    private IOException deleteMasterPasswordFileException;
+    private int deleteMasterPasswordFileCalls;
+    private SecurityNetworkThreatLevel lastNetworkThreatLevel;
+    private SecurityPhysicalThreatLevel lastPhysicalThreatLevel;
+
+    @Override
+    public SecurityLevelsSnapshot snapshot() {
+      return new SecurityLevelsSnapshot(
+          currentNetworkThreatLevel, currentPhysicalThreatLevel, hasDatabase, false, "");
+    }
+
+    @Override
+    public String networkThreatLevelConfirmWarningHtml(
+        SecurityNetworkThreatLevel newLevel, String checkboxName) {
+      return networkWarningHtml;
+    }
+
+    @Override
+    public void setNetworkThreatLevel(SecurityNetworkThreatLevel newLevel) {
+      lastNetworkThreatLevel = newLevel;
+    }
+
+    @Override
+    public void setPhysicalThreatLevel(SecurityPhysicalThreatLevel newLevel) {
+      lastPhysicalThreatLevel = newLevel;
+    }
+
+    @Override
+    public network.crypta.runtime.spi.MasterPasswordMutationStatus changeMasterPassword(
+        String oldPassword, String newPassword) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public network.crypta.runtime.spi.MasterPasswordMutationStatus setMasterPassword(
+        String password) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteMasterPasswordFile() throws IOException {
+      deleteMasterPasswordFileCalls++;
+      if (deleteMasterPasswordFileException != null) {
+        throw deleteMasterPasswordFileException;
+      }
+    }
+  }
+
+  private static final class RecordingConfigPort implements ConfigPort {
+    private int persistCalls;
+
+    @Override
+    public ConfigSnapshot export(Set<ConfigSection> sections) {
+      return ConfigSnapshot.empty();
+    }
+
+    @Override
+    public void applyOverrides(Map<String, String> overrides) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void persist() {
+      persistCalls++;
+    }
+  }
+
+  private static final class RecordingFirstTimeWizardPort implements FirstTimeWizardPort {
+    private SecurityPhysicalThreatLevel lastPhysicalThreatLevel;
+
+    @Override
+    public FirstTimeWizardSnapshot snapshot() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isOpennetEnabled() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SecurityLevelsSnapshot securitySnapshot() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setNetworkThreatLevel(SecurityNetworkThreatLevel level) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPhysicalThreatLevel(SecurityPhysicalThreatLevel level) {
+      lastPhysicalThreatLevel = level;
+    }
+
+    @Override
+    public network.crypta.runtime.spi.MasterPasswordMutationStatus changeMasterPassword(
+        String oldPassword, String newPassword) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public network.crypta.runtime.spi.MasterPasswordMutationStatus setMasterPassword(
+        String password) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteMasterPasswordFile() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void applySubmission(FirstTimeWizardSubmission submission) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/updates/UpdatesApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/updates/UpdatesApiHandlerTest.java
@@ -1,0 +1,118 @@
+package network.crypta.platform.api.updates;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class UpdatesApiHandlerTest {
+  @Test
+  void coreSnapshot_whenUpdaterAvailable_expectAvailabilityFlags() {
+    RecordingCoreUpdateActionPort coreUpdateActionPort = new RecordingCoreUpdateActionPort();
+    coreUpdateActionPort.available = true;
+    coreUpdateActionPort.downloadAvailable = true;
+    UpdatesApiHandler handler = new UpdatesApiHandler(coreUpdateActionPort);
+
+    Map<String, Object> response = handler.coreSnapshot();
+
+    assertEquals(Map.of("available", true, "downloadAllowed", true), response);
+  }
+
+  @Test
+  void coreSnapshot_whenUpdaterAvailableWithoutSelectableUpdate_expectDownloadDisallowed() {
+    RecordingCoreUpdateActionPort coreUpdateActionPort = new RecordingCoreUpdateActionPort();
+    coreUpdateActionPort.available = true;
+    UpdatesApiHandler handler = new UpdatesApiHandler(coreUpdateActionPort);
+
+    Map<String, Object> response = handler.coreSnapshot();
+
+    assertEquals(Map.of("available", true, "downloadAllowed", false), response);
+  }
+
+  @Test
+  void startCoreDownload_whenUpdaterUnavailable_expectConflictException() {
+    UpdatesApiHandler handler = new UpdatesApiHandler(new RecordingCoreUpdateActionPort());
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, handler::startCoreDownload);
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("updater_unavailable", exception.errorCode());
+  }
+
+  @Test
+  void startCoreDownload_whenUpdaterAvailable_expectDelegatesAndReturnsSummary() {
+    RecordingCoreUpdateActionPort coreUpdateActionPort = new RecordingCoreUpdateActionPort();
+    coreUpdateActionPort.available = true;
+    coreUpdateActionPort.downloadAvailable = true;
+    coreUpdateActionPort.startResult = true;
+    UpdatesApiHandler handler = new UpdatesApiHandler(coreUpdateActionPort);
+
+    Map<String, Object> response = handler.startCoreDownload();
+
+    assertEquals(1, coreUpdateActionPort.startCalls);
+    assertEquals("start_core_download", response.get("operation"));
+    assertEquals(Boolean.TRUE, response.get("downloadTriggered"));
+  }
+
+  @Test
+  void startCoreDownload_whenStartReturnsFalse_expectConflictException() {
+    RecordingCoreUpdateActionPort coreUpdateActionPort = new RecordingCoreUpdateActionPort();
+    coreUpdateActionPort.available = true;
+    coreUpdateActionPort.downloadAvailable = true;
+    UpdatesApiHandler handler = new UpdatesApiHandler(coreUpdateActionPort);
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, handler::startCoreDownload);
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("core_download_not_started", exception.errorCode());
+  }
+
+  @Test
+  void startCoreDownload_whenSelectableUpdateMissing_expectConflictException() {
+    RecordingCoreUpdateActionPort coreUpdateActionPort = new RecordingCoreUpdateActionPort();
+    coreUpdateActionPort.available = true;
+    UpdatesApiHandler handler = new UpdatesApiHandler(coreUpdateActionPort);
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, handler::startCoreDownload);
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("core_update_unavailable", exception.errorCode());
+  }
+
+  private static final class RecordingCoreUpdateActionPort implements CoreUpdateActionPort {
+    private boolean available;
+    private boolean downloadAvailable;
+    private boolean startResult;
+    private int startCalls;
+
+    @Override
+    public boolean isCoreUpdaterAvailable() {
+      return available;
+    }
+
+    @Override
+    public boolean isCoreDownloadAvailable() {
+      return downloadAvailable;
+    }
+
+    @Override
+    public boolean startCoreDownloadFromUi() {
+      startCalls++;
+      return startResult;
+    }
+
+    @Override
+    public Optional<Path> resolveDownloadedInstaller(String rawPath) {
+      return Optional.empty();
+    }
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/wizard/FirstTimeWizardApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/wizard/FirstTimeWizardApiHandlerTest.java
@@ -1,0 +1,294 @@
+package network.crypta.platform.api.wizard;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.runtime.spi.MasterPasswordMutationStatus;
+import network.crypta.runtime.spi.SecurityLevelsSnapshot;
+import network.crypta.runtime.spi.SecurityNetworkThreatLevel;
+import network.crypta.runtime.spi.SecurityPhysicalThreatLevel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class FirstTimeWizardApiHandlerTest {
+  @Test
+  void snapshot_whenRequested_expectDetachedWizardJson() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+
+    Map<String, Object> response = handler.snapshot();
+
+    assertEquals(Boolean.TRUE, response.get("passwordAlreadySet"));
+    assertEquals(Boolean.TRUE, response.get("opennetEnabled"));
+    assertEquals("HIGH", response.get("currentNetworkThreatLevel"));
+    assertEquals("HIGH", response.get("currentPhysicalThreatLevel"));
+    assertEquals("2.50", response.get("initialStorageLimitGiB"));
+    assertEquals("49.44", response.get("minBandwidthMonthlyLimitGiB"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> currentBandwidthLimits =
+        (Map<String, Object>) response.get("currentBandwidthLimits");
+    assertEquals(4096L, currentBandwidthLimits.get("downloadBytes"));
+    assertEquals(1024L, currentBandwidthLimits.get("uploadBytes"));
+  }
+
+  @Test
+  void apply_whenValidSubmissionProvided_expectDelegatesDetachedSubmission() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    wizardPort.passwordAlreadySet = false;
+    wizardPort.securitySnapshot =
+        new SecurityLevelsSnapshot(
+            SecurityNetworkThreatLevel.NORMAL,
+            SecurityPhysicalThreatLevel.NORMAL,
+            false,
+            false,
+            "");
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+
+    Map<String, Object> response =
+        handler.apply(
+            orderedParameters(
+                Map.entry("knowSomeone", List.of("on")),
+                Map.entry("downloadLimitKiB", List.of("20000")),
+                Map.entry("uploadLimitKiB", List.of("10000")),
+                Map.entry("storageLimitGiB", List.of("2")),
+                Map.entry("setPassword", List.of("true")),
+                Map.entry("password", List.of("secret"))));
+
+    assertEquals(
+        new FirstTimeWizardSubmission(
+            true, false, false, "20000", "10000", "", "2", true, "secret"),
+        wizardPort.lastSubmission);
+    assertEquals("apply_submission", response.get("operation"));
+    assertEquals(Boolean.TRUE, response.get("wizardApplied"));
+  }
+
+  @Test
+  void apply_whenPreserveBandwidthRequested_expectDelegatesPreserveBandwidthSubmission() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    wizardPort.passwordAlreadySet = false;
+    wizardPort.securitySnapshot =
+        new SecurityLevelsSnapshot(
+            SecurityNetworkThreatLevel.NORMAL,
+            SecurityPhysicalThreatLevel.NORMAL,
+            false,
+            false,
+            "");
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+
+    Map<String, Object> response =
+        handler.apply(
+            orderedParameters(
+                Map.entry("preserveBandwidthSettings", List.of("on")),
+                Map.entry("storageLimitGiB", List.of("2")),
+                Map.entry("setPassword", List.of("true")),
+                Map.entry("password", List.of("secret"))));
+
+    assertEquals(
+        new FirstTimeWizardSubmission(false, false, false, true, "", "", "", "2", true, "secret"),
+        wizardPort.lastSubmission);
+    assertEquals("apply_submission", response.get("operation"));
+    assertEquals(Boolean.TRUE, response.get("wizardApplied"));
+  }
+
+  @Test
+  void apply_whenPreserveBandwidthRequestedWithoutCurrentBandwidthRow_expectDelegatesSubmission() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    wizardPort.passwordAlreadySet = false;
+    wizardPort.currentBandwidthLimits = null;
+    wizardPort.securitySnapshot =
+        new SecurityLevelsSnapshot(
+            SecurityNetworkThreatLevel.NORMAL,
+            SecurityPhysicalThreatLevel.NORMAL,
+            false,
+            false,
+            "");
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+
+    Map<String, Object> response =
+        handler.apply(
+            orderedParameters(
+                Map.entry("preserveBandwidthSettings", List.of("on")),
+                Map.entry("storageLimitGiB", List.of("2"))));
+
+    assertEquals(
+        new FirstTimeWizardSubmission(false, false, false, true, "", "", "", "2", false, ""),
+        wizardPort.lastSubmission);
+    assertEquals("apply_submission", response.get("operation"));
+    assertEquals(Boolean.TRUE, response.get("wizardApplied"));
+  }
+
+  @Test
+  void apply_whenCurrentSecurityStateIsLowOrMaximumWithoutPreserveFlags_expectConflictException() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    wizardPort.passwordAlreadySet = false;
+    wizardPort.securitySnapshot =
+        new SecurityLevelsSnapshot(
+            SecurityNetworkThreatLevel.MAXIMUM, SecurityPhysicalThreatLevel.LOW, false, false, "");
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+    Map<String, List<String>> queryParameters =
+        orderedParameters(
+            Map.entry("downloadLimitKiB", List.of("20000")),
+            Map.entry("uploadLimitKiB", List.of("10000")),
+            Map.entry("storageLimitGiB", List.of("2")));
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, () -> handler.apply(queryParameters));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("wizard_current_security_unsupported", exception.errorCode());
+    assertNull(wizardPort.lastSubmission);
+  }
+
+  @Test
+  void apply_whenCurrentSecurityStateIsLowOrMaximumWithPreserveFlags_expectDelegatesSubmission() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    wizardPort.passwordAlreadySet = false;
+    wizardPort.securitySnapshot =
+        new SecurityLevelsSnapshot(
+            SecurityNetworkThreatLevel.MAXIMUM, SecurityPhysicalThreatLevel.LOW, false, false, "");
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+
+    Map<String, Object> response =
+        handler.apply(
+            orderedParameters(
+                Map.entry("preserveCurrentNetworkThreatLevel", List.of("on")),
+                Map.entry("preserveCurrentPhysicalThreatLevel", List.of("on")),
+                Map.entry("downloadLimitKiB", List.of("20000")),
+                Map.entry("uploadLimitKiB", List.of("10000")),
+                Map.entry("storageLimitGiB", List.of("2"))));
+
+    assertEquals(
+        new FirstTimeWizardSubmission(
+            false, false, false, false, true, true, "20000", "10000", "", "2", false, ""),
+        wizardPort.lastSubmission);
+    assertEquals("apply_submission", response.get("operation"));
+    assertEquals(Boolean.TRUE, response.get("wizardApplied"));
+  }
+
+  @Test
+  void apply_whenPasswordAlreadySetAndWizardPasswordRequested_expectConflictException() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+    Map<String, List<String>> queryParameters =
+        orderedParameters(
+            Map.entry("downloadLimitKiB", List.of("20000")),
+            Map.entry("uploadLimitKiB", List.of("10000")),
+            Map.entry("storageLimitGiB", List.of("2")),
+            Map.entry("setPassword", List.of("true")),
+            Map.entry("password", List.of("secret")));
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, () -> handler.apply(queryParameters));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("wizard_password_already_set", exception.errorCode());
+    assertNull(wizardPort.lastSubmission);
+  }
+
+  @Test
+  void apply_whenStorageLimitBelowMinimum_expectInvalidQueryException() {
+    RecordingFirstTimeWizardPort wizardPort = new RecordingFirstTimeWizardPort();
+    FirstTimeWizardApiHandler handler = new FirstTimeWizardApiHandler(wizardPort);
+    Map<String, List<String>> queryParameters =
+        orderedParameters(
+            Map.entry("downloadLimitKiB", List.of("20000")),
+            Map.entry("uploadLimitKiB", List.of("10000")),
+            Map.entry("storageLimitGiB", List.of("0.50")));
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, () -> handler.apply(queryParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_query_parameter", exception.errorCode());
+  }
+
+  @SafeVarargs
+  private static Map<String, List<String>> orderedParameters(
+      Map.Entry<String, List<String>>... entries) {
+    LinkedHashMap<String, List<String>> parameters = LinkedHashMap.newLinkedHashMap(entries.length);
+    for (Map.Entry<String, List<String>> entry : entries) {
+      parameters.put(entry.getKey(), entry.getValue());
+    }
+    return parameters;
+  }
+
+  private static final class RecordingFirstTimeWizardPort implements FirstTimeWizardPort {
+    private boolean passwordAlreadySet = true;
+    private FirstTimeWizardCurrentBandwidthLimits currentBandwidthLimits =
+        new FirstTimeWizardCurrentBandwidthLimits(4096L, 1024L);
+    private SecurityLevelsSnapshot securitySnapshot =
+        new SecurityLevelsSnapshot(
+            SecurityNetworkThreatLevel.HIGH, SecurityPhysicalThreatLevel.HIGH, false, false, "");
+    private FirstTimeWizardSubmission lastSubmission;
+
+    @Override
+    public FirstTimeWizardSnapshot snapshot() {
+      return new FirstTimeWizardSnapshot(
+          passwordAlreadySet,
+          "2.50",
+          "1.25",
+          network.crypta.support.Fields.parseLong("1.25GiB"),
+          "10.00",
+          network.crypta.support.Fields.parseLong("10GiB"),
+          network.crypta.support.Fields.parseLong("12GiB"),
+          10,
+          976562,
+          "49.44",
+          "2048",
+          "1024",
+          currentBandwidthLimits,
+          -1L);
+    }
+
+    @Override
+    public boolean isOpennetEnabled() {
+      return true;
+    }
+
+    @Override
+    public SecurityLevelsSnapshot securitySnapshot() {
+      return securitySnapshot;
+    }
+
+    @Override
+    public void setNetworkThreatLevel(network.crypta.runtime.spi.SecurityNetworkThreatLevel level) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPhysicalThreatLevel(
+        network.crypta.runtime.spi.SecurityPhysicalThreatLevel level) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MasterPasswordMutationStatus changeMasterPassword(
+        String oldPassword, String newPassword) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MasterPasswordMutationStatus setMasterPassword(String password) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteMasterPasswordFile() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void applySubmission(FirstTimeWizardSubmission submission) {
+      lastSubmission = submission;
+    }
+  }
+}

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -15,8 +15,8 @@
         <p class="eyebrow">Cryptad node management</p>
         <h1>Web Shell v1</h1>
         <p class="lede">
-          Snapshot views, queue control, and selective legacy deep links powered by Platform API
-          v1.
+          Snapshot views, config changes, updater triggers, first-run controls, queue actions, and
+          selective legacy deep links powered by Platform API v1.
         </p>
         <div class="hero-actions">
           <a class="button button-primary" href="/api/v1/node/greeting">Node greeting JSON</a>
@@ -50,8 +50,202 @@
             <p class="panel-kicker">Security</p>
             <h2>Threat levels</h2>
           </div>
+          <p class="panel-description">
+            Review and adjust the node threat levels from the shell. Legacy warning-heavy and
+            password-management flows remain available through the legacy page when needed.
+          </p>
+          <div class="queue-status" id="security-status" aria-live="polite"></div>
+          <p class="panel-description" hidden id="security-readonly-hint">
+            Security mutations are unavailable in read-only mode.
+          </p>
+          <form class="control-form" hidden id="security-form">
+            <div class="control-form-grid">
+              <label class="queue-field" for="security-network-level">
+                <span>Network threat level</span>
+                <select id="security-network-level">
+                  <option value="LOW">Low</option>
+                  <option value="NORMAL">Normal</option>
+                  <option value="HIGH">High</option>
+                  <option value="MAXIMUM">Maximum</option>
+                </select>
+              </label>
+              <label class="queue-field" for="security-physical-level">
+                <span>Physical threat level</span>
+                <select id="security-physical-level">
+                  <option value="LOW">Low</option>
+                  <option value="NORMAL">Normal</option>
+                  <option value="HIGH">High</option>
+                  <option value="MAXIMUM">Maximum</option>
+                </select>
+              </label>
+            </div>
+            <div class="control-form-actions">
+              <button class="button button-primary" id="security-save-button" type="submit">
+                Save threat levels
+              </button>
+            </div>
+          </form>
           <div class="panel-body" id="security-body">
             <p class="loading">Loading security snapshot...</p>
+          </div>
+        </article>
+
+        <article class="panel" id="updates-panel">
+          <div class="panel-header">
+            <p class="panel-kicker">Updates</p>
+            <h2>Core updater</h2>
+          </div>
+          <p class="panel-description">
+            Check whether the package-based core updater is available and trigger the current core
+            download from the shell.
+          </p>
+          <div class="queue-toolbar">
+            <button class="button button-secondary" id="updates-refresh-button" type="button">
+              Refresh updater
+            </button>
+            <button class="button button-primary" id="updates-download-button" type="button">
+              Trigger download
+            </button>
+          </div>
+          <div class="queue-status" id="updates-status" aria-live="polite"></div>
+          <p class="panel-description" hidden id="updates-readonly-hint">
+            Updater actions are unavailable in read-only mode.
+          </p>
+          <div class="panel-body" id="updates-body">
+            <p class="loading">Loading updater status...</p>
+          </div>
+        </article>
+
+        <article class="panel panel-span-2" id="config-panel">
+          <div class="panel-header">
+            <p class="panel-kicker">Config</p>
+            <h2>Operator subset</h2>
+          </div>
+          <p class="panel-description">
+            Edit a constrained shell-native config subset and persist the result without dropping
+            back to the legacy config page.
+          </p>
+          <div class="queue-toolbar">
+            <button class="button button-secondary" id="config-refresh-button" type="button">
+              Refresh config
+            </button>
+          </div>
+          <div class="queue-status" id="config-status" aria-live="polite"></div>
+          <p class="panel-description" hidden id="config-readonly-hint">
+            Config mutations are unavailable in read-only mode.
+          </p>
+          <form class="control-form" hidden id="config-form">
+            <div class="control-form-grid">
+              <label class="checkbox-inline" for="config-updater-enabled">
+                <input id="config-updater-enabled" type="checkbox">
+                <span>Enable core updater</span>
+              </label>
+              <label class="checkbox-inline" for="config-updater-autoupdate">
+                <input id="config-updater-autoupdate" type="checkbox">
+                <span>Enable auto-update</span>
+              </label>
+              <label class="queue-field" for="config-input-bandwidth-limit">
+                <span>Input bandwidth limit</span>
+                <input id="config-input-bandwidth-limit" type="text" autocomplete="off">
+              </label>
+              <label class="queue-field" for="config-output-bandwidth-limit">
+                <span>Output bandwidth limit</span>
+                <input id="config-output-bandwidth-limit" type="text" autocomplete="off">
+              </label>
+            </div>
+            <div class="control-form-actions">
+              <button class="button button-primary" id="config-save-button" type="submit">
+                Apply and persist
+              </button>
+              <button class="button button-secondary" id="config-persist-button" type="button">
+                Persist current config
+              </button>
+            </div>
+          </form>
+          <div class="panel-body" id="config-body">
+            <p class="loading">Loading config snapshot...</p>
+          </div>
+        </article>
+
+        <article class="panel panel-span-2" id="wizard-panel">
+          <div class="panel-header">
+            <p class="panel-kicker">Wizard</p>
+            <h2>First-time setup</h2>
+          </div>
+          <p class="panel-description">
+            Apply the detached first-time-wizard submission from the shell for routine onboarding
+            and operator reset scenarios.
+          </p>
+          <div class="queue-toolbar">
+            <button class="button button-secondary" id="wizard-refresh-button" type="button">
+              Refresh wizard state
+            </button>
+          </div>
+          <div class="queue-status" id="wizard-status" aria-live="polite"></div>
+          <p class="panel-description" hidden id="wizard-readonly-hint">
+            Wizard submission is unavailable in read-only mode.
+          </p>
+          <form class="control-form" hidden id="wizard-form">
+            <div class="control-form-grid">
+              <label class="checkbox-inline" for="wizard-know-someone">
+                <input id="wizard-know-someone" type="checkbox">
+                <span>I know existing trusted operators</span>
+              </label>
+              <label class="checkbox-inline" for="wizard-connect-to-strangers">
+                <input id="wizard-connect-to-strangers" type="checkbox">
+                <span>Connect to strangers</span>
+              </label>
+              <label class="checkbox-inline" for="wizard-edit-bandwidth" hidden>
+                <input id="wizard-edit-bandwidth" type="checkbox">
+                <span>Change bandwidth settings</span>
+              </label>
+              <label class="checkbox-inline" for="wizard-have-monthly-limit">
+                <input id="wizard-have-monthly-limit" type="checkbox">
+                <span>Use a monthly transfer limit</span>
+              </label>
+              <label class="checkbox-inline" for="wizard-set-password">
+                <input id="wizard-set-password" type="checkbox">
+                <span>Set startup password</span>
+              </label>
+            </div>
+            <div class="control-form-grid" id="wizard-rate-fields">
+              <label class="queue-field" for="wizard-download-limit">
+                <span>Download limit (KiB/s)</span>
+                <input id="wizard-download-limit" type="text" autocomplete="off">
+              </label>
+              <label class="queue-field" for="wizard-upload-limit">
+                <span>Upload limit (KiB/s)</span>
+                <input id="wizard-upload-limit" type="text" autocomplete="off">
+              </label>
+            </div>
+            <div class="control-form-grid">
+              <label class="queue-field" for="wizard-monthly-limit" id="wizard-monthly-limit-field">
+                <span>Monthly limit (GiB)</span>
+                <input id="wizard-monthly-limit" type="text" autocomplete="off">
+              </label>
+              <label class="queue-field" for="wizard-storage-limit">
+                <span>Storage limit (GiB)</span>
+                <input id="wizard-storage-limit" type="text" autocomplete="off">
+              </label>
+            </div>
+            <div class="control-form-grid" id="wizard-password-fields">
+              <label class="queue-field" for="wizard-password">
+                <span>Password</span>
+                <input id="wizard-password" type="password" autocomplete="new-password">
+              </label>
+              <label class="queue-field" for="wizard-confirm-password">
+                <span>Confirm password</span>
+                <input id="wizard-confirm-password" type="password" autocomplete="new-password">
+              </label>
+            </div>
+            <div class="control-form-actions">
+              <button class="button button-primary" id="wizard-apply-button" type="submit">
+                Apply wizard settings
+              </button>
+            </div>
+          </form>
+          <div class="panel-body" id="wizard-body">
+            <p class="loading">Loading wizard snapshot...</p>
           </div>
         </article>
 

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -351,6 +351,27 @@ a {
   background: rgba(255, 255, 255, 0.03);
 }
 
+.control-form {
+  display: grid;
+  gap: 14px;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.control-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.control-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .queue-create-copy,
 .queue-create-description,
 .peer-add-copy,
@@ -402,6 +423,32 @@ a {
 .queue-key-export {
   display: grid;
   gap: 10px;
+}
+
+.json-details {
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.json-details summary {
+  cursor: pointer;
+  color: var(--shell-accent);
+  font-weight: 700;
+}
+
+.json-code {
+  margin: 0;
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(4, 8, 16, 0.48);
+  color: var(--shell-text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9rem;
+  overflow: auto;
 }
 
 .queue-key-text {
@@ -616,7 +663,8 @@ a {
 
   .queue-create-form,
   .peer-create-form,
-  .peer-form-grid {
+  .peer-form-grid,
+  .control-form-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -12,6 +12,12 @@
   const shellRootUrl = new URL(shellRoot, window.location.origin);
   let formPassword = typeof bootstrap.formPassword === "string" ? bootstrap.formPassword : "";
   const legacyLinks = Array.isArray(bootstrap.legacyLinks) ? bootstrap.legacyLinks : [];
+  const shellState = {
+    configSnapshot: null,
+    securitySnapshot: null,
+    updatesSnapshot: null,
+    wizardSnapshot: null,
+  };
   const directDownloadOperation = "create_direct_download";
   const queueState = {
     page: "downloads",
@@ -22,12 +28,27 @@
   };
   let peerLoadGeneration = 0;
   let queueLoadGeneration = 0;
+  let securityLoadGeneration = 0;
+  let updatesLoadGeneration = 0;
+  let configLoadGeneration = 0;
+  let wizardLoadGeneration = 0;
   const nativeQueueSubmitBypass = new WeakSet();
 
   const sections = {
     overview: document.getElementById("overview-body"),
     connectivity: document.getElementById("connectivity-body"),
     security: document.getElementById("security-body"),
+    securityStatus: document.getElementById("security-status"),
+    securityReadonlyHint: document.getElementById("security-readonly-hint"),
+    updates: document.getElementById("updates-body"),
+    updatesStatus: document.getElementById("updates-status"),
+    updatesReadonlyHint: document.getElementById("updates-readonly-hint"),
+    config: document.getElementById("config-body"),
+    configStatus: document.getElementById("config-status"),
+    configReadonlyHint: document.getElementById("config-readonly-hint"),
+    wizard: document.getElementById("wizard-body"),
+    wizardStatus: document.getElementById("wizard-status"),
+    wizardReadonlyHint: document.getElementById("wizard-readonly-hint"),
     peers: document.getElementById("peers-body"),
     peersStatus: document.getElementById("peers-status"),
     peersReadonlyHint: document.getElementById("peers-readonly-hint"),
@@ -43,6 +64,42 @@
     createReference: document.getElementById("peer-reference-text"),
     createSubmit: document.getElementById("peer-create-submit"),
   };
+  const securityControls = {
+    form: document.getElementById("security-form"),
+    networkLevel: document.getElementById("security-network-level"),
+    physicalLevel: document.getElementById("security-physical-level"),
+  };
+  const updatesControls = {
+    refreshButton: document.getElementById("updates-refresh-button"),
+    downloadButton: document.getElementById("updates-download-button"),
+  };
+  const configControls = {
+    form: document.getElementById("config-form"),
+    refreshButton: document.getElementById("config-refresh-button"),
+    persistButton: document.getElementById("config-persist-button"),
+    updaterEnabled: document.getElementById("config-updater-enabled"),
+    updaterAutoupdate: document.getElementById("config-updater-autoupdate"),
+    inputBandwidthLimit: document.getElementById("config-input-bandwidth-limit"),
+    outputBandwidthLimit: document.getElementById("config-output-bandwidth-limit"),
+  };
+  const wizardControls = {
+    form: document.getElementById("wizard-form"),
+    refreshButton: document.getElementById("wizard-refresh-button"),
+    knowSomeone: document.getElementById("wizard-know-someone"),
+    connectToStrangers: document.getElementById("wizard-connect-to-strangers"),
+    editBandwidth: document.getElementById("wizard-edit-bandwidth"),
+    haveMonthlyLimit: document.getElementById("wizard-have-monthly-limit"),
+    setPassword: document.getElementById("wizard-set-password"),
+    downloadLimit: document.getElementById("wizard-download-limit"),
+    uploadLimit: document.getElementById("wizard-upload-limit"),
+    monthlyLimit: document.getElementById("wizard-monthly-limit"),
+    storageLimit: document.getElementById("wizard-storage-limit"),
+    password: document.getElementById("wizard-password"),
+    confirmPassword: document.getElementById("wizard-confirm-password"),
+    rateFields: document.getElementById("wizard-rate-fields"),
+    monthlyLimitField: document.getElementById("wizard-monthly-limit-field"),
+    passwordFields: document.getElementById("wizard-password-fields"),
+  };
   const queueControls = {
     downloadsButton: document.getElementById("queue-downloads-button"),
     uploadsButton: document.getElementById("queue-uploads-button"),
@@ -56,6 +113,17 @@
 
   function apiUrl(path) {
     return new URL(path, apiRootUrl).toString();
+  }
+
+  function apiUrlWithQuery(path, query) {
+    const url = new URL(path, apiRootUrl);
+    for (const [key, value] of Object.entries(query || {})) {
+      if (value == null || value === "") {
+        continue;
+      }
+      url.searchParams.set(key, value);
+    }
+    return url.toString();
   }
 
   function normalizeLocalRootPath(value, fallback) {
@@ -91,21 +159,35 @@
   }
 
   function setStatus(message, tone) {
-    clear(sections.queueStatus);
-    if (!message) {
-      return;
-    }
-    sections.queueStatus.append(text("p", tone ? `status-message ${tone}` : "status-message", message));
+    setSectionStatus(sections.queueStatus, message, tone);
   }
 
   function setPeerStatus(message, tone) {
-    clear(sections.peersStatus);
+    setSectionStatus(sections.peersStatus, message, tone);
+  }
+
+  function setSectionStatus(container, message, tone) {
+    clear(container);
     if (!message) {
       return;
     }
-    sections.peersStatus.append(
-      text("p", tone ? `status-message ${tone}` : "status-message", message),
-    );
+    container.append(text("p", tone ? `status-message ${tone}` : "status-message", message));
+  }
+
+  function setSecurityStatus(message, tone) {
+    setSectionStatus(sections.securityStatus, message, tone);
+  }
+
+  function setUpdatesStatus(message, tone) {
+    setSectionStatus(sections.updatesStatus, message, tone);
+  }
+
+  function setConfigStatus(message, tone) {
+    setSectionStatus(sections.configStatus, message, tone);
+  }
+
+  function setWizardStatus(message, tone) {
+    setSectionStatus(sections.wizardStatus, message, tone);
   }
 
   function definitionList(entries) {
@@ -145,6 +227,15 @@
       .slice(0, 4)
       .map(([key, entryValue]) => `${key}: ${scalar(entryValue)}`)
       .join(" • ");
+  }
+
+  function htmlToText(html) {
+    if (typeof html !== "string" || !html) {
+      return "";
+    }
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    return (container.textContent || "").replace(/\s+/g, " ").trim();
   }
 
   function formatJson(value) {
@@ -239,6 +330,8 @@
   }
 
   function renderSecurity(data) {
+    shellState.securitySnapshot = data;
+    updateSecurityToolbar();
     clear(sections.security);
     sections.security.append(
       summaryCard("Threat levels", [
@@ -249,6 +342,237 @@
         ["Password file path", data.masterPasswordFilePath || "Unavailable"],
       ]),
     );
+    if (securityControls.networkLevel) {
+      securityControls.networkLevel.value = data.networkThreatLevel || "NORMAL";
+    }
+    if (securityControls.physicalLevel) {
+      securityControls.physicalLevel.value = data.physicalThreatLevel || "NORMAL";
+    }
+  }
+
+  function renderUpdates(data) {
+    shellState.updatesSnapshot = data;
+    updateUpdatesToolbar();
+    clear(sections.updates);
+    sections.updates.append(
+      summaryCard("Core updater", [
+        ["Available", data.available ? "Yes" : "No"],
+        ["Download action", data.downloadAllowed ? "Ready" : "Unavailable"],
+      ], data.available ? "" : "is-warning"),
+    );
+  }
+
+  function getNestedValue(root, path) {
+    let current = root;
+    for (let index = 0; index < path.length; index += 1) {
+      if (!current || typeof current !== "object" || Array.isArray(current)) {
+        return null;
+      }
+      const segment = path[index];
+      if (Object.prototype.hasOwnProperty.call(current, segment)) {
+        current = current[segment];
+        continue;
+      }
+      const remainingPath = path.slice(index).join(".");
+      if (Object.prototype.hasOwnProperty.call(current, remainingPath)) {
+        return current[remainingPath];
+      }
+      return null;
+    }
+    return current;
+  }
+
+  function configBoolean(value) {
+    return value === true || value === "true";
+  }
+
+  function renderConfig(data) {
+    shellState.configSnapshot = data;
+    updateConfigToolbar();
+    clear(sections.config);
+
+    const currentSection =
+      data && typeof data.CURRENT === "object" && !Array.isArray(data.CURRENT) ? data.CURRENT : {};
+    const updaterEnabled = getNestedValue(currentSection, ["node", "updater", "enabled"]);
+    const updaterAutoupdate = getNestedValue(currentSection, ["node", "updater", "autoupdate"]);
+    const inputBandwidthLimit = getNestedValue(currentSection, ["node", "inputBandwidthLimit"]);
+    const outputBandwidthLimit = getNestedValue(currentSection, ["node", "outputBandwidthLimit"]);
+
+    configControls.updaterEnabled.checked = configBoolean(updaterEnabled);
+    configControls.updaterAutoupdate.checked = configBoolean(updaterAutoupdate);
+    configControls.inputBandwidthLimit.value =
+      typeof inputBandwidthLimit === "string" ? inputBandwidthLimit : "";
+    configControls.outputBandwidthLimit.value =
+      typeof outputBandwidthLimit === "string" ? outputBandwidthLimit : "";
+
+    sections.config.append(
+      summaryCard("Current values", [
+        ["node.updater.enabled", scalar(updaterEnabled)],
+        ["node.updater.autoupdate", scalar(updaterAutoupdate)],
+        ["node.inputBandwidthLimit", scalar(inputBandwidthLimit)],
+        ["node.outputBandwidthLimit", scalar(outputBandwidthLimit)],
+      ]),
+    );
+
+    const rawDetails = document.createElement("details");
+    rawDetails.className = "json-details";
+    const summary = document.createElement("summary");
+    summary.textContent = "Raw current config JSON";
+    const rawPre = document.createElement("pre");
+    rawPre.className = "json-code";
+    rawPre.textContent = formatJson(data);
+    rawDetails.append(summary, rawPre);
+    sections.config.append(rawDetails);
+  }
+
+  function updateWizardFieldVisibility() {
+    const usingMonthlyLimit = wizardControls.haveMonthlyLimit.checked;
+    const knowsTrustedOperators = wizardControls.knowSomeone.checked;
+    const passwordAlreadySet =
+      !!(shellState.wizardSnapshot && shellState.wizardSnapshot.passwordAlreadySet);
+    const editingBandwidth = wizardControls.editBandwidth.checked;
+    const networkThreatEditable =
+      wizardCanEditCurrentNetworkThreatLevel(shellState.wizardSnapshot);
+    const physicalThreatEditable =
+      wizardCanEditCurrentPhysicalThreatLevel(shellState.wizardSnapshot);
+    wizardControls.knowSomeone.parentElement.hidden = !networkThreatEditable;
+    wizardControls.editBandwidth.parentElement.hidden = false;
+    wizardControls.haveMonthlyLimit.parentElement.hidden = !editingBandwidth;
+    wizardControls.rateFields.hidden = !editingBandwidth || usingMonthlyLimit;
+    wizardControls.monthlyLimitField.hidden = !editingBandwidth || !usingMonthlyLimit;
+    wizardControls.connectToStrangers.parentElement.hidden =
+      !networkThreatEditable || !knowsTrustedOperators;
+    if (!networkThreatEditable || !knowsTrustedOperators) {
+      wizardControls.connectToStrangers.checked = false;
+    }
+    wizardControls.setPassword.parentElement.hidden = passwordAlreadySet || !physicalThreatEditable;
+    wizardControls.passwordFields.hidden =
+      passwordAlreadySet || !physicalThreatEditable || !wizardControls.setPassword.checked;
+  }
+
+  function wizardBandwidthModeUnknown(data) {
+    return !!(
+      data &&
+      typeof data === "object" &&
+      data.currentBandwidthLimits &&
+      typeof data.currentBandwidthLimits === "object"
+    );
+  }
+
+  function wizardCanEditCurrentNetworkThreatLevel(data) {
+    return !!(
+      data &&
+      typeof data === "object" &&
+      (data.currentNetworkThreatLevel === "NORMAL" || data.currentNetworkThreatLevel === "HIGH")
+    );
+  }
+
+  function wizardCanEditCurrentPhysicalThreatLevel(data) {
+    return !!(
+      data &&
+      typeof data === "object" &&
+      (data.currentPhysicalThreatLevel === "NORMAL" || data.currentPhysicalThreatLevel === "HIGH")
+    );
+  }
+
+  function wizardSubmissionSupported(data) {
+    return !!(data && typeof data === "object");
+  }
+
+  function wizardUnsupportedMessage(data) {
+    if (!data || typeof data !== "object") {
+      return "Wizard controls stay unavailable until the current snapshot loads.";
+    }
+    return "";
+  }
+
+  function wizardBandwidthChoiceRequired(data) {
+    return false;
+  }
+
+  function wizardBandwidthChoiceMessage() {
+    return "Current bandwidth settings are already configured. Choose direct rates or monthly budget explicitly and enter the values you want before applying wizard changes.";
+  }
+
+  function renderWizard(data) {
+    shellState.wizardSnapshot = data;
+    updateWizardToolbar();
+    clear(sections.wizard);
+
+    const currentBandwidthLimits =
+      data.currentBandwidthLimits && typeof data.currentBandwidthLimits === "object"
+        ? data.currentBandwidthLimits
+        : null;
+    const detectedDownloadLimit = data.detectedDownloadLimitKiB || "";
+    const detectedUploadLimit = data.detectedUploadLimitKiB || "";
+    const configuredBandwidth = wizardBandwidthModeUnknown(data);
+    const networkThreatEditable = wizardCanEditCurrentNetworkThreatLevel(data);
+    const physicalThreatEditable = wizardCanEditCurrentPhysicalThreatLevel(data);
+    wizardControls.knowSomeone.checked =
+      networkThreatEditable && data.currentNetworkThreatLevel === "HIGH";
+    wizardControls.connectToStrangers.checked = false;
+    wizardControls.editBandwidth.checked = false;
+    wizardControls.haveMonthlyLimit.checked = false;
+    wizardControls.haveMonthlyLimit.indeterminate = false;
+    wizardControls.downloadLimit.value =
+      currentBandwidthLimits && Number.isFinite(currentBandwidthLimits.downloadBytes)
+        ? String(Math.round(currentBandwidthLimits.downloadBytes / 1024))
+        : detectedDownloadLimit || String(data.minBandwidthKiB || "");
+    wizardControls.uploadLimit.value =
+      currentBandwidthLimits && Number.isFinite(currentBandwidthLimits.uploadBytes)
+        ? String(Math.round(currentBandwidthLimits.uploadBytes / 1024))
+        : detectedUploadLimit || String(data.minBandwidthKiB || "");
+    wizardControls.monthlyLimit.value = data.minBandwidthMonthlyLimitGiB || "";
+    wizardControls.storageLimit.value = data.initialStorageLimitGiB || "";
+    wizardControls.setPassword.checked = false;
+    wizardControls.password.value = "";
+    wizardControls.confirmPassword.value = "";
+    updateWizardFieldVisibility();
+
+    const currentBandwidthSummary =
+      currentBandwidthLimits
+        ? `${scalar(currentBandwidthLimits.downloadBytes)} / ${scalar(currentBandwidthLimits.uploadBytes)}`
+        : "Unavailable";
+
+    sections.wizard.append(
+      summaryCard("Current defaults", [
+        ["Opennet enabled", scalar(data.opennetEnabled)],
+        ["Password already set", scalar(data.passwordAlreadySet)],
+        ["Current network threat", scalar(data.currentNetworkThreatLevel)],
+        ["Current physical threat", scalar(data.currentPhysicalThreatLevel)],
+        [
+          "Storage range",
+          `${scalar(data.minStorageLimitGiB)} GiB to ${scalar(data.maxStorageLimitGiB)} GiB`,
+        ],
+        ["Minimum bandwidth", `${scalar(data.minBandwidthKiB)} KiB/s`],
+        ["Detected bandwidth", `${scalar(detectedDownloadLimit)} / ${scalar(detectedUploadLimit)}`],
+        ["Current bandwidth row", currentBandwidthSummary],
+      ]),
+    );
+    const unsupportedMessage = wizardUnsupportedMessage(data);
+    if (unsupportedMessage) {
+      setWizardStatus(unsupportedMessage, "is-error");
+    } else if (wizardBandwidthChoiceRequired(data)) {
+      setWizardStatus(wizardBandwidthChoiceMessage(), "is-error");
+    } else {
+      const notes = [];
+      if (!networkThreatEditable) {
+        notes.push(
+          "Current LOW/MAXIMUM network threat level will be preserved; use the security controls to change it.",
+        );
+      }
+      if (!physicalThreatEditable) {
+        notes.push(
+          "Current LOW/MAXIMUM physical threat level will be preserved; use the security controls to change it.",
+        );
+      }
+      notes.push(
+        configuredBandwidth
+          ? "Current bandwidth settings will be preserved unless you enable bandwidth editing."
+          : "Default bandwidth settings will be preserved unless you enable bandwidth editing.",
+      );
+      setWizardStatus(notes.join(" "));
+    }
   }
 
   function updatePeerToolbar() {
@@ -256,6 +580,39 @@
     if (sections.peersReadonlyHint) {
       sections.peersReadonlyHint.hidden = !!formPassword;
     }
+  }
+
+  function updateSecurityToolbar() {
+    securityControls.form.hidden = !formPassword || !shellState.securitySnapshot;
+    if (sections.securityReadonlyHint) {
+      sections.securityReadonlyHint.hidden = !!formPassword;
+    }
+  }
+
+  function updateUpdatesToolbar() {
+    const available =
+      !!(shellState.updatesSnapshot && shellState.updatesSnapshot.downloadAllowed);
+    updatesControls.downloadButton.hidden = !formPassword;
+    updatesControls.downloadButton.disabled = !available;
+    if (sections.updatesReadonlyHint) {
+      sections.updatesReadonlyHint.hidden = !!formPassword;
+    }
+  }
+
+  function updateConfigToolbar() {
+    configControls.form.hidden = !formPassword || !shellState.configSnapshot;
+    if (sections.configReadonlyHint) {
+      sections.configReadonlyHint.hidden = !!formPassword;
+    }
+  }
+
+  function updateWizardToolbar() {
+    wizardControls.form.hidden =
+      !formPassword || !shellState.wizardSnapshot || !wizardSubmissionSupported(shellState.wizardSnapshot);
+    if (sections.wizardReadonlyHint) {
+      sections.wizardReadonlyHint.hidden = !!formPassword;
+    }
+    updateWizardFieldVisibility();
   }
 
   function familyLabel(peer) {
@@ -599,6 +956,10 @@
     }
     const nextBootstrap = JSON.parse(nextBootstrapElement.textContent || "{}");
     formPassword = typeof nextBootstrap.formPassword === "string" ? nextBootstrap.formPassword : "";
+    updateSecurityToolbar();
+    updateUpdatesToolbar();
+    updateConfigToolbar();
+    updateWizardToolbar();
     return formPassword;
   }
 
@@ -761,6 +1122,90 @@
       throw new Error(extractApiError(data, response));
     }
     return data;
+  }
+
+  async function loadSecuritySection() {
+    const loadGeneration = ++securityLoadGeneration;
+    shellState.securitySnapshot = null;
+    clear(sections.security);
+    sections.security.append(text("p", "loading", "Loading security snapshot..."));
+    updateSecurityToolbar();
+
+    try {
+      const snapshot = await loadJson(apiUrl("security-levels"));
+      if (loadGeneration !== securityLoadGeneration) {
+        return;
+      }
+      renderSecurity(snapshot);
+    } catch (error) {
+      if (loadGeneration !== securityLoadGeneration) {
+        return;
+      }
+      renderError(sections.security, "security", error);
+    }
+  }
+
+  async function loadUpdatesSection() {
+    const loadGeneration = ++updatesLoadGeneration;
+    shellState.updatesSnapshot = null;
+    clear(sections.updates);
+    sections.updates.append(text("p", "loading", "Loading updater status..."));
+    updateUpdatesToolbar();
+
+    try {
+      const snapshot = await loadJson(apiUrl("updates/core"));
+      if (loadGeneration !== updatesLoadGeneration) {
+        return;
+      }
+      renderUpdates(snapshot);
+    } catch (error) {
+      if (loadGeneration !== updatesLoadGeneration) {
+        return;
+      }
+      renderError(sections.updates, "updates", error);
+    }
+  }
+
+  async function loadConfigSection() {
+    const loadGeneration = ++configLoadGeneration;
+    shellState.configSnapshot = null;
+    clear(sections.config);
+    sections.config.append(text("p", "loading", "Loading config snapshot..."));
+    updateConfigToolbar();
+
+    try {
+      const snapshot = await loadJson(apiUrl("config?sections=CURRENT"));
+      if (loadGeneration !== configLoadGeneration) {
+        return;
+      }
+      renderConfig(snapshot);
+    } catch (error) {
+      if (loadGeneration !== configLoadGeneration) {
+        return;
+      }
+      renderError(sections.config, "config", error);
+    }
+  }
+
+  async function loadWizardSection() {
+    const loadGeneration = ++wizardLoadGeneration;
+    shellState.wizardSnapshot = null;
+    clear(sections.wizard);
+    sections.wizard.append(text("p", "loading", "Loading wizard snapshot..."));
+    updateWizardToolbar();
+
+    try {
+      const snapshot = await loadJson(apiUrl("wizard/first-time"));
+      if (loadGeneration !== wizardLoadGeneration) {
+        return;
+      }
+      renderWizard(snapshot);
+    } catch (error) {
+      if (loadGeneration !== wizardLoadGeneration) {
+        return;
+      }
+      renderError(sections.wizard, "wizard", error);
+    }
   }
 
   function peerPath(peerIdentity, action) {
@@ -960,6 +1405,261 @@
     }
   }
 
+  async function submitSecurityForm(event) {
+    event.preventDefault();
+    const currentSnapshot = shellState.securitySnapshot;
+    if (!currentSnapshot) {
+      setSecurityStatus("Security controls stay unavailable until the current snapshot loads.", "is-error");
+      return;
+    }
+    const requestedNetwork = securityControls.networkLevel.value;
+    const requestedPhysical = securityControls.physicalLevel.value;
+    const networkChanged = requestedNetwork !== currentSnapshot.networkThreatLevel;
+    const physicalChanged = requestedPhysical !== currentSnapshot.physicalThreatLevel;
+
+    if (!networkChanged && !physicalChanged) {
+      setSecurityStatus("No threat-level changes to apply.");
+      return;
+    }
+
+    if (networkChanged && physicalChanged) {
+      setSecurityStatus(
+        "Save one threat-level change at a time so warnings and failures cannot partially apply a combined update.",
+        "is-error",
+      );
+      return;
+    }
+
+    if (
+      physicalChanged &&
+      (requestedPhysical === "HIGH" ||
+        (currentSnapshot.physicalThreatLevel === "HIGH" &&
+          (requestedPhysical === "LOW" || requestedPhysical === "NORMAL")))
+    ) {
+      setSecurityStatus(
+        "Changing to or from physical HIGH still requires the legacy security page because it updates master-password state.",
+        "is-error",
+      );
+      return;
+    }
+    if (
+      physicalChanged &&
+      requestedPhysical === "MAXIMUM" &&
+      currentSnapshot.hasDatabase &&
+      !window.confirm(
+        "Changing the physical threat level to MAXIMUM can delete queued work. Continue?",
+      )
+    ) {
+      return;
+    }
+
+    try {
+      if (networkChanged) {
+        const warning = await loadJson(
+          apiUrlWithQuery("security-levels/network-warning", { newLevel: requestedNetwork }),
+        );
+        const networkFormData = new FormData();
+        networkFormData.set("newLevel", requestedNetwork);
+        if (warning.confirmationRequired) {
+          const warningText =
+            htmlToText(warning.warningHtml) ||
+            `Change the network threat level to ${requestedNetwork}?`;
+          if (!window.confirm(warningText)) {
+            return;
+          }
+          networkFormData.set("confirmed", "true");
+        } else if (!window.confirm(`Change the network threat level to ${requestedNetwork}?`)) {
+          return;
+        }
+        await postForm(
+          "security-levels/network",
+          networkFormData,
+          "Security mutations unavailable in read-only mode.",
+        );
+      }
+      if (physicalChanged) {
+        const physicalFormData = new FormData();
+        physicalFormData.set("newLevel", requestedPhysical);
+        if (requestedPhysical === "MAXIMUM" && currentSnapshot.hasDatabase) {
+          physicalFormData.set("confirmed", "true");
+        }
+        await postForm(
+          "security-levels/physical",
+          physicalFormData,
+          "Security mutations unavailable in read-only mode.",
+        );
+      }
+      setSecurityStatus("Security levels updated.", "is-success");
+      shellState.wizardSnapshot = null;
+      updateWizardToolbar();
+      await Promise.all([loadSecuritySection(), loadWizardSection()]);
+    } catch (error) {
+      setSecurityStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  function buildConfigFormData() {
+    const formData = new FormData();
+    formData.set("node.updater.enabled", String(configControls.updaterEnabled.checked));
+    formData.set("node.updater.autoupdate", String(configControls.updaterAutoupdate.checked));
+    if (configControls.inputBandwidthLimit.value.trim()) {
+      formData.set("node.inputBandwidthLimit", configControls.inputBandwidthLimit.value.trim());
+    }
+    if (configControls.outputBandwidthLimit.value.trim()) {
+      formData.set("node.outputBandwidthLimit", configControls.outputBandwidthLimit.value.trim());
+    }
+    return formData;
+  }
+
+  async function submitConfigForm(event) {
+    event.preventDefault();
+    if (!shellState.configSnapshot) {
+      setConfigStatus("Config controls stay unavailable until the current snapshot loads.", "is-error");
+      return;
+    }
+    const formData = buildConfigFormData();
+
+    try {
+      await postForm("config/overrides", formData, "Config mutations unavailable in read-only mode.");
+      await postForm("config/persist", new FormData(), "Config mutations unavailable in read-only mode.");
+      setConfigStatus("Config overrides applied and persisted.", "is-success");
+      shellState.updatesSnapshot = null;
+      shellState.wizardSnapshot = null;
+      updateUpdatesToolbar();
+      updateWizardToolbar();
+      await Promise.all([loadConfigSection(), loadUpdatesSection(), loadWizardSection()]);
+    } catch (error) {
+      setConfigStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  async function persistCurrentConfig() {
+    if (!shellState.configSnapshot) {
+      setConfigStatus("Config controls stay unavailable until the current snapshot loads.", "is-error");
+      return;
+    }
+    try {
+      await postForm("config/persist", new FormData(), "Config mutations unavailable in read-only mode.");
+      setConfigStatus("Current config persisted.", "is-success");
+      await loadConfigSection();
+    } catch (error) {
+      setConfigStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  async function triggerCoreDownload() {
+    if (!shellState.updatesSnapshot) {
+      setUpdatesStatus("Updater actions stay unavailable until the current status loads.", "is-error");
+      return;
+    }
+    if (!shellState.updatesSnapshot.downloadAllowed) {
+      setUpdatesStatus("No downloadable core update is currently available.", "is-error");
+      return;
+    }
+    try {
+      await postForm("updates/core/download", new FormData(), "Updater actions unavailable in read-only mode.");
+      setUpdatesStatus("Core download triggered.", "is-success");
+      await loadUpdatesSection();
+    } catch (error) {
+      setUpdatesStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  function buildWizardFormData() {
+    const formData = new FormData();
+    const preserveBandwidthSettings = !wizardControls.editBandwidth.checked;
+    const preserveCurrentNetworkThreatLevel =
+      !wizardCanEditCurrentNetworkThreatLevel(shellState.wizardSnapshot);
+    const preserveCurrentPhysicalThreatLevel =
+      !wizardCanEditCurrentPhysicalThreatLevel(shellState.wizardSnapshot);
+    if (wizardControls.knowSomeone.checked) {
+      formData.set("knowSomeone", "on");
+    }
+    if (wizardControls.connectToStrangers.checked) {
+      formData.set("connectToStrangers", "on");
+    }
+    if (preserveBandwidthSettings) {
+      formData.set("preserveBandwidthSettings", "on");
+    } else if (wizardControls.haveMonthlyLimit.checked) {
+      formData.set("haveMonthlyLimit", "on");
+    }
+    if (preserveCurrentNetworkThreatLevel) {
+      formData.set("preserveCurrentNetworkThreatLevel", "on");
+    }
+    if (preserveCurrentPhysicalThreatLevel) {
+      formData.set("preserveCurrentPhysicalThreatLevel", "on");
+    }
+    if (wizardControls.setPassword.checked) {
+      formData.set("setPassword", "on");
+    }
+    if (!preserveBandwidthSettings) {
+      formData.set(
+        "downloadLimitKiB",
+        wizardControls.haveMonthlyLimit.checked ? "" : wizardControls.downloadLimit.value.trim(),
+      );
+      formData.set(
+        "uploadLimitKiB",
+        wizardControls.haveMonthlyLimit.checked ? "" : wizardControls.uploadLimit.value.trim(),
+      );
+      formData.set(
+        "bandwidthMonthlyLimitGiB",
+        wizardControls.haveMonthlyLimit.checked ? wizardControls.monthlyLimit.value.trim() : "",
+      );
+    }
+    formData.set("storageLimitGiB", wizardControls.storageLimit.value.trim());
+    formData.set("password", wizardControls.setPassword.checked ? wizardControls.password.value : "");
+    return formData;
+  }
+
+  function clearWizardBandwidthChoiceRequirement() {
+    if (wizardControls.haveMonthlyLimit.indeterminate) {
+      wizardControls.haveMonthlyLimit.indeterminate = false;
+    }
+  }
+
+  async function submitWizardForm(event) {
+    event.preventDefault();
+    if (!shellState.wizardSnapshot) {
+      setWizardStatus("Wizard controls stay unavailable until the current snapshot loads.", "is-error");
+      return;
+    }
+    if (!wizardSubmissionSupported(shellState.wizardSnapshot)) {
+      setWizardStatus(wizardUnsupportedMessage(shellState.wizardSnapshot), "is-error");
+      return;
+    }
+    if (wizardBandwidthChoiceRequired(shellState.wizardSnapshot) && wizardControls.haveMonthlyLimit.indeterminate) {
+      setWizardStatus(wizardBandwidthChoiceMessage(), "is-error");
+      return;
+    }
+    const passwordAlreadySet = !!shellState.wizardSnapshot.passwordAlreadySet;
+    if (
+      !passwordAlreadySet &&
+      wizardControls.setPassword.checked &&
+      wizardControls.password.value !== wizardControls.confirmPassword.value
+    ) {
+      setWizardStatus("Password confirmation does not match.", "is-error");
+      return;
+    }
+
+    try {
+      await postForm(
+        "wizard/first-time/apply",
+        buildWizardFormData(),
+        "Wizard submission unavailable in read-only mode.",
+      );
+      setWizardStatus("Wizard settings applied.", "is-success");
+      await Promise.all([
+        loadShellData(),
+        loadSecuritySection(),
+        loadUpdatesSection(),
+        loadConfigSection(),
+        loadWizardSection(),
+      ]);
+    } catch (error) {
+      setWizardStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
   function submitLegacyQueueForm(form, submitter) {
     if (
       typeof form.requestSubmit === "function" &&
@@ -1108,6 +1808,49 @@
     });
   }
 
+  function bindSecurityInteractions() {
+    securityControls.form.addEventListener("submit", submitSecurityForm);
+  }
+
+  function bindUpdatesInteractions() {
+    updatesControls.refreshButton.addEventListener("click", () => {
+      setUpdatesStatus("Refreshing updater state.");
+      loadUpdatesSection();
+    });
+    updatesControls.downloadButton.addEventListener("click", () => {
+      triggerCoreDownload();
+    });
+  }
+
+  function bindConfigInteractions() {
+    configControls.refreshButton.addEventListener("click", () => {
+      setConfigStatus("Refreshing config snapshot.");
+      loadConfigSection();
+    });
+    configControls.form.addEventListener("submit", submitConfigForm);
+    configControls.persistButton.addEventListener("click", () => {
+      persistCurrentConfig();
+    });
+  }
+
+  function bindWizardInteractions() {
+    wizardControls.refreshButton.addEventListener("click", () => {
+      setWizardStatus("Refreshing wizard snapshot.");
+      loadWizardSection();
+    });
+    wizardControls.knowSomeone.addEventListener("change", updateWizardFieldVisibility);
+    wizardControls.editBandwidth.addEventListener("change", updateWizardFieldVisibility);
+    wizardControls.haveMonthlyLimit.addEventListener("change", () => {
+      clearWizardBandwidthChoiceRequirement();
+      updateWizardFieldVisibility();
+    });
+    wizardControls.downloadLimit.addEventListener("input", clearWizardBandwidthChoiceRequirement);
+    wizardControls.uploadLimit.addEventListener("input", clearWizardBandwidthChoiceRequirement);
+    wizardControls.monthlyLimit.addEventListener("input", clearWizardBandwidthChoiceRequirement);
+    wizardControls.setPassword.addEventListener("change", updateWizardFieldVisibility);
+    wizardControls.form.addEventListener("submit", submitWizardForm);
+  }
+
   async function loadShellData() {
     const requests = [
       loadJson(apiUrl("node/greeting"))
@@ -1116,9 +1859,6 @@
       loadJson(apiUrl("connectivity"))
         .then((data) => ({ section: "connectivity", data }))
         .catch((error) => ({ section: "connectivity", error })),
-      loadJson(apiUrl("security-levels"))
-        .then((data) => ({ section: "security", data }))
-        .catch((error) => ({ section: "security", error })),
     ];
 
     const results = await Promise.all(requests);
@@ -1131,19 +1871,37 @@
         renderOverview(result.data);
       } else if (result.section === "connectivity") {
         renderConnectivity(result.data);
-      } else if (result.section === "security") {
-        renderSecurity(result.data);
       }
     }
   }
 
   renderLegacyLinks();
+  bindSecurityInteractions();
+  bindUpdatesInteractions();
+  bindConfigInteractions();
+  bindWizardInteractions();
   bindPeerInteractions();
   bindQueueInteractions();
+  updateSecurityToolbar();
+  updateUpdatesToolbar();
+  updateConfigToolbar();
+  updateWizardToolbar();
   updatePeerToolbar();
   updateQueueToolbar();
   loadShellData().catch((error) => {
     renderError(sections.overview, "Shell", error);
+  });
+  loadSecuritySection().catch((error) => {
+    renderError(sections.security, "security", error);
+  });
+  loadUpdatesSection().catch((error) => {
+    renderError(sections.updates, "updates", error);
+  });
+  loadConfigSection().catch((error) => {
+    renderError(sections.config, "config", error);
+  });
+  loadWizardSection().catch((error) => {
+    renderError(sections.wizard, "wizard", error);
   });
   loadPeersSection().catch((error) => {
     renderError(sections.peers, "peers", error);

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -14,12 +14,19 @@ class WebShellResourcesTest {
     assertTrue(html.contains("Web Shell v1"));
     assertTrue(html.contains("Peer control plane"));
     assertTrue(html.contains("Queue control plane"));
+    assertTrue(html.contains("Core updater"));
+    assertTrue(html.contains("Operator subset"));
+    assertTrue(html.contains("First-time setup"));
     assertTrue(html.contains("__BOOTSTRAP_JSON__"));
     assertTrue(html.contains("peer-create-form\" hidden"));
     assertTrue(html.contains("name=\"referenceText\""));
     assertTrue(html.contains("id=\"peers-status\""));
     assertTrue(html.contains("name=\"filterData\" type=\"checkbox\" checked"));
     assertTrue(html.contains("queue-create-form\" hidden"));
+    assertTrue(html.contains("id=\"security-form\""));
+    assertTrue(html.contains("id=\"updates-body\""));
+    assertTrue(html.contains("id=\"config-form\""));
+    assertTrue(html.contains("id=\"wizard-form\""));
   }
 
   @Test
@@ -35,6 +42,7 @@ class WebShellResourcesTest {
     assertPeerMutationMarkersPresent(script);
     assertPeerMutationSubmissionOrder(script);
     assertPeerLoadSequencing(script);
+    assertPlatformControlPlaneMarkersPresent(script);
   }
 
   private static void assertQueueMutationMarkersPresent(String script) {
@@ -54,6 +62,10 @@ class WebShellResourcesTest {
     assertTrue(script.contains("case \"change_priority_top\":"));
     assertTrue(script.contains("case \"change_priority_bottom\":"));
     assertTrue(script.contains("let queueLoadGeneration = 0;"));
+    assertTrue(script.contains("let securityLoadGeneration = 0;"));
+    assertTrue(script.contains("let updatesLoadGeneration = 0;"));
+    assertTrue(script.contains("let configLoadGeneration = 0;"));
+    assertTrue(script.contains("let wizardLoadGeneration = 0;"));
     assertTrue(script.contains("let formPassword ="));
     assertTrue(
         script.contains(
@@ -215,5 +227,126 @@ class WebShellResourcesTest {
     assertTrue(errorGuardIndex > renderPeersIndex);
     assertTrue(renderErrorIndex > errorGuardIndex);
     assertTrue(loadPeersCatchIndex > renderErrorIndex);
+  }
+
+  private static void assertPlatformControlPlaneMarkersPresent(String script) {
+    assertTrue(script.contains("const shellState = {"));
+    assertTrue(script.contains("function apiUrlWithQuery(path, query)"));
+    assertTrue(script.contains("function htmlToText(html)"));
+    assertTrue(script.contains("async function loadSecuritySection()"));
+    assertTrue(script.contains("async function loadUpdatesSection()"));
+    assertTrue(script.contains("async function loadConfigSection()"));
+    assertTrue(script.contains("async function loadWizardSection()"));
+    assertTrue(script.contains("async function submitSecurityForm(event)"));
+    assertTrue(script.contains("async function submitConfigForm(event)"));
+    assertTrue(script.contains("async function triggerCoreDownload()"));
+    assertTrue(script.contains("async function submitWizardForm(event)"));
+    assertTrue(script.contains("function wizardSubmissionSupported(data)"));
+    assertTrue(script.contains("function wizardBandwidthModeUnknown(data)"));
+    assertTrue(script.contains("function wizardCanEditCurrentNetworkThreatLevel(data)"));
+    assertTrue(script.contains("function wizardCanEditCurrentPhysicalThreatLevel(data)"));
+    assertTrue(script.contains("function wizardBandwidthChoiceRequired(data)"));
+    assertTrue(
+        script.contains("function wizardBandwidthChoiceRequired(data) {\n    return false;\n  }"));
+    assertTrue(script.contains("function wizardBandwidthChoiceMessage()"));
+    assertTrue(script.contains("function clearWizardBandwidthChoiceRequirement()"));
+    assertTrue(script.contains("function wizardUnsupportedMessage(data)"));
+    assertTrue(script.contains("apiUrlWithQuery(\"security-levels/network-warning\""));
+    assertTrue(script.contains("loadJson(apiUrl(\"updates/core\"))"));
+    assertTrue(script.contains("loadJson(apiUrl(\"config?sections=CURRENT\"))"));
+    assertTrue(script.contains("loadJson(apiUrl(\"wizard/first-time\"))"));
+    assertTrue(
+        script.contains(
+            "securityControls.form.hidden = !formPassword || !shellState.securitySnapshot;"));
+    assertTrue(
+        script.contains(
+            "configControls.form.hidden = !formPassword || !shellState.configSnapshot;"));
+    assertTrue(
+        script.contains(
+            "wizardControls.form.hidden =\n"
+                + "      !formPassword || !shellState.wizardSnapshot ||"
+                + " !wizardSubmissionSupported(shellState.wizardSnapshot);"));
+    assertTrue(
+        script.contains(
+            "wizardControls.knowSomeone.parentElement.hidden = !networkThreatEditable;"));
+    assertTrue(
+        script.contains(
+            "wizardControls.connectToStrangers.parentElement.hidden =\n"
+                + "      !networkThreatEditable || !knowsTrustedOperators;"));
+    assertTrue(script.contains("wizardControls.editBandwidth.parentElement.hidden = false;"));
+    assertTrue(script.contains("wizardControls.connectToStrangers.checked = false;"));
+    assertTrue(script.contains("wizardControls.editBandwidth.checked = false;"));
+    assertTrue(
+        script.contains(
+            "wizardControls.knowSomeone.checked =\n"
+                + "      networkThreatEditable && data.currentNetworkThreatLevel === \"HIGH\";"));
+    assertTrue(script.contains("wizardControls.haveMonthlyLimit.indeterminate = false;"));
+    assertTrue(script.contains("currentNetworkThreatLevel"));
+    assertTrue(script.contains("currentPhysicalThreatLevel"));
+    assertTrue(
+        script.contains(
+            "Current LOW/MAXIMUM network threat level will be preserved; use the security controls"
+                + " to change it."));
+    assertTrue(
+        script.contains(
+            "Current LOW/MAXIMUM physical threat level will be preserved; use the security controls"
+                + " to change it."));
+    assertTrue(
+        script.contains(
+            "Current bandwidth settings will be preserved unless you enable bandwidth editing."));
+    assertTrue(
+        script.contains(
+            "Default bandwidth settings will be preserved unless you enable bandwidth editing."));
+    assertTrue(script.contains("can delete queued work. Continue?"));
+    assertTrue(
+        script.contains(
+            "Save one threat-level change at a time so warnings and failures cannot partially apply"
+                + " a combined update."));
+    assertTrue(script.contains("shellState.securitySnapshot = null;"));
+    assertTrue(script.contains("shellState.configSnapshot = null;"));
+    assertTrue(script.contains("shellState.updatesSnapshot = null;"));
+    assertTrue(script.contains("shellState.wizardSnapshot = null;"));
+    assertTrue(script.contains("const loadGeneration = ++securityLoadGeneration;"));
+    assertTrue(script.contains("const loadGeneration = ++updatesLoadGeneration;"));
+    assertTrue(script.contains("const loadGeneration = ++configLoadGeneration;"));
+    assertTrue(script.contains("const loadGeneration = ++wizardLoadGeneration;"));
+    assertTrue(script.contains("if (loadGeneration !== securityLoadGeneration) {"));
+    assertTrue(script.contains("if (loadGeneration !== updatesLoadGeneration) {"));
+    assertTrue(script.contains("if (loadGeneration !== configLoadGeneration) {"));
+    assertTrue(script.contains("if (loadGeneration !== wizardLoadGeneration) {"));
+    assertTrue(script.contains("await Promise.all([loadSecuritySection(), loadWizardSection()]);"));
+    assertTrue(
+        script.contains(
+            "await Promise.all([loadConfigSection(), loadUpdatesSection(),"
+                + " loadWizardSection()]);"));
+    assertTrue(
+        script.contains(
+            "wizardControls.knowSomeone.addEventListener(\"change\","
+                + " updateWizardFieldVisibility);"));
+    assertTrue(
+        script.contains(
+            "wizardControls.editBandwidth.addEventListener(\"change\","
+                + " updateWizardFieldVisibility);"));
+    assertTrue(
+        script.contains(
+            "wizardControls.downloadLimit.addEventListener(\"input\","
+                + " clearWizardBandwidthChoiceRequirement);"));
+    assertTrue(
+        script.contains(
+            "wizardControls.uploadLimit.addEventListener(\"input\","
+                + " clearWizardBandwidthChoiceRequirement);"));
+    assertTrue(
+        script.contains(
+            "wizardControls.monthlyLimit.addEventListener(\"input\","
+                + " clearWizardBandwidthChoiceRequirement);"));
+    assertTrue(script.contains("await postForm(\"config/overrides\", formData"));
+    assertTrue(script.contains("await postForm(\"updates/core/download\", new FormData()"));
+    assertTrue(
+        script.contains(
+            "const preserveBandwidthSettings = !wizardControls.editBandwidth.checked;"));
+    assertTrue(script.contains("formData.set(\"preserveBandwidthSettings\", \"on\");"));
+    assertTrue(script.contains("formData.set(\"preserveCurrentNetworkThreatLevel\", \"on\");"));
+    assertTrue(script.contains("formData.set(\"preserveCurrentPhysicalThreatLevel\", \"on\");"));
+    assertTrue(script.contains("await postForm("));
   }
 }

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyFirstTimeWizardPort.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyFirstTimeWizardPort.java
@@ -71,6 +71,9 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
   /** Shared message text for unexpected legacy failures that are logged and kept daemon-local. */
   private static final String UNEXPECTED_ERROR_MESSAGE = "Should not happen, please report! {}";
 
+  /** Legacy node-config key for the direct download bandwidth limit. */
+  private static final String INPUT_BANDWIDTH_LIMIT = "inputBandwidthLimit";
+
   /** Live node backing the wizard's security, network, storage, and config reads. */
   private final Node node;
 
@@ -207,12 +210,14 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
   public void applySubmission(FirstTimeWizardSubmission submission) {
     Objects.requireNonNull(submission, "submission");
 
-    node.services()
-        .securityLevels()
-        .setThreatLevel(
-            submission.knowSomeone() && !submission.connectToStrangers()
-                ? NETWORK_THREAT_LEVEL.HIGH
-                : NETWORK_THREAT_LEVEL.NORMAL);
+    if (!submission.preserveCurrentNetworkThreatLevel()) {
+      node.services()
+          .securityLevels()
+          .setThreatLevel(
+              submission.knowSomeone() && !submission.connectToStrangers()
+                  ? NETWORK_THREAT_LEVEL.HIGH
+                  : NETWORK_THREAT_LEVEL.NORMAL);
+    }
 
     Config config = node.getConfig();
     applyBandwidth(config, submission);
@@ -303,15 +308,19 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
   /**
    * Returns the legacy rate-page current-bandwidth row when the node is not using defaults.
    *
-   * <p>The old multipage wizard showed a detached "current settings" row only when the upload limit
-   * had been explicitly configured. That behavior is preserved here so the HTTP layer can render
-   * the row without directly consulting live daemon config or network state.
+   * <p>The legacy wizard originally surfaced the row only when the upload limit had been explicitly
+   * configured. The shell-native wizard preserve path also needs to protect nodes where only the
+   * download limit was customized, so the detached row is now exposed whenever either direct
+   * bandwidth limit differs from its default.
    *
    * @param config live daemon config used to determine whether the current-bandwidth row is needed
    * @return detached current-bandwidth row, or {@code null} when the legacy page should omit it
    */
   private FirstTimeWizardCurrentBandwidthLimits currentBandwidthLimits(Config config) {
-    if (config.get("node").getOption(LegacyWelcomeActionPort.OUTPUT_BANDWIDTH_LIMIT).isDefault()) {
+    boolean outputLimitIsDefault =
+        config.get("node").getOption(LegacyWelcomeActionPort.OUTPUT_BANDWIDTH_LIMIT).isDefault();
+    boolean inputLimitIsDefault = config.get("node").getOption(INPUT_BANDWIDTH_LIMIT).isDefault();
+    if (outputLimitIsDefault && inputLimitIsDefault) {
       return null;
     }
 
@@ -331,9 +340,12 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
    *     the HTTP layer
    */
   private void applyBandwidth(Config config, FirstTimeWizardSubmission submission) {
+    if (submission.preserveBandwidthSettings()) {
+      return;
+    }
     try {
       if (!submission.haveMonthlyLimit()) {
-        config.get("node").set("inputBandwidthLimit", submission.downloadLimitKiB() + "KiB");
+        config.get("node").set(INPUT_BANDWIDTH_LIMIT, submission.downloadLimitKiB() + "KiB");
         config
             .get("node")
             .set(
@@ -346,7 +358,7 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
           BandwidthLimit.fromMonthlyBudget(
               Fields.parseLong(submission.bandwidthMonthlyLimitGiB() + "GiB"),
               Node.getMinimumBandwidth());
-      config.get("node").set("inputBandwidthLimit", Long.toString(bandwidth.downBytes()));
+      config.get("node").set(INPUT_BANDWIDTH_LIMIT, Long.toString(bandwidth.downBytes()));
       config
           .get("node")
           .set(LegacyWelcomeActionPort.OUTPUT_BANDWIDTH_LIMIT, Long.toString(bandwidth.upBytes()));
@@ -379,7 +391,7 @@ final class LegacyFirstTimeWizardPort implements FirstTimeWizardPort {
    * @param submission detached wizard submission containing the password-related choices
    */
   private void applyPasswordIfRequired(FirstTimeWizardSubmission submission) {
-    if (passwordAlreadySet()) {
+    if (submission.preserveCurrentPhysicalThreatLevel() || passwordAlreadySet()) {
       return;
     }
 

--- a/runtime-node/src/main/java/network/crypta/runtime/core/LegacyCoreUpdateActionPort.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/core/LegacyCoreUpdateActionPort.java
@@ -48,8 +48,13 @@ final class LegacyCoreUpdateActionPort implements CoreUpdateActionPort {
   }
 
   @Override
-  public void startCoreDownloadFromUi() {
-    getCoreUpdater().ifPresent(CoreUpdater::startDownloadFromUI);
+  public boolean isCoreDownloadAvailable() {
+    return getCoreUpdater().map(CoreUpdater::isUiDownloadAvailable).orElse(false);
+  }
+
+  @Override
+  public boolean startCoreDownloadFromUi() {
+    return getCoreUpdater().map(CoreUpdater::startDownloadFromUI).orElse(false);
   }
 
   @Override

--- a/runtime-node/src/main/java/network/crypta/runtime/updater/CoreUpdater.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/updater/CoreUpdater.java
@@ -209,6 +209,59 @@ public class CoreUpdater extends NodeUpdater {
     return isNewerThanCurrentBuild(latestVersionBuild.get());
   }
 
+  /**
+   * Returns whether the current UI download action can fetch a selected package payload.
+   *
+   * <p>This is intentionally different from {@link #canUpdateNow()}. Release gating only advertises
+   * integer build labels as an available update, but the manual download action may still fetch a
+   * CHK-backed package selected from a valid descriptor whose human-facing version label is not an
+   * integer build number. The UI download button should therefore be enabled whenever the selected
+   * package has a CHK payload that this updater can actually download.
+   *
+   * @return {@code true} when the current selected package is directly downloadable
+   */
+  public boolean isUiDownloadAvailable() {
+    PackageSpec spec = selectedSpec.get();
+    if (!canPrepareUiDownload(spec)) {
+      return false;
+    }
+
+    PackageFetcher matchingFetcher = fetcherMatchesSelection();
+    if (matchingFetcher != null) {
+      return !matchingFetcher.isInProgress() && !matchingFetcher.isSuccess();
+    }
+
+    PackageFetcher inFlight = fetcher.get();
+    return inFlight == null || !inFlight.isInProgress();
+  }
+
+  private boolean canPrepareUiDownload(PackageSpec spec) {
+    if (spec == null || spec.chk() == null || selectedKey == null) {
+      return false;
+    }
+    try {
+      new FreenetURI(spec.chk());
+      return canPrepareDownloadTargetPath();
+    } catch (MalformedURLException _) {
+      return false;
+    }
+  }
+
+  private boolean canPrepareDownloadTargetPath() {
+    File versionDir = updatesDir();
+    if (versionDir.exists()) {
+      return versionDir.isDirectory() && versionDir.canWrite();
+    }
+
+    File updatesRoot = getUpdatesRoot();
+    if (updatesRoot.exists()) {
+      return updatesRoot.isDirectory() && updatesRoot.canWrite();
+    }
+
+    File nodeDir = manager.getNode().nodeDir().dir();
+    return nodeDir.exists() && nodeDir.isDirectory() && nodeDir.canWrite();
+  }
+
   @Override
   public void onChangeURI(FreenetURI newUri, int subscribeEditionSeed) {
     resetDescriptorStateForUriChange();
@@ -413,11 +466,11 @@ public class CoreUpdater extends NodeUpdater {
     return f != null && !f.hasFailed();
   }
 
-  private void tryStartDownload() {
+  private boolean tryStartDownload() {
     PackageSpec spec = selectedSpec.get();
     File target = downloadTarget();
     if (spec == null || target == null || spec.chk() == null) {
-      return;
+      return false;
     }
     String chk = spec.chk();
     FreenetURI uri;
@@ -425,7 +478,7 @@ public class CoreUpdater extends NodeUpdater {
       uri = new FreenetURI(chk);
     } catch (MalformedURLException e) {
       logError("Invalid CHK URI for selected package: " + chk, e);
-      return;
+      return false;
     }
     PackageFetcher f = new PackageFetcher(target, uri, chk);
     fetcher.set(f);
@@ -436,27 +489,27 @@ public class CoreUpdater extends NodeUpdater {
             + target.getAbsolutePath()
             + ", chk="
             + chk);
-    f.start();
+    return f.start();
   }
 
   /** Start downloading the currently selected package if not already in progress. */
-  public void startDownloadFromUI() {
+  public boolean startDownloadFromUI() {
     if (selectedSpec.get() == null) {
-      return;
+      return false;
     }
     PackageFetcher matchingFetcher = fetcherMatchesSelection();
     if (matchingFetcher != null) {
       if (matchingFetcher.isInProgress() || matchingFetcher.isSuccess()) {
-        return;
+        return false;
       }
     } else {
       PackageFetcher inFlight = fetcher.get();
       if (inFlight != null && inFlight.isInProgress()) {
         logInfo("Skipping download start: another package download is still running");
-        return;
+        return false;
       }
     }
-    tryStartDownload();
+    return tryStartDownload();
   }
 
   /**
@@ -758,7 +811,7 @@ public class CoreUpdater extends NodeUpdater {
       this.chkString = chkString;
     }
 
-    void start() {
+    boolean start() {
       var ctx =
           manager
               .getNode()
@@ -777,6 +830,7 @@ public class CoreUpdater extends NodeUpdater {
         manager.getNode().services().clientCore().getClientContext().start(createdGetter);
         CoreUpdater.this.logInfo(
             "download started (listener attached): target=" + outFile.getAbsolutePath());
+        return true;
       } catch (FetchException e) {
         markStartFailure(
             e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), safeIsFatal(e));
@@ -785,6 +839,7 @@ public class CoreUpdater extends NodeUpdater {
             "Failed to start package download: "
                 + (errorMsg != null ? errorMsg : e.getClass().getSimpleName()),
             e);
+        return false;
       } catch (Exception e) {
         markStartFailure(
             e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName(), false);
@@ -793,6 +848,7 @@ public class CoreUpdater extends NodeUpdater {
             "Error starting package download: "
                 + (errorMsg != null ? errorMsg : e.getClass().getSimpleName()),
             e);
+        return false;
       }
     }
 

--- a/runtime-node/src/main/java/network/crypta/runtime/updater/CoreUpdater.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/updater/CoreUpdater.java
@@ -252,14 +252,17 @@ public class CoreUpdater extends NodeUpdater {
     if (versionDir.exists()) {
       return versionDir.isDirectory() && versionDir.canWrite();
     }
+    return canPrepareAncestorDirectory(versionDir.getParentFile());
+  }
 
-    File updatesRoot = getUpdatesRoot();
-    if (updatesRoot.exists()) {
-      return updatesRoot.isDirectory() && updatesRoot.canWrite();
+  private static boolean canPrepareAncestorDirectory(File directory) {
+    if (directory == null) {
+      return false;
     }
-
-    File nodeDir = manager.getNode().nodeDir().dir();
-    return nodeDir.exists() && nodeDir.isDirectory() && nodeDir.canWrite();
+    if (directory.exists()) {
+      return directory.isDirectory() && directory.canWrite();
+    }
+    return canPrepareAncestorDirectory(directory.getParentFile());
   }
 
   @Override

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/CoreUpdateActionPort.java
@@ -34,6 +34,18 @@ public interface CoreUpdateActionPort {
   boolean isCoreUpdaterAvailable();
 
   /**
+   * Returns whether a selectable core update is currently available for UI-triggered download.
+   *
+   * <p>This is narrower than {@link #isCoreUpdaterAvailable()}: the updater service may be wired
+   * and ready while no newer package currently matches the running platform or release gate.
+   * Callers use this to decide whether a download action should be offered for the current request.
+   *
+   * @return {@code true} when the updater currently has a newer selectable core package; {@code
+   *     false} when no UI-downloadable package is presently available
+   */
+  boolean isCoreDownloadAvailable();
+
+  /**
    * Starts the current core-package download from the updater UI.
    *
    * <p>Implementations preserve the daemon-side selection and in-progress checks used by the legacy
@@ -42,7 +54,7 @@ public interface CoreUpdateActionPort {
    * separate calls. The method remains a trigger rather than a completion signal; follow-up status,
    * redirects, or operator-visible errors still come from the HTTP layer and the updater itself.
    */
-  void startCoreDownloadFromUi();
+  boolean startCoreDownloadFromUi();
 
   /**
    * Resolves one raw installer path to a canonical downloaded-installer path when it stays within

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSnapshot.java
@@ -37,8 +37,8 @@ import java.util.Objects;
  *     string when automatic detection is unavailable
  * @param detectedUploadLimitKiB recommended direct upload limit in KiB/s text or an empty string
  *     when automatic detection is unavailable
- * @param currentBandwidthLimits detached effective bandwidth row for the legacy rate page, or
- *     {@code null} when the page should omit the current-settings row
+ * @param currentBandwidthLimits detached effective bandwidth row for the legacy rate page and
+ *     shell-side preserve logic, or {@code null} when no current-settings row is needed
  * @param autodetectedStorageLimitBytes autodetected datastore suggestion in exact bytes, or {@code
  *     -1} when the legacy datastore page should fall back to its fixed-size defaults
  */

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSubmission.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/FirstTimeWizardSubmission.java
@@ -18,6 +18,13 @@ import java.util.Objects;
  * @param connectToStrangers whether the user still opts into connecting to untrusted peers
  * @param haveMonthlyLimit whether the submission uses a monthly transfer budget instead of direct
  *     per-second limits
+ * @param preserveBandwidthSettings whether the submission should leave the current bandwidth
+ *     settings unchanged instead of applying any wizard bandwidth fields
+ * @param preserveCurrentNetworkThreatLevel whether the submission should leave the current network
+ *     threat level unchanged instead of applying the wizard's darknet/opennet choice
+ * @param preserveCurrentPhysicalThreatLevel whether the submission should leave the current
+ *     physical threat level unchanged instead of applying the wizard's password/high-security
+ *     choice
  * @param downloadLimitKiB requested direct download limit, preserved as KiB/s text from the form
  * @param uploadLimitKiB requested direct upload limit, preserved as KiB/s text from the form
  * @param bandwidthMonthlyLimitGiB requested monthly transfer budget, preserved as GiB text from the
@@ -31,6 +38,9 @@ public record FirstTimeWizardSubmission(
     boolean knowSomeone,
     boolean connectToStrangers,
     boolean haveMonthlyLimit,
+    boolean preserveBandwidthSettings,
+    boolean preserveCurrentNetworkThreatLevel,
+    boolean preserveCurrentPhysicalThreatLevel,
     String downloadLimitKiB,
     String uploadLimitKiB,
     String bandwidthMonthlyLimitGiB,
@@ -52,5 +62,68 @@ public record FirstTimeWizardSubmission(
     Objects.requireNonNull(bandwidthMonthlyLimitGiB, "bandwidthMonthlyLimitGiB");
     Objects.requireNonNull(storageLimitGiB, "storageLimitGiB");
     Objects.requireNonNull(password, "password");
+  }
+
+  /**
+   * Creates an immutable first-time-wizard submission without the preserve-bandwidth flag.
+   *
+   * <p>This compatibility constructor preserves the older detached submission shape for legacy
+   * callers that always intended wizard submissions to rewrite bandwidth settings.
+   */
+  public FirstTimeWizardSubmission(
+      boolean knowSomeone,
+      boolean connectToStrangers,
+      boolean haveMonthlyLimit,
+      boolean preserveBandwidthSettings,
+      String downloadLimitKiB,
+      String uploadLimitKiB,
+      String bandwidthMonthlyLimitGiB,
+      String storageLimitGiB,
+      boolean setPassword,
+      String password) {
+    this(
+        knowSomeone,
+        connectToStrangers,
+        haveMonthlyLimit,
+        preserveBandwidthSettings,
+        false,
+        false,
+        downloadLimitKiB,
+        uploadLimitKiB,
+        bandwidthMonthlyLimitGiB,
+        storageLimitGiB,
+        setPassword,
+        password);
+  }
+
+  /**
+   * Creates an immutable first-time-wizard submission without any preserve flags.
+   *
+   * <p>This compatibility constructor preserves the original detached submission shape for callers
+   * that always intended wizard submissions to rewrite bandwidth and security settings.
+   */
+  public FirstTimeWizardSubmission(
+      boolean knowSomeone,
+      boolean connectToStrangers,
+      boolean haveMonthlyLimit,
+      String downloadLimitKiB,
+      String uploadLimitKiB,
+      String bandwidthMonthlyLimitGiB,
+      String storageLimitGiB,
+      boolean setPassword,
+      String password) {
+    this(
+        knowSomeone,
+        connectToStrangers,
+        haveMonthlyLimit,
+        false,
+        false,
+        false,
+        downloadLimitKiB,
+        uploadLimitKiB,
+        bandwidthMonthlyLimitGiB,
+        storageLimitGiB,
+        setPassword,
+        password);
   }
 }

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -16,6 +16,8 @@ import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -426,6 +428,25 @@ End
         bodyWrite.bodyText());
   }
 
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://localhost/api/v1/config/overrides",
+        "http://localhost/api/v1/security-levels/network",
+        "http://localhost/api/v1/updates/core/download",
+        "http://localhost/api/v1/wizard/first-time/apply",
+      })
+  void handleMethodPOST_whenProtectedMutationPasswordMissing_expectJson403WithoutRouting(
+      String requestUri) throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(false);
+
+    toadlet.handleMethodPOST(URI.create(requestUri), request, ctx);
+
+    verifyNoInteractions(router);
+    assertForbiddenBody();
+  }
+
   @Test
   void handleMethodPOST_whenNonAppsRoute_expectRouterJson405WithoutPasswordCheck()
       throws Exception {
@@ -661,6 +682,17 @@ End
 
     return new BodyWriteCapture(
         new String(body.getValue(), StandardCharsets.UTF_8), offset.getValue(), length.getValue());
+  }
+
+  private void assertForbiddenBody() throws Exception {
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals("Forbidden", replyHeaders.reasonPhrase());
+    assertEquals("application/json; charset=UTF-8", replyHeaders.mimeType());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"forbidden\",\"message\":\"Valid form password is required.\"}}",
+        bodyWrite.bodyText());
   }
 
   private record ReplyHeadersCapture(

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -29,9 +29,14 @@ import network.crypta.runtime.spi.ConnectivitySnapshot;
 import network.crypta.runtime.spi.ConnectivitySocketSnapshot;
 import network.crypta.runtime.spi.ConnectivityTrafficEntrySnapshot;
 import network.crypta.runtime.spi.ConnectivityTrafficInitiator;
+import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
+import network.crypta.runtime.spi.FirstTimeWizardPort;
+import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
+import network.crypta.runtime.spi.FirstTimeWizardSubmission;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.runtime.spi.NodeInfoPort;
@@ -79,6 +84,11 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class PlatformApiRouterTest {
+  private static final String CANONICAL_UPDATE_URI =
+      "uQnFwn0aEFSAZihnSDduEHUd3GUmGg68ATn5R95MKJo,"
+          + "mcNiZqosfZ1F~PkZY8v1TuDKsY6noda-hGRXvu7uUFc,AQACAAE";
+  private static final String FULL_UPDATE_URI = "USK@" + CANONICAL_UPDATE_URI + "/info/1234";
+
   private static final Instant STARTED_AT = Instant.parse("2024-01-02T03:04:05Z");
   private static final String APP_ID = "alpha";
   private static final String INSTALL_ROUTE_APP_ID = "install";
@@ -94,6 +104,8 @@ class PlatformApiRouterTest {
   @Mock private ConfigPort configPort;
   @Mock private ConnectivityPort connectivityPort;
   @Mock private SecurityLevelsPort securityLevelsPort;
+  @Mock private CoreUpdateActionPort coreUpdateActionPort;
+  @Mock private FirstTimeWizardPort firstTimeWizardPort;
   @Mock private QueuePagePort queuePagePort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueDownloadPort queueDownloadPort;
@@ -113,6 +125,8 @@ class PlatformApiRouterTest {
     when(runtimePorts.config()).thenReturn(configPort);
     when(runtimePorts.connectivity()).thenReturn(connectivityPort);
     when(runtimePorts.securityLevels()).thenReturn(securityLevelsPort);
+    when(runtimePorts.coreUpdateAction()).thenReturn(coreUpdateActionPort);
+    when(runtimePorts.firstTimeWizard()).thenReturn(firstTimeWizardPort);
     when(runtimePorts.queuePage()).thenReturn(queuePagePort);
     when(runtimePorts.queueMutation()).thenReturn(queueMutationPort);
     when(runtimePorts.queueDownload()).thenReturn(queueDownloadPort);
@@ -698,6 +712,759 @@ class PlatformApiRouterTest {
   }
 
   @Test
+  void route_whenConfigOverridesRequested_expectMutationSummary() {
+    when(configPort.export(EnumSet.of(ConfigSection.CURRENT, ConfigSection.DATA_TYPES)))
+        .thenReturn(
+            verificationConfigSnapshot(
+                Map.of("updater.enabled", "true", "updater.autoupdate", "false"),
+                Map.of("updater.enabled", "boolean", "updater.autoupdate", "boolean")),
+            verificationConfigSnapshot(
+                Map.of("updater.enabled", "false", "updater.autoupdate", "true"),
+                Map.of("updater.enabled", "boolean", "updater.autoupdate", "boolean")));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("config", "overrides"),
+                orderedStringParameters(
+                    Map.entry("node.updater.enabled", List.of("false")),
+                    Map.entry("node.updater.autoupdate", List.of("true")))));
+
+    verify(configPort)
+        .applyOverrides(Map.of("node.updater.enabled", "false", "node.updater.autoupdate", "true"));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_overrides\",\"overrideCount\":2}", response.body());
+  }
+
+  @Test
+  void route_whenConfigOverridesRejected_expectJson400WithoutPersisting() {
+    when(configPort.export(EnumSet.of(ConfigSection.CURRENT, ConfigSection.DATA_TYPES)))
+        .thenReturn(
+            verificationConfigSnapshot(
+                Map.of("updater.enabled", "true", "updater.autoupdate", "false"),
+                Map.of("updater.enabled", "boolean", "updater.autoupdate", "boolean")),
+            verificationConfigSnapshot(
+                Map.of("updater.enabled", "false", "updater.autoupdate", "false"),
+                Map.of("updater.enabled", "boolean", "updater.autoupdate", "boolean")));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("config", "overrides"),
+                orderedStringParameters(
+                    Map.entry("node.updater.enabled", List.of("false")),
+                    Map.entry("node.updater.autoupdate", List.of("true")))));
+
+    verify(configPort)
+        .applyOverrides(Map.of("node.updater.enabled", "false", "node.updater.autoupdate", "true"));
+    verify(configPort).applyOverrides(Map.of("node.updater.enabled", "true"));
+    verify(configPort, never()).persist();
+    assertEquals(400, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"config_override_rejected\",\"message\":\"Rejected config"
+            + " overrides: node.updater.autoupdate\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenStringArrayConfigOverrideUsesDecodedValue_expectAccepted() {
+    String canonicalValue = network.crypta.support.URLEncoder.encode("/home/alice/My Files", false);
+    when(configPort.export(EnumSet.of(ConfigSection.CURRENT, ConfigSection.DATA_TYPES)))
+        .thenReturn(
+            verificationConfigSnapshot(
+                Map.of("downloadAllowedDirs", ""), Map.of("downloadAllowedDirs", "stringArray")),
+            verificationConfigSnapshot(
+                Map.of("downloadAllowedDirs", canonicalValue),
+                Map.of("downloadAllowedDirs", "stringArray")));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("config", "overrides"),
+                orderedStringParameters(
+                    Map.entry("node.downloadAllowedDirs", List.of("/home/alice/My Files")))));
+
+    verify(configPort).applyOverrides(Map.of("node.downloadAllowedDirs", "/home/alice/My Files"));
+    verify(configPort, never()).applyOverrides(Map.of("node.downloadAllowedDirs", ""));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_overrides\",\"overrideCount\":1}", response.body());
+  }
+
+  @Test
+  void route_whenStringConfigOverrideIsNormalized_expectAccepted() {
+    when(configPort.export(EnumSet.of(ConfigSection.CURRENT, ConfigSection.DATA_TYPES)))
+        .thenReturn(
+            verificationConfigSnapshot(
+                Map.of("updater.URI", "USK@old-key"), Map.of("updater.URI", "string")),
+            verificationConfigSnapshot(
+                Map.of("updater.URI", CANONICAL_UPDATE_URI), Map.of("updater.URI", "string")));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("config", "overrides"),
+                orderedStringParameters(Map.entry("node.updater.URI", List.of(FULL_UPDATE_URI)))));
+
+    verify(configPort).applyOverrides(Map.of("node.updater.URI", FULL_UPDATE_URI));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_overrides\",\"overrideCount\":1}", response.body());
+  }
+
+  @Test
+  void route_whenNormalizedStringConfigOverrideIsIdempotent_expectAccepted() {
+    when(configPort.export(EnumSet.of(ConfigSection.CURRENT, ConfigSection.DATA_TYPES)))
+        .thenReturn(
+            verificationConfigSnapshot(
+                Map.of("updater.URI", CANONICAL_UPDATE_URI), Map.of("updater.URI", "string")),
+            verificationConfigSnapshot(
+                Map.of("updater.URI", CANONICAL_UPDATE_URI), Map.of("updater.URI", "string")));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("config", "overrides"),
+                orderedStringParameters(Map.entry("node.updater.URI", List.of(FULL_UPDATE_URI)))));
+
+    verify(configPort).applyOverrides(Map.of("node.updater.URI", FULL_UPDATE_URI));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_overrides\",\"overrideCount\":1}", response.body());
+  }
+
+  @Test
+  void route_whenConfigPersistRequested_expectMutationSummary() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("config", "persist"), Map.of()));
+
+    verify(configPort).persist();
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"persist\"}", response.body());
+  }
+
+  @Test
+  void route_whenNetworkThreatLevelMutationRequested_expectPersistedSummary() {
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "network"),
+                Map.of("newLevel", List.of("HIGH"))));
+
+    verify(securityLevelsPort).setNetworkThreatLevel(SecurityNetworkThreatLevel.HIGH);
+    verify(configPort).persist();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"operation\":\"set_network_threat_level\",\"networkThreatLevel\":\"HIGH\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenNetworkThreatLevelWarningRequested_expectWarningJson() {
+    when(securityLevelsPort.networkThreatLevelConfirmWarningHtml(
+            SecurityNetworkThreatLevel.LOW, "confirmed"))
+        .thenReturn("<p>Needs confirmation</p>");
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "GET",
+                List.of("security-levels", "network-warning"),
+                Map.of("newLevel", List.of("LOW"))));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"newLevel\":\"LOW\",\"confirmationRequired\":true,\"warningHtml\":\"<p>Needs"
+            + " confirmation</p>\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenNetworkThreatLevelMutationRequiresConfirmation_expectConflictJson() {
+    when(securityLevelsPort.networkThreatLevelConfirmWarningHtml(
+            SecurityNetworkThreatLevel.LOW, "confirmed"))
+        .thenReturn("<p>Needs confirmation</p>");
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST", List.of("security-levels", "network"), Map.of("newLevel", List.of("LOW"))));
+
+    verify(securityLevelsPort, never()).setNetworkThreatLevel(any());
+    verify(configPort, never()).persist();
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"network_threat_level_confirmation_required\",\"message\":\"This"
+            + " network threat-level change requires server-side confirmation. Retry after"
+            + " acknowledging the warning in the Web Shell or use the legacy security page.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenNetworkThreatLevelMutationConfirmedViaCheckbox_expectPersistedSummary() {
+    when(securityLevelsPort.networkThreatLevelConfirmWarningHtml(
+            SecurityNetworkThreatLevel.LOW, "confirmed"))
+        .thenReturn("<p>Needs confirmation</p>");
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "network"),
+                Map.of("newLevel", List.of("LOW"), "confirmed", List.of("on"))));
+
+    verify(securityLevelsPort).setNetworkThreatLevel(SecurityNetworkThreatLevel.LOW);
+    verify(configPort).persist();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"operation\":\"set_network_threat_level\",\"networkThreatLevel\":\"LOW\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenPhysicalThreatLevelMutationRequested_expectPersistedSummary() throws IOException {
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                false,
+                false,
+                ""));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "physical"),
+                Map.of("newLevel", List.of("MAXIMUM"))));
+
+    verify(securityLevelsPort).deleteMasterPasswordFile();
+    verify(securityLevelsPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.MAXIMUM);
+    verify(configPort).persist();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"operation\":\"set_physical_threat_level\",\"physicalThreatLevel\":\"MAXIMUM\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenPhysicalMaximumMutationNeedsConfirmation_expectConflictJson() throws IOException {
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                true,
+                false,
+                ""));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "physical"),
+                Map.of("newLevel", List.of("MAXIMUM"))));
+
+    verify(securityLevelsPort, never()).deleteMasterPasswordFile();
+    verify(securityLevelsPort, never()).setPhysicalThreatLevel(any());
+    verify(configPort, never()).persist();
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"physical_threat_level_confirmation_required\",\"message\":\"Changing"
+            + " the physical threat level to MAXIMUM can delete queued work. Retry after"
+            + " acknowledging the confirmation.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenPhysicalMaximumMutationConfirmed_expectPersistedSummary() throws IOException {
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                true,
+                false,
+                ""));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "physical"),
+                Map.of("newLevel", List.of("MAXIMUM"), "confirmed", List.of("true"))));
+
+    verify(securityLevelsPort).deleteMasterPasswordFile();
+    verify(securityLevelsPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.MAXIMUM);
+    verify(configPort).persist();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"operation\":\"set_physical_threat_level\",\"physicalThreatLevel\":\"MAXIMUM\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenPhysicalThreatLevelMutationNeedsPasswordFlow_expectConflictJson() {
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                false,
+                false,
+                ""));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "physical"),
+                Map.of("newLevel", List.of("HIGH"))));
+
+    verify(securityLevelsPort, never()).setPhysicalThreatLevel(any());
+    verify(configPort, never()).persist();
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"physical_threat_level_password_required\",\"message\":\"Changing"
+            + " to or from physical HIGH still requires the legacy password flow. Use the legacy"
+            + " security page for this transition.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenPhysicalMaximumMutationFromHigh_expectPersistedSummary() throws IOException {
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.HIGH,
+                true,
+                true,
+                "/master.keys"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "physical"),
+                Map.of("newLevel", List.of("MAXIMUM"), "confirmed", List.of("true"))));
+
+    verify(securityLevelsPort).deleteMasterPasswordFile();
+    verify(securityLevelsPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.MAXIMUM);
+    verify(configPort).persist();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"operation\":\"set_physical_threat_level\",\"physicalThreatLevel\":\"MAXIMUM\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenLeavingPhysicalMaximum_expectWizardPhysicalSetter() {
+    when(securityLevelsPort.snapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.MAXIMUM,
+                true,
+                false,
+                ""));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("security-levels", "physical"),
+                Map.of("newLevel", List.of("NORMAL"))));
+
+    verify(firstTimeWizardPort).setPhysicalThreatLevel(SecurityPhysicalThreatLevel.NORMAL);
+    verify(securityLevelsPort, never()).setPhysicalThreatLevel(any());
+    verify(configPort, never()).persist();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"operation\":\"set_physical_threat_level\",\"physicalThreatLevel\":\"NORMAL\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenCoreUpdatesRequested_expectAvailabilityJson() {
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
+    when(coreUpdateActionPort.isCoreDownloadAvailable()).thenReturn(true);
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("updates", "core"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"available\":true,\"downloadAllowed\":true}", response.body());
+  }
+
+  @Test
+  void route_whenCoreUpdateDownloadRequested_expectTriggeredSummary() {
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
+    when(coreUpdateActionPort.isCoreDownloadAvailable()).thenReturn(true);
+    when(coreUpdateActionPort.startCoreDownloadFromUi()).thenReturn(true);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("updates", "core", "download"), Map.of()));
+
+    verify(coreUpdateActionPort).startCoreDownloadFromUi();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"operation\":\"start_core_download\",\"downloadTriggered\":true}", response.body());
+  }
+
+  @Test
+  void route_whenCoreUpdateDownloadRequestedWhileUnavailable_expectConflictJson() {
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(false);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("updates", "core", "download"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"updater_unavailable\",\"message\":\"Core updater is not currently"
+            + " available.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenCoreUpdateDownloadRequestedWithoutSelectablePackage_expectConflictJson() {
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
+    when(coreUpdateActionPort.isCoreDownloadAvailable()).thenReturn(false);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("updates", "core", "download"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"core_update_unavailable\",\"message\":\"No selectable core update"
+            + " is currently available.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenCoreUpdateDownloadDoesNotStart_expectConflictJson() {
+    when(coreUpdateActionPort.isCoreUpdaterAvailable()).thenReturn(true);
+    when(coreUpdateActionPort.isCoreDownloadAvailable()).thenReturn(true);
+    when(coreUpdateActionPort.startCoreDownloadFromUi()).thenReturn(false);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("updates", "core", "download"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"core_download_not_started\",\"message\":\"The core download could"
+            + " not be started. Refresh updater state and retry.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenFirstTimeWizardRequested_expectSnapshotJson() {
+    when(firstTimeWizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                true,
+                "2.50",
+                "1.25",
+                1342177280L,
+                "10.00",
+                10737418240L,
+                12884901888L,
+                10L,
+                976562L,
+                "49.44",
+                "2048",
+                "1024",
+                new FirstTimeWizardCurrentBandwidthLimits(4096L, 1024L),
+                -1L));
+    when(firstTimeWizardPort.isOpennetEnabled()).thenReturn(true);
+    when(firstTimeWizardPort.securitySnapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.HIGH,
+                SecurityPhysicalThreatLevel.HIGH,
+                false,
+                false,
+                ""));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("wizard", "first-time"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"passwordAlreadySet\":true,\"opennetEnabled\":true,\"currentNetworkThreatLevel\":\"HIGH\",\"currentPhysicalThreatLevel\":\"HIGH\",\"initialStorageLimitGiB\":\"2.50\",\"minStorageLimitGiB\":\"1.25\",\"minStorageLimitBytes\":1342177280,\"maxStorageLimitGiB\":\"10.00\",\"maxStorageLimitBytes\":10737418240,\"legacyMaxStorageLimitBytes\":12884901888,\"minBandwidthKiB\":10,\"maxUploadLimitKiB\":976562,\"minBandwidthMonthlyLimitGiB\":\"49.44\",\"detectedDownloadLimitKiB\":\"2048\",\"detectedUploadLimitKiB\":\"1024\",\"currentBandwidthLimits\":{\"downloadBytes\":4096,\"uploadBytes\":1024},\"autodetectedStorageLimitBytes\":-1}",
+        response.body());
+  }
+
+  @Test
+  void route_whenFirstTimeWizardApplyRequested_expectSubmissionSummary() {
+    when(firstTimeWizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                false,
+                "2.00",
+                "1.25",
+                1342177280L,
+                "10.00",
+                10737418240L,
+                10L,
+                976562L,
+                "49.44",
+                "",
+                "",
+                -1L));
+    when(firstTimeWizardPort.securitySnapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                false,
+                false,
+                ""));
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("wizard", "first-time", "apply"),
+                orderedStringParameters(
+                    Map.entry("knowSomeone", List.of("on")),
+                    Map.entry("downloadLimitKiB", List.of("20000")),
+                    Map.entry("uploadLimitKiB", List.of("10000")),
+                    Map.entry("storageLimitGiB", List.of("2")),
+                    Map.entry("setPassword", List.of("on")),
+                    Map.entry("password", List.of("secret")))));
+
+    verify(firstTimeWizardPort)
+        .applySubmission(
+            new FirstTimeWizardSubmission(
+                true, false, false, "20000", "10000", "", "2", true, "secret"));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_submission\",\"wizardApplied\":true}", response.body());
+  }
+
+  @Test
+  void route_whenFirstTimeWizardApplyRequestedWithPreserveBandwidth_expectSubmissionSummary() {
+    when(firstTimeWizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                false,
+                "2.00",
+                "1.25",
+                1342177280L,
+                "10.00",
+                10737418240L,
+                10737418240L,
+                10L,
+                976562L,
+                "49.44",
+                "",
+                "",
+                new FirstTimeWizardCurrentBandwidthLimits(4096L, 1024L),
+                -1L));
+    when(firstTimeWizardPort.securitySnapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                false,
+                false,
+                ""));
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("wizard", "first-time", "apply"),
+                orderedStringParameters(
+                    Map.entry("preserveBandwidthSettings", List.of("on")),
+                    Map.entry("storageLimitGiB", List.of("2")),
+                    Map.entry("setPassword", List.of("on")),
+                    Map.entry("password", List.of("secret")))));
+
+    verify(firstTimeWizardPort)
+        .applySubmission(
+            new FirstTimeWizardSubmission(
+                false, false, false, true, "", "", "", "2", true, "secret"));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_submission\",\"wizardApplied\":true}", response.body());
+  }
+
+  @Test
+  void
+      route_whenFirstTimeWizardApplyRequestedWithPreserveBandwidthAndNoCurrentBandwidthRow_expectSubmissionSummary() {
+    when(firstTimeWizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                false,
+                "2.00",
+                "1.25",
+                1342177280L,
+                "10.00",
+                10737418240L,
+                10L,
+                976562L,
+                "49.44",
+                "",
+                "",
+                -1L));
+    when(firstTimeWizardPort.securitySnapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.NORMAL,
+                SecurityPhysicalThreatLevel.NORMAL,
+                false,
+                false,
+                ""));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("wizard", "first-time", "apply"),
+                orderedStringParameters(
+                    Map.entry("preserveBandwidthSettings", List.of("on")),
+                    Map.entry("storageLimitGiB", List.of("2")))));
+
+    verify(firstTimeWizardPort)
+        .applySubmission(
+            new FirstTimeWizardSubmission(false, false, false, true, "", "", "", "2", false, ""));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_submission\",\"wizardApplied\":true}", response.body());
+  }
+
+  @Test
+  void
+      route_whenFirstTimeWizardApplyRequestedFromLowOrMaximumCurrentSecurityWithoutPreserveFlags_expectConflictJson() {
+    when(firstTimeWizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                false,
+                "2.00",
+                "1.25",
+                1342177280L,
+                "10.00",
+                10737418240L,
+                10L,
+                976562L,
+                "49.44",
+                "",
+                "",
+                -1L));
+    when(firstTimeWizardPort.securitySnapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.MAXIMUM,
+                SecurityPhysicalThreatLevel.NORMAL,
+                false,
+                false,
+                ""));
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("wizard", "first-time", "apply"),
+                orderedStringParameters(
+                    Map.entry("downloadLimitKiB", List.of("20000")),
+                    Map.entry("uploadLimitKiB", List.of("10000")),
+                    Map.entry("storageLimitGiB", List.of("2")))));
+
+    verify(firstTimeWizardPort, never()).applySubmission(any());
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"wizard_current_security_unsupported\",\"message\":\"Current LOW"
+            + " or MAXIMUM network threat levels cannot be represented by the wizard controls."
+            + " Retry with preserveCurrentNetworkThreatLevel=true or use the dedicated security"
+            + " controls.\"}}",
+        response.body());
+  }
+
+  @Test
+  void
+      route_whenFirstTimeWizardApplyRequestedFromLowOrMaximumCurrentSecurityWithPreserveFlags_expectSubmissionSummary() {
+    when(firstTimeWizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                false,
+                "2.00",
+                "1.25",
+                1342177280L,
+                "10.00",
+                10737418240L,
+                10L,
+                976562L,
+                "49.44",
+                "",
+                "",
+                -1L));
+    when(firstTimeWizardPort.securitySnapshot())
+        .thenReturn(
+            new SecurityLevelsSnapshot(
+                SecurityNetworkThreatLevel.MAXIMUM,
+                SecurityPhysicalThreatLevel.LOW,
+                false,
+                false,
+                ""));
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("wizard", "first-time", "apply"),
+                orderedStringParameters(
+                    Map.entry("preserveCurrentNetworkThreatLevel", List.of("on")),
+                    Map.entry("preserveCurrentPhysicalThreatLevel", List.of("on")),
+                    Map.entry("downloadLimitKiB", List.of("20000")),
+                    Map.entry("uploadLimitKiB", List.of("10000")),
+                    Map.entry("storageLimitGiB", List.of("2")))));
+
+    verify(firstTimeWizardPort)
+        .applySubmission(
+            new FirstTimeWizardSubmission(
+                false, false, false, false, true, true, "20000", "10000", "", "2", false, ""));
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"apply_submission\",\"wizardApplied\":true}", response.body());
+  }
+
+  @Test
+  void route_whenFirstTimeWizardPasswordRequestedAfterPasswordAlreadySet_expectConflictJson() {
+    when(firstTimeWizardPort.snapshot())
+        .thenReturn(
+            new FirstTimeWizardSnapshot(
+                true,
+                "2.00",
+                "1.25",
+                1342177280L,
+                "10.00",
+                10737418240L,
+                10L,
+                976562L,
+                "49.44",
+                "",
+                "",
+                -1L));
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("wizard", "first-time", "apply"),
+                orderedStringParameters(
+                    Map.entry("downloadLimitKiB", List.of("20000")),
+                    Map.entry("uploadLimitKiB", List.of("10000")),
+                    Map.entry("storageLimitGiB", List.of("2")),
+                    Map.entry("setPassword", List.of("on")),
+                    Map.entry("password", List.of("secret")))));
+
+    verify(firstTimeWizardPort, never()).applySubmission(any());
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"wizard_password_already_set\",\"message\":\"A startup password is"
+            + " already set. Use the dedicated security/password flow instead of the first-time"
+            + " wizard submission.\"}}",
+        response.body());
+  }
+
+  @Test
   void route_whenPeerMissing_expectJson404() throws UnknownPeerException {
     when(peerPort.get("peer-1", true, false)).thenThrow(new UnknownPeerException("peer-1"));
 
@@ -727,6 +1494,16 @@ class PlatformApiRouterTest {
     assertEquals(200, response.statusCode());
     assertEquals(
         "{\"CURRENT\":{\"enabled\":\"true\",\"node\":{\"name\":\"alpha\"}}}", response.body());
+  }
+
+  private static ConfigSnapshot verificationConfigSnapshot(
+      Map<String, String> nodeValues, Map<String, String> dataTypes) {
+    return new ConfigSnapshot(
+        Map.of(
+            ConfigSection.CURRENT,
+            new ConfigFieldSet(Map.of(), Map.of("node", new ConfigFieldSet(nodeValues, Map.of()))),
+            ConfigSection.DATA_TYPES,
+            new ConfigFieldSet(Map.of(), Map.of("node", new ConfigFieldSet(dataTypes, Map.of())))));
   }
 
   @Test

--- a/src/test/java/network/crypta/runtime/admin/LegacyFirstTimeWizardPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyFirstTimeWizardPortTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -74,6 +75,7 @@ class LegacyFirstTimeWizardPortTest {
     Option<Long> storeSize = mockLongOption();
     Option<Long> clientCache = mockLongOption();
     Option<Long> slashdotCache = mockLongOption();
+    Option<?> inputBandwidthLimit = mockOption();
     Option<?> outputBandwidthLimit = mockOption();
     BandwidthIndicator bandwidthIndicator = mock(BandwidthIndicator.class);
     NodeIPDetector ipDetector = mock(NodeIPDetector.class);
@@ -92,7 +94,9 @@ class LegacyFirstTimeWizardPortTest {
     when(networkSubsystem.outputBandwidthLimit()).thenReturn(1024);
     when(securityLevels.getPhysicalThreatLevel())
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+    doReturn(inputBandwidthLimit).when(nodeSubConfig).getOption("inputBandwidthLimit");
     doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(inputBandwidthLimit.isDefault()).thenReturn(true);
     when(outputBandwidthLimit.isDefault()).thenReturn(false);
     when(storeSize.isDefault()).thenReturn(false);
     when(storeSize.getValue()).thenReturn(2L * DatastoreUtil.ONE_GIB);
@@ -156,6 +160,7 @@ class LegacyFirstTimeWizardPortTest {
   @Test
   void snapshot_whenAutodetectAndDetectionUnavailable_returnsFallbackAndEmptySuggestions() {
     Option<Long> storeSize = mockLongOption();
+    Option<?> inputBandwidthLimit = mockOption();
     Option<?> outputBandwidthLimit = mockOption();
     NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
 
@@ -165,7 +170,9 @@ class LegacyFirstTimeWizardPortTest {
     when(services.securityLevels()).thenReturn(securityLevels);
     when(securityLevels.getPhysicalThreatLevel())
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    doReturn(inputBandwidthLimit).when(nodeSubConfig).getOption("inputBandwidthLimit");
     doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(inputBandwidthLimit.isDefault()).thenReturn(true);
     when(outputBandwidthLimit.isDefault()).thenReturn(true);
 
     try (MockedStatic<Config> configStatic = mockStatic(Config.class);
@@ -201,8 +208,53 @@ class LegacyFirstTimeWizardPortTest {
   }
 
   @Test
+  void snapshot_whenOnlyInputBandwidthLimitCustomized_returnsCurrentBandwidthLimits() {
+    Option<Long> storeSize = mockLongOption();
+    Option<?> inputBandwidthLimit = mockOption();
+    Option<?> outputBandwidthLimit = mockOption();
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    network.crypta.node.subsystem.NodeNetworkSubsystem networkSubsystem =
+        mock(network.crypta.node.subsystem.NodeNetworkSubsystem.class);
+
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("node")).thenReturn(nodeSubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    when(node.network()).thenReturn(networkSubsystem);
+    when(networkSubsystem.ipDetector()).thenReturn(null);
+    when(networkSubsystem.inputBandwidthLimit()).thenReturn(2048);
+    when(networkSubsystem.outputBandwidthLimit()).thenReturn(1024);
+    doReturn(inputBandwidthLimit).when(nodeSubConfig).getOption("inputBandwidthLimit");
+    doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(inputBandwidthLimit.isDefault()).thenReturn(false);
+    when(outputBandwidthLimit.isDefault()).thenReturn(true);
+
+    try (MockedStatic<Config> configStatic = mockStatic(Config.class);
+        MockedStatic<DatastoreUtil> datastore = mockStatic(DatastoreUtil.class)) {
+      configStatic.when(() -> Config.longOption(nodeSubConfig, "storeSize")).thenReturn(storeSize);
+      when(storeSize.isDefault()).thenReturn(true);
+      datastore.when(() -> DatastoreUtil.autodetectDatastoreSize(core, config)).thenReturn(0L);
+      datastore.when(DatastoreUtil::maxDatastoreSize).thenReturn(10L * DatastoreUtil.ONE_GIB);
+      datastore
+          .when(() -> DatastoreUtil.maxDatastoreSize(node))
+          .thenReturn(6L * DatastoreUtil.ONE_GIB);
+
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      FirstTimeWizardSnapshot snapshot = port.snapshot();
+
+      assertNotNull(snapshot.currentBandwidthLimits());
+      assertEquals(2048L, snapshot.currentBandwidthLimits().downloadBytes());
+      assertEquals(1024L, snapshot.currentBandwidthLimits().uploadBytes());
+    }
+  }
+
+  @Test
   void snapshot_whenIpDetectorNotInitialized_returnsStorageSuggestionAndEmptyBandwidthHints() {
     Option<Long> storeSize = mockLongOption();
+    Option<?> inputBandwidthLimit = mockOption();
     Option<?> outputBandwidthLimit = mockOption();
     NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
     network.crypta.node.subsystem.NodeNetworkSubsystem networkSubsystem =
@@ -217,7 +269,9 @@ class LegacyFirstTimeWizardPortTest {
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
     when(node.network()).thenReturn(networkSubsystem);
     when(networkSubsystem.ipDetector()).thenReturn(null);
+    doReturn(inputBandwidthLimit).when(nodeSubConfig).getOption("inputBandwidthLimit");
     doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(inputBandwidthLimit.isDefault()).thenReturn(true);
     when(outputBandwidthLimit.isDefault()).thenReturn(true);
 
     try (MockedStatic<Config> configStatic = mockStatic(Config.class);
@@ -248,6 +302,7 @@ class LegacyFirstTimeWizardPortTest {
   @Test
   void snapshot_whenStorageCapNeedsRounding_preservesExactStorageBytes() {
     Option<Long> storeSize = mockLongOption();
+    Option<?> inputBandwidthLimit = mockOption();
     Option<?> outputBandwidthLimit = mockOption();
     NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
     long roundedUpMaxStorageLimitBytes = Fields.parseLong("1.235GiB");
@@ -258,7 +313,9 @@ class LegacyFirstTimeWizardPortTest {
     when(services.securityLevels()).thenReturn(securityLevels);
     when(securityLevels.getPhysicalThreatLevel())
         .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+    doReturn(inputBandwidthLimit).when(nodeSubConfig).getOption("inputBandwidthLimit");
     doReturn(outputBandwidthLimit).when(nodeSubConfig).getOption("outputBandwidthLimit");
+    when(inputBandwidthLimit.isDefault()).thenReturn(true);
     when(outputBandwidthLimit.isDefault()).thenReturn(true);
 
     try (MockedStatic<Config> configStatic = mockStatic(Config.class);
@@ -564,6 +621,40 @@ class LegacyFirstTimeWizardPortTest {
           times(1));
       verify(securityLevels, never()).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
       verify(node, never()).storage();
+      verify(core).storeConfig();
+    }
+  }
+
+  @Test
+  void applySubmission_whenPreserveBandwidthRequested_skipsBandwidthWrites() throws Exception {
+    NodeServicesSubsystem services = mock(NodeServicesSubsystem.class);
+    when(node.getConfig()).thenReturn(config);
+    when(config.get("fproxy")).thenReturn(fproxySubConfig);
+    when(node.services()).thenReturn(services);
+    when(services.securityLevels()).thenReturn(securityLevels);
+    when(node.storage()).thenReturn(storage);
+    when(securityLevels.getPhysicalThreatLevel())
+        .thenReturn(SecurityLevels.PHYSICAL_THREAT_LEVEL.NORMAL);
+
+    try (MockedStatic<DatastoreSizingSupport> datastoreSize =
+        mockStatic(DatastoreSizingSupport.class)) {
+      LegacyFirstTimeWizardPort port = new LegacyFirstTimeWizardPort(node, core);
+
+      port.applySubmission(
+          new FirstTimeWizardSubmission(
+              false, false, false, true, "", "", "", "2", true, "secret"));
+
+      verify(nodeSubConfig, never()).set(eq("inputBandwidthLimit"), anyString());
+      verify(nodeSubConfig, never()).set(eq("outputBandwidthLimit"), anyString());
+      datastoreSize.verify(
+          () ->
+              DatastoreSizingSupport.setDatastoreSize(
+                  eq("2GiB"), eq(config), any(java.util.function.LongSupplier.class)),
+          times(1));
+      verify(securityLevels).setThreatLevel(SecurityLevels.NETWORK_THREAT_LEVEL.NORMAL);
+      verify(securityLevels).setThreatLevel(SecurityLevels.PHYSICAL_THREAT_LEVEL.HIGH);
+      verify(storage).changeMasterPassword("", "secret", true);
+      verify(fproxySubConfig).set("hasCompletedWizard", true);
       verify(core).storeConfig();
     }
   }

--- a/src/test/java/network/crypta/runtime/core/LegacyCoreUpdateActionPortTest.java
+++ b/src/test/java/network/crypta/runtime/core/LegacyCoreUpdateActionPortTest.java
@@ -50,12 +50,45 @@ class LegacyCoreUpdateActionPortTest {
   }
 
   @Test
+  void isCoreDownloadAvailable_whenSelectableUpdatePresent_expectTrue() {
+    when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
+    when(nodeUpdateManager.getCoreUpdater()).thenReturn(coreUpdater);
+    when(coreUpdater.isUiDownloadAvailable()).thenReturn(true);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+
+    assertTrue(port.isCoreDownloadAvailable());
+  }
+
+  @Test
+  void isCoreDownloadAvailable_whenSelectableUpdateMissing_expectFalse() {
+    when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
+    when(nodeUpdateManager.getCoreUpdater()).thenReturn(coreUpdater);
+    when(coreUpdater.isUiDownloadAvailable()).thenReturn(false);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+
+    assertFalse(port.isCoreDownloadAvailable());
+  }
+
+  @Test
+  void isCoreDownloadAvailable_whenUpdaterMissing_expectFalse() {
+    when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
+    when(nodeUpdateManager.getCoreUpdater()).thenReturn(null);
+
+    LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
+
+    assertFalse(port.isCoreDownloadAvailable());
+  }
+
+  @Test
   void startCoreDownloadFromUi_whenUpdaterPresent_expectDelegatesToCoreUpdater() {
     when(node.services().nodeUpdater()).thenReturn(nodeUpdateManager);
     when(nodeUpdateManager.getCoreUpdater()).thenReturn(coreUpdater);
+    when(coreUpdater.startDownloadFromUI()).thenReturn(true);
 
     LegacyCoreUpdateActionPort port = new LegacyCoreUpdateActionPort(node);
-    port.startCoreDownloadFromUi();
+    assertTrue(port.startCoreDownloadFromUi());
 
     verify(coreUpdater).startDownloadFromUI();
   }

--- a/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
+++ b/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
@@ -174,6 +174,7 @@ class CoreUpdaterTest {
           versionDir.canWrite(), "Test environment cannot simulate a non-writable directory.");
 
       CoreUpdater updater = createCoreUpdater(nodeDir);
+      setField(updater, "latestInfo", new CoreInfo("1200", null, Map.of(), null, null));
       setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
       setSelectedKey(updater);
 

--- a/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
+++ b/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
@@ -1,9 +1,15 @@
 package network.crypta.runtime.updater;
 
+import java.io.File;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
 import network.crypta.client.HighLevelSimpleClient;
@@ -11,6 +17,7 @@ import network.crypta.client.events.SimpleEventProducer;
 import network.crypta.keys.FreenetURI;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
+import network.crypta.node.Version;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.Ticker;
 import network.crypta.support.http.ExternalLinkSupport;
@@ -18,8 +25,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.mock;
@@ -27,6 +37,11 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("java:S100")
 class CoreUpdaterTest {
+  private static final String VALID_CHK =
+      "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,"
+          + "PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
+  private static final String SELECTED_PACKAGE_KEY = "amd64.deb";
+
   @Test
   void parseJson_minimal() {
     String json =
@@ -91,7 +106,7 @@ class CoreUpdaterTest {
     PackageSpec spec = new PackageSpec(null, null, storeUrl);
 
     // Act
-    HTMLNode links = invokeBuildLinksNode(updater, info, spec, "amd64.deb");
+    HTMLNode links = invokeBuildLinksNode(updater, info, spec);
     List<HTMLNode> anchors =
         links.getChildren().stream().filter(node -> "a".equals(node.getName())).toList();
 
@@ -104,7 +119,131 @@ class CoreUpdaterTest {
     assertEquals("Open in Store", anchors.get(1).generateChildren());
   }
 
+  @Test
+  void isUiDownloadAvailable_whenSelectedPackageHasChk_expectTrue() throws Exception {
+    CoreUpdater updater = createCoreUpdater();
+    setField(updater, "latestVersionBuild", Version.currentBuildNumber() + 1);
+    setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+    setSelectedKey(updater);
+
+    assertTrue(updater.isUiDownloadAvailable());
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenSelectedPackageHasChkAndVersionLabelIsNonInteger_expectTrue()
+      throws Exception {
+    CoreUpdater updater = createCoreUpdater();
+    setField(updater, "latestVersionBuild", null);
+    setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+    setSelectedKey(updater);
+
+    assertTrue(updater.isUiDownloadAvailable());
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenSelectedPackageChkIsMalformed_expectFalse() throws Exception {
+    CoreUpdater updater = createCoreUpdater();
+    setField(updater, "selectedSpec", new PackageSpec("not-a-chk", 10L, null));
+    setSelectedKey(updater);
+
+    assertFalse(updater.isUiDownloadAvailable());
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenUpdatesDirectoryCannotBePrepared_expectFalse() throws Exception {
+    File nonDirectoryNodeRoot =
+        java.nio.file.Files.createTempFile("cryptad-core-updater", ".tmp").toFile();
+    CoreUpdater updater = createCoreUpdater(nonDirectoryNodeRoot);
+    setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+    setSelectedKey(updater);
+
+    assertFalse(updater.isUiDownloadAvailable());
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenVersionDirectoryExistsButIsNotWritable_expectFalse()
+      throws Exception {
+    File nodeDir = Files.createTempDirectory("cryptad-core-updater").toFile();
+    File versionDir = new File(nodeDir, "updates/core/1200");
+    assertTrue(versionDir.mkdirs());
+    try {
+      Files.setPosixFilePermissions(
+          versionDir.toPath(),
+          Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE));
+      assumeFalse(
+          versionDir.canWrite(), "Test environment cannot simulate a non-writable directory.");
+
+      CoreUpdater updater = createCoreUpdater(nodeDir);
+      setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+      setSelectedKey(updater);
+
+      assertFalse(updater.isUiDownloadAvailable());
+    } finally {
+      assertTrue(versionDir.setWritable(true, true));
+    }
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenSelectedPackageIsStoreBacked_expectFalse() throws Exception {
+    CoreUpdater updater = createCoreUpdater();
+    setField(updater, "latestVersionBuild", Version.currentBuildNumber() + 1);
+    setField(
+        updater,
+        "selectedSpec",
+        new PackageSpec(null, 10L, "https://store.example.com/apps/core?id=cryptad"));
+
+    assertFalse(updater.isUiDownloadAvailable());
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenMatchingPackageDownloadInProgress_expectFalse() throws Exception {
+    CoreUpdater updater = createCoreUpdater();
+    setField(updater, "latestVersionBuild", Version.currentBuildNumber() + 1);
+    setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+    setSelectedKey(updater);
+    CoreUpdater.PackageFetcher fetcher = mock(CoreUpdater.PackageFetcher.class);
+    when(fetcher.matchesChk(VALID_CHK)).thenReturn(true);
+    when(fetcher.isInProgress()).thenReturn(true);
+    setField(updater, "fetcher", fetcher);
+
+    assertFalse(updater.isUiDownloadAvailable());
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenMatchingPackageAlreadyFetched_expectFalse() throws Exception {
+    CoreUpdater updater = createCoreUpdater();
+    setField(updater, "latestVersionBuild", Version.currentBuildNumber() + 1);
+    setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+    setSelectedKey(updater);
+    CoreUpdater.PackageFetcher fetcher = mock(CoreUpdater.PackageFetcher.class);
+    when(fetcher.matchesChk(VALID_CHK)).thenReturn(true);
+    when(fetcher.isInProgress()).thenReturn(false);
+    when(fetcher.isSuccess()).thenReturn(true);
+    setField(updater, "fetcher", fetcher);
+
+    assertFalse(updater.isUiDownloadAvailable());
+  }
+
+  @Test
+  void isUiDownloadAvailable_whenOtherPackageDownloadInProgress_expectFalse() throws Exception {
+    CoreUpdater updater = createCoreUpdater();
+    setField(updater, "latestVersionBuild", Version.currentBuildNumber() + 1);
+    setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+    setSelectedKey(updater);
+    CoreUpdater.PackageFetcher fetcher = mock(CoreUpdater.PackageFetcher.class);
+    when(fetcher.matchesChk(VALID_CHK)).thenReturn(false);
+    when(fetcher.isInProgress()).thenReturn(true);
+    setField(updater, "fetcher", fetcher);
+
+    assertFalse(updater.isUiDownloadAvailable());
+  }
+
   private static CoreUpdater createCoreUpdater() throws Exception {
+    return createCoreUpdater(
+        java.nio.file.Files.createTempDirectory("cryptad-core-updater").toFile());
+  }
+
+  private static CoreUpdater createCoreUpdater(File nodeDir) throws Exception {
     NodeUpdateManager manager = mock(NodeUpdateManager.class);
     Node node = mock(Node.class, Answers.RETURNS_DEEP_STUBS);
     NodeClientCore core = mock(NodeClientCore.class);
@@ -112,6 +251,7 @@ class CoreUpdaterTest {
     Ticker ticker = mock(Ticker.class);
 
     when(manager.getNode()).thenReturn(node);
+    when(node.nodeDir().dir()).thenReturn(nodeDir);
     when(node.services().clientCore()).thenReturn(core);
     when(node.network().ticker()).thenReturn(ticker);
     when(core.makeClient(anyShort(), anyBoolean(), anyBoolean())).thenReturn(client);
@@ -146,12 +286,26 @@ class CoreUpdaterTest {
             .build());
   }
 
-  private static HTMLNode invokeBuildLinksNode(
-      CoreUpdater updater, CoreInfo info, PackageSpec spec, String chosenKey) throws Exception {
+  private static HTMLNode invokeBuildLinksNode(CoreUpdater updater, CoreInfo info, PackageSpec spec)
+      throws Exception {
     Method buildLinksNode =
         CoreUpdater.class.getDeclaredMethod(
             "buildLinksNode", CoreInfo.class, PackageSpec.class, String.class);
     buildLinksNode.setAccessible(true);
-    return (HTMLNode) buildLinksNode.invoke(updater, info, spec, chosenKey);
+    return (HTMLNode) buildLinksNode.invoke(updater, info, spec, SELECTED_PACKAGE_KEY);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> void setField(CoreUpdater updater, String fieldName, T value)
+      throws Exception {
+    Field field = CoreUpdater.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    ((AtomicReference<T>) field.get(updater)).set(value);
+  }
+
+  private static void setSelectedKey(CoreUpdater updater) throws Exception {
+    Field field = CoreUpdater.class.getDeclaredField("selectedKey");
+    field.setAccessible(true);
+    field.set(updater, SELECTED_PACKAGE_KEY);
   }
 }

--- a/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
+++ b/src/test/java/network/crypta/runtime/updater/CoreUpdaterTest.java
@@ -184,6 +184,19 @@ class CoreUpdaterTest {
   }
 
   @Test
+  void isUiDownloadAvailable_whenUpdatesPathIsBlockedByFile_expectFalse() throws Exception {
+    File nodeDir = Files.createTempDirectory("cryptad-core-updater").toFile();
+    File updatesFile = new File(nodeDir, "updates");
+    assertTrue(updatesFile.createNewFile());
+
+    CoreUpdater updater = createCoreUpdater(nodeDir);
+    setField(updater, "selectedSpec", new PackageSpec(VALID_CHK, 10L, null));
+    setSelectedKey(updater);
+
+    assertFalse(updater.isUiDownloadAvailable());
+  }
+
+  @Test
   void isUiDownloadAvailable_whenSelectedPackageIsStoreBacked_expectFalse() throws Exception {
     CoreUpdater updater = createCoreUpdater();
     setField(updater, "latestVersionBuild", Version.currentBuildNumber() + 1);


### PR DESCRIPTION
## Summary
Add the next Phase 3 node control-plane surface for Platform API and the Web Shell.

This PR:
- adds Platform API control-plane routes for config, security-level mutations, core updates, and first-time wizard operations
- wires `/app/node/` to use shell-native forms/cards for those operator workflows instead of dropping straight to the legacy pages
- preserves the existing admin full-access plus form-password bridge and keeps the legacy pages available as fallback/debug surfaces
- tightens updater and wizard runtime behavior so the new API/shell flows match the daemon’s existing semantics for confirmation, preservation, and download readiness
- adds focused regression coverage for the new Platform API handlers, router wiring, Web Shell resources, and the runtime updater/wizard adapters

## How to test
- `./gradlew test`

## Notes
- Base branch: `develop`
- Branch: `feature/pr-188-control-plane`