### PR TITLE
feat(platform): Add alerts and diagnostics surfaces

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -50,6 +50,7 @@ public final class PlatformApiToadlet extends Toadlet {
   private static final String URL_ENCODED_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
   private static final String DELETE_METHOD = "DELETE";
+  private static final String ALERTS_SEGMENT = "alerts";
   private static final String FORM_PASSWORD_PARAMETER = "formPassword";
   private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = QueueToadlet.MAX_KEY_LENGTH;
   private static final String CONFIG_SEGMENT = "config";
@@ -378,6 +379,7 @@ public final class PlatformApiToadlet extends Toadlet {
         || requiresConfigFormPassword(method, pathSegments)
         || requiresSecurityLevelsFormPassword(method, pathSegments)
         || requiresUpdatesFormPassword(method, pathSegments)
+        || requiresAlertsFormPassword(method, pathSegments)
         || requiresWizardFormPassword(method, pathSegments);
   }
 
@@ -473,6 +475,20 @@ public final class PlatformApiToadlet extends Toadlet {
         && UPDATES_SEGMENT.equals(pathSegments.getFirst())
         && "core".equals(pathSegments.get(1))
         && "download".equals(pathSegments.get(2));
+  }
+
+  /**
+   * Returns whether the current request targets the mutating alerts dismissal route.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresAlertsFormPassword(String method, List<String> pathSegments) {
+    return "POST".equals(method)
+        && pathSegments.size() == 3
+        && ALERTS_SEGMENT.equals(pathSegments.getFirst())
+        && "dismiss".equals(pathSegments.get(2));
   }
 
   /**

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -3,9 +3,11 @@ package network.crypta.platform.api;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import network.crypta.platform.api.alerts.AlertsApiHandler;
 import network.crypta.platform.api.apps.AppsApiHandler;
 import network.crypta.platform.api.config.ConfigApiHandler;
 import network.crypta.platform.api.connectivity.ConnectivityApiHandler;
+import network.crypta.platform.api.diagnostics.DiagnosticsApiHandler;
 import network.crypta.platform.api.node.NodeApiHandler;
 import network.crypta.platform.api.peers.PeersApiHandler;
 import network.crypta.platform.api.queue.QueueApiHandler;
@@ -57,6 +59,12 @@ public final class PlatformApiRouter {
   /** Handler for the {@code /queue/...} endpoint family. */
   private final QueueApiHandler queueApiHandler;
 
+  /** Handler for the {@code /alerts/...} endpoint family. */
+  private final AlertsApiHandler alertsApiHandler;
+
+  /** Handler for the {@code /diagnostics} endpoint family. */
+  private final DiagnosticsApiHandler diagnosticsApiHandler;
+
   /** Handler for the {@code /apps/...} endpoint family, when AppHost support is available. */
   private final AppsApiHandler appsApiHandler;
 
@@ -95,6 +103,8 @@ public final class PlatformApiRouter {
             runtimePorts.queueDownload(),
             runtimePorts.queueSupport(),
             runtimePorts.queueCompletion());
+    alertsApiHandler = new AlertsApiHandler(runtimePorts.alertFeed(), runtimePorts.alertMutation());
+    diagnosticsApiHandler = new DiagnosticsApiHandler(runtimePorts.diagnostic());
     appsApiHandler = appHost == null ? null : new AppsApiHandler(appHost);
   }
 
@@ -153,6 +163,9 @@ public final class PlatformApiRouter {
     if ("wizard".equals(firstSegment)) {
       return routeWizardRequest(segments, request);
     }
+    if ("alerts".equals(firstSegment)) {
+      return routeAlertsRequest(segments, request);
+    }
 
     if (!"GET".equals(request.method())) {
       return PlatformApiResponse.error(
@@ -165,7 +178,44 @@ public final class PlatformApiRouter {
     if ("connectivity".equals(firstSegment) && segments.size() == 1) {
       return PlatformApiResponse.ok(connectivityApiHandler.snapshot(request.queryParameters()));
     }
+    if ("diagnostics".equals(firstSegment) && segments.size() == 1) {
+      return PlatformApiResponse.ok(diagnosticsApiHandler.snapshot());
+    }
 
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  /**
+   * Routes requests beneath the {@code /alerts} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected alert endpoint
+   */
+  private PlatformApiResponse routeAlertsRequest(
+      List<String> segments, PlatformApiRequest request) {
+    return switch (segments.size()) {
+      case 1 -> routeAlertsCollection(request);
+      case 3 -> routeAlertAction(segments.get(1), segments.get(2), request);
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  private PlatformApiResponse routeAlertsCollection(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(alertsApiHandler.list());
+  }
+
+  private PlatformApiResponse routeAlertAction(
+      String alertIdSegment, String action, PlatformApiRequest request) {
+    if (!"POST".equals(request.method())) {
+      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+    }
+    if ("dismiss".equals(action)) {
+      return PlatformApiResponse.ok(alertsApiHandler.dismiss(alertIdSegment));
+    }
     throw new PlatformApiException(404, "not_found", "Platform API route not found.");
   }
 

--- a/platform-api/src/main/java/network/crypta/platform/api/alerts/AlertsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/alerts/AlertsApiHandler.java
@@ -1,0 +1,162 @@
+package network.crypta.platform.api.alerts;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.AlertFeedPort;
+import network.crypta.runtime.spi.AlertListSnapshot;
+import network.crypta.runtime.spi.AlertMutationPort;
+import network.crypta.runtime.spi.AlertSeverity;
+import network.crypta.runtime.spi.AlertSnapshot;
+
+/**
+ * Alert endpoint family for Platform API v1.
+ *
+ * <p>This handler turns the detached runtime alert SPI into stable, shell-facing JSON. It keeps the
+ * contract intentionally small: callers can fetch the current alert list, inspect a few precomputed
+ * summary counts, and request dismissal by the detached identifier already used by the legacy HTTP
+ * flow. That keeps alert transport details out of the bridge layer while still giving the Web Shell
+ * enough structure to render badges, cards, and per-alert actions without additional server-side
+ * shaping.
+ *
+ * <p>The class is transport-neutral. It validates path-derived alert identifiers and packages the
+ * response body, but it does not interpret HTTP authentication, form-password policy, or redirect
+ * behavior. Those concerns stay in the bridge and router layers. Runtime-owned alert ordering,
+ * dismissal side effects, and localized dismiss labels continue to come from the runtime ports.
+ *
+ * <ul>
+ *   <li>{@link #list()} exposes one ordered snapshot plus summary fields.
+ *   <li>{@link #dismiss(String)} preserves the best-effort legacy dismissal semantics.
+ * </ul>
+ */
+public final class AlertsApiHandler {
+  /** Detached runtime alert read port. */
+  private final AlertFeedPort alertFeedPort;
+
+  /** Detached runtime alert mutation port. */
+  private final AlertMutationPort alertMutationPort;
+
+  /**
+   * Creates an alert API handler backed by the supplied detached runtime ports.
+   *
+   * <p>Typical callers create one handler while assembling the router and then reuse it for every
+   * request. The feed and mutation ports may share a backing adapter, but the handler does not rely
+   * on that detail. It only requires that both ports refer to the same live alert domain so list
+   * and dismiss operations observe the same node state.
+   *
+   * @param alertFeedPort detached runtime port used to read the current alert snapshot
+   * @param alertMutationPort detached runtime port used to dismiss alerts by stable identifier
+   * @throws NullPointerException if either port is {@code null}
+   */
+  public AlertsApiHandler(AlertFeedPort alertFeedPort, AlertMutationPort alertMutationPort) {
+    this.alertFeedPort = Objects.requireNonNull(alertFeedPort, "alertFeedPort");
+    this.alertMutationPort = Objects.requireNonNull(alertMutationPort, "alertMutationPort");
+  }
+
+  /**
+   * Returns the current detached alert list as a JSON-compatible object.
+   *
+   * <p>The returned map is stable in both field names and encounter order so browser clients can
+   * render directly from the payload. Summary values are derived from the same snapshot used to
+   * build the alert array, which avoids count mismatches caused by multiple runtime reads during a
+   * single request. When no alerts are present, the method returns an empty list, zero counts, and
+   * a {@code null} highest-severity field rather than inventing a placeholder severity.
+   *
+   * @return JSON-compatible alert list snapshot in encounter order, including summary counts and
+   *     per-alert entries
+   */
+  public Map<String, Object> list() {
+    AlertListSnapshot snapshot = alertFeedPort.snapshot();
+    List<Map<String, Object>> alerts =
+        snapshot.alerts().stream().map(AlertsApiHandler::toJson).toList();
+
+    long dismissibleCount = snapshot.alerts().stream().filter(AlertSnapshot::dismissible).count();
+    long eventNotificationCount =
+        snapshot.alerts().stream().filter(AlertSnapshot::eventNotification).count();
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(5);
+    json.put("alertCount", alerts.size());
+    json.put("dismissibleCount", dismissibleCount);
+    json.put("eventNotificationCount", eventNotificationCount);
+    json.put("highestSeverity", highestSeverity(snapshot.alerts()));
+    json.put("alerts", alerts);
+    return json;
+  }
+
+  /**
+   * Dismisses one alert identified by a path-derived alert id.
+   *
+   * <p>This method performs only syntactic validation on the supplied route segment. Once the
+   * segment parses as an integer, the request is forwarded to the detached mutation port and the
+   * response echoes the requested identifier. Missing alerts, already-cleared alerts, and
+   * non-dismissible alerts remain a runtime concern and continue to follow the legacy best-effort
+   * behavior rather than producing a separate not-found response. That keeps the Platform API
+   * aligned with the existing operator-facing dismissal semantics.
+   *
+   * @param alertIdSegment route segment identifying the alert to dismiss
+   * @return JSON-compatible mutation summary echoing the requested alert identifier after the
+   *     dismissal request is forwarded
+   * @throws PlatformApiException if the route segment is absent or not a valid integer
+   */
+  public Map<String, Object> dismiss(String alertIdSegment) {
+    int alertId = parseAlertId(alertIdSegment);
+    alertMutationPort.dismiss(alertId);
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("operation", "dismiss");
+    json.put("alertId", alertId);
+    return json;
+  }
+
+  private static Map<String, Object> toJson(AlertSnapshot alert) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(9);
+    json.put("id", alert.id());
+    json.put("title", alert.title());
+    json.put("shortText", alert.shortText());
+    json.put("text", alert.text());
+    json.put("severity", alert.severity());
+    json.put("dismissible", alert.dismissible());
+    json.put("dismissLabel", alert.dismissLabel());
+    json.put("eventNotification", alert.eventNotification());
+    json.put("updatedTimeMillis", alert.updatedTimeMillis());
+    return json;
+  }
+
+  private static AlertSeverity highestSeverity(List<AlertSnapshot> alerts) {
+    AlertSeverity highest = null;
+    int highestRank = Integer.MAX_VALUE;
+    for (AlertSnapshot alert : alerts) {
+      int rank = severityRank(alert.severity());
+      if (rank < highestRank) {
+        highestRank = rank;
+        highest = alert.severity();
+      }
+    }
+    return highest;
+  }
+
+  private static int severityRank(AlertSeverity severity) {
+    if (severity == null) {
+      return Integer.MAX_VALUE;
+    }
+    return switch (severity) {
+      case CRITICAL_ERROR -> 0;
+      case ERROR -> 1;
+      case WARNING -> 2;
+      case MINOR -> 3;
+    };
+  }
+
+  private static int parseAlertId(String alertIdSegment) {
+    try {
+      return Integer.parseInt(Objects.requireNonNull(alertIdSegment, "alertIdSegment"));
+    } catch (IllegalArgumentException _) {
+      throw new PlatformApiException(
+          400,
+          "invalid_path_parameter",
+          "Alert route parameter 'alertId' must be a valid integer.");
+    }
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/alerts/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/alerts/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Alert-oriented Platform API handlers.
+ *
+ * <p>This package owns the narrow alert surface for Platform API v1. Its job is to translate the
+ * detached alert SPI into stable JSON that the Web Shell and other local operator tooling can
+ * consume directly. The package preserves the current runtime-owned alert model, including legacy
+ * hash-based dismissal identifiers and localized action labels, while keeping those runtime types
+ * behind the {@code :runtime-spi} boundary.
+ *
+ * <p>The package does not own HTTP authentication, HTML rendering, Atom feeds, or the broader
+ * legacy toadlet alert pages. Those concerns remain in the bridge and runtime layers. Here, the
+ * focus stays on transport-neutral request validation and JSON payload assembly for alert snapshots
+ * and simple dismiss actions.
+ */
+package network.crypta.platform.api.alerts;

--- a/platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java
@@ -1,0 +1,84 @@
+package network.crypta.platform.api.diagnostics;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.runtime.spi.DiagnosticPort;
+import network.crypta.runtime.spi.DiagnosticReportSnapshot;
+import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
+
+/**
+ * Diagnostics endpoint family for Platform API v1.
+ *
+ * <p>This handler exposes the detached diagnostic report as a stable read-only JSON payload. It
+ * keeps the runtime-provided section ordering intact so shell clients can render the same logical
+ * report structure the legacy diagnostics page exposes, while avoiding any dependency on page
+ * toadlets or legacy plain-text assembly code in higher layers. The result is suitable for
+ * shell-native panels, lightweight export actions, and future local tooling that needs a
+ * transport-neutral diagnostic snapshot.
+ *
+ * <p>The handler also emits one plain-text export string alongside the structured section list.
+ * That avoids forcing browser clients to reverse-engineer the exact legacy line layout when they
+ * need a copy-friendly representation. Section content still comes from the runtime SPI; this class
+ * only packages it into JSON and mirrors the established text concatenation order.
+ */
+public final class DiagnosticsApiHandler {
+  /** Detached runtime diagnostic-report port. */
+  private final DiagnosticPort diagnosticPort;
+
+  /**
+   * Creates a diagnostics API handler backed by the supplied detached runtime port.
+   *
+   * <p>Routers typically create one instance during startup and reuse it for every diagnostics
+   * request. The supplied port remains the single authority for report content and section order;
+   * this handler does not cache or merge reports across requests.
+   *
+   * @param diagnosticPort detached runtime port used to read the current diagnostic report
+   * @throws NullPointerException if {@code diagnosticPort} is {@code null}
+   */
+  public DiagnosticsApiHandler(DiagnosticPort diagnosticPort) {
+    this.diagnosticPort = Objects.requireNonNull(diagnosticPort, "diagnosticPort");
+  }
+
+  /**
+   * Returns the current detached diagnostic report as a JSON-compatible object.
+   *
+   * <p>The response always includes the ordered section array and a pre-rendered plain-text export.
+   * When the runtime reports no sections, the handler returns an empty list, a zero section count,
+   * and an empty export string. Callers therefore do not need special-case parsing for missing
+   * fields or optional export content.
+   *
+   * @return JSON-compatible diagnostic report containing ordered sections and a plain-text export
+   *     that mirrors the same snapshot
+   */
+  public Map<String, Object> snapshot() {
+    DiagnosticReportSnapshot snapshot = diagnosticPort.snapshot();
+    List<Map<String, Object>> sections =
+        snapshot.sections().stream().map(DiagnosticsApiHandler::toJson).toList();
+
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put("sectionCount", sections.size());
+    json.put("sections", sections);
+    json.put("plainTextExport", render(snapshot));
+    return json;
+  }
+
+  private static Map<String, Object> toJson(DiagnosticSectionSnapshot section) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("title", section.title());
+    json.put("lines", section.lines());
+    return json;
+  }
+
+  private static String render(DiagnosticReportSnapshot snapshot) {
+    StringBuilder builder = new StringBuilder();
+    for (DiagnosticSectionSnapshot section : snapshot.sections()) {
+      builder.append(section.title()).append('\n');
+      for (String line : section.lines()) {
+        builder.append(line).append('\n');
+      }
+    }
+    return builder.toString();
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/diagnostics/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/diagnostics/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Diagnostic-report Platform API handlers.
+ *
+ * <p>This package owns the read-only diagnostics surface for Platform API v1. It turns the detached
+ * runtime diagnostic report into stable JSON while preserving the original section order supplied
+ * by {@code :runtime-spi}. That lets the Web Shell and other local tooling render diagnostics
+ * natively without depending on legacy diagnostic toadlets or rebuilding the report structure from
+ * ad hoc text parsing.
+ *
+ * <p>The package is intentionally small. It does not interpret authentication policy or render HTML
+ * views. Its responsibility is to expose one transport-neutral report shape that contains both the
+ * structured sections and a copy-friendly plain-text export derived from the same snapshot.
+ */
+package network.crypta.platform.api.diagnostics;

--- a/platform-api/src/test/java/network/crypta/platform/api/alerts/AlertsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/alerts/AlertsApiHandlerTest.java
@@ -1,0 +1,160 @@
+package network.crypta.platform.api.alerts;
+
+import java.util.List;
+import java.util.Map;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.runtime.spi.AlertFeedPort;
+import network.crypta.runtime.spi.AlertListSnapshot;
+import network.crypta.runtime.spi.AlertMutationPort;
+import network.crypta.runtime.spi.AlertSeverity;
+import network.crypta.runtime.spi.AlertSnapshot;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class AlertsApiHandlerTest {
+  @Test
+  void list_whenSnapshotEmpty_expectZeroCountsAndNullHighestSeverity() {
+    Map<String, Object> response = listResponse(new AlertListSnapshot(List.of()));
+
+    assertEquals(0, response.get("alertCount"));
+    assertEquals(0L, response.get("dismissibleCount"));
+    assertEquals(0L, response.get("eventNotificationCount"));
+    assertNull(response.get("highestSeverity"));
+    assertEquals(List.of(), response.get("alerts"));
+  }
+
+  @Test
+  void list_whenSnapshotReturned_expectSummaryCountsAndStructuredAlerts() {
+    AlertListSnapshot snapshot =
+        new AlertListSnapshot(
+            List.of(
+                new AlertSnapshot(
+                    42,
+                    "Update available",
+                    "Updater",
+                    "A new core package is ready.",
+                    AlertSeverity.WARNING,
+                    true,
+                    "Delete",
+                    false,
+                    123L)));
+
+    Map<String, Object> response = listResponse(snapshot);
+
+    assertEquals(1, response.get("alertCount"));
+    assertEquals(1L, response.get("dismissibleCount"));
+    assertEquals(0L, response.get("eventNotificationCount"));
+    assertEquals(AlertSeverity.WARNING, response.get("highestSeverity"));
+    assertEquals(
+        List.of(
+            Map.of(
+                "id",
+                42,
+                "title",
+                "Update available",
+                "shortText",
+                "Updater",
+                "text",
+                "A new core package is ready.",
+                "severity",
+                AlertSeverity.WARNING,
+                "dismissible",
+                true,
+                "dismissLabel",
+                "Delete",
+                "eventNotification",
+                false,
+                "updatedTimeMillis",
+                123L)),
+        response.get("alerts"));
+  }
+
+  @Test
+  void list_whenAlertsSpanSeveritiesAndFlags_expectHighestSeverityAndSummaryCounts() {
+    AlertListSnapshot snapshot =
+        new AlertListSnapshot(
+            List.of(
+                new AlertSnapshot(
+                    1,
+                    "Minor event",
+                    "Event",
+                    "Minor event body.",
+                    AlertSeverity.MINOR,
+                    false,
+                    null,
+                    true,
+                    100L),
+                new AlertSnapshot(
+                    2,
+                    "Critical issue",
+                    "Critical",
+                    "Critical issue body.",
+                    AlertSeverity.CRITICAL_ERROR,
+                    true,
+                    "Acknowledge",
+                    false,
+                    200L),
+                new AlertSnapshot(
+                    3,
+                    "Warning",
+                    "Warning",
+                    "Warning body.",
+                    AlertSeverity.WARNING,
+                    true,
+                    "Dismiss",
+                    false,
+                    300L)));
+
+    Map<String, Object> response = listResponse(snapshot);
+
+    assertEquals(3, response.get("alertCount"));
+    assertEquals(2L, response.get("dismissibleCount"));
+    assertEquals(1L, response.get("eventNotificationCount"));
+    assertEquals(AlertSeverity.CRITICAL_ERROR, response.get("highestSeverity"));
+  }
+
+  @Test
+  void dismiss_whenNumericAlertIdProvided_expectDelegatesAndReturnsSummary() {
+    RecordingAlertMutationPort mutationPort = new RecordingAlertMutationPort();
+    AlertsApiHandler handler = new AlertsApiHandler(emptyFeed(), mutationPort);
+
+    Map<String, Object> response = handler.dismiss("-17");
+
+    assertEquals(-17, mutationPort.lastDismissedAlertId);
+    assertEquals("dismiss", response.get("operation"));
+    assertEquals(-17, response.get("alertId"));
+  }
+
+  @Test
+  void dismiss_whenAlertIdMalformed_expectBadRequest() {
+    AlertsApiHandler handler = new AlertsApiHandler(emptyFeed(), ignored -> {});
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.dismiss("not-a-number"));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_path_parameter", error.errorCode());
+    assertEquals("Alert route parameter 'alertId' must be a valid integer.", error.getMessage());
+  }
+
+  private static AlertFeedPort emptyFeed() {
+    return () -> new AlertListSnapshot(List.of());
+  }
+
+  private static Map<String, Object> listResponse(AlertListSnapshot snapshot) {
+    return new AlertsApiHandler(() -> snapshot, ignored -> {}).list();
+  }
+
+  private static final class RecordingAlertMutationPort implements AlertMutationPort {
+    private Integer lastDismissedAlertId;
+
+    @Override
+    public void dismiss(int alertId) {
+      lastDismissedAlertId = alertId;
+    }
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandlerTest.java
@@ -1,0 +1,49 @@
+package network.crypta.platform.api.diagnostics;
+
+import java.util.List;
+import java.util.Map;
+import network.crypta.runtime.spi.DiagnosticReportSnapshot;
+import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("java:S100")
+class DiagnosticsApiHandlerTest {
+  @Test
+  void snapshot_whenReportEmpty_expectEmptySectionsAndBlankPlainTextExport() {
+    DiagnosticsApiHandler handler =
+        new DiagnosticsApiHandler(() -> new DiagnosticReportSnapshot(List.of()));
+
+    Map<String, Object> response = handler.snapshot();
+
+    assertEquals(0, response.get("sectionCount"));
+    assertEquals(List.of(), response.get("sections"));
+    assertEquals("", response.get("plainTextExport"));
+  }
+
+  @Test
+  void snapshot_whenReportReturned_expectStructuredSectionsAndPlainTextExport() {
+    DiagnosticsApiHandler handler =
+        new DiagnosticsApiHandler(
+            () ->
+                new DiagnosticReportSnapshot(
+                    List.of(
+                        new DiagnosticSectionSnapshot(
+                            "System Information:", List.of("alpha", "", "beta")),
+                        new DiagnosticSectionSnapshot(
+                            "Queue:", List.of("Downloads Queued: 1", "")))));
+
+    Map<String, Object> response = handler.snapshot();
+
+    assertEquals(2, response.get("sectionCount"));
+    assertEquals(
+        List.of(
+            Map.of("title", "System Information:", "lines", List.of("alpha", "", "beta")),
+            Map.of("title", "Queue:", "lines", List.of("Downloads Queued: 1", ""))),
+        response.get("sections"));
+    assertEquals(
+        "System Information:\nalpha\n\nbeta\nQueue:\nDownloads Queued: 1\n\n",
+        response.get("plainTextExport"));
+  }
+}

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -16,10 +16,12 @@
         <h1>Web Shell v1</h1>
         <p class="lede">
           Snapshot views, config changes, updater triggers, first-run controls, queue actions, and
-          selective legacy deep links powered by Platform API v1.
+          alerts and diagnostics snapshots powered by Platform API v1.
         </p>
         <div class="hero-actions">
           <a class="button button-primary" href="/api/v1/node/greeting">Node greeting JSON</a>
+          <a class="button button-secondary" href="/api/v1/alerts">Alerts JSON</a>
+          <a class="button button-secondary" href="/api/v1/diagnostics">Diagnostics JSON</a>
           <a class="button button-secondary" href="/">Legacy root</a>
         </div>
       </header>
@@ -42,6 +44,49 @@
           </div>
           <div class="panel-body" id="connectivity-body">
             <p class="loading">Loading connectivity snapshot...</p>
+          </div>
+        </article>
+
+        <article class="panel" id="alerts-panel">
+          <div class="panel-header">
+            <p class="panel-kicker">Alerts</p>
+            <h2>Alert queue</h2>
+          </div>
+          <p class="panel-description">
+            Current alerts stay native to the shell, including dismiss actions for alerts that can
+            be cleared from Platform API v1.
+          </p>
+          <div class="queue-toolbar">
+            <button class="button button-secondary" id="alerts-refresh-button" type="button">
+              Refresh alerts
+            </button>
+          </div>
+          <div class="queue-status" id="alerts-status" aria-live="polite"></div>
+          <p class="panel-description" hidden id="alerts-readonly-hint">
+            Alert dismissal is unavailable in read-only mode.
+          </p>
+          <div class="panel-body" id="alerts-body">
+            <p class="loading">Loading alerts snapshot...</p>
+          </div>
+        </article>
+
+        <article class="panel" id="diagnostics-panel">
+          <div class="panel-header">
+            <p class="panel-kicker">Diagnostics</p>
+            <h2>Runtime diagnostics</h2>
+          </div>
+          <p class="panel-description">
+            Review the exported diagnostic sections and the plain-text export without leaving the
+            shell.
+          </p>
+          <div class="queue-toolbar">
+            <button class="button button-secondary" id="diagnostics-refresh-button" type="button">
+              Refresh diagnostics
+            </button>
+          </div>
+          <div class="queue-status" id="diagnostics-status" aria-live="polite"></div>
+          <div class="panel-body" id="diagnostics-body">
+            <p class="empty-state">Use Refresh diagnostics to load the current diagnostics snapshot.</p>
           </div>
         </article>
 

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -425,6 +425,71 @@ a {
   gap: 10px;
 }
 
+.alert-card-list,
+.diagnostics-section-list {
+  display: grid;
+  gap: 14px;
+}
+
+.alert-card,
+.diagnostics-section {
+  display: grid;
+  gap: 12px;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.alert-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.alert-card-heading {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.alert-card-title,
+.diagnostics-section-title {
+  margin: 0;
+}
+
+.alert-card-subtitle,
+.alert-card-text {
+  margin: 0;
+  color: var(--shell-muted);
+  overflow-wrap: anywhere;
+}
+
+.alert-card-text {
+  white-space: pre-wrap;
+}
+
+.alert-card-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.alert-dismiss-form {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.diagnostics-lines,
+.diagnostics-export {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .json-details {
   display: grid;
   gap: 10px;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -13,7 +13,9 @@
   let formPassword = typeof bootstrap.formPassword === "string" ? bootstrap.formPassword : "";
   const legacyLinks = Array.isArray(bootstrap.legacyLinks) ? bootstrap.legacyLinks : [];
   const shellState = {
+    alertsSnapshot: null,
     configSnapshot: null,
+    diagnosticsSnapshot: null,
     securitySnapshot: null,
     updatesSnapshot: null,
     wizardSnapshot: null,
@@ -28,6 +30,8 @@
   };
   let peerLoadGeneration = 0;
   let queueLoadGeneration = 0;
+  let alertsLoadGeneration = 0;
+  let diagnosticsLoadGeneration = 0;
   let securityLoadGeneration = 0;
   let updatesLoadGeneration = 0;
   let configLoadGeneration = 0;
@@ -37,6 +41,11 @@
   const sections = {
     overview: document.getElementById("overview-body"),
     connectivity: document.getElementById("connectivity-body"),
+    alerts: document.getElementById("alerts-body"),
+    alertsStatus: document.getElementById("alerts-status"),
+    alertsReadonlyHint: document.getElementById("alerts-readonly-hint"),
+    diagnostics: document.getElementById("diagnostics-body"),
+    diagnosticsStatus: document.getElementById("diagnostics-status"),
     security: document.getElementById("security-body"),
     securityStatus: document.getElementById("security-status"),
     securityReadonlyHint: document.getElementById("security-readonly-hint"),
@@ -63,6 +72,12 @@
     createForm: document.getElementById("peer-create-form"),
     createReference: document.getElementById("peer-reference-text"),
     createSubmit: document.getElementById("peer-create-submit"),
+  };
+  const alertsControls = {
+    refreshButton: document.getElementById("alerts-refresh-button"),
+  };
+  const diagnosticsControls = {
+    refreshButton: document.getElementById("diagnostics-refresh-button"),
   };
   const securityControls = {
     form: document.getElementById("security-form"),
@@ -166,6 +181,14 @@
     setSectionStatus(sections.peersStatus, message, tone);
   }
 
+  function setAlertsStatus(message, tone) {
+    setSectionStatus(sections.alertsStatus, message, tone);
+  }
+
+  function setDiagnosticsStatus(message, tone) {
+    setSectionStatus(sections.diagnosticsStatus, message, tone);
+  }
+
   function setSectionStatus(container, message, tone) {
     clear(container);
     if (!message) {
@@ -252,6 +275,37 @@
     return card;
   }
 
+  function topLevelFieldEntries(data, excludedKeys) {
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      return [];
+    }
+    const excluded = new Set(Array.isArray(excludedKeys) ? excludedKeys : []);
+    return Object.entries(data)
+      .filter(([key]) => !excluded.has(key))
+      .map(([key, value]) => [key, scalar(value)]);
+  }
+
+  function formatTimestampMillis(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      const date = new Date(value);
+      if (!Number.isNaN(date.getTime())) {
+        return date.toLocaleString();
+      }
+    }
+    return scalar(value);
+  }
+
+  function severityTone(severity) {
+    const normalized = typeof severity === "string" ? severity.toLowerCase() : "";
+    if (normalized.includes("critical") || normalized.includes("error") || normalized.includes("high")) {
+      return "is-error";
+    }
+    if (normalized.includes("warn") || normalized.includes("medium") || normalized.includes("moderate")) {
+      return "is-warning";
+    }
+    return "";
+  }
+
   function renderLegacyLinks() {
     clear(sections.legacy);
     for (const link of legacyLinks) {
@@ -327,6 +381,184 @@
         ], "is-warning"),
       );
     }
+  }
+
+  function alertDismissPath(alertId) {
+    return `alerts/${encodeURIComponent(alertId)}/dismiss`;
+  }
+
+  function renderAlertCard(alert, index) {
+    const card = document.createElement("section");
+    card.className = "alert-card";
+    const title = typeof alert.title === "string" && alert.title ? alert.title : `Alert ${index + 1}`;
+    const shortText =
+      typeof alert.shortText === "string" && alert.shortText
+        ? alert.shortText
+        : "No short text provided.";
+    const textBody = typeof alert.text === "string" && alert.text ? alert.text : "";
+
+    const header = document.createElement("div");
+    header.className = "alert-card-header";
+
+    const heading = document.createElement("div");
+    heading.className = "alert-card-heading";
+    heading.append(text("h3", "alert-card-title", title), text("p", "alert-card-subtitle", shortText));
+
+    const pills = document.createElement("div");
+    pills.className = "alert-card-pills";
+    if (alert.severity) {
+      pills.append(createPill(String(alert.severity), severityTone(alert.severity)));
+    }
+    if (alert.eventNotification) {
+      pills.append(createPill("Event notification", "is-warning"));
+    }
+    if (alert.dismissible === false) {
+      pills.append(createPill("Not dismissible", "is-warning"));
+    }
+
+    header.append(heading, pills);
+    card.append(header);
+
+    if (textBody) {
+      card.append(text("p", "alert-card-text", textBody));
+    }
+
+    card.append(
+      definitionList([
+        ["ID", scalar(alert.id)],
+        ["Updated", formatTimestampMillis(alert.updatedTimeMillis)],
+      ]),
+    );
+
+    const extraFields = topLevelFieldEntries(alert, [
+      "id",
+      "title",
+      "shortText",
+      "text",
+      "severity",
+      "dismissible",
+      "dismissLabel",
+      "eventNotification",
+      "updatedTimeMillis",
+    ]);
+    if (extraFields.length) {
+      card.append(definitionList(extraFields));
+    }
+
+    if (alert.dismissible !== false && formPassword) {
+      const form = document.createElement("form");
+      form.className = "alert-dismiss-form";
+      form.dataset.alertId = alert.id == null ? "" : String(alert.id);
+
+      const submit = document.createElement("button");
+      submit.className = "button button-secondary";
+      submit.type = "submit";
+      submit.textContent =
+        typeof alert.dismissLabel === "string" && alert.dismissLabel
+          ? alert.dismissLabel
+          : "Dismiss alert";
+      form.append(submit);
+      card.append(form);
+    }
+
+    return card;
+  }
+
+  function renderAlerts(data) {
+    shellState.alertsSnapshot = data;
+    updateAlertsToolbar();
+    clear(sections.alerts);
+
+    const alerts = Array.isArray(data.alerts) ? data.alerts : [];
+    const summaryEntries = [["Alerts", `${alerts.length}`], ...topLevelFieldEntries(data, ["alerts"])];
+    sections.alerts.append(summaryCard("Alerts summary", summaryEntries, alerts.length ? "" : "is-warning"));
+
+    if (!alerts.length) {
+      sections.alerts.append(text("p", "empty-state", "No alerts were returned."));
+      return;
+    }
+
+    const list = document.createElement("div");
+    list.className = "alert-card-list";
+    alerts.forEach((alert, index) => {
+      list.append(renderAlertCard(alert && typeof alert === "object" ? alert : {}, index));
+    });
+    sections.alerts.append(list);
+  }
+
+  function renderDiagnosticsSection(section, index) {
+    const card = document.createElement("section");
+    card.className = "diagnostics-section";
+    const title =
+      typeof section.title === "string" && section.title ? section.title : `Section ${index + 1}`;
+
+    card.append(text("h3", "diagnostics-section-title", title));
+
+    const lines = Array.isArray(section.lines) ? section.lines : [];
+    if (!lines.length) {
+      card.append(text("p", "empty-state", "No diagnostic lines were exported."));
+    } else {
+      const pre = document.createElement("pre");
+      pre.className = "diagnostics-lines";
+      pre.textContent = lines
+        .map((line) => (typeof line === "string" ? line : formatJson(line)))
+        .join("\n");
+      card.append(pre);
+    }
+
+    const extraFields = topLevelFieldEntries(section, ["title", "lines"]);
+    if (extraFields.length) {
+      card.append(definitionList(extraFields));
+    }
+
+    return card;
+  }
+
+  function renderDiagnostics(data) {
+    shellState.diagnosticsSnapshot = data;
+    updateDiagnosticsToolbar();
+    clear(sections.diagnostics);
+
+    const sectionsList = Array.isArray(data.sections) ? data.sections : [];
+    const summaryEntries = [
+      ["Sections", `${sectionsList.length}`],
+      ...topLevelFieldEntries(data, ["sections", "plainTextExport", "export", "textExport"]),
+    ];
+    sections.diagnostics.append(
+      summaryCard("Diagnostics summary", summaryEntries, sectionsList.length ? "" : "is-warning"),
+    );
+
+    const exportText =
+      typeof data.plainTextExport === "string"
+        ? data.plainTextExport
+        : typeof data.export === "string"
+          ? data.export
+          : typeof data.textExport === "string"
+            ? data.textExport
+            : null;
+    if (exportText) {
+      const exportDetails = document.createElement("details");
+      exportDetails.className = "json-details";
+      const summary = document.createElement("summary");
+      summary.textContent = "Plain-text export";
+      const pre = document.createElement("pre");
+      pre.className = "json-code diagnostics-export";
+      pre.textContent = exportText;
+      exportDetails.append(summary, pre);
+      sections.diagnostics.append(exportDetails);
+    }
+
+    if (!sectionsList.length) {
+      sections.diagnostics.append(text("p", "empty-state", "No diagnostic sections were returned."));
+      return;
+    }
+
+    const list = document.createElement("div");
+    list.className = "diagnostics-section-list";
+    sectionsList.forEach((section, index) => {
+      list.append(renderDiagnosticsSection(section && typeof section === "object" ? section : {}, index));
+    });
+    sections.diagnostics.append(list);
   }
 
   function renderSecurity(data) {
@@ -581,6 +813,14 @@
       sections.peersReadonlyHint.hidden = !!formPassword;
     }
   }
+
+  function updateAlertsToolbar() {
+    if (sections.alertsReadonlyHint) {
+      sections.alertsReadonlyHint.hidden = !!formPassword;
+    }
+  }
+
+  function updateDiagnosticsToolbar() {}
 
   function updateSecurityToolbar() {
     securityControls.form.hidden = !formPassword || !shellState.securitySnapshot;
@@ -1232,6 +1472,68 @@
     }
   }
 
+  async function loadAlertsSection() {
+    const loadGeneration = ++alertsLoadGeneration;
+    shellState.alertsSnapshot = null;
+    clear(sections.alerts);
+    sections.alerts.append(text("p", "loading", "Loading alerts snapshot..."));
+    updateAlertsToolbar();
+
+    try {
+      const snapshot = await loadJson(apiUrl("alerts"));
+      if (loadGeneration !== alertsLoadGeneration) {
+        return;
+      }
+      renderAlerts(snapshot);
+    } catch (error) {
+      if (loadGeneration !== alertsLoadGeneration) {
+        return;
+      }
+      renderError(sections.alerts, "alerts", error);
+    }
+  }
+
+  async function loadDiagnosticsSection() {
+    const loadGeneration = ++diagnosticsLoadGeneration;
+    shellState.diagnosticsSnapshot = null;
+    clear(sections.diagnostics);
+    sections.diagnostics.append(text("p", "loading", "Loading diagnostics snapshot..."));
+    updateDiagnosticsToolbar();
+
+    try {
+      const snapshot = await loadJson(apiUrl("diagnostics"));
+      if (loadGeneration !== diagnosticsLoadGeneration) {
+        return;
+      }
+      renderDiagnostics(snapshot);
+    } catch (error) {
+      if (loadGeneration !== diagnosticsLoadGeneration) {
+        return;
+      }
+      renderError(sections.diagnostics, "diagnostics", error);
+    }
+  }
+
+  async function dismissAlert(form) {
+    const alertId = form.dataset.alertId ?? "";
+    if (alertId === "") {
+      setAlertsStatus("Alert dismissal unavailable without an alert ID.", "is-error");
+      return;
+    }
+
+    try {
+      await postForm(
+        alertDismissPath(alertId),
+        new FormData(),
+        "Alert dismissal unavailable in read-only mode.",
+      );
+      setAlertsStatus("Alert dismissed.", "is-success");
+      await loadAlertsSection();
+    } catch (error) {
+      setAlertsStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
   function queueMutationPath(submitterName) {
     switch (submitterName) {
       case "remove_request":
@@ -1808,6 +2110,31 @@
     });
   }
 
+  function bindAlertsInteractions() {
+    alertsControls.refreshButton.addEventListener("click", () => {
+      setAlertsStatus("Refreshing alerts.");
+      loadAlertsSection();
+    });
+    sections.alerts.addEventListener("submit", async (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+      if (form.dataset.alertId == null) {
+        return;
+      }
+      event.preventDefault();
+      await dismissAlert(form);
+    });
+  }
+
+  function bindDiagnosticsInteractions() {
+    diagnosticsControls.refreshButton.addEventListener("click", () => {
+      setDiagnosticsStatus("Refreshing diagnostics.");
+      loadDiagnosticsSection();
+    });
+  }
+
   function bindSecurityInteractions() {
     securityControls.form.addEventListener("submit", submitSecurityForm);
   }
@@ -1876,12 +2203,16 @@
   }
 
   renderLegacyLinks();
+  bindAlertsInteractions();
   bindSecurityInteractions();
   bindUpdatesInteractions();
   bindConfigInteractions();
   bindWizardInteractions();
   bindPeerInteractions();
+  bindDiagnosticsInteractions();
   bindQueueInteractions();
+  updateAlertsToolbar();
+  updateDiagnosticsToolbar();
   updateSecurityToolbar();
   updateUpdatesToolbar();
   updateConfigToolbar();
@@ -1893,6 +2224,9 @@
   });
   loadSecuritySection().catch((error) => {
     renderError(sections.security, "security", error);
+  });
+  loadAlertsSection().catch((error) => {
+    renderError(sections.alerts, "alerts", error);
   });
   loadUpdatesSection().catch((error) => {
     renderError(sections.updates, "updates", error);

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -3,6 +3,7 @@ package network.crypta.platform.webshell;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
@@ -13,14 +14,23 @@ class WebShellResourcesTest {
 
     assertTrue(html.contains("Web Shell v1"));
     assertTrue(html.contains("Peer control plane"));
+    assertTrue(html.contains("Alert queue"));
+    assertTrue(html.contains("Runtime diagnostics"));
     assertTrue(html.contains("Queue control plane"));
     assertTrue(html.contains("Core updater"));
     assertTrue(html.contains("Operator subset"));
     assertTrue(html.contains("First-time setup"));
+    assertTrue(html.contains("Alerts JSON"));
+    assertTrue(html.contains("Diagnostics JSON"));
     assertTrue(html.contains("__BOOTSTRAP_JSON__"));
     assertTrue(html.contains("peer-create-form\" hidden"));
     assertTrue(html.contains("name=\"referenceText\""));
     assertTrue(html.contains("id=\"peers-status\""));
+    assertTrue(html.contains("id=\"alerts-panel\""));
+    assertTrue(html.contains("id=\"alerts-body\""));
+    assertTrue(html.contains("id=\"diagnostics-panel\""));
+    assertTrue(html.contains("id=\"diagnostics-body\""));
+    assertTrue(html.contains("Use Refresh diagnostics to load the current diagnostics snapshot."));
     assertTrue(html.contains("name=\"filterData\" type=\"checkbox\" checked"));
     assertTrue(html.contains("queue-create-form\" hidden"));
     assertTrue(html.contains("id=\"security-form\""));
@@ -42,7 +52,17 @@ class WebShellResourcesTest {
     assertPeerMutationMarkersPresent(script);
     assertPeerMutationSubmissionOrder(script);
     assertPeerLoadSequencing(script);
+    assertAlertsAndDiagnosticsMarkersPresent(script);
     assertPlatformControlPlaneMarkersPresent(script);
+  }
+
+  @Test
+  void readText_whenStylesheetResourceRequested_expectAlertTextPreservesNewlines() {
+    String stylesheet =
+        WebShellResources.readText(WebShellPaths.resourcePath(WebShellPaths.STYLESHEET_PATH));
+
+    assertTrue(stylesheet.contains(".alert-card-text {"));
+    assertTrue(stylesheet.contains("white-space: pre-wrap;"));
   }
 
   private static void assertQueueMutationMarkersPresent(String script) {
@@ -227,6 +247,38 @@ class WebShellResourcesTest {
     assertTrue(errorGuardIndex > renderPeersIndex);
     assertTrue(renderErrorIndex > errorGuardIndex);
     assertTrue(loadPeersCatchIndex > renderErrorIndex);
+  }
+
+  private static void assertAlertsAndDiagnosticsMarkersPresent(String script) {
+    assertTrue(script.contains("alertsSnapshot"));
+    assertTrue(script.contains("diagnosticsSnapshot"));
+    assertTrue(script.contains("let alertsLoadGeneration = 0;"));
+    assertTrue(script.contains("let diagnosticsLoadGeneration = 0;"));
+    assertTrue(script.contains("const alertsControls = {"));
+    assertTrue(script.contains("const diagnosticsControls = {"));
+    assertTrue(script.contains("function updateAlertsToolbar()"));
+    assertTrue(script.contains("function updateDiagnosticsToolbar()"));
+    assertTrue(script.contains("function renderAlerts(data)"));
+    assertTrue(script.contains("function renderDiagnostics(data)"));
+    assertTrue(script.contains("function renderAlertCard(alert, index)"));
+    assertTrue(script.contains("function renderDiagnosticsSection(section, index)"));
+    assertTrue(script.contains("function alertDismissPath(alertId)"));
+    assertTrue(script.contains("loadJson(apiUrl(\"alerts\"))"));
+    assertTrue(script.contains("loadJson(apiUrl(\"diagnostics\"))"));
+    assertTrue(script.contains("alertDismissPath(alertId),"));
+    assertTrue(script.contains("plainTextExport"));
+    assertTrue(script.contains("alert-dismiss-form"));
+    assertTrue(script.contains("diagnostics-section-list"));
+    assertTrue(
+        script.contains(
+            "...topLevelFieldEntries(data, [\"sections\", \"plainTextExport\", \"export\","
+                + " \"textExport\"])"));
+    assertTrue(
+        script.contains("form.dataset.alertId = alert.id == null ? \"\" : String(alert.id);"));
+    assertTrue(script.contains("const alertId = form.dataset.alertId ?? \"\";"));
+    assertTrue(script.contains("if (form.dataset.alertId == null) {"));
+    assertTrue(script.contains("typeof alert.dismissLabel === \"string\" && alert.dismissLabel"));
+    assertFalse(script.contains("loadDiagnosticsSection().catch((error) => {"));
   }
 
   private static void assertPlatformControlPlaneMarkersPresent(String script) {

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsBundle.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsBundle.java
@@ -1,5 +1,7 @@
 package network.crypta.runtime.admin;
 
+import network.crypta.runtime.spi.AlertFeedPort;
+import network.crypta.runtime.spi.AlertMutationPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -38,6 +40,8 @@ import network.crypta.runtime.spi.WelcomePagePort;
  * @param darknetConnections adapter that resolves detached darknet friend actions against live
  *     peers
  * @param darknetMessaging adapter that sends detached darknet messages and file offers on demand
+ * @param alertFeed adapter that exposes detached alert snapshots for admin-facing pages
+ * @param alertMutation adapter that dismisses alerts by detached id
  * @param diagnostic adapter that exports detached diagnostic and report-oriented admin snapshots
  * @param pageChrome adapter that exposes shared page-shell status for admin toadlets and page maker
  * @param queueCompletion adapter that serves queue-completion exports and completion-oriented
@@ -58,6 +62,8 @@ public record AdminRuntimePortsBundle(
     ConnectionsSupportPort connectionsSupport,
     DarknetConnectionsPort darknetConnections,
     DarknetMessagingPort darknetMessaging,
+    AlertFeedPort alertFeed,
+    AlertMutationPort alertMutation,
     DiagnosticPort diagnostic,
     PageChromePort pageChrome,
     QueueCompletionPort queueCompletion,

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/AdminRuntimePortsFactory.java
@@ -1,9 +1,11 @@
 package network.crypta.runtime.admin;
 
+import java.util.Objects;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
+import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.support.http.HttpFetchSizeLimits;
 
 /**
@@ -45,11 +47,15 @@ public final class AdminRuntimePortsFactory {
         core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
     peerReferenceClient.setMaxLength(maxLengthNoProgress);
     peerReferenceClient.setMaxIntermediateLength(maxLengthNoProgress);
+    UserAlertManager alertManager = Objects.requireNonNull(core.getAlerts(), "alerts");
+    LegacyAlertPort alertPort = new LegacyAlertPort(alertManager);
     return new AdminRuntimePortsBundle(
         new LegacyConnectionsPagePort(node, bridgeInputs.geoIpCountryLookup()),
         new LegacyConnectionsSupportPort(node, peerReferenceClient),
         new LegacyDarknetConnectionsPort(node),
         new LegacyDarknetMessagingPort(node),
+        alertPort,
+        alertPort,
         new LegacyDiagnosticPort(node, core, bridgeInputs.queueAdminBackend()),
         new LegacyPageChromePort(node),
         bridgeInputs.queueCompletionPort(),

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyAlertPort.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyAlertPort.java
@@ -1,0 +1,103 @@
+package network.crypta.runtime.admin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import network.crypta.runtime.alerts.UserAlert;
+import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.spi.AlertFeedPort;
+import network.crypta.runtime.spi.AlertListSnapshot;
+import network.crypta.runtime.spi.AlertMutationPort;
+import network.crypta.runtime.spi.AlertSeverity;
+import network.crypta.runtime.spi.AlertSnapshot;
+
+/**
+ * Bridges the runtime alert manager to the detached alert SPI.
+ *
+ * <p>This adapter is the runtime-node side of the new alert boundary. It keeps the live {@link
+ * UserAlertManager} and its rich alert types inside the daemon module, then projects the current
+ * alert state into the small JDK-only DTOs defined in {@code :runtime-spi}. That lets admin-facing
+ * callers such as Platform API handlers and legacy HTTP bridges work with stable, serializable
+ * alert data without importing runtime-owned alert implementations, HTML fragments, or feed
+ * helpers.
+ *
+ * <p>The adapter intentionally stays mechanical. It preserves manager ordering, forwards dismissals
+ * unchanged, and filters out alerts that are already invalid at snapshot time. It does not cache
+ * results, merge alerts, or interpret alert semantics beyond the field mapping needed for the
+ * detached SPI.
+ */
+final class LegacyAlertPort implements AlertFeedPort, AlertMutationPort {
+  /** Live alert manager that remains the owner of alert ordering and dismissal semantics. */
+  private final UserAlertManager alertManager;
+
+  /**
+   * Creates a detached alert adapter backed by the live alert manager.
+   *
+   * <p>Callers normally create one adapter and reuse it for both alert reads and dismissals so both
+   * operations see the same underlying manager. The adapter does not assume exclusive ownership of
+   * the manager; other runtime code may continue to register, invalidate, or dismiss alerts in
+   * parallel.
+   *
+   * @param alertManager shared runtime alert manager
+   * @throws NullPointerException if {@code alertManager} is {@code null}
+   */
+  LegacyAlertPort(UserAlertManager alertManager) {
+    this.alertManager = Objects.requireNonNull(alertManager, "alertManager");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned snapshot preserves the manager's encounter order and excludes alerts that are
+   * already invalid at the moment they are inspected. That mirrors the legacy operator-facing
+   * surfaces, which only show alerts that remain active, while still leaving the underlying alert
+   * lifecycle entirely under manager control.
+   */
+  @Override
+  public AlertListSnapshot snapshot() {
+    UserAlert[] alerts = alertManager.getAlerts();
+    List<AlertSnapshot> snapshots = new ArrayList<>(alerts.length);
+    for (UserAlert alert : alerts) {
+      if (!alert.isValid()) {
+        continue;
+      }
+      snapshots.add(toSnapshot(alert));
+    }
+    return new AlertListSnapshot(snapshots);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Dismissal is delegated directly to the live manager so the runtime retains its existing side
+   * effects, including unregister-on-dismiss behavior and per-alert cleanup hooks. The detached
+   * adapter does not add not-found handling or authorization checks.
+   */
+  @Override
+  public void dismiss(int alertId) {
+    alertManager.dismissAlert(alertId);
+  }
+
+  /**
+   * Converts one runtime-owned alert into the detached SPI snapshot used by higher layers.
+   *
+   * <p>The mapping copies only the values required by the current detached contract: identifier,
+   * textual content, severity, dismissal metadata, event-notification state, and update time. No
+   * runtime-owned alert object escapes the method.
+   *
+   * @param alert live alert instance from the runtime manager snapshot
+   * @return detached alert snapshot carrying only JDK values
+   */
+  private static AlertSnapshot toSnapshot(UserAlert alert) {
+    return new AlertSnapshot(
+        alert.hashCode(),
+        alert.getTitle(),
+        alert.getShortText(),
+        alert.getText(),
+        AlertSeverity.fromPriorityClass(alert.getPriorityClass()),
+        alert.userCanDismiss(),
+        alert.dismissButtonText(),
+        alert.isEventNotification(),
+        alert.getUpdatedTime());
+  }
+}

--- a/runtime-node/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
@@ -9,6 +9,8 @@ import network.crypta.runtime.admin.AdminRuntimeBridgeInputs;
 import network.crypta.runtime.admin.AdminRuntimePortsBundle;
 import network.crypta.runtime.admin.AdminRuntimePortsFactory;
 import network.crypta.runtime.bootstrap.NodeStarter;
+import network.crypta.runtime.spi.AlertFeedPort;
+import network.crypta.runtime.spi.AlertMutationPort;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
@@ -67,6 +69,8 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final DarknetConnectionsPort darknetConnectionsPort;
   private final DarknetMessagingPort darknetMessagingPort;
   private final DiagnosticPort diagnosticPort;
+  private final AlertFeedPort alertFeedPort;
+  private final AlertMutationPort alertMutationPort;
   private final PageChromePort pageChromePort;
   private final CoreUpdateActionPort coreUpdateActionPort;
   private final QueueCompletionPort queueCompletionPort;
@@ -189,6 +193,8 @@ public final class LegacyRuntimePorts implements RuntimePorts {
     this.darknetConnectionsPort = adminRuntimePorts.darknetConnections();
     this.darknetMessagingPort = adminRuntimePorts.darknetMessaging();
     this.diagnosticPort = adminRuntimePorts.diagnostic();
+    this.alertFeedPort = adminRuntimePorts.alertFeed();
+    this.alertMutationPort = adminRuntimePorts.alertMutation();
     this.pageChromePort = adminRuntimePorts.pageChrome();
     this.queueCompletionPort = adminRuntimePorts.queueCompletion();
     this.queuePagePort = adminRuntimePorts.queuePage();
@@ -324,6 +330,27 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public DiagnosticPort diagnostic() {
     return diagnosticPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port delegates to the runtime-node alert manager and exposes detached alert
+   * snapshots.
+   */
+  @Override
+  public AlertFeedPort alertFeed() {
+    return alertFeedPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port delegates dismissals to the runtime-node alert manager.
+   */
+  @Override
+  public AlertMutationPort alertMutation() {
+    return alertMutationPort;
   }
 
   /**

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertFeedPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertFeedPort.java
@@ -1,0 +1,23 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Read-only detached alert surface exposed to admin-facing runtime consumers.
+ *
+ * <p>This port gives higher layers a stable way to inspect the current alert state without taking a
+ * dependency on runtime alert implementations. Callers typically use it to populate management UIs,
+ * JSON endpoints, or other local operator tooling that needs an ordered list of visible alerts and
+ * their detached metadata. The port is intentionally narrow: it exposes snapshots only and leaves
+ * alert lifecycle, registration, and rendering policy to the runtime and transport layers.
+ */
+public interface AlertFeedPort {
+  /**
+   * Returns a detached snapshot of the current visible alerts.
+   *
+   * <p>Implementations should preserve the runtime-defined encounter order so callers can render
+   * alerts consistently across surfaces. The returned snapshot should be detached from any live
+   * runtime alert objects and safe to retain for the lifetime of one request or render pass.
+   *
+   * @return immutable list snapshot of the current visible alerts in runtime-defined order
+   */
+  AlertListSnapshot snapshot();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertListSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertListSnapshot.java
@@ -1,0 +1,33 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detached snapshot containing the current alert list.
+ *
+ * <p>This record packages the full ordered alert feed for one read operation. The structure stays
+ * intentionally small because callers can derive counts, empty-state decisions, and display order
+ * directly from the list itself. No additional metadata is required to preserve the current alert
+ * semantics across the detached boundary.
+ *
+ * <p>The list order is significant. Implementations should preserve the runtime-defined encounter
+ * order so consumers can render alerts consistently with other operator-facing surfaces. The record
+ * also makes a defensive copy of the incoming list, which means callers can safely hold the
+ * snapshot after the originating collection is mutated or discarded.
+ *
+ * @param alerts ordered detached alert snapshots
+ */
+public record AlertListSnapshot(List<AlertSnapshot> alerts) {
+  /**
+   * Creates one detached alert-list snapshot.
+   *
+   * <p>The compact constructor copies the supplied list into an unmodifiable list so later
+   * mutations to the source collection do not affect the snapshot.
+   *
+   * @throws NullPointerException if {@code alerts} is {@code null}
+   */
+  public AlertListSnapshot {
+    alerts = List.copyOf(Objects.requireNonNull(alerts, "alerts"));
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertMutationPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertMutationPort.java
@@ -1,0 +1,23 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached mutation surface for alert dismissal.
+ *
+ * <p>This port keeps alert-changing operations separate from the read-only snapshot surface. It is
+ * intentionally limited to the smallest mutation needed by the current Platform API and shell work:
+ * dismissing one alert by the detached identifier previously exposed in an {@link AlertSnapshot}.
+ * Implementations remain responsible for any runtime-side side effects such as unregistering the
+ * alert, marking it invalid, or triggering cleanup work.
+ */
+public interface AlertMutationPort {
+  /**
+   * Dismisses the alert identified by the supplied id.
+   *
+   * <p>The identifier must be one that was previously exposed through the detached alert feed. The
+   * interface does not require implementations to report missing or non-dismissible alerts as
+   * separate errors; callers should treat the operation as a runtime-defined best-effort mutation.
+   *
+   * @param alertId alert identifier previously exposed in a detached snapshot
+   */
+  void dismiss(int alertId);
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertSeverity.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertSeverity.java
@@ -1,0 +1,88 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Detached alert severity mapped from the runtime's legacy user-alert priority classes.
+ *
+ * <p>This enum provides the stable severity vocabulary that higher layers use when rendering or
+ * summarizing alerts. It is deliberately separate from the runtime alert interfaces so Platform
+ * API, the Web Shell, and other detached consumers can classify alerts without importing
+ * daemon-owned types. The mapping remains one-to-one with the legacy short-valued priority classes
+ * already used inside the runtime.
+ *
+ * <p>The declaration order is descriptive only. Callers must not infer ordering or persistence
+ * semantics from the enum ordinal. Use {@link #priorityClass()} when a legacy numeric value is
+ * required, or compare explicit enum constants when choosing the highest visible severity.
+ */
+public enum AlertSeverity {
+  /**
+   * An error that requires immediate attention.
+   *
+   * <p>Consumers should treat this as the most urgent alert class and render it with the strongest
+   * emphasis available to that surface.
+   */
+  CRITICAL_ERROR((short) 0),
+
+  /**
+   * A serious error that may still allow some operation.
+   *
+   * <p>This severity still indicates operator action is likely needed, but it is below {@link
+   * #CRITICAL_ERROR} in urgency.
+   */
+  ERROR((short) 1),
+
+  /**
+   * A warning about degraded operation or reduced anonymity.
+   *
+   * <p>Warnings normally indicate reduced quality, capacity, or safety rather than an outright
+   * failure.
+   */
+  WARNING((short) 2),
+
+  /**
+   * A minor informational alert.
+   *
+   * <p>Consumers may render this class less prominently than error and warning severities.
+   */
+  MINOR((short) 3);
+
+  private final short priorityClass;
+
+  AlertSeverity(short priorityClass) {
+    this.priorityClass = priorityClass;
+  }
+
+  /**
+   * Returns the legacy user-alert priority class represented by this detached severity.
+   *
+   * <p>The value matches the short constant expected by the existing runtime alert machinery. This
+   * method exists for callers that need to compare or persist the legacy representation without
+   * depending on runtime-owned alert constants.
+   *
+   * @return legacy priority-class value used by the daemon alert manager
+   */
+  public short priorityClass() {
+    return priorityClass;
+  }
+
+  /**
+   * Maps a legacy priority class to the detached severity enum.
+   *
+   * <p>This is the normalization point between the runtime's historic short constants and the
+   * detached enum contract used elsewhere. Callers should pass only values produced by the runtime
+   * alert system.
+   *
+   * @param priorityClass legacy user-alert priority class
+   * @return detached severity matching the supplied legacy value
+   * @throws IllegalArgumentException when the supplied value is not recognized
+   */
+  public static AlertSeverity fromPriorityClass(short priorityClass) {
+    return switch (priorityClass) {
+      case 0 -> CRITICAL_ERROR;
+      case 1 -> ERROR;
+      case 2 -> WARNING;
+      case 3 -> MINOR;
+      default ->
+          throw new IllegalArgumentException("Unknown alert priority class: " + priorityClass);
+    };
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/AlertSnapshot.java
@@ -1,0 +1,52 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Detached snapshot of one alert entry exposed through the runtime SPI.
+ *
+ * <p>This record is the stable value object that crosses from runtime-owned alert machinery into
+ * detached consumers such as Platform API and the Web Shell. It carries only JDK types, making it
+ * safe to serialize, cache for the lifetime of one request, and compare in tests without keeping
+ * references to live runtime alert implementations. The record is intentionally descriptive rather
+ * than behavioral: it does not expose dismissal callbacks, HTML fragments, or feed helpers.
+ *
+ * <p>The identifier and textual fields preserve the current alert manager contract. In particular,
+ * {@link #id()} is the detached identifier used for dismiss actions, {@link #text()} may contain
+ * multi-line plain text, and {@link #dismissLabel()} may be {@code null} when the runtime has no
+ * specialized label to expose. Consumers should treat {@link #updatedTimeMillis()} as an ordering
+ * and freshness hint, not a guarantee about wall-clock precision.
+ *
+ * @param id stable alert identifier used for dismiss actions
+ * @param title alert title shown in compact and expanded views
+ * @param shortText short summary shown in constrained placements
+ * @param text full plain-text body of the alert
+ * @param severity detached alert severity mapped from the legacy priority class
+ * @param dismissible whether the alert may be dismissed by the user
+ * @param dismissLabel localized label for the dismiss action when the alert is dismissible; may be
+ *     {@code null} when the runtime does not supply one
+ * @param eventNotification whether the alert is a transient event notification
+ * @param updatedTimeMillis last update time in milliseconds since the Unix epoch
+ */
+public record AlertSnapshot(
+    int id,
+    String title,
+    String shortText,
+    String text,
+    AlertSeverity severity,
+    boolean dismissible,
+    String dismissLabel,
+    boolean eventNotification,
+    long updatedTimeMillis) {
+
+  /**
+   * Creates one detached alert snapshot.
+   *
+   * <p>The compact constructor enforces the one non-optional enum field required by the detached
+   * contract. Other textual fields may be empty or {@code null} when the runtime does not provide a
+   * value.
+   */
+  public AlertSnapshot {
+    Objects.requireNonNull(severity, "severity");
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -25,6 +25,8 @@ package network.crypta.runtime.spi;
  * @see DarknetConnectionsPort
  * @see DarknetMessagingPort
  * @see DiagnosticPort
+ * @see AlertFeedPort
+ * @see AlertMutationPort
  * @see CoreUpdateActionPort
  * @see QueueCompletionPort
  * @see QueuePagePort
@@ -175,6 +177,28 @@ public interface RuntimePorts {
    * @return diagnostic-report runtime port for read-only report snapshots
    */
   DiagnosticPort diagnostic();
+
+  /**
+   * Returns the detached alert feed capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port lets higher layers request one detached alert-list snapshot containing the current
+   * visible alerts without depending on daemon alert classes. The HTTP layer remains responsible
+   * for request parsing, markup, and any request-context-only rendering concerns.
+   *
+   * @return alert-feed runtime port for detached alert list snapshots
+   */
+  AlertFeedPort alertFeed();
+
+  /**
+   * Returns the detached alert mutation capability exposed to admin-facing HTTP code.
+   *
+   * <p>This port lets higher layers dismiss one alert by its detached identifier while keeping the
+   * underlying alert manager inside the daemon root module. The HTTP layer remains responsible for
+   * request parsing and redirect behavior.
+   *
+   * @return alert-mutation runtime port for dismiss actions
+   */
+  AlertMutationPort alertMutation();
 
   /**
    * Returns the shared admin page-chrome capability exposed to HTTP shell rendering code.

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -389,6 +389,20 @@ End
   }
 
   @Test
+  void handleMethodPOST_whenAlertDismissRequested_routesDecodedMutationRequest() throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(true);
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(router.route(any(PlatformApiRequest.class))).thenReturn(PlatformApiResponse.ok(Map.of()));
+
+    toadlet.handleMethodPOST(
+        URI.create("http://localhost/api/v1/alerts/-17/dismiss"), request, ctx);
+
+    verify(router)
+        .route(new PlatformApiRequest("POST", List.of("alerts", "-17", "dismiss"), Map.of()));
+  }
+
+  @Test
   void handleMethodPOST_whenQueueMutationPasswordMissing_expectJson403WithoutRouting()
       throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
@@ -434,6 +448,7 @@ End
         "http://localhost/api/v1/config/overrides",
         "http://localhost/api/v1/security-levels/network",
         "http://localhost/api/v1/updates/core/download",
+        "http://localhost/api/v1/alerts/42/dismiss",
         "http://localhost/api/v1/wizard/first-time/apply",
       })
   void handleMethodPOST_whenProtectedMutationPasswordMissing_expectJson403WithoutRouting(

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -16,6 +16,11 @@ import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.runtime.spi.AlertFeedPort;
+import network.crypta.runtime.spi.AlertListSnapshot;
+import network.crypta.runtime.spi.AlertMutationPort;
+import network.crypta.runtime.spi.AlertSeverity;
+import network.crypta.runtime.spi.AlertSnapshot;
 import network.crypta.runtime.spi.ConfigFieldSet;
 import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConfigSection;
@@ -33,6 +38,9 @@ import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionPeerSnapshot;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetPeerSettingsUpdate;
+import network.crypta.runtime.spi.DiagnosticPort;
+import network.crypta.runtime.spi.DiagnosticReportSnapshot;
+import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
 import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
@@ -106,11 +114,14 @@ class PlatformApiRouterTest {
   @Mock private SecurityLevelsPort securityLevelsPort;
   @Mock private CoreUpdateActionPort coreUpdateActionPort;
   @Mock private FirstTimeWizardPort firstTimeWizardPort;
+  @Mock private DiagnosticPort diagnosticPort;
   @Mock private QueuePagePort queuePagePort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueSupportPort queueSupportPort;
   @Mock private QueueCompletionPort queueCompletionPort;
+  @Mock private AlertFeedPort alertFeedPort;
+  @Mock private AlertMutationPort alertMutationPort;
   @Mock private AppHost appHost;
 
   @TempDir private Path tempDir;
@@ -127,11 +138,14 @@ class PlatformApiRouterTest {
     when(runtimePorts.securityLevels()).thenReturn(securityLevelsPort);
     when(runtimePorts.coreUpdateAction()).thenReturn(coreUpdateActionPort);
     when(runtimePorts.firstTimeWizard()).thenReturn(firstTimeWizardPort);
+    when(runtimePorts.diagnostic()).thenReturn(diagnosticPort);
     when(runtimePorts.queuePage()).thenReturn(queuePagePort);
     when(runtimePorts.queueMutation()).thenReturn(queueMutationPort);
     when(runtimePorts.queueDownload()).thenReturn(queueDownloadPort);
     when(runtimePorts.queueSupport()).thenReturn(queueSupportPort);
     when(runtimePorts.queueCompletion()).thenReturn(queueCompletionPort);
+    when(runtimePorts.alertFeed()).thenReturn(alertFeedPort);
+    when(runtimePorts.alertMutation()).thenReturn(alertMutationPort);
     router = new PlatformApiRouter(runtimePorts, appHost);
   }
 
@@ -160,6 +174,77 @@ class PlatformApiRouterTest {
     assertEquals(200, response.statusCode());
     assertEquals(
         "{\"nodeName\":\"Crypta\",\"versionString\":\"1.0\",\"buildNumber\":7,\"revision\":\"abc123\",\"testnetEnabled\":true,\"compressionCodecs\":\"gzip\",\"nodeLanguage\":\"en\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAlertsRequested_expectStructuredAlertSnapshotJson() {
+    AlertListSnapshot snapshot = org.mockito.Mockito.mock(AlertListSnapshot.class);
+    AlertSnapshot alert = org.mockito.Mockito.mock(AlertSnapshot.class);
+    when(alert.id()).thenReturn(42);
+    when(alert.title()).thenReturn("Update available");
+    when(alert.shortText()).thenReturn("Updater");
+    when(alert.text()).thenReturn("A new core package is ready.");
+    when(alert.severity()).thenReturn(AlertSeverity.WARNING);
+    when(alert.dismissible()).thenReturn(true);
+    when(alert.dismissLabel()).thenReturn("Delete");
+    when(alert.eventNotification()).thenReturn(false);
+    when(alert.updatedTimeMillis()).thenReturn(123L);
+    when(snapshot.alerts()).thenReturn(List.of(alert));
+    when(alertFeedPort.snapshot()).thenReturn(snapshot);
+
+    PlatformApiResponse response = router.route(request("GET", List.of("alerts"), Map.of()));
+
+    verify(alertFeedPort).snapshot();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"alertCount\":1,\"dismissibleCount\":1,\"eventNotificationCount\":0,"
+            + "\"highestSeverity\":\"WARNING\",\"alerts\":[{\"id\":42,\"title\":\"Update"
+            + " available\",\"shortText\":\"Updater\",\"text\":\"A new core package is ready.\","
+            + "\"severity\":\"WARNING\",\"dismissible\":true,\"dismissLabel\":\"Delete\","
+            + "\"eventNotification\":false,\"updatedTimeMillis\":123}]}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAlertDismissRequested_expectMutationSummary() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("alerts", "-17", "dismiss"), Map.of()));
+
+    verify(alertMutationPort).dismiss(-17);
+    assertEquals(200, response.statusCode());
+    assertEquals("{\"operation\":\"dismiss\",\"alertId\":-17}", response.body());
+  }
+
+  @Test
+  void route_whenAlertDismissAlertIdMalformed_expectBadRequestJson() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("alerts", "not-a-number", "dismiss"), Map.of()));
+
+    verifyNoInteractions(alertMutationPort);
+    assertEquals(400, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_path_parameter\",\"message\":\"Alert route parameter"
+            + " 'alertId' must be a valid integer.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenDiagnosticsRequested_expectStructuredDiagnosticsJson() {
+    when(diagnosticPort.snapshot())
+        .thenReturn(
+            new DiagnosticReportSnapshot(
+                List.of(
+                    new DiagnosticSectionSnapshot(
+                        "System Information:", List.of("alpha", "", "beta")))));
+
+    PlatformApiResponse response = router.route(request("GET", List.of("diagnostics"), Map.of()));
+
+    verify(diagnosticPort).snapshot();
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"sectionCount\":1,\"sections\":[{\"title\":\"System Information:\",\"lines\":[\"alpha\","
+            + "\"\",\"beta\"]}],\"plainTextExport\":\"System Information:\\nalpha\\n\\nbeta\\n\"}",
         response.body());
   }
 

--- a/src/test/java/network/crypta/runtime/admin/AdminRuntimePortsFactoryTest.java
+++ b/src/test/java/network/crypta/runtime/admin/AdminRuntimePortsFactoryTest.java
@@ -7,6 +7,7 @@ import network.crypta.node.RequestStarter;
 import network.crypta.runtime.admin.geoip.GeoIpCountryLookup;
 import network.crypta.runtime.admin.queue.QueueAdminBackend;
 import network.crypta.runtime.admin.queue.page.QueuePageBackend;
+import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueInsertPort;
@@ -17,7 +18,11 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,6 +43,7 @@ class AdminRuntimePortsFactoryTest {
   @Mock private QueueDownloadPort queueDownloadPort;
   @Mock private QueueInsertPort queueInsertPort;
   @Mock private GeoIpCountryLookup geoIpCountryLookup;
+  @Mock private UserAlertManager alertManager;
 
   @Test
   void create_whenBuildingBundle_usesRealtimeSizeCappedClientForPeerReferenceLoading() {
@@ -51,14 +57,39 @@ class AdminRuntimePortsFactoryTest {
             geoIpCountryLookup);
     when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true))
         .thenReturn(peerReferenceClient);
+    when(core.getAlerts()).thenReturn(alertManager);
 
     AdminRuntimePortsBundle bundle = AdminRuntimePortsFactory.create(node, core, bridgeInputs);
 
     assertNotNull(bundle.connectionsSupport());
+    assertInstanceOf(LegacyAlertPort.class, bundle.alertFeed());
+    assertSame(bundle.alertFeed(), bundle.alertMutation());
     verify(core).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true);
     verify(peerReferenceClient).setMaxLength(HttpFetchSizeLimits.getMaxLengthNoProgress());
     verify(peerReferenceClient)
         .setMaxIntermediateLength(HttpFetchSizeLimits.getMaxLengthNoProgress());
     verify(core, never()).makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, false);
+  }
+
+  @Test
+  void create_whenAlertManagerMissing_expectNullPointerException() {
+    AdminRuntimeBridgeInputs bridgeInputs =
+        new AdminRuntimeBridgeInputs(
+            queueAdminBackend,
+            queuePageBackend,
+            queueCompletionPort,
+            queueDownloadPort,
+            queueInsertPort,
+            geoIpCountryLookup);
+    when(core.makeClient(RequestStarter.INTERACTIVE_PRIORITY_CLASS, true, true))
+        .thenReturn(peerReferenceClient);
+    when(core.getAlerts()).thenReturn(null);
+
+    NullPointerException error =
+        assertThrows(
+            NullPointerException.class,
+            () -> AdminRuntimePortsFactory.create(node, core, bridgeInputs));
+
+    assertEquals("alerts", error.getMessage());
   }
 }

--- a/src/test/java/network/crypta/runtime/admin/LegacyAlertPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyAlertPortTest.java
@@ -1,0 +1,91 @@
+package network.crypta.runtime.admin;
+
+import network.crypta.runtime.alerts.AbstractUserAlert;
+import network.crypta.runtime.alerts.UserAlert;
+import network.crypta.runtime.alerts.UserAlertManager;
+import network.crypta.runtime.spi.AlertListSnapshot;
+import network.crypta.runtime.spi.AlertSeverity;
+import network.crypta.runtime.spi.AlertSnapshot;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S100")
+class LegacyAlertPortTest {
+
+  @Mock private UserAlertManager alertManager;
+
+  @Test
+  void snapshot_whenCalled_returnsDetachedVisibleAlertsInManagerOrder() {
+    UserAlert visibleAlert =
+        new TestUserAlert(
+            42, "Visible title", "Visible short", "Visible text", UserAlert.WARNING, true, 1234L);
+    UserAlert hiddenAlert =
+        new TestUserAlert(
+            99, "Hidden title", "Hidden short", "Hidden text", UserAlert.MINOR, false, 5678L);
+    when(alertManager.getAlerts()).thenReturn(new UserAlert[] {visibleAlert, hiddenAlert});
+
+    AlertListSnapshot snapshot = new LegacyAlertPort(alertManager).snapshot();
+
+    assertEquals(1, snapshot.alerts().size());
+    assertEquals(
+        new AlertSnapshot(
+            42,
+            "Visible title",
+            "Visible short",
+            "Visible text",
+            AlertSeverity.WARNING,
+            true,
+            "Delete",
+            false,
+            1234L),
+        snapshot.alerts().getFirst());
+  }
+
+  @Test
+  void dismiss_whenCalled_delegatesToManagerByAlertId() {
+    new LegacyAlertPort(alertManager).dismiss(17);
+
+    verify(alertManager).dismissAlert(17);
+  }
+
+  private static final class TestUserAlert extends AbstractUserAlert {
+    private final int id;
+    private final long updatedTimeMillis;
+
+    private TestUserAlert(
+        int id,
+        String title,
+        String shortText,
+        String text,
+        short priorityClass,
+        boolean valid,
+        long updatedTimeMillis) {
+      super(
+          true,
+          title,
+          Body.of(text, shortText, null),
+          priorityClass,
+          valid,
+          new DismissOptions("Delete", true));
+      this.id = id;
+      this.updatedTimeMillis = updatedTimeMillis;
+    }
+
+    @Override
+    public long getUpdatedTime() {
+      return updatedTimeMillis;
+    }
+
+    @Override
+    public int hashCode() {
+      return id;
+    }
+  }
+}

--- a/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
@@ -102,6 +102,8 @@ class LegacyRuntimePortsTest {
         () -> assertSame(snapshot.darknetConnectionsPort(), ports.darknetConnections()),
         () -> assertSame(snapshot.darknetMessagingPort(), ports.darknetMessaging()),
         () -> assertSame(snapshot.diagnosticPort(), ports.diagnostic()),
+        () -> assertSame(snapshot.alertFeedPort(), ports.alertFeed()),
+        () -> assertSame(snapshot.alertMutationPort(), ports.alertMutation()),
         () -> assertSame(snapshot.pageChromePort(), ports.pageChrome()),
         () -> assertSame(snapshot.coreUpdateActionPort(), ports.coreUpdateAction()));
   }
@@ -152,6 +154,11 @@ class LegacyRuntimePortsTest {
             assertInstanceOf(
                 loadClass("network.crypta.runtime.admin.LegacyDiagnosticPort"),
                 snapshot.diagnosticPort()),
+        () ->
+            assertInstanceOf(
+                loadClass("network.crypta.runtime.admin.LegacyAlertPort"),
+                snapshot.alertFeedPort()),
+        () -> assertSame(snapshot.alertFeedPort(), snapshot.alertMutationPort()),
         () ->
             assertInstanceOf(
                 loadClass("network.crypta.runtime.admin.LegacyPageChromePort"),
@@ -263,6 +270,8 @@ class LegacyRuntimePortsTest {
         ports.darknetConnections(),
         ports.darknetMessaging(),
         ports.diagnostic(),
+        ports.alertFeed(),
+        ports.alertMutation(),
         ports.pageChrome(),
         ports.coreUpdateAction(),
         ports.queueSupport(),
@@ -302,6 +311,8 @@ class LegacyRuntimePortsTest {
       Object darknetConnectionsPort,
       Object darknetMessagingPort,
       Object diagnosticPort,
+      Object alertFeedPort,
+      Object alertMutationPort,
       Object pageChromePort,
       Object coreUpdateActionPort,
       Object queueSupportPort,

--- a/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
+++ b/src/test/java/network/crypta/runtime/core/LegacyRuntimePortsTest.java
@@ -131,6 +131,11 @@ class LegacyRuntimePortsTest {
   void getters_whenRequested_expectInjectedBridgePortsAndLegacyAdapterTypes() {
     PortsSnapshot snapshot = capturePorts();
 
+    assertInjectedInfrastructureAdapterTypes(snapshot);
+    assertInjectedFeatureAdapterTypes(snapshot);
+  }
+
+  private void assertInjectedInfrastructureAdapterTypes(PortsSnapshot snapshot) {
     assertAll(
         () -> assertInstanceOf(LegacyConfigPort.class, snapshot.configPort()),
         () -> assertInstanceOf(LegacyConnectivityPort.class, snapshot.connectivityPort()),
@@ -163,7 +168,11 @@ class LegacyRuntimePortsTest {
             assertInstanceOf(
                 loadClass("network.crypta.runtime.admin.LegacyPageChromePort"),
                 snapshot.pageChromePort()),
-        () -> assertInstanceOf(LegacyCoreUpdateActionPort.class, snapshot.coreUpdateActionPort()),
+        () -> assertInstanceOf(LegacyCoreUpdateActionPort.class, snapshot.coreUpdateActionPort()));
+  }
+
+  private void assertInjectedFeatureAdapterTypes(PortsSnapshot snapshot) {
+    assertAll(
         () ->
             assertInstanceOf(
                 loadClass("network.crypta.runtime.admin.LegacyQueueSupportPort"),

--- a/src/test/java/network/crypta/runtime/spi/AlertListSnapshotTest.java
+++ b/src/test/java/network/crypta/runtime/spi/AlertListSnapshotTest.java
@@ -1,0 +1,56 @@
+package network.crypta.runtime.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class AlertListSnapshotTest {
+
+  @Test
+  void constructor_whenSourceListMutatedAfterCreation_expectDefensiveCopyAndEncounterOrder() {
+    List<AlertSnapshot> sourceAlerts = new ArrayList<>();
+    AlertSnapshot firstAlert = sampleAlert(1, AlertSeverity.WARNING);
+    AlertSnapshot secondAlert = sampleAlert(2, AlertSeverity.ERROR);
+    sourceAlerts.add(firstAlert);
+    sourceAlerts.add(secondAlert);
+
+    AlertListSnapshot snapshot = new AlertListSnapshot(sourceAlerts);
+
+    sourceAlerts.clear();
+    sourceAlerts.add(sampleAlert(3, AlertSeverity.MINOR));
+
+    assertEquals(List.of(firstAlert, secondAlert), snapshot.alerts());
+  }
+
+  @Test
+  void constructor_whenAlertsExposed_expectUnmodifiableView() {
+    AlertListSnapshot snapshot =
+        new AlertListSnapshot(List.of(sampleAlert(1, AlertSeverity.WARNING)));
+    List<AlertSnapshot> alerts = snapshot.alerts();
+    AlertSnapshot addedAlert = sampleAlert(2, AlertSeverity.ERROR);
+
+    assertThrows(UnsupportedOperationException.class, () -> alerts.add(addedAlert));
+  }
+
+  @Test
+  void constructor_whenAlertsNull_expectNullPointerException() {
+    assertThrows(NullPointerException.class, () -> new AlertListSnapshot(null));
+  }
+
+  private static AlertSnapshot sampleAlert(int id, AlertSeverity severity) {
+    return new AlertSnapshot(
+        id,
+        "Alert " + id,
+        "Summary " + id,
+        "Body " + id,
+        severity,
+        true,
+        "Dismiss",
+        false,
+        id * 100L);
+  }
+}

--- a/src/test/java/network/crypta/runtime/spi/AlertSeverityTest.java
+++ b/src/test/java/network/crypta/runtime/spi/AlertSeverityTest.java
@@ -1,0 +1,41 @@
+package network.crypta.runtime.spi;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class AlertSeverityTest {
+
+  @ParameterizedTest
+  @MethodSource("knownPriorityClasses")
+  void fromPriorityClass_whenKnownValueProvided_expectMatchingSeverityAndRoundTrip(
+      short priorityClass, AlertSeverity expectedSeverity) {
+    AlertSeverity severity = AlertSeverity.fromPriorityClass(priorityClass);
+
+    assertEquals(expectedSeverity, severity);
+    assertEquals(priorityClass, severity.priorityClass());
+  }
+
+  @Test
+  void fromPriorityClass_whenUnknownValueProvided_expectIllegalArgumentException() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class, () -> AlertSeverity.fromPriorityClass((short) 9));
+
+    assertEquals("Unknown alert priority class: 9", error.getMessage());
+  }
+
+  private static Stream<Arguments> knownPriorityClasses() {
+    return Stream.of(
+        Arguments.of((short) 0, AlertSeverity.CRITICAL_ERROR),
+        Arguments.of((short) 1, AlertSeverity.ERROR),
+        Arguments.of((short) 2, AlertSeverity.WARNING),
+        Arguments.of((short) 3, AlertSeverity.MINOR));
+  }
+}


### PR DESCRIPTION
## Summary
- add a detached alert SPI with runtime-node-backed alert snapshot and dismissal adapters
- expose `/api/v1/alerts` and `/api/v1/diagnostics`, and route alert dismissal through the existing full-access plus form-password bridge
- add shell-native alerts and diagnostics panels with refresh, alert-specific dismiss labels, lazy diagnostics loading, multiline alert rendering, focused tests, and enriched Javadoc for the new Java files

## How to test
- `./gradlew :platform-api:test`
- `./gradlew :platform-web-shell:test`
- `./gradlew :test --tests network.crypta.platform.api.PlatformApiRouterTest --tests network.crypta.clients.http.PlatformApiToadletTest --tests network.crypta.runtime.admin.LegacyAlertPortTest --tests network.crypta.runtime.admin.AdminRuntimePortsFactoryTest --tests network.crypta.runtime.core.LegacyRuntimePortsTest`
- `./gradlew :test --tests network.crypta.clients.http.WebShellToadletTest`
- `./gradlew :test --tests network.crypta.runtime.spi.AlertSeverityTest --tests network.crypta.runtime.spi.AlertListSnapshotTest`
- `./gradlew test`
