### PR TITLE
feat(platform): Add Publisher app and queue inserts

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -407,6 +407,9 @@ public final class PlatformApiToadlet extends Toadlet {
           || "restart".equals(pathSegments.get(2))
           || "priority".equals(pathSegments.get(2));
     }
+    if ("inserts".equals(pathSegments.get(1))) {
+      return "file".equals(pathSegments.get(2)) || "directory".equals(pathSegments.get(2));
+    }
     return "cleanup".equals(pathSegments.get(1))
         && ("uploads".equals(pathSegments.get(2)) || "downloads".equals(pathSegments.get(2)));
   }

--- a/apps/publisher/README.md
+++ b/apps/publisher/README.md
@@ -1,0 +1,49 @@
+# Publisher App
+
+`apps/publisher` stages the first repo-owned Publisher AppHost bundle for PR-191.
+
+Build the staged bundle with:
+
+```bash
+./gradlew :apps:publisher:stageApp
+```
+
+The staged output is written to:
+
+```text
+apps/publisher/build/cryptad-app/publisher
+```
+
+The staged bundle contains:
+
+```text
+cryptad-app.properties
+bin/publisher.sh
+static/README.txt
+```
+
+Install it through the existing Platform API by passing the absolute staged directory path:
+
+```bash
+curl -X POST \
+  --data-urlencode "formPassword=<token>" \
+  --data-urlencode "stagedDir=/abs/path/to/apps/publisher/build/cryptad-app/publisher" \
+  http://127.0.0.1:<port>/api/v1/apps/install
+```
+
+Start and stop it through the existing app-management routes:
+
+```bash
+curl -X POST --data-urlencode "formPassword=<token>" \
+  http://127.0.0.1:<port>/api/v1/apps/publisher/start
+
+curl -X POST --data-urlencode "formPassword=<token>" \
+  http://127.0.0.1:<port>/api/v1/apps/publisher/stop
+```
+
+The bundle intentionally stays conservative in PR-191:
+
+- Signed app bundles and remote catalogs are deferred.
+- App proxying and app-owned static serving are deferred.
+- The bundle points `app.ui.entry` at the shell-native publisher route: `/app/node/#publisher`.
+- The launcher is a POSIX shell script; Windows-specific first-party app launch packaging remains deferred.

--- a/apps/publisher/build.gradle.kts
+++ b/apps/publisher/build.gradle.kts
@@ -1,0 +1,67 @@
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermissions
+import org.gradle.api.tasks.PathSensitivity
+
+plugins {
+  id("cryptad.java-kotlin-conventions")
+  id("cryptad.spotless")
+  `java-library`
+}
+
+version = rootProject.version
+
+val mainSourceSet = sourceSets.named("main")
+val stageAppDir = layout.buildDirectory.dir("cryptad-app/publisher")
+val generatedManifestDir = layout.buildDirectory.dir("generated/stageApp")
+val stageAssetsDir = layout.projectDirectory.dir("src/staged")
+val manifestTemplateFile = stageAssetsDir.file("cryptad-app.properties.template")
+val launcherRelativePath = "bin/publisher.sh"
+val stagedLauncher =
+  stageAppDir.map { stageDirectory -> stageDirectory.file(launcherRelativePath).asFile.toPath() }
+
+dependencies {
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(project(":platform-apphost"))
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+val generateManifest by
+  tasks.registering(Copy::class) {
+    from(manifestTemplateFile) {
+      rename { "cryptad-app.properties" }
+      expand("appVersion" to project.version.toString())
+    }
+    into(generatedManifestDir)
+    filteringCharset = "UTF-8"
+  }
+
+val stageApp by
+  tasks.registering(Sync::class) {
+    group = "build"
+    description = "Stages the Publisher AppHost bundle."
+    dependsOn(generateManifest)
+    into(stageAppDir)
+    from(stageAssetsDir) { exclude("cryptad-app.properties.template") }
+    from(generatedManifestDir)
+    doLast {
+      val launcher = stagedLauncher.get()
+      if (
+        Files.exists(launcher) && Files.getFileStore(launcher).supportsFileAttributeView("posix")
+      ) {
+        Files.setPosixFilePermissions(launcher, PosixFilePermissions.fromString("rwxr-xr-x"))
+      }
+    }
+  }
+
+tasks.named<Test>("test") {
+  dependsOn(stageApp)
+  inputs
+    .dir(stageAppDir)
+    .withPropertyName("publisherStagedBundle")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.property("publisherAppVersion", project.version.toString())
+  systemProperty("publisher.stageDir", stageAppDir.get().asFile.absolutePath)
+  systemProperty("publisher.appVersion", project.version.toString())
+}

--- a/apps/publisher/src/staged/bin/publisher.sh
+++ b/apps/publisher/src/staged/bin/publisher.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+log_file="${CRYPTAD_APP_RUN_DIR:-.}/publisher.log"
+
+printf 'Publisher started for %s %s\n' \
+  "${CRYPTAD_APP_NAME:-Publisher}" \
+  "${CRYPTAD_APP_VERSION:-unknown}" >>"$log_file"
+
+trap 'printf "Publisher stopping\n" >>"$log_file"; exit 0' INT TERM
+
+while :; do
+  sleep 5
+done

--- a/apps/publisher/src/staged/cryptad-app.properties.template
+++ b/apps/publisher/src/staged/cryptad-app.properties.template
@@ -1,0 +1,9 @@
+manifest.version=1
+app.id=publisher
+app.name=Publisher
+app.version=${appVersion}
+app.exec=bin/publisher.sh
+app.ui.entry=/app/node/#publisher
+app.permissions=queue.read,queue.write,content.insert
+quota.data.bytes=0
+quota.cache.bytes=0

--- a/apps/publisher/src/staged/static/README.txt
+++ b/apps/publisher/src/staged/static/README.txt
@@ -1,0 +1,2 @@
+Publisher is packaged as a first-party staged AppHost bundle for PR-191.
+Its UI entry points back to the shell-native publishing surface at /app/node/#publisher.

--- a/apps/publisher/src/test/java/network/crypta/apps/publisher/PublisherBundleStagingTest.java
+++ b/apps/publisher/src/test/java/network/crypta/apps/publisher/PublisherBundleStagingTest.java
@@ -1,0 +1,77 @@
+package network.crypta.apps.publisher;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PublisherBundleStagingTest {
+  private static final String APP_VERSION_PROPERTY = "publisher.appVersion";
+  private static final String STAGE_DIR_PROPERTY = "publisher.stageDir";
+  private static final String EXPECTED_APP_ID = "publisher";
+  private static final String EXPECTED_APP_NAME = "Publisher";
+  private static final String EXPECTED_UI_ENTRY = "/app/node/#publisher";
+  private static final String EXPECTED_LAUNCHER_PATH = "bin/publisher.sh";
+  private static final String EXPECTED_PERMISSIONS = "queue.read,queue.write,content.insert";
+
+  @Test
+  void stagedBundle_whenManifestParsed_expectExpectedAppHostFields() throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parse(stageDirectory().resolve(AppManifestParser.MANIFEST_FILE_NAME));
+
+    assertEquals(EXPECTED_APP_ID, manifest.appId());
+    assertEquals(EXPECTED_APP_NAME, manifest.appName());
+    assertEquals(EXPECTED_LAUNCHER_PATH, manifest.execPathText());
+    assertEquals(EXPECTED_UI_ENTRY, manifest.uiEntry());
+    assertEquals(
+        java.util.List.of("queue.read", "queue.write", "content.insert"), manifest.permissions());
+    assertEquals(Long.valueOf(0L), manifest.dataQuotaBytes());
+    assertEquals(Long.valueOf(0L), manifest.cacheQuotaBytes());
+  }
+
+  @Test
+  void stagedBundle_whenManifestRead_expectExpectedRenderedContent() throws Exception {
+    String manifestText =
+        Files.readString(stageDirectory().resolve(AppManifestParser.MANIFEST_FILE_NAME));
+
+    assertTrue(manifestText.contains("manifest.version=1"));
+    assertTrue(manifestText.contains("app.id=" + EXPECTED_APP_ID));
+    assertTrue(manifestText.contains("app.name=" + EXPECTED_APP_NAME));
+    assertTrue(manifestText.contains("app.version=" + System.getProperty(APP_VERSION_PROPERTY)));
+    assertTrue(manifestText.contains("app.exec=" + EXPECTED_LAUNCHER_PATH));
+    assertTrue(manifestText.contains("app.ui.entry=" + EXPECTED_UI_ENTRY));
+    assertTrue(manifestText.contains("app.permissions=" + EXPECTED_PERMISSIONS));
+    assertTrue(manifestText.contains("quota.data.bytes=0"));
+    assertTrue(manifestText.contains("quota.cache.bytes=0"));
+  }
+
+  @Test
+  void stagedBundle_whenLauncherStaged_expectLongRunningExecutableLoop() throws Exception {
+    Path launcher = stageDirectory().resolve(EXPECTED_LAUNCHER_PATH);
+    String launcherScript = Files.readString(launcher);
+
+    assertTrue(launcherScript.startsWith("#!/bin/sh\n"));
+    assertTrue(launcherScript.contains("log_file=\"${CRYPTAD_APP_RUN_DIR:-.}/publisher.log\""));
+    assertTrue(launcherScript.contains("Publisher started"));
+    assertTrue(launcherScript.contains("trap 'printf \"Publisher stopping"));
+    assertTrue(launcherScript.contains("while :; do"));
+    assertTrue(launcherScript.contains("sleep 5"));
+
+    Assumptions.assumeTrue(Files.getFileStore(launcher).supportsFileAttributeView("posix"));
+    Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(launcher);
+    assertTrue(permissions.contains(PosixFilePermission.OWNER_EXECUTE));
+    assertTrue(permissions.contains(PosixFilePermission.GROUP_EXECUTE));
+    assertTrue(permissions.contains(PosixFilePermission.OTHERS_EXECUTE));
+  }
+
+  private static Path stageDirectory() {
+    return Path.of(System.getProperty(STAGE_DIR_PROPERTY));
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -504,6 +504,7 @@ tasks.register("stageFirstPartyApps") {
   group = "build"
   description = "Stages the repo-owned first-party AppHost bundles."
   dependsOn(":apps:queue-manager:stageApp")
+  dependsOn(":apps:publisher:stageApp")
 }
 
 // The default from build-logic (512m) is too small for the full test suite on Windows and can

--- a/kernel-content/src/main/java/network/crypta/support/MediaType.java
+++ b/kernel-content/src/main/java/network/crypta/support/MediaType.java
@@ -146,6 +146,30 @@ public final class MediaType {
     this.parameters.putAll(parameters);
   }
 
+  /**
+   * Guesses a MIME type from a filename using Cryptad's legacy MIME registry.
+   *
+   * <p>This wrapper preserves the queue/FCP behavior that prefers {@link DefaultMIMETypes} over the
+   * JDK's platform MIME tables. Unknown extensions therefore fall back to Cryptad's default binary
+   * MIME type instead of returning {@code null}. Callers should pass only the display name or
+   * basename that carries the extension they want inspected.
+   *
+   * <p>Use this helper when you need the same filename-to-MIME mapping that queue inserts, FCP
+   * uploads, and manifest construction already rely on. It is especially useful for extensions that
+   * Cryptad tracks in its own registry but the JDK platform tables do not know about yet, such as
+   * newer image formats. The method performs lookup only; it does not validate an explicit MIME
+   * string or parse any media-type parameters.
+   *
+   * @param filename candidate filename whose extension should be inspected; may be a path-like
+   *     string as long as the final segment contains the relevant extension and the caller accepts
+   *     the registry's path-style parsing rules
+   * @return inferred MIME type from Cryptad's registry, or the default binary MIME type when the
+   *     extension is not known
+   */
+  public static String guessMIMEType(String filename) {
+    return DefaultMIMETypes.guessMIMEType(filename, false);
+  }
+
   //
   // ACCESSORS
   //

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -11,6 +11,7 @@ val mainSourceSet = sourceSets.named("main")
 dependencies {
   implementation(project(":foundation-crypto-keys"))
   implementation(project(":foundation-support"))
+  implementation(project(":kernel-content"))
 
   api(project(":runtime-spi"))
   api(project(":platform-apphost"))

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -101,6 +101,7 @@ public final class PlatformApiRouter {
             runtimePorts.queuePage(),
             runtimePorts.queueMutation(),
             runtimePorts.queueDownload(),
+            runtimePorts.queueInsert(),
             runtimePorts.queueSupport(),
             runtimePorts.queueCompletion());
     alertsApiHandler = new AlertsApiHandler(runtimePorts.alertFeed(), runtimePorts.alertMutation());
@@ -575,6 +576,18 @@ public final class PlatformApiRouter {
       String resource, String action, PlatformApiRequest request) {
     if (!"POST".equals(request.method())) {
       return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+    }
+    if ("inserts".equals(resource)) {
+      return switch (action) {
+        case "file" ->
+            PlatformApiResponse.created(
+                queueApiHandler.createLocalFileInsert(request.queryParameters()));
+        case "directory" ->
+            PlatformApiResponse.created(
+                queueApiHandler.createLocalDirectoryInsert(request.queryParameters()));
+        default ->
+            throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+      };
     }
     if ("requests".equals(resource)) {
       return switch (action) {

--- a/platform-api/src/main/java/network/crypta/platform/api/queue/QueueApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/queue/QueueApiHandler.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.api.queue;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
@@ -14,12 +15,20 @@ import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRejectedException;
 import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueInsertFailureReason;
+import network.crypta.runtime.spi.QueueInsertOptions;
+import network.crypta.runtime.spi.QueueInsertOutcome;
+import network.crypta.runtime.spi.QueueInsertPort;
+import network.crypta.runtime.spi.QueueInsertRejectedException;
+import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
+import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
 import network.crypta.runtime.spi.QueuePageSnapshot;
 import network.crypta.runtime.spi.QueueSupportPort;
 import network.crypta.runtime.spi.RequestQueueUnavailableException;
+import network.crypta.support.MediaType;
 
 /**
  * Serves the Platform API v1 queue control-plane surface.
@@ -40,21 +49,36 @@ import network.crypta.runtime.spi.RequestQueueUnavailableException;
  */
 public final class QueueApiHandler {
   private static final String ALERT_SUMMARY_PLACEHOLDER = "<!--CRYPTA_ALERT_SUMMARY-->";
+  private static final String COMPATIBILITY_MODE_CURRENT = "COMPAT_CURRENT";
+  private static final String COMPATIBILITY_MODE_DEFAULT = "COMPAT_DEFAULT";
   private static final String FORM_PASSWORD_PLACEHOLDER = "<!--CRYPTA_QUEUE_FORM_PASSWORD-->";
   private static final String PANIC_BOX_PLACEHOLDER = "<!--CRYPTA_QUEUE_PANIC_BOX-->";
   private static final String FIELD_OPERATION = "operation";
   private static final String FIELD_IDENTIFIER_COUNT = "identifierCount";
   private static final String IDENTIFIER_PARAMETER_PREFIX = "identifier-";
+  private static final String PARAMETER_COMPATIBILITY_MODE = "compatibilityMode";
+  private static final String PARAMETER_COMPRESS = "compress";
+  private static final String PARAMETER_CONTENT_TYPE = "contentType";
   private static final String PARAMETER_DISABLE_FILTER_DATA = "disableFilterData";
   private static final String PARAMETER_FETCH_URI = "fetchUri";
   private static final String PARAMETER_FILTER_DATA = "filterData";
+  private static final String PARAMETER_IDENTIFIER = "identifier";
+  private static final String PARAMETER_INSERT_URI = "insertUri";
+  private static final String PARAMETER_OVERRIDE_SPLITFILE_CRYPTO_KEY =
+      "overrideSplitfileCryptoKey";
   private static final String PARAMETER_PAGE = "page";
   private static final String PARAMETER_PRIORITY = "priority";
+  private static final String PARAMETER_SOURCE_PATH = "sourcePath";
+  private static final String PARAMETER_TARGET_FILENAME = "targetFilename";
   private static final short MINIMUM_PRIORITY_CLASS = 0;
   private static final short MAXIMUM_PRIORITY_CLASS = 6;
+  private static final String OPERATION_LOCAL_DIRECTORY_INSERT = "create_local_directory_insert";
+  private static final String OPERATION_LOCAL_FILE_INSERT = "create_local_file_insert";
   private static final String QUERY_PARAMETER_PREFIX = "Query parameter '";
   private static final String QUEUE_PAGE_DOWNLOADS = "downloads";
   private static final String QUEUE_PAGE_UPLOADS = "uploads";
+  private static final String SOURCE_TYPE_DIRECTORY = "directory";
+  private static final String SOURCE_TYPE_FILE = "file";
 
   /** Detached queue snapshot read port. */
   private final QueuePagePort queuePagePort;
@@ -64,6 +88,9 @@ public final class QueueApiHandler {
 
   /** Detached download-creation port for new direct downloads. */
   private final QueueDownloadPort queueDownloadPort;
+
+  /** Detached insert-creation port for new local file and directory inserts. */
+  private final QueueInsertPort queueInsertPort;
 
   /** Detached queue support port used for availability checks. */
   private final QueueSupportPort queueSupportPort;
@@ -81,6 +108,7 @@ public final class QueueApiHandler {
    * @param queuePagePort detached queue snapshot read port used for queue pages and count views
    * @param queueMutationPort detached mutation port for already-existing queue requests
    * @param queueDownloadPort detached direct-download creation port for new download requests
+   * @param queueInsertPort detached insert-creation port for new local file and directory inserts
    * @param queueSupportPort detached queue support port used for backend availability checks
    * @param queueCompletionPort detached completion-tracker startup hook for rendered queue sides
    * @throws NullPointerException if any required detached runtime port reference is {@code null}
@@ -89,11 +117,13 @@ public final class QueueApiHandler {
       QueuePagePort queuePagePort,
       QueueMutationPort queueMutationPort,
       QueueDownloadPort queueDownloadPort,
+      QueueInsertPort queueInsertPort,
       QueueSupportPort queueSupportPort,
       QueueCompletionPort queueCompletionPort) {
     this.queuePagePort = Objects.requireNonNull(queuePagePort, "queuePagePort");
     this.queueMutationPort = Objects.requireNonNull(queueMutationPort, "queueMutationPort");
     this.queueDownloadPort = Objects.requireNonNull(queueDownloadPort, "queueDownloadPort");
+    this.queueInsertPort = Objects.requireNonNull(queueInsertPort, "queueInsertPort");
     this.queueSupportPort = Objects.requireNonNull(queueSupportPort, "queueSupportPort");
     this.queueCompletionPort = Objects.requireNonNull(queueCompletionPort, "queueCompletionPort");
   }
@@ -362,6 +392,111 @@ public final class QueueApiHandler {
     return json;
   }
 
+  /**
+   * Queues one new persistent insert backed by a local file path.
+   *
+   * <p>The handler validates the small Platform API surface up front, keeps compatibility-mode and
+   * compression parsing inside the transport-neutral layer, and then delegates the actual access
+   * checks plus request creation to the detached runtime insert port.
+   *
+   * <p>Two legacy queue semantics are preserved here because they directly affect the retrieval URI
+   * users will see later. First, when the caller omits {@code contentType}, the handler infers one
+   * from the local file name using Cryptad's MIME registry rather than the host JVM's platform MIME
+   * tables. Second, when the insert URI already carries a doc name, the handler suppresses any
+   * explicit target filename so the insert does not become a one-file manifest wrapper rooted below
+   * an extra path segment. Compatibility-mode validation also comes from the runtime-facing queue
+   * support port, so {@code COMPAT_CURRENT} and {@code COMPAT_DEFAULT} expand to whatever concrete
+   * mode the live node currently treats as its queue insert default.
+   *
+   * @param queryParameters decoded request parameters for the current API call
+   * @return JSON-compatible creation summary describing the local-file insert request
+   * @throws PlatformApiException if required parameters are missing, malformed, rejected by the
+   *     runtime, or the queue backend is unavailable
+   */
+  public Map<String, Object> createLocalFileInsert(Map<String, List<String>> queryParameters) {
+    File sourceFile = requireSourcePath(queryParameters, false);
+    String insertUri = PlatformApiParameters.requireString(queryParameters, PARAMETER_INSERT_URI);
+    FreenetURI parsedInsertUri = requireInsertUri(insertUri);
+    String identifier = PlatformApiParameters.requireString(queryParameters, PARAMETER_IDENTIFIER);
+    String contentType = resolveContentType(queryParameters, sourceFile);
+    String targetFilename = resolveTargetFilename(queryParameters, sourceFile, parsedInsertUri);
+    QueueInsertOptions options = requireInsertOptions(queryParameters);
+    ensureQueueBackendEnabled();
+
+    QueueInsertOutcome outcome;
+    try {
+      outcome =
+          queueInsertPort.enqueueLocalFileInsert(
+              new QueueLocalFileInsertRequest(
+                  sourceFile, insertUri, identifier, contentType, options, targetFilename));
+    } catch (QueueInsertRejectedException e) {
+      throw queueInsertRejected(SOURCE_TYPE_FILE, e);
+    } catch (RequestQueueUnavailableException _) {
+      throw queueUnavailable();
+    } catch (IOException _) {
+      throw new PlatformApiException(500, "internal_error", "Failed to enqueue local file insert.");
+    }
+
+    return insertCreationResult(
+        OPERATION_LOCAL_FILE_INSERT,
+        SOURCE_TYPE_FILE,
+        sourceFile.getPath(),
+        insertUri,
+        identifier,
+        outcome);
+  }
+
+  /**
+   * Queues one new persistent insert backed by a local directory path.
+   *
+   * <p>The Platform API deliberately keeps directory insert creation narrow for this phase: callers
+   * provide one local path plus the detached insert metadata, and the runtime insert port remains
+   * authoritative for directory traversal, file-count limits, and queue registration.
+   *
+   * <p>Directory inserts still share the queue insert compatibility policy with the legacy HTTP
+   * queue flow. The handler therefore validates the supplied compatibility mode against the live
+   * queue support port instead of freezing a historical list of accepted names inside the Platform
+   * API leaf. That keeps queue inserts, the Publisher surface, and the legacy queue forms aligned
+   * when the runtime changes which historical modes are still accepted or which concrete mode the
+   * node treats as its default.
+   *
+   * @param queryParameters decoded request parameters for the current API call
+   * @return JSON-compatible creation summary describing the local-directory insert request
+   * @throws PlatformApiException if required parameters are missing, malformed, rejected by the
+   *     runtime, or the queue backend is unavailable
+   */
+  public Map<String, Object> createLocalDirectoryInsert(Map<String, List<String>> queryParameters) {
+    File sourceDirectory = requireSourcePath(queryParameters, true);
+    String insertUri = PlatformApiParameters.requireString(queryParameters, PARAMETER_INSERT_URI);
+    requireInsertUri(insertUri);
+    String identifier = PlatformApiParameters.requireString(queryParameters, PARAMETER_IDENTIFIER);
+    QueueInsertOptions options = requireInsertOptions(queryParameters);
+    ensureQueueBackendEnabled();
+
+    QueueInsertOutcome outcome;
+    try {
+      outcome =
+          queueInsertPort.enqueueLocalDirectoryInsert(
+              new QueueLocalDirectoryInsertRequest(
+                  sourceDirectory, insertUri, identifier, options));
+    } catch (QueueInsertRejectedException e) {
+      throw queueInsertRejected(SOURCE_TYPE_DIRECTORY, e);
+    } catch (RequestQueueUnavailableException _) {
+      throw queueUnavailable();
+    } catch (IOException _) {
+      throw new PlatformApiException(
+          500, "internal_error", "Failed to enqueue local directory insert.");
+    }
+
+    return insertCreationResult(
+        OPERATION_LOCAL_DIRECTORY_INSERT,
+        SOURCE_TYPE_DIRECTORY,
+        sourceDirectory.getPath(),
+        insertUri,
+        identifier,
+        outcome);
+  }
+
   private void ensureQueueReadable(boolean uploads) {
     ensureQueueBackendEnabled();
     queueCompletionPort.ensureTrackingStarted(uploads);
@@ -437,9 +572,111 @@ public final class QueueApiHandler {
     return fetchUri;
   }
 
+  private static File requireSourcePath(
+      Map<String, List<String>> queryParameters, boolean expectDirectory) {
+    String sourcePath = PlatformApiParameters.requireString(queryParameters, PARAMETER_SOURCE_PATH);
+    File source = new File(sourcePath);
+    if (source.exists()) {
+      if (expectDirectory && !source.isDirectory()) {
+        throw invalidQuery(
+            queryParameter(PARAMETER_SOURCE_PATH)
+                + " must refer to a local directory for this endpoint.");
+      }
+      if (!expectDirectory && !source.isFile()) {
+        throw invalidQuery(
+            queryParameter(PARAMETER_SOURCE_PATH)
+                + " must refer to a local file for this endpoint.");
+      }
+    }
+    return source;
+  }
+
+  private static FreenetURI requireInsertUri(String insertUri) {
+    try {
+      return new FreenetURI(insertUri);
+    } catch (MalformedURLException _) {
+      throw invalidQuery(queryParameter(PARAMETER_INSERT_URI) + " must be a valid insert URI.");
+    }
+  }
+
+  private static String resolveTargetFilename(
+      Map<String, List<String>> queryParameters, File sourceFile, FreenetURI insertUri) {
+    if (insertUri.getDocName() != null) {
+      return null;
+    }
+    String explicitTargetFilename = optionalString(queryParameters, PARAMETER_TARGET_FILENAME);
+    if (explicitTargetFilename != null) {
+      return explicitTargetFilename;
+    }
+    return sourceFile.getName();
+  }
+
+  private static String resolveContentType(
+      Map<String, List<String>> queryParameters, File sourceFile) {
+    String contentType = optionalString(queryParameters, PARAMETER_CONTENT_TYPE);
+    if (contentType == null) {
+      contentType = guessContentType(sourceFile.getName());
+    }
+    validateContentType(contentType);
+    return contentType;
+  }
+
+  private static String guessContentType(String filename) {
+    return MediaType.guessMIMEType(filename);
+  }
+
+  private static void validateContentType(String contentType) {
+    try {
+      new MediaType(contentType);
+    } catch (MalformedURLException | NullPointerException _) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_CONTENT_TYPE) + " must be a plausible MIME type.");
+    }
+  }
+
+  private QueueInsertOptions requireInsertOptions(Map<String, List<String>> queryParameters) {
+    rejectOverrideSplitfileCryptoKey(queryParameters);
+    return new QueueInsertOptions(
+        readCheckboxBoolean(queryParameters, PARAMETER_COMPRESS),
+        requireCompatibilityMode(queryParameters),
+        null);
+  }
+
+  private String requireCompatibilityMode(Map<String, List<String>> queryParameters) {
+    String compatibilityMode =
+        PlatformApiParameters.requireString(queryParameters, PARAMETER_COMPATIBILITY_MODE);
+    String defaultCompatibilityMode = queueSupportPort.defaultInsertCompatibilityMode();
+    List<String> supportedCompatibilityModes = queueSupportPort.supportedInsertCompatibilityModes();
+    if (COMPATIBILITY_MODE_CURRENT.equals(compatibilityMode)
+        || COMPATIBILITY_MODE_DEFAULT.equals(compatibilityMode)) {
+      return defaultCompatibilityMode;
+    }
+    if (supportedCompatibilityModes.contains(compatibilityMode)) {
+      return compatibilityMode;
+    }
+    throw invalidQuery(
+        queryParameter(PARAMETER_COMPATIBILITY_MODE)
+            + " must be one of '"
+            + COMPATIBILITY_MODE_CURRENT
+            + "', '"
+            + COMPATIBILITY_MODE_DEFAULT
+            + "', or one of the concrete modes: "
+            + String.join(", ", supportedCompatibilityModes)
+            + ".");
+  }
+
+  private static void rejectOverrideSplitfileCryptoKey(Map<String, List<String>> queryParameters) {
+    String overrideKey = optionalString(queryParameters, PARAMETER_OVERRIDE_SPLITFILE_CRYPTO_KEY);
+    if (overrideKey != null) {
+      throw invalidQuery(
+          queryParameter(PARAMETER_OVERRIDE_SPLITFILE_CRYPTO_KEY)
+              + " is not supported by this endpoint yet.");
+    }
+  }
+
   private static List<String> requireIdentifiers(Map<String, List<String>> queryParameters) {
     ArrayList<String> identifiers = new ArrayList<>();
-    List<String> repeatedIdentifiers = queryParameters.get("identifier");
+    List<String> repeatedIdentifiers = queryParameters.get(PARAMETER_IDENTIFIER);
     if (repeatedIdentifiers != null) {
       for (String identifier : repeatedIdentifiers) {
         addIdentifier(identifiers, identifier);
@@ -568,11 +805,47 @@ public final class QueueApiHandler {
     return QUERY_PARAMETER_PREFIX + name + "'";
   }
 
+  private static Map<String, Object> insertCreationResult(
+      String operation,
+      String sourceType,
+      String sourcePath,
+      String insertUri,
+      String identifier,
+      QueueInsertOutcome outcome) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(6);
+    json.put(FIELD_OPERATION, operation);
+    json.put("sourceType", sourceType);
+    json.put(PARAMETER_SOURCE_PATH, sourcePath);
+    json.put(PARAMETER_INSERT_URI, insertUri);
+    json.put(PARAMETER_IDENTIFIER, identifier);
+    json.put("outcome", outcome.name());
+    return json;
+  }
+
   private static String stripRuntimePlaceholders(String contentHtmlTemplate) {
     return contentHtmlTemplate
         .replace(ALERT_SUMMARY_PLACEHOLDER, "")
         .replace(FORM_PASSWORD_PLACEHOLDER, "")
         .replace(PANIC_BOX_PLACEHOLDER, "");
+  }
+
+  private static PlatformApiException queueInsertRejected(
+      String sourceType, QueueInsertRejectedException rejection) {
+    QueueInsertFailureReason reason = rejection.reason();
+    String normalizedSourceType =
+        SOURCE_TYPE_DIRECTORY.equals(sourceType) ? SOURCE_TYPE_DIRECTORY : SOURCE_TYPE_FILE;
+    return new PlatformApiException(
+        400,
+        switch (reason) {
+          case ACCESS_DENIED -> "queue_insert_rejected_access_denied";
+          case SOURCE_NOT_FOUND -> "queue_insert_rejected_source_not_found";
+          case TOO_MANY_FILES -> "queue_insert_rejected_too_many_files";
+        },
+        "Local "
+            + normalizedSourceType
+            + " insert rejected by the queue backend: "
+            + reason.name()
+            + ".");
   }
 
   private static PlatformApiException queueUnavailable() {

--- a/platform-api/src/test/java/network/crypta/platform/api/queue/QueueApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/queue/QueueApiHandlerTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.api.queue;
 
+import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -7,6 +8,13 @@ import network.crypta.platform.api.PlatformApiException;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueInsertFailureReason;
+import network.crypta.runtime.spi.QueueInsertOptions;
+import network.crypta.runtime.spi.QueueInsertOutcome;
+import network.crypta.runtime.spi.QueueInsertPort;
+import network.crypta.runtime.spi.QueueInsertRejectedException;
+import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
+import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
@@ -35,6 +43,7 @@ class QueueApiHandlerTest {
             queuePagePort,
             new RecordingQueueMutationPort(),
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             queueCompletionPort);
 
@@ -66,6 +75,7 @@ class QueueApiHandlerTest {
             queuePagePort,
             new RecordingQueueMutationPort(),
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             queueCompletionPort);
     Map<String, List<String>> parameters = orderedParameters(Map.entry("page", List.of("uploads")));
@@ -89,6 +99,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             queueMutationPort,
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
 
@@ -111,6 +122,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             queueMutationPort,
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
 
@@ -135,6 +147,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             queueMutationPort,
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
 
@@ -155,6 +168,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             new RecordingQueueMutationPort(),
             queueDownloadPort,
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
 
@@ -184,6 +198,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             new RecordingQueueMutationPort(),
             queueDownloadPort,
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
 
@@ -205,6 +220,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             new RecordingQueueMutationPort(),
             queueDownloadPort,
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
     Map<String, List<String>> parameters =
@@ -226,6 +242,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             new RecordingQueueMutationPort(),
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
     Map<String, List<String>> parameters =
@@ -248,6 +265,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             queueMutationPort,
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
     Map<String, List<String>> parameters =
@@ -272,6 +290,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             new RecordingQueueMutationPort(),
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
     Map<String, List<String>> parameters =
@@ -294,6 +313,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             queueMutationPort,
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
 
@@ -316,6 +336,7 @@ class QueueApiHandlerTest {
             new RecordingQueuePagePort(),
             queueMutationPort,
             new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
             new FixedQueueSupportPort(true),
             new RecordingQueueCompletionPort());
 
@@ -328,6 +349,376 @@ class QueueApiHandlerTest {
     assertEquals("restart", result.get("operation"));
     assertEquals(Boolean.TRUE, result.get("disableFilterData"));
     assertEquals(Boolean.TRUE, queueMutationPort.lastDisableFilterData);
+  }
+
+  @Test
+  void createLocalFileInsert_whenRequested_expectDetachedLocalFileInsertRequest() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.createLocalFileInsert(
+            orderedParameters(
+                Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+                Map.entry("insertUri", List.of("SSK@publisher-file")),
+                Map.entry("identifier", List.of("publisher-file-1")),
+                Map.entry("contentType", List.of("text/plain")),
+                Map.entry("targetFilename", List.of("file.txt")),
+                Map.entry("compatibilityMode", List.of("COMPAT_CURRENT")),
+                Map.entry("compress", List.of("on"))));
+
+    assertEquals(
+        new QueueLocalFileInsertRequest(
+            new File("/tmp/publisher/file.txt"),
+            "SSK@publisher-file",
+            "publisher-file-1",
+            "text/plain",
+            new QueueInsertOptions(true, "COMPAT_1468", null),
+            "file.txt"),
+        queueInsertPort.lastLocalFileRequest);
+    assertEquals("create_local_file_insert", result.get("operation"));
+    assertEquals("file", result.get("sourceType"));
+    assertEquals("/tmp/publisher/file.txt", result.get("sourcePath"));
+    assertEquals("SSK@publisher-file", result.get("insertUri"));
+    assertEquals("publisher-file-1", result.get("identifier"));
+    assertEquals("STARTED", result.get("outcome"));
+  }
+
+  @Test
+  void createLocalFileInsert_whenTargetFilenameMissingAndInsertUriHasNoDocName_expectBasename() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    handler.createLocalFileInsert(
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("CHK@")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    assertEquals("file.txt", queueInsertPort.lastLocalFileRequest.targetFilename());
+    assertEquals("COMPAT_1468", queueInsertPort.lastLocalFileRequest.compatibilityMode());
+  }
+
+  @Test
+  void createLocalFileInsert_whenContentTypeMissing_expectCryptadMimeInference() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    handler.createLocalFileInsert(
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/image.avif")),
+            Map.entry("insertUri", List.of("CHK@")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    assertEquals("image/avif", queueInsertPort.lastLocalFileRequest.contentType());
+  }
+
+  @Test
+  void createLocalFileInsert_whenTargetFilenameMissingAndInsertUriHasDocName_expectNoDefault() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    handler.createLocalFileInsert(
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("KSK@site-name")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    assertNull(queueInsertPort.lastLocalFileRequest.targetFilename());
+  }
+
+  @Test
+  void createLocalFileInsert_whenTargetFilenameProvidedAndInsertUriHasDocName_expectSuppressed() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    handler.createLocalFileInsert(
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("KSK@site-name")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("targetFilename", List.of("ignored-name.txt")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    assertNull(queueInsertPort.lastLocalFileRequest.targetFilename());
+  }
+
+  @Test
+  void createLocalDirectoryInsert_whenRequested_expectDetachedLocalDirectoryInsertRequest() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    queueInsertPort.nextOutcome = QueueInsertOutcome.IDENTIFIER_COLLISION;
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+
+    Map<String, Object> result =
+        handler.createLocalDirectoryInsert(
+            orderedParameters(
+                Map.entry("sourcePath", List.of("/tmp/publisher/site")),
+                Map.entry("insertUri", List.of("SSK@publisher-site")),
+                Map.entry("identifier", List.of("publisher-dir-1")),
+                Map.entry("compatibilityMode", List.of("COMPAT_1468")),
+                Map.entry("compress", List.of("false"))));
+
+    assertEquals(
+        new QueueLocalDirectoryInsertRequest(
+            new File("/tmp/publisher/site"),
+            "SSK@publisher-site",
+            "publisher-dir-1",
+            new QueueInsertOptions(false, "COMPAT_1468", null)),
+        queueInsertPort.lastLocalDirectoryRequest);
+    assertEquals("create_local_directory_insert", result.get("operation"));
+    assertEquals("directory", result.get("sourceType"));
+    assertEquals("/tmp/publisher/site", result.get("sourcePath"));
+    assertEquals("SSK@publisher-site", result.get("insertUri"));
+    assertEquals("publisher-dir-1", result.get("identifier"));
+    assertEquals("IDENTIFIER_COLLISION", result.get("outcome"));
+  }
+
+  @Test
+  void createLocalFileInsert_whenSourcePathMissing_expectBadRequest() {
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("insertUri", List.of("SSK@publisher-file")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.createLocalFileInsert(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals("Missing required query parameter 'sourcePath'.", error.getMessage());
+  }
+
+  @Test
+  void createLocalFileInsert_whenInsertUriMissing_expectBadRequest() {
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.createLocalFileInsert(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals("Missing required query parameter 'insertUri'.", error.getMessage());
+  }
+
+  @Test
+  void createLocalFileInsert_whenIdentifierMissing_expectBadRequest() {
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("SSK@publisher-file")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.createLocalFileInsert(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals("Missing required query parameter 'identifier'.", error.getMessage());
+  }
+
+  @Test
+  void createLocalFileInsert_whenContentTypeMalformed_expectBadRequest() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("CHK@")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("contentType", List.of("textplain")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.createLocalFileInsert(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals(
+        "Query parameter 'contentType' must be a plausible MIME type.", error.getMessage());
+    assertNull(queueInsertPort.lastLocalFileRequest);
+  }
+
+  @Test
+  void createLocalFileInsert_whenCompatibilityModeCurrent_expectRuntimeDefault() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true, List.of("COMPAT_1255", "COMPAT_1416"), "COMPAT_1255"),
+            new RecordingQueueCompletionPort());
+
+    handler.createLocalFileInsert(
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("CHK@")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    assertEquals("COMPAT_1255", queueInsertPort.lastLocalFileRequest.compatibilityMode());
+  }
+
+  @Test
+  void createLocalFileInsert_whenCompatibilityModeSupportedByRuntime_expectPassedThrough() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true, List.of("COMPAT_1255", "COMPAT_1416"), "COMPAT_1255"),
+            new RecordingQueueCompletionPort());
+
+    handler.createLocalFileInsert(
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("CHK@")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_1416"))));
+
+    assertEquals("COMPAT_1416", queueInsertPort.lastLocalFileRequest.compatibilityMode());
+  }
+
+  @Test
+  void createLocalFileInsert_whenCompatibilityModeUnsupported_expectBadRequest() {
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            new RecordingQueueInsertPort(),
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("CHK@")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_TYPO")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.createLocalFileInsert(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("invalid_query_parameter", error.errorCode());
+    assertEquals(
+        "Query parameter 'compatibilityMode' must be one of 'COMPAT_CURRENT',"
+            + " 'COMPAT_DEFAULT', or one of the concrete modes: COMPAT_1468,"
+            + " COMPAT_1250_EXACT, COMPAT_1250, COMPAT_1251, COMPAT_1255, COMPAT_1416.",
+        error.getMessage());
+  }
+
+  @Test
+  void createLocalFileInsert_whenRejected_expectDeterministicPlatformApiException() {
+    RecordingQueueInsertPort queueInsertPort = new RecordingQueueInsertPort();
+    queueInsertPort.rejectedException =
+        new QueueInsertRejectedException(QueueInsertFailureReason.ACCESS_DENIED, "denied");
+    QueueApiHandler handler =
+        new QueueApiHandler(
+            new RecordingQueuePagePort(),
+            new RecordingQueueMutationPort(),
+            new RecordingQueueDownloadPort(),
+            queueInsertPort,
+            new FixedQueueSupportPort(true),
+            new RecordingQueueCompletionPort());
+    Map<String, List<String>> parameters =
+        orderedParameters(
+            Map.entry("sourcePath", List.of("/tmp/publisher/file.txt")),
+            Map.entry("insertUri", List.of("SSK@publisher-file")),
+            Map.entry("identifier", List.of("publisher-file-1")),
+            Map.entry("compatibilityMode", List.of("COMPAT_CURRENT")));
+
+    PlatformApiException error =
+        assertThrows(PlatformApiException.class, () -> handler.createLocalFileInsert(parameters));
+
+    assertEquals(400, error.statusCode());
+    assertEquals("queue_insert_rejected_access_denied", error.errorCode());
+    assertEquals(
+        "Local file insert rejected by the queue backend: ACCESS_DENIED.", error.getMessage());
   }
 
   @SafeVarargs
@@ -412,17 +803,81 @@ class QueueApiHandlerTest {
     }
   }
 
+  private static final class RecordingQueueInsertPort implements QueueInsertPort {
+    private QueueLocalFileInsertRequest lastLocalFileRequest;
+    private QueueLocalDirectoryInsertRequest lastLocalDirectoryRequest;
+    private QueueInsertOutcome nextOutcome = QueueInsertOutcome.STARTED;
+    private QueueInsertRejectedException rejectedException;
+
+    @Override
+    public QueueInsertOutcome enqueueBrowserUploadInsert(
+        network.crypta.runtime.spi.QueueBrowserUploadInsertRequest request) {
+      throw new UnsupportedOperationException(
+          "Browser-upload inserts are not exercised by this test double.");
+    }
+
+    @Override
+    public QueueInsertOutcome enqueueLocalFileInsert(QueueLocalFileInsertRequest request)
+        throws QueueInsertRejectedException {
+      lastLocalFileRequest = request;
+      if (rejectedException != null) {
+        throw rejectedException;
+      }
+      return nextOutcome;
+    }
+
+    @Override
+    public QueueInsertOutcome enqueueLocalDirectoryInsert(QueueLocalDirectoryInsertRequest request)
+        throws QueueInsertRejectedException {
+      lastLocalDirectoryRequest = request;
+      if (rejectedException != null) {
+        throw rejectedException;
+      }
+      return nextOutcome;
+    }
+  }
+
   @SuppressWarnings("ClassCanBeRecord")
   private static final class FixedQueueSupportPort implements QueueSupportPort {
+    private static final List<String> DEFAULT_SUPPORTED_INSERT_COMPATIBILITY_MODES =
+        List.of(
+            "COMPAT_1468",
+            "COMPAT_1250_EXACT",
+            "COMPAT_1250",
+            "COMPAT_1251",
+            "COMPAT_1255",
+            "COMPAT_1416");
+
     private final boolean enabled;
+    private final List<String> supportedInsertCompatibilityModes;
+    private final String defaultInsertCompatibilityMode;
 
     private FixedQueueSupportPort(boolean enabled) {
+      this(enabled, DEFAULT_SUPPORTED_INSERT_COMPATIBILITY_MODES, "COMPAT_1468");
+    }
+
+    private FixedQueueSupportPort(
+        boolean enabled,
+        List<String> supportedInsertCompatibilityModes,
+        String defaultInsertCompatibilityMode) {
       this.enabled = enabled;
+      this.supportedInsertCompatibilityModes = List.copyOf(supportedInsertCompatibilityModes);
+      this.defaultInsertCompatibilityMode = defaultInsertCompatibilityMode;
     }
 
     @Override
     public boolean isQueueBackendEnabled() {
       return enabled;
+    }
+
+    @Override
+    public List<String> supportedInsertCompatibilityModes() {
+      return supportedInsertCompatibilityModes;
+    }
+
+    @Override
+    public String defaultInsertCompatibilityMode() {
+      return defaultInsertCompatibilityMode;
     }
 
     @Override

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -21,6 +21,7 @@
         <div class="hero-actions">
           <a class="button button-primary" href="/api/v1/node/greeting">Node greeting JSON</a>
           <a class="button button-secondary" href="/api/v1/apps">Installed apps JSON</a>
+          <a class="button button-secondary" href="#publisher">Publisher</a>
           <a class="button button-secondary" href="/api/v1/alerts">Alerts JSON</a>
           <a class="button button-secondary" href="/api/v1/diagnostics">Diagnostics JSON</a>
           <a class="button button-secondary" href="/">Legacy root</a>
@@ -380,6 +381,202 @@
             <p class="loading">Loading peer roster...</p>
           </div>
         </article>
+      </section>
+
+      <section class="panel panel-wide" id="publisher">
+        <div class="panel-header">
+          <p class="panel-kicker">Publisher</p>
+          <h2>First-party publishing surface</h2>
+        </div>
+        <p class="panel-description">
+          Queue one persistent local file or local directory insert through the shell-native
+          Publisher surface. Installed apps can deep-link here with
+          <code>/app/node/#publisher</code>.
+        </p>
+        <div class="queue-toolbar">
+          <a class="button button-secondary" href="#queue">View upload queue</a>
+        </div>
+        <div class="queue-status" id="publisher-status" aria-live="polite"></div>
+        <p class="panel-description" hidden id="publisher-readonly-hint">
+          Publisher actions are unavailable in read-only mode.
+        </p>
+        <div class="publisher-forms">
+          <form
+            class="control-form publisher-form"
+            hidden
+            id="publisher-file-form"
+            data-publisher-source-type="file"
+          >
+            <div class="queue-create-copy">
+              <p class="panel-kicker">Local file</p>
+              <p class="queue-create-description">
+                Queue a persistent insert from one local file path.
+              </p>
+            </div>
+            <div class="control-form-grid">
+              <label class="queue-field" for="publisher-file-source-path">
+                <span>Source path</span>
+                <input
+                  id="publisher-file-source-path"
+                  name="sourcePath"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+              <label class="queue-field" for="publisher-file-insert-uri">
+                <span>Insert URI</span>
+                <input
+                  id="publisher-file-insert-uri"
+                  name="insertUri"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+            </div>
+            <div class="control-form-grid">
+              <label class="queue-field" for="publisher-file-identifier">
+                <span>Identifier</span>
+                <input
+                  id="publisher-file-identifier"
+                  name="identifier"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+              <label class="queue-field" for="publisher-file-compatibility-mode">
+                <span>Compatibility mode</span>
+                <input
+                  id="publisher-file-compatibility-mode"
+                  name="compatibilityMode"
+                  type="text"
+                  value="COMPAT_CURRENT"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+            </div>
+            <div class="control-form-grid">
+              <label class="queue-field" for="publisher-file-content-type">
+                <span>Content type</span>
+                <input
+                  id="publisher-file-content-type"
+                  name="contentType"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                >
+              </label>
+              <label class="queue-field" for="publisher-file-target-filename">
+                <span>Target filename</span>
+                <input
+                  id="publisher-file-target-filename"
+                  name="targetFilename"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                >
+              </label>
+            </div>
+            <label class="checkbox-inline" for="publisher-file-compress">
+              <input id="publisher-file-compress" name="compress" type="checkbox" checked>
+              <span>Compress</span>
+            </label>
+            <div class="control-form-actions">
+              <button class="button button-primary" id="publisher-file-submit" type="submit">
+                Publish local file
+              </button>
+            </div>
+          </form>
+
+          <form
+            class="control-form publisher-form"
+            hidden
+            id="publisher-directory-form"
+            data-publisher-source-type="directory"
+          >
+            <div class="queue-create-copy">
+              <p class="panel-kicker">Local directory</p>
+              <p class="queue-create-description">
+                Queue a persistent insert from one local directory tree.
+              </p>
+            </div>
+            <div class="control-form-grid">
+              <label class="queue-field" for="publisher-directory-source-path">
+                <span>Source path</span>
+                <input
+                  id="publisher-directory-source-path"
+                  name="sourcePath"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+              <label class="queue-field" for="publisher-directory-insert-uri">
+                <span>Insert URI</span>
+                <input
+                  id="publisher-directory-insert-uri"
+                  name="insertUri"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+            </div>
+            <div class="control-form-grid">
+              <label class="queue-field" for="publisher-directory-identifier">
+                <span>Identifier</span>
+                <input
+                  id="publisher-directory-identifier"
+                  name="identifier"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+              <label class="queue-field" for="publisher-directory-compatibility-mode">
+                <span>Compatibility mode</span>
+                <input
+                  id="publisher-directory-compatibility-mode"
+                  name="compatibilityMode"
+                  type="text"
+                  value="COMPAT_CURRENT"
+                  autocomplete="off"
+                  spellcheck="false"
+                  required
+                >
+              </label>
+            </div>
+            <label class="checkbox-inline" for="publisher-directory-compress">
+              <input id="publisher-directory-compress" name="compress" type="checkbox" checked>
+              <span>Compress</span>
+            </label>
+            <div class="control-form-actions">
+              <button
+                class="button button-primary"
+                id="publisher-directory-submit"
+                type="submit"
+              >
+                Publish directory tree
+              </button>
+            </div>
+          </form>
+        </div>
+        <div class="panel-body" id="publisher-body">
+          <p class="empty-state">
+            Use the file or directory form to queue a persistent insert, then jump to the upload
+            queue to follow progress.
+          </p>
+        </div>
       </section>
 
       <section class="panel panel-wide" id="queue">

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -327,6 +327,23 @@ a {
   min-height: 24px;
 }
 
+.publisher-forms {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.publisher-form {
+  height: 100%;
+}
+
+.publisher-result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .status-message {
   margin: 0;
   padding: 10px 14px;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -22,6 +22,7 @@
     wizardSnapshot: null,
   };
   const directDownloadOperation = "create_direct_download";
+  const publisherDefaultCompatibilityMode = "COMPAT_CURRENT";
   const queueState = {
     page: "downloads",
     advancedMode: false,
@@ -49,6 +50,9 @@
     apps: document.getElementById("apps-body"),
     appsStatus: document.getElementById("apps-status"),
     appsReadonlyHint: document.getElementById("apps-readonly-hint"),
+    publisher: document.getElementById("publisher-body"),
+    publisherStatus: document.getElementById("publisher-status"),
+    publisherReadonlyHint: document.getElementById("publisher-readonly-hint"),
     diagnostics: document.getElementById("diagnostics-body"),
     diagnosticsStatus: document.getElementById("diagnostics-status"),
     security: document.getElementById("security-body"),
@@ -83,6 +87,11 @@
   };
   const appsControls = {
     refreshButton: document.getElementById("apps-refresh-button"),
+  };
+  const publisherControls = {
+    fileForm: document.getElementById("publisher-file-form"),
+    directoryForm: document.getElementById("publisher-directory-form"),
+    queueLink: document.querySelector('#publisher .queue-toolbar a[href="#queue"]'),
   };
   const diagnosticsControls = {
     refreshButton: document.getElementById("diagnostics-refresh-button"),
@@ -195,6 +204,10 @@
 
   function setAppsStatus(message, tone) {
     setSectionStatus(sections.appsStatus, message, tone);
+  }
+
+  function setPublisherStatus(message, tone) {
+    setSectionStatus(sections.publisherStatus, message, tone);
   }
 
   function setDiagnosticsStatus(message, tone) {
@@ -647,6 +660,206 @@
     );
   }
 
+  function publisherSourceType(form) {
+    return form instanceof HTMLFormElement && form.dataset.publisherSourceType === "directory"
+      ? "directory"
+      : "file";
+  }
+
+  function publisherLabel(sourceType) {
+    return sourceType === "directory" ? "directory" : "file";
+  }
+
+  function publisherMutationPath(sourceType) {
+    return sourceType === "directory" ? "queue/inserts/directory" : "queue/inserts/file";
+  }
+
+  function generatePublisherIdentifier(sourceType) {
+    const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+    const randomToken = Math.random().toString(36).slice(2, 8);
+    return `publisher-${publisherLabel(sourceType)}-${timestamp}-${randomToken}`;
+  }
+
+  function trimPublisherValue(form, fieldName) {
+    const field = form.querySelector(`[name="${fieldName}"]`);
+    return field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement
+      ? field.value.trim()
+      : "";
+  }
+
+  function initializePublisherForm(form) {
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+    const identifierField = form.querySelector('input[name="identifier"]');
+    if (identifierField instanceof HTMLInputElement && identifierField.value.trim() === "") {
+      identifierField.value = generatePublisherIdentifier(publisherSourceType(form));
+    }
+    const compatibilityField = form.querySelector('input[name="compatibilityMode"]');
+    if (
+      compatibilityField instanceof HTMLInputElement &&
+      compatibilityField.value.trim() === ""
+    ) {
+      compatibilityField.value = publisherDefaultCompatibilityMode;
+    }
+  }
+
+  function resetPublisherForm(form) {
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+    form.reset();
+    initializePublisherForm(form);
+  }
+
+  function buildPublisherFormData(form) {
+    const sourceType = publisherSourceType(form);
+    const formData = new FormData();
+    const sourcePath = trimPublisherValue(form, "sourcePath");
+    const insertUri = trimPublisherValue(form, "insertUri");
+    let identifier = trimPublisherValue(form, "identifier");
+    if (!identifier) {
+      identifier = generatePublisherIdentifier(sourceType);
+      const identifierField = form.querySelector('input[name="identifier"]');
+      if (identifierField instanceof HTMLInputElement) {
+        identifierField.value = identifier;
+      }
+    }
+    const compatibilityMode =
+      trimPublisherValue(form, "compatibilityMode") || publisherDefaultCompatibilityMode;
+
+    formData.set("sourcePath", sourcePath);
+    formData.set("insertUri", insertUri);
+    formData.set("identifier", identifier);
+    formData.set("compatibilityMode", compatibilityMode);
+
+    const compressField = form.querySelector('input[name="compress"]');
+    if (compressField instanceof HTMLInputElement && compressField.checked) {
+      formData.set("compress", "on");
+    }
+
+    const contentType = trimPublisherValue(form, "contentType");
+    if (contentType) {
+      formData.set("contentType", contentType);
+    }
+
+    const targetFilename = trimPublisherValue(form, "targetFilename");
+    if (targetFilename) {
+      formData.set("targetFilename", targetFilename);
+    }
+
+    return formData;
+  }
+
+  function renderPublisherResult(data, sourceType) {
+    clear(sections.publisher);
+
+    const resolvedSourceType =
+      typeof data.sourceType === "string" && data.sourceType ? data.sourceType : publisherLabel(sourceType);
+    const insertAccepted = publisherInsertAccepted(data);
+    const summaryEntries = [
+      ["Operation", data.operation || `create_local_${resolvedSourceType}_insert`],
+      ["Source type", resolvedSourceType],
+      ["Source path", data.sourcePath || "Unavailable"],
+      ["Insert URI", data.insertUri || "Unavailable"],
+      ["Identifier", data.identifier || "Unavailable"],
+      ["Outcome", data.outcome || "Unknown"],
+    ];
+    sections.publisher.append(
+      summaryCard("Publisher result", summaryEntries, insertAccepted ? "is-success" : "is-warning"),
+    );
+
+    if (insertAccepted) {
+      const actions = document.createElement("div");
+      actions.className = "publisher-result-actions";
+      const queueLink = document.createElement("a");
+      queueLink.className = "button button-secondary";
+      queueLink.href = "#queue";
+      queueLink.textContent = "Open upload queue";
+      queueLink.addEventListener("click", () => {
+        showUploadQueueFromPublisher().catch((error) => {
+          setStatus(error instanceof Error ? error.message : String(error), "is-error");
+        });
+      });
+      actions.append(queueLink);
+      sections.publisher.append(actions);
+    }
+
+    const extraFields = topLevelFieldEntries(data, [
+      "operation",
+      "sourceType",
+      "sourcePath",
+      "insertUri",
+      "identifier",
+      "outcome",
+    ]);
+    if (extraFields.length) {
+      sections.publisher.append(definitionList(extraFields));
+    }
+  }
+
+  function publisherInsertAccepted(data) {
+    switch (publisherInsertOutcome(data)) {
+      case "STARTED":
+      case "IDENTIFIER_COLLISION":
+      case "METADATA_UNRESOLVED":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function publisherInsertOutcome(data) {
+    return typeof data?.outcome === "string" && data.outcome ? data.outcome : "Unknown";
+  }
+
+  async function showUploadQueueFromPublisher() {
+    queueState.page = "uploads";
+    queueState.sortBy = null;
+    queueState.reversed = false;
+    queueState.keysVisible = false;
+    setStatus("Refreshing upload queue.");
+    await loadQueueSection();
+  }
+
+  async function submitPublisherForm(event) {
+    event.preventDefault();
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+    if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+      return;
+    }
+
+    const sourceType = publisherSourceType(form);
+    const formData = buildPublisherFormData(form);
+
+    try {
+      const data = await postForm(
+        publisherMutationPath(sourceType),
+        formData,
+        "Publisher actions unavailable in read-only mode.",
+      );
+      renderPublisherResult(data, sourceType);
+      if (publisherInsertAccepted(data)) {
+        resetPublisherForm(form);
+        setPublisherStatus(
+          `Local ${publisherLabel(sourceType)} insert handled: ${publisherInsertOutcome(data)}.`,
+          "is-success",
+        );
+        await showUploadQueueFromPublisher();
+      } else {
+        setPublisherStatus(
+          `Local ${publisherLabel(sourceType)} insert did not start: ${publisherInsertOutcome(data)}.`,
+          "is-error",
+        );
+      }
+    } catch (error) {
+      setPublisherStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
   function appDisplayName(app) {
     return typeof app.name === "string" && app.name ? app.name : typeof app.appId === "string" ? app.appId : "App";
   }
@@ -1016,6 +1229,14 @@
   function updateAppsToolbar() {
     if (sections.appsReadonlyHint) {
       sections.appsReadonlyHint.hidden = !!formPassword;
+    }
+  }
+
+  function updatePublisherToolbar() {
+    publisherControls.fileForm.hidden = !formPassword;
+    publisherControls.directoryForm.hidden = !formPassword;
+    if (sections.publisherReadonlyHint) {
+      sections.publisherReadonlyHint.hidden = !!formPassword;
     }
   }
 
@@ -1397,6 +1618,7 @@
     formPassword = typeof nextBootstrap.formPassword === "string" ? nextBootstrap.formPassword : "";
     updateSecurityToolbar();
     updateAppsToolbar();
+    updatePublisherToolbar();
     updateUpdatesToolbar();
     updateConfigToolbar();
     updateWizardToolbar();
@@ -2417,6 +2639,18 @@
     });
   }
 
+  function bindPublisherInteractions() {
+    publisherControls.fileForm.addEventListener("submit", submitPublisherForm);
+    publisherControls.directoryForm.addEventListener("submit", submitPublisherForm);
+    if (publisherControls.queueLink instanceof HTMLAnchorElement) {
+      publisherControls.queueLink.addEventListener("click", () => {
+        showUploadQueueFromPublisher().catch((error) => {
+          setStatus(error instanceof Error ? error.message : String(error), "is-error");
+        });
+      });
+    }
+  }
+
   function bindSecurityInteractions() {
     securityControls.form.addEventListener("submit", submitSecurityForm);
   }
@@ -2484,9 +2718,12 @@
     }
   }
 
+  initializePublisherForm(publisherControls.fileForm);
+  initializePublisherForm(publisherControls.directoryForm);
   renderLegacyLinks();
   bindAlertsInteractions();
   bindAppsInteractions();
+  bindPublisherInteractions();
   bindSecurityInteractions();
   bindUpdatesInteractions();
   bindConfigInteractions();
@@ -2496,6 +2733,7 @@
   bindQueueInteractions();
   updateAlertsToolbar();
   updateAppsToolbar();
+  updatePublisherToolbar();
   updateDiagnosticsToolbar();
   updateSecurityToolbar();
   updateUpdatesToolbar();

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellPageRendererTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellPageRendererTest.java
@@ -23,6 +23,7 @@ class WebShellPageRendererTest {
     assertTrue(html.contains(WebShellBootstrap.DEFAULT_SHELL_TITLE));
     assertTrue(html.contains("id=\"queue\""));
     assertTrue(html.contains("id=\"apps\""));
+    assertTrue(html.contains("id=\"publisher\""));
     assertFalse(html.contains("__BOOTSTRAP_JSON__"));
   }
 }

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -23,6 +23,7 @@ class WebShellResourcesTest {
         "Operator subset",
         "First-time setup",
         "Installed apps",
+        "First-party publishing surface",
         "Installed apps JSON",
         "Alerts JSON",
         "Diagnostics JSON",
@@ -40,6 +41,16 @@ class WebShellResourcesTest {
         "id=\"alerts-body\"",
         "id=\"diagnostics-panel\"",
         "id=\"diagnostics-body\"",
+        "href=\"#publisher\"",
+        "id=\"publisher\"",
+        "id=\"publisher-status\"",
+        "id=\"publisher-body\"",
+        "id=\"publisher-file-form\"",
+        "data-publisher-source-type=\"file\"",
+        "id=\"publisher-directory-form\"",
+        "data-publisher-source-type=\"directory\"",
+        "id=\"publisher-file-submit\"",
+        "id=\"publisher-directory-submit\"",
         "name=\"filterData\" type=\"checkbox\" checked",
         "queue-create-form\" hidden",
         "id=\"queue\"",
@@ -65,6 +76,8 @@ class WebShellResourcesTest {
     assertAppsMarkersPresent(script);
     assertAppsSubmissionOrder(script);
     assertAppsLoadSequencing(script);
+    assertPublisherMarkersPresent(script);
+    assertPublisherSubmissionOrder(script);
     assertAlertsAndDiagnosticsMarkersPresent(script);
     assertPlatformControlPlaneMarkersPresent(script);
   }
@@ -78,6 +91,8 @@ class WebShellResourcesTest {
     assertTrue(stylesheet.contains("white-space: pre-wrap;"));
     assertTrue(stylesheet.contains(".app-card-list {"));
     assertTrue(stylesheet.contains(".app-card-actions {"));
+    assertTrue(stylesheet.contains(".publisher-forms {"));
+    assertTrue(stylesheet.contains(".publisher-result-actions {"));
     assertTrue(stylesheet.contains(".status-pill.is-success::before {"));
   }
 
@@ -328,6 +343,82 @@ class WebShellResourcesTest {
     assertTrue(renderAppsIndex > successGuardIndex);
     assertTrue(errorGuardIndex > renderAppsIndex);
     assertTrue(renderErrorIndex > errorGuardIndex);
+  }
+
+  private static void assertPublisherMarkersPresent(String script) {
+    assertTrue(script.contains("const publisherDefaultCompatibilityMode = \"COMPAT_CURRENT\";"));
+    assertTrue(script.contains("publisher: document.getElementById(\"publisher-body\")"));
+    assertTrue(script.contains("publisherStatus: document.getElementById(\"publisher-status\")"));
+    assertTrue(
+        script.contains(
+            "publisherReadonlyHint: document.getElementById(\"publisher-readonly-hint\")"));
+    assertTrue(script.contains("const publisherControls = {"));
+    assertTrue(
+        script.contains(
+            "queueLink: document.querySelector('#publisher .queue-toolbar a[href=\"#queue\"]'),"));
+    assertTrue(script.contains("function updatePublisherToolbar()"));
+    assertTrue(script.contains("function publisherSourceType(form)"));
+    assertTrue(script.contains("function publisherMutationPath(sourceType)"));
+    assertTrue(script.contains("function generatePublisherIdentifier(sourceType)"));
+    assertTrue(script.contains("function initializePublisherForm(form)"));
+    assertTrue(script.contains("function resetPublisherForm(form)"));
+    assertTrue(script.contains("function buildPublisherFormData(form)"));
+    assertTrue(script.contains("function renderPublisherResult(data, sourceType)"));
+    assertTrue(script.contains("function publisherInsertAccepted(data)"));
+    assertTrue(script.contains("function publisherInsertOutcome(data)"));
+    assertTrue(script.contains("async function showUploadQueueFromPublisher()"));
+    assertTrue(script.contains("async function submitPublisherForm(event)"));
+    assertTrue(script.contains("Publisher actions unavailable in read-only mode."));
+    assertTrue(script.contains("setStatus(\"Refreshing upload queue.\");"));
+    assertTrue(script.contains("case \"IDENTIFIER_COLLISION\":"));
+    assertTrue(script.contains("case \"METADATA_UNRESOLVED\":"));
+    assertTrue(script.contains("insert handled:"));
+    assertTrue(script.contains("insert did not start:"));
+    assertTrue(script.contains("${publisherInsertOutcome(data)}."));
+    assertTrue(script.contains("initializePublisherForm(publisherControls.fileForm);"));
+    assertTrue(script.contains("initializePublisherForm(publisherControls.directoryForm);"));
+    assertTrue(script.contains("bindPublisherInteractions();"));
+    assertTrue(script.contains("updatePublisherToolbar();"));
+  }
+
+  private static void assertPublisherSubmissionOrder(String script) {
+    int submitPublisherIndex = script.indexOf("async function submitPublisherForm(event)");
+    int postFormIndex = script.indexOf("await postForm(", submitPublisherIndex);
+    int renderResultIndex =
+        script.indexOf("renderPublisherResult(data, sourceType);", submitPublisherIndex);
+    int startedGuardIndex =
+        script.indexOf("if (publisherInsertAccepted(data)) {", submitPublisherIndex);
+    int resetFormIndex = script.indexOf("resetPublisherForm(form);", submitPublisherIndex);
+    int successStatusIndex =
+        script.indexOf(
+            "setPublisherStatus(\n"
+                + "          `Local ${publisherLabel(sourceType)} insert handled:"
+                + " ${publisherInsertOutcome(data)}.`",
+            submitPublisherIndex);
+    int refreshQueueIndex =
+        script.indexOf("await showUploadQueueFromPublisher();", submitPublisherIndex);
+    int failureStatusIndex = script.indexOf("insert did not start:", submitPublisherIndex);
+    int bindPublisherIndex = script.indexOf("function bindPublisherInteractions()");
+    int fileSubmitIndex =
+        script.indexOf(
+            "publisherControls.fileForm.addEventListener(\"submit\", submitPublisherForm);",
+            bindPublisherIndex);
+    int directorySubmitIndex =
+        script.indexOf(
+            "publisherControls.directoryForm.addEventListener(\"submit\", submitPublisherForm);",
+            bindPublisherIndex);
+
+    assertTrue(submitPublisherIndex >= 0);
+    assertTrue(postFormIndex > submitPublisherIndex);
+    assertTrue(renderResultIndex > postFormIndex);
+    assertTrue(startedGuardIndex > renderResultIndex);
+    assertTrue(resetFormIndex > startedGuardIndex);
+    assertTrue(successStatusIndex > resetFormIndex);
+    assertTrue(refreshQueueIndex > successStatusIndex);
+    assertTrue(failureStatusIndex > refreshQueueIndex);
+    assertTrue(bindPublisherIndex >= 0);
+    assertTrue(fileSubmitIndex > bindPublisherIndex);
+    assertTrue(directorySubmitIndex > fileSubmitIndex);
   }
 
   private static void assertAlertsAndDiagnosticsMarkersPresent(String script) {

--- a/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyQueueSupportPort.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/admin/LegacyQueueSupportPort.java
@@ -1,7 +1,10 @@
 package network.crypta.runtime.admin;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
+import network.crypta.client.InsertContext.CompatibilityMode;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.runtime.admin.queue.QueueAdminBackend;
@@ -19,7 +22,10 @@ import network.crypta.runtime.spi.QueueSupportPort;
  * <p>The adapter does not attempt to normalize or reinterpret the daemon state. It forwards the
  * live checks in the same order the legacy queue code previously used, including the short-circuit
  * that avoids resolving persistence-broken path details while the node is still awaiting a password
- * or already stopping.
+ * or already stopping. It now also exposes the insert compatibility-mode policy that legacy HTTP
+ * already used indirectly through the shell runtime support, so the Platform API and queue toadlets
+ * resolve {@code COMPAT_CURRENT} and validate concrete historical modes against the same runtime
+ * source of truth.
  */
 final class LegacyQueueSupportPort implements QueueSupportPort {
   /** Shared daemon client core used to reach the live queue support state. */
@@ -51,6 +57,39 @@ final class LegacyQueueSupportPort implements QueueSupportPort {
   @Override
   public boolean isQueueBackendEnabled() {
     return queueBackend.isEnabled();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation derives the accepted names from the live runtime compatibility enum
+   * using the same normalization rules as the legacy HTTP insert forms.
+   *
+   * <p>The returned list keeps the runtime enum order after pseudo-values are interned to concrete
+   * modes and duplicate concrete names are removed. That means the list is suitable for direct UI
+   * display and API validation without a second normalization pass in higher layers.
+   */
+  @Override
+  public List<String> supportedInsertCompatibilityModes() {
+    return Arrays.stream(CompatibilityMode.values())
+        .map(CompatibilityMode::intern)
+        .filter(mode -> mode != CompatibilityMode.COMPAT_UNKNOWN)
+        .map(CompatibilityMode::name)
+        .distinct()
+        .toList();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation resolves the runtime's current insert default to a concrete mode name.
+   * The lookup intentionally follows {@link CompatibilityMode#COMPAT_DEFAULT} instead of {@link
+   * CompatibilityMode#latest()} so the queue APIs honor deliberate runtime policy choices when the
+   * default is pinned behind the newest available concrete mode.
+   */
+  @Override
+  public String defaultInsertCompatibilityMode() {
+    return CompatibilityMode.COMPAT_DEFAULT.intern().name();
   }
 
   /**

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueSupportPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/QueueSupportPort.java
@@ -1,6 +1,7 @@
 package network.crypta.runtime.spi;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Exposes the remaining queue support hooks still needed by the HTTP layer.
@@ -14,10 +15,14 @@ import java.io.IOException;
  * <p>The port is not a general queue-management API. Queue reads, queue creation, completed-list
  * tracking, and existing-request mutations stay on their dedicated ports. Implementations may still
  * consult live daemon objects internally, but callers should only rely on the detached contract
- * defined here.
+ * defined here. The insert-compatibility accessors also make this port the queue-side policy source
+ * of truth for higher layers that need to validate local insert requests. That keeps the Platform
+ * API and the legacy HTTP queue flow aligned even when the runtime changes which concrete
+ * compatibility mode is considered the default or which historical modes remain accepted.
  *
  * <ul>
  *   <li>Availability gating for the queue backend.
+ *   <li>Insert compatibility-mode choices derived from the live runtime policy.
  *   <li>Point-in-time persistence support state for queue error pages.
  *   <li>Start and finish hooks for the legacy panic workflow.
  * </ul>
@@ -36,6 +41,41 @@ public interface QueueSupportPort {
    * @return {@code true} when the live queue backend is enabled
    */
   boolean isQueueBackendEnabled();
+
+  /**
+   * Returns the concrete insert compatibility-mode names currently accepted by the runtime.
+   *
+   * <p>The returned list preserves the runtime's chosen display and validation order after
+   * normalizing pseudo-modes such as {@code COMPAT_CURRENT}. Callers should treat the list as the
+   * source of truth for validating user-supplied insert compatibility-mode names rather than
+   * hard-coding historic mode constants in higher layers.
+   *
+   * <p>Callers are expected to render or validate against this ordered list as-is. In particular,
+   * callers should not sort it, infer that the latest known mode must be the default, or assume
+   * that pseudo-modes such as {@code COMPAT_CURRENT} will appear in the result. Implementations may
+   * intentionally pin the default to an older concrete mode while still advertising newer concrete
+   * modes for explicit opt-in use.
+   *
+   * @return ordered concrete compatibility-mode names accepted for new inserts
+   */
+  List<String> supportedInsertCompatibilityModes();
+
+  /**
+   * Returns the current concrete default insert compatibility-mode name.
+   *
+   * <p>This value is the runtime-resolved default that callers should use when a higher layer
+   * accepts pseudo-values such as {@code COMPAT_CURRENT} or {@code COMPAT_DEFAULT}. The returned
+   * name is always concrete and may intentionally differ from the latest known compatibility mode.
+   *
+   * <p>Callers should use this value for expansion only after they have accepted a pseudo-mode from
+   * user input or configuration. They should not substitute it for every incoming value, because a
+   * user may explicitly request one of the older concrete modes listed by {@link
+   * #supportedInsertCompatibilityModes()} and expect that exact mode to reach the queue insert
+   * adapter unchanged.
+   *
+   * @return current concrete default insert compatibility-mode name
+   */
+  String defaultInsertCompatibilityMode();
 
   /**
    * Returns the current detached persistence-support status for the queue pages.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ rootProject.name = "cryptad"
 
 include(
   ":apps:queue-manager",
+  ":apps:publisher",
   ":foundation-support",
   ":foundation-store",
   ":foundation-store-contracts",

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -422,6 +422,23 @@ End
         bodyWrite.bodyText());
   }
 
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://localhost/api/v1/queue/inserts/file",
+        "http://localhost/api/v1/queue/inserts/directory",
+      })
+  void handleMethodPOST_whenQueueInsertPasswordMissing_expectJson403WithoutRouting(
+      String requestUri) throws Exception {
+    when(ctx.isAllowedFullAccess()).thenReturn(true);
+    when(ctx.hasFormPassword(request)).thenReturn(false);
+
+    toadlet.handleMethodPOST(URI.create(requestUri), request, ctx);
+
+    verifyNoInteractions(router);
+    assertForbiddenBody();
+  }
+
   @Test
   void handleMethodPOST_whenPeerMutationPasswordMissing_expectJson403WithoutRouting()
       throws Exception {

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -59,6 +59,11 @@ import network.crypta.runtime.spi.PeerVisibility;
 import network.crypta.runtime.spi.QueueCompletionPort;
 import network.crypta.runtime.spi.QueueDownloadPort;
 import network.crypta.runtime.spi.QueueDownloadRequest;
+import network.crypta.runtime.spi.QueueInsertOptions;
+import network.crypta.runtime.spi.QueueInsertOutcome;
+import network.crypta.runtime.spi.QueueInsertPort;
+import network.crypta.runtime.spi.QueueLocalDirectoryInsertRequest;
+import network.crypta.runtime.spi.QueueLocalFileInsertRequest;
 import network.crypta.runtime.spi.QueueMutationPort;
 import network.crypta.runtime.spi.QueuePagePort;
 import network.crypta.runtime.spi.QueuePageRequest;
@@ -118,6 +123,7 @@ class PlatformApiRouterTest {
   @Mock private QueuePagePort queuePagePort;
   @Mock private QueueMutationPort queueMutationPort;
   @Mock private QueueDownloadPort queueDownloadPort;
+  @Mock private QueueInsertPort queueInsertPort;
   @Mock private QueueSupportPort queueSupportPort;
   @Mock private QueueCompletionPort queueCompletionPort;
   @Mock private AlertFeedPort alertFeedPort;
@@ -142,11 +148,25 @@ class PlatformApiRouterTest {
     when(runtimePorts.queuePage()).thenReturn(queuePagePort);
     when(runtimePorts.queueMutation()).thenReturn(queueMutationPort);
     when(runtimePorts.queueDownload()).thenReturn(queueDownloadPort);
+    when(runtimePorts.queueInsert()).thenReturn(queueInsertPort);
     when(runtimePorts.queueSupport()).thenReturn(queueSupportPort);
     when(runtimePorts.queueCompletion()).thenReturn(queueCompletionPort);
     when(runtimePorts.alertFeed()).thenReturn(alertFeedPort);
     when(runtimePorts.alertMutation()).thenReturn(alertMutationPort);
     router = new PlatformApiRouter(runtimePorts, appHost);
+  }
+
+  private void stubQueueInsertCompatibilityModes() {
+    when(queueSupportPort.supportedInsertCompatibilityModes())
+        .thenReturn(
+            List.of(
+                "COMPAT_1468",
+                "COMPAT_1250_EXACT",
+                "COMPAT_1250",
+                "COMPAT_1251",
+                "COMPAT_1255",
+                "COMPAT_1416"));
+    when(queueSupportPort.defaultInsertCompatibilityMode()).thenReturn("COMPAT_1468");
   }
 
   @Test
@@ -1741,6 +1761,206 @@ class PlatformApiRouterTest {
                 Map.entry("filterData", true),
                 Map.entry("expectedMimeType", "text/plain"),
                 Map.entry("returnType", "direct"))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueLocalFileInsertRequested_expectCreatedJsonAndDetachedRequest()
+      throws Exception {
+    Path sourceFile = tempDir.resolve("publisher-file.txt");
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    stubQueueInsertCompatibilityModes();
+    when(queueInsertPort.enqueueLocalFileInsert(any())).thenReturn(QueueInsertOutcome.STARTED);
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("queue", "inserts", "file"),
+                Map.of(
+                    "sourcePath", List.of(sourceFile.toString()),
+                    "insertUri", List.of("SSK@publisher-file"),
+                    "identifier", List.of("publisher-file-1"),
+                    "contentType", List.of("text/plain"),
+                    "targetFilename", List.of("publisher-file.txt"),
+                    "compatibilityMode", List.of("COMPAT_CURRENT"),
+                    "compress", List.of("on"))));
+
+    verify(queueInsertPort)
+        .enqueueLocalFileInsert(
+            new QueueLocalFileInsertRequest(
+                sourceFile.toFile(),
+                "SSK@publisher-file",
+                "publisher-file-1",
+                "text/plain",
+                new QueueInsertOptions(true, "COMPAT_1468", null),
+                "publisher-file.txt"));
+    assertEquals(201, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(
+                Map.entry("operation", "create_local_file_insert"),
+                Map.entry("sourceType", "file"),
+                Map.entry("sourcePath", sourceFile.toString()),
+                Map.entry("insertUri", "SSK@publisher-file"),
+                Map.entry("identifier", "publisher-file-1"),
+                Map.entry("outcome", "STARTED"))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueLocalFileInsertRequestedWithoutContentType_expectCryptadGuessedMime()
+      throws Exception {
+    Path sourceFile = tempDir.resolve("image.avif");
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    stubQueueInsertCompatibilityModes();
+    when(queueInsertPort.enqueueLocalFileInsert(any())).thenReturn(QueueInsertOutcome.STARTED);
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("queue", "inserts", "file"),
+                Map.of(
+                    "sourcePath", List.of(sourceFile.toString()),
+                    "insertUri", List.of("CHK@"),
+                    "identifier", List.of("publisher-file-2"),
+                    "compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    verify(queueInsertPort)
+        .enqueueLocalFileInsert(
+            new QueueLocalFileInsertRequest(
+                sourceFile.toFile(),
+                "CHK@",
+                "publisher-file-2",
+                "image/avif",
+                new QueueInsertOptions(false, "COMPAT_1468", null),
+                "image.avif"));
+    assertEquals(201, response.statusCode());
+  }
+
+  @Test
+  void
+      route_whenQueueLocalFileInsertRequestedWithDocnamedUriAndTargetFilename_expectTargetSuppressed()
+          throws Exception {
+    Path sourceFile = tempDir.resolve("publisher-file.txt");
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    stubQueueInsertCompatibilityModes();
+    when(queueInsertPort.enqueueLocalFileInsert(any())).thenReturn(QueueInsertOutcome.STARTED);
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("queue", "inserts", "file"),
+                Map.of(
+                    "sourcePath", List.of(sourceFile.toString()),
+                    "insertUri", List.of("KSK@site-name"),
+                    "identifier", List.of("publisher-file-3"),
+                    "targetFilename", List.of("ignored-name.txt"),
+                    "compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    verify(queueInsertPort)
+        .enqueueLocalFileInsert(
+            new QueueLocalFileInsertRequest(
+                sourceFile.toFile(),
+                "KSK@site-name",
+                "publisher-file-3",
+                "text/plain",
+                new QueueInsertOptions(false, "COMPAT_1468", null),
+                null));
+    assertEquals(201, response.statusCode());
+  }
+
+  @Test
+  void route_whenQueueLocalFileInsertRequestedWithMalformedContentType_expectBadRequest()
+      throws Exception {
+    Path sourceFile = tempDir.resolve("publisher-file.txt");
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("queue", "inserts", "file"),
+                Map.of(
+                    "sourcePath", List.of(sourceFile.toString()),
+                    "insertUri", List.of("CHK@"),
+                    "identifier", List.of("publisher-file-4"),
+                    "contentType", List.of("textplain"),
+                    "compatibilityMode", List.of("COMPAT_CURRENT"))));
+
+    verify(queueInsertPort, never()).enqueueLocalFileInsert(any());
+    assertEquals(400, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_query_parameter\",\"message\":\"Query parameter"
+            + " 'contentType' must be a plausible MIME type.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueLocalDirectoryInsertRequested_expectCreatedJsonAndDetachedRequest()
+      throws Exception {
+    Path sourceDirectory = tempDir.resolve("publisher-site");
+    when(queueSupportPort.isQueueBackendEnabled()).thenReturn(true);
+    stubQueueInsertCompatibilityModes();
+    when(queueInsertPort.enqueueLocalDirectoryInsert(any()))
+        .thenReturn(QueueInsertOutcome.IDENTIFIER_COLLISION);
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("queue", "inserts", "directory"),
+                Map.of(
+                    "sourcePath", List.of(sourceDirectory.toString()),
+                    "insertUri", List.of("SSK@publisher-site"),
+                    "identifier", List.of("publisher-dir-1"),
+                    "compatibilityMode", List.of("COMPAT_1468"),
+                    "compress", List.of("false"))));
+
+    verify(queueInsertPort)
+        .enqueueLocalDirectoryInsert(
+            new QueueLocalDirectoryInsertRequest(
+                sourceDirectory.toFile(),
+                "SSK@publisher-site",
+                "publisher-dir-1",
+                new QueueInsertOptions(false, "COMPAT_1468", null)));
+    assertEquals(201, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            orderedJson(
+                Map.entry("operation", "create_local_directory_insert"),
+                Map.entry("sourceType", "directory"),
+                Map.entry("sourcePath", sourceDirectory.toString()),
+                Map.entry("insertUri", "SSK@publisher-site"),
+                Map.entry("identifier", "publisher-dir-1"),
+                Map.entry("outcome", "IDENTIFIER_COLLISION"))),
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueLocalFileInsertRequestedWithGet_expectMethodNotAllowed() {
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("queue", "inserts", "file"), Map.of()));
+
+    assertEquals(405, response.statusCode());
+    assertEquals(Map.of("Allow", "POST"), response.headers());
+    assertEquals(
+        "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Platform API v1 supports POST"
+            + " requests only.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenQueueLocalDirectoryInsertRequestedWithGet_expectMethodNotAllowed() {
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("queue", "inserts", "directory"), Map.of()));
+
+    assertEquals(405, response.statusCode());
+    assertEquals(Map.of("Allow", "POST"), response.headers());
+    assertEquals(
+        "{\"error\":{\"code\":\"method_not_allowed\",\"message\":\"Platform API v1 supports POST"
+            + " requests only.\"}}",
         response.body());
   }
 

--- a/src/test/java/network/crypta/runtime/admin/LegacyQueueSupportPortTest.java
+++ b/src/test/java/network/crypta/runtime/admin/LegacyQueueSupportPortTest.java
@@ -2,6 +2,7 @@ package network.crypta.runtime.admin;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.List;
 import network.crypta.node.Node;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.subsystem.NodeStorageSubsystem;
@@ -48,6 +49,24 @@ class LegacyQueueSupportPortTest {
 
     assertTrue(port.isQueueBackendEnabled());
     assertFalse(port.isQueueBackendEnabled());
+  }
+
+  @Test
+  void supportedInsertCompatibilityModes_whenQueried_returnsConcreteRuntimeModes() {
+    assertEquals(
+        List.of(
+            "COMPAT_1468",
+            "COMPAT_1250_EXACT",
+            "COMPAT_1250",
+            "COMPAT_1251",
+            "COMPAT_1255",
+            "COMPAT_1416"),
+        port.supportedInsertCompatibilityModes());
+  }
+
+  @Test
+  void defaultInsertCompatibilityMode_whenQueried_returnsConcreteRuntimeDefault() {
+    assertEquals("COMPAT_1468", port.defaultInsertCompatibilityMode());
   }
 
   @Test

--- a/src/test/java/network/crypta/support/MediaTypeTest.java
+++ b/src/test/java/network/crypta/support/MediaTypeTest.java
@@ -26,6 +26,26 @@ class MediaTypeTest {
       MIME_TEXT_HTML + "; " + PARAM_CHARSET + "=" + CHARSET_UTF8;
 
   @Test
+  @DisplayName("guessMIMEType uses Cryptad registry for extensions missing from JDK tables")
+  void guessMIMEType_whenCryptadOnlyExtension_expectRegistryMime() {
+    // Arrange + Act
+    String mimeType = MediaType.guessMIMEType("image.avif");
+
+    // Assert
+    assertEquals("image/avif", mimeType);
+  }
+
+  @Test
+  @DisplayName("guessMIMEType falls back to Cryptad default binary type")
+  void guessMIMEType_whenUnknownExtension_expectDefaultMime() {
+    // Arrange + Act
+    String mimeType = MediaType.guessMIMEType("artifact.unknownext");
+
+    // Assert
+    assertEquals("application/octet-stream", mimeType);
+  }
+
+  @Test
   @DisplayName("parse constructor: simple type/subtype without parameters")
   void constructor_whenSimpleType_expectParsedCorrectly() throws Exception {
     // Arrange & Act


### PR DESCRIPTION
## Summary

- add the first-party `:apps:publisher` staged AppHost bundle and wire it into `stageFirstPartyApps`
- extend the Platform API queue surface with local file and directory insert creation
- add the shell-native Publisher section and point the staged app UI entry at `#/publisher`
- preserve legacy queue semantics for filename handling, MIME inference, redirect-only insert outcomes, and runtime-derived compatibility-mode policy
- add focused tests for app staging, queue insert handling, router wiring, runtime queue support policy, media-type lookup, and Web Shell publisher resources

## What changed

### First-party app
- added `apps/publisher` with staged manifest, launcher, static readme, module build, and staging test
- added `:apps:publisher` to `settings.gradle.kts`
- updated root `stageFirstPartyApps` wiring so `queue-manager` and `publisher` are both staged

### Platform API
- added `POST /api/v1/queue/inserts/file`
- added `POST /api/v1/queue/inserts/directory`
- file parameters: `sourcePath`, `insertUri`, `identifier`, `compatibilityMode`, optional `compress`, optional `contentType`, optional `targetFilename`
- directory parameters: `sourcePath`, `insertUri`, `identifier`, `compatibilityMode`, optional `compress`
- local file insert handling now matches legacy queue behavior for:
  - inferred MIME types
  - suppressing `targetFilename` for docnamed insert URIs
  - redirect-only outcomes
  - runtime-provided compatibility-mode validation and default expansion

### Web Shell
- added the shell-native Publisher section with file and directory publish forms
- wired Publisher mutations to the new queue insert API endpoints
- treated `STARTED`, `IDENTIFIER_COLLISION`, and `METADATA_UNRESOLVED` as the accepted legacy queue outcomes

## Tests

- added `PublisherBundleStagingTest`
- extended `QueueApiHandlerTest`
- extended `PlatformApiRouterTest`
- extended `LegacyQueueSupportPortTest`
- extended `MediaTypeTest`
- extended `WebShellResourcesTest`
- extended `WebShellPageRendererTest`

## Validation

Ran:

```bash
./gradlew stageFirstPartyApps test
./gradlew :platform-api:test --tests 'network.crypta.platform.api.queue.QueueApiHandlerTest'
```

Additional focused validation also passed while iterating on the queue insert and shell changes, including the Platform API router slice and Web Shell tests.

## Deferred / non-goals

This PR does not implement:

- signed app bundles
- signed catalogs
- remote catalog fetch
- app proxying
- app-owned static asset serving through AppHost
- browser multipart upload publishing
- freesite editor UX
- SSK/USK key generation beyond user-supplied insert URIs
- interop gate changes
- replacement of legacy InsertFreesite/FProxy pages
- `overrideSplitfileCryptoKey` support on the new insert endpoints
