### PR TITLE
feat(apps): Add Queue Manager app staging and shell controls

### DIFF
--- a/apps/queue-manager/README.md
+++ b/apps/queue-manager/README.md
@@ -1,0 +1,49 @@
+# Queue Manager App
+
+`apps/queue-manager` stages the first repo-owned AppHost bundle for PR-190.
+
+Build the staged bundle with:
+
+```bash
+./gradlew :apps:queue-manager:stageApp
+```
+
+The staged output is written to:
+
+```text
+apps/queue-manager/build/cryptad-app/queue-manager
+```
+
+The staged bundle contains:
+
+```text
+cryptad-app.properties
+bin/queue-manager.sh
+static/README.txt
+```
+
+Install it through the existing Platform API by passing the absolute staged directory path:
+
+```bash
+curl -X POST \
+  --data-urlencode "formPassword=<token>" \
+  --data-urlencode "stagedDir=/abs/path/to/apps/queue-manager/build/cryptad-app/queue-manager" \
+  http://127.0.0.1:<port>/api/v1/apps/install
+```
+
+Start and stop it through the existing app-management routes:
+
+```bash
+curl -X POST --data-urlencode "formPassword=<token>" \
+  http://127.0.0.1:<port>/api/v1/apps/queue-manager/start
+
+curl -X POST --data-urlencode "formPassword=<token>" \
+  http://127.0.0.1:<port>/api/v1/apps/queue-manager/stop
+```
+
+The bundle intentionally stays conservative in PR-190:
+
+- Signed app bundles and remote catalogs are deferred.
+- App proxying and app-owned static serving are deferred.
+- The bundle points `app.ui.entry` at the existing shell-native queue route: `/app/node/#queue`.
+- The launcher is a POSIX shell script; Windows-specific first-party app launch packaging remains deferred.

--- a/apps/queue-manager/build.gradle.kts
+++ b/apps/queue-manager/build.gradle.kts
@@ -1,0 +1,67 @@
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermissions
+import org.gradle.api.tasks.PathSensitivity
+
+plugins {
+  id("cryptad.java-kotlin-conventions")
+  id("cryptad.spotless")
+  `java-library`
+}
+
+version = rootProject.version
+
+val mainSourceSet = sourceSets.named("main")
+val stageAppDir = layout.buildDirectory.dir("cryptad-app/queue-manager")
+val generatedManifestDir = layout.buildDirectory.dir("generated/stageApp")
+val stageAssetsDir = layout.projectDirectory.dir("src/staged")
+val manifestTemplateFile = stageAssetsDir.file("cryptad-app.properties.template")
+val launcherRelativePath = "bin/queue-manager.sh"
+val stagedLauncher =
+  stageAppDir.map { stageDirectory -> stageDirectory.file(launcherRelativePath).asFile.toPath() }
+
+dependencies {
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(project(":platform-apphost"))
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+val generateManifest by
+  tasks.registering(Copy::class) {
+    from(manifestTemplateFile) {
+      rename { "cryptad-app.properties" }
+      expand("appVersion" to project.version.toString())
+    }
+    into(generatedManifestDir)
+    filteringCharset = "UTF-8"
+  }
+
+val stageApp by
+  tasks.registering(Sync::class) {
+    group = "build"
+    description = "Stages the Queue Manager AppHost bundle."
+    dependsOn(generateManifest)
+    into(stageAppDir)
+    from(stageAssetsDir) { exclude("cryptad-app.properties.template") }
+    from(generatedManifestDir)
+    doLast {
+      val launcher = stagedLauncher.get()
+      if (
+        Files.exists(launcher) && Files.getFileStore(launcher).supportsFileAttributeView("posix")
+      ) {
+        Files.setPosixFilePermissions(launcher, PosixFilePermissions.fromString("rwxr-xr-x"))
+      }
+    }
+  }
+
+tasks.named<Test>("test") {
+  dependsOn(stageApp)
+  inputs
+    .dir(stageAppDir)
+    .withPropertyName("queueManagerStagedBundle")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.property("queueManagerAppVersion", project.version.toString())
+  systemProperty("queueManager.stageDir", stageAppDir.get().asFile.absolutePath)
+  systemProperty("queueManager.appVersion", project.version.toString())
+}

--- a/apps/queue-manager/src/staged/bin/queue-manager.sh
+++ b/apps/queue-manager/src/staged/bin/queue-manager.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+log_file="${CRYPTAD_APP_RUN_DIR:-.}/queue-manager.log"
+
+printf 'Queue Manager started for %s %s\n' \
+  "${CRYPTAD_APP_NAME:-Queue Manager}" \
+  "${CRYPTAD_APP_VERSION:-unknown}" >>"$log_file"
+
+trap 'printf "Queue Manager stopping\n" >>"$log_file"; exit 0' INT TERM
+
+while :; do
+  sleep 5
+done

--- a/apps/queue-manager/src/staged/cryptad-app.properties.template
+++ b/apps/queue-manager/src/staged/cryptad-app.properties.template
@@ -1,0 +1,9 @@
+manifest.version=1
+app.id=queue-manager
+app.name=Queue Manager
+app.version=${appVersion}
+app.exec=bin/queue-manager.sh
+app.ui.entry=/app/node/#queue
+app.permissions=queue.read,queue.write
+quota.data.bytes=0
+quota.cache.bytes=0

--- a/apps/queue-manager/src/staged/static/README.txt
+++ b/apps/queue-manager/src/staged/static/README.txt
@@ -1,0 +1,2 @@
+Queue Manager is packaged as a first-party staged AppHost bundle for PR-190.
+Its UI entry points back to the shell-native queue surface at /app/node/#queue.

--- a/apps/queue-manager/src/test/java/network/crypta/apps/queuemanager/QueueManagerBundleStagingTest.java
+++ b/apps/queue-manager/src/test/java/network/crypta/apps/queuemanager/QueueManagerBundleStagingTest.java
@@ -1,0 +1,75 @@
+package network.crypta.apps.queuemanager;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueueManagerBundleStagingTest {
+  private static final String APP_VERSION_PROPERTY = "queueManager.appVersion";
+  private static final String STAGE_DIR_PROPERTY = "queueManager.stageDir";
+  private static final String EXPECTED_APP_ID = "queue-manager";
+  private static final String EXPECTED_APP_NAME = "Queue Manager";
+  private static final String EXPECTED_UI_ENTRY = "/app/node/#queue";
+  private static final String EXPECTED_LAUNCHER_PATH = "bin/queue-manager.sh";
+  private static final String EXPECTED_PERMISSIONS = "queue.read,queue.write";
+
+  @Test
+  void stagedBundle_whenManifestParsed_expectExpectedAppHostFields() throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parse(stageDirectory().resolve(AppManifestParser.MANIFEST_FILE_NAME));
+
+    assertEquals(EXPECTED_APP_ID, manifest.appId());
+    assertEquals(EXPECTED_APP_NAME, manifest.appName());
+    assertEquals(EXPECTED_LAUNCHER_PATH, manifest.execPathText());
+    assertEquals(EXPECTED_UI_ENTRY, manifest.uiEntry());
+    assertEquals(java.util.List.of("queue.read", "queue.write"), manifest.permissions());
+    assertEquals(Long.valueOf(0L), manifest.dataQuotaBytes());
+    assertEquals(Long.valueOf(0L), manifest.cacheQuotaBytes());
+  }
+
+  @Test
+  void stagedBundle_whenManifestRead_expectExpectedRenderedContent() throws Exception {
+    String manifestText =
+        Files.readString(stageDirectory().resolve(AppManifestParser.MANIFEST_FILE_NAME));
+
+    assertTrue(manifestText.contains("manifest.version=1"));
+    assertTrue(manifestText.contains("app.id=" + EXPECTED_APP_ID));
+    assertTrue(manifestText.contains("app.name=" + EXPECTED_APP_NAME));
+    assertTrue(manifestText.contains("app.version=" + System.getProperty(APP_VERSION_PROPERTY)));
+    assertTrue(manifestText.contains("app.exec=" + EXPECTED_LAUNCHER_PATH));
+    assertTrue(manifestText.contains("app.ui.entry=" + EXPECTED_UI_ENTRY));
+    assertTrue(manifestText.contains("app.permissions=" + EXPECTED_PERMISSIONS));
+    assertTrue(manifestText.contains("quota.data.bytes=0"));
+    assertTrue(manifestText.contains("quota.cache.bytes=0"));
+  }
+
+  @Test
+  void stagedBundle_whenLauncherStaged_expectLongRunningExecutableLoop() throws Exception {
+    Path launcher = stageDirectory().resolve(EXPECTED_LAUNCHER_PATH);
+    String launcherScript = Files.readString(launcher);
+
+    assertTrue(launcherScript.startsWith("#!/bin/sh\n"));
+    assertTrue(launcherScript.contains("Queue Manager started"));
+    assertTrue(launcherScript.contains("trap 'printf \"Queue Manager stopping"));
+    assertTrue(launcherScript.contains("while :; do"));
+    assertTrue(launcherScript.contains("sleep 5"));
+
+    Assumptions.assumeTrue(Files.getFileStore(launcher).supportsFileAttributeView("posix"));
+    Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(launcher);
+    assertTrue(permissions.contains(PosixFilePermission.OWNER_EXECUTE));
+    assertTrue(permissions.contains(PosixFilePermission.GROUP_EXECUTE));
+    assertTrue(permissions.contains(PosixFilePermission.OTHERS_EXECUTE));
+  }
+
+  private static Path stageDirectory() {
+    return Path.of(System.getProperty(STAGE_DIR_PROPERTY));
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -500,6 +500,12 @@ tasks.register("printVersion") {
   doLast { println(project.version.toString()) }
 }
 
+tasks.register("stageFirstPartyApps") {
+  group = "build"
+  description = "Stages the repo-owned first-party AppHost bundles."
+  dependsOn(":apps:queue-manager:stageApp")
+}
+
 // The default from build-logic (512m) is too small for the full test suite on Windows and can
 // trigger OOM in long-running integration tests.
 tasks.withType<Test>().configureEach { maxHeapSize = "2g" }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -16,10 +16,11 @@
         <h1>Web Shell v1</h1>
         <p class="lede">
           Snapshot views, config changes, updater triggers, first-run controls, queue actions, and
-          alerts and diagnostics snapshots powered by Platform API v1.
+          alerts, diagnostics, and installed-app lifecycle controls powered by Platform API v1.
         </p>
         <div class="hero-actions">
           <a class="button button-primary" href="/api/v1/node/greeting">Node greeting JSON</a>
+          <a class="button button-secondary" href="/api/v1/apps">Installed apps JSON</a>
           <a class="button button-secondary" href="/api/v1/alerts">Alerts JSON</a>
           <a class="button button-secondary" href="/api/v1/diagnostics">Diagnostics JSON</a>
           <a class="button button-secondary" href="/">Legacy root</a>
@@ -87,6 +88,29 @@
           <div class="queue-status" id="diagnostics-status" aria-live="polite"></div>
           <div class="panel-body" id="diagnostics-body">
             <p class="empty-state">Use Refresh diagnostics to load the current diagnostics snapshot.</p>
+          </div>
+        </article>
+
+        <article class="panel panel-span-2" id="apps">
+          <div class="panel-header">
+            <p class="panel-kicker">Apps</p>
+            <h2>Installed apps</h2>
+          </div>
+          <p class="panel-description">
+            Review installed apps, see permissions and runtime status, open an app UI when one is
+            declared, and control start, stop, or uninstall actions from the shell.
+          </p>
+          <div class="queue-toolbar">
+            <button class="button button-secondary" id="apps-refresh-button" type="button">
+              Refresh apps
+            </button>
+          </div>
+          <div class="queue-status" id="apps-status" aria-live="polite"></div>
+          <p class="panel-description" hidden id="apps-readonly-hint">
+            App lifecycle actions are unavailable in read-only mode.
+          </p>
+          <div class="panel-body" id="apps-body">
+            <p class="loading">Loading installed apps...</p>
           </div>
         </article>
 
@@ -358,7 +382,7 @@
         </article>
       </section>
 
-      <section class="panel panel-wide" id="queue-panel">
+      <section class="panel panel-wide" id="queue">
         <div class="panel-header">
           <p class="panel-kicker">Queue</p>
           <h2>Queue control plane</h2>

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -167,6 +167,7 @@ a {
   background: var(--shell-panel);
   box-shadow: var(--shell-shadow);
   backdrop-filter: blur(14px);
+  scroll-margin-top: 24px;
 }
 
 .panel-wide {
@@ -235,6 +236,11 @@ a {
 .status-pill.is-warning::before {
   background: var(--shell-warm);
   box-shadow: 0 0 0 4px rgba(255, 209, 125, 0.18);
+}
+
+.status-pill.is-success::before {
+  background: var(--shell-accent-2);
+  box-shadow: 0 0 0 4px rgba(142, 240, 181, 0.16);
 }
 
 .status-pill.is-error::before {
@@ -481,6 +487,66 @@ a {
 .alert-dismiss-form {
   display: flex;
   justify-content: flex-start;
+}
+
+.app-card-list {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.app-card {
+  display: grid;
+  gap: 14px;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.app-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.app-card-heading {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.app-card-title {
+  margin: 0;
+}
+
+.app-card-subtitle {
+  margin: 0;
+  color: var(--shell-muted);
+  font-size: 0.9rem;
+  overflow-wrap: anywhere;
+}
+
+.app-card-pills,
+.app-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.app-card-actions {
+  align-items: center;
+}
+
+.app-action-form {
+  display: flex;
+}
+
+.app-ui-entry {
+  display: inline-flex;
+  align-items: center;
 }
 
 .diagnostics-lines,

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -14,6 +14,7 @@
   const legacyLinks = Array.isArray(bootstrap.legacyLinks) ? bootstrap.legacyLinks : [];
   const shellState = {
     alertsSnapshot: null,
+    appsSnapshot: null,
     configSnapshot: null,
     diagnosticsSnapshot: null,
     securitySnapshot: null,
@@ -31,6 +32,7 @@
   let peerLoadGeneration = 0;
   let queueLoadGeneration = 0;
   let alertsLoadGeneration = 0;
+  let appsLoadGeneration = 0;
   let diagnosticsLoadGeneration = 0;
   let securityLoadGeneration = 0;
   let updatesLoadGeneration = 0;
@@ -44,6 +46,9 @@
     alerts: document.getElementById("alerts-body"),
     alertsStatus: document.getElementById("alerts-status"),
     alertsReadonlyHint: document.getElementById("alerts-readonly-hint"),
+    apps: document.getElementById("apps-body"),
+    appsStatus: document.getElementById("apps-status"),
+    appsReadonlyHint: document.getElementById("apps-readonly-hint"),
     diagnostics: document.getElementById("diagnostics-body"),
     diagnosticsStatus: document.getElementById("diagnostics-status"),
     security: document.getElementById("security-body"),
@@ -75,6 +80,9 @@
   };
   const alertsControls = {
     refreshButton: document.getElementById("alerts-refresh-button"),
+  };
+  const appsControls = {
+    refreshButton: document.getElementById("apps-refresh-button"),
   };
   const diagnosticsControls = {
     refreshButton: document.getElementById("diagnostics-refresh-button"),
@@ -185,6 +193,10 @@
     setSectionStatus(sections.alertsStatus, message, tone);
   }
 
+  function setAppsStatus(message, tone) {
+    setSectionStatus(sections.appsStatus, message, tone);
+  }
+
   function setDiagnosticsStatus(message, tone) {
     setSectionStatus(sections.diagnosticsStatus, message, tone);
   }
@@ -221,7 +233,13 @@
       row.className = "kv-row";
 
       const labelNode = text("div", "kv-label", label);
-      const valueNode = text("div", "kv-value", value);
+      const valueNode = document.createElement("div");
+      valueNode.className = "kv-value";
+      if (value instanceof Node) {
+        valueNode.append(value);
+      } else {
+        valueNode.textContent = scalar(value);
+      }
 
       row.append(labelNode, valueNode);
       list.append(row);
@@ -295,6 +313,26 @@
     return scalar(value);
   }
 
+  function formatPermissions(value) {
+    if (!Array.isArray(value) || value.length === 0) {
+      return "None";
+    }
+    return value
+      .map((permission) => (typeof permission === "string" && permission ? permission : scalar(permission)))
+      .join(", ");
+  }
+
+  function formatIsoTimestamp(value) {
+    if (typeof value !== "string" || value.length === 0) {
+      return "Unavailable";
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+    return date.toLocaleString();
+  }
+
   function severityTone(severity) {
     const normalized = typeof severity === "string" ? severity.toLowerCase() : "";
     if (normalized.includes("critical") || normalized.includes("error") || normalized.includes("high")) {
@@ -321,6 +359,21 @@
       anchor.textContent = link.label;
       item.append(anchor);
       sections.legacy.append(item);
+    }
+  }
+
+  function normalizeAppUiEntryHref(value) {
+    if (typeof value !== "string" || value.length === 0) {
+      return null;
+    }
+    try {
+      const url = new URL(value, shellRootUrl);
+      if (url.origin !== window.location.origin) {
+        return null;
+      }
+      return `${url.pathname}${url.search}${url.hash}`;
+    } catch (error) {
+      return null;
     }
   }
 
@@ -594,6 +647,146 @@
     );
   }
 
+  function appDisplayName(app) {
+    return typeof app.name === "string" && app.name ? app.name : typeof app.appId === "string" ? app.appId : "App";
+  }
+
+  function appMutationPath(appId, action) {
+    if (typeof appId !== "string" || appId.length === 0) {
+      return null;
+    }
+    const encodedAppId = encodeURIComponent(appId);
+    switch (action) {
+      case "start":
+      case "stop":
+        return `apps/${encodedAppId}/${action}`;
+      case "uninstall":
+        return `apps/${encodedAppId}`;
+      default:
+        return null;
+    }
+  }
+
+  function appUiEntryNode(app) {
+    const href = normalizeAppUiEntryHref(app.uiEntry);
+    if (!href) {
+      return null;
+    }
+    const container = document.createElement("span");
+    container.className = "app-ui-entry";
+    const link = document.createElement("a");
+    link.className = "button button-secondary";
+    link.href = href;
+    link.textContent = "Open UI";
+    container.append(link);
+    return container;
+  }
+
+  function buildAppActionForm(app, action, label) {
+    const appId = typeof app.appId === "string" ? app.appId : "";
+    const path = appMutationPath(appId, action);
+    if (!path) {
+      return null;
+    }
+
+    const form = document.createElement("form");
+    form.className = "app-action-form";
+    form.dataset.appId = appId;
+    form.dataset.appAction = action;
+    form.dataset.appName = appDisplayName(app);
+
+    const submit = document.createElement("button");
+    submit.className = "button button-secondary";
+    submit.type = "submit";
+    submit.textContent = label;
+    form.append(submit);
+    return form;
+  }
+
+  function renderAppCard(app) {
+    const card = document.createElement("article");
+    card.className = "app-card";
+
+    const header = document.createElement("div");
+    header.className = "app-card-header";
+    const heading = document.createElement("div");
+    heading.className = "app-card-heading";
+    heading.append(
+      text("h3", "app-card-title", appDisplayName(app)),
+      text("p", "app-card-subtitle", typeof app.appId === "string" && app.appId ? app.appId : "Unavailable"),
+    );
+
+    const pills = document.createElement("div");
+    pills.className = "app-card-pills";
+    pills.append(createPill("Installed"));
+    pills.append(createPill(app.running ? "Running" : "Stopped", app.running ? "is-success" : "is-warning"));
+    if (app.uiEntry) {
+      pills.append(createPill("UI entry"));
+    }
+    header.append(heading, pills);
+    card.append(header);
+
+    const uiEntryNode = appUiEntryNode(app);
+    const entries = [
+      ["App ID", typeof app.appId === "string" && app.appId ? app.appId : "Unavailable"],
+      ["Version", typeof app.version === "string" && app.version ? app.version : "Unavailable"],
+      ["Permissions", formatPermissions(app.permissions)],
+      ["UI entry", uiEntryNode || scalar(app.uiEntry)],
+      ["Running", app.running ? "Yes" : "No"],
+      ["PID", app.running ? scalar(app.pid) : "Unavailable"],
+      ["Started at", app.running ? formatIsoTimestamp(app.startedAt) : "Unavailable"],
+    ];
+    card.append(definitionList(entries));
+
+    const actions = document.createElement("div");
+    actions.className = "app-card-actions";
+    if (formPassword) {
+      const startForm = buildAppActionForm(app, app.running ? "stop" : "start", app.running ? "Stop" : "Start");
+      const uninstallForm = app.running
+        ? null
+        : buildAppActionForm(app, "uninstall", "Uninstall");
+      if (startForm) {
+        actions.append(startForm);
+      }
+      if (uninstallForm) {
+        actions.append(uninstallForm);
+      }
+    }
+    if (actions.childNodes.length) {
+      card.append(actions);
+    }
+
+    return card;
+  }
+
+  function renderApps(data) {
+    shellState.appsSnapshot = data;
+    updateAppsToolbar();
+    clear(sections.apps);
+
+    const apps = Array.isArray(data.apps) ? data.apps : [];
+    const runningApps = apps.filter((app) => app && typeof app === "object" && app.running).length;
+    const summaryEntries = [
+      ["Installed apps", `${apps.length}`],
+      ["Running apps", `${runningApps}`],
+      ["Scope", formPassword ? "Shell-native" : "Read-only"],
+      ...topLevelFieldEntries(data, ["apps"]),
+    ];
+    sections.apps.append(summaryCard("Apps summary", summaryEntries, apps.length ? "" : "is-warning"));
+
+    if (!apps.length) {
+      sections.apps.append(text("p", "empty-state", "No installed apps were returned."));
+      return;
+    }
+
+    const list = document.createElement("div");
+    list.className = "app-card-list";
+    apps.forEach((app) => {
+      list.append(renderAppCard(app && typeof app === "object" ? app : {}));
+    });
+    sections.apps.append(list);
+  }
+
   function getNestedValue(root, path) {
     let current = root;
     for (let index = 0; index < path.length; index += 1) {
@@ -817,6 +1010,12 @@
   function updateAlertsToolbar() {
     if (sections.alertsReadonlyHint) {
       sections.alertsReadonlyHint.hidden = !!formPassword;
+    }
+  }
+
+  function updateAppsToolbar() {
+    if (sections.appsReadonlyHint) {
+      sections.appsReadonlyHint.hidden = !!formPassword;
     }
   }
 
@@ -1197,6 +1396,7 @@
     const nextBootstrap = JSON.parse(nextBootstrapElement.textContent || "{}");
     formPassword = typeof nextBootstrap.formPassword === "string" ? nextBootstrap.formPassword : "";
     updateSecurityToolbar();
+    updateAppsToolbar();
     updateUpdatesToolbar();
     updateConfigToolbar();
     updateWizardToolbar();
@@ -1335,6 +1535,15 @@
   }
 
   async function postForm(path, formData, unavailableMessage) {
+    return submitFormMutation("POST", path, formData, unavailableMessage);
+  }
+
+  // DELETE reuses the same formPassword body flow so uninstall stays behind the existing bridge auth.
+  async function deleteForm(path, formData, unavailableMessage) {
+    return submitFormMutation("DELETE", path, formData, unavailableMessage);
+  }
+
+  async function submitFormMutation(method, path, formData, unavailableMessage) {
     const currentFormPassword = await refreshFormPassword();
     if (!currentFormPassword) {
       throw new Error(unavailableMessage || "Queue mutations unavailable in read-only mode.");
@@ -1350,7 +1559,7 @@
     }
 
     const response = await fetch(apiUrl(path), {
-      method: "POST",
+      method,
       headers: {
         Accept: "application/json",
         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
@@ -1514,6 +1723,27 @@
     }
   }
 
+  async function loadAppsSection() {
+    const loadGeneration = ++appsLoadGeneration;
+    shellState.appsSnapshot = null;
+    clear(sections.apps);
+    sections.apps.append(text("p", "loading", "Loading installed apps..."));
+    updateAppsToolbar();
+
+    try {
+      const snapshot = await loadJson(apiUrl("apps"));
+      if (loadGeneration !== appsLoadGeneration) {
+        return;
+      }
+      renderApps(snapshot);
+    } catch (error) {
+      if (loadGeneration !== appsLoadGeneration) {
+        return;
+      }
+      renderError(sections.apps, "apps", error);
+    }
+  }
+
   async function dismissAlert(form) {
     const alertId = form.dataset.alertId ?? "";
     if (alertId === "") {
@@ -1531,6 +1761,39 @@
       await loadAlertsSection();
     } catch (error) {
       setAlertsStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  async function submitAppMutation(form, action) {
+    const appId = form.dataset.appId || "";
+    const path = appMutationPath(appId, action);
+    const appName = form.dataset.appName || appDisplayName({ appId });
+    if (!path) {
+      setAppsStatus("App lifecycle action unavailable for this app.", "is-error");
+      return;
+    }
+
+    const formData = new FormData(form);
+
+    try {
+      const data =
+        action === "uninstall"
+          ? await deleteForm(path, formData, "App lifecycle actions unavailable in read-only mode.")
+          : await postForm(path, formData, "App lifecycle actions unavailable in read-only mode.");
+      const operation = data.operation || action;
+      if (action === "uninstall") {
+        setAppsStatus(`${appName} uninstalled.`, "is-success");
+      } else if (action === "stop") {
+        setAppsStatus(`${appName} stopped.`, "is-success");
+      } else {
+        setAppsStatus(`${appName} started.`, "is-success");
+      }
+      if (operation && operation !== action) {
+        setAppsStatus(`App action completed: ${operation.replaceAll("_", " ")}.`, "is-success");
+      }
+      await loadAppsSection();
+    } catch (error) {
+      setAppsStatus(error instanceof Error ? error.message : String(error), "is-error");
     }
   }
 
@@ -2135,6 +2398,25 @@
     });
   }
 
+  function bindAppsInteractions() {
+    appsControls.refreshButton.addEventListener("click", () => {
+      setAppsStatus("Refreshing installed apps.");
+      loadAppsSection();
+    });
+    sections.apps.addEventListener("submit", async (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+      const action = form.dataset.appAction;
+      if (!action) {
+        return;
+      }
+      event.preventDefault();
+      await submitAppMutation(form, action);
+    });
+  }
+
   function bindSecurityInteractions() {
     securityControls.form.addEventListener("submit", submitSecurityForm);
   }
@@ -2204,6 +2486,7 @@
 
   renderLegacyLinks();
   bindAlertsInteractions();
+  bindAppsInteractions();
   bindSecurityInteractions();
   bindUpdatesInteractions();
   bindConfigInteractions();
@@ -2212,6 +2495,7 @@
   bindDiagnosticsInteractions();
   bindQueueInteractions();
   updateAlertsToolbar();
+  updateAppsToolbar();
   updateDiagnosticsToolbar();
   updateSecurityToolbar();
   updateUpdatesToolbar();
@@ -2227,6 +2511,9 @@
   });
   loadAlertsSection().catch((error) => {
     renderError(sections.alerts, "alerts", error);
+  });
+  loadAppsSection().catch((error) => {
+    renderError(sections.apps, "apps", error);
   });
   loadUpdatesSection().catch((error) => {
     renderError(sections.updates, "updates", error);

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellPageRendererTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellPageRendererTest.java
@@ -21,6 +21,8 @@ class WebShellPageRendererTest {
     assertTrue(html.contains(WebShellPaths.SCRIPT_PATH));
     assertTrue(html.contains(WebShellPaths.BOOTSTRAP_ELEMENT_ID));
     assertTrue(html.contains(WebShellBootstrap.DEFAULT_SHELL_TITLE));
+    assertTrue(html.contains("id=\"queue\""));
+    assertTrue(html.contains("id=\"apps\""));
     assertFalse(html.contains("__BOOTSTRAP_JSON__"));
   }
 }

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -12,31 +12,41 @@ class WebShellResourcesTest {
   void readText_whenIndexResourceRequested_expectShellMarkup() {
     String html = WebShellResources.readText(WebShellPaths.INDEX_RESOURCE_PATH);
 
-    assertTrue(html.contains("Web Shell v1"));
-    assertTrue(html.contains("Peer control plane"));
-    assertTrue(html.contains("Alert queue"));
-    assertTrue(html.contains("Runtime diagnostics"));
-    assertTrue(html.contains("Queue control plane"));
-    assertTrue(html.contains("Core updater"));
-    assertTrue(html.contains("Operator subset"));
-    assertTrue(html.contains("First-time setup"));
-    assertTrue(html.contains("Alerts JSON"));
-    assertTrue(html.contains("Diagnostics JSON"));
-    assertTrue(html.contains("__BOOTSTRAP_JSON__"));
-    assertTrue(html.contains("peer-create-form\" hidden"));
-    assertTrue(html.contains("name=\"referenceText\""));
-    assertTrue(html.contains("id=\"peers-status\""));
-    assertTrue(html.contains("id=\"alerts-panel\""));
-    assertTrue(html.contains("id=\"alerts-body\""));
-    assertTrue(html.contains("id=\"diagnostics-panel\""));
-    assertTrue(html.contains("id=\"diagnostics-body\""));
-    assertTrue(html.contains("Use Refresh diagnostics to load the current diagnostics snapshot."));
-    assertTrue(html.contains("name=\"filterData\" type=\"checkbox\" checked"));
-    assertTrue(html.contains("queue-create-form\" hidden"));
-    assertTrue(html.contains("id=\"security-form\""));
-    assertTrue(html.contains("id=\"updates-body\""));
-    assertTrue(html.contains("id=\"config-form\""));
-    assertTrue(html.contains("id=\"wizard-form\""));
+    assertContainsAll(
+        html,
+        "Web Shell v1",
+        "Peer control plane",
+        "Alert queue",
+        "Runtime diagnostics",
+        "Queue control plane",
+        "Core updater",
+        "Operator subset",
+        "First-time setup",
+        "Installed apps",
+        "Installed apps JSON",
+        "Alerts JSON",
+        "Diagnostics JSON",
+        "__BOOTSTRAP_JSON__",
+        "Use Refresh diagnostics to load the current diagnostics snapshot.");
+    assertContainsAll(
+        html,
+        "id=\"apps\"",
+        "id=\"apps-body\"",
+        "id=\"apps-status\"",
+        "peer-create-form\" hidden",
+        "name=\"referenceText\"",
+        "id=\"peers-status\"",
+        "id=\"alerts-panel\"",
+        "id=\"alerts-body\"",
+        "id=\"diagnostics-panel\"",
+        "id=\"diagnostics-body\"",
+        "name=\"filterData\" type=\"checkbox\" checked",
+        "queue-create-form\" hidden",
+        "id=\"queue\"",
+        "id=\"security-form\"",
+        "id=\"updates-body\"",
+        "id=\"config-form\"",
+        "id=\"wizard-form\"");
   }
 
   @Test
@@ -52,6 +62,9 @@ class WebShellResourcesTest {
     assertPeerMutationMarkersPresent(script);
     assertPeerMutationSubmissionOrder(script);
     assertPeerLoadSequencing(script);
+    assertAppsMarkersPresent(script);
+    assertAppsSubmissionOrder(script);
+    assertAppsLoadSequencing(script);
     assertAlertsAndDiagnosticsMarkersPresent(script);
     assertPlatformControlPlaneMarkersPresent(script);
   }
@@ -63,6 +76,16 @@ class WebShellResourcesTest {
 
     assertTrue(stylesheet.contains(".alert-card-text {"));
     assertTrue(stylesheet.contains("white-space: pre-wrap;"));
+    assertTrue(stylesheet.contains(".app-card-list {"));
+    assertTrue(stylesheet.contains(".app-card-actions {"));
+    assertTrue(stylesheet.contains(".status-pill.is-success::before {"));
+  }
+
+  private static void assertContainsAll(String text, String... expectedFragments) {
+    for (String expectedFragment : expectedFragments) {
+      assertTrue(
+          text.contains(expectedFragment), () -> "Expected fragment missing: " + expectedFragment);
+    }
   }
 
   private static void assertQueueMutationMarkersPresent(String script) {
@@ -247,6 +270,64 @@ class WebShellResourcesTest {
     assertTrue(errorGuardIndex > renderPeersIndex);
     assertTrue(renderErrorIndex > errorGuardIndex);
     assertTrue(loadPeersCatchIndex > renderErrorIndex);
+  }
+
+  private static void assertAppsMarkersPresent(String script) {
+    int appUiEntryHelperIndex = script.indexOf("function normalizeAppUiEntryHref(value)");
+    int legacyLinkHelperIndex = script.indexOf("function normalizeLegacyLinkPath(value)");
+    String appUiEntryHelper = script.substring(appUiEntryHelperIndex, legacyLinkHelperIndex);
+
+    assertTrue(script.contains("appsSnapshot: null"));
+    assertTrue(script.contains("let appsLoadGeneration = 0;"));
+    assertTrue(script.contains("apps: document.getElementById(\"apps-body\")"));
+    assertTrue(script.contains("appsStatus: document.getElementById(\"apps-status\")"));
+    assertTrue(
+        script.contains("appsReadonlyHint: document.getElementById(\"apps-readonly-hint\")"));
+    assertTrue(script.contains("const appsControls = {"));
+    assertTrue(script.contains("function normalizeAppUiEntryHref(value)"));
+    assertTrue(appUiEntryHelper.contains("const url = new URL(value, shellRootUrl);"));
+    assertTrue(script.contains("return `${url.pathname}${url.search}${url.hash}`;"));
+    assertFalse(appUiEntryHelper.contains("const url = new URL(value, window.location.origin);"));
+    assertTrue(script.contains("function renderAppCard(app)"));
+    assertTrue(script.contains("function renderApps(data)"));
+    assertTrue(script.contains("function appMutationPath(appId, action)"));
+    assertTrue(script.contains("async function loadAppsSection()"));
+    assertTrue(script.contains("async function deleteForm(path, formData, unavailableMessage)"));
+    assertTrue(script.contains("setAppsStatus(\"Refreshing installed apps.\");"));
+    assertTrue(script.contains("loadJson(apiUrl(\"apps\"))"));
+    assertTrue(script.contains("return `apps/${encodedAppId}/${action}`;"));
+    assertTrue(script.contains("return `apps/${encodedAppId}`;"));
+    assertTrue(script.contains("action === \"uninstall\""));
+    assertTrue(script.contains("App lifecycle actions unavailable in read-only mode."));
+  }
+
+  private static void assertAppsSubmissionOrder(String script) {
+    int bindAppsIndex = script.indexOf("function bindAppsInteractions()");
+    int actionLookupIndex = script.indexOf("const action = form.dataset.appAction;", bindAppsIndex);
+    int preventDefaultIndex = script.indexOf("event.preventDefault();", actionLookupIndex);
+    int mutationIndex = script.indexOf("await submitAppMutation(form, action);", bindAppsIndex);
+
+    assertTrue(bindAppsIndex >= 0);
+    assertTrue(actionLookupIndex > bindAppsIndex);
+    assertTrue(preventDefaultIndex > actionLookupIndex);
+    assertTrue(mutationIndex > preventDefaultIndex);
+  }
+
+  private static void assertAppsLoadSequencing(String script) {
+    int loadAppsIndex = script.indexOf("const loadGeneration = ++appsLoadGeneration;");
+    int successGuardIndex =
+        script.indexOf("if (loadGeneration !== appsLoadGeneration) {", loadAppsIndex);
+    int renderAppsIndex = script.indexOf("renderApps(snapshot);", loadAppsIndex);
+    int errorGuardIndex =
+        script.indexOf("if (loadGeneration !== appsLoadGeneration) {", successGuardIndex + 1);
+    int renderErrorIndex =
+        script.indexOf("renderError(sections.apps, \"apps\", error);", loadAppsIndex);
+
+    assertTrue(loadAppsIndex >= 0);
+    assertTrue(successGuardIndex > loadAppsIndex);
+    assertTrue(renderAppsIndex > successGuardIndex);
+    assertTrue(errorGuardIndex > renderAppsIndex);
+    assertTrue(renderErrorIndex > errorGuardIndex);
   }
 
   private static void assertAlertsAndDiagnosticsMarkersPresent(String script) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ dependencyResolutionManagement {
 rootProject.name = "cryptad"
 
 include(
+  ":apps:queue-manager",
   ":foundation-support",
   ":foundation-store",
   ":foundation-store-contracts",

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.support.MultiValueTable;
+import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.HTTPRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,23 +50,13 @@ class ToadletContextImplTest {
   @BeforeEach
   void setUp() throws Exception {
     outputStream = new ByteArrayOutputStream();
-    Socket socket = new FakeSocket(outputStream, InetAddress.getLoopbackAddress());
 
     // Minimal stubbing used across tests
     org.mockito.Mockito.when(container.getFormPassword()).thenReturn("secret");
     org.mockito.Mockito.when(container.isFProxyJavascriptEnabled()).thenReturn(false);
     org.mockito.Mockito.when(container.isSSL()).thenReturn(false);
 
-    ToadletRequestServices services =
-        new ToadletRequestServices(container, pageMaker, alertManager, bookmarkManager);
-    context =
-        new ToadletContextImpl(
-            socket,
-            new MultiValueTable<>(),
-            bucketFactory,
-            services,
-            new URI("http://example.com/"),
-            1L);
+    context = newContext(new MultiValueTable<>());
   }
 
   @Test
@@ -113,6 +104,22 @@ class ToadletContextImplTest {
         .thenReturn("wrong");
 
     assertFalse(context.hasFormPassword(request));
+  }
+
+  @Test
+  void hasFormPassword_whenUrlEncodedRequestBodyContainsPassword_returnsTrue() throws Exception {
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    headers.put("content-type", "application/x-www-form-urlencoded; charset=UTF-8");
+    ToadletContextImpl requestContext = newContext(headers);
+    HTTPRequestImpl urlEncodedRequest =
+        new HTTPRequestImpl(
+            new URI("http://example.com/api/v1/apps/queue-manager/start"),
+            new SimpleReadOnlyArrayBucket(
+                "formPassword=secret".getBytes(StandardCharsets.US_ASCII)),
+            requestContext,
+            "POST");
+
+    assertTrue(requestContext.hasFormPassword(urlEncodedRequest));
   }
 
   @Test
@@ -299,6 +306,14 @@ class ToadletContextImplTest {
       end--;
     }
     return end == parts.length ? parts : java.util.Arrays.copyOf(parts, end);
+  }
+
+  private ToadletContextImpl newContext(MultiValueTable<String, String> headers) throws Exception {
+    Socket socket = new FakeSocket(outputStream, InetAddress.getLoopbackAddress());
+    ToadletRequestServices services =
+        new ToadletRequestServices(container, pageMaker, alertManager, bookmarkManager);
+    return new ToadletContextImpl(
+        socket, headers, bucketFactory, services, new URI("http://example.com/"), 1L);
   }
 
   private static class FakeSocket extends Socket {


### PR DESCRIPTION
## Summary
- add `:apps:queue-manager` with a deterministic `stageApp` task and a root `stageFirstPartyApps` aggregate task
- stage an AppHost-compatible Queue Manager bundle with a manifest, POSIX launcher, `uiEntry`, README, and focused staging tests
- add a Web Shell `Apps` section for installed/running app inventory and start/stop/uninstall lifecycle actions through the existing Platform API routes
- extend Web Shell and HTTP auth tests to cover the new shell resources and the urlencoded `formPassword` bridge path used by shell mutations

## How to test
- `./gradlew :apps:queue-manager:test :platform-apphost:test :platform-api:test :platform-web-shell:test :test --tests *ToadletContextImplTest --tests *PlatformApiToadletTest`

## Notes
- Queue Manager uses `/app/node/#queue` as its `uiEntry` in this phase
- Windows-specific first-party launcher packaging remains deferred; the staged launcher is POSIX shell-based