### PR TITLE
feat(appdist): Add signed app distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ data, and serves applications.
 - [Overview](#overview)
 - [Quick Start](#quick-start)
 - [Building](#building)
+- [Signed App Bundles](#signed-app-bundles)
 - [Testing](#testing)
 - [Code Quality](#code-quality)
 - [Running Your Build](#running-your-build)
@@ -320,6 +321,35 @@ Cryptad now uses a partial multi-project Gradle build.
 The wrapper validates the distribution URL (`validateDistributionUrl=true` in
 `gradle/wrapper/gradle-wrapper.properties`). To also verify the download by checksum, add
 `distributionSha256Sum=<sha256>` for the chosen Gradle distribution.
+
+## Signed App Bundles
+
+PR-192 keeps `stageApp` unsigned by default and adds local signing and verification tasks for first-party AppHost bundles.
+
+Common commands:
+
+```bash
+./gradlew stageFirstPartyApps
+./gradlew signFirstPartyApps \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem
+./gradlew verifyFirstPartyApps \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPublicKeyFile=/abs/path/to/dev-app-signing-public.pem
+```
+
+Signed staged bundles add `cryptad-app.digests` and `cryptad-app.signature` at the bundle root. The digest uses deterministic SHA-256 file entries, and the signature uses Ed25519 over the exact digest sidecar bytes.
+
+Production-facing installs reject unsigned bundles by default. To install signed bundles through a
+live node, configure a trusted public key with `CRYPTAD_APPHOST_TRUSTED_KEY_ID` plus
+`CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_BASE64` or `CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_FILE`, or use
+`CRYPTAD_APPHOST_TRUSTED_KEYS_FILE`. `CRYPTAD_APPHOST_ALLOW_UNSIGNED=true` is an explicit
+development-only escape hatch for unsigned local testing.
+
+Do not commit production private signing keys to this repository. Keep local development keys
+outside the repo and pass them through Gradle properties or environment variables. Remote catalogs
+and remote downloads are future work. See [docs/app-distribution.md](docs/app-distribution.md) for
+the full workflow and exact signing inputs.
 
 ## Testing
 
@@ -744,8 +774,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 - For developer testing, replacing `build/libs/cryptad.jar` manually (as noted above) is fine; for production use CoreUpdater and platform packages.
 - Local app lifecycle work is separate from CoreUpdater. The current platform can install, start,
   stop, uninstall, and replace an installed app bundle from a caller-supplied local staged
-  directory through `:platform-apphost` and the Platform API v1. Remote catalogs, signed app
-  channels, and background app-update fetching remain future work.
+  directory through `:platform-apphost` and the Platform API v1. Signed local staged bundles are
+  now supported; remote catalogs, remote downloads, and background app-update fetching remain
+  future work.
 
 ## Architecture Overview
 

--- a/apps/publisher/README.md
+++ b/apps/publisher/README.md
@@ -8,6 +8,22 @@ Build the staged bundle with:
 ./gradlew :apps:publisher:stageApp
 ```
 
+`stageApp` stays unsigned by default. Add the PR-192 local sidecars with:
+
+```bash
+./gradlew :apps:publisher:signApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem
+```
+
+Verify the signed staged bundle with:
+
+```bash
+./gradlew :apps:publisher:verifyApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPublicKeyFile=/abs/path/to/dev-app-signing-public.pem
+```
+
 The staged output is written to:
 
 ```text
@@ -20,9 +36,17 @@ The staged bundle contains:
 cryptad-app.properties
 bin/publisher.sh
 static/README.txt
+cryptad-app.digests          # after signApp
+cryptad-app.signature        # after signApp
 ```
 
 Install it through the existing Platform API by passing the absolute staged directory path:
+
+For the default production-like path, start the node with the matching trusted public key
+configured, for example `CRYPTAD_APPHOST_TRUSTED_KEY_ID=dev-local` plus
+`CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_FILE=/abs/path/to/dev-app-signing-public.pem`. Use
+`CRYPTAD_APPHOST_ALLOW_UNSIGNED=true` only for explicit local development/testing of unsigned
+bundles.
 
 ```bash
 curl -X POST \
@@ -41,9 +65,11 @@ curl -X POST --data-urlencode "formPassword=<token>" \
   http://127.0.0.1:<port>/api/v1/apps/publisher/stop
 ```
 
-The bundle intentionally stays conservative in PR-191:
+The bundle intentionally stays conservative in PR-192:
 
-- Signed app bundles and remote catalogs are deferred.
+- Local signed staged bundles are supported. Remote catalogs and remote downloads are deferred.
 - App proxying and app-owned static serving are deferred.
 - The bundle points `app.ui.entry` at the shell-native publisher route: `/app/node/#publisher`.
 - The launcher is a POSIX shell script; Windows-specific first-party app launch packaging remains deferred.
+
+See [docs/app-distribution.md](../../docs/app-distribution.md) for the exact signing inputs and the shared first-party app workflow.

--- a/apps/publisher/build.gradle.kts
+++ b/apps/publisher/build.gradle.kts
@@ -10,16 +10,102 @@ plugins {
 
 version = rootProject.version
 
+val appDisplayName = "Publisher"
+val appId = "publisher"
+val appDistMainClass = "network.crypta.platform.appdist.AppDistributionTool"
 val mainSourceSet = sourceSets.named("main")
-val stageAppDir = layout.buildDirectory.dir("cryptad-app/publisher")
+val appDistCli by configurations.creating
+val stageAppDir = layout.buildDirectory.dir("cryptad-app/$appId")
 val generatedManifestDir = layout.buildDirectory.dir("generated/stageApp")
 val stageAssetsDir = layout.projectDirectory.dir("src/staged")
 val manifestTemplateFile = stageAssetsDir.file("cryptad-app.properties.template")
 val launcherRelativePath = "bin/publisher.sh"
+val appDistPrivateKeyEnvironmentName = "CRYPTAD_APP_DIST_PRIVATE_KEY_BASE64"
 val stagedLauncher =
   stageAppDir.map { stageDirectory -> stageDirectory.file(launcherRelativePath).asFile.toPath() }
 
+fun Project.optionalSigningInput(propertyName: String, environmentName: String): String? =
+  providers
+    .gradleProperty(propertyName)
+    .orElse(providers.environmentVariable(environmentName))
+    .orNull
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
+
+fun Project.requiredSigningInput(
+  propertyName: String,
+  environmentName: String,
+  taskName: String,
+): String =
+  optionalSigningInput(propertyName, environmentName)
+    ?: throw GradleException("$taskName requires -P$propertyName or $environmentName to be set.")
+
+fun Project.addPrivateKeyArguments(
+  task: JavaExec,
+  taskName: String,
+  arguments: MutableList<String>,
+) {
+  val privateKeyBase64 =
+    optionalSigningInput(
+      "cryptadAppSigningPrivateKeyBase64",
+      "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64",
+    )
+  val privateKeyFile =
+    optionalSigningInput("cryptadAppSigningPrivateKeyFile", "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE")
+  when {
+    privateKeyBase64 != null && privateKeyFile != null ->
+      throw GradleException(
+        "$taskName requires app signing private key material from " +
+          "exactly one of -PcryptadAppSigningPrivateKeyBase64 / " +
+          "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64 or -PcryptadAppSigningPrivateKeyFile / " +
+          "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE."
+      )
+    privateKeyBase64 != null -> {
+      task.environment(appDistPrivateKeyEnvironmentName, privateKeyBase64)
+      arguments += listOf("--private-key-env", appDistPrivateKeyEnvironmentName)
+    }
+    privateKeyFile != null ->
+      arguments += listOf("--private-key-file", file(privateKeyFile).absolutePath)
+    else ->
+      throw GradleException(
+        "$taskName requires app signing private key material via " +
+          "-PcryptadAppSigningPrivateKeyBase64 / CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64 or " +
+          "-PcryptadAppSigningPrivateKeyFile / CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE."
+      )
+  }
+}
+
+fun Project.addPublicKeyArguments(taskName: String, arguments: MutableList<String>) {
+  val publicKeyBase64 =
+    optionalSigningInput(
+      "cryptadAppSigningPublicKeyBase64",
+      "CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64",
+    )
+  val publicKeyFile =
+    optionalSigningInput("cryptadAppSigningPublicKeyFile", "CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE")
+  when {
+    publicKeyBase64 != null && publicKeyFile != null ->
+      throw GradleException(
+        "$taskName requires app signing public key material from " +
+          "exactly one of -PcryptadAppSigningPublicKeyBase64 / " +
+          "CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64 or -PcryptadAppSigningPublicKeyFile / " +
+          "CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE."
+      )
+    publicKeyBase64 != null -> arguments += listOf("--trusted-public-key-base64", publicKeyBase64)
+    publicKeyFile != null ->
+      arguments += listOf("--trusted-public-key-file", file(publicKeyFile).absolutePath)
+    else ->
+      throw GradleException(
+        "$taskName requires app signing public key material via " +
+          "-PcryptadAppSigningPublicKeyBase64 / CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64 or " +
+          "-PcryptadAppSigningPublicKeyFile / CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE."
+      )
+  }
+}
+
 dependencies {
+  appDistCli(project(":platform-appdist"))
+
   testImplementation(mainSourceSet.map { it.output })
   testImplementation(project(":platform-apphost"))
   testImplementation(libs.junitJupiterApi)
@@ -40,7 +126,7 @@ val generateManifest by
 val stageApp by
   tasks.registering(Sync::class) {
     group = "build"
-    description = "Stages the Publisher AppHost bundle."
+    description = "Stages the $appDisplayName AppHost bundle."
     dependsOn(generateManifest)
     into(stageAppDir)
     from(stageAssetsDir) { exclude("cryptad-app.properties.template") }
@@ -52,6 +138,53 @@ val stageApp by
       ) {
         Files.setPosixFilePermissions(launcher, PosixFilePermissions.fromString("rwxr-xr-x"))
       }
+    }
+  }
+
+val signApp by
+  tasks.registering(JavaExec::class) {
+    group = "build"
+    description = "Signs the staged $appDisplayName AppHost bundle."
+    dependsOn(stageApp)
+    classpath = appDistCli
+    mainClass.set(appDistMainClass)
+    inputs
+      .dir(stageAppDir)
+      .withPropertyName("publisherStagedBundleForSigning")
+      .withPathSensitivity(PathSensitivity.RELATIVE)
+    doFirst {
+      val signingTask = this as JavaExec
+      val arguments = mutableListOf("sign", "--bundle-dir", stageAppDir.get().asFile.absolutePath)
+      arguments +=
+        listOf(
+          "--key-id",
+          requiredSigningInput("cryptadAppSigningKeyId", "CRYPTAD_APP_SIGNING_KEY_ID", name),
+        )
+      addPrivateKeyArguments(signingTask, name, arguments)
+      setArgs(arguments)
+    }
+  }
+
+val verifyApp by
+  tasks.registering(JavaExec::class) {
+    group = "verification"
+    description = "Verifies the signed staged $appDisplayName AppHost bundle."
+    mustRunAfter(signApp)
+    classpath = appDistCli
+    mainClass.set(appDistMainClass)
+    inputs
+      .dir(stageAppDir)
+      .withPropertyName("publisherStagedBundleForVerification")
+      .withPathSensitivity(PathSensitivity.RELATIVE)
+    doFirst {
+      val arguments = mutableListOf("verify", "--bundle-dir", stageAppDir.get().asFile.absolutePath)
+      arguments +=
+        listOf(
+          "--trusted-key-id",
+          requiredSigningInput("cryptadAppSigningKeyId", "CRYPTAD_APP_SIGNING_KEY_ID", name),
+        )
+      addPublicKeyArguments(name, arguments)
+      setArgs(arguments)
     }
   }
 

--- a/apps/queue-manager/README.md
+++ b/apps/queue-manager/README.md
@@ -8,6 +8,22 @@ Build the staged bundle with:
 ./gradlew :apps:queue-manager:stageApp
 ```
 
+`stageApp` stays unsigned by default. Add the PR-192 local sidecars with:
+
+```bash
+./gradlew :apps:queue-manager:signApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem
+```
+
+Verify the signed staged bundle with:
+
+```bash
+./gradlew :apps:queue-manager:verifyApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPublicKeyFile=/abs/path/to/dev-app-signing-public.pem
+```
+
 The staged output is written to:
 
 ```text
@@ -20,9 +36,17 @@ The staged bundle contains:
 cryptad-app.properties
 bin/queue-manager.sh
 static/README.txt
+cryptad-app.digests          # after signApp
+cryptad-app.signature        # after signApp
 ```
 
 Install it through the existing Platform API by passing the absolute staged directory path:
+
+For the default production-like path, start the node with the matching trusted public key
+configured, for example `CRYPTAD_APPHOST_TRUSTED_KEY_ID=dev-local` plus
+`CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_FILE=/abs/path/to/dev-app-signing-public.pem`. Use
+`CRYPTAD_APPHOST_ALLOW_UNSIGNED=true` only for explicit local development/testing of unsigned
+bundles.
 
 ```bash
 curl -X POST \
@@ -41,9 +65,11 @@ curl -X POST --data-urlencode "formPassword=<token>" \
   http://127.0.0.1:<port>/api/v1/apps/queue-manager/stop
 ```
 
-The bundle intentionally stays conservative in PR-190:
+The bundle intentionally stays conservative in PR-192:
 
-- Signed app bundles and remote catalogs are deferred.
+- Local signed staged bundles are supported. Remote catalogs and remote downloads are deferred.
 - App proxying and app-owned static serving are deferred.
 - The bundle points `app.ui.entry` at the existing shell-native queue route: `/app/node/#queue`.
 - The launcher is a POSIX shell script; Windows-specific first-party app launch packaging remains deferred.
+
+See [docs/app-distribution.md](../../docs/app-distribution.md) for the exact signing inputs and the shared first-party app workflow.

--- a/apps/queue-manager/build.gradle.kts
+++ b/apps/queue-manager/build.gradle.kts
@@ -10,16 +10,102 @@ plugins {
 
 version = rootProject.version
 
+val appDisplayName = "Queue Manager"
+val appId = "queue-manager"
+val appDistMainClass = "network.crypta.platform.appdist.AppDistributionTool"
 val mainSourceSet = sourceSets.named("main")
-val stageAppDir = layout.buildDirectory.dir("cryptad-app/queue-manager")
+val appDistCli by configurations.creating
+val stageAppDir = layout.buildDirectory.dir("cryptad-app/$appId")
 val generatedManifestDir = layout.buildDirectory.dir("generated/stageApp")
 val stageAssetsDir = layout.projectDirectory.dir("src/staged")
 val manifestTemplateFile = stageAssetsDir.file("cryptad-app.properties.template")
 val launcherRelativePath = "bin/queue-manager.sh"
+val appDistPrivateKeyEnvironmentName = "CRYPTAD_APP_DIST_PRIVATE_KEY_BASE64"
 val stagedLauncher =
   stageAppDir.map { stageDirectory -> stageDirectory.file(launcherRelativePath).asFile.toPath() }
 
+fun Project.optionalSigningInput(propertyName: String, environmentName: String): String? =
+  providers
+    .gradleProperty(propertyName)
+    .orElse(providers.environmentVariable(environmentName))
+    .orNull
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
+
+fun Project.requiredSigningInput(
+  propertyName: String,
+  environmentName: String,
+  taskName: String,
+): String =
+  optionalSigningInput(propertyName, environmentName)
+    ?: throw GradleException("$taskName requires -P$propertyName or $environmentName to be set.")
+
+fun Project.addPrivateKeyArguments(
+  task: JavaExec,
+  taskName: String,
+  arguments: MutableList<String>,
+) {
+  val privateKeyBase64 =
+    optionalSigningInput(
+      "cryptadAppSigningPrivateKeyBase64",
+      "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64",
+    )
+  val privateKeyFile =
+    optionalSigningInput("cryptadAppSigningPrivateKeyFile", "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE")
+  when {
+    privateKeyBase64 != null && privateKeyFile != null ->
+      throw GradleException(
+        "$taskName requires app signing private key material from " +
+          "exactly one of -PcryptadAppSigningPrivateKeyBase64 / " +
+          "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64 or -PcryptadAppSigningPrivateKeyFile / " +
+          "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE."
+      )
+    privateKeyBase64 != null -> {
+      task.environment(appDistPrivateKeyEnvironmentName, privateKeyBase64)
+      arguments += listOf("--private-key-env", appDistPrivateKeyEnvironmentName)
+    }
+    privateKeyFile != null ->
+      arguments += listOf("--private-key-file", file(privateKeyFile).absolutePath)
+    else ->
+      throw GradleException(
+        "$taskName requires app signing private key material via " +
+          "-PcryptadAppSigningPrivateKeyBase64 / CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64 or " +
+          "-PcryptadAppSigningPrivateKeyFile / CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE."
+      )
+  }
+}
+
+fun Project.addPublicKeyArguments(taskName: String, arguments: MutableList<String>) {
+  val publicKeyBase64 =
+    optionalSigningInput(
+      "cryptadAppSigningPublicKeyBase64",
+      "CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64",
+    )
+  val publicKeyFile =
+    optionalSigningInput("cryptadAppSigningPublicKeyFile", "CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE")
+  when {
+    publicKeyBase64 != null && publicKeyFile != null ->
+      throw GradleException(
+        "$taskName requires app signing public key material from " +
+          "exactly one of -PcryptadAppSigningPublicKeyBase64 / " +
+          "CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64 or -PcryptadAppSigningPublicKeyFile / " +
+          "CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE."
+      )
+    publicKeyBase64 != null -> arguments += listOf("--trusted-public-key-base64", publicKeyBase64)
+    publicKeyFile != null ->
+      arguments += listOf("--trusted-public-key-file", file(publicKeyFile).absolutePath)
+    else ->
+      throw GradleException(
+        "$taskName requires app signing public key material via " +
+          "-PcryptadAppSigningPublicKeyBase64 / CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64 or " +
+          "-PcryptadAppSigningPublicKeyFile / CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE."
+      )
+  }
+}
+
 dependencies {
+  appDistCli(project(":platform-appdist"))
+
   testImplementation(mainSourceSet.map { it.output })
   testImplementation(project(":platform-apphost"))
   testImplementation(libs.junitJupiterApi)
@@ -40,7 +126,7 @@ val generateManifest by
 val stageApp by
   tasks.registering(Sync::class) {
     group = "build"
-    description = "Stages the Queue Manager AppHost bundle."
+    description = "Stages the $appDisplayName AppHost bundle."
     dependsOn(generateManifest)
     into(stageAppDir)
     from(stageAssetsDir) { exclude("cryptad-app.properties.template") }
@@ -52,6 +138,53 @@ val stageApp by
       ) {
         Files.setPosixFilePermissions(launcher, PosixFilePermissions.fromString("rwxr-xr-x"))
       }
+    }
+  }
+
+val signApp by
+  tasks.registering(JavaExec::class) {
+    group = "build"
+    description = "Signs the staged $appDisplayName AppHost bundle."
+    dependsOn(stageApp)
+    classpath = appDistCli
+    mainClass.set(appDistMainClass)
+    inputs
+      .dir(stageAppDir)
+      .withPropertyName("queueManagerStagedBundleForSigning")
+      .withPathSensitivity(PathSensitivity.RELATIVE)
+    doFirst {
+      val signingTask = this as JavaExec
+      val arguments = mutableListOf("sign", "--bundle-dir", stageAppDir.get().asFile.absolutePath)
+      arguments +=
+        listOf(
+          "--key-id",
+          requiredSigningInput("cryptadAppSigningKeyId", "CRYPTAD_APP_SIGNING_KEY_ID", name),
+        )
+      addPrivateKeyArguments(signingTask, name, arguments)
+      setArgs(arguments)
+    }
+  }
+
+val verifyApp by
+  tasks.registering(JavaExec::class) {
+    group = "verification"
+    description = "Verifies the signed staged $appDisplayName AppHost bundle."
+    mustRunAfter(signApp)
+    classpath = appDistCli
+    mainClass.set(appDistMainClass)
+    inputs
+      .dir(stageAppDir)
+      .withPropertyName("queueManagerStagedBundleForVerification")
+      .withPathSensitivity(PathSensitivity.RELATIVE)
+    doFirst {
+      val arguments = mutableListOf("verify", "--bundle-dir", stageAppDir.get().asFile.absolutePath)
+      arguments +=
+        listOf(
+          "--trusted-key-id",
+          requiredSigningInput("cryptadAppSigningKeyId", "CRYPTAD_APP_SIGNING_KEY_ID", name),
+        )
+      addPublicKeyArguments(name, arguments)
+      setArgs(arguments)
     }
   }
 

--- a/bridge-http-runtime/build.gradle.kts
+++ b/bridge-http-runtime/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation(project(":foundation-crypto-keys"))
   implementation(project(":kernel-content"))
   implementation(project(":kernel-routing"))
+  implementation(project(":platform-appdist"))
   implementation(project(":runtime-alerts"))
   implementation(project(":runtime-spi"))
   implementation(project(":platform-apphost"))

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -2,6 +2,10 @@ package network.crypta.clients.http.bridge;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Objects;
 import network.crypta.client.InsertContext.CompatibilityMode;
@@ -24,8 +28,16 @@ import network.crypta.node.RequestPriorityClasses;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.platform.appdist.AppBundleDigest;
+import network.crypta.platform.appdist.AppBundleSignature;
+import network.crypta.platform.appdist.AppBundleVerifier;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appdist.TrustedAppKey;
+import network.crypta.platform.appdist.TrustedAppKeys;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostConfigurationException;
 import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.AppInstallVerificationPolicy;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
 import network.crypta.runtime.alerts.UserAlertSurface;
@@ -50,6 +62,22 @@ import org.slf4j.LoggerFactory;
 public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
     implements network.crypta.runtime.http.HttpShellRuntimeSupport, HttpShellRuntimeSupport {
   private static final Logger LOG = LoggerFactory.getLogger(CoreHttpShellRuntimeSupport.class);
+  private static final String APPHOST_ALLOW_UNSIGNED_PROPERTY = "cryptad.apphost.allowUnsigned";
+  private static final String APPHOST_ALLOW_UNSIGNED_ENV = "CRYPTAD_APPHOST_ALLOW_UNSIGNED";
+  private static final String TRUSTED_KEYS_FILE_PROPERTY = "cryptad.apphost.trustedKeysFile";
+  private static final String TRUSTED_KEYS_FILE_ENV = "CRYPTAD_APPHOST_TRUSTED_KEYS_FILE";
+  private static final String TRUSTED_KEY_ID_PROPERTY = "cryptad.apphost.trustedKeyId";
+  private static final String TRUSTED_KEY_ID_ENV = "CRYPTAD_APPHOST_TRUSTED_KEY_ID";
+  private static final String TRUSTED_PUBLIC_KEY_BASE64_PROPERTY =
+      "cryptad.apphost.trustedPublicKeyBase64";
+  private static final String TRUSTED_PUBLIC_KEY_BASE64_ENV =
+      "CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_BASE64";
+  private static final String TRUSTED_PUBLIC_KEY_FILE_PROPERTY =
+      "cryptad.apphost.trustedPublicKeyFile";
+  private static final String TRUSTED_PUBLIC_KEY_FILE_ENV =
+      "CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_FILE";
+  private static final String TRUST_CONFIGURATION_ERROR_MESSAGE =
+      "Failed to load trusted app verification configuration.";
 
   /**
    * Creates a core-backed HTTP runtime adapter.
@@ -84,11 +112,6 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
   @Override
   public Config config() {
     return core.getNode().getConfig();
-  }
-
-  @Override
-  public AppHost appHost() {
-    return appHost;
   }
 
   @Override
@@ -245,8 +268,150 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
         new AppHostLayout(
             core.getNode().nodeDir().dir().toPath(),
             core.getPersistentTempDir().toPath(),
-            core.getNode().runDir().dir().toPath()));
+            core.getNode().runDir().dir().toPath()),
+        createInstallVerificationPolicy());
   }
+
+  private static AppInstallVerificationPolicy createInstallVerificationPolicy() {
+    AppHostTrustConfiguration trustConfiguration = readTrustConfiguration();
+    AppInstallVerificationPolicy.CopiedBundleVerifier verifier =
+        copiedBundleDirectory ->
+            verifyBundleAgainstConfiguredTrust(copiedBundleDirectory, trustConfiguration);
+    return trustConfiguration.allowUnsigned()
+        ? AppInstallVerificationPolicy.allowUnsignedForDevelopmentOnly(verifier)
+        : AppInstallVerificationPolicy.requireSigned(verifier);
+  }
+
+  private static void verifyBundleAgainstConfiguredTrust(
+      Path copiedBundleDirectory, AppHostTrustConfiguration trustConfiguration) throws IOException {
+    if (trustConfiguration.allowUnsigned()
+        && bundleHasNoDistributionSidecars(copiedBundleDirectory)) {
+      return;
+    }
+    AppBundleVerifier verifier;
+    try {
+      verifier = createBundleVerifier(trustConfiguration);
+    } catch (RuntimeException exception) {
+      throw new AppHostConfigurationException(
+          messageOrTrustConfigurationDefault(exception), exception);
+    }
+    verifier.verify(copiedBundleDirectory);
+  }
+
+  private static boolean bundleHasNoDistributionSidecars(Path copiedBundleDirectory) {
+    Path bundleRoot = copiedBundleDirectory.toAbsolutePath().normalize();
+    return !Files.exists(
+            bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), LinkOption.NOFOLLOW_LINKS)
+        && !Files.exists(
+            bundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME), LinkOption.NOFOLLOW_LINKS);
+  }
+
+  private static AppBundleVerifier createBundleVerifier(
+      AppHostTrustConfiguration trustConfiguration) {
+    TrustedAppKeys trustedKeys = loadTrustedAppKeys(trustConfiguration);
+    return trustConfiguration.allowUnsigned()
+        ? AppBundleVerifier.allowUnsignedForDevelopmentOnly(trustedKeys)
+        : AppBundleVerifier.requireSigned(trustedKeys);
+  }
+
+  private static AppHostTrustConfiguration readTrustConfiguration() {
+    return new AppHostTrustConfiguration(
+        allowUnsignedBundles(),
+        configuredValue(TRUSTED_KEYS_FILE_PROPERTY, TRUSTED_KEYS_FILE_ENV),
+        configuredValue(TRUSTED_KEY_ID_PROPERTY, TRUSTED_KEY_ID_ENV),
+        configuredValue(TRUSTED_PUBLIC_KEY_BASE64_PROPERTY, TRUSTED_PUBLIC_KEY_BASE64_ENV),
+        configuredValue(TRUSTED_PUBLIC_KEY_FILE_PROPERTY, TRUSTED_PUBLIC_KEY_FILE_ENV));
+  }
+
+  private static boolean allowUnsignedBundles() {
+    String configuredValue =
+        configuredValue(APPHOST_ALLOW_UNSIGNED_PROPERTY, APPHOST_ALLOW_UNSIGNED_ENV);
+    return Boolean.parseBoolean(configuredValue);
+  }
+
+  private static TrustedAppKeys loadTrustedAppKeys(AppHostTrustConfiguration trustConfiguration) {
+    TrustedAppKeys trustedKeys =
+        loadTrustedKeysFileIfConfigured(trustConfiguration.trustedKeysFile());
+    rejectPartialDirectTrustedKeyConfiguration(trustConfiguration);
+    if (trustConfiguration.keyId() == null) {
+      return trustedKeys;
+    }
+    return trustedKeys.plus(
+        loadDirectTrustedKey(
+            trustConfiguration.keyId(),
+            trustConfiguration.publicKeyBase64(),
+            trustConfiguration.publicKeyFile()));
+  }
+
+  private static void rejectPartialDirectTrustedKeyConfiguration(
+      AppHostTrustConfiguration trustConfiguration) {
+    if (trustConfiguration.keyId() == null
+        && (trustConfiguration.publicKeyBase64() != null
+            || trustConfiguration.publicKeyFile() != null)) {
+      throw new IllegalStateException(
+          "Trusted app public key material requires trusted app key id.");
+    }
+  }
+
+  private static TrustedAppKeys loadTrustedKeysFileIfConfigured(String configuredPath) {
+    if (configuredPath == null) {
+      return TrustedAppKeys.empty();
+    }
+    try {
+      return TrustedAppKeys.load(Path.of(configuredPath));
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to load trusted app keys file.", e);
+    }
+  }
+
+  private static TrustedAppKey loadDirectTrustedKey(
+      String keyId, String publicKeyBase64, String publicKeyFile) {
+    if (publicKeyBase64 == null && publicKeyFile == null) {
+      throw new IllegalStateException("Trusted app key id requires trusted public key material.");
+    }
+    if (publicKeyBase64 != null && publicKeyFile != null) {
+      throw new IllegalStateException(
+          "Trusted app public key material must be configured by base64 or file, not both.");
+    }
+    try {
+      return publicKeyFile != null
+          ? decodeTrustedPublicKeyFile(keyId, Path.of(publicKeyFile))
+          : TrustedAppKey.ed25519(keyId, publicKeyBase64);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to load trusted app public key.", e);
+    }
+  }
+
+  private static TrustedAppKey decodeTrustedPublicKeyFile(String keyId, Path file)
+      throws IOException {
+    byte[] rawBytes = Files.readAllBytes(file.toAbsolutePath().normalize());
+    try {
+      return TrustedAppKey.ed25519(keyId, new String(rawBytes, StandardCharsets.UTF_8));
+    } catch (AppDistributionException | IllegalArgumentException _) {
+      return TrustedAppKey.ed25519(keyId, rawBytes);
+    }
+  }
+
+  private static String configuredValue(String propertyName, String environmentName) {
+    String propertyValue = System.getProperty(propertyName);
+    if (propertyValue != null && !propertyValue.isBlank()) {
+      return propertyValue.trim();
+    }
+    String environmentValue = System.getenv(environmentName);
+    return environmentValue == null || environmentValue.isBlank() ? null : environmentValue.trim();
+  }
+
+  private static String messageOrTrustConfigurationDefault(Throwable failure) {
+    String message = failure.getMessage();
+    return message == null || message.isBlank() ? TRUST_CONFIGURATION_ERROR_MESSAGE : message;
+  }
+
+  private record AppHostTrustConfiguration(
+      boolean allowUnsigned,
+      String trustedKeysFile,
+      String keyId,
+      String publicKeyBase64,
+      String publicKeyFile) {}
 
   /**
    * Creates the shutdown job that stops any AppHost-managed child processes on node exit.

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Objects;
@@ -28,8 +27,6 @@ import network.crypta.node.RequestPriorityClasses;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.SemiOrderedShutdownHook;
-import network.crypta.platform.appdist.AppBundleDigest;
-import network.crypta.platform.appdist.AppBundleSignature;
 import network.crypta.platform.appdist.AppBundleVerifier;
 import network.crypta.platform.appdist.AppDistributionException;
 import network.crypta.platform.appdist.TrustedAppKey;
@@ -285,7 +282,7 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
   private static void verifyBundleAgainstConfiguredTrust(
       Path copiedBundleDirectory, AppHostTrustConfiguration trustConfiguration) throws IOException {
     if (trustConfiguration.allowUnsigned()
-        && bundleHasNoDistributionSidecars(copiedBundleDirectory)) {
+        && !AppBundleVerifier.hasDistributionSidecar(copiedBundleDirectory)) {
       return;
     }
     AppBundleVerifier verifier;
@@ -296,14 +293,6 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
           messageOrTrustConfigurationDefault(exception), exception);
     }
     verifier.verify(copiedBundleDirectory);
-  }
-
-  private static boolean bundleHasNoDistributionSidecars(Path copiedBundleDirectory) {
-    Path bundleRoot = copiedBundleDirectory.toAbsolutePath().normalize();
-    return !Files.exists(
-            bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), LinkOption.NOFOLLOW_LINKS)
-        && !Files.exists(
-            bundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME), LinkOption.NOFOLLOW_LINKS);
   }
 
   private static AppBundleVerifier createBundleVerifier(

--- a/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
+++ b/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
@@ -3,9 +3,14 @@ package network.crypta.clients.http.bridge;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -36,11 +41,15 @@ import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels;
 import network.crypta.node.SemiOrderedShutdownHook;
 import network.crypta.node.subsystem.NodeNetworkSubsystem;
+import network.crypta.platform.appdist.AppBundleSigner;
+import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostConfigurationException;
 import network.crypta.platform.apphost.AppHostLayout;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
 import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.alerts.UserAlertSurface;
@@ -81,6 +90,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("java:S100")
 @ExtendWith(MockitoExtension.class)
 class CoreHttpShellRuntimeSupportTest {
+  private static final String TRUSTED_KEY_ID = "local-dev";
 
   @Test
   void constructor_whenCoreIsNull_throwsNullPointerException() {
@@ -241,9 +251,7 @@ class CoreHttpShellRuntimeSupportTest {
     CoreHttpShellRuntimeSupport runtimeSupport;
     try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
         mockStatic(SemiOrderedShutdownHook.class)) {
-      shutdownHooks
-          .when(() -> assertNotSame(shutdownHook, SemiOrderedShutdownHook.get()))
-          .thenReturn(shutdownHook);
+      stubShutdownHookLookup(shutdownHooks, shutdownHook);
       runtimeSupport = new CoreHttpShellRuntimeSupport(core);
     }
 
@@ -254,6 +262,343 @@ class CoreHttpShellRuntimeSupportTest {
     assertEquals(expectedCacheDir.toAbsolutePath(), layout.cacheDir());
     assertEquals(expectedRunDir.toAbsolutePath(), layout.runDir());
     verify(shutdownHook).addEarlyJob(any(Thread.class));
+  }
+
+  @Test
+  void appHost_whenConstructedFromCore_expectUnsignedInstallRejectedByProductionPolicy(
+      @TempDir Path tempDir) throws IOException {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    Path stagedDir = stageUnsignedApp(tempDir.resolve("staged"));
+
+    CoreHttpShellRuntimeSupport runtimeSupport;
+    try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+        mockStatic(SemiOrderedShutdownHook.class)) {
+      stubShutdownHookLookup(shutdownHooks, shutdownHook);
+      runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+    }
+
+    AppBundleVerificationException exception =
+        assertThrows(
+            AppBundleVerificationException.class,
+            () -> runtimeSupport.appHost().installFromDirectory(stagedDir));
+
+    assertEquals("missing signature sidecar", exception.getMessage());
+  }
+
+  @Test
+  void appHost_whenTrustedKeyConfigured_expectSignedInstallAccepted(@TempDir Path tempDir)
+      throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+    Path stagedDir = stageSignedApp(tempDir.resolve("staged-signed"), keyPair);
+    String previousKeyId = System.getProperty("cryptad.apphost.trustedKeyId");
+    String previousPublicKey = System.getProperty("cryptad.apphost.trustedPublicKeyBase64");
+
+    try {
+      System.setProperty("cryptad.apphost.trustedKeyId", TRUSTED_KEY_ID);
+      System.setProperty(
+          "cryptad.apphost.trustedPublicKeyBase64",
+          Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+
+      CoreHttpShellRuntimeSupport runtimeSupport;
+      try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+          mockStatic(SemiOrderedShutdownHook.class)) {
+        stubShutdownHookLookup(shutdownHooks, shutdownHook);
+        runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+      }
+
+      assertEquals(
+          "demo-app", runtimeSupport.appHost().installFromDirectory(stagedDir).manifest().appId());
+    } finally {
+      restoreSystemProperty("cryptad.apphost.trustedKeyId", previousKeyId);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyBase64", previousPublicKey);
+    }
+  }
+
+  @Test
+  void appHost_whenTrustedPublicKeyFileContainsRawDer_expectSignedInstallAccepted(
+      @TempDir Path tempDir) throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+    Path stagedDir = stageSignedApp(tempDir.resolve("staged-raw-der"), keyPair);
+    Path publicKeyFile = tempDir.resolve("public-key.der");
+    Files.write(publicKeyFile, keyPair.getPublic().getEncoded());
+    String previousKeyId = System.getProperty("cryptad.apphost.trustedKeyId");
+    String previousPublicKey = System.getProperty("cryptad.apphost.trustedPublicKeyBase64");
+    String previousPublicKeyFile = System.getProperty("cryptad.apphost.trustedPublicKeyFile");
+
+    try {
+      System.setProperty("cryptad.apphost.trustedKeyId", TRUSTED_KEY_ID);
+      System.clearProperty("cryptad.apphost.trustedPublicKeyBase64");
+      System.setProperty("cryptad.apphost.trustedPublicKeyFile", publicKeyFile.toString());
+
+      CoreHttpShellRuntimeSupport runtimeSupport;
+      try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+          mockStatic(SemiOrderedShutdownHook.class)) {
+        stubShutdownHookLookup(shutdownHooks, shutdownHook);
+        runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+      }
+
+      assertEquals(
+          "demo-app", runtimeSupport.appHost().installFromDirectory(stagedDir).manifest().appId());
+    } finally {
+      restoreSystemProperty("cryptad.apphost.trustedKeyId", previousKeyId);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyBase64", previousPublicKey);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyFile", previousPublicKeyFile);
+    }
+  }
+
+  @Test
+  void appHost_whenTrustedKeysFileIsUnreadable_expectBootstrapSucceedsAndInstallFailsOnDemand(
+      @TempDir Path tempDir) throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    Path stagedDir = stageUnsignedApp(tempDir.resolve("staged"));
+    String previousTrustedKeysFile = System.getProperty("cryptad.apphost.trustedKeysFile");
+
+    try {
+      System.setProperty(
+          "cryptad.apphost.trustedKeysFile",
+          tempDir.resolve("missing-trusted-keys.properties").toString());
+
+      CoreHttpShellRuntimeSupport runtimeSupport;
+      try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+          mockStatic(SemiOrderedShutdownHook.class)) {
+        stubShutdownHookLookup(shutdownHooks, shutdownHook);
+        runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+      }
+
+      AppHostConfigurationException exception =
+          assertThrows(
+              AppHostConfigurationException.class,
+              () -> runtimeSupport.appHost().installFromDirectory(stagedDir));
+
+      assertEquals("Failed to load trusted app keys file.", exception.getMessage());
+    } finally {
+      restoreSystemProperty("cryptad.apphost.trustedKeysFile", previousTrustedKeysFile);
+    }
+  }
+
+  @Test
+  void appHost_whenTrustedKeyIdDuplicatesTrustedKeysFile_expectInstallFailsWithVerificationError(
+      @TempDir Path tempDir) throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    Path stagedDir = stageUnsignedApp(tempDir.resolve("staged"));
+    KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+    Path trustedKeysFile = tempDir.resolve("trusted-keys.properties");
+    Files.writeString(
+        trustedKeysFile,
+        """
+        trusted.keys.version=1
+        key.0.id=%s
+        key.0.algorithm=Ed25519
+        key.0.public.key.base64=%s
+        """
+            .formatted(
+                TRUSTED_KEY_ID,
+                Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())),
+        StandardCharsets.UTF_8);
+    String previousTrustedKeysFile = System.getProperty("cryptad.apphost.trustedKeysFile");
+    String previousKeyId = System.getProperty("cryptad.apphost.trustedKeyId");
+    String previousPublicKey = System.getProperty("cryptad.apphost.trustedPublicKeyBase64");
+
+    try {
+      System.setProperty("cryptad.apphost.trustedKeysFile", trustedKeysFile.toString());
+      System.setProperty("cryptad.apphost.trustedKeyId", TRUSTED_KEY_ID);
+      System.setProperty(
+          "cryptad.apphost.trustedPublicKeyBase64",
+          Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+
+      CoreHttpShellRuntimeSupport runtimeSupport;
+      try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+          mockStatic(SemiOrderedShutdownHook.class)) {
+        stubShutdownHookLookup(shutdownHooks, shutdownHook);
+        runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+      }
+
+      AppHostConfigurationException exception =
+          assertThrows(
+              AppHostConfigurationException.class,
+              () -> runtimeSupport.appHost().installFromDirectory(stagedDir));
+
+      assertEquals("duplicate trusted key id: " + TRUSTED_KEY_ID, exception.getMessage());
+    } finally {
+      restoreSystemProperty("cryptad.apphost.trustedKeysFile", previousTrustedKeysFile);
+      restoreSystemProperty("cryptad.apphost.trustedKeyId", previousKeyId);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyBase64", previousPublicKey);
+    }
+  }
+
+  @Test
+  void appHost_whenTrustedPublicKeyConfiguredWithoutKeyId_expectInstallFailsWithVerificationError(
+      @TempDir Path tempDir) throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    Path stagedDir = stageUnsignedApp(tempDir.resolve("staged"));
+    KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+    String previousKeyId = System.getProperty("cryptad.apphost.trustedKeyId");
+    String previousPublicKey = System.getProperty("cryptad.apphost.trustedPublicKeyBase64");
+    String previousPublicKeyFile = System.getProperty("cryptad.apphost.trustedPublicKeyFile");
+
+    try {
+      System.clearProperty("cryptad.apphost.trustedKeyId");
+      System.setProperty(
+          "cryptad.apphost.trustedPublicKeyBase64",
+          Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+      System.clearProperty("cryptad.apphost.trustedPublicKeyFile");
+
+      CoreHttpShellRuntimeSupport runtimeSupport;
+      try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+          mockStatic(SemiOrderedShutdownHook.class)) {
+        stubShutdownHookLookup(shutdownHooks, shutdownHook);
+        runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+      }
+
+      AppHostConfigurationException exception =
+          assertThrows(
+              AppHostConfigurationException.class,
+              () -> runtimeSupport.appHost().installFromDirectory(stagedDir));
+
+      assertEquals(
+          "Trusted app public key material requires trusted app key id.", exception.getMessage());
+    } finally {
+      restoreSystemProperty("cryptad.apphost.trustedKeyId", previousKeyId);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyBase64", previousPublicKey);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyFile", previousPublicKeyFile);
+    }
+  }
+
+  @Test
+  void appHost_whenConflictingTrustedPublicKeyInputsProvided_expectConfigurationFailure(
+      @TempDir Path tempDir) throws Exception {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    Path stagedDir = stageUnsignedApp(tempDir.resolve("staged"));
+    KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+    Path publicKeyFile = tempDir.resolve("public.pem");
+    Files.writeString(
+        publicKeyFile,
+        Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()),
+        StandardCharsets.UTF_8);
+    String previousKeyId = System.getProperty("cryptad.apphost.trustedKeyId");
+    String previousPublicKey = System.getProperty("cryptad.apphost.trustedPublicKeyBase64");
+    String previousPublicKeyFile = System.getProperty("cryptad.apphost.trustedPublicKeyFile");
+
+    try {
+      System.setProperty("cryptad.apphost.trustedKeyId", TRUSTED_KEY_ID);
+      System.setProperty(
+          "cryptad.apphost.trustedPublicKeyBase64",
+          Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+      System.setProperty("cryptad.apphost.trustedPublicKeyFile", publicKeyFile.toString());
+
+      CoreHttpShellRuntimeSupport runtimeSupport;
+      try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+          mockStatic(SemiOrderedShutdownHook.class)) {
+        stubShutdownHookLookup(shutdownHooks, shutdownHook);
+        runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+      }
+
+      AppHostConfigurationException exception =
+          assertThrows(
+              AppHostConfigurationException.class,
+              () -> runtimeSupport.appHost().installFromDirectory(stagedDir));
+
+      assertEquals(
+          "Trusted app public key material must be configured by base64 or file, not both.",
+          exception.getMessage());
+    } finally {
+      restoreSystemProperty("cryptad.apphost.trustedKeyId", previousKeyId);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyBase64", previousPublicKey);
+      restoreSystemProperty("cryptad.apphost.trustedPublicKeyFile", previousPublicKeyFile);
+    }
   }
 
   @ParameterizedTest
@@ -566,6 +911,54 @@ class CoreHttpShellRuntimeSupportTest {
             Path.of("build", "test-runtime", "apphost", "run", appId).toAbsolutePath());
     return new RunningAppSnapshot(
         manifest, paths, "token-" + appId, 4242L, Instant.parse("2024-01-02T03:04:05Z"));
+  }
+
+  private static Path stageUnsignedApp(Path stagedDir) throws IOException {
+    Path binDir = Files.createDirectories(stagedDir.resolve("bin"));
+    Path launcher = binDir.resolve("launch.sh");
+    Files.writeString(
+        launcher,
+        """
+        #!/bin/sh
+        exit 0
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        stagedDir.resolve(AppManifestParser.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=demo-app
+        app.name=Demo App
+        app.version=1.0.0
+        app.exec=bin/launch.sh
+        app.ui.entry=/
+        app.permissions=network.access
+        quota.data.bytes=1024
+        quota.cache.bytes=512
+        """,
+        StandardCharsets.UTF_8);
+    return stagedDir;
+  }
+
+  private static Path stageSignedApp(Path stagedDir, KeyPair keyPair) throws IOException {
+    Path unsigned = stageUnsignedApp(stagedDir);
+    AppBundleSigner.sign(unsigned, TRUSTED_KEY_ID, keyPair.getPrivate());
+    return unsigned;
+  }
+
+  private static void stubShutdownHookLookup(
+      MockedStatic<SemiOrderedShutdownHook> shutdownHooks, SemiOrderedShutdownHook shutdownHook) {
+    shutdownHooks
+        .when(() -> assertNotSame(shutdownHook, SemiOrderedShutdownHook.get()))
+        .thenReturn(shutdownHook);
+  }
+
+  private static void restoreSystemProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name);
+    } else {
+      System.setProperty(name, value);
+    }
   }
 
   private static void assertContentToadlet(Toadlet toadlet) {

--- a/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
+++ b/bridge-http-runtime/src/test/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupportTest.java
@@ -299,6 +299,48 @@ class CoreHttpShellRuntimeSupportTest {
   }
 
   @Test
+  void appHost_whenAllowUnsignedAndCaseVariantSidecarPresent_expectSignedVerificationRequired(
+      @TempDir Path tempDir) throws IOException {
+    NodeClientCore core = mock(NodeClientCore.class);
+    Node node = mock(Node.class);
+    ProgramDirectory nodeDir = mock(ProgramDirectory.class);
+    ProgramDirectory runDir = mock(ProgramDirectory.class);
+    SemiOrderedShutdownHook shutdownHook = mock(SemiOrderedShutdownHook.class);
+    Path nodeDataDir = tempDir.resolve("node");
+    Path cacheDir = tempDir.resolve("persistent-temp");
+    Path runDataDir = tempDir.resolve("run");
+    when(core.getNode()).thenReturn(node);
+    when(node.nodeDir()).thenReturn(nodeDir);
+    when(node.runDir()).thenReturn(runDir);
+    when(nodeDir.dir()).thenReturn(nodeDataDir.toFile());
+    when(runDir.dir()).thenReturn(runDataDir.toFile());
+    when(core.getPersistentTempDir()).thenReturn(cacheDir.toFile());
+    Path stagedDir = stageUnsignedApp(tempDir.resolve("staged"));
+    Files.writeString(stagedDir.resolve("CRYPTAD-APP.DIGESTS"), "stale-digest");
+    String previousAllowUnsigned = System.getProperty("cryptad.apphost.allowUnsigned");
+
+    try {
+      System.setProperty("cryptad.apphost.allowUnsigned", "true");
+
+      CoreHttpShellRuntimeSupport runtimeSupport;
+      try (MockedStatic<SemiOrderedShutdownHook> shutdownHooks =
+          mockStatic(SemiOrderedShutdownHook.class)) {
+        stubShutdownHookLookup(shutdownHooks, shutdownHook);
+        runtimeSupport = new CoreHttpShellRuntimeSupport(core);
+      }
+
+      AppBundleVerificationException exception =
+          assertThrows(
+              AppBundleVerificationException.class,
+              () -> runtimeSupport.appHost().installFromDirectory(stagedDir));
+
+      assertEquals("missing signature sidecar", exception.getMessage());
+    } finally {
+      restoreSystemProperty("cryptad.apphost.allowUnsigned", previousAllowUnsigned);
+    }
+  }
+
+  @Test
   void appHost_whenTrustedKeyConfigured_expectSignedInstallAccepted(@TempDir Path tempDir)
       throws Exception {
     NodeClientCore core = mock(NodeClientCore.class);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ version = "3"
 
 val internalLeafProjects =
   listOf(
+    project(":platform-appdist"),
     project(":foundation-support"),
     project(":foundation-store"),
     project(":foundation-store-contracts"),
@@ -146,6 +147,7 @@ dependencies {
 
   // testImplementation
   testImplementation(project(":launcher-desktop"))
+  testImplementation(project(":platform-appdist"))
   testImplementation(libs.junitJupiterApi)
   testImplementation(libs.junitJupiterParams)
   testImplementation(libs.junitPlatformSuite)
@@ -505,6 +507,21 @@ tasks.register("stageFirstPartyApps") {
   description = "Stages the repo-owned first-party AppHost bundles."
   dependsOn(":apps:queue-manager:stageApp")
   dependsOn(":apps:publisher:stageApp")
+}
+
+tasks.register("signFirstPartyApps") {
+  group = "build"
+  description = "Signs the repo-owned first-party AppHost bundles."
+  dependsOn(":apps:queue-manager:signApp")
+  dependsOn(":apps:publisher:signApp")
+}
+
+tasks.register("verifyFirstPartyApps") {
+  group = "verification"
+  description = "Verifies the signed repo-owned first-party AppHost bundles."
+  dependsOn(":apps:queue-manager:verifyApp")
+  dependsOn(":apps:publisher:verifyApp")
+  mustRunAfter("signFirstPartyApps")
 }
 
 // The default from build-logic (512m) is too small for the full test suite on Windows and can

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -48,3 +48,15 @@ someone in danger.
 
 We will acknowledge a report within one week. If you do not get a reply
 within one week, it most likely got lost: Please send it again!
+
+
+App Bundle Signing Keys
+-----------------------
+
+Signed local AppHost bundles use developer-supplied key material during local build and verification tasks.
+
+- Do not commit production private keys, keystores, or exported PKCS#8 private key material to this repository.
+- Keep local development keys outside the repo and pass them through Gradle properties or environment variables, or point at local files outside the checkout.
+- If you generate a development-only key pair for testing signed bundles, label it clearly as non-production and rotate or remove it when no longer needed.
+
+Remote catalogs and remote bundle downloads are future work. PR-192 only establishes local signed staged bundle files and local verification hooks.

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -1,0 +1,167 @@
+# Signed App Distribution
+
+This document describes Cryptad's local signed staged app bundle workflow for first-party AppHost apps.
+
+## Scope
+
+PR-192 adds signed local bundle sidecars and Gradle tasks for staging, signing, and verifying first-party apps.
+
+Out of scope in this PR:
+
+- Remote catalog fetching
+- Remote bundle downloads
+- Public app store UI
+- Browser-side bundle uploads
+- App proxying and app-owned static serving
+
+## Bundle Files
+
+`stageApp` still produces an unsigned staged bundle by default. Signing adds two UTF-8 sidecars at the bundle root:
+
+```text
+cryptad-app.properties
+bin/<launcher>.sh
+static/...
+cryptad-app.digests
+cryptad-app.signature
+```
+
+The sidecars follow the PR-192 local distribution format:
+
+- `cryptad-app.digests`
+  - `digest.version=1`
+  - `digest.algorithm=SHA-256`
+  - `file.<N>.path=<normalized relative path>`
+  - `file.<N>.sha256=<lowercase hex sha256>`
+- `cryptad-app.signature`
+  - `signature.version=1`
+  - `signature.algorithm=Ed25519`
+  - `signature.key.id=<stable key id>`
+  - `signature.payload=cryptad-app.digests`
+  - `signature.value.base64=<base64 Ed25519 signature over the exact digest sidecar bytes>`
+
+The digest includes `cryptad-app.properties` and regular bundle files. It excludes distribution sidecars such as `cryptad-app.digests`, `cryptad-app.signature`, and reserved future catalog sidecars.
+
+## Gradle Tasks
+
+Per app:
+
+- `:apps:queue-manager:stageApp`
+- `:apps:queue-manager:signApp`
+- `:apps:queue-manager:verifyApp`
+- `:apps:publisher:stageApp`
+- `:apps:publisher:signApp`
+- `:apps:publisher:verifyApp`
+
+Root convenience tasks:
+
+- `stageFirstPartyApps`
+- `signFirstPartyApps`
+- `verifyFirstPartyApps`
+
+`stageApp` remains unsigned on purpose. Use `signApp` when you need a signed local bundle, and `verifyApp` to re-digest and verify a signed staged bundle with the configured public key.
+
+## Signing Inputs
+
+Use Gradle properties or environment variables. The same inputs work for both first-party app projects and the root convenience tasks.
+
+| Purpose | Gradle property | Environment variable | Notes |
+| --- | --- | --- | --- |
+| Stable signing key id | `cryptadAppSigningKeyId` | `CRYPTAD_APP_SIGNING_KEY_ID` | Required for `signApp` and `verifyApp`. |
+| Private key bytes | `cryptadAppSigningPrivateKeyBase64` | `CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64` | Required for `signApp`. Base64-encoded PKCS#8 Ed25519 private key bytes. |
+| Private key file | `cryptadAppSigningPrivateKeyFile` | `CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE` | Alternative to `*PrivateKeyBase64`. File may contain PEM, Base64 text, or raw DER bytes. |
+| Public key bytes | `cryptadAppSigningPublicKeyBase64` | `CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64` | Required for `verifyApp`. Base64-encoded X.509 Ed25519 public key bytes. |
+| Public key file | `cryptadAppSigningPublicKeyFile` | `CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE` | Alternative to `*PublicKeyBase64`. File may contain PEM, Base64 text, or raw DER bytes. |
+
+For private keys, prefer `CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64` or
+`cryptadAppSigningPrivateKeyFile`. Avoid putting base64 private key material directly on the shell
+command line with `-PcryptadAppSigningPrivateKeyBase64=...`.
+
+## Runtime Trust Inputs
+
+Production-facing AppHost installs and updates reject unsigned bundles by default. To install a
+signed staged bundle through the live node, start the node with either direct trusted-key inputs or
+ a trusted-keys properties file.
+
+| Purpose | System property | Environment variable | Notes |
+| --- | --- | --- | --- |
+| Trusted key id | `cryptad.apphost.trustedKeyId` | `CRYPTAD_APPHOST_TRUSTED_KEY_ID` | Pairs with a direct trusted public key. |
+| Trusted public key bytes | `cryptad.apphost.trustedPublicKeyBase64` | `CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_BASE64` | Base64-encoded X.509 Ed25519 public key bytes. |
+| Trusted public key file | `cryptad.apphost.trustedPublicKeyFile` | `CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_FILE` | File may contain PEM, Base64 text, or raw DER bytes. |
+| Trusted keys file | `cryptad.apphost.trustedKeysFile` | `CRYPTAD_APPHOST_TRUSTED_KEYS_FILE` | Properties file with `trusted.keys.version=1` plus `key.<n>.id`, `key.<n>.algorithm`, and `key.<n>.public.key.base64`. |
+| Development-only unsigned installs | `cryptad.apphost.allowUnsigned=true` | `CRYPTAD_APPHOST_ALLOW_UNSIGNED=true` | Explicit escape hatch for local development and tests. Do not enable in production. |
+
+Example trusted-keys file:
+
+```text
+trusted.keys.version=1
+key.0.id=dev-local
+key.0.algorithm=Ed25519
+key.0.public.key.base64=<base64-x509-public-key>
+```
+
+## Local Workflow
+
+Stage an unsigned bundle:
+
+```bash
+./gradlew :apps:queue-manager:stageApp
+```
+
+Sign it with a local development key pair:
+
+```bash
+./gradlew :apps:queue-manager:signApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem
+```
+
+Verify it with the matching public key:
+
+```bash
+./gradlew :apps:queue-manager:verifyApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPublicKeyFile=/abs/path/to/dev-app-signing-public.pem
+```
+
+Stage, sign, and verify both first-party apps:
+
+```bash
+./gradlew \
+  stageFirstPartyApps \
+  signFirstPartyApps \
+  verifyFirstPartyApps \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem \
+  -PcryptadAppSigningPublicKeyFile=/abs/path/to/dev-app-signing-public.pem
+```
+
+To install the signed bundle through the running node, export the matching trusted public key
+before starting Cryptad:
+
+```bash
+export CRYPTAD_APPHOST_TRUSTED_KEY_ID=dev-local
+export CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_FILE=/abs/path/to/dev-app-signing-public.pem
+```
+
+If you deliberately want to test unsigned local bundles against a live node, opt in explicitly:
+
+```bash
+export CRYPTAD_APPHOST_ALLOW_UNSIGNED=true
+```
+
+## Key Handling
+
+Do not commit production private keys, keystores, exported PKCS#8 private keys, or long-lived test secrets to this repository.
+
+Preferred local patterns:
+
+- Keep signing keys outside the repo and pass file paths with `-P...File=...`.
+- Keep trusted public keys outside the repo and pass them through environment variables or a local
+  trusted-keys file outside the checkout.
+- Use environment variables for short-lived automation when file-based secrets are not practical.
+- Label local development keys clearly as non-production.
+
+## Future Work
+
+Remote catalog fetching, remote bundle downloads, and public catalog management are deferred to later PRs. PR-192 only establishes signed local bundle files and Gradle-side signing and verification hooks.

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
@@ -49,6 +50,8 @@ public final class AppsApiHandler {
   private static final String APP_ALREADY_INSTALLED_PREFIX = "app already installed: ";
   private static final String APP_NOT_INSTALLED_PREFIX = "app is not installed: ";
   private static final String CANNOT_UPDATE_RUNNING_APP_PREFIX = "cannot update a running app: ";
+  private static final String SIGNED_BUNDLE_FAILURE_MESSAGE =
+      "Staged app bundle must pass trusted signature verification.";
 
   /** Detached AppHost core used for app lifecycle and inventory operations. */
   private final AppHost appHost;
@@ -501,6 +504,9 @@ public final class AppsApiHandler {
     if (installed(appId)) {
       return conflict(APP_ALREADY_INSTALLED_PREFIX + appId);
     }
+    if (isSignedBundleVerificationFailure(failure)) {
+      return invalidBundle(SIGNED_BUNDLE_FAILURE_MESSAGE);
+    }
     if (isInvalidAppBundleFailure(failure)) {
       return invalidBundle(
           messageOrDefault(failure, "Staged app bundle failed AppHost validation."));
@@ -526,6 +532,9 @@ public final class AppsApiHandler {
     if (isMissingAppFailure(failure)) {
       return appNotFound();
     }
+    if (isSignedBundleVerificationFailure(failure)) {
+      return invalidBundle(SIGNED_BUNDLE_FAILURE_MESSAGE);
+    }
     if (isInvalidAppBundleFailure(failure)) {
       return invalidBundle(
           messageOrDefault(failure, "Staged app bundle failed AppHost validation."));
@@ -541,6 +550,10 @@ public final class AppsApiHandler {
   private static boolean isMissingAppFailure(AppHostException failure) {
     String message = failure.getMessage();
     return message != null && message.startsWith(APP_NOT_INSTALLED_PREFIX);
+  }
+
+  private static boolean isSignedBundleVerificationFailure(AppHostException failure) {
+    return failure instanceof AppBundleVerificationException;
   }
 
   /**

--- a/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
@@ -1,0 +1,162 @@
+package network.crypta.platform.api.apps;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.apphost.AppBundleVerificationException;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostConfigurationException;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifestParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("java:S100")
+class AppsApiHandlerTest {
+  private static final String APP_ID = "demo-app";
+  private static final String SIGNED_BUNDLE_FAILURE_MESSAGE =
+      "Staged app bundle must pass trusted signature verification.";
+  private static final String STAGED_DIR_PARAMETER = "stagedDir";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void install_whenSignedBundleVerificationFails_expectBadRequestWithoutAbsolutePathLeak()
+      throws IOException {
+    ThrowingAppHost appHost = new ThrowingAppHost();
+    appHost.installFailure =
+        new AppBundleVerificationException(
+            "signature sidecar missing in copied bundle: /srv/node/apps/installed/demo-app");
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+    Path stagedDir = stageApp(tempDir.resolve("staged-install"));
+    Map<String, List<String>> installParameters =
+        Map.of(STAGED_DIR_PARAMETER, List.of(stagedDir.toString()));
+
+    PlatformApiException exception =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            PlatformApiException.class, () -> handler.install(installParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_app_bundle", exception.errorCode());
+    assertEquals(SIGNED_BUNDLE_FAILURE_MESSAGE, exception.getMessage());
+  }
+
+  @Test
+  void update_whenSignedBundleVerificationFails_expectBadRequestWithoutAbsolutePathLeak()
+      throws IOException {
+    ThrowingAppHost appHost = new ThrowingAppHost();
+    appHost.updateFailure =
+        new AppBundleVerificationException(
+            "trusted key not found for bundle at C:\\cryptad\\apps\\installed\\demo-app");
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+    Path stagedDir = stageApp(tempDir.resolve("staged-update"));
+    Map<String, List<String>> updateParameters =
+        Map.of(STAGED_DIR_PARAMETER, List.of(stagedDir.toString()));
+
+    PlatformApiException exception =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            PlatformApiException.class, () -> handler.update(APP_ID, updateParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_app_bundle", exception.errorCode());
+    assertEquals(SIGNED_BUNDLE_FAILURE_MESSAGE, exception.getMessage());
+  }
+
+  @Test
+  void install_whenTrustConfigurationFails_expectInternalError() throws IOException {
+    ThrowingAppHost appHost = new ThrowingAppHost();
+    appHost.installFailure =
+        new AppHostConfigurationException("Failed to load trusted app keys file.");
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+    Path stagedDir = stageApp(tempDir.resolve("staged-config"));
+    Map<String, List<String>> installParameters =
+        Map.of(STAGED_DIR_PARAMETER, List.of(stagedDir.toString()));
+
+    PlatformApiException exception =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            PlatformApiException.class, () -> handler.install(installParameters));
+
+    assertEquals(500, exception.statusCode());
+    assertEquals("internal_error", exception.errorCode());
+    assertEquals("Failed to install app.", exception.getMessage());
+  }
+
+  private Path stageApp(Path stagedDir) throws IOException {
+    Files.createDirectories(stagedDir);
+    Files.writeString(
+        stagedDir.resolve(AppManifestParser.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=Demo App
+        app.version=1.0.0
+        app.exec=bin/launch.sh
+        app.ui.entry=/
+        app.permissions=network.access
+        quota.data.bytes=1024
+        quota.cache.bytes=512
+        """
+            .formatted(APP_ID),
+        StandardCharsets.UTF_8);
+    return stagedDir;
+  }
+
+  private static final class ThrowingAppHost implements AppHost {
+    private IOException installFailure;
+    private IOException updateFailure;
+
+    @Override
+    public InstalledAppSnapshot installFromDirectory(Path stagedAppDirectory) throws IOException {
+      throw installFailure;
+    }
+
+    @Override
+    public InstalledAppSnapshot updateFromDirectory(String appId, Path stagedAppDirectory)
+        throws IOException {
+      throw updateFailure;
+    }
+
+    @Override
+    public void uninstall(String appId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<InstalledAppSnapshot> listInstalled() {
+      return List.of();
+    }
+
+    @Override
+    public Optional<InstalledAppSnapshot> describe(String appId) {
+      return Optional.empty();
+    }
+
+    @Override
+    public RunningAppSnapshot start(String appId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean stop(String appId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<RunningAppSnapshot> status(String appId) {
+      return Optional.empty();
+    }
+
+    @Override
+    public List<RunningAppSnapshot> listRunning() {
+      return List.of();
+    }
+  }
+}

--- a/platform-appdist/build.gradle.kts
+++ b/platform-appdist/build.gradle.kts
@@ -9,17 +9,9 @@ version = rootProject.version
 val mainSourceSet = sourceSets.named("main")
 
 dependencies {
-  // AppEnv is the repo's single source of truth for OS detection and keeps Windows launch
-  // handling out of raw os.name checks.
-  implementation(project(":foundation-fs"))
-  implementation(project(":platform-appdist"))
-
   compileOnly(libs.jetbrainsAnnotations)
 
-  // Keep leaf-local tests runnable through :platform-apphost:test without depending on the root
-  // project's aggregated classpath.
   testImplementation(mainSourceSet.map { it.output })
-  testImplementation(project(":platform-appdist"))
   testImplementation(libs.junitJupiterApi)
   testRuntimeOnly(libs.junitJupiterEngine)
   testRuntimeOnly(libs.junitPlatformLauncher)

--- a/platform-appdist/gradle/owned-output-patterns.txt
+++ b/platform-appdist/gradle/owned-output-patterns.txt
@@ -1,0 +1,4 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :platform-appdist owns
+# them now.
+
+network/crypta/platform/appdist/**

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigest.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigest.java
@@ -1,0 +1,106 @@
+package network.crypta.platform.appdist;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable parsed or generated content of {@code cryptad-app.digests}.
+ *
+ * <p>The digest sidecar is the canonical inventory for a staged app bundle. Each entry names one
+ * regular file by its normalized bundle-relative path and records the file's SHA-256 content hash,
+ * plus any launchability metadata that must be authenticated for that file. The record enforces the
+ * properties that make the sidecar reproducible: version {@code 1}, algorithm {@code SHA-256},
+ * lexicographic path ordering, at least one entry, and mandatory coverage for {@code
+ * cryptad-app.properties}.
+ *
+ * <p>Distribution control files are intentionally not allowed as digest entries. They are either
+ * regenerated from the payload, such as {@code cryptad-app.digests}, or authenticate the generated
+ * payload, such as {@code cryptad-app.signature}. Keeping that boundary explicit prevents callers
+ * from accidentally signing mutable verification metadata as if it were app code or assets.
+ *
+ * @param version digest schema version, currently required to be {@code 1}
+ * @param algorithm digest algorithm name, currently required to be {@code SHA-256}
+ * @param entries deterministic bundle file digests sorted by normalized path
+ */
+public record AppBundleDigest(int version, String algorithm, List<AppBundleDigestEntry> entries) {
+  /**
+   * Canonical digest sidecar filename at the staged bundle root.
+   *
+   * <p>Writers replace this file when producing a fresh digest, and verifiers read this exact file
+   * before comparing it with the current bundle contents.
+   */
+  public static final String DIGEST_FILE_NAME = "cryptad-app.digests";
+
+  /**
+   * Required app manifest filename that must be covered by every valid digest.
+   *
+   * <p>The manifest contains the app identity, version, and executable path, so omitting it would
+   * allow launch-relevant metadata to change after signing.
+   */
+  public static final String MANIFEST_FILE_NAME = "cryptad-app.properties";
+
+  /**
+   * Current digest sidecar schema version.
+   *
+   * <p>Unsupported versions are rejected instead of interpreted leniently so future format changes
+   * cannot be mistaken for this deterministic v1 layout.
+   */
+  public static final int DIGEST_VERSION = 1;
+
+  /**
+   * Supported content digest algorithm for bundle entries.
+   *
+   * <p>The text sidecar stores this algorithm name explicitly, but the implementation currently
+   * accepts only SHA-256 to keep signing and verification behavior deterministic.
+   */
+  public static final String DIGEST_ALGORITHM = "SHA-256";
+
+  /**
+   * Creates a validated digest snapshot.
+   *
+   * <p>Construction performs format-level validation only. It checks ordering, required manifest
+   * coverage, sidecar exclusion, and supported metadata values. It does not read files from disk or
+   * verify the recorded hashes; use {@link AppBundleDigestVerifier#verify(java.nio.file.Path)} when
+   * a bundle tree must be compared with an existing sidecar.
+   *
+   * @param version digest schema version, currently required to be {@code 1}
+   * @param algorithm digest algorithm name, currently required to be {@code SHA-256}
+   * @param entries deterministic bundle file digests sorted by normalized path
+   * @throws IllegalArgumentException if the supplied values cannot represent a v1 digest sidecar
+   */
+  public AppBundleDigest {
+    if (version != DIGEST_VERSION) {
+      throw new IllegalArgumentException("unsupported digest.version: " + version);
+    }
+    if (!DIGEST_ALGORITHM.equals(Objects.requireNonNull(algorithm, "algorithm"))) {
+      throw new IllegalArgumentException("unsupported digest.algorithm: " + algorithm);
+    }
+    entries = List.copyOf(Objects.requireNonNull(entries, "entries"));
+    if (entries.isEmpty()) {
+      throw new IllegalArgumentException("digest must contain at least one file entry");
+    }
+    validateEntries(entries);
+  }
+
+  private static void validateEntries(List<AppBundleDigestEntry> entries) {
+    String previousPath = null;
+    boolean manifestSeen = false;
+    for (AppBundleDigestEntry entry : entries) {
+      String path = entry.path();
+      if (AppDistributionSidecars.isDistributionSidecar(path)) {
+        throw new IllegalArgumentException("digest entries must not include distribution sidecars");
+      }
+      if (previousPath != null && previousPath.compareTo(path) >= 0) {
+        throw new IllegalArgumentException("digest entries must be sorted lexicographically");
+      }
+      if (MANIFEST_FILE_NAME.equals(path)) {
+        manifestSeen = true;
+      }
+      previousPath = path;
+    }
+    if (!manifestSeen) {
+      throw new IllegalArgumentException(
+          "digest entries must include " + AppBundleDigest.MANIFEST_FILE_NAME);
+    }
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestEntry.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestEntry.java
@@ -1,0 +1,67 @@
+package network.crypta.platform.appdist;
+
+import java.util.regex.Pattern;
+
+/**
+ * One deterministic file digest entry inside {@code cryptad-app.digests}.
+ *
+ * <p>Entries use the same normalized path rules as the rest of the distribution sidecar format:
+ * paths are relative to the bundle root, use {@code /} separators, and cannot contain traversal or
+ * empty segments. The content hash is always lowercase hexadecimal SHA-256 of the exact file bytes
+ * observed while generating or verifying the sidecar.
+ *
+ * <p>The optional {@code executable} field is deliberately nullable. A missing value means the file
+ * has no authenticated executable-bit state, which keeps cross-platform signatures stable for
+ * scripts and Windows launchers. A present value is used only when the declared {@code app.exec}
+ * target is launchable because of POSIX executable permissions, so changing that permission after
+ * signing invalidates the digest.
+ *
+ * @param path normalized relative bundle path using {@code /} separators
+ * @param sha256 lowercase hexadecimal SHA-256 of the file bytes
+ * @param executable authenticated POSIX executable-bit state for {@code app.exec}, or {@code null}
+ *     when no permission metadata is part of the signed payload
+ */
+public record AppBundleDigestEntry(String path, String sha256, Boolean executable) {
+  private static final Pattern SHA_256_HEX_PATTERN = Pattern.compile("[0-9a-f]{64}");
+
+  /**
+   * Creates a validated digest entry.
+   *
+   * <p>The constructor normalizes the supplied path and rejects malformed hash text. It does not
+   * inspect the file system; callers are responsible for deciding whether executable-bit metadata
+   * is applicable before constructing the entry.
+   *
+   * @param path normalized relative bundle path using {@code /} separators
+   * @param sha256 lowercase hexadecimal SHA-256 of the file bytes
+   * @param executable authenticated POSIX executable-bit state for {@code app.exec}, or {@code
+   *     null} when no permission metadata is part of the signed payload
+   * @throws IllegalArgumentException if the path or hash cannot be encoded in the sidecar format
+   */
+  public AppBundleDigestEntry {
+    path = AppDistributionSidecars.normalizeBundleRelativePath(path, "digest path");
+    sha256 = normalizeSha256(sha256);
+  }
+
+  /**
+   * Creates a digest entry without authenticated executable metadata.
+   *
+   * <p>This overload is appropriate for ordinary payload files, manifest files, and launcher types
+   * whose launchability does not depend on POSIX execute bits.
+   *
+   * @param path normalized relative bundle path using {@code /} separators
+   * @param sha256 lowercase hexadecimal SHA-256 of the file bytes
+   * @throws IllegalArgumentException if the path or hash cannot be encoded in the sidecar format
+   */
+  @SuppressWarnings("unused")
+  public AppBundleDigestEntry(String path, String sha256) {
+    this(path, sha256, null);
+  }
+
+  private static String normalizeSha256(String sha256) {
+    String normalized = AppDistributionSidecars.requireNonBlankSingleLine(sha256, "sha256");
+    if (!SHA_256_HEX_PATTERN.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("sha256 must be 64 lowercase hex characters");
+    }
+    return normalized;
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestVerifier.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestVerifier.java
@@ -1,10 +1,12 @@
 package network.crypta.platform.appdist;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,7 +43,23 @@ public final class AppBundleDigestVerifier {
    * @throws IOException if the sidecar is missing, malformed, unsupported, or unsafe
    */
   public static AppBundleDigest read(Path digestFile) throws IOException {
-    String content = AppDistributionSidecars.readRequiredUtf8File(digestFile, "digest sidecar");
+    return read(AppDistributionSidecars.readRequiredBytes(digestFile, "digest sidecar"));
+  }
+
+  /**
+   * Parses and validates already-read digest sidecar bytes.
+   *
+   * <p>This overload is used by signed-bundle verification after the signature has been checked
+   * over the exact byte array read from {@code cryptad-app.digests}. Parsing those same bytes
+   * avoids a second filesystem read that could otherwise observe a different digest sidecar.
+   *
+   * @param digestBytes exact UTF-8 bytes read from {@code cryptad-app.digests}
+   * @return parsed digest snapshot with normalized paths and validated metadata
+   * @throws AppDistributionException if the sidecar bytes are malformed or unsupported
+   */
+  public static AppBundleDigest read(byte[] digestBytes) throws AppDistributionException {
+    String content =
+        new String(Objects.requireNonNull(digestBytes, "digestBytes"), StandardCharsets.UTF_8);
     Map<String, String> properties =
         AppDistributionSidecars.parseKeyValueSidecar(content, "digest sidecar");
     DigestHeader header = readDigestHeader(properties);
@@ -158,11 +176,36 @@ public final class AppBundleDigestVerifier {
   public static AppBundleDigest verify(Path bundleRoot) throws IOException {
     Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
     AppBundleDigest expected = read(normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME));
+    return verifyNormalizedBundleRoot(normalizedBundleRoot, expected);
+  }
+
+  /**
+   * Verifies the current bundle contents against a caller-supplied digest snapshot.
+   *
+   * <p>Unlike {@link #verify(Path)}, this method does not read {@code cryptad-app.digests} from the
+   * bundle root. Signed-bundle callers should pass the digest parsed from the same bytes whose
+   * signature was just verified, so a concurrent rewrite of the sidecar cannot substitute a
+   * different digest inventory between signature validation and payload validation.
+   *
+   * @param bundleRoot staged app bundle root directory to compare with the supplied digest
+   * @param expected digest snapshot that was already parsed by the caller
+   * @return the supplied digest snapshot when verification succeeds
+   * @throws IOException if the bundle is unsafe, unreadable, or does not match the supplied digest
+   */
+  public static AppBundleDigest verify(Path bundleRoot, AppBundleDigest expected)
+      throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    return verifyNormalizedBundleRoot(normalizedBundleRoot, expected);
+  }
+
+  private static AppBundleDigest verifyNormalizedBundleRoot(
+      Path normalizedBundleRoot, AppBundleDigest expected) throws IOException {
+    AppBundleDigest checkedExpected = Objects.requireNonNull(expected, "expected");
     AppBundleDigest actual = AppBundleDigestWriter.create(normalizedBundleRoot);
-    if (!expected.equals(actual)) {
+    if (!checkedExpected.equals(actual)) {
       throw new AppDistributionException("digest sidecar does not match bundle contents");
     }
-    return expected;
+    return checkedExpected;
   }
 
   private static int parseIndex(String rawIndex, String propertyName)

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestVerifier.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestVerifier.java
@@ -1,0 +1,196 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses and verifies {@code cryptad-app.digests} sidecars against bundle contents.
+ *
+ * <p>The verifier is intentionally stricter than a generic properties' reader. It accepts only the
+ * v1 digest keys, requires contiguous {@code file.N.*} indexes, rejects unsupported per-file
+ * metadata, and delegates every path to the shared bundle-relative path validator. That makes
+ * malformed sidecars fail before any signature check can treat them as trusted input.
+ *
+ * <p>{@link #verify(Path)} compares the sidecar with a newly generated digest of the current bundle
+ * tree. This catches modified files, changed manifest contents, changed POSIX executable-bit state
+ * when that state is authenticated, missing payload files, and extra payload files that were added
+ * after signing. The method reads from the supplied local directory only; it does not fetch remote
+ * catalogs or artifacts.
+ */
+public final class AppBundleDigestVerifier {
+  private static final Pattern FILE_PROPERTY_PATTERN =
+      Pattern.compile("file\\.(\\d+)\\.(path|sha256|executable)");
+
+  private AppBundleDigestVerifier() {}
+
+  /**
+   * Reads and validates a digest sidecar.
+   *
+   * <p>This method validates the textual sidecar format but does not compare it with a bundle
+   * directory. It is useful when callers need the declared digest inventory, for example before
+   * checking the Ed25519 signature over the exact digest sidecar bytes.
+   *
+   * @param digestFile path to {@code cryptad-app.digests}, resolved by the caller
+   * @return parsed digest snapshot with normalized paths and validated metadata
+   * @throws IOException if the sidecar is missing, malformed, unsupported, or unsafe
+   */
+  public static AppBundleDigest read(Path digestFile) throws IOException {
+    String content = AppDistributionSidecars.readRequiredUtf8File(digestFile, "digest sidecar");
+    Map<String, String> properties =
+        AppDistributionSidecars.parseKeyValueSidecar(content, "digest sidecar");
+    DigestHeader header = readDigestHeader(properties);
+    Map<Integer, DigestEntryBuilder> builders = readDigestEntries(properties);
+    List<AppBundleDigestEntry> entries = buildDigestEntries(builders);
+
+    return createDigest(header, entries);
+  }
+
+  private static DigestHeader readDigestHeader(Map<String, String> properties)
+      throws AppDistributionException {
+    String versionText = properties.remove("digest.version");
+    String algorithm = properties.remove("digest.algorithm");
+    if (versionText == null) {
+      throw new AppDistributionException("missing digest.version");
+    }
+    if (algorithm == null) {
+      throw new AppDistributionException("missing digest.algorithm");
+    }
+    return new DigestHeader(versionText, algorithm);
+  }
+
+  private static Map<Integer, DigestEntryBuilder> readDigestEntries(Map<String, String> properties)
+      throws AppDistributionException {
+    Map<Integer, DigestEntryBuilder> builders = new TreeMap<>();
+    for (Map.Entry<String, String> property : properties.entrySet()) {
+      DigestProperty digestProperty = parseDigestProperty(property.getKey());
+      DigestEntryBuilder builder =
+          builders.computeIfAbsent(digestProperty.index(), ignored -> new DigestEntryBuilder());
+      setDigestEntryField(builder, digestProperty.field(), property.getValue(), property.getKey());
+    }
+    if (builders.isEmpty()) {
+      throw new AppDistributionException("digest sidecar must contain at least one file entry");
+    }
+    return builders;
+  }
+
+  private static DigestProperty parseDigestProperty(String propertyName)
+      throws AppDistributionException {
+    Matcher matcher = FILE_PROPERTY_PATTERN.matcher(propertyName);
+    if (!matcher.matches()) {
+      throw new AppDistributionException("unsupported digest property: " + propertyName);
+    }
+    return new DigestProperty(parseIndex(matcher.group(1), propertyName), matcher.group(2));
+  }
+
+  private static void setDigestEntryField(
+      DigestEntryBuilder builder, String field, String value, String propertyName)
+      throws AppDistributionException {
+    switch (field) {
+      case "path" -> builder.path = value;
+      case "executable" -> builder.executable = parseExecutable(value, propertyName);
+      default -> builder.sha256 = value;
+    }
+  }
+
+  private static List<AppBundleDigestEntry> buildDigestEntries(
+      Map<Integer, DigestEntryBuilder> builders) throws AppDistributionException {
+    List<AppBundleDigestEntry> entries = new ArrayList<>(builders.size());
+    for (int expectedIndex = 0; expectedIndex < builders.size(); expectedIndex++) {
+      DigestEntryBuilder builder = requireDigestEntryBuilder(builders, expectedIndex);
+      entries.add(buildDigestEntry(builder, expectedIndex));
+    }
+    return entries;
+  }
+
+  private static DigestEntryBuilder requireDigestEntryBuilder(
+      Map<Integer, DigestEntryBuilder> builders, int expectedIndex)
+      throws AppDistributionException {
+    DigestEntryBuilder builder = builders.get(expectedIndex);
+    if (builder == null) {
+      throw new AppDistributionException("digest entries must use contiguous indexes");
+    }
+    return builder;
+  }
+
+  private static AppBundleDigestEntry buildDigestEntry(
+      DigestEntryBuilder builder, int expectedIndex) throws AppDistributionException {
+    if (builder.path == null || builder.sha256 == null) {
+      throw new AppDistributionException("digest entry " + expectedIndex + " is incomplete");
+    }
+    try {
+      return new AppBundleDigestEntry(builder.path, builder.sha256, builder.executable);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException("invalid digest entry " + expectedIndex, exception);
+    }
+  }
+
+  private static AppBundleDigest createDigest(
+      DigestHeader header, List<AppBundleDigestEntry> entries) throws AppDistributionException {
+    try {
+      return new AppBundleDigest(
+          Integer.parseInt(header.versionText()), header.algorithm(), entries);
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException(
+          "invalid digest.version: " + header.versionText(), exception);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(exception.getMessage(), exception);
+    }
+  }
+
+  /**
+   * Verifies that the digest sidecar matches the current bundle contents.
+   *
+   * <p>The bundle root must be a real local directory. Verification regenerates the digest from the
+   * current tree using {@link AppBundleDigestWriter#create(Path)} and then performs an exact value
+   * comparison with the parsed sidecar. A mismatch is reported generically so API callers do not
+   * receive unnecessary filesystem detail.
+   *
+   * @param bundleRoot staged app bundle root directory to compare with the digest sidecar
+   * @return parsed digest snapshot when verification succeeds
+   * @throws IOException if the sidecar is missing, malformed, unsafe, or does not match the bundle
+   */
+  public static AppBundleDigest verify(Path bundleRoot) throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    AppBundleDigest expected = read(normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME));
+    AppBundleDigest actual = AppBundleDigestWriter.create(normalizedBundleRoot);
+    if (!expected.equals(actual)) {
+      throw new AppDistributionException("digest sidecar does not match bundle contents");
+    }
+    return expected;
+  }
+
+  private static int parseIndex(String rawIndex, String propertyName)
+      throws AppDistributionException {
+    try {
+      return Integer.parseInt(rawIndex);
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException(
+          "invalid digest entry index in " + propertyName, exception);
+    }
+  }
+
+  private static Boolean parseExecutable(String rawValue, String propertyName)
+      throws AppDistributionException {
+    return switch (rawValue) {
+      case "true" -> Boolean.TRUE;
+      case "false" -> Boolean.FALSE;
+      default -> throw new AppDistributionException("invalid executable flag in " + propertyName);
+    };
+  }
+
+  private record DigestHeader(String versionText, String algorithm) {}
+
+  private record DigestProperty(int index, String field) {}
+
+  private static final class DigestEntryBuilder {
+    private String path;
+    private String sha256;
+    private Boolean executable;
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestWriter.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleDigestWriter.java
@@ -1,0 +1,250 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Creates and writes deterministic {@code cryptad-app.digests} sidecars.
+ *
+ * <p>The writer is the canonical producer for bundle digests used by signing, verification, and
+ * local build tooling. It validates the bundle structure first, walks only the caller-supplied
+ * bundle directory, rejects symbolic links and aliased directory entries, hashes regular files, and
+ * serializes entries in lexicographic path order. The generated sidecar is UTF-8 text so operators
+ * can inspect it, but callers should treat {@link AppBundleDigest} as the authoritative parsed
+ * representation.
+ *
+ * <p>Distribution sidecars are excluded from the digest input. The app manifest remains included
+ * because it controls app identity and launch behavior. File hashes are streamed through a fixed
+ * buffer instead of materializing whole files in memory, which keeps signing and install-time
+ * verification reliable for bundles with large local assets.
+ */
+public final class AppBundleDigestWriter {
+  private static final int DIGEST_BUFFER_BYTES = 64 * 1024;
+  private static final String FILE_PROPERTY_PREFIX = "file.";
+
+  private AppBundleDigestWriter() {}
+
+  /**
+   * Computes a digest snapshot for the current bundle contents.
+   *
+   * <p>The method performs all structural validation needed before signing: the bundle root must be
+   * a directory, the manifest must be valid, {@code app.exec} must resolve to a launchable file,
+   * and every walked entry must remain inside the real bundle root. Sidecars such as {@code
+   * cryptad-app.digests} and {@code cryptad-app.signature} are skipped so repeated signing produces
+   * the same digest for the same payload.
+   *
+   * @param bundleRoot staged app bundle root directory to inspect without following unsafe links
+   * @return deterministic digest snapshot for the current bundle payload
+   * @throws IOException if the bundle cannot be read safely or the digest cannot be computed
+   */
+  public static AppBundleDigest create(Path bundleRoot) throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    Path bundleRealRoot = normalizedBundleRoot.toRealPath();
+    AppBundleStructureValidator.ValidatedBundle validatedBundle =
+        AppBundleStructureValidator.validate(normalizedBundleRoot);
+    DigestInventory inventory =
+        collectDigestInventory(normalizedBundleRoot, bundleRealRoot, validatedBundle);
+    return createDigest(inventory);
+  }
+
+  private static DigestInventory collectDigestInventory(
+      Path normalizedBundleRoot,
+      Path bundleRealRoot,
+      AppBundleStructureValidator.ValidatedBundle validatedBundle)
+      throws IOException {
+    DigestInventory inventory = new DigestInventory();
+    Files.walkFileTree(
+        normalizedBundleRoot,
+        new DigestFileVisitor(normalizedBundleRoot, bundleRealRoot, validatedBundle, inventory));
+    return inventory;
+  }
+
+  private static AppBundleDigest createDigest(DigestInventory inventory)
+      throws AppDistributionException {
+    List<AppBundleDigestEntry> entries = new ArrayList<>(inventory.shaByPath().size());
+    try {
+      for (Map.Entry<String, String> entry : inventory.shaByPath().entrySet()) {
+        entries.add(
+            new AppBundleDigestEntry(
+                entry.getKey(),
+                entry.getValue(),
+                inventory.executableByPath().get(entry.getKey())));
+      }
+      return new AppBundleDigest(
+          AppBundleDigest.DIGEST_VERSION, AppBundleDigest.DIGEST_ALGORITHM, entries);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(exception.getMessage(), exception);
+    }
+  }
+
+  /**
+   * Writes a canonical digest sidecar for the bundle.
+   *
+   * <p>The sidecar is regenerated from the current bundle contents and atomically replaces the text
+   * content of {@code cryptad-app.digests}. Callers that sign a bundle should use the returned
+   * digest only as a snapshot; the signature itself is computed over the exact sidecar bytes
+   * written by {@link AppBundleSigner}.
+   *
+   * @param bundleRoot staged app bundle root directory where the sidecar should be written
+   * @return digest snapshot that was written to disk
+   * @throws IOException if the bundle cannot be read safely or the sidecar cannot be written
+   */
+  public static AppBundleDigest write(Path bundleRoot) throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    AppBundleDigest digest = create(normalizedBundleRoot);
+    AppDistributionSidecars.writeUtf8File(
+        normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), serialize(digest));
+    return digest;
+  }
+
+  static String serialize(AppBundleDigest digest) {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append("digest.version=")
+        .append(digest.version())
+        .append('\n')
+        .append("digest.algorithm=")
+        .append(digest.algorithm())
+        .append('\n');
+    List<AppBundleDigestEntry> entries =
+        digest.entries().stream().sorted(Comparator.comparing(AppBundleDigestEntry::path)).toList();
+    for (int index = 0; index < entries.size(); index++) {
+      AppBundleDigestEntry entry = entries.get(index);
+      builder
+          .append(FILE_PROPERTY_PREFIX)
+          .append(index)
+          .append(".path=")
+          .append(entry.path())
+          .append('\n')
+          .append(FILE_PROPERTY_PREFIX)
+          .append(index)
+          .append(".sha256=")
+          .append(entry.sha256())
+          .append('\n');
+      if (entry.executable() != null) {
+        builder
+            .append(FILE_PROPERTY_PREFIX)
+            .append(index)
+            .append(".executable=")
+            .append(entry.executable())
+            .append('\n');
+      }
+    }
+    return builder.toString();
+  }
+
+  private record DigestInventory(
+      Map<String, String> shaByPath, Map<String, Boolean> executableByPath) {
+    private DigestInventory() {
+      this(new TreeMap<>(), new TreeMap<>());
+    }
+  }
+
+  private static final class DigestFileVisitor extends SimpleFileVisitor<Path> {
+    private final Path normalizedBundleRoot;
+    private final Path bundleRealRoot;
+    private final AppBundleStructureValidator.ValidatedBundle validatedBundle;
+    private final DigestInventory inventory;
+    private final Set<Path> visitedRealDirectories = new HashSet<>();
+
+    private DigestFileVisitor(
+        Path normalizedBundleRoot,
+        Path bundleRealRoot,
+        AppBundleStructureValidator.ValidatedBundle validatedBundle,
+        DigestInventory inventory) {
+      this.normalizedBundleRoot = normalizedBundleRoot;
+      this.bundleRealRoot = bundleRealRoot;
+      this.validatedBundle = validatedBundle;
+      this.inventory = inventory;
+    }
+
+    @Override
+    public @NotNull FileVisitResult preVisitDirectory(
+        @NotNull Path directory, @NotNull BasicFileAttributes attributes) throws IOException {
+      Path realDirectory =
+          AppDistributionSidecars.validateBundleEntry(
+              normalizedBundleRoot, bundleRealRoot, directory);
+      if (!visitedRealDirectories.add(realDirectory)) {
+        throw new AppDistributionException(
+            "bundle must not revisit directories via links or reparse points: " + directory);
+      }
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public @NotNull FileVisitResult visitFile(
+        @NotNull Path file, @NotNull BasicFileAttributes attributes) throws IOException {
+      AppDistributionSidecars.validateBundleEntry(normalizedBundleRoot, bundleRealRoot, file);
+      if (!attributes.isRegularFile()) {
+        throw new AppDistributionException("bundle must contain regular files only");
+      }
+      String relativePath = normalizeRelativePath(file);
+      if (AppDistributionSidecars.isDistributionSidecar(relativePath)) {
+        return FileVisitResult.CONTINUE;
+      }
+      inventory.shaByPath().put(relativePath, sha256Hex(file));
+      recordExecutableMode(relativePath);
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public @NotNull FileVisitResult visitFileFailed(
+        @NotNull Path file, @NotNull IOException exception) throws IOException {
+      if (isLinkOrAliasedEntry(file)) {
+        throw new AppDistributionException(
+            "bundle must not contain links or reparse points: " + file);
+      }
+      throw new AppDistributionException("failed to inspect bundle contents", exception);
+    }
+
+    private String normalizeRelativePath(Path file) throws AppDistributionException {
+      try {
+        return AppDistributionSidecars.normalizeBundleRelativePath(normalizedBundleRoot, file);
+      } catch (IllegalArgumentException exception) {
+        throw new AppDistributionException("bundle contains an invalid relative path", exception);
+      }
+    }
+
+    private void recordExecutableMode(String relativePath) {
+      if (relativePath.equals(validatedBundle.manifest().execPathText())) {
+        inventory
+            .executableByPath()
+            .put(relativePath, validatedBundle.authenticatedExecutableBit());
+      }
+    }
+
+    private static String sha256Hex(Path file) throws IOException {
+      MessageDigest digest = AppDistributionSidecars.newSha256Digest();
+      byte[] buffer = new byte[DIGEST_BUFFER_BYTES];
+      try (InputStream input = Files.newInputStream(file)) {
+        int bytesRead;
+        while ((bytesRead = input.read(buffer)) >= 0) {
+          if (bytesRead > 0) {
+            digest.update(buffer, 0, bytesRead);
+          }
+        }
+      }
+      return AppDistributionSidecars.lowercaseHex(digest.digest());
+    }
+
+    private static boolean isLinkOrAliasedEntry(Path file) throws IOException {
+      return Files.exists(file, LinkOption.NOFOLLOW_LINKS)
+          && (Files.isSymbolicLink(file) || AppDistributionSidecars.isAliasedPathEntry(file));
+    }
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifest.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifest.java
@@ -1,0 +1,141 @@
+package network.crypta.platform.appdist;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Parsed v1 manifest for a staged app bundle.
+ *
+ * <p>{@code AppBundleManifest} is the appdist-owned normalized form of {@code
+ * cryptad-app.properties}. It preserves the manifest fields that matter to bundle signing,
+ * verification, and installability checks without depending on the higher-level AppHost model.
+ * Parsing normalizes app identifiers, executable paths, permissions, and quota metadata before
+ * callers use the values for digest generation.
+ *
+ * <p>The manifest is signed indirectly because {@code cryptad-app.properties} is always included in
+ * {@code cryptad-app.digests}. Any change to app identity, display version, executable path,
+ * permissions, or quota metadata after signing therefore invalidates the bundle. The record remains
+ * immutable after construction and is safe to pass between parser, digest writer, and verification
+ * code without defensive copying beyond the permissions list.
+ *
+ * @param manifestVersion manifest schema version, currently required to be {@code 1}
+ * @param appId stable lower-case application identifier safe for managed bundle paths
+ * @param appName human-readable application name shown by host and API surfaces
+ * @param appVersion display version string recorded in installed app summaries
+ * @param execPathText executable path relative to the bundle root, using normalized separators
+ * @param uiEntry optional UI entry path, or {@code null} when the app has no bundled UI surface
+ * @param permissions normalized permission strings declared by the app manifest
+ * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
+ * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+ */
+public record AppBundleManifest(
+    int manifestVersion,
+    String appId,
+    String appName,
+    String appVersion,
+    String execPathText,
+    String uiEntry,
+    List<String> permissions,
+    Long dataQuotaBytes,
+    Long cacheQuotaBytes) {
+  private static final Pattern APP_ID_PATTERN =
+      Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
+
+  /**
+   * Creates a validated staged-bundle manifest snapshot.
+   *
+   * <p>This constructor enforces value-level invariants after the parser has handled manifest text
+   * syntax. It rejects unsupported schema versions, blank required fields, malformed app ids, null
+   * permission lists, and negative quotas. It does not check whether {@code app.exec} exists on
+   * disk; use {@link AppBundleStructureValidator#validate(Path)} for filesystem and launchability
+   * checks.
+   *
+   * @param manifestVersion manifest schema version, currently required to be {@code 1}
+   * @param appId stable lower-case application identifier safe for managed bundle paths
+   * @param appName human-readable application name shown by host and API surfaces
+   * @param appVersion display version string recorded in installed app summaries
+   * @param execPathText executable path relative to the bundle root, using normalized separators
+   * @param uiEntry optional UI entry path, or {@code null} when the app has no bundled UI surface
+   * @param permissions normalized permission strings declared by the app manifest
+   * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
+   * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+   * @throws IllegalArgumentException if any value cannot represent a valid v1 app manifest
+   */
+  public AppBundleManifest {
+    if (manifestVersion != 1) {
+      throw new IllegalArgumentException("unsupported manifest.version: " + manifestVersion);
+    }
+    appId = normalizeAppId(appId);
+    appName = requireNonBlank(appName, "app.name");
+    appVersion = requireNonBlank(appVersion, "app.version");
+    execPathText = requireNonBlank(execPathText, "app.exec");
+    uiEntry = normalizeOptional(uiEntry);
+    permissions = List.copyOf(Objects.requireNonNull(permissions, "permissions"));
+    dataQuotaBytes = normalizeQuota(dataQuotaBytes, "quota.data.bytes");
+    cacheQuotaBytes = normalizeQuota(cacheQuotaBytes, "quota.cache.bytes");
+  }
+
+  /**
+   * Returns the executable path as a normalized relative bundle path.
+   *
+   * <p>The returned {@link Path} is suitable for resolving against a known bundle root. Callers
+   * should still validate the resolved path with {@link AppBundleStructureValidator} before
+   * trusting it, because this method does not inspect the file system.
+   *
+   * @return normalized executable path within the bundle
+   */
+  public Path execPath() {
+    return Path.of(execPathText).normalize();
+  }
+
+  /**
+   * Normalizes and validates an app id.
+   *
+   * <p>App ids are trimmed, converted to lower case, and constrained to path-safe characters. The
+   * same normalization is used before digesting or installing a bundle so callers do not need a
+   * second app-id canonicalization step.
+   *
+   * @param appId raw application identifier from a manifest or caller input
+   * @return normalized lower-case app id
+   * @throws NullPointerException if {@code appId} is {@code null}
+   * @throws IllegalArgumentException if the normalized id is empty or contains unsupported syntax
+   */
+  public static String normalizeAppId(String appId) {
+    Objects.requireNonNull(appId, "appId");
+    String normalized = appId.trim().toLowerCase(Locale.ROOT);
+    if (!APP_ID_PATTERN.matcher(normalized).matches()) {
+      throw new IllegalArgumentException("invalid app id: " + appId);
+    }
+    return normalized;
+  }
+
+  private static String normalizeOptional(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private static Long normalizeQuota(Long quota, String fieldName) {
+    if (quota == null) {
+      return null;
+    }
+    if (quota < 0L) {
+      throw new IllegalArgumentException(fieldName + " must be >= 0");
+    }
+    return quota;
+  }
+
+  private static String requireNonBlank(String value, String fieldName) {
+    Objects.requireNonNull(value, fieldName);
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return trimmed;
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
@@ -1,0 +1,412 @@
+package network.crypta.platform.appdist;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Parser and validator for the v1 staged-bundle manifest format.
+ *
+ * <p>This keeps the signed-bundle tooling aligned with AppHost's narrow manifest semantics without
+ * introducing an upward dependency on AppHost classes. The parser accepts the properties-style
+ * syntax used by {@code cryptad-app.properties}, strips a leading UTF-8 byte-order mark, preserves
+ * literal Windows backslashes in {@code app.exec} where Java {@link Properties#load} would treat
+ * them as escapes, and still decodes ordinary escaped text for other fields.
+ *
+ * <p>Validation is intentionally strict because the manifest is part of the signed payload. Missing
+ * required keys, blank optional values, unsupported schema versions, invalid permissions, unsafe
+ * executable paths, and executable paths that point at distribution sidecars are rejected before
+ * the bundle can be digested or installed. Filesystem launchability checks live in {@link
+ * AppBundleStructureValidator}; this class only validates manifest syntax and normalized values.
+ */
+public final class AppBundleManifestParser {
+  /**
+   * Canonical manifest filename stored at the bundle root.
+   *
+   * <p>This file is always included in the digest sidecar, so changes to manifest metadata after
+   * signing invalidate the bundle.
+   */
+  public static final String MANIFEST_FILE_NAME = "cryptad-app.properties";
+
+  private static final char UTF_8_BOM = '\uFEFF';
+  private static final Pattern PERMISSION_PATTERN =
+      Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
+  private static final Pattern WINDOWS_DRIVE_PREFIX_PATTERN = Pattern.compile("^[a-zA-Z]:.*");
+
+  private AppBundleManifestParser() {}
+
+  /**
+   * Parses a manifest from UTF-8 text content.
+   *
+   * <p>This entry point is useful for tests and callers that already loaded the manifest text. It
+   * applies the same syntax rules as {@link #parse(Path)}, including BOM removal, comment handling,
+   * key/value separator parsing, and manifest field validation.
+   *
+   * @param content manifest content in the supported properties-style syntax
+   * @return validated staged-bundle manifest snapshot with normalized field values
+   * @throws IOException if the manifest content is invalid, incomplete, or unsupported
+   */
+  public static AppBundleManifest parseContent(String content) throws IOException {
+    return parse(parseProperties(stripLeadingBom(content)));
+  }
+
+  /**
+   * Parses a manifest from an on-disk properties file.
+   *
+   * <p>The manifest path must be a regular file and must not be a symbolic link. This prevents
+   * staged bundles from pointing manifest parsing at content outside the bundle tree before the
+   * digest writer or AppHost performs its broader directory-boundary checks.
+   *
+   * @param manifestFile path to {@code cryptad-app.properties}
+   * @return validated staged-bundle manifest snapshot with normalized field values
+   * @throws IOException if the file cannot be read safely or the manifest content is invalid
+   */
+  public static AppBundleManifest parse(Path manifestFile) throws IOException {
+    if (Files.isSymbolicLink(manifestFile)) {
+      throw new AppDistributionException("manifest file must not be a symlink: " + manifestFile);
+    }
+    if (!Files.isRegularFile(manifestFile, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException("missing manifest file: " + manifestFile);
+    }
+    return parseContent(Files.readString(manifestFile));
+  }
+
+  private static Properties parseProperties(String content) throws IOException {
+    Properties properties = new Properties();
+    try (BufferedReader reader = new BufferedReader(new StringReader(content))) {
+      String line;
+      int lineNumber = 0;
+      while ((line = reader.readLine()) != null) {
+        lineNumber++;
+        parsePropertyLine(properties, line, lineNumber);
+      }
+      return properties;
+    }
+  }
+
+  private static String stripLeadingBom(String content) {
+    if (!content.isEmpty() && content.charAt(0) == UTF_8_BOM) {
+      return content.substring(1);
+    }
+    return content;
+  }
+
+  private static void parsePropertyLine(Properties properties, String line, int lineNumber)
+      throws AppDistributionException {
+    String trimmedLine = line.trim();
+    if (trimmedLine.isEmpty() || trimmedLine.startsWith("#") || trimmedLine.startsWith("!")) {
+      return;
+    }
+    int separatorIndex = findSeparatorIndex(line);
+    if (separatorIndex < 0) {
+      throw new AppDistributionException("invalid manifest line " + lineNumber + ": " + line);
+    }
+    String key =
+        decodePropertiesComponent(line.substring(0, separatorIndex).trim(), lineNumber, true, true);
+    if (key.isEmpty()) {
+      throw new AppDistributionException("invalid manifest line " + lineNumber + ": " + line);
+    }
+    String rawValue = line.substring(separatorIndex + 1).trim();
+    String value =
+        decodePropertiesComponent(
+            rawValue, lineNumber, false, shouldDecodeUnicodeEscapesInValue(key, rawValue));
+    properties.setProperty(key, value);
+  }
+
+  private static boolean shouldDecodeUnicodeEscapesInValue(String key, String rawValue) {
+    if (!key.equals("app.exec")) {
+      return true;
+    }
+    return rawValue.contains("/")
+        || rawValue.contains("\\\\")
+        || rawValue.startsWith("\\u")
+        || rawValue.startsWith("\\U")
+        || (containsUnicodeEscape(rawValue) && !containsPlainBackslash(rawValue));
+  }
+
+  private static boolean containsUnicodeEscape(String rawValue) {
+    for (int index = 0; index + 5 < rawValue.length(); index++) {
+      if (rawValue.charAt(index) == '\\'
+          && (rawValue.charAt(index + 1) == 'u' || rawValue.charAt(index + 1) == 'U')
+          && isHexSequence(rawValue, index + 2)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsPlainBackslash(String rawValue) {
+    for (int index = 0; index < rawValue.length() - 1; index++) {
+      if (rawValue.charAt(index) == '\\'
+          && rawValue.charAt(index + 1) != 'u'
+          && rawValue.charAt(index + 1) != 'U') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isHexSequence(String rawValue, int startIndex) {
+    if (startIndex + 4 > rawValue.length()) {
+      return false;
+    }
+    for (int offset = 0; offset < 4; offset++) {
+      if (Character.digit(rawValue.charAt(startIndex + offset), 16) < 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int findSeparatorIndex(String line) {
+    int equalsIndex = line.indexOf('=');
+    int colonIndex = line.indexOf(':');
+    if (equalsIndex < 0) {
+      return colonIndex;
+    }
+    if (colonIndex < 0) {
+      return equalsIndex;
+    }
+    return Math.min(equalsIndex, colonIndex);
+  }
+
+  private static String decodePropertiesComponent(
+      String text, int lineNumber, boolean decodeControlEscapes, boolean decodeUnicodeEscapes)
+      throws AppDistributionException {
+    StringBuilder decoded = new StringBuilder(text.length());
+    int index = 0;
+    while (index < text.length()) {
+      char character = text.charAt(index);
+      if (character != '\\' || index + 1 >= text.length()) {
+        decoded.append(character);
+        index++;
+      } else {
+        index =
+            appendEscapedCharacter(
+                decoded, text, index, lineNumber, decodeControlEscapes, decodeUnicodeEscapes);
+      }
+    }
+    return decoded.toString();
+  }
+
+  private static int appendEscapedCharacter(
+      StringBuilder decoded,
+      String text,
+      int escapeIndex,
+      int lineNumber,
+      boolean decodeControlEscapes,
+      boolean decodeUnicodeEscapes)
+      throws AppDistributionException {
+    int nextIndex = escapeIndex + 1;
+    char escaped = text.charAt(nextIndex);
+    switch (escaped) {
+      case 't' -> appendControlEscape(decoded, escaped, '\t', decodeControlEscapes);
+      case 'n' -> appendControlEscape(decoded, escaped, '\n', decodeControlEscapes);
+      case 'r' -> appendControlEscape(decoded, escaped, '\r', decodeControlEscapes);
+      case 'f' -> appendControlEscape(decoded, escaped, '\f', decodeControlEscapes);
+      case '\\' -> decoded.append('\\');
+      case ' ' -> decoded.append(' ');
+      case ':', '=', '#', '!' -> decoded.append(escaped);
+      case 'u' -> {
+        if (decodeUnicodeEscapes) {
+          decoded.append(decodeUnicodeEscape(text, nextIndex, lineNumber));
+          nextIndex += 4;
+        } else {
+          decoded.append('\\').append(escaped);
+        }
+      }
+      default -> decoded.append('\\').append(escaped);
+    }
+    return nextIndex + 1;
+  }
+
+  private static void appendControlEscape(
+      StringBuilder decoded, char escaped, char decodedValue, boolean decodeControlEscapes) {
+    if (decodeControlEscapes) {
+      decoded.append(decodedValue);
+    } else {
+      decoded.append('\\').append(escaped);
+    }
+  }
+
+  private static char decodeUnicodeEscape(String text, int escapeStartIndex, int lineNumber)
+      throws AppDistributionException {
+    if (escapeStartIndex + 4 >= text.length()) {
+      throw new AppDistributionException("invalid unicode escape in manifest line " + lineNumber);
+    }
+    int codePoint = 0;
+    for (int offset = 1; offset <= 4; offset++) {
+      int digit = Character.digit(text.charAt(escapeStartIndex + offset), 16);
+      if (digit < 0) {
+        throw new AppDistributionException("invalid unicode escape in manifest line " + lineNumber);
+      }
+      codePoint = (codePoint << 4) + digit;
+    }
+    return (char) codePoint;
+  }
+
+  private static AppBundleManifest parse(Properties properties) throws AppDistributionException {
+    int manifestVersion = parseRequiredVersion(properties);
+    String appId = required(properties, "app.id");
+    String appName = required(properties, "app.name");
+    String appVersion = required(properties, "app.version");
+    String execPathText = normalizeExecPath(required(properties, "app.exec"));
+    String uiEntry = optional(properties, "app.ui.entry");
+    List<String> permissions = parsePermissions(optional(properties, "app.permissions"));
+    Long dataQuotaBytes = parseOptionalLong(properties, "quota.data.bytes");
+    Long cacheQuotaBytes = parseOptionalLong(properties, "quota.cache.bytes");
+    try {
+      return new AppBundleManifest(
+          manifestVersion,
+          appId,
+          appName,
+          appVersion,
+          execPathText,
+          uiEntry,
+          permissions,
+          dataQuotaBytes,
+          cacheQuotaBytes);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(exception.getMessage(), exception);
+    }
+  }
+
+  private static int parseRequiredVersion(Properties properties) throws AppDistributionException {
+    String value = required(properties, "manifest.version");
+    try {
+      int version = Integer.parseInt(value);
+      if (version != 1) {
+        throw new AppDistributionException("unsupported manifest.version: " + value);
+      }
+      return version;
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException("invalid manifest.version: " + value, exception);
+    }
+  }
+
+  private static String normalizeExecPath(String rawValue) throws AppDistributionException {
+    String normalized = rawValue.trim().replace('\\', '/');
+    if (normalized.isEmpty()) {
+      throw new AppDistributionException("app.exec must not be blank");
+    }
+    if (normalized.startsWith("/")
+        || normalized.startsWith("\\")
+        || WINDOWS_DRIVE_PREFIX_PATTERN.matcher(normalized).matches()) {
+      throw new AppDistributionException("app.exec must be relative: " + rawValue);
+    }
+    ArrayList<String> normalizedSegments = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    for (int index = 0; index < normalized.length(); index++) {
+      char character = normalized.charAt(index);
+      if (character == '/') {
+        addExecSegment(normalizedSegments, current, rawValue);
+      } else {
+        current.append(character);
+      }
+    }
+    addExecSegment(normalizedSegments, current, rawValue);
+    for (String segment : normalizedSegments) {
+      if (segment.isBlank()) {
+        throw new AppDistributionException("app.exec must be normalized: " + rawValue);
+      }
+      if (segment.equals(".") || segment.equals("..")) {
+        throw new AppDistributionException("app.exec must stay under the app root: " + rawValue);
+      }
+    }
+    String execPath = String.join("/", normalizedSegments);
+    if (AppDistributionSidecars.isDistributionSidecar(execPath)) {
+      throw new AppDistributionException(
+          "app.exec must not point at distribution sidecar: " + execPath);
+    }
+    return execPath;
+  }
+
+  private static List<String> parsePermissions(String rawPermissions)
+      throws AppDistributionException {
+    if (rawPermissions == null) {
+      return List.of();
+    }
+    LinkedHashSet<String> normalized = new LinkedHashSet<>();
+    StringBuilder current = new StringBuilder();
+    for (int index = 0; index < rawPermissions.length(); index++) {
+      char character = rawPermissions.charAt(index);
+      if (character == ',') {
+        addPermission(normalized, current, rawPermissions);
+      } else {
+        current.append(character);
+      }
+    }
+    addPermission(normalized, current, rawPermissions);
+    return List.copyOf(normalized);
+  }
+
+  private static void addExecSegment(
+      List<String> normalizedSegments, StringBuilder current, String rawValue)
+      throws AppDistributionException {
+    String segment = current.toString();
+    current.setLength(0);
+    if (segment.isBlank()) {
+      throw new AppDistributionException("app.exec must be normalized: " + rawValue);
+    }
+    normalizedSegments.add(segment);
+  }
+
+  private static void addPermission(
+      Set<String> normalized, StringBuilder current, String rawPermissions)
+      throws AppDistributionException {
+    String permission = current.toString().trim().toLowerCase(Locale.ROOT);
+    current.setLength(0);
+    if (permission.isEmpty()) {
+      throw new AppDistributionException("app.permissions must not contain blank entries");
+    }
+    if (!PERMISSION_PATTERN.matcher(permission).matches()) {
+      throw new AppDistributionException("invalid permission in manifest: " + rawPermissions);
+    }
+    normalized.add(permission);
+  }
+
+  private static Long parseOptionalLong(Properties properties, String key)
+      throws AppDistributionException {
+    String value = optional(properties, key);
+    if (value == null) {
+      return null;
+    }
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException("invalid " + key + ": " + value, exception);
+    }
+  }
+
+  private static String required(Properties properties, String key)
+      throws AppDistributionException {
+    String value = optional(properties, key);
+    if (value == null) {
+      throw new AppDistributionException("missing " + key);
+    }
+    return value;
+  }
+
+  private static String optional(Properties properties, String key)
+      throws AppDistributionException {
+    String value = properties.getProperty(key);
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    if (trimmed.isEmpty()) {
+      throw new AppDistributionException(key + " must not be blank");
+    }
+    return trimmed;
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleSignature.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleSignature.java
@@ -1,0 +1,89 @@
+package network.crypta.platform.appdist;
+
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Immutable parsed or generated content of {@code cryptad-app.signature}.
+ *
+ * <p>The signature sidecar authenticates the exact bytes of {@code cryptad-app.digests}, not a
+ * reparsed or normalized representation. That detail matters because the verifier first checks the
+ * Ed25519 signature over the sidecar payload and then compares the parsed digest with the current
+ * bundle tree. Any change to either the digest sidecar bytes or the files named by the digest
+ * causes verification to fail.
+ *
+ * <p>{@code keyId} is a stable lookup key into {@link TrustedAppKeys}. It is not a proof by itself;
+ * the public key registry still decides whether the signer is trusted for this node or tool
+ * invocation. The record validates only the sidecar schema and base64 encoding.
+ *
+ * @param version signature schema version, currently required to be {@code 1}
+ * @param algorithm signature algorithm name, currently required to be {@code Ed25519}
+ * @param keyId stable trusted-key identifier used to select the verification key
+ * @param payload signed payload filename, currently {@code cryptad-app.digests}
+ * @param valueBase64 base64-encoded signature over the exact digest sidecar bytes
+ */
+public record AppBundleSignature(
+    int version, String algorithm, String keyId, String payload, String valueBase64) {
+  /**
+   * Canonical signature sidecar filename at the staged bundle root.
+   *
+   * <p>The verifier reads this file next to {@code cryptad-app.digests}; it is excluded from digest
+   * generation so signatures can be regenerated without changing the payload digest.
+   */
+  public static final String SIGNATURE_FILE_NAME = "cryptad-app.signature";
+
+  /**
+   * Current signature sidecar schema version.
+   *
+   * <p>Unsupported versions are rejected instead of interpreted leniently so later signature
+   * formats cannot be confused with the v1 Ed25519 payload contract.
+   */
+  public static final int SIGNATURE_VERSION = 1;
+
+  /**
+   * Supported signature algorithm for local app bundle signatures.
+   *
+   * <p>The first distribution layer intentionally uses only JDK Ed25519 support and does not depend
+   * on external crypto providers.
+   */
+  public static final String SIGNATURE_ALGORITHM = "Ed25519";
+
+  /**
+   * Creates a validated signature snapshot.
+   *
+   * <p>Construction validates the declared schema, algorithm, single-line key id, single-line
+   * payload name, and base64 signature encoding. It does not check whether the key id is trusted or
+   * whether the signature is cryptographically valid; use {@link AppBundleVerifier} for that.
+   *
+   * @param version signature schema version, currently required to be {@code 1}
+   * @param algorithm signature algorithm name, currently required to be {@code Ed25519}
+   * @param keyId stable trusted-key identifier used to select the verification key
+   * @param payload signed payload filename, currently {@code cryptad-app.digests}
+   * @param valueBase64 base64-encoded signature over the exact digest sidecar bytes
+   * @throws IllegalArgumentException if the supplied fields cannot represent a v1 signature sidecar
+   */
+  public AppBundleSignature {
+    if (version != SIGNATURE_VERSION) {
+      throw new IllegalArgumentException("unsupported signature.version: " + version);
+    }
+    if (!SIGNATURE_ALGORITHM.equals(Objects.requireNonNull(algorithm, "algorithm"))) {
+      throw new IllegalArgumentException("unsupported signature.algorithm: " + algorithm);
+    }
+    keyId = AppDistributionSidecars.requireNonBlankSingleLine(keyId, "signature.key.id");
+    payload = AppDistributionSidecars.requireNonBlankSingleLine(payload, "signature.payload");
+    valueBase64 = AppDistributionSidecars.requireNonBlankSingleLine(valueBase64, "signature");
+    AppDistributionSidecars.decodeBase64(valueBase64, "signature.value.base64");
+  }
+
+  /**
+   * Decodes the signature bytes.
+   *
+   * <p>The returned array is a fresh decode of the immutable base64 text and may be safely modified
+   * by the caller.
+   *
+   * @return signature bytes decoded from {@link #valueBase64()}
+   */
+  public byte[] signatureBytes() {
+    return Base64.getDecoder().decode(valueBase64);
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleSigner.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleSigner.java
@@ -1,0 +1,137 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Writes deterministic Ed25519 signatures for bundle digest sidecars.
+ *
+ * <p>The signer is the local build/tooling entry point for producing {@code cryptad-app.digests}
+ * and {@code cryptad-app.signature}. It first regenerates the digest from the current bundle tree,
+ * reads the exact UTF-8 sidecar bytes that were written, and signs those bytes with a
+ * caller-supplied Ed25519 private key. Verification uses the same byte-for-byte payload, so callers
+ * must not rewrite or normalize the digest file between signing and verification.
+ *
+ * <p>This class deliberately does not load production secrets from global state. Callers provide
+ * key material explicitly, typically from an environment variable or a private key file outside the
+ * repository. Do not pass production private keys through shell command arguments or commit them
+ * with staged app bundles.
+ */
+public final class AppBundleSigner {
+  private AppBundleSigner() {}
+
+  /**
+   * Loads an Ed25519 private key from base64-encoded PKCS#8 bytes or a PEM payload.
+   *
+   * <p>The accepted textual forms are raw base64 PKCS#8 bytes and PEM text with standard header and
+   * footer lines. The returned key is suitable for {@link #sign(Path, String, PrivateKey)} but is
+   * not cached or stored by this class.
+   *
+   * @param privateKeyMaterial base64-encoded PKCS#8 bytes or a PEM payload
+   * @return decoded Ed25519 private key
+   * @throws AppDistributionException if the key material is blank or cannot be decoded
+   */
+  public static PrivateKey loadPrivateKey(String privateKeyMaterial)
+      throws AppDistributionException {
+    return loadPrivateKey(
+        AppDistributionSidecars.decodeBase64KeyMaterial(
+            privateKeyMaterial, "private key material"));
+  }
+
+  /**
+   * Loads an Ed25519 private key from PKCS#8 bytes.
+   *
+   * <p>This overload is useful when the caller already read key material from a file or secret
+   * manager. The byte array is not retained after the key factory returns.
+   *
+   * @param privateKeyBytes PKCS#8 private key bytes
+   * @return decoded Ed25519 private key
+   * @throws AppDistributionException if the key material cannot be decoded as an Ed25519 key
+   */
+  public static PrivateKey loadPrivateKey(byte[] privateKeyBytes) throws AppDistributionException {
+    try {
+      return KeyFactory.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM)
+          .generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+    } catch (GeneralSecurityException | IllegalArgumentException exception) {
+      throw new AppDistributionException("failed to decode Ed25519 private key", exception);
+    }
+  }
+
+  /**
+   * Rewrites the digest sidecar and signs its exact bytes with Ed25519.
+   *
+   * <p>The bundle is validated and re-digested every time this method runs. Existing digest and
+   * signature sidecars are excluded from the new digest and then replaced. The supplied {@code
+   * keyId} is written into the signature sidecar so verifiers can select the corresponding trusted
+   * public key.
+   *
+   * @param bundleRoot staged app bundle root directory to digest and sign
+   * @param keyId stable signing-key identifier expected by trusted-key registries
+   * @param privateKey private Ed25519 signing key supplied by the caller
+   * @return signature snapshot written to disk
+   * @throws IOException if the bundle cannot be read safely or sidecars cannot be written
+   */
+  public static AppBundleSignature sign(Path bundleRoot, String keyId, PrivateKey privateKey)
+      throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    Objects.requireNonNull(privateKey, "privateKey");
+
+    AppBundleDigestWriter.write(normalizedBundleRoot);
+    byte[] digestBytes =
+        AppDistributionSidecars.readRequiredBytes(
+            normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), "digest sidecar");
+    byte[] signatureBytes = signDigestBytes(digestBytes, privateKey);
+    AppBundleSignature signature;
+    try {
+      signature =
+          new AppBundleSignature(
+              AppBundleSignature.SIGNATURE_VERSION,
+              AppBundleSignature.SIGNATURE_ALGORITHM,
+              keyId,
+              AppBundleDigest.DIGEST_FILE_NAME,
+              Base64.getEncoder().encodeToString(signatureBytes));
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(exception.getMessage(), exception);
+    }
+    AppDistributionSidecars.writeUtf8File(
+        normalizedBundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME), serialize(signature));
+    return signature;
+  }
+
+  static String serialize(AppBundleSignature signature) {
+    return "signature.version="
+        + signature.version()
+        + '\n'
+        + "signature.algorithm="
+        + signature.algorithm()
+        + '\n'
+        + "signature.key.id="
+        + signature.keyId()
+        + '\n'
+        + "signature.payload="
+        + signature.payload()
+        + '\n'
+        + "signature.value.base64="
+        + signature.valueBase64()
+        + '\n';
+  }
+
+  private static byte[] signDigestBytes(byte[] digestBytes, PrivateKey privateKey)
+      throws AppDistributionException {
+    try {
+      Signature signer = Signature.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM);
+      signer.initSign(privateKey);
+      signer.update(digestBytes);
+      return signer.sign();
+    } catch (GeneralSecurityException exception) {
+      throw new AppDistributionException("failed to sign digest sidecar", exception);
+    }
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleStructureValidator.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleStructureValidator.java
@@ -1,0 +1,360 @@
+package network.crypta.platform.appdist;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Validates staged bundle structure and host-independent launchability metadata.
+ *
+ * <p>This validator keeps signing and verification deterministic across build hosts while still
+ * rejecting bundles whose declared executable is not launchable on any supported platform. It does
+ * not ask whether the current host can execute the app. Instead, it recognizes bundle metadata that
+ * is portable enough to sign on one platform and install on another, such as Windows batch files,
+ * Windows PE executables, POSIX shell scripts, and POSIX files whose execute bit is part of the
+ * signed digest.
+ *
+ * <p>The validator also protects the signing input boundary. The manifest must be present and safe,
+ * {@code app.exec} must resolve to a regular file under the bundle root, and aliased paths such as
+ * symlinks or reparse-point escapes are rejected before digest generation reads file contents.
+ */
+public final class AppBundleStructureValidator {
+  private static final int MAX_SHEBANG_PROBE_BYTES = 4096;
+  private static final int DOS_HEADER_SIZE = 64;
+  private static final int PE_POINTER_OFFSET = 0x3C;
+  private static final int COFF_HEADER_SIZE = 24;
+  private static final int IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002;
+  private static final int IMAGE_FILE_DLL = 0x2000;
+
+  private AppBundleStructureValidator() {}
+
+  /**
+   * Validates one staged bundle and returns the parsed manifest plus resolved executable path.
+   *
+   * <p>The returned snapshot is consumed by {@link AppBundleDigestWriter} so executable permission
+   * metadata can be authenticated only when it affects launchability. The method performs
+   * filesystem checks for the manifest and executable, but it does not walk every bundle entry; the
+   * digest writer performs the full tree traversal after this launchability gate succeeds.
+   *
+   * @param bundleRoot staged bundle root directory to validate as a local bundle
+   * @return validated bundle structure snapshot with manifest, executable path, and launch mode
+   * @throws IOException if the bundle manifest, executable path, or launchability checks fail
+   */
+  public static ValidatedBundle validate(Path bundleRoot) throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    Path bundleRealRoot = normalizedBundleRoot.toRealPath();
+    AppBundleManifest manifest =
+        AppBundleManifestParser.parse(
+            normalizedBundleRoot.resolve(AppBundleManifestParser.MANIFEST_FILE_NAME));
+    Path executable = normalizedBundleRoot.resolve(manifest.execPath()).normalize();
+    if (!Files.isRegularFile(executable, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException(
+          "app.exec does not resolve to a file in bundle: " + manifest.execPathText());
+    }
+    AppDistributionSidecars.validateBundleEntry(normalizedBundleRoot, bundleRealRoot, executable);
+    LaunchMode launchMode = classifyLaunchMode(executable);
+    if (launchMode == null) {
+      throw new AppDistributionException(
+          "app.exec is not launchable on any supported platform: " + manifest.execPathText());
+    }
+    return new ValidatedBundle(manifest, executable, launchMode);
+  }
+
+  private static LaunchMode classifyLaunchMode(Path executable) throws IOException {
+    if (isWindowsBatchScript(executable)) {
+      return LaunchMode.WINDOWS_BATCH;
+    }
+    if (hasWindowsComExecutableSuffix(executable)) {
+      return LaunchMode.WINDOWS_COM;
+    }
+    if (hasLaunchablePortableExecutable(executable)) {
+      return LaunchMode.WINDOWS_PE;
+    }
+    if (isInterpreterManagedPosixLauncher(executable)) {
+      return LaunchMode.POSIX_INTERPRETED;
+    }
+    if (hasAnyPosixExecuteBit(executable)) {
+      return LaunchMode.POSIX_EXECUTABLE;
+    }
+    return null;
+  }
+
+  private static boolean isWindowsBatchScript(Path executable) {
+    String fileName = fileNameLowercase(executable);
+    return fileName.endsWith(".cmd") || fileName.endsWith(".bat");
+  }
+
+  private static boolean hasWindowsComExecutableSuffix(Path executable) {
+    return fileNameLowercase(executable).endsWith(".com");
+  }
+
+  private static boolean hasLaunchablePortableExecutable(Path executable) throws IOException {
+    try (SeekableByteChannel channel = Files.newByteChannel(executable)) {
+      if (channel.size() < DOS_HEADER_SIZE) {
+        return false;
+      }
+      ByteBuffer dosHeader = ByteBuffer.allocate(DOS_HEADER_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+      if (channel.read(dosHeader) < DOS_HEADER_SIZE) {
+        return false;
+      }
+      dosHeader.flip();
+      if (dosHeader.get() != 'M' || dosHeader.get() != 'Z') {
+        return false;
+      }
+
+      int peHeaderOffset = dosHeader.getInt(PE_POINTER_OFFSET);
+      if (peHeaderOffset < DOS_HEADER_SIZE
+          || channel.size() < (long) peHeaderOffset + COFF_HEADER_SIZE) {
+        return false;
+      }
+
+      ByteBuffer coffHeader = ByteBuffer.allocate(COFF_HEADER_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+      channel.position(peHeaderOffset);
+      if (channel.read(coffHeader) < COFF_HEADER_SIZE) {
+        return false;
+      }
+      coffHeader.flip();
+      if (coffHeader.get() != 'P'
+          || coffHeader.get() != 'E'
+          || coffHeader.get() != 0
+          || coffHeader.get() != 0) {
+        return false;
+      }
+      coffHeader.position(22);
+      int characteristics = Short.toUnsignedInt(coffHeader.getShort());
+      return (characteristics & IMAGE_FILE_EXECUTABLE_IMAGE) != 0
+          && (characteristics & IMAGE_FILE_DLL) == 0;
+    }
+  }
+
+  private static boolean isInterpreterManagedPosixLauncher(Path executable) throws IOException {
+    return classifyPosixLauncher(executable) != null;
+  }
+
+  private static PosixLauncher classifyPosixLauncher(Path executable) throws IOException {
+    String shebang = readShebang(executable);
+    if (shebang.isBlank()) {
+      return hasPosixShellScriptSuffix(executable)
+          ? new PosixLauncher(List.of(posixShellInterpreter()), true)
+          : null;
+    }
+    List<String> interpreter = parseShebangInterpreter(shebang);
+    return new PosixLauncher(interpreter, isPosixShellInterpreter(interpreter));
+  }
+
+  private static String readShebang(Path executable) throws IOException {
+    try (var input = Files.newInputStream(executable)) {
+      if (input.read() != '#' || input.read() != '!') {
+        return "";
+      }
+      var shebangBytes = new ByteArrayOutputStream();
+      for (int bytesRead = 2; bytesRead < MAX_SHEBANG_PROBE_BYTES; bytesRead++) {
+        int nextByte = input.read();
+        if (nextByte < 0 || nextByte == '\n' || nextByte == '\r') {
+          break;
+        }
+        shebangBytes.write(nextByte);
+      }
+      return shebangBytes.toString(StandardCharsets.UTF_8).trim();
+    }
+  }
+
+  private static List<String> parseShebangInterpreter(String shebang)
+      throws AppDistributionException {
+    int argumentOffset = firstWhitespaceOffset(shebang);
+    if (argumentOffset < 0) {
+      validateShebangInterpreter(shebang);
+      return List.of(shebang);
+    }
+    String interpreter = shebang.substring(0, argumentOffset);
+    validateShebangInterpreter(interpreter);
+    String interpreterArgument = shebang.substring(argumentOffset).trim();
+    if (interpreterArgument.isEmpty()) {
+      return List.of(interpreter);
+    }
+    return List.of(interpreter, interpreterArgument);
+  }
+
+  private static boolean isPosixShellInterpreter(List<String> interpreter) {
+    if (interpreter.isEmpty()) {
+      return false;
+    }
+    String interpreterName = commandBasename(interpreter.getFirst());
+    if (isKnownPosixShellName(interpreterName)) {
+      return true;
+    }
+    if (!interpreterName.equals("env") || interpreter.size() < 2) {
+      return false;
+    }
+    return envInvokesPosixShell(interpreter.get(1));
+  }
+
+  private static boolean envInvokesPosixShell(String argumentText) {
+    String trimmed = argumentText.trim();
+    if (trimmed.isEmpty()) {
+      return false;
+    }
+    if (trimmed.startsWith("-S ")) {
+      trimmed = trimmed.substring(3).trim();
+    }
+    return isKnownPosixShellName(commandBasename(firstToken(trimmed)));
+  }
+
+  private static boolean isKnownPosixShellName(String commandName) {
+    return switch (commandName) {
+      case "sh", "ash", "bash", "dash", "ksh", "mksh", "zsh" -> true;
+      default -> false;
+    };
+  }
+
+  private static boolean hasAnyPosixExecuteBit(Path executable) throws IOException {
+    if (!Files.getFileStore(executable).supportsFileAttributeView("posix")) {
+      return false;
+    }
+    Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(executable);
+    return permissions.contains(PosixFilePermission.OWNER_EXECUTE)
+        || permissions.contains(PosixFilePermission.GROUP_EXECUTE)
+        || permissions.contains(PosixFilePermission.OTHERS_EXECUTE);
+  }
+
+  private static String firstToken(String text) {
+    int offset = firstWhitespaceOffset(text);
+    return offset < 0 ? text : text.substring(0, offset);
+  }
+
+  private static void validateShebangInterpreter(String interpreter)
+      throws AppDistributionException {
+    if (commandBasename(interpreter).isEmpty()) {
+      throw new AppDistributionException("invalid shebang interpreter: " + interpreter);
+    }
+  }
+
+  private static int firstWhitespaceOffset(String text) {
+    for (int i = 0; i < text.length(); i++) {
+      if (Character.isWhitespace(text.charAt(i))) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static boolean hasPosixShellScriptSuffix(Path executable) {
+    return fileNameLowercase(executable).endsWith(".sh");
+  }
+
+  private static String posixShellInterpreter() {
+    return Path.of("/bin", "sh").toString();
+  }
+
+  private static String commandBasename(String command) {
+    if (command.isBlank()) {
+      return "";
+    }
+    Path fileName = Path.of(command).getFileName();
+    if (fileName == null) {
+      return "";
+    }
+    return fileName.toString().toLowerCase(Locale.ROOT);
+  }
+
+  private static String fileNameLowercase(Path path) {
+    Path fileName = path.getFileName();
+    return (fileName == null ? "" : fileName.toString()).toLowerCase(Locale.ROOT);
+  }
+
+  private record PosixLauncher(List<String> interpreter, boolean shellManaged) {
+    private PosixLauncher {
+      interpreter = List.copyOf(interpreter);
+    }
+  }
+
+  /** Host-independent launch mode classification for {@code app.exec}. */
+  public enum LaunchMode {
+    /**
+     * Windows batch or command script launcher.
+     *
+     * <p>These files are launched through the Windows command interpreter by AppHost and do not
+     * rely on POSIX execute-bit metadata.
+     */
+    WINDOWS_BATCH(false),
+    /**
+     * Windows {@code .com} executable launcher.
+     *
+     * <p>The suffix is treated as launchable Windows metadata and does not require an authenticated
+     * POSIX executable bit.
+     */
+    WINDOWS_COM(false),
+    /**
+     * Windows Portable Executable launcher.
+     *
+     * <p>The file must contain a PE header marked as an executable image and not as a DLL.
+     */
+    WINDOWS_PE(false),
+    /**
+     * POSIX launcher handled by an interpreter.
+     *
+     * <p>This covers supported shebangs and shell-script suffixes where AppHost can invoke the
+     * interpreter directly. POSIX execute-bit state is not part of the signed payload for this
+     * mode.
+     */
+    POSIX_INTERPRETED(false),
+    /**
+     * POSIX launcher whose launchability depends on execute permissions.
+     *
+     * <p>Digest entries for this mode authenticate the executable-bit state so permission changes
+     * after signing are detected during verification.
+     */
+    POSIX_EXECUTABLE(true);
+
+    private final boolean authenticatesExecutableBit;
+
+    LaunchMode(boolean authenticatesExecutableBit) {
+      this.authenticatesExecutableBit = authenticatesExecutableBit;
+    }
+
+    boolean authenticatesExecutableBit() {
+      return authenticatesExecutableBit;
+    }
+  }
+
+  /**
+   * Validated bundle structure snapshot.
+   *
+   * <p>The snapshot carries the normalized manifest and executable path that were checked before
+   * digest generation. It also records the host-independent launch mode so the digest writer can
+   * decide whether executable permission metadata must be included for the declared launcher.
+   *
+   * @param manifest parsed and normalized bundle manifest
+   * @param executable resolved executable path under the bundle root
+   * @param launchMode host-independent launchability classification for {@code app.exec}
+   */
+  public record ValidatedBundle(
+      AppBundleManifest manifest, Path executable, LaunchMode launchMode) {
+    /**
+     * Creates a validated bundle structure snapshot.
+     *
+     * @param manifest parsed and normalized bundle manifest
+     * @param executable resolved executable path under the bundle root
+     * @param launchMode host-independent launchability classification for {@code app.exec}
+     */
+    public ValidatedBundle {
+      java.util.Objects.requireNonNull(manifest, "manifest");
+      java.util.Objects.requireNonNull(executable, "executable");
+      java.util.Objects.requireNonNull(launchMode, "launchMode");
+    }
+
+    Boolean authenticatedExecutableBit() {
+      return launchMode.authenticatesExecutableBit() ? Boolean.TRUE : null;
+    }
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerification.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerification.java
@@ -1,0 +1,46 @@
+package network.crypta.platform.appdist;
+
+/**
+ * Result of verifying one staged app bundle against the current trust policy.
+ *
+ * <p>This value describes the outcome of a single verifier call. It is intentionally small so
+ * AppHost or API layers can expose conservative distribution status without carrying public keys,
+ * signature bytes, or filesystem paths. A signed result means the digest and signature sidecars
+ * were present, the digest matched the bundle contents, and the signature verified with a trusted
+ * key.
+ *
+ * <p>An unsigned result is possible only when the caller selected an explicit development policy.
+ * It should not be persisted or interpreted as a production trust decision.
+ *
+ * @param signed whether the bundle carried verified signature sidecars
+ * @param keyId trusted key id that verified the signature, or {@code null} for unsigned
+ * @param algorithm signature algorithm that verified the bundle, or {@code null} for unsigned
+ */
+public record AppBundleVerification(boolean signed, String keyId, String algorithm) {
+  /**
+   * Returns an unsigned verification result accepted only under an explicit development policy.
+   *
+   * <p>This result is used for completely unsigned local bundles. Partially signed bundles still
+   * fail verification, even under development policy, because stale sidecars are more dangerous
+   * than intentionally unsigned test fixtures.
+   *
+   * @return unsigned verification result
+   */
+  public static AppBundleVerification unsigned() {
+    return new AppBundleVerification(false, null, null);
+  }
+
+  /**
+   * Returns a verified signed-bundle result.
+   *
+   * <p>The caller is responsible for passing values from a successful cryptographic verification
+   * path. This factory does not re-check the signature; it only builds the immutable result.
+   *
+   * @param keyId trusted key id that verified the bundle
+   * @param algorithm signature algorithm that verified the bundle
+   * @return signed verification result
+   */
+  public static AppBundleVerification signed(String keyId, String algorithm) {
+    return new AppBundleVerification(true, keyId, algorithm);
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
@@ -1,8 +1,6 @@
 package network.crypta.platform.appdist;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.Signature;
@@ -165,11 +163,7 @@ public final class AppBundleVerifier {
    */
   public AppBundleVerification verify(Path bundleRoot) throws IOException {
     Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
-    Path digestSidecar = normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME);
-    Path signatureSidecar = normalizedBundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME);
-    if (allowUnsigned
-        && !Files.exists(digestSidecar, LinkOption.NOFOLLOW_LINKS)
-        && !Files.exists(signatureSidecar, LinkOption.NOFOLLOW_LINKS)) {
+    if (allowUnsigned && !AppDistributionSidecars.hasDistributionSidecar(normalizedBundleRoot)) {
       return AppBundleVerification.unsigned();
     }
     AppBundleSignature signature = verify(normalizedBundleRoot, trustedKeys);

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
@@ -57,6 +57,22 @@ public final class AppBundleVerifier {
   }
 
   /**
+   * Returns whether a bundle root contains any reserved distribution sidecar.
+   *
+   * <p>The scan is case-insensitive and covers the reserved local distribution metadata names used
+   * by digest, signature, and catalog sidecars. Runtime integrations use this before applying an
+   * unsigned-development bypass so case variants such as {@code CRYPTAD-APP.DIGESTS} cannot be
+   * treated as ordinary payload files on case-sensitive filesystems.
+   *
+   * @param bundleRoot staged app bundle root directory to inspect
+   * @return {@code true} when a reserved sidecar name is present at the bundle root
+   * @throws IOException if the root is missing, unsafe, or cannot be listed
+   */
+  public static boolean hasDistributionSidecar(Path bundleRoot) throws IOException {
+    return AppDistributionSidecars.hasDistributionSidecar(bundleRoot);
+  }
+
+  /**
    * Reads and validates a signature sidecar.
    *
    * <p>This method validates only the signature sidecar format and supported algorithm/payload
@@ -163,7 +179,7 @@ public final class AppBundleVerifier {
    */
   public AppBundleVerification verify(Path bundleRoot) throws IOException {
     Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
-    if (allowUnsigned && !AppDistributionSidecars.hasDistributionSidecar(normalizedBundleRoot)) {
+    if (allowUnsigned && !hasDistributionSidecar(normalizedBundleRoot)) {
       return AppBundleVerification.unsigned();
     }
     AppBundleSignature signature = verify(normalizedBundleRoot, trustedKeys);

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
@@ -1,0 +1,192 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.Signature;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Verifies signed local app bundles against explicit trusted public keys.
+ *
+ * <p>The verifier is deliberately local and policy-driven. It does not consult global trust stores,
+ * fetch catalogs, or download app artifacts. Callers supply a {@link TrustedAppKeys} registry and
+ * choose whether unsigned bundles are forbidden or allowed only for development. Production-facing
+ * paths should use {@link #requireSigned(TrustedAppKeys)}.
+ *
+ * <p>For signed bundles, verification has two phases. First, the signature sidecar is parsed and
+ * checked against the exact bytes of {@code cryptad-app.digests}. Second, the digest sidecar is
+ * parsed and compared with the current bundle contents. This order detects tampering with either
+ * the digest metadata or the payload files before AppHost trusts the copied installation tree.
+ */
+public final class AppBundleVerifier {
+  private final TrustedAppKeys trustedKeys;
+  private final boolean allowUnsigned;
+
+  private AppBundleVerifier(TrustedAppKeys trustedKeys, boolean allowUnsigned) {
+    this.trustedKeys = Objects.requireNonNull(trustedKeys, "trustedKeys");
+    this.allowUnsigned = allowUnsigned;
+  }
+
+  /**
+   * Returns a verifier that rejects missing digest or signature sidecars.
+   *
+   * <p>This is the correct default for runtime install and update paths. An empty trusted-key set
+   * is valid but will reject every signed bundle as unknown.
+   *
+   * @param trustedKeys explicit trusted public keys available for bundle verification
+   * @return verifier that requires digest and signature sidecars
+   */
+  public static AppBundleVerifier requireSigned(TrustedAppKeys trustedKeys) {
+    return new AppBundleVerifier(trustedKeys, false);
+  }
+
+  /**
+   * Returns a verifier that accepts completely unsigned bundles for development only.
+   *
+   * <p>If either sidecar is present, the bundle must still verify as signed. This prevents local
+   * tests and development installs from hiding stale or broken sidecars that production would
+   * reject. Use this mode only where the caller has made unsigned local bundles an explicit choice.
+   *
+   * @param trustedKeys explicit trusted public keys used when sidecars are present
+   * @return verifier that accepts fully unsigned bundles for development only
+   */
+  public static AppBundleVerifier allowUnsignedForDevelopmentOnly(TrustedAppKeys trustedKeys) {
+    return new AppBundleVerifier(trustedKeys, true);
+  }
+
+  /**
+   * Reads and validates a signature sidecar.
+   *
+   * <p>This method validates only the signature sidecar format and supported algorithm/payload
+   * values. It does not load trusted keys or verify the signature bytes.
+   *
+   * @param signatureFile path to {@code cryptad-app.signature}
+   * @return parsed signature metadata
+   * @throws IOException if the sidecar is missing, malformed, or unsupported
+   */
+  public static AppBundleSignature read(Path signatureFile) throws IOException {
+    String content =
+        AppDistributionSidecars.readRequiredUtf8File(signatureFile, "signature sidecar");
+    Map<String, String> properties =
+        AppDistributionSidecars.parseKeyValueSidecar(content, "signature sidecar");
+
+    String versionText = properties.remove("signature.version");
+    String algorithm = properties.remove("signature.algorithm");
+    String keyId = properties.remove("signature.key.id");
+    String payload = properties.remove("signature.payload");
+    String signatureValue = properties.remove("signature.value.base64");
+
+    if (versionText == null) {
+      throw new AppDistributionException("missing signature.version");
+    }
+    if (algorithm == null) {
+      throw new AppDistributionException("missing signature.algorithm");
+    }
+    if (keyId == null) {
+      throw new AppDistributionException("missing signature.key.id");
+    }
+    if (payload == null) {
+      throw new AppDistributionException("missing signature.payload");
+    }
+    if (signatureValue == null) {
+      throw new AppDistributionException("missing signature.value.base64");
+    }
+    if (!AppBundleSignature.SIGNATURE_ALGORITHM.equals(algorithm)) {
+      throw new AppDistributionException("unsupported signature.algorithm: " + algorithm);
+    }
+    if (!AppBundleDigest.DIGEST_FILE_NAME.equals(payload)) {
+      throw new AppDistributionException("unsupported signature.payload: " + payload);
+    }
+    if (!properties.isEmpty()) {
+      throw new AppDistributionException(
+          "unsupported signature property: " + properties.keySet().iterator().next());
+    }
+    try {
+      return new AppBundleSignature(
+          Integer.parseInt(versionText), algorithm, keyId, payload, signatureValue);
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException("invalid signature.version: " + versionText, exception);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(exception.getMessage(), exception);
+    }
+  }
+
+  /**
+   * Verifies a signed bundle against the supplied trusted public keys.
+   *
+   * <p>The verifier checks the signature sidecar first so mutations to the digest sidecar itself
+   * are rejected before any bundle-content comparison. It then verifies that the digest sidecar
+   * still matches the current bundle files.
+   *
+   * @param bundleRoot staged app bundle root directory containing both sidecars
+   * @param trustedKeys explicit trusted public keys available for signature verification
+   * @return parsed signature metadata when verification succeeds
+   * @throws IOException if the signature or digest sidecars are missing, malformed, untrusted, or
+   *     inconsistent with the bundle contents
+   */
+  public static AppBundleSignature verify(Path bundleRoot, TrustedAppKeys trustedKeys)
+      throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    TrustedAppKeys keys = Objects.requireNonNull(trustedKeys, "trustedKeys");
+    AppBundleSignature signature =
+        read(normalizedBundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME));
+    TrustedAppKey trustedKey =
+        keys.find(signature.keyId())
+            .orElseThrow(
+                () -> new AppDistributionException("unknown trusted key id: " + signature.keyId()));
+    if (!signature.algorithm().equals(trustedKey.algorithm())) {
+      throw new AppDistributionException(
+          "trusted key algorithm does not match bundle signature: " + signature.keyId());
+    }
+
+    byte[] digestBytes =
+        AppDistributionSidecars.readRequiredBytes(
+            normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), "digest sidecar");
+    verifySignature(digestBytes, signature, trustedKey);
+    AppBundleDigestVerifier.verify(normalizedBundleRoot);
+    return signature;
+  }
+
+  /**
+   * Verifies one bundle against the configured trust policy.
+   *
+   * <p>In development-unsigned mode, the only unsigned success case is a bundle with neither digest
+   * nor signature sidecar. Any partial or complete sidecar set is treated as an attempted signed
+   * bundle and must pass full verification.
+   *
+   * @param bundleRoot staged app bundle root directory to verify
+   * @return signed verification metadata, or an explicit unsigned development result
+   * @throws IOException if verification fails under the configured trust policy
+   */
+  public AppBundleVerification verify(Path bundleRoot) throws IOException {
+    Path normalizedBundleRoot = AppDistributionSidecars.requireBundleRoot(bundleRoot);
+    Path digestSidecar = normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME);
+    Path signatureSidecar = normalizedBundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME);
+    if (allowUnsigned
+        && !Files.exists(digestSidecar, LinkOption.NOFOLLOW_LINKS)
+        && !Files.exists(signatureSidecar, LinkOption.NOFOLLOW_LINKS)) {
+      return AppBundleVerification.unsigned();
+    }
+    AppBundleSignature signature = verify(normalizedBundleRoot, trustedKeys);
+    return AppBundleVerification.signed(signature.keyId(), signature.algorithm());
+  }
+
+  private static void verifySignature(
+      byte[] digestBytes, AppBundleSignature signature, TrustedAppKey trustedKey)
+      throws AppDistributionException {
+    try {
+      Signature verifier = Signature.getInstance(signature.algorithm());
+      verifier.initVerify(trustedKey.publicKey());
+      verifier.update(digestBytes);
+      if (!verifier.verify(signature.signatureBytes())) {
+        throw new AppDistributionException("signature sidecar does not match digest sidecar");
+      }
+    } catch (GeneralSecurityException exception) {
+      throw new AppDistributionException("failed to verify digest signature", exception);
+    }
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleVerifier.java
@@ -147,7 +147,8 @@ public final class AppBundleVerifier {
         AppDistributionSidecars.readRequiredBytes(
             normalizedBundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), "digest sidecar");
     verifySignature(digestBytes, signature, trustedKey);
-    AppBundleDigestVerifier.verify(normalizedBundleRoot);
+    AppBundleDigest signedDigest = AppBundleDigestVerifier.read(digestBytes);
+    AppBundleDigestVerifier.verify(normalizedBundleRoot, signedDigest);
     return signature;
   }
 

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionException.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionException.java
@@ -1,0 +1,37 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+
+/**
+ * Signals digest, signature, or trust-policy failures for local app bundles.
+ *
+ * <p>{@code AppDistributionException} keeps bundle-distribution failures in the same checked I/O
+ * flow as filesystem work while still letting callers distinguish invalid sidecars, unsupported
+ * algorithms, untrusted keys, and tampered bundle contents from other generic {@link IOException}
+ * cases. Code that maps errors to API responses can treat this exception as caller-fixable bundle
+ * input when it arises from sidecar or trust validation, while still preserving unrelated raw
+ * {@code IOException} failures as host-side problems.
+ *
+ * <p>Messages are written for local operators and tests. They should identify the rejected
+ * distribution state without relying on absolute paths, secrets, or private key material.
+ */
+public class AppDistributionException extends IOException {
+  /**
+   * Creates an exception with a human-readable failure message.
+   *
+   * @param message detail describing the rejected bundle state or distribution metadata
+   */
+  public AppDistributionException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception with a human-readable failure message and underlying cause.
+   *
+   * @param message detail describing the rejected bundle state or distribution metadata
+   * @param cause underlying parse, filesystem, or crypto error that triggered the failure
+   */
+  public AppDistributionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionSidecars.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionSidecars.java
@@ -1,0 +1,393 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Shared parsing, path-safety, and encoding helpers for app distribution sidecars.
+ *
+ * <p>This package-private utility keeps the digest, signature, trusted-key, and command-line
+ * tooling classes aligned on the same local bundle rules. It centralizes UTF-8 text handling,
+ * bundle-root validation, sidecar path names, base64 key material decoding, and checks that reject
+ * symlinks or filesystem aliases before distribution metadata is trusted.
+ */
+final class AppDistributionSidecars {
+  private static final String BUNDLE_ROOT_PARAMETER = "bundleRoot";
+
+  /** UTF-8 byte-order mark accepted at the beginning of operator-authored text sidecars. */
+  private static final char UTF_8_BOM = '\uFEFF';
+
+  /** Prevents construction of this stateless utility class. */
+  private AppDistributionSidecars() {}
+
+  /**
+   * Validates and normalizes a local bundle root directory.
+   *
+   * @param bundleRoot caller-supplied bundle root path
+   * @return absolute normalized bundle root path
+   * @throws AppDistributionException if the root is missing, not a directory, or aliased
+   */
+  static Path requireBundleRoot(Path bundleRoot) throws AppDistributionException {
+    Objects.requireNonNull(bundleRoot, BUNDLE_ROOT_PARAMETER);
+    Path normalized = bundleRoot.toAbsolutePath().normalize();
+    if (!Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException("bundle root must be an existing directory");
+    }
+    try {
+      if (Files.isSymbolicLink(normalized) || isAliasedPathEntry(normalized)) {
+        throw new AppDistributionException(
+            "bundle root must not be a symlink, reparse point, or alias: " + normalized);
+      }
+    } catch (IOException exception) {
+      throw new AppDistributionException("failed to inspect bundle root", exception);
+    }
+    return normalized;
+  }
+
+  /**
+   * Requires a sidecar field value to be present on one text line.
+   *
+   * @param value raw field value
+   * @param fieldName field name used in error messages
+   * @return original value when it is non-blank and single-line
+   */
+  static String requireNonBlankSingleLine(String value, String fieldName) {
+    Objects.requireNonNull(value, fieldName);
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+      throw new IllegalArgumentException(fieldName + " must be a single line");
+    }
+    return value;
+  }
+
+  /**
+   * Converts a bundle file path into normalized sidecar path text.
+   *
+   * @param bundleRoot normalized bundle root path
+   * @param file file path under the bundle root
+   * @return bundle-relative path using {@code /} separators
+   */
+  static String normalizeBundleRelativePath(Path bundleRoot, Path file) {
+    return normalizeBundleRelativePath(
+        toNormalizedRelativePath(Objects.requireNonNull(bundleRoot, BUNDLE_ROOT_PARAMETER), file),
+        "bundle path");
+  }
+
+  /**
+   * Validates normalized bundle-relative sidecar path text.
+   *
+   * @param path path text from a sidecar or manifest
+   * @param fieldName field name used in error messages
+   * @return validated path text using {@code /} separators
+   */
+  static String normalizeBundleRelativePath(String path, String fieldName) {
+    String normalized = requireNonBlankSingleLine(path, fieldName);
+    if (normalized.contains("\\")) {
+      throw new IllegalArgumentException(fieldName + " must use '/' separators");
+    }
+    if (normalized.startsWith("/")) {
+      throw new IllegalArgumentException(fieldName + " must be relative");
+    }
+    if (normalized.length() >= 2
+        && Character.isLetter(normalized.charAt(0))
+        && normalized.charAt(1) == ':') {
+      throw new IllegalArgumentException(fieldName + " must not use a drive prefix");
+    }
+    validateRelativePathSegments(normalized, fieldName);
+    return normalized;
+  }
+
+  /**
+   * Returns whether a normalized path is reserved for distribution metadata.
+   *
+   * @param path normalized bundle-relative path
+   * @return {@code true} when the path names a digest, signature, or catalog sidecar
+   */
+  static boolean isDistributionSidecar(String path) {
+    return AppBundleDigest.DIGEST_FILE_NAME.equals(path)
+        || AppBundleSignature.SIGNATURE_FILE_NAME.equals(path)
+        || "cryptad-app.catalog".equals(path)
+        || "cryptad-app.catalog.signature".equals(path);
+  }
+
+  /**
+   * Creates an SHA-256 message digest from the current JDK provider set.
+   *
+   * @return new SHA-256 digest instance
+   * @throws AppDistributionException if SHA-256 is unavailable in the running JDK
+   */
+  static MessageDigest newSha256Digest() throws AppDistributionException {
+    try {
+      return MessageDigest.getInstance(AppBundleDigest.DIGEST_ALGORITHM);
+    } catch (NoSuchAlgorithmException exception) {
+      throw new AppDistributionException("SHA-256 is not supported by the current JDK", exception);
+    }
+  }
+
+  /**
+   * Encodes bytes as lowercase hexadecimal text.
+   *
+   * @param bytes bytes to encode
+   * @return lowercase hexadecimal text with two characters per byte
+   */
+  static String lowercaseHex(byte[] bytes) {
+    StringBuilder builder = new StringBuilder(bytes.length * 2);
+    for (byte value : bytes) {
+      builder.append(Character.forDigit((value >>> 4) & 0x0F, 16));
+      builder.append(Character.forDigit(value & 0x0F, 16));
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Reads a required sidecar as UTF-8 text.
+   *
+   * @param file expected file path
+   * @param description human-readable sidecar description for errors
+   * @return decoded UTF-8 content
+   * @throws IOException if the file is missing, unsafe, or unreadable
+   */
+  static String readRequiredUtf8File(Path file, String description) throws IOException {
+    return new String(readRequiredBytes(file, description), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Reads a required non-symlink file as bytes.
+   *
+   * @param file expected file path
+   * @param description human-readable file description for errors
+   * @return file bytes
+   * @throws IOException if the file is missing, unsafe, or unreadable
+   */
+  static byte[] readRequiredBytes(Path file, String description) throws IOException {
+    Path normalized = Objects.requireNonNull(file, "file").toAbsolutePath().normalize();
+    if (Files.isSymbolicLink(normalized)) {
+      throw new AppDistributionException(description + " must not be a symbolic link");
+    }
+    if (!Files.isRegularFile(normalized, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException("missing " + description);
+    }
+    return Files.readAllBytes(normalized);
+  }
+
+  /**
+   * Writes UTF-8 text to a sidecar path after rejecting symbolic-link replacement.
+   *
+   * @param file destination sidecar path
+   * @param content UTF-8 text content to write
+   * @throws IOException if the destination is unsafe or cannot be written
+   */
+  static void writeUtf8File(Path file, String content) throws IOException {
+    Path normalized = Objects.requireNonNull(file, "file").toAbsolutePath().normalize();
+    if (Files.exists(normalized, LinkOption.NOFOLLOW_LINKS) && Files.isSymbolicLink(normalized)) {
+      throw new AppDistributionException("sidecar path must not be a symbolic link");
+    }
+    Files.writeString(normalized, content, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Parses a strict {@code key=value} sidecar format.
+   *
+   * @param content complete text sidecar content
+   * @param description human-readable sidecar description for errors
+   * @return insertion-ordered key/value properties
+   * @throws AppDistributionException if a line is malformed or a key is duplicated
+   */
+  static Map<String, String> parseKeyValueSidecar(String content, String description)
+      throws AppDistributionException {
+    Objects.requireNonNull(content, "content");
+    Map<String, String> properties = new LinkedHashMap<>();
+    String[] lines = stripLeadingBom(content).split("\\R", -1);
+    for (String line : lines) {
+      if (line.isEmpty() || line.startsWith("#") || line.startsWith("!")) {
+        continue;
+      }
+      int separatorIndex = line.indexOf('=');
+      if (separatorIndex < 0) {
+        throw new AppDistributionException("invalid " + description + " line: " + line);
+      }
+      String key = line.substring(0, separatorIndex).trim();
+      if (key.isEmpty()) {
+        throw new AppDistributionException("invalid " + description + " line: " + line);
+      }
+      String value = line.substring(separatorIndex + 1);
+      String previous = properties.putIfAbsent(key, value);
+      if (previous != null) {
+        throw new AppDistributionException("duplicate " + description + " property: " + key);
+      }
+    }
+    return properties;
+  }
+
+  /**
+   * Removes one leading UTF-8 byte-order mark if present.
+   *
+   * @param content text content read from a sidecar
+   * @return content without a leading BOM
+   */
+  private static String stripLeadingBom(String content) {
+    if (!content.isEmpty() && content.charAt(0) == UTF_8_BOM) {
+      return content.substring(1);
+    }
+    return content;
+  }
+
+  /**
+   * Decodes strict base64 text for one sidecar field.
+   *
+   * @param value base64-encoded field value
+   * @param fieldName field name used in error messages
+   * @return decoded bytes
+   */
+  static byte[] decodeBase64(String value, String fieldName) {
+    try {
+      return java.util.Base64.getDecoder().decode(value);
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("invalid " + fieldName, exception);
+    }
+  }
+
+  /**
+   * Decodes base64 key material, accepting PEM wrapper lines.
+   *
+   * @param value base64 or PEM-encoded key material
+   * @param fieldName field name used in error messages
+   * @return decoded key bytes
+   */
+  static byte[] decodeBase64KeyMaterial(String value, String fieldName) {
+    Objects.requireNonNull(value, fieldName);
+    String normalized =
+        value
+            .lines()
+            .map(String::trim)
+            .filter(line -> !line.isEmpty())
+            .filter(line -> !line.startsWith("-----BEGIN"))
+            .filter(line -> !line.startsWith("-----END"))
+            .collect(Collectors.joining());
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return decodeBase64(normalized, fieldName);
+  }
+
+  /**
+   * Reads key material as PEM/base64 text with raw-byte fallback.
+   *
+   * @param file key material file path
+   * @return decoded key bytes or raw file bytes when text decoding is not applicable
+   * @throws IOException if the file is missing, unsafe, or unreadable
+   */
+  static byte[] readKeyMaterial(Path file) throws IOException {
+    byte[] rawBytes = readRequiredBytes(file, "key material");
+    String text = new String(rawBytes, StandardCharsets.UTF_8);
+    try {
+      return decodeBase64KeyMaterial(text, "key material");
+    } catch (IllegalArgumentException _) {
+      return rawBytes;
+    }
+  }
+
+  /**
+   * Validates that a bundle entry resolves exactly under the real bundle root.
+   *
+   * @param bundleRoot normalized bundle root path
+   * @param bundleRealRoot real bundle root path
+   * @param entry path being walked or resolved
+   * @return real path for the entry
+   * @throws IOException if the entry is a symlink, alias, reparse-point escape, or unreadable
+   */
+  static Path validateBundleEntry(Path bundleRoot, Path bundleRealRoot, Path entry)
+      throws IOException {
+    Objects.requireNonNull(bundleRoot, BUNDLE_ROOT_PARAMETER);
+    Objects.requireNonNull(bundleRealRoot, "bundleRealRoot");
+    Objects.requireNonNull(entry, "entry");
+    if (entry.equals(bundleRoot)) {
+      return bundleRealRoot;
+    }
+    if (Files.isSymbolicLink(entry)) {
+      throw new AppDistributionException("bundle must not contain symlinks: " + entry);
+    }
+    Path expectedRealPath = bundleRealRoot.resolve(bundleRoot.relativize(entry)).normalize();
+    Path actualRealPath = entry.toRealPath();
+    if (!actualRealPath.equals(expectedRealPath)) {
+      throw new AppDistributionException(
+          "bundle must not contain links or reparse points: " + entry);
+    }
+    return actualRealPath;
+  }
+
+  /**
+   * Returns whether an entry resolves somewhere other than its lexical parent would imply.
+   *
+   * @param entry filesystem entry to inspect
+   * @return {@code true} when the path is a symlink or other alias
+   * @throws IOException if the entry or its parent cannot be resolved
+   */
+  static boolean isAliasedPathEntry(Path entry) throws IOException {
+    Objects.requireNonNull(entry, "entry");
+    if (Files.isSymbolicLink(entry)) {
+      return true;
+    }
+    Path parent = entry.getParent();
+    if (parent == null) {
+      return false;
+    }
+    Path expectedRealPath = parent.toRealPath().resolve(entry.getFileName()).normalize();
+    Path actualRealPath = entry.toRealPath();
+    return !actualRealPath.equals(expectedRealPath);
+  }
+
+  /**
+   * Converts a file under a bundle root to slash-separated relative text.
+   *
+   * @param bundleRoot normalized bundle root path
+   * @param file file path under the bundle root
+   * @return relative path text before sidecar path validation
+   */
+  private static String toNormalizedRelativePath(Path bundleRoot, Path file) {
+    Path relative = bundleRoot.relativize(file);
+    StringBuilder builder = new StringBuilder();
+    for (Path name : relative) {
+      if (!builder.isEmpty()) {
+        builder.append('/');
+      }
+      builder.append(name.toString());
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Rejects empty, current-directory, and parent-directory path segments.
+   *
+   * @param normalized slash-separated path text
+   * @param fieldName field name used in error messages
+   */
+  private static void validateRelativePathSegments(String normalized, String fieldName) {
+    int start = 0;
+    while (start <= normalized.length()) {
+      int separatorIndex = normalized.indexOf('/', start);
+      String segment =
+          separatorIndex >= 0
+              ? normalized.substring(start, separatorIndex)
+              : normalized.substring(start);
+      if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+        throw new IllegalArgumentException(fieldName + " must not escape the bundle root");
+      }
+      if (separatorIndex < 0) {
+        return;
+      }
+      start = separatorIndex + 1;
+    }
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionSidecars.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionSidecars.java
@@ -8,8 +8,10 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -22,6 +24,14 @@ import java.util.stream.Collectors;
  */
 final class AppDistributionSidecars {
   private static final String BUNDLE_ROOT_PARAMETER = "bundleRoot";
+  private static final String CATALOG_FILE_NAME = "cryptad-app.catalog";
+  private static final String CATALOG_SIGNATURE_FILE_NAME = "cryptad-app.catalog.signature";
+  private static final Set<String> DISTRIBUTION_SIDECAR_NAMES =
+      Set.of(
+          AppBundleDigest.DIGEST_FILE_NAME,
+          AppBundleSignature.SIGNATURE_FILE_NAME,
+          CATALOG_FILE_NAME,
+          CATALOG_SIGNATURE_FILE_NAME);
 
   /** UTF-8 byte-order mark accepted at the beginning of operator-authored text sidecars. */
   private static final char UTF_8_BOM = '\uFEFF';
@@ -115,10 +125,8 @@ final class AppDistributionSidecars {
    * @return {@code true} when the path names a digest, signature, or catalog sidecar
    */
   static boolean isDistributionSidecar(String path) {
-    return AppBundleDigest.DIGEST_FILE_NAME.equals(path)
-        || AppBundleSignature.SIGNATURE_FILE_NAME.equals(path)
-        || "cryptad-app.catalog".equals(path)
-        || "cryptad-app.catalog.signature".equals(path);
+    return DISTRIBUTION_SIDECAR_NAMES.contains(
+        Objects.requireNonNull(path, "path").toLowerCase(Locale.ROOT));
   }
 
   /**

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionSidecars.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionSidecars.java
@@ -2,6 +2,7 @@ package network.crypta.platform.appdist;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -127,6 +128,31 @@ final class AppDistributionSidecars {
   static boolean isDistributionSidecar(String path) {
     return DISTRIBUTION_SIDECAR_NAMES.contains(
         Objects.requireNonNull(path, "path").toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Returns whether the bundle root contains any reserved distribution sidecar name.
+   *
+   * <p>The comparison is intentionally case-insensitive even on case-sensitive filesystems. That
+   * mirrors the reserved-name checks used while digesting bundle contents and prevents development
+   * unsigned policy from treating case variants such as {@code CRYPTAD-APP.DIGESTS} as ordinary app
+   * payload files.
+   *
+   * @param bundleRoot bundle root directory to inspect
+   * @return {@code true} when any direct root entry uses a reserved sidecar name
+   * @throws IOException if the bundle root is unsafe or cannot be listed
+   */
+  static boolean hasDistributionSidecar(Path bundleRoot) throws IOException {
+    Path normalizedBundleRoot = requireBundleRoot(bundleRoot);
+    try (DirectoryStream<Path> entries = Files.newDirectoryStream(normalizedBundleRoot)) {
+      for (Path entry : entries) {
+        Path fileName = entry.getFileName();
+        if (fileName != null && isDistributionSidecar(fileName.toString())) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionTool.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionTool.java
@@ -77,7 +77,7 @@ public final class AppDistributionTool {
     Arguments args = Arguments.parse(arguments);
     Path bundleDir = AppDistributionSidecars.requireBundleRoot(args.requirePath(OPTION_BUNDLE_DIR));
     boolean allowUnsigned = args.has(OPTION_ALLOW_UNSIGNED);
-    if (allowUnsigned && !AppDistributionSidecars.hasDistributionSidecar(bundleDir)) {
+    if (allowUnsigned && !AppBundleVerifier.hasDistributionSidecar(bundleDir)) {
       validateBundleStructure(bundleDir);
       return;
     }

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionTool.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionTool.java
@@ -1,8 +1,6 @@
 package network.crypta.platform.appdist;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.util.List;
@@ -79,7 +77,7 @@ public final class AppDistributionTool {
     Arguments args = Arguments.parse(arguments);
     Path bundleDir = AppDistributionSidecars.requireBundleRoot(args.requirePath(OPTION_BUNDLE_DIR));
     boolean allowUnsigned = args.has(OPTION_ALLOW_UNSIGNED);
-    if (allowUnsigned && bundleHasNoDistributionSidecars(bundleDir)) {
+    if (allowUnsigned && !AppDistributionSidecars.hasDistributionSidecar(bundleDir)) {
       validateBundleStructure(bundleDir);
       return;
     }
@@ -136,13 +134,6 @@ public final class AppDistributionTool {
           arguments.requireEnvironmentValue(arguments.require(OPTION_PRIVATE_KEY_ENV)));
     }
     return AppBundleSigner.loadPrivateKey(arguments.require(OPTION_PRIVATE_KEY_BASE64));
-  }
-
-  private static boolean bundleHasNoDistributionSidecars(Path bundleDir) {
-    return !Files.exists(
-            bundleDir.resolve(AppBundleDigest.DIGEST_FILE_NAME), LinkOption.NOFOLLOW_LINKS)
-        && !Files.exists(
-            bundleDir.resolve(AppBundleSignature.SIGNATURE_FILE_NAME), LinkOption.NOFOLLOW_LINKS);
   }
 
   private static void validateBundleStructure(Path bundleDir) throws IOException {

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionTool.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppDistributionTool.java
@@ -1,0 +1,186 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.PrivateKey;
+import java.util.List;
+
+/**
+ * Small JDK-only CLI for signing and verifying local staged app bundles.
+ *
+ * <p>This keeps first-party Gradle tasks and ad-hoc local workflows wired to the same
+ * implementation used by the runtime verifier, without duplicating digest or crypto logic in the
+ * build scripts. The tool is intentionally limited to local directories. It does not fetch
+ * catalogs, download bundles, or manage a remote app store.
+ *
+ * <p>The {@code sign} command regenerates {@code cryptad-app.digests} and writes {@code
+ * cryptad-app.signature}. The {@code verify} command checks signed bundles against trusted public
+ * keys and, when {@code --allow-unsigned} is present, accepts only completely unsigned development
+ * bundles after validating their structure. Private signing material can be supplied through a file
+ * or environment variable so Gradle tasks do not need to place secrets in child-process arguments.
+ */
+public final class AppDistributionTool {
+  private static final String COMMAND_SIGN = "sign";
+  private static final String COMMAND_VERIFY = "verify";
+  private static final String OPTION_ALLOW_UNSIGNED = "--allow-unsigned";
+  private static final String OPTION_BUNDLE_DIR = "--bundle-dir";
+  private static final String OPTION_KEY_ID = "--key-id";
+  private static final String OPTION_PRIVATE_KEY_BASE64 = "--private-key-base64";
+  private static final String OPTION_PRIVATE_KEY_ENV = "--private-key-env";
+  private static final String OPTION_PRIVATE_KEY_FILE = "--private-key-file";
+  private static final String OPTION_TRUSTED_KEY_ID = "--trusted-key-id";
+  private static final String OPTION_TRUSTED_KEYS_FILE = "--trusted-keys-file";
+  private static final String OPTION_TRUSTED_PUBLIC_KEY_BASE64 = "--trusted-public-key-base64";
+  private static final String OPTION_TRUSTED_PUBLIC_KEY_FILE = "--trusted-public-key-file";
+  private static final String USAGE =
+      """
+      Usage:
+        sign --bundle-dir <dir> --key-id <id> (--private-key-base64 <base64> | --private-key-file <path> | --private-key-env <name>)
+        verify --bundle-dir <dir> [--allow-unsigned] [--trusted-keys-file <path>]
+        verify --bundle-dir <dir> [--allow-unsigned] --trusted-key-id <id> (--trusted-public-key-base64 <base64> | --trusted-public-key-file <path>)
+      """;
+
+  private AppDistributionTool() {}
+
+  /**
+   * Runs one of the supported signing or verification commands.
+   *
+   * <p>The method throws checked exceptions directly so Gradle {@code JavaExec} tasks and shell
+   * callers receive a non-zero process exit with the underlying validation message. Unsupported
+   * invocations receive the usage text emitted by this tool.
+   *
+   * @param arguments command-line arguments starting with {@code sign} or {@code verify}
+   * @throws IOException when command parsing, key loading, signing, or verification fails
+   */
+  public static void main(String[] arguments) throws IOException {
+    if (arguments.length == 0) {
+      throw new AppDistributionException(USAGE);
+    }
+    String command = arguments[0];
+    List<String> args = List.of(arguments).subList(1, arguments.length);
+    switch (command) {
+      case COMMAND_SIGN -> sign(args);
+      case COMMAND_VERIFY -> verify(args);
+      default -> throw new AppDistributionException(USAGE);
+    }
+  }
+
+  private static void sign(List<String> arguments) throws IOException {
+    Arguments args = Arguments.parse(arguments);
+    Path bundleDir = args.requirePath(OPTION_BUNDLE_DIR);
+    String keyId = args.require(OPTION_KEY_ID);
+    PrivateKey privateKey = loadPrivateKey(args);
+    AppBundleSigner.sign(bundleDir, keyId, privateKey);
+  }
+
+  private static void verify(List<String> arguments) throws IOException {
+    Arguments args = Arguments.parse(arguments);
+    Path bundleDir = AppDistributionSidecars.requireBundleRoot(args.requirePath(OPTION_BUNDLE_DIR));
+    boolean allowUnsigned = args.has(OPTION_ALLOW_UNSIGNED);
+    if (allowUnsigned && bundleHasNoDistributionSidecars(bundleDir)) {
+      validateBundleStructure(bundleDir);
+      return;
+    }
+    TrustedAppKeys trustedKeys = trustedKeys(args);
+    AppBundleVerifier verifier =
+        allowUnsigned
+            ? AppBundleVerifier.allowUnsignedForDevelopmentOnly(trustedKeys)
+            : AppBundleVerifier.requireSigned(trustedKeys);
+    verifier.verify(bundleDir);
+    validateBundleStructure(bundleDir);
+  }
+
+  private static TrustedAppKeys trustedKeys(Arguments arguments) throws IOException {
+    if (arguments.has(OPTION_TRUSTED_KEYS_FILE)) {
+      return TrustedAppKeys.load(arguments.requirePath(OPTION_TRUSTED_KEYS_FILE));
+    }
+    if (arguments.has(OPTION_TRUSTED_PUBLIC_KEY_BASE64)
+        && arguments.has(OPTION_TRUSTED_PUBLIC_KEY_FILE)) {
+      throw new AppDistributionException(
+          "Trusted app public key material must be configured by base64 or file, not both.");
+    }
+    if (arguments.has(OPTION_TRUSTED_KEY_ID)
+        && (arguments.has(OPTION_TRUSTED_PUBLIC_KEY_BASE64)
+            || arguments.has(OPTION_TRUSTED_PUBLIC_KEY_FILE))) {
+      return TrustedAppKeys.of(
+          arguments.has(OPTION_TRUSTED_PUBLIC_KEY_FILE)
+              ? TrustedAppKey.ed25519(
+                  arguments.require(OPTION_TRUSTED_KEY_ID),
+                  AppDistributionSidecars.readKeyMaterial(
+                      arguments.requirePath(OPTION_TRUSTED_PUBLIC_KEY_FILE)))
+              : TrustedAppKey.ed25519(
+                  arguments.require(OPTION_TRUSTED_KEY_ID),
+                  arguments.require(OPTION_TRUSTED_PUBLIC_KEY_BASE64)));
+    }
+    return TrustedAppKeys.empty();
+  }
+
+  private static PrivateKey loadPrivateKey(Arguments arguments) throws IOException {
+    int configuredPrivateKeySources =
+        (arguments.has(OPTION_PRIVATE_KEY_FILE) ? 1 : 0)
+            + (arguments.has(OPTION_PRIVATE_KEY_ENV) ? 1 : 0)
+            + (arguments.has(OPTION_PRIVATE_KEY_BASE64) ? 1 : 0);
+    if (configuredPrivateKeySources > 1) {
+      throw new AppDistributionException(
+          "Trusted app private key material must be configured by base64, file, or env, not"
+              + " multiple sources.");
+    }
+    if (arguments.has(OPTION_PRIVATE_KEY_FILE)) {
+      return AppBundleSigner.loadPrivateKey(
+          AppDistributionSidecars.readKeyMaterial(arguments.requirePath(OPTION_PRIVATE_KEY_FILE)));
+    }
+    if (arguments.has(OPTION_PRIVATE_KEY_ENV)) {
+      return AppBundleSigner.loadPrivateKey(
+          arguments.requireEnvironmentValue(arguments.require(OPTION_PRIVATE_KEY_ENV)));
+    }
+    return AppBundleSigner.loadPrivateKey(arguments.require(OPTION_PRIVATE_KEY_BASE64));
+  }
+
+  private static boolean bundleHasNoDistributionSidecars(Path bundleDir) {
+    return !Files.exists(
+            bundleDir.resolve(AppBundleDigest.DIGEST_FILE_NAME), LinkOption.NOFOLLOW_LINKS)
+        && !Files.exists(
+            bundleDir.resolve(AppBundleSignature.SIGNATURE_FILE_NAME), LinkOption.NOFOLLOW_LINKS);
+  }
+
+  private static void validateBundleStructure(Path bundleDir) throws IOException {
+    AppBundleDigestWriter.create(bundleDir);
+  }
+
+  private record Arguments(List<String> tokens) {
+    private Arguments {
+      tokens = List.copyOf(tokens);
+    }
+
+    static Arguments parse(List<String> tokens) {
+      return new Arguments(tokens);
+    }
+
+    boolean has(String name) {
+      return tokens.contains(name);
+    }
+
+    String require(String name) throws AppDistributionException {
+      int index = tokens.indexOf(name);
+      if (index < 0 || index + 1 >= tokens.size()) {
+        throw new AppDistributionException("missing required argument: " + name);
+      }
+      return tokens.get(index + 1);
+    }
+
+    String requireEnvironmentValue(String environmentName) throws AppDistributionException {
+      String value = System.getenv(environmentName);
+      if (value == null || value.isBlank()) {
+        throw new AppDistributionException(
+            "missing required environment variable: " + environmentName);
+      }
+      return value.trim();
+    }
+
+    Path requirePath(String name) throws AppDistributionException {
+      return Path.of(require(name)).toAbsolutePath().normalize();
+    }
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/TrustedAppKey.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/TrustedAppKey.java
@@ -1,0 +1,91 @@
+package network.crypta.platform.appdist;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Objects;
+
+/**
+ * One explicit trusted public signing key.
+ *
+ * <p>A trusted key binds a stable key id from {@code cryptad-app.signature} to the public key used
+ * for Ed25519 verification. The key id is not discovered from the key material; operators and build
+ * tooling choose it so signatures can rotate keys without changing the bundle format. Trust remains
+ * explicit because callers pass {@link TrustedAppKeys} into each verifier rather than relying on
+ * global mutable state.
+ *
+ * <p>Public keys use standard X.509 SubjectPublicKeyInfo encoding. Text helpers accept raw base64
+ * or PEM-wrapped material so configuration files and environment variables can use common
+ * key-export formats.
+ *
+ * @param keyId stable key identifier used by bundle signatures
+ * @param algorithm signature algorithm supported by the key
+ * @param publicKey public verification key
+ */
+public record TrustedAppKey(String keyId, String algorithm, PublicKey publicKey) {
+  /**
+   * Creates a trusted Ed25519 public key from base64-encoded X.509 bytes or a PEM payload.
+   *
+   * <p>This overload is intended for operator configuration values. Whitespace and PEM wrapper
+   * lines are ignored before base64 decoding; malformed key material is reported as a distribution
+   * configuration error.
+   *
+   * @param keyId stable signature key identifier expected in signed bundle sidecars
+   * @param publicKeyMaterial base64-encoded X.509 bytes or a PEM payload
+   * @return decoded trusted Ed25519 public key
+   * @throws AppDistributionException if the key material cannot be decoded
+   */
+  public static TrustedAppKey ed25519(String keyId, String publicKeyMaterial)
+      throws AppDistributionException {
+    try {
+      return ed25519(
+          keyId,
+          AppDistributionSidecars.decodeBase64KeyMaterial(
+              publicKeyMaterial, "public key material"));
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException("invalid public key material", exception);
+    }
+  }
+
+  /**
+   * Creates a trusted Ed25519 public key from X.509 key bytes.
+   *
+   * <p>This overload is useful when callers already read raw DER bytes from a trusted-key file. The
+   * byte array is not retained after the JDK key factory decodes it.
+   *
+   * @param keyId stable signature key identifier expected in signed bundle sidecars
+   * @param publicKeyBytes X.509 public key bytes
+   * @return decoded trusted Ed25519 public key
+   * @throws AppDistributionException if the key material cannot be decoded
+   */
+  public static TrustedAppKey ed25519(String keyId, byte[] publicKeyBytes)
+      throws AppDistributionException {
+    try {
+      PublicKey publicKey =
+          KeyFactory.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM)
+              .generatePublic(new X509EncodedKeySpec(publicKeyBytes));
+      return new TrustedAppKey(keyId, AppBundleSignature.SIGNATURE_ALGORITHM, publicKey);
+    } catch (GeneralSecurityException | IllegalArgumentException exception) {
+      throw new AppDistributionException("failed to decode Ed25519 public key", exception);
+    }
+  }
+
+  /**
+   * Creates a validated trusted-key entry.
+   *
+   * <p>The constructor validates sidecar-safe text fields and requires a non-null public key. It
+   * does not verify that the public key's JDK algorithm string matches {@code algorithm}; factory
+   * methods should be preferred when constructing keys from encoded material.
+   *
+   * @param keyId stable key identifier used by bundle signatures
+   * @param algorithm signature algorithm supported by the key
+   * @param publicKey public verification key
+   * @throws IllegalArgumentException if the key id or algorithm is blank or multi-line
+   */
+  public TrustedAppKey {
+    keyId = AppDistributionSidecars.requireNonBlankSingleLine(keyId, "keyId");
+    algorithm = AppDistributionSidecars.requireNonBlankSingleLine(algorithm, "algorithm");
+    Objects.requireNonNull(publicKey, "publicKey");
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/TrustedAppKeys.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/TrustedAppKeys.java
@@ -1,0 +1,244 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Immutable trusted-key registry used during bundle verification.
+ *
+ * <p>The registry maps stable signature key ids to explicit public keys. It is passed into {@link
+ * AppBundleVerifier} rather than read from global state, which keeps app-host policy construction
+ * deterministic and testable. Instances are immutable snapshots; adding a direct key returns a new
+ * registry and duplicate key ids are rejected instead of silently overriding trust material.
+ *
+ * <p>The local file format is intentionally small and line-oriented. It supports only version
+ * {@code 1}, contiguous {@code key.N.*} entries, and Ed25519 public keys encoded as X.509 base64.
+ * Remote catalog trust and key discovery are outside this module.
+ */
+public final class TrustedAppKeys {
+  private static final Pattern KEY_PROPERTY_PATTERN =
+      Pattern.compile("key\\.(\\d+)\\.(id|algorithm|public\\.key\\.base64)");
+  private static final TrustedAppKeys EMPTY = new TrustedAppKeys(Map.of());
+
+  private final Map<String, TrustedAppKey> keysById;
+
+  private TrustedAppKeys(Map<String, TrustedAppKey> keysById) {
+    this.keysById = Map.copyOf(keysById);
+  }
+
+  /**
+   * Creates a trusted-key registry from a collection.
+   *
+   * <p>The collection is copied immediately, null entries are rejected, and duplicate key ids fail
+   * fast. Iteration order is preserved only for deterministic construction; lookup behavior is by
+   * key id.
+   *
+   * @param keys trusted public keys indexed by their stable key ids
+   * @return immutable trusted-key registry
+   * @throws IllegalArgumentException if two entries use the same key id
+   */
+  public static TrustedAppKeys of(Collection<TrustedAppKey> keys) {
+    Objects.requireNonNull(keys, "keys");
+    Map<String, TrustedAppKey> keysById = new LinkedHashMap<>();
+    for (TrustedAppKey key : keys) {
+      TrustedAppKey trustedKey = Objects.requireNonNull(key, "key");
+      TrustedAppKey previous = keysById.putIfAbsent(trustedKey.keyId(), trustedKey);
+      if (previous != null) {
+        throw new IllegalArgumentException("duplicate trusted key id: " + trustedKey.keyId());
+      }
+    }
+    return new TrustedAppKeys(keysById);
+  }
+
+  /**
+   * Creates a trusted-key registry from individual entries.
+   *
+   * @param keys trusted public keys indexed by their stable key ids
+   * @return immutable trusted-key registry
+   * @throws IllegalArgumentException if two entries use the same key id
+   */
+  public static TrustedAppKeys of(TrustedAppKey... keys) {
+    return of(Arrays.asList(keys));
+  }
+
+  /**
+   * Returns an empty trusted-key registry.
+   *
+   * <p>An empty registry is useful for development policies that allow fully unsigned bundles but
+   * still need to reject partially signed bundles or bundles signed by unknown keys.
+   *
+   * @return shared empty trusted-key registry
+   */
+  public static TrustedAppKeys empty() {
+    return EMPTY;
+  }
+
+  /**
+   * Loads trusted public keys from a local properties-style sidecar.
+   *
+   * <p>The supported format is:
+   *
+   * <pre>{@code
+   * trusted.keys.version=1
+   * key.0.id=test-ed25519
+   * key.0.algorithm=Ed25519
+   * key.0.public.key.base64=<base64-x509-public-key>
+   * }</pre>
+   *
+   * <p>A leading UTF-8 byte-order mark is tolerated so operator-edited files saved by common text
+   * editors remain usable. Unknown properties, non-contiguous indexes, incomplete entries,
+   * unsupported algorithms, and duplicate ids are rejected.
+   *
+   * @param trustedKeysFile local trusted-key sidecar path
+   * @return parsed trusted-key registry
+   * @throws IOException if the sidecar is missing, malformed, or contains unsupported algorithms
+   */
+  public static TrustedAppKeys load(Path trustedKeysFile) throws IOException {
+    String content =
+        AppDistributionSidecars.readRequiredUtf8File(trustedKeysFile, "trusted keys file");
+    Map<String, String> properties =
+        AppDistributionSidecars.parseKeyValueSidecar(content, "trusted keys file");
+    validateTrustedKeysVersion(properties.remove("trusted.keys.version"));
+    Map<Integer, TrustedKeyBuilder> builders = readTrustedKeyBuilders(properties);
+    return buildTrustedKeys(builders);
+  }
+
+  private static void validateTrustedKeysVersion(String versionText)
+      throws AppDistributionException {
+    if (versionText == null) {
+      throw new AppDistributionException("missing trusted.keys.version");
+    }
+    int version;
+    try {
+      version = Integer.parseInt(versionText);
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException("invalid trusted.keys.version: " + versionText, exception);
+    }
+    if (version != 1) {
+      throw new AppDistributionException("unsupported trusted.keys.version: " + version);
+    }
+  }
+
+  private static Map<Integer, TrustedKeyBuilder> readTrustedKeyBuilders(
+      Map<String, String> properties) throws AppDistributionException {
+    Map<Integer, TrustedKeyBuilder> builders = new TreeMap<>();
+    for (Map.Entry<String, String> property : properties.entrySet()) {
+      TrustedKeyProperty trustedKeyProperty = parseTrustedKeyProperty(property.getKey());
+      TrustedKeyBuilder builder =
+          builders.computeIfAbsent(trustedKeyProperty.index(), ignored -> new TrustedKeyBuilder());
+      setTrustedKeyField(builder, trustedKeyProperty.field(), property.getValue());
+    }
+    return builders;
+  }
+
+  private static TrustedKeyProperty parseTrustedKeyProperty(String propertyName)
+      throws AppDistributionException {
+    Matcher matcher = KEY_PROPERTY_PATTERN.matcher(propertyName);
+    if (!matcher.matches()) {
+      throw new AppDistributionException("unsupported trusted keys property: " + propertyName);
+    }
+    return new TrustedKeyProperty(parseIndex(matcher.group(1), propertyName), matcher.group(2));
+  }
+
+  private static void setTrustedKeyField(TrustedKeyBuilder builder, String field, String value) {
+    switch (field) {
+      case "id" -> builder.id = value;
+      case "algorithm" -> builder.algorithm = value;
+      case "public.key.base64" -> builder.publicKeyBase64 = value;
+      default -> throw new IllegalArgumentException("unsupported trusted key field: " + field);
+    }
+  }
+
+  private static TrustedAppKeys buildTrustedKeys(Map<Integer, TrustedKeyBuilder> builders)
+      throws IOException {
+    if (builders.isEmpty()) {
+      return empty();
+    }
+
+    List<TrustedAppKey> keys = new ArrayList<>(builders.size());
+    for (int expectedIndex = 0; expectedIndex < builders.size(); expectedIndex++) {
+      TrustedKeyBuilder builder = requireTrustedKeyBuilder(builders, expectedIndex);
+      keys.add(buildTrustedKey(builder, expectedIndex));
+    }
+    return of(keys);
+  }
+
+  private static TrustedKeyBuilder requireTrustedKeyBuilder(
+      Map<Integer, TrustedKeyBuilder> builders, int expectedIndex) throws AppDistributionException {
+    TrustedKeyBuilder builder = builders.get(expectedIndex);
+    if (builder == null) {
+      throw new AppDistributionException("trusted keys must use contiguous indexes");
+    }
+    return builder;
+  }
+
+  private static TrustedAppKey buildTrustedKey(TrustedKeyBuilder builder, int expectedIndex)
+      throws IOException {
+    if (builder.id == null || builder.algorithm == null || builder.publicKeyBase64 == null) {
+      throw new AppDistributionException("trusted key " + expectedIndex + " is incomplete");
+    }
+    if (!AppBundleSignature.SIGNATURE_ALGORITHM.equals(builder.algorithm)) {
+      throw new AppDistributionException("unsupported trusted key algorithm: " + builder.algorithm);
+    }
+    return TrustedAppKey.ed25519(builder.id, builder.publicKeyBase64);
+  }
+
+  /**
+   * Looks up a trusted key by id.
+   *
+   * @param keyId stable signature key identifier from a bundle signature sidecar
+   * @return matching trusted key, when configured
+   */
+  public Optional<TrustedAppKey> find(String keyId) {
+    return Optional.ofNullable(keysById.get(keyId));
+  }
+
+  /**
+   * Returns a new trusted-key registry with one additional key.
+   *
+   * <p>This is used by runtime configuration when an operator supplies both a trusted-keys file and
+   * one direct key. A duplicate key id is treated as configuration ambiguity and rejected.
+   *
+   * @param key trusted key to add
+   * @return combined trusted-key registry
+   * @throws IllegalArgumentException if the key id already exists in this registry
+   */
+  public TrustedAppKeys plus(TrustedAppKey key) {
+    Map<String, TrustedAppKey> combined = new LinkedHashMap<>(keysById);
+    TrustedAppKey trustedKey = Objects.requireNonNull(key, "key");
+    TrustedAppKey previous = combined.putIfAbsent(trustedKey.keyId(), trustedKey);
+    if (previous != null) {
+      throw new IllegalArgumentException("duplicate trusted key id: " + trustedKey.keyId());
+    }
+    return new TrustedAppKeys(combined);
+  }
+
+  private static int parseIndex(String rawIndex, String propertyName)
+      throws AppDistributionException {
+    try {
+      return Integer.parseInt(rawIndex);
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException(
+          "invalid trusted key entry index in " + propertyName, exception);
+    }
+  }
+
+  private record TrustedKeyProperty(int index, String field) {}
+
+  private static final class TrustedKeyBuilder {
+    private String id;
+    private String algorithm;
+    private String publicKeyBase64;
+  }
+}

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/package-info.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Deterministic local app-bundle digest and signature primitives.
+ *
+ * <p>This package owns the signed-distribution sidecars for locally staged Crypta application
+ * bundles. It defines the deterministic {@code cryptad-app.digests} format, the corresponding
+ * {@code cryptad-app.signature} format, the JDK-only SHA-256 and Ed25519 helpers that write and
+ * verify those sidecars, and the immutable trust model used by higher layers.
+ *
+ * <p>The implementation intentionally stays below AppHost, HTTP adapters, shell code, and runtime
+ * process orchestration. It works only with local bundle directories, regular files, and explicit
+ * trusted public keys so higher layers can enforce signing without coupling distribution metadata
+ * to transport or runtime concerns. The package also contains the shared manifest parser used by
+ * signing tools and AppHost adapters so signed-bundle validation and runtime installation interpret
+ * {@code cryptad-app.properties} the same way.
+ *
+ * <p>This is not a remote app-store implementation. It does not fetch catalogs, resolve download
+ * URLs, serve app assets, or manage production private keys. Those responsibilities belong to
+ * higher-level distribution or release tooling built on top of these local, deterministic
+ * primitives.
+ */
+package network.crypta.platform.appdist;

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleDigestWriterTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleDigestWriterTest.java
@@ -1,0 +1,209 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AppBundleDigestWriterTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void write_whenBundleContainsManifestAndFiles_expectDeterministicSortedDigest() throws Exception {
+    Path bundleRoot = createBundle();
+    Files.writeString(bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), "stale-digest");
+    Files.writeString(
+        bundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME), "stale-signature");
+    Files.createDirectories(bundleRoot.resolve("assets"));
+    Files.writeString(bundleRoot.resolve("assets/logo.txt"), "logo");
+    Files.writeString(bundleRoot.resolve("z-last.txt"), "tail");
+
+    AppBundleDigest firstDigest = AppBundleDigestWriter.write(bundleRoot);
+    String firstSidecar =
+        Files.readString(
+            bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), StandardCharsets.UTF_8);
+    AppBundleDigest secondDigest = AppBundleDigestWriter.write(bundleRoot);
+    String secondSidecar =
+        Files.readString(
+            bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), StandardCharsets.UTF_8);
+
+    assertEquals(firstDigest, secondDigest);
+    assertEquals(firstSidecar, secondSidecar);
+    assertEquals(
+        List.of(
+            "assets/logo.txt", "bin/start.sh", AppBundleDigest.MANIFEST_FILE_NAME, "z-last.txt"),
+        secondDigest.entries().stream().map(AppBundleDigestEntry::path).toList());
+    assertTrue(
+        secondDigest.entries().stream()
+            .anyMatch(entry -> entry.path().equals(AppBundleDigest.MANIFEST_FILE_NAME)));
+    assertFalse(secondSidecar.contains(".executable="));
+    assertFalse(secondSidecar.contains(AppBundleSignature.SIGNATURE_FILE_NAME));
+    assertFalse(secondSidecar.contains("stale-signature"));
+  }
+
+  @Test
+  void write_whenPosixExecutableRequiresExecBit_expectDigestIncludesExecutableFlag()
+      throws Exception {
+    Path bundleRoot = createPosixExecutableBundle();
+
+    AppBundleDigest digest = AppBundleDigestWriter.write(bundleRoot);
+    String sidecar =
+        Files.readString(
+            bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), StandardCharsets.UTF_8);
+
+    assertTrue(
+        digest.entries().stream()
+            .anyMatch(
+                entry ->
+                    entry.path().equals("bin/tool") && Boolean.TRUE.equals(entry.executable())));
+    assertTrue(sidecar.contains(".executable=true"));
+  }
+
+  @Test
+  void verify_whenDigestSidecarContainsTraversalPath_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    String manifestSha = sha256Hex(bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME));
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME),
+        """
+        digest.version=1
+        digest.algorithm=SHA-256
+        file.0.path=../escape.txt
+        file.0.sha256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        file.1.path=cryptad-app.properties
+        file.1.sha256=%s
+        """
+            .formatted(manifestSha),
+        StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class, () -> AppBundleDigestVerifier.verify(bundleRoot));
+
+    assertTrue(exception.getMessage().contains("invalid digest entry 0"));
+  }
+
+  @Test
+  void write_whenBundleContainsSymlink_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    Path symlink = bundleRoot.resolve("linked.txt");
+    Assumptions.assumeTrue(canCreateSymlink(symlink));
+    Path target = tempDir.resolve("target.txt");
+    Files.writeString(target, "linked");
+    Files.createSymbolicLink(symlink, target);
+
+    AppDistributionException exception =
+        assertThrows(AppDistributionException.class, () -> AppBundleDigestWriter.write(bundleRoot));
+
+    assertTrue(exception.getMessage().contains("symlink"));
+  }
+
+  @Test
+  void write_whenWindowsJunctionEscapesBundleRoot_expectFailure() throws Exception {
+    Assumptions.assumeTrue(isWindows());
+    Path bundleRoot = createBundle();
+    Path externalRoot = Files.createDirectories(tempDir.resolve("outside-root"));
+    Path junction = bundleRoot.resolve("outside-junction");
+
+    Process mklink =
+        new ProcessBuilder(
+                windowsCommandInterpreter(),
+                "/c",
+                "mklink",
+                "/J",
+                junction.toString(),
+                externalRoot.toString())
+            .start();
+    assertEquals(0, waitForExit(mklink));
+
+    AppDistributionException exception =
+        assertThrows(AppDistributionException.class, () -> AppBundleDigestWriter.write(bundleRoot));
+
+    assertTrue(exception.getMessage().contains("links or reparse points"));
+  }
+
+  private Path createBundle() throws IOException {
+    Path bundleRoot = tempDir.resolve("bundle");
+    Files.createDirectories(bundleRoot.resolve("bin"));
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=sample-app
+        app.name=Sample App
+        app.version=1.0.0
+        app.exec=bin/start.sh
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        bundleRoot.resolve("bin/start.sh"), "#!/bin/sh\necho sample\n", StandardCharsets.UTF_8);
+    return bundleRoot;
+  }
+
+  private Path createPosixExecutableBundle() throws IOException {
+    Assumptions.assumeTrue(
+        Files.getFileStore(tempDir).supportsFileAttributeView("posix"),
+        "POSIX execute-bit authentication requires POSIX file attributes");
+    Path bundleRoot = tempDir.resolve("posix-bundle");
+    Path binDir = Files.createDirectories(bundleRoot.resolve("bin"));
+    Path executable = binDir.resolve("tool");
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=sample-app
+        app.name=Sample App
+        app.version=1.0.0
+        app.exec=bin/tool
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(executable, "echo sample\n", StandardCharsets.UTF_8);
+    Files.setPosixFilePermissions(
+        executable, java.nio.file.attribute.PosixFilePermissions.fromString("rwxr-xr-x"));
+    return bundleRoot;
+  }
+
+  private static boolean canCreateSymlink(Path symlink) {
+    try {
+      Files.createSymbolicLink(symlink, Path.of("missing-target"));
+      Files.deleteIfExists(symlink);
+      return true;
+    } catch (IOException | SecurityException | UnsupportedOperationException _) {
+      return false;
+    }
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
+  }
+
+  private static String windowsCommandInterpreter() {
+    String comSpec = System.getenv("ComSpec");
+    return comSpec != null && !comSpec.isBlank() ? comSpec : "cmd.exe";
+  }
+
+  private static int waitForExit(Process process) throws Exception {
+    if (!process.waitFor(5, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      throw new java.io.IOException("timed out waiting for process to exit: " + process.pid());
+    }
+    return process.exitValue();
+  }
+
+  private static String sha256Hex(Path file) throws Exception {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    return AppDistributionSidecars.lowercaseHex(digest.digest(Files.readAllBytes(file)));
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleDigestWriterTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleDigestWriterTest.java
@@ -54,6 +54,21 @@ class AppBundleDigestWriterTest {
   }
 
   @Test
+  void write_whenBundleContainsCaseVariantSidecars_expectDigestExcludesThem() throws Exception {
+    Path bundleRoot = createBundle();
+    Files.writeString(bundleRoot.resolve("CRYPTAD-APP.DIGESTS"), "case-variant-digest");
+    Files.writeString(bundleRoot.resolve("CRYPTAD-APP.SIGNATURE"), "case-variant-signature");
+    Files.writeString(bundleRoot.resolve("CRYPTAD-APP.CATALOG"), "case-variant-catalog");
+
+    AppBundleDigest digest = AppBundleDigestWriter.write(bundleRoot);
+
+    assertFalse(
+        digest.entries().stream()
+            .map(AppBundleDigestEntry::path)
+            .anyMatch(path -> path.startsWith("CRYPTAD-APP.")));
+  }
+
+  @Test
   void write_whenPosixExecutableRequiresExecBit_expectDigestIncludesExecutableFlag()
       throws Exception {
     Path bundleRoot = createPosixExecutableBundle();

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
@@ -43,6 +43,26 @@ class AppBundleManifestParserTest {
   }
 
   @Test
+  void parseContent_whenExecPointsAtCaseVariantDistributionSidecar_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppBundleManifestParser.parseContent(
+                    """
+                    manifest.version=1
+                    app.id=sample-app
+                    app.name=Sample App
+                    app.version=1.0.0
+                    app.exec=CRYPTAD-APP.CATALOG
+                    """));
+
+    assertEquals(
+        "app.exec must not point at distribution sidecar: CRYPTAD-APP.CATALOG",
+        exception.getMessage());
+  }
+
+  @Test
   void parseContent_whenOptionalPermissionsValueIsBlank_expectFailure() {
     AppDistributionException exception =
         assertThrows(

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
@@ -1,0 +1,82 @@
+package network.crypta.platform.appdist;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AppBundleManifestParserTest {
+  @Test
+  void parseContent_whenExecUsesWindowsBackslashes_expectNormalizedRelativeExecPath()
+      throws Exception {
+    AppBundleManifest manifest =
+        AppBundleManifestParser.parseContent(
+            """
+            manifest.version=1
+            app.id=sample-app
+            app.name=Sample App
+            app.version=1.0.0
+            app.exec=bin\\launch.bat
+            """);
+
+    assertEquals("bin/launch.bat", manifest.execPathText());
+  }
+
+  @Test
+  void parseContent_whenExecPointsAtDistributionSidecar_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppBundleManifestParser.parseContent(
+                    """
+                    manifest.version=1
+                    app.id=sample-app
+                    app.name=Sample App
+                    app.version=1.0.0
+                    app.exec=cryptad-app.catalog
+                    """));
+
+    assertEquals(
+        "app.exec must not point at distribution sidecar: cryptad-app.catalog",
+        exception.getMessage());
+  }
+
+  @Test
+  void parseContent_whenOptionalPermissionsValueIsBlank_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppBundleManifestParser.parseContent(
+                    """
+                    manifest.version=1
+                    app.id=sample-app
+                    app.name=Sample App
+                    app.version=1.0.0
+                    app.exec=bin/launch.sh
+                    app.permissions=
+                    """));
+
+    assertEquals("app.permissions must not be blank", exception.getMessage());
+  }
+
+  @Test
+  void parseContent_whenOptionalQuotaValueIsBlank_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppBundleManifestParser.parseContent(
+                    """
+                    manifest.version=1
+                    app.id=sample-app
+                    app.name=Sample App
+                    app.version=1.0.0
+                    app.exec=bin/launch.sh
+                    quota.data.bytes=
+                    """));
+
+    assertEquals("quota.data.bytes must not be blank", exception.getMessage());
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleStructureValidatorTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleStructureValidatorTest.java
@@ -1,0 +1,135 @@
+package network.crypta.platform.appdist;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AppBundleStructureValidatorTest {
+  private static final int PE_HEADER_OFFSET_FIELD = 0x3C;
+  private static final int PE_HEADER_OFFSET = 0x80;
+  private static final int COFF_CHARACTERISTICS_OFFSET = PE_HEADER_OFFSET + 22;
+  private static final short IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002;
+  private static final short IMAGE_FILE_DLL = 0x2000;
+
+  @TempDir Path tempDir;
+
+  @Test
+  void validate_whenWindowsBatchLauncherDeclared_expectWindowsBatchLaunchMode() throws Exception {
+    Path bundleRoot = createBundle("bin/start.cmd", "echo sample\r\n");
+
+    AppBundleStructureValidator.ValidatedBundle validated =
+        AppBundleStructureValidator.validate(bundleRoot);
+
+    assertEquals(AppBundleStructureValidator.LaunchMode.WINDOWS_BATCH, validated.launchMode());
+    assertNull(validated.authenticatedExecutableBit());
+  }
+
+  @Test
+  void validate_whenShellScriptSuffixHasNoShebang_expectPosixInterpretedLaunchMode()
+      throws Exception {
+    Path bundleRoot = createBundle("bin/start.sh", "echo sample\n");
+
+    AppBundleStructureValidator.ValidatedBundle validated =
+        AppBundleStructureValidator.validate(bundleRoot);
+
+    assertEquals(AppBundleStructureValidator.LaunchMode.POSIX_INTERPRETED, validated.launchMode());
+    assertNull(validated.authenticatedExecutableBit());
+  }
+
+  @Test
+  void validate_whenEnvSplitShellShebangDeclared_expectPosixInterpretedLaunchMode()
+      throws Exception {
+    Path bundleRoot = createBundle("bin/start", "#!/usr/bin/env -S sh -eu\necho sample\n");
+
+    AppBundleStructureValidator.ValidatedBundle validated =
+        AppBundleStructureValidator.validate(bundleRoot);
+
+    assertEquals(AppBundleStructureValidator.LaunchMode.POSIX_INTERPRETED, validated.launchMode());
+    assertNull(validated.authenticatedExecutableBit());
+  }
+
+  @Test
+  void validate_whenValidPortableExecutableDeclared_expectWindowsPeLaunchMode() throws Exception {
+    Path bundleRoot = createBundle("bin/start.exe", "");
+    Files.write(bundleRoot.resolve("bin/start.exe"), portableExecutableBytes(false));
+
+    AppBundleStructureValidator.ValidatedBundle validated =
+        AppBundleStructureValidator.validate(bundleRoot);
+
+    assertEquals(AppBundleStructureValidator.LaunchMode.WINDOWS_PE, validated.launchMode());
+    assertNull(validated.authenticatedExecutableBit());
+  }
+
+  @Test
+  void validate_whenPortableExecutableIsDll_expectNotLaunchableFailure() throws Exception {
+    Path bundleRoot = createBundle("bin/plugin.exe", "");
+    Files.write(bundleRoot.resolve("bin/plugin.exe"), portableExecutableBytes(true));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class, () -> AppBundleStructureValidator.validate(bundleRoot));
+
+    assertEquals(
+        "app.exec is not launchable on any supported platform: bin/plugin.exe",
+        exception.getMessage());
+  }
+
+  @Test
+  void validate_whenPlainExtensionlessFileHasNoLaunchMetadata_expectNotLaunchableFailure()
+      throws Exception {
+    Path bundleRoot = createBundle("bin/start", "echo sample\n");
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class, () -> AppBundleStructureValidator.validate(bundleRoot));
+
+    assertEquals(
+        "app.exec is not launchable on any supported platform: bin/start", exception.getMessage());
+  }
+
+  private Path createBundle(String execPath, String executableContent) throws Exception {
+    Path bundleRoot = Files.createTempDirectory(tempDir, "bundle-");
+    Path executable = bundleRoot.resolve(execPath);
+    Files.createDirectories(executable.getParent());
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=sample-app
+        app.name=Sample App
+        app.version=1.0.0
+        app.exec=%s
+        """
+            .formatted(execPath),
+        StandardCharsets.UTF_8);
+    Files.writeString(executable, executableContent, StandardCharsets.UTF_8);
+    return bundleRoot;
+  }
+
+  private static byte[] portableExecutableBytes(boolean dll) {
+    byte[] bytes = new byte[PE_HEADER_OFFSET + 24];
+    bytes[0] = 'M';
+    bytes[1] = 'Z';
+    ByteBuffer.wrap(bytes)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(PE_HEADER_OFFSET_FIELD, PE_HEADER_OFFSET);
+    bytes[PE_HEADER_OFFSET] = 'P';
+    bytes[PE_HEADER_OFFSET + 1] = 'E';
+    short characteristics = IMAGE_FILE_EXECUTABLE_IMAGE;
+    if (dll) {
+      characteristics |= IMAGE_FILE_DLL;
+    }
+    ByteBuffer.wrap(bytes)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putShort(COFF_CHARACTERISTICS_OFFSET, characteristics);
+    return bytes;
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleVerifierTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleVerifierTest.java
@@ -215,6 +215,27 @@ class AppBundleVerifierTest {
     assertEquals("unsupported digest.algorithm: SHA-1", exception.getMessage());
   }
 
+  @Test
+  void digestVerifier_whenSidecarIsRewrittenAfterDigestRead_expectSuppliedDigestStillEnforced()
+      throws Exception {
+    Path bundleRoot = createBundle();
+    AppBundleDigestWriter.write(bundleRoot);
+    AppBundleDigest signedDigest =
+        AppBundleDigestVerifier.read(
+            Files.readAllBytes(bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME)));
+    Files.writeString(bundleRoot.resolve("README.txt"), "mutated", StandardCharsets.UTF_8);
+    AppBundleDigest rewrittenDigest = AppBundleDigestWriter.write(bundleRoot);
+
+    AppBundleDigest rereadDigest = AppBundleDigestVerifier.verify(bundleRoot);
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleDigestVerifier.verify(bundleRoot, signedDigest));
+
+    assertEquals(rewrittenDigest, rereadDigest);
+    assertEquals("digest sidecar does not match bundle contents", exception.getMessage());
+  }
+
   private Path createBundle() throws IOException {
     Path bundleRoot = tempDir.resolve("bundle");
     Files.createDirectories(bundleRoot.resolve("bin"));

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleVerifierTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleVerifierTest.java
@@ -1,0 +1,268 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AppBundleVerifierTest {
+  private static final String TEST_KEY_ID = "test-ed25519";
+
+  @TempDir Path tempDir;
+
+  @Test
+  void verify_whenBundleIsSignedAndUntouched_expectSuccess() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSignature writtenSignature =
+        AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+
+    AppBundleSignature verifiedSignature =
+        AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID));
+
+    assertEquals(writtenSignature, verifiedSignature);
+    assertEquals(TEST_KEY_ID, verifiedSignature.keyId());
+    assertEquals(AppBundleSignature.SIGNATURE_ALGORITHM, verifiedSignature.algorithm());
+  }
+
+  @Test
+  void verify_whenBundleFileChangesAfterSigning_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Files.writeString(bundleRoot.resolve("README.txt"), "mutated", StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID)));
+
+    assertEquals("digest sidecar does not match bundle contents", exception.getMessage());
+  }
+
+  @Test
+  void verify_whenManifestChangesAfterSigning_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=sample-app
+        app.name=Tampered App
+        app.version=1.0.0
+        app.exec=bin/start.sh
+        """,
+        StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID)));
+
+    assertEquals("digest sidecar does not match bundle contents", exception.getMessage());
+  }
+
+  @Test
+  void verify_whenExecutableBitChangesAfterSigning_expectFailure() throws Exception {
+    Path bundleRoot = createPosixExecutableBundle();
+    Path executable = bundleRoot.resolve("bin/tool");
+    Assumptions.assumeTrue(Files.getFileStore(executable).supportsFileAttributeView("posix"));
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Files.setPosixFilePermissions(executable, PosixFilePermissions.fromString("rw-r--r--"));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID)));
+
+    assertEquals(
+        "app.exec is not launchable on any supported platform: bin/tool", exception.getMessage());
+  }
+
+  @Test
+  void verify_whenDigestSidecarBytesChangeAfterSigning_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Path digestSidecar = bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME);
+    Files.writeString(
+        digestSidecar,
+        Files.readString(digestSidecar, StandardCharsets.UTF_8).replace("SHA-256", "SHA-256 "),
+        StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID)));
+
+    assertEquals("signature sidecar does not match digest sidecar", exception.getMessage());
+  }
+
+  @Test
+  void verify_whenKeyIdIsUnknown_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair signingKeyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, signingKeyPair.getPrivate());
+    KeyPair unrelatedKeyPair = generateEd25519KeyPair();
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(unrelatedKeyPair, "other-key")));
+
+    assertEquals("unknown trusted key id: " + TEST_KEY_ID, exception.getMessage());
+  }
+
+  @Test
+  void verify_whenSignatureAlgorithmUnsupported_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSignature signature =
+        AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Files.writeString(
+        bundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME),
+        AppBundleSigner.serialize(
+                new AppBundleSignature(
+                    signature.version(),
+                    signature.algorithm(),
+                    signature.keyId(),
+                    signature.payload(),
+                    signature.valueBase64()))
+            .replace("signature.algorithm=Ed25519", "signature.algorithm=RSA"),
+        StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID)));
+
+    assertEquals("unsupported signature.algorithm: RSA", exception.getMessage());
+  }
+
+  @Test
+  void verify_whenSignatureSidecarIsMissing_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Files.delete(bundleRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID)));
+
+    assertEquals("missing signature sidecar", exception.getMessage());
+  }
+
+  @Test
+  void verify_whenUnsignedAllowedAndNoSidecarsPresent_expectUnsignedSuccess() throws Exception {
+    Path bundleRoot = createBundle();
+
+    AppBundleVerification verification =
+        AppBundleVerifier.allowUnsignedForDevelopmentOnly(TrustedAppKeys.empty())
+            .verify(bundleRoot);
+
+    assertFalse(verification.signed());
+    assertNull(verification.keyId());
+    assertNull(verification.algorithm());
+  }
+
+  @Test
+  void verify_whenDigestSidecarIsMissing_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Files.delete(bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleVerifier.verify(bundleRoot, trustedKeys(keyPair, TEST_KEY_ID)));
+
+    assertEquals("missing digest sidecar", exception.getMessage());
+  }
+
+  @Test
+  void digestVerifier_whenDigestAlgorithmUnsupported_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppBundleSigner.sign(bundleRoot, TEST_KEY_ID, keyPair.getPrivate());
+    Path digestSidecar = bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME);
+    Files.writeString(
+        digestSidecar,
+        Files.readString(digestSidecar, StandardCharsets.UTF_8)
+            .replace("digest.algorithm=SHA-256", "digest.algorithm=SHA-1"),
+        StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class, () -> AppBundleDigestVerifier.verify(bundleRoot));
+
+    assertEquals("unsupported digest.algorithm: SHA-1", exception.getMessage());
+  }
+
+  private Path createBundle() throws IOException {
+    Path bundleRoot = tempDir.resolve("bundle");
+    Files.createDirectories(bundleRoot.resolve("bin"));
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=sample-app
+        app.name=Sample App
+        app.version=1.0.0
+        app.exec=bin/start.sh
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        bundleRoot.resolve("bin/start.sh"), "#!/bin/sh\necho sample\n", StandardCharsets.UTF_8);
+    Files.writeString(bundleRoot.resolve("README.txt"), "bundle-readme", StandardCharsets.UTF_8);
+    return bundleRoot;
+  }
+
+  private Path createPosixExecutableBundle() throws IOException {
+    Assumptions.assumeTrue(
+        Files.getFileStore(tempDir).supportsFileAttributeView("posix"),
+        "POSIX execute-bit authentication requires POSIX file attributes");
+    Path bundleRoot = tempDir.resolve("posix-bundle");
+    Path binDir = Files.createDirectories(bundleRoot.resolve("bin"));
+    Path executable = binDir.resolve("tool");
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=sample-app
+        app.name=Sample App
+        app.version=1.0.0
+        app.exec=bin/tool
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(executable, "echo sample\n", StandardCharsets.UTF_8);
+    Files.setPosixFilePermissions(executable, PosixFilePermissions.fromString("rwxr-xr-x"));
+    Files.writeString(bundleRoot.resolve("README.txt"), "bundle-readme", StandardCharsets.UTF_8);
+    return bundleRoot;
+  }
+
+  private static KeyPair generateEd25519KeyPair() throws Exception {
+    return KeyPairGenerator.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM).generateKeyPair();
+  }
+
+  private static TrustedAppKeys trustedKeys(KeyPair keyPair, String keyId) {
+    return TrustedAppKeys.of(
+        new TrustedAppKey(keyId, AppBundleSignature.SIGNATURE_ALGORITHM, keyPair.getPublic()));
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleVerifierTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleVerifierTest.java
@@ -182,6 +182,22 @@ class AppBundleVerifierTest {
   }
 
   @Test
+  void verify_whenUnsignedAllowedAndCaseVariantSidecarPresent_expectSignedPathFailure()
+      throws Exception {
+    Path bundleRoot = createBundle();
+    Files.writeString(bundleRoot.resolve("CRYPTAD-APP.DIGESTS"), "stale-digest");
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppBundleVerifier.allowUnsignedForDevelopmentOnly(TrustedAppKeys.empty())
+                    .verify(bundleRoot));
+
+    assertEquals("missing signature sidecar", exception.getMessage());
+  }
+
+  @Test
   void verify_whenDigestSidecarIsMissing_expectFailure() throws Exception {
     Path bundleRoot = createBundle();
     KeyPair keyPair = generateEd25519KeyPair();

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppDistributionBoundaryTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppDistributionBoundaryTest.java
@@ -1,0 +1,183 @@
+package network.crypta.platform.appdist;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AppDistributionBoundaryTest {
+  private static final String MODULE_NAME = "platform-appdist";
+  private static final Path ROOT_PACKAGE =
+      Path.of("src", "main", "java", "network", "crypta", "platform", "appdist");
+  private static final Path MODULE_PACKAGE =
+      Path.of(MODULE_NAME, "src", "main", "java", "network", "crypta", "platform", "appdist");
+  private static final Path OWNERSHIP_METADATA =
+      Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
+  private static final Set<String> FORBIDDEN_IMPORT_PREFIXES =
+      Set.of(
+          "network.crypta.clients.",
+          "network.crypta.runtime.",
+          "network.crypta.node.",
+          "network.crypta.client.",
+          "network.crypta.platform.api.",
+          "network.crypta.platform.apphost.",
+          "network.crypta.launcher.");
+
+  @Test
+  void mainSourceLayout_whenCheckingLeafOwnership_expectDetachedAppdistTree() throws IOException {
+    Path repoRoot = repoRoot();
+
+    assertTrue(
+        Files.isDirectory(repoRoot.resolve(MODULE_PACKAGE)),
+        ":platform-appdist must own network/crypta/platform/appdist main sources");
+    assertFalse(
+        Files.exists(repoRoot.resolve(ROOT_PACKAGE)),
+        "Root project must not own network/crypta/platform/appdist main sources");
+  }
+
+  @Test
+  void buildWiring_whenCheckingLeafMetadata_expectLeafDeclaredAndOwned() throws IOException {
+    Path repoRoot = repoRoot();
+    String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
+    String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String moduleBuild =
+        Files.readString(repoRoot.resolve(MODULE_NAME).resolve("build.gradle.kts"));
+    String metadata = Files.readString(repoRoot.resolve(OWNERSHIP_METADATA));
+
+    assertTrue(settings.contains("\":platform-appdist\""));
+    assertTrue(build.contains("project(\":platform-appdist\")"));
+    assertFalse(moduleBuild.contains("bcprov"));
+    assertFalse(moduleBuild.contains("bcpkix"));
+    assertTrue(metadata.contains("network/crypta/platform/appdist/**"));
+  }
+
+  @Test
+  void mainSources_whenScanningImports_expectNoRuntimeOrApphostImports() throws IOException {
+    Path repoRoot = repoRoot();
+    Path mainJava = repoRoot.resolve(Path.of(MODULE_NAME, "src", "main", "java"));
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile : findJavaSources(mainJava)) {
+      Set<String> imports = readForbiddenImports(sourceFile);
+      if (!imports.isEmpty()) {
+        violations.add(repoRoot.relativize(sourceFile) + " -> " + String.join(", ", imports));
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        ":platform-appdist main sources must stay free of runtime, adapter, launcher, client,"
+            + " node, Platform API, and AppHost imports."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  @Test
+  void mainSources_whenScanningProductionPackages_expectPackageInfoInEveryPackage()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    Path mainJava = repoRoot.resolve(Path.of(MODULE_NAME, "src", "main", "java"));
+    Set<Path> productionPackages = new TreeSet<>(Comparator.comparing(Path::toString));
+    List<String> missingPackageInfos = new ArrayList<>();
+
+    for (Path sourceFile : findJavaSources(mainJava)) {
+      String fileName = fileNameOrThrow(sourceFile);
+      if (fileName.equals("package-info.java") || fileName.equals("module-info.java")) {
+        continue;
+      }
+      productionPackages.add(parentOrThrow(sourceFile));
+    }
+
+    for (Path packagePath : productionPackages) {
+      if (!Files.isRegularFile(packagePath.resolve("package-info.java"))) {
+        missingPackageInfos.add(repoRoot.relativize(packagePath).toString());
+      }
+    }
+
+    assertTrue(
+        missingPackageInfos.isEmpty(),
+        "Every :platform-appdist main package with production Java files must declare"
+            + " package-info.java."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), missingPackageInfos));
+  }
+
+  private static List<Path> findJavaSources(Path root) throws IOException {
+    try (Stream<Path> walk = Files.walk(root)) {
+      return walk.filter(Files::isRegularFile)
+          .filter(AppDistributionBoundaryTest::isTrackedJavaSource)
+          .sorted(Comparator.comparing(Path::toString))
+          .toList();
+    }
+  }
+
+  private static boolean isTrackedJavaSource(Path path) {
+    String fileName = fileNameOrThrow(path);
+    return fileName.endsWith(".java") && !fileName.startsWith("._");
+  }
+
+  private static Set<String> readForbiddenImports(Path file) throws IOException {
+    try (Stream<String> lines = Files.lines(file)) {
+      return lines
+          .map(String::trim)
+          .filter(line -> line.startsWith("import "))
+          .map(AppDistributionBoundaryTest::extractImportTarget)
+          .filter(importTarget -> !importTarget.isEmpty())
+          .filter(AppDistributionBoundaryTest::isForbiddenImport)
+          .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static boolean isForbiddenImport(String importTarget) {
+    return FORBIDDEN_IMPORT_PREFIXES.stream().anyMatch(importTarget::startsWith);
+  }
+
+  private static String extractImportTarget(String line) {
+    String importTarget = line.substring("import ".length()).trim();
+    if (importTarget.startsWith("static ")) {
+      importTarget = importTarget.substring("static ".length()).trim();
+    }
+    return importTarget.endsWith(";")
+        ? importTarget.substring(0, importTarget.length() - 1)
+        : importTarget;
+  }
+
+  private static Path parentOrThrow(Path path) {
+    Path parent = path.getParent();
+    assertNotNull(parent, "Java source path must have a parent: " + path);
+    return parent;
+  }
+
+  private static String fileNameOrThrow(Path path) {
+    Path fileName = path.getFileName();
+    assertNotNull(fileName, "Java source path must have a file name: " + path);
+    return fileName.toString();
+  }
+
+  private static Path repoRoot() throws IOException {
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !looksLikeRepoRoot(directory)) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
+  }
+
+  private static boolean looksLikeRepoRoot(Path directory) {
+    return Files.isRegularFile(directory.resolve("settings.gradle.kts"))
+        && Files.isRegularFile(directory.resolve("build.gradle.kts"))
+        && Files.isDirectory(directory.resolve(MODULE_NAME));
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppDistributionToolTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppDistributionToolTest.java
@@ -53,6 +53,24 @@ class AppDistributionToolTest {
   }
 
   @Test
+  void verify_whenAllowUnsignedAndCaseVariantSidecarPresent_expectSignedPathFailure()
+      throws Exception {
+    Path bundleRoot = createBundle();
+    Files.writeString(bundleRoot.resolve("CRYPTAD-APP.DIGESTS"), "stale-digest");
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppDistributionTool.main(
+                    new String[] {
+                      "verify", "--bundle-dir", bundleRoot.toString(), "--allow-unsigned"
+                    }));
+
+    assertEquals("missing signature sidecar", exception.getMessage());
+  }
+
+  @Test
   void verify_whenAllowUnsignedAndBundleContainsSymlink_expectFailure() throws Exception {
     Path bundleRoot = createBundle();
     Path symlink = bundleRoot.resolve("linked.txt");

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppDistributionToolTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppDistributionToolTest.java
@@ -1,0 +1,156 @@
+package network.crypta.platform.appdist;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AppDistributionToolTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void verify_whenAllowUnsignedAndBundleHasNoSidecars_expectTrustInputsIgnored() throws Exception {
+    Path bundleRoot = createBundle();
+    Path missingTrustedKeysFile = tempDir.resolve("missing-trusted-keys.properties");
+
+    assertDoesNotThrow(
+        () ->
+            AppDistributionTool.main(
+                new String[] {
+                  "verify",
+                  "--bundle-dir",
+                  bundleRoot.toString(),
+                  "--allow-unsigned",
+                  "--trusted-keys-file",
+                  missingTrustedKeysFile.toString()
+                }));
+  }
+
+  @Test
+  void verify_whenAllowUnsignedAndExecutableMissing_expectBundleFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    Files.delete(bundleRoot.resolve("bin/start.sh"));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppDistributionTool.main(
+                    new String[] {
+                      "verify", "--bundle-dir", bundleRoot.toString(), "--allow-unsigned"
+                    }));
+
+    assertEquals(
+        "app.exec does not resolve to a file in bundle: bin/start.sh", exception.getMessage());
+  }
+
+  @Test
+  void verify_whenAllowUnsignedAndBundleContainsSymlink_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    Path symlink = bundleRoot.resolve("linked.txt");
+    Assumptions.assumeTrue(canCreateSymlink(symlink));
+    Files.createSymbolicLink(symlink, tempDir.resolve("outside.txt"));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppDistributionTool.main(
+                    new String[] {
+                      "verify", "--bundle-dir", bundleRoot.toString(), "--allow-unsigned"
+                    }));
+
+    assertEquals("bundle must not contain symlinks: " + symlink, exception.getMessage());
+  }
+
+  @Test
+  void verify_whenConflictingTrustedPublicKeyInputsProvided_expectFailure() throws Exception {
+    Path bundleRoot = createBundle();
+    Files.writeString(bundleRoot.resolve(AppBundleDigest.DIGEST_FILE_NAME), "stub-digest");
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppDistributionTool.main(
+                    new String[] {
+                      "verify",
+                      "--bundle-dir",
+                      bundleRoot.toString(),
+                      "--allow-unsigned",
+                      "--trusted-key-id",
+                      "local-dev",
+                      "--trusted-public-key-base64",
+                      "ZmFrZQ==",
+                      "--trusted-public-key-file",
+                      tempDir.resolve("public.pem").toString()
+                    }));
+
+    assertEquals(
+        "Trusted app public key material must be configured by base64 or file, not both.",
+        exception.getMessage());
+  }
+
+  @Test
+  void verify_whenSignedBundleExecutableMissing_expectBundleFailureAfterSignatureCheck()
+      throws Exception {
+    Path bundleRoot = createBundle();
+    KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+    AppBundleSigner.sign(bundleRoot, "local-dev", keyPair.getPrivate());
+    Files.delete(bundleRoot.resolve("bin/start.sh"));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppDistributionTool.main(
+                    new String[] {
+                      "verify",
+                      "--bundle-dir",
+                      bundleRoot.toString(),
+                      "--trusted-key-id",
+                      "local-dev",
+                      "--trusted-public-key-base64",
+                      java.util.Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())
+                    }));
+
+    assertEquals(
+        "app.exec does not resolve to a file in bundle: bin/start.sh", exception.getMessage());
+  }
+
+  private Path createBundle() throws Exception {
+    Path bundleRoot = tempDir.resolve("bundle");
+    Files.createDirectories(bundleRoot.resolve("bin"));
+    Files.writeString(
+        bundleRoot.resolve(AppBundleDigest.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=sample-app
+        app.name=Sample App
+        app.version=1.0.0
+        app.exec=bin/start.sh
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        bundleRoot.resolve("bin/start.sh"), "#!/bin/sh\necho sample\n", StandardCharsets.UTF_8);
+    return bundleRoot;
+  }
+
+  private static boolean canCreateSymlink(Path symlink) {
+    try {
+      Files.createSymbolicLink(symlink, Path.of("missing-target"));
+      Files.deleteIfExists(symlink);
+      return true;
+    } catch (Exception _) {
+      return false;
+    }
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/TrustedAppKeysTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/TrustedAppKeysTest.java
@@ -1,0 +1,37 @@
+package network.crypta.platform.appdist;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TrustedAppKeysTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void load_whenTrustedKeysFileStartsWithUtf8Bom_expectTrustedKeyParsed() throws Exception {
+    KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+    Path trustedKeysFile = tempDir.resolve("trusted-keys.properties");
+    Files.writeString(
+        trustedKeysFile,
+        "\uFEFF"
+            + """
+            trusted.keys.version=1
+            key.0.id=local-dev
+            key.0.algorithm=Ed25519
+            key.0.public.key.base64=%s
+            """
+                .formatted(Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded())),
+        StandardCharsets.UTF_8);
+
+    TrustedAppKeys trustedKeys = TrustedAppKeys.load(trustedKeysFile);
+
+    assertTrue(trustedKeys.find("local-dev").isPresent());
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppBundleVerificationException.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppBundleVerificationException.java
@@ -1,0 +1,36 @@
+package network.crypta.platform.apphost;
+
+/**
+ * Signals that a staged app bundle failed signed-distribution verification.
+ *
+ * <p>{@code AppBundleVerificationException} is the AppHost-facing failure type for bundle digest,
+ * signature, trust-policy, or other signed-distribution checks that reject a copied staged bundle
+ * before installation or update proceeds. Platform API callers treat this as a client-fixable
+ * staged-bundle problem rather than an internal host-layout failure.
+ *
+ * <p>The exception is thrown after AppHost has copied the caller-owned staging directory into its
+ * managed temporary tree and a verifier determines that the bundle is unsigned, partially signed,
+ * tampered, or signed by an untrusted key. Raw filesystem failures in the managed tree should
+ * remain plain {@link java.io.IOException} cases so the API can report host-side problems
+ * separately.
+ */
+public final class AppBundleVerificationException extends AppHostException {
+  /**
+   * Creates a verification failure with a message.
+   *
+   * @param message human-readable verification failure detail safe for logs or API mapping
+   */
+  public AppBundleVerificationException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a verification failure with a message and cause.
+   *
+   * @param message human-readable verification failure detail safe for logs or API mapping
+   * @param cause underlying distribution verifier failure cause
+   */
+  public AppBundleVerificationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostConfigurationException.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostConfigurationException.java
@@ -1,0 +1,35 @@
+package network.crypta.platform.apphost;
+
+/**
+ * Signals AppHost-side configuration failures rather than staged-bundle input problems.
+ *
+ * <p>{@code AppHostConfigurationException} is the checked failure type for invalid operator or node
+ * configuration that prevents AppHost work from proceeding before bundle validation can even start.
+ * Platform API callers treat this as a server-side internal error rather than a client-fixable
+ * {@code invalid_app_bundle} problem.
+ *
+ * <p>Typical examples include missing or malformed trusted-key files, duplicate trusted key ids
+ * between file-backed and direct configuration, unsupported public key material, or partial direct
+ * key setup where key material is configured without a key id. These cases require operator action
+ * on the node configuration, not changes to the staged app bundle.
+ */
+public final class AppHostConfigurationException extends AppHostException {
+  /**
+   * Creates a configuration failure with a message.
+   *
+   * @param message human-readable configuration failure detail for logs and server-side reporting
+   */
+  public AppHostConfigurationException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a configuration failure with a message and cause.
+   *
+   * @param message human-readable configuration failure detail for logs and server-side reporting
+   * @param cause underlying configuration, path, or key parsing failure
+   */
+  public AppHostConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppInstallVerificationPolicy.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppInstallVerificationPolicy.java
@@ -1,0 +1,163 @@
+package network.crypta.platform.apphost;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+import network.crypta.platform.appdist.AppBundleVerifier;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appdist.TrustedAppKeys;
+
+/**
+ * Selects how {@link network.crypta.platform.apphost.runtime.LocalProcessAppHost} validates copied
+ * staged bundles before installation or update continues.
+ *
+ * <p>AppHost copies caller-owned staged directories into a managed temporary tree before it trusts
+ * their contents. This policy runs against that copied tree and therefore decides whether a bundle
+ * must pass signed-distribution verification or whether unsigned bundles are temporarily allowed
+ * for development and tests.
+ *
+ * <p>The production-facing default is fail-closed: unsigned bundles are rejected unless the runtime
+ * wires a verifier backed by trusted public keys. Tests and local development can opt into
+ * unsigned-bundle support explicitly, but that mode still verifies any sidecars that are present so
+ * stale or partially signed bundles do not pass in development while failing in production.
+ */
+public final class AppInstallVerificationPolicy {
+  private static final String DEFAULT_SIGNED_BUNDLE_REQUIRED_MESSAGE =
+      "signed app bundle verification is required";
+  private static final AppBundleVerifier DEFAULT_DEVELOPMENT_BUNDLE_VERIFIER =
+      AppBundleVerifier.allowUnsignedForDevelopmentOnly(TrustedAppKeys.empty());
+
+  private static final AppInstallVerificationPolicy ALLOW_UNSIGNED_FOR_DEVELOPMENT =
+      allowUnsignedForDevelopmentOnly(DEFAULT_DEVELOPMENT_BUNDLE_VERIFIER::verify);
+
+  private final boolean allowUnsignedForDevelopment;
+  private final CopiedBundleVerifier verifier;
+
+  private AppInstallVerificationPolicy(
+      boolean allowUnsignedForDevelopment, CopiedBundleVerifier verifier) {
+    this.allowUnsignedForDevelopment = allowUnsignedForDevelopment;
+    this.verifier = Objects.requireNonNull(verifier, "verifier");
+  }
+
+  /**
+   * Creates a policy that requires a caller-supplied verifier to accept the copied bundle.
+   *
+   * <p>The callback receives the AppHost-owned temporary bundle tree, not the original staging path
+   * supplied by the API caller. Implementations should therefore verify only the copied tree that
+   * will be moved into managed storage.
+   *
+   * @param verifier verification callback that runs against the copied managed bundle tree
+   * @return policy that requires signed-distribution verification
+   */
+  public static AppInstallVerificationPolicy requireSigned(CopiedBundleVerifier verifier) {
+    return new AppInstallVerificationPolicy(false, verifier);
+  }
+
+  /**
+   * Creates a policy that rejects installs and updates until a signed-bundle verifier is supplied.
+   *
+   * <p>This is the safe production-facing default while the host has no trusted key material or
+   * concrete bundle verifier configured. It prevents constructors from silently accepting unsigned
+   * bundles just because the caller forgot to supply a distribution policy.
+   *
+   * @return policy that rejects copied bundles with a clear signed-verification error
+   */
+  public static AppInstallVerificationPolicy rejectUnsignedByDefault() {
+    return requireSigned(
+        _ -> {
+          throw new AppBundleVerificationException(DEFAULT_SIGNED_BUNDLE_REQUIRED_MESSAGE);
+        });
+  }
+
+  /**
+   * Creates a policy that allows completely unsigned staged bundles for tests and development only.
+   *
+   * <p>If digest or signature sidecars are present, this default development policy still verifies
+   * them against an empty trusted-key set instead of silently bypassing signed-bundle checks. That
+   * means fully unsigned fixtures can install, but a bundle that looks signed must still be
+   * internally consistent and trusted by the configured verifier.
+   *
+   * @return permissive development-only policy
+   */
+  public static AppInstallVerificationPolicy allowUnsignedForDevelopmentOnly() {
+    return ALLOW_UNSIGNED_FOR_DEVELOPMENT;
+  }
+
+  /**
+   * Creates a development-only policy that still runs a caller-supplied verifier.
+   *
+   * <p>Use this when local or test flows may accept fully unsigned bundles but any present sidecars
+   * must still pass a concrete signed-distribution verifier. Runtime integration uses this shape so
+   * optional unsigned development mode can share the same trusted-key loading path as production
+   * signed installations.
+   *
+   * @param verifier verification callback that runs against the copied managed bundle tree
+   * @return development-only policy that may allow fully unsigned bundles
+   */
+  public static AppInstallVerificationPolicy allowUnsignedForDevelopmentOnly(
+      CopiedBundleVerifier verifier) {
+    return new AppInstallVerificationPolicy(true, verifier);
+  }
+
+  /**
+   * Returns whether this policy explicitly allows unsigned bundles for development.
+   *
+   * <p>This flag is informational for host/test code. The actual verification decision is still
+   * made by {@link #verifyCopiedBundle(Path)}.
+   *
+   * @return {@code true} when copied bundles may remain fully unsigned for development use
+   */
+  @SuppressWarnings("unused")
+  public boolean allowsUnsignedForDevelopmentOnly() {
+    return allowUnsignedForDevelopment;
+  }
+
+  /**
+   * Verifies one copied staged bundle.
+   *
+   * <p>{@link AppDistributionException} and other AppHost verification rejections are converted to
+   * {@link AppBundleVerificationException} so API layers can classify them as invalid app bundles.
+   * {@link AppHostConfigurationException} and raw {@link IOException} failures are preserved so
+   * node-configuration and managed-filesystem problems are not misreported as bad client input.
+   *
+   * @param copiedBundleDirectory copied managed bundle directory that is about to be installed
+   * @throws IOException if verification fails, configuration is invalid, or the copied tree cannot
+   *     be inspected
+   */
+  public void verifyCopiedBundle(Path copiedBundleDirectory) throws IOException {
+    Path normalized =
+        Objects.requireNonNull(copiedBundleDirectory, "copiedBundleDirectory")
+            .toAbsolutePath()
+            .normalize();
+    try {
+      verifier.verifyCopiedBundle(normalized);
+    } catch (AppBundleVerificationException | AppHostConfigurationException e) {
+      throw e;
+    } catch (AppDistributionException | AppHostException e) {
+      throw new AppBundleVerificationException(messageOrDefault(e), e);
+    }
+  }
+
+  private static String messageOrDefault(Throwable failure) {
+    String message = failure.getMessage();
+    return message == null || message.isBlank() ? "signed app bundle verification failed" : message;
+  }
+
+  /**
+   * Verifies a copied managed bundle directory.
+   *
+   * <p>Implementations are expected to read only the copied tree that AppHost controls rather than
+   * the original caller-owned staging directory. This avoids time-of-check/time-of-use races where
+   * a caller could mutate the staging tree between verification and installation.
+   */
+  @FunctionalInterface
+  public interface CopiedBundleVerifier {
+    /**
+     * Verifies one copied bundle directory.
+     *
+     * @param copiedBundleDirectory copied managed bundle directory that AppHost is about to trust
+     * @throws IOException if verification fails or the copied bundle cannot be inspected
+     */
+    void verifyCopiedBundle(Path copiedBundleDirectory) throws IOException;
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
@@ -1,409 +1,63 @@
 package network.crypta.platform.apphost.manifest;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.StringReader;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
-import java.util.Set;
-import java.util.regex.Pattern;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppBundleManifestParser;
+import network.crypta.platform.appdist.AppDistributionException;
 
 /**
  * Parser and validator for the v1 app-host manifest format.
  *
- * <p>{@code AppManifestParser} converts the narrow properties-style {@code cryptad-app.properties}
- * format into an immutable {@link AppManifest}. The parser does not delegate blindly to the full
- * Java properties reader because AppHost needs tighter control over escaping, UTF-8 handling,
- * backslash preservation for Windows-style paths, and the small subset of keys that are valid for
- * the v1 manifest schema.
- *
- * <p>Parsing is intentionally strict. The parser rejects missing required properties, unsupported
- * schema versions, malformed numeric values, invalid permission identifiers, unsafe executable
- * paths, and ambiguous or blank values before runtime code is allowed to inspect the manifest. That
- * keeps bundle validation failures close to the source file and gives callers a deterministic
- * checked exception model.
+ * <p>This AppHost-facing adapter delegates the low-level parsing rules to the appdist leaf so the
+ * staged-bundle tooling and runtime installation flow stay aligned on manifest semantics.
  */
 public final class AppManifestParser {
   /** Canonical manifest filename stored at the installed app root. */
-  public static final String MANIFEST_FILE_NAME = "cryptad-app.properties";
-
-  private static final char UTF_8_BOM = '\uFEFF';
-  private static final Pattern PERMISSION_PATTERN =
-      Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
-  private static final Pattern WINDOWS_DRIVE_PREFIX_PATTERN = Pattern.compile("^[a-zA-Z]:.*");
+  public static final String MANIFEST_FILE_NAME = AppBundleManifestParser.MANIFEST_FILE_NAME;
 
   private AppManifestParser() {}
 
   /**
    * Parses a manifest from UTF-8 text content.
    *
-   * <p>The manifest intentionally uses a narrow key/value syntax instead of Java's full {@link
-   * Properties#load(java.io.Reader)} behavior so UTF-8 characters and literal backslashes survive
-   * round-tripping before field validation normalizes them.
-   *
    * @param content manifest content in properties-style syntax
-   * @return the validated manifest snapshot
+   * @return the validated AppHost manifest snapshot
    * @throws IOException if the manifest content is invalid, incomplete, or cannot be normalized
-   *     into the AppHost v1 manifest model
    */
   public static AppManifest parseContent(String content) throws IOException {
-    return parse(parseProperties(stripLeadingBom(content)));
+    try {
+      return toAppManifest(AppBundleManifestParser.parseContent(content));
+    } catch (AppDistributionException exception) {
+      throw new AppManifestException(exception.getMessage(), exception);
+    }
   }
 
   /**
    * Parses a manifest from an on-disk properties file.
    *
-   * <p>The path must refer to a regular file and must not be a symbolic link. Callers that validate
-   * a staged or installed bundle can therefore use this entry point without accidentally following
-   * a manifest that escapes the intended bundle tree.
-   *
    * @param manifestFile path to {@code cryptad-app.properties}
-   * @return the validated manifest snapshot
+   * @return the validated AppHost manifest snapshot
    * @throws IOException if the file cannot be read safely or the manifest content is invalid
    */
   public static AppManifest parse(Path manifestFile) throws IOException {
-    if (Files.isSymbolicLink(manifestFile)) {
-      throw new AppManifestException("manifest file must not be a symlink: " + manifestFile);
-    }
-    if (!Files.isRegularFile(manifestFile, LinkOption.NOFOLLOW_LINKS)) {
-      throw new AppManifestException("missing manifest file: " + manifestFile);
-    }
-    return parseContent(Files.readString(manifestFile));
-  }
-
-  private static Properties parseProperties(String content) throws IOException {
-    Properties properties = new Properties();
-    try (BufferedReader reader = new BufferedReader(new StringReader(content))) {
-      String line;
-      int lineNumber = 0;
-      while ((line = reader.readLine()) != null) {
-        lineNumber++;
-        parsePropertyLine(properties, line, lineNumber);
-      }
-      return properties;
-    }
-  }
-
-  private static String stripLeadingBom(String content) {
-    if (!content.isEmpty() && content.charAt(0) == UTF_8_BOM) {
-      return content.substring(1);
-    }
-    return content;
-  }
-
-  private static void parsePropertyLine(Properties properties, String line, int lineNumber)
-      throws AppManifestException {
-    String trimmedLine = line.trim();
-    if (trimmedLine.isEmpty() || trimmedLine.startsWith("#") || trimmedLine.startsWith("!")) {
-      return;
-    }
-    int separatorIndex = findSeparatorIndex(line);
-    if (separatorIndex < 0) {
-      throw new AppManifestException("invalid manifest line " + lineNumber + ": " + line);
-    }
-    String key =
-        decodePropertiesComponent(line.substring(0, separatorIndex).trim(), lineNumber, true, true);
-    if (key.isEmpty()) {
-      throw new AppManifestException("invalid manifest line " + lineNumber + ": " + line);
-    }
-    String rawValue = line.substring(separatorIndex + 1).trim();
-    String value =
-        decodePropertiesComponent(
-            rawValue, lineNumber, false, shouldDecodeUnicodeEscapesInValue(key, rawValue));
-    properties.setProperty(key, value);
-  }
-
-  private static boolean shouldDecodeUnicodeEscapesInValue(String key, String rawValue) {
-    if (!key.equals("app.exec")) {
-      return true;
-    }
-    return rawValue.contains("/")
-        || rawValue.contains("\\\\")
-        || rawValue.startsWith("\\u")
-        || rawValue.startsWith("\\U")
-        || (containsUnicodeEscape(rawValue) && !containsPlainBackslash(rawValue));
-  }
-
-  private static boolean containsUnicodeEscape(String rawValue) {
-    for (int index = 0; index + 5 < rawValue.length(); index++) {
-      if (rawValue.charAt(index) == '\\'
-          && (rawValue.charAt(index + 1) == 'u' || rawValue.charAt(index + 1) == 'U')
-          && isHexSequence(rawValue, index + 2)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean containsPlainBackslash(String rawValue) {
-    for (int index = 0; index < rawValue.length() - 1; index++) {
-      if (rawValue.charAt(index) == '\\'
-          && rawValue.charAt(index + 1) != 'u'
-          && rawValue.charAt(index + 1) != 'U') {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean isHexSequence(String rawValue, int startIndex) {
-    if (startIndex + 4 > rawValue.length()) {
-      return false;
-    }
-    for (int offset = 0; offset < 4; offset++) {
-      if (Character.digit(rawValue.charAt(startIndex + offset), 16) < 0) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private static int findSeparatorIndex(String line) {
-    int equalsIndex = line.indexOf('=');
-    int colonIndex = line.indexOf(':');
-    if (equalsIndex < 0) {
-      return colonIndex;
-    }
-    if (colonIndex < 0) {
-      return equalsIndex;
-    }
-    return Math.min(equalsIndex, colonIndex);
-  }
-
-  private static String decodePropertiesComponent(
-      String text, int lineNumber, boolean decodeControlEscapes, boolean decodeUnicodeEscapes)
-      throws AppManifestException {
-    StringBuilder decoded = new StringBuilder(text.length());
-    int index = 0;
-    while (index < text.length()) {
-      char character = text.charAt(index);
-      if (character != '\\' || index + 1 >= text.length()) {
-        decoded.append(character);
-        index++;
-      } else {
-        index =
-            appendEscapedCharacter(
-                decoded, text, index, lineNumber, decodeControlEscapes, decodeUnicodeEscapes);
-      }
-    }
-    return decoded.toString();
-  }
-
-  private static int appendEscapedCharacter(
-      StringBuilder decoded,
-      String text,
-      int escapeIndex,
-      int lineNumber,
-      boolean decodeControlEscapes,
-      boolean decodeUnicodeEscapes)
-      throws AppManifestException {
-    int nextIndex = escapeIndex + 1;
-    char escaped = text.charAt(nextIndex);
-    switch (escaped) {
-      case 't' -> appendControlEscape(decoded, escaped, '\t', decodeControlEscapes);
-      case 'n' -> appendControlEscape(decoded, escaped, '\n', decodeControlEscapes);
-      case 'r' -> appendControlEscape(decoded, escaped, '\r', decodeControlEscapes);
-      case 'f' -> appendControlEscape(decoded, escaped, '\f', decodeControlEscapes);
-      case '\\' -> decoded.append('\\');
-      case ' ' -> decoded.append(' ');
-      case ':', '=', '#', '!' -> decoded.append(escaped);
-      case 'u' -> {
-        if (decodeUnicodeEscapes) {
-          decoded.append(decodeUnicodeEscape(text, nextIndex, lineNumber));
-          nextIndex += 4;
-        } else {
-          decoded.append('\\');
-          decoded.append(escaped);
-        }
-      }
-      default -> {
-        decoded.append('\\');
-        decoded.append(escaped);
-      }
-    }
-    return nextIndex + 1;
-  }
-
-  private static void appendControlEscape(
-      StringBuilder decoded, char escaped, char decodedCharacter, boolean decodeControlEscapes) {
-    if (decodeControlEscapes) {
-      decoded.append(decodedCharacter);
-    } else {
-      decoded.append('\\');
-      decoded.append(escaped);
-    }
-  }
-
-  private static char decodeUnicodeEscape(String text, int escapeStartIndex, int lineNumber)
-      throws AppManifestException {
-    if (escapeStartIndex + 4 >= text.length()) {
-      throw new AppManifestException("invalid unicode escape in manifest line " + lineNumber);
-    }
-    int codePoint = 0;
-    for (int offset = 1; offset <= 4; offset++) {
-      int digit = Character.digit(text.charAt(escapeStartIndex + offset), 16);
-      if (digit < 0) {
-        throw new AppManifestException("invalid unicode escape in manifest line " + lineNumber);
-      }
-      codePoint = (codePoint << 4) + digit;
-    }
-    return (char) codePoint;
-  }
-
-  private static AppManifest parse(Properties properties) throws AppManifestException {
-    int manifestVersion = parseRequiredVersion(properties);
-    String appId = required(properties, "app.id");
-    String appName = required(properties, "app.name");
-    String appVersion = required(properties, "app.version");
-    String execPathText = normalizeExecPath(required(properties, "app.exec"));
-    String uiEntry = optional(properties, "app.ui.entry");
-    List<String> permissions = parsePermissions(optional(properties, "app.permissions"));
-    Long dataQuotaBytes = parseOptionalLong(properties, "quota.data.bytes");
-    Long cacheQuotaBytes = parseOptionalLong(properties, "quota.cache.bytes");
     try {
-      return new AppManifest(
-          manifestVersion,
-          appId,
-          appName,
-          appVersion,
-          execPathText,
-          uiEntry,
-          permissions,
-          dataQuotaBytes,
-          cacheQuotaBytes);
-    } catch (IllegalArgumentException e) {
-      throw new AppManifestException(e.getMessage(), e);
+      return toAppManifest(AppBundleManifestParser.parse(manifestFile));
+    } catch (AppDistributionException exception) {
+      throw new AppManifestException(exception.getMessage(), exception);
     }
   }
 
-  private static int parseRequiredVersion(Properties properties) throws AppManifestException {
-    String value = required(properties, "manifest.version");
-    try {
-      int version = Integer.parseInt(value);
-      if (version != 1) {
-        throw new AppManifestException("unsupported manifest.version: " + value);
-      }
-      return version;
-    } catch (NumberFormatException e) {
-      throw new AppManifestException("invalid manifest.version: " + value, e);
-    }
-  }
-
-  private static String normalizeExecPath(String rawValue) throws AppManifestException {
-    String normalized = rawValue.trim().replace('\\', '/');
-    if (normalized.isEmpty()) {
-      throw new AppManifestException("app.exec must not be blank");
-    }
-    if (normalized.startsWith("/")
-        || normalized.startsWith("\\")
-        || WINDOWS_DRIVE_PREFIX_PATTERN.matcher(normalized).matches()) {
-      throw new AppManifestException("app.exec must be relative: " + rawValue);
-    }
-    ArrayList<String> normalizedSegments = new ArrayList<>();
-    StringBuilder current = new StringBuilder();
-    for (int index = 0; index < normalized.length(); index++) {
-      char character = normalized.charAt(index);
-      if (character == '/') {
-        addExecSegment(normalizedSegments, current, rawValue);
-      } else {
-        current.append(character);
-      }
-    }
-    addExecSegment(normalizedSegments, current, rawValue);
-    for (String segment : normalizedSegments) {
-      if (segment.isBlank()) {
-        throw new AppManifestException("app.exec must be normalized: " + rawValue);
-      }
-      if (segment.equals(".") || segment.equals("..")) {
-        throw new AppManifestException("app.exec must stay under the app root: " + rawValue);
-      }
-    }
-    return String.join("/", normalizedSegments);
-  }
-
-  private static List<String> parsePermissions(String rawPermissions) throws AppManifestException {
-    if (rawPermissions == null) {
-      return List.of();
-    }
-    LinkedHashSet<String> normalized = new LinkedHashSet<>();
-    StringBuilder current = new StringBuilder();
-    for (int index = 0; index < rawPermissions.length(); index++) {
-      char character = rawPermissions.charAt(index);
-      if (character == ',') {
-        addPermission(normalized, current, rawPermissions);
-      } else {
-        current.append(character);
-      }
-    }
-    addPermission(normalized, current, rawPermissions);
-    return List.copyOf(normalized);
-  }
-
-  private static void addExecSegment(
-      List<String> normalizedSegments, StringBuilder current, String rawValue)
-      throws AppManifestException {
-    String segment = current.toString();
-    current.setLength(0);
-    if (segment.isBlank()) {
-      throw new AppManifestException("app.exec must be normalized: " + rawValue);
-    }
-    normalizedSegments.add(segment);
-  }
-
-  private static void addPermission(
-      Set<String> normalized, StringBuilder current, String rawPermissions)
-      throws AppManifestException {
-    String permission = current.toString().trim().toLowerCase(Locale.ROOT);
-    current.setLength(0);
-    if (permission.isEmpty()) {
-      throw new AppManifestException("app.permissions must not contain blank entries");
-    }
-    if (!PERMISSION_PATTERN.matcher(permission).matches()) {
-      throw new AppManifestException("invalid app.permissions entry: " + rawPermissions);
-    }
-    normalized.add(permission);
-  }
-
-  private static Long parseOptionalLong(Properties properties, String key)
-      throws AppManifestException {
-    String value = optional(properties, key);
-    if (value == null) {
-      return null;
-    }
-    try {
-      long parsed = Long.parseLong(value);
-      if (parsed < 0L) {
-        throw new AppManifestException(key + " must be >= 0");
-      }
-      return parsed;
-    } catch (NumberFormatException e) {
-      throw new AppManifestException("invalid " + key + ": " + value, e);
-    }
-  }
-
-  private static String required(Properties properties, String key) throws AppManifestException {
-    String value = optional(properties, key);
-    if (value == null) {
-      throw new AppManifestException("missing required property: " + key);
-    }
-    return value;
-  }
-
-  private static String optional(Properties properties, String key) throws AppManifestException {
-    String value = properties.getProperty(key);
-    if (value == null) {
-      return null;
-    }
-    String trimmed = value.trim();
-    if (trimmed.isEmpty()) {
-      throw new AppManifestException(key + " must not be blank");
-    }
-    return trimmed;
+  private static AppManifest toAppManifest(AppBundleManifest manifest) {
+    return new AppManifest(
+        manifest.manifestVersion(),
+        manifest.appId(),
+        manifest.appName(),
+        manifest.appVersion(),
+        manifest.execPathText(),
+        manifest.uiEntry(),
+        manifest.permissions(),
+        manifest.dataQuotaBytes(),
+        manifest.cacheQuotaBytes());
   }
 }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -37,6 +37,7 @@ import network.crypta.fs.AppEnv;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
 import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.AppInstallVerificationPolicy;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
@@ -111,19 +112,49 @@ public final class LocalProcessAppHost implements AppHost {
   private final AppEnv appEnv;
   private final TimingConfig timing;
   private final ManagedTreeDeleter managedTreeDeleter;
+  private final AppInstallVerificationPolicy installVerificationPolicy;
   private final Map<String, RunningProcess> runningApps = new ConcurrentHashMap<>();
 
   /**
    * Creates a host bound to the supplied layout.
    *
    * <p>This convenience constructor uses the default stop timeout, a fresh secure token generator,
-   * and the ambient {@link AppEnv} for platform detection.
+   * and the ambient {@link AppEnv} for platform detection. It also rejects copied staged bundles
+   * until an explicit signed-bundle verifier is wired in.
    *
    * @param layout filesystem layout managed by the host
    */
   @SuppressWarnings("unused")
   public LocalProcessAppHost(AppHostLayout layout) {
-    this(layout, DEFAULT_STOP_TIMEOUT, new SecureRandom(), new AppEnv());
+    this(
+        layout,
+        DEFAULT_STOP_TIMEOUT,
+        new SecureRandom(),
+        new AppEnv(),
+        DEFAULT_TIMING,
+        LocalProcessAppHost::deleteRecursively,
+        AppInstallVerificationPolicy.rejectUnsignedByDefault());
+  }
+
+  /**
+   * Creates a host bound to the supplied layout and copied-bundle verification policy.
+   *
+   * <p>This overload uses the default stop timeout, a fresh secure token generator, and the ambient
+   * {@link AppEnv} for platform detection.
+   *
+   * @param layout filesystem layout managed by the host
+   * @param installVerificationPolicy copied-bundle verification policy applied on install/update
+   */
+  public LocalProcessAppHost(
+      AppHostLayout layout, AppInstallVerificationPolicy installVerificationPolicy) {
+    this(
+        layout,
+        DEFAULT_STOP_TIMEOUT,
+        new SecureRandom(),
+        new AppEnv(),
+        DEFAULT_TIMING,
+        LocalProcessAppHost::deleteRecursively,
+        installVerificationPolicy);
   }
 
   /**
@@ -131,7 +162,8 @@ public final class LocalProcessAppHost implements AppHost {
    *
    * <p>This overload is primarily useful for tests and controlled embeddings that need a
    * non-default shutdown policy or deterministic token generation while still using the ambient
-   * platform environment.
+   * platform environment. Production-facing defaults still reject unsigned copied bundles unless
+   * the caller supplies an explicit development/test verification policy overload.
    *
    * @param layout filesystem layout managed by the host
    * @param stopTimeout bounded timeout used before force-killing a child process
@@ -139,21 +171,67 @@ public final class LocalProcessAppHost implements AppHost {
    */
   public LocalProcessAppHost(
       AppHostLayout layout, Duration stopTimeout, SecureRandom secureRandom) {
-    this(layout, stopTimeout, secureRandom, new AppEnv(), DEFAULT_TIMING);
+    this(
+        layout,
+        stopTimeout,
+        secureRandom,
+        new AppEnv(),
+        DEFAULT_TIMING,
+        LocalProcessAppHost::deleteRecursively,
+        AppInstallVerificationPolicy.rejectUnsignedByDefault());
   }
 
+  /**
+   * Creates a host with an explicit stop timeout, token generator, and verification policy.
+   *
+   * @param layout filesystem layout managed by the host
+   * @param stopTimeout bounded timeout used before force-killing a child process
+   * @param secureRandom secure token generator for launch-token generation
+   * @param installVerificationPolicy copied-bundle verification policy applied on install/update
+   */
+  public LocalProcessAppHost(
+      AppHostLayout layout,
+      Duration stopTimeout,
+      SecureRandom secureRandom,
+      AppInstallVerificationPolicy installVerificationPolicy) {
+    this(
+        layout,
+        stopTimeout,
+        secureRandom,
+        new AppEnv(),
+        DEFAULT_TIMING,
+        LocalProcessAppHost::deleteRecursively,
+        installVerificationPolicy);
+  }
+
+  @SuppressWarnings("unused")
   LocalProcessAppHost(
       AppHostLayout layout, Duration stopTimeout, SecureRandom secureRandom, AppEnv appEnv) {
-    this(layout, stopTimeout, secureRandom, appEnv, DEFAULT_TIMING);
+    this(
+        layout,
+        stopTimeout,
+        secureRandom,
+        appEnv,
+        DEFAULT_TIMING,
+        LocalProcessAppHost::deleteRecursively,
+        AppInstallVerificationPolicy.rejectUnsignedByDefault());
   }
 
+  @SuppressWarnings("unused")
   LocalProcessAppHost(
       AppHostLayout layout,
       Duration stopTimeout,
       SecureRandom secureRandom,
       AppEnv appEnv,
       TimingConfig timing) {
-    this(layout, stopTimeout, secureRandom, appEnv, timing, LocalProcessAppHost::deleteRecursively);
+    this(
+        layout,
+        stopTimeout,
+        secureRandom,
+        appEnv,
+        timing,
+        LocalProcessAppHost::deleteRecursively,
+        AppInstallVerificationPolicy.rejectUnsignedByDefault());
   }
 
   LocalProcessAppHost(
@@ -162,13 +240,51 @@ public final class LocalProcessAppHost implements AppHost {
       SecureRandom secureRandom,
       AppEnv appEnv,
       TimingConfig timing,
+      AppInstallVerificationPolicy installVerificationPolicy) {
+    this(
+        layout,
+        stopTimeout,
+        secureRandom,
+        appEnv,
+        timing,
+        LocalProcessAppHost::deleteRecursively,
+        installVerificationPolicy);
+  }
+
+  @SuppressWarnings("unused")
+  LocalProcessAppHost(
+      AppHostLayout layout,
+      Duration stopTimeout,
+      SecureRandom secureRandom,
+      AppEnv appEnv,
+      TimingConfig timing,
       ManagedTreeDeleter managedTreeDeleter) {
+    this(
+        layout,
+        stopTimeout,
+        secureRandom,
+        appEnv,
+        timing,
+        managedTreeDeleter,
+        AppInstallVerificationPolicy.rejectUnsignedByDefault());
+  }
+
+  LocalProcessAppHost(
+      AppHostLayout layout,
+      Duration stopTimeout,
+      SecureRandom secureRandom,
+      AppEnv appEnv,
+      TimingConfig timing,
+      ManagedTreeDeleter managedTreeDeleter,
+      AppInstallVerificationPolicy installVerificationPolicy) {
     this.layout = Objects.requireNonNull(layout, "layout");
     this.stopTimeout = Objects.requireNonNull(stopTimeout, "stopTimeout");
     this.secureRandom = Objects.requireNonNull(secureRandom, "secureRandom");
     this.appEnv = Objects.requireNonNull(appEnv, "appEnv");
     this.timing = Objects.requireNonNull(timing, "timing");
     this.managedTreeDeleter = Objects.requireNonNull(managedTreeDeleter, "managedTreeDeleter");
+    this.installVerificationPolicy =
+        Objects.requireNonNull(installVerificationPolicy, "installVerificationPolicy");
     if (stopTimeout.isZero() || stopTimeout.isNegative()) {
       throw new IllegalArgumentException("stopTimeout must be positive");
     }
@@ -197,6 +313,7 @@ public final class LocalProcessAppHost implements AppHost {
     Path temporaryInstallRoot = Files.createTempDirectory(installedAppsDir, TEMP_INSTALL_PREFIX);
     try {
       copyDirectoryTree(stagingRoot, temporaryInstallRoot);
+      verifyCopiedBundle(temporaryInstallRoot);
       AppManifest manifest = validateCopiedBundle(temporaryInstallRoot);
       InstalledAppPaths paths = layout.pathsFor(manifest.appId());
       rejectOverlappingMutableAppDirectories(stagingRoot, paths);
@@ -254,6 +371,7 @@ public final class LocalProcessAppHost implements AppHost {
         temporaryManagedPath(installedAppsDir, TEMP_UPDATE_BACKUP_PREFIX + normalizedAppId + "-");
     try {
       copyDirectoryTree(stagingRoot, temporaryInstallRoot);
+      verifyCopiedBundle(temporaryInstallRoot);
       AppManifest manifest = validateCopiedBundle(temporaryInstallRoot);
       requireMatchingUpdateTarget(normalizedAppId, manifest);
       replaceInstalledBundle(paths.installedRoot(), temporaryInstallRoot, backupInstallRoot);
@@ -508,6 +626,10 @@ public final class LocalProcessAppHost implements AppHost {
           "installed manifest app.id does not match directory name: " + installedDirectoryName);
     }
     return manifest;
+  }
+
+  private void verifyCopiedBundle(Path copiedRoot) throws IOException {
+    installVerificationPolicy.verifyCopiedBundle(copiedRoot);
   }
 
   private AppManifest validateCopiedBundle(Path copiedRoot) throws IOException {

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
@@ -223,6 +223,20 @@ class AppManifestParserTest {
   }
 
   @Test
+  void parseContent_whenAppExecPointsAtDistributionSidecar_expectFailure() {
+    String invalidManifest =
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, "cryptad-app.catalog");
+
+    AppManifestException exception =
+        assertThrows(
+            AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
+
+    assertEquals(
+        "app.exec must not point at distribution sidecar: cryptad-app.catalog",
+        exception.getMessage());
+  }
+
+  @Test
   void parseContent_whenQuotaValueIsMalformed_expectFailure() {
     String invalidDataQuotaManifest =
         minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT)
@@ -235,6 +249,20 @@ class AppManifestParserTest {
     assertThrows(
         AppManifestException.class,
         () -> AppManifestParser.parseContent(invalidCacheQuotaManifest));
+  }
+
+  @Test
+  void parseContent_whenOptionalManifestValueIsBlank_expectFailure() {
+    String invalidPermissionsManifest =
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT)
+            + "app.permissions=\n";
+
+    AppManifestException exception =
+        assertThrows(
+            AppManifestException.class,
+            () -> AppManifestParser.parseContent(invalidPermissionsManifest));
+
+    assertEquals("app.permissions must not be blank", exception.getMessage());
   }
 
   private static String minimalManifest(

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -16,6 +16,8 @@ import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -29,11 +31,19 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import network.crypta.fs.AppEnv;
+import network.crypta.platform.appdist.AppBundleSignature;
+import network.crypta.platform.appdist.AppBundleSigner;
+import network.crypta.platform.appdist.AppBundleVerifier;
+import network.crypta.platform.appdist.TrustedAppKey;
+import network.crypta.platform.appdist.TrustedAppKeys;
+import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
 import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.AppInstallVerificationPolicy;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
@@ -49,6 +59,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,6 +68,7 @@ class LocalProcessAppHostTest {
   private static final String SAMPLE_APP_ID = "sample-app";
   private static final String RUNNER_APP_ID = "runner-app";
   private static final String DUPLICATE_APP_ID = "duplicate-app";
+  private static final String TEST_KEY_ID = "test-ed25519";
   private static final String MIXED_CASE_APP_ID = "MixedCase-App";
   private static final String NORMALIZED_MIXED_CASE_APP_ID = "mixedcase-app";
   private static final String PYTHON_DAEMON_APP_ID = "python-daemon-app";
@@ -275,10 +288,70 @@ class LocalProcessAppHostTest {
   @TempDir private Path tempDir;
 
   @Test
+  void installFromDirectory_whenUsingProductionDefault_expectRejectsUnsignedBundle()
+      throws IOException {
+    AppHost host = new LocalProcessAppHost(layout());
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+
+    AppBundleVerificationException exception =
+        assertThrows(
+            AppBundleVerificationException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertEquals("signed app bundle verification is required", exception.getMessage());
+    assertTrue(host.describe(SAMPLE_APP_ID).isEmpty());
+    assertEquals(List.of(), host.listInstalled());
+  }
+
+  @Test
+  void installFromDirectory_whenVerifierRejectsCopiedBundle_expectVerifierRunsBeforeManifestRead()
+      throws IOException {
+    AtomicReference<Path> verifiedBundle = new AtomicReference<>();
+    AppHost host =
+        requireSignedHost(
+            copiedBundleDirectory -> {
+              verifiedBundle.set(copiedBundleDirectory);
+              throw new AppBundleVerificationException(
+                  "signed app bundle verification is required");
+            });
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+    Files.writeString(stagedApp.resolve(MANIFEST_FILE_NAME), "manifest.version=1\n");
+
+    AppBundleVerificationException exception =
+        assertThrows(
+            AppBundleVerificationException.class, () -> host.installFromDirectory(stagedApp));
+
+    Path copiedBundle = verifiedBundle.get();
+    assertEquals("signed app bundle verification is required", exception.getMessage());
+    assertNotNull(copiedBundle);
+    assertNotEquals(stagedApp.toAbsolutePath().normalize(), copiedBundle);
+    assertTrue(copiedBundle.startsWith(layout().installedAppsDir()));
+    assertTrue(copiedBundle.getFileName().toString().startsWith("app-install-"));
+  }
+
+  @SuppressWarnings("unused")
+  @Test
+  void installFromDirectory_whenVerifierThrowsManagedTreeIoFailure_expectRawIoFailure()
+      throws IOException {
+    IOException managedTreeFailure = new IOException("managed copied bundle became unreadable");
+    AppHost host =
+        requireSignedHost(
+            copiedBundleDirectory -> {
+              throw managedTreeFailure;
+            });
+    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+
+    IOException exception =
+        assertThrows(IOException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertSame(managedTreeFailure, exception);
+  }
+
+  @Test
   void installFromDirectory_whenInstallingValidBundle_expectCopiedLayoutAndDescribe()
       throws IOException {
-    AppHost host = host();
-    Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppHost host = signedHost(keyPair);
+    Path stagedApp = signBundle(stageInstalledApp(SAMPLE_APP_ID), keyPair);
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
 
@@ -298,7 +371,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void installFromDirectory_whenAppAlreadyInstalled_expectFailure() throws IOException {
-    AppHost host = host();
+    AppHost host = requireSignedHost(_ -> {});
     Path stagedApp = stageInstalledApp(DUPLICATE_APP_ID);
 
     host.installFromDirectory(stagedApp);
@@ -310,17 +383,20 @@ class LocalProcessAppHostTest {
   void
       updateFromDirectory_whenInstalledStoppedApp_expectManifestAndExecutableReplacedPreservingMutableDirs()
           throws IOException {
-    AppHost host = host();
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppHost host = signedHost(keyPair);
     Path installedStage =
-        stageInstalledAppAt(
-            tempDir.resolve("stage-installed").resolve(SAMPLE_APP_ID),
-            SAMPLE_APP_ID,
-            APP_VERSION,
-            """
-            #!/bin/sh
-            printf 'old\\n'
-            """,
-            Map.of("bundle-only.txt", "old-bundle\n"));
+        signBundle(
+            stageInstalledAppAt(
+                tempDir.resolve("stage-installed").resolve(SAMPLE_APP_ID),
+                SAMPLE_APP_ID,
+                APP_VERSION,
+                """
+                #!/bin/sh
+                printf 'old\\n'
+                """,
+                Map.of("bundle-only.txt", "old-bundle\n")),
+            keyPair);
     InstalledAppSnapshot installation = host.installFromDirectory(installedStage);
     Path dataSentinel =
         Files.writeString(
@@ -338,15 +414,17 @@ class LocalProcessAppHostTest {
             "keep-run",
             StandardCharsets.UTF_8);
     Path updatedStage =
-        stageInstalledAppAt(
-            tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
-            SAMPLE_APP_ID,
-            "3.0.0",
-            """
-            #!/bin/sh
-            printf 'new\\n'
-            """,
-            Map.of("new-bundle.txt", "new-bundle\n"));
+        signBundle(
+            stageInstalledAppAt(
+                tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
+                SAMPLE_APP_ID,
+                "3.0.0",
+                """
+                #!/bin/sh
+                printf 'new\\n'
+                """,
+                Map.of("new-bundle.txt", "new-bundle\n")),
+            keyPair);
 
     InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
 
@@ -372,8 +450,73 @@ class LocalProcessAppHostTest {
   }
 
   @Test
+  void installFromDirectory_whenSignedBundleIsTampered_expectVerificationFailure()
+      throws Exception {
+    KeyPair keyPair = generateEd25519KeyPair();
+    AppHost host = signedHost(keyPair);
+    Path stagedApp = signBundle(stageInstalledApp(SAMPLE_APP_ID), keyPair);
+    Files.writeString(stagedApp.resolve(CONTENT_FILE_NAME), "tampered", StandardCharsets.UTF_8);
+
+    AppBundleVerificationException exception =
+        assertThrows(
+            AppBundleVerificationException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertEquals("digest sidecar does not match bundle contents", exception.getMessage());
+  }
+
+  @Test
+  void
+      installFromDirectory_whenDevelopmentPolicyReceivesSignatureSidecars_expectVerificationFailure()
+          throws Exception {
+    AppHost host = allowUnsignedHost();
+    KeyPair keyPair = generateEd25519KeyPair();
+    Path stagedApp = signBundle(stageInstalledApp(SAMPLE_APP_ID), keyPair);
+
+    AppBundleVerificationException exception =
+        assertThrows(
+            AppBundleVerificationException.class, () -> host.installFromDirectory(stagedApp));
+
+    assertEquals("unknown trusted key id: " + TEST_KEY_ID, exception.getMessage());
+  }
+
+  @Test
+  void updateFromDirectory_whenVerifierRejectsCopiedBundle_expectVerifierRunsBeforeManifestRead()
+      throws IOException {
+    allowUnsignedHost().installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
+    AtomicReference<Path> verifiedBundle = new AtomicReference<>();
+    AppHost host =
+        requireSignedHost(
+            copiedBundleDirectory -> {
+              verifiedBundle.set(copiedBundleDirectory);
+              throw new AppBundleVerificationException(
+                  "signed app bundle verification is required");
+            });
+    Path updatedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-update-unsigned").resolve(SAMPLE_APP_ID),
+            SAMPLE_APP_ID,
+            "3.0.0",
+            scriptContent(new AppEnv()),
+            Map.of());
+    Files.writeString(updatedStage.resolve(MANIFEST_FILE_NAME), "manifest.version=1\n");
+
+    AppBundleVerificationException exception =
+        assertThrows(
+            AppBundleVerificationException.class,
+            () -> host.updateFromDirectory(SAMPLE_APP_ID, updatedStage));
+
+    Path copiedBundle = verifiedBundle.get();
+    assertEquals("signed app bundle verification is required", exception.getMessage());
+    assertNotNull(copiedBundle);
+    assertNotEquals(updatedStage.toAbsolutePath().normalize(), copiedBundle);
+    assertTrue(copiedBundle.startsWith(layout().installedAppsDir()));
+    assertTrue(copiedBundle.getFileName().toString().startsWith("app-install-"));
+    assertEquals(APP_VERSION, host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+  }
+
+  @Test
   void updateFromDirectory_whenInstalledManifestMissing_expectBundleRepaired() throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Files.delete(installation.paths().manifestFile());
     Path updatedStage =
@@ -400,7 +543,7 @@ class LocalProcessAppHostTest {
   @Test
   void updateFromDirectory_whenStagedManifestTargetsDifferentApp_expectFailure()
       throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Path mismatchedStage =
         stageInstalledAppAt(
@@ -421,7 +564,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void updateFromDirectory_whenAppNotInstalled_expectFailure() throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
 
     AppHostException exception =
@@ -434,7 +577,7 @@ class LocalProcessAppHostTest {
   @Test
   void updateFromDirectory_whenInstalledManifestUnreadable_expectReplacementRepairsBundle()
       throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Files.delete(installation.paths().manifestFile());
     Path updatedStage =
@@ -461,7 +604,7 @@ class LocalProcessAppHostTest {
   void updateFromDirectory_whenBackupCleanupFails_expectSuccessfulReplacementAndReadableInstall()
       throws IOException {
     LocalProcessAppHost host =
-        host(
+        allowUnsignedHost(
             Duration.ofSeconds(1),
             new AppEnv(),
             _ -> {
@@ -493,7 +636,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void updateFromDirectory_whenAppIsRunning_expectFailure() throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     host.installFromDirectory(stageInstalledRunnerApp(DAEMONIZED_CHILD_PROCESS_SCRIPT));
     host.start(RUNNER_APP_ID);
 
@@ -514,7 +657,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void updateFromDirectory_whenStagedDirectoryInvalid_expectFailure() throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
 
     AppHostException exception =
@@ -537,7 +680,8 @@ class LocalProcessAppHostTest {
         new LocalProcessAppHost(
             new AppHostLayout(dataDir, cacheDir, runDir),
             Duration.ofSeconds(1),
-            new java.security.SecureRandom());
+            new java.security.SecureRandom(),
+            AppInstallVerificationPolicy.allowUnsignedForDevelopmentOnly());
     Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
     Path installParent = Files.createDirectories(dataDir.resolve("apps"));
     Path externalInstalled = Files.createDirectories(tempDir.resolve("external-installed"));
@@ -565,7 +709,8 @@ class LocalProcessAppHostTest {
         new LocalProcessAppHost(
             new AppHostLayout(dataDir, cacheDir, runDir),
             Duration.ofSeconds(1),
-            new java.security.SecureRandom());
+            new java.security.SecureRandom(),
+            AppInstallVerificationPolicy.allowUnsignedForDevelopmentOnly());
 
     host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
 
@@ -596,7 +741,8 @@ class LocalProcessAppHostTest {
         new LocalProcessAppHost(
             new AppHostLayout(dataDir, cacheDir, runDir),
             Duration.ofSeconds(1),
-            new java.security.SecureRandom());
+            new java.security.SecureRandom(),
+            AppInstallVerificationPolicy.allowUnsignedForDevelopmentOnly());
 
     host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
 
@@ -622,7 +768,7 @@ class LocalProcessAppHostTest {
   @Test
   void listInstalled_whenStaleTemporaryInstallDirectoryExists_expectInstalledAppsOnly()
       throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Path staleInstallDirectory =
         tempDir
@@ -642,7 +788,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp =
         stageInstalledExecutableApp(
             "non-launchable-app",
@@ -664,7 +810,7 @@ class LocalProcessAppHostTest {
   @Test
   void installFromDirectory_whenWindowsLauncherUsesUnsupportedScript_expectFailure()
       throws IOException {
-    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), WINDOWS_11));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1), new AppEnv(Map.of(), WINDOWS_11));
     Path stagedApp =
         stageInstalledExecutableApp(
             "unsupported-windows-script-app", "bin/launch.ps1", "Write-Output 'hi'\n", Map.of());
@@ -677,7 +823,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void installFromDirectory_whenWindowsLauncherIsGenericMzBlob_expectFailure() throws IOException {
-    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), WINDOWS_11));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1), new AppEnv(Map.of(), WINDOWS_11));
     Path stagedApp =
         stageInstalledExecutableApp("generic-mz-app", "bin/fake.bin", "placeholder", Map.of());
     byte[] fakeMz = new byte[64];
@@ -694,7 +840,7 @@ class LocalProcessAppHostTest {
   @Test
   void lifecycle_whenManifestUsesMixedCaseAppId_expectPublicApiAcceptsOriginalCase()
       throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation =
         host.installFromDirectory(stageInstalledApp(MIXED_CASE_APP_ID));
 
@@ -713,7 +859,7 @@ class LocalProcessAppHostTest {
 
   @Test
   void lifecycle_whenInstalledScriptRuns_expectEnvTokenStopAndUninstall() throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp = stageInstalledApp(RUNNER_APP_ID);
 
     InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
@@ -749,7 +895,7 @@ class LocalProcessAppHostTest {
   @Test
   void start_whenInstalledProcessExitsImmediately_expectFailureAndNoRunningState()
       throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     host.installFromDirectory(stageInstalledRunnerApp(immediateExitScriptContent(new AppEnv())));
 
     Instant started = Instant.now();
@@ -768,7 +914,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     host.installFromDirectory(stageInstalledRunnerApp(DELAYED_STARTUP_EXIT_SCRIPT));
 
     try {
@@ -787,7 +933,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
     Path externalBin = Files.createDirectories(tempDir.resolve("external-bin"));
     Path externalLaunch = externalBin.resolve(scriptName(appEnv));
@@ -820,7 +966,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(1));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1));
     Path stagedApp =
         stageInstalledApp(
             RUNNER_APP_ID,
@@ -861,7 +1007,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(1));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1));
     Path stagedApp =
         stageInstalledApp(
             RUNNER_APP_ID,
@@ -907,7 +1053,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(1));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1));
     Path stagedApp =
         stageInstalledApp(
             RUNNER_APP_ID,
@@ -942,7 +1088,7 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     Assumptions.assumeTrue(appEnv.onPath(PYTHON3_COMMAND));
-    AppHost host = host(Duration.ofSeconds(1));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1));
     Path stagedApp =
         stageInstalledExecutableApp(
             PYTHON_DAEMON_APP_ID,
@@ -978,7 +1124,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "Mac OS X"));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1), new AppEnv(Map.of(), "Mac OS X"));
     Path stagedApp =
         stageInstalledApp(
             RUNNER_APP_ID,
@@ -1016,7 +1162,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(1), new AppEnv(Map.of(), "FreeBSD"));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1), new AppEnv(Map.of(), "FreeBSD"));
     Path stagedApp =
         stageInstalledApp(
             RUNNER_APP_ID,
@@ -1188,7 +1334,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(1));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(1));
     Path stagedApp =
         stageInstalledExecutableApp(
             LATE_CHILD_APP_ID,
@@ -1222,7 +1368,7 @@ class LocalProcessAppHostTest {
   @Test
   void stop_whenProcessDoesNotExit_expectRunningStatePreserved()
       throws ReflectiveOperationException {
-    LocalProcessAppHost host = host(Duration.ofMillis(10));
+    LocalProcessAppHost host = allowUnsignedHost(Duration.ofMillis(10));
     RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
     injectRunningProcess(host, RUNNER_APP_ID, snapshot, new NonStoppingProcess(snapshot.pid()));
 
@@ -1243,7 +1389,7 @@ class LocalProcessAppHostTest {
   @Test
   void stop_whenProcessExitsBetweenRefreshAndTracking_expectCleanSuccess()
       throws IOException, ReflectiveOperationException {
-    LocalProcessAppHost host = host();
+    LocalProcessAppHost host = allowUnsignedHost();
     RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
     injectRunningProcess(
         host,
@@ -1260,7 +1406,7 @@ class LocalProcessAppHostTest {
   @Test
   void status_whenLiveProcessHandleOmitsOptionalMetadata_expectSnapshotRetained()
       throws ReflectiveOperationException {
-    LocalProcessAppHost host = host();
+    LocalProcessAppHost host = allowUnsignedHost();
     RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
     injectRunningProcess(host, RUNNER_APP_ID, snapshot, new NonStoppingProcess(snapshot.pid()));
 
@@ -1273,7 +1419,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(2));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(2));
     Path stagedApp =
         stageInstalledApp(
             RUNNER_APP_ID, WRAPPER_SCRIPT, Map.of(CHILD_SCRIPT_PATH, CHILD_PROCESS_SCRIPT));
@@ -1297,7 +1443,7 @@ class LocalProcessAppHostTest {
   void stop_whenRecoveredLateChildExitsWithinStopTimeout_expectCleanSuccess()
       throws IOException, ReflectiveOperationException {
     long recoveredChildPid = 84L;
-    LocalProcessAppHost host = host(Duration.ofMillis(200));
+    LocalProcessAppHost host = allowUnsignedHost(Duration.ofMillis(200));
     RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
     injectRunningProcess(
         host,
@@ -1316,7 +1462,7 @@ class LocalProcessAppHostTest {
       throws ReflectiveOperationException {
     String appId = "shutdown-respawn-app";
     long replacementChildPid = 84L;
-    LocalProcessAppHost host = host(Duration.ofMillis(200));
+    LocalProcessAppHost host = allowUnsignedHost(Duration.ofMillis(200));
     RunningAppSnapshot snapshot = runningSnapshot(appId);
     injectRunningProcess(
         host, appId, snapshot, new LateChildSpawningProcess(snapshot.pid(), replacementChildPid));
@@ -1374,7 +1520,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp =
         stageInstalledExecutableApp(
             "invalid-shebang-app",
@@ -1417,7 +1563,7 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     Assumptions.assumeTrue(appEnv.onPath(PYTHON3_COMMAND));
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp =
         stageInstalledExecutableApp(
             "non-utf8-launcher-app",
@@ -1451,7 +1597,7 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     Assumptions.assumeTrue(appEnv.onPath("bash"));
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation =
         host.installFromDirectory(
             stageInstalledRunnerApp(
@@ -1480,7 +1626,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation =
         host.installFromDirectory(
             stageInstalledExecutableApp(
@@ -1511,7 +1657,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host(Duration.ofSeconds(2));
+    AppHost host = allowUnsignedHost(Duration.ofSeconds(2));
     InstalledAppSnapshot installation =
         host.installFromDirectory(stageInstalledRunnerApp(STDIN_EOF_SCRIPT));
 
@@ -1528,7 +1674,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation =
         host.installFromDirectory(stageInstalledRunnerApp(SINGLE_RUN_EXIT_SCRIPT));
 
@@ -1610,7 +1756,7 @@ class LocalProcessAppHostTest {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
     Assumptions.assumeTrue(appEnv.onPath(MKFIFO_COMMAND));
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
     Path namedPipe = stagedApp.resolve("blocked.pipe");
 
@@ -1629,7 +1775,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp =
         Files.createDirectories(tempDir.resolve(STAGE_DIR_NAME).resolve("manifest-symlink"));
     Path externalManifest = tempDir.resolve("outside-manifest.properties");
@@ -1649,7 +1795,7 @@ class LocalProcessAppHostTest {
   void installFromDirectory_whenStagingRootIsSymlink_expectFailure() throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
     Path linkedRoot = tempDir.resolve("linked-stage-root");
     Files.createSymbolicLink(linkedRoot, stagedApp.toAbsolutePath());
@@ -1664,7 +1810,7 @@ class LocalProcessAppHostTest {
   void installFromDirectory_whenStagingRootHasAliasedAncestor_expectSuccess() throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path realStagingParent = Files.createDirectories(tempDir.resolve("real-staging-parent"));
     Path aliasedParent = tempDir.resolve("aliased-staging-parent");
     Files.createSymbolicLink(aliasedParent, realStagingParent.toAbsolutePath());
@@ -1683,7 +1829,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
     Path externalRun = Files.createDirectories(tempDir.resolve("external-run"));
     Files.delete(installation.paths().runDir());
@@ -1701,7 +1847,7 @@ class LocalProcessAppHostTest {
       throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
     Path runAppsDir = tempDir.resolve("run").resolve("apps");
     Path externalRunAppsDir = tempDir.resolve("external-run-apps");
@@ -1718,7 +1864,7 @@ class LocalProcessAppHostTest {
   @Test
   void installFromDirectory_whenStagingRootOverlapsInstalledTree_expectCleanFailure()
       throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp =
         stageInstalledAppAt(
             tempDir.resolve("data"), SAMPLE_APP_ID, scriptContent(new AppEnv()), Map.of());
@@ -1733,7 +1879,7 @@ class LocalProcessAppHostTest {
   @Test
   void installFromDirectory_whenStagingRootCollidesWithRunDir_expectCleanFailure()
       throws IOException {
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp =
         stageInstalledAppAt(
             tempDir.resolve("run").resolve("apps").resolve(SAMPLE_APP_ID),
@@ -1753,7 +1899,7 @@ class LocalProcessAppHostTest {
   void installFromDirectory_whenWindowsJunctionEscapesStagingRoot_expectFailure() throws Exception {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeTrue(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
     Path externalRoot = Files.createDirectories(tempDir.resolve("outside-root"));
     Path junction = stagedApp.resolve("outside-junction");
@@ -1779,7 +1925,7 @@ class LocalProcessAppHostTest {
   void uninstall_whenWindowsJunctionExistsUnderAppData_expectTargetPreserved() throws Exception {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeTrue(appEnv.isWindows());
-    AppHost host = host();
+    AppHost host = allowUnsignedHost();
     InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Path externalRoot = Files.createDirectories(tempDir.resolve("outside-uninstall-root"));
     Path externalFile = externalRoot.resolve("outside.txt");
@@ -1809,7 +1955,7 @@ class LocalProcessAppHostTest {
   @Test
   void preserveRunningState_whenTrackedProcessAlreadyExited_expectEntryRemovedWithoutFailure()
       throws ReflectiveOperationException {
-    LocalProcessAppHost host = host();
+    LocalProcessAppHost host = allowUnsignedHost();
     RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
     injectRunningProcess(host, RUNNER_APP_ID, snapshot, new ExitedProcess(snapshot.pid()));
 
@@ -1824,7 +1970,7 @@ class LocalProcessAppHostTest {
   @Test
   void preserveRunningState_whenTrackedProcessExitsDuringRefresh_expectEntryRemovedWithoutFailure()
       throws ReflectiveOperationException {
-    LocalProcessAppHost host = host();
+    LocalProcessAppHost host = allowUnsignedHost();
     RunningAppSnapshot snapshot = runningSnapshot(RUNNER_APP_ID);
     injectRunningProcess(host, RUNNER_APP_ID, snapshot, new FadingProcess(snapshot.pid(), 1));
 
@@ -1836,40 +1982,70 @@ class LocalProcessAppHostTest {
     assertTrue(host.listRunning().isEmpty());
   }
 
-  private LocalProcessAppHost host() {
-    return host(Duration.ofSeconds(1));
+  private LocalProcessAppHost allowUnsignedHost() {
+    return allowUnsignedHost(Duration.ofSeconds(1));
   }
 
-  private LocalProcessAppHost host(Duration stopTimeout) {
-    return host(stopTimeout, new AppEnv());
+  private LocalProcessAppHost allowUnsignedHost(Duration stopTimeout) {
+    return allowUnsignedHost(stopTimeout, new AppEnv());
   }
 
-  private LocalProcessAppHost host(Duration stopTimeout, AppEnv appEnv) {
+  private LocalProcessAppHost allowUnsignedHost(Duration stopTimeout, AppEnv appEnv) {
     return new LocalProcessAppHost(
-        new AppHostLayout(
-            tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run")),
-        stopTimeout,
-        new java.security.SecureRandom(),
-        appEnv,
-        TEST_TIMING);
-  }
-
-  private LocalProcessAppHost host(
-      Duration stopTimeout,
-      AppEnv appEnv,
-      LocalProcessAppHost.ManagedTreeDeleter managedTreeDeleter) {
-    return new LocalProcessAppHost(
-        new AppHostLayout(
-            tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run")),
+        layout(),
         stopTimeout,
         new java.security.SecureRandom(),
         appEnv,
         TEST_TIMING,
-        managedTreeDeleter);
+        AppInstallVerificationPolicy.allowUnsignedForDevelopmentOnly());
+  }
+
+  private LocalProcessAppHost allowUnsignedHost(
+      Duration stopTimeout,
+      AppEnv appEnv,
+      LocalProcessAppHost.ManagedTreeDeleter managedTreeDeleter) {
+    return new LocalProcessAppHost(
+        layout(),
+        stopTimeout,
+        new java.security.SecureRandom(),
+        appEnv,
+        TEST_TIMING,
+        managedTreeDeleter,
+        AppInstallVerificationPolicy.allowUnsignedForDevelopmentOnly());
+  }
+
+  private LocalProcessAppHost requireSignedHost(
+      AppInstallVerificationPolicy.CopiedBundleVerifier verifier) {
+    return new LocalProcessAppHost(
+        layout(),
+        Duration.ofSeconds(1),
+        new java.security.SecureRandom(),
+        new AppEnv(),
+        TEST_TIMING,
+        AppInstallVerificationPolicy.requireSigned(verifier));
+  }
+
+  private LocalProcessAppHost signedHost(KeyPair keyPair) {
+    TrustedAppKeys trustedKeys =
+        TrustedAppKeys.of(
+            new TrustedAppKey(
+                TEST_KEY_ID, AppBundleSignature.SIGNATURE_ALGORITHM, keyPair.getPublic()));
+    return requireSignedHost(
+        copiedBundleDirectory -> AppBundleVerifier.verify(copiedBundleDirectory, trustedKeys));
+  }
+
+  private AppHostLayout layout() {
+    return new AppHostLayout(
+        tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run"));
   }
 
   private Path stageInstalledApp(String appId) throws IOException {
     return stageInstalledApp(appId, scriptContent(new AppEnv()), Map.of());
+  }
+
+  private Path signBundle(Path stagedDir, KeyPair keyPair) throws IOException {
+    AppBundleSigner.sign(stagedDir, TEST_KEY_ID, keyPair.getPrivate());
+    return stagedDir;
   }
 
   private Path stageInstalledRunnerApp(String scriptContent) throws IOException {
@@ -1984,6 +2160,14 @@ class LocalProcessAppHostTest {
                 tempDir.resolve("data"), tempDir.resolve(CACHE_DIR_NAME), tempDir.resolve("run"))
             .pathsFor(appId);
     return new RunningAppSnapshot(manifest, paths, DEFAULT_TOKEN, 42L, Instant.EPOCH);
+  }
+
+  private static KeyPair generateEd25519KeyPair() {
+    try {
+      return KeyPairGenerator.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM).generateKeyPair();
+    } catch (Exception exception) {
+      throw new IllegalStateException("Failed to generate Ed25519 test key pair.", exception);
+    }
   }
 
   @SuppressWarnings({"java:S3011"})
@@ -2399,7 +2583,7 @@ class LocalProcessAppHostTest {
 
     try {
       return new ObservedPid(Long.parseLong(contents), contents);
-    } catch (NumberFormatException e) {
+    } catch (NumberFormatException _) {
       return new ObservedPid(null, contents);
     }
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ rootProject.name = "cryptad"
 include(
   ":apps:queue-manager",
   ":apps:publisher",
+  ":platform-appdist",
   ":foundation-support",
   ":foundation-store",
   ":foundation-store-contracts",

--- a/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
@@ -3,13 +3,21 @@ package network.crypta.platform.api;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import network.crypta.fs.AppEnv;
+import network.crypta.platform.appdist.AppBundleSignature;
+import network.crypta.platform.appdist.AppBundleSigner;
+import network.crypta.platform.appdist.AppBundleVerifier;
+import network.crypta.platform.appdist.TrustedAppKey;
+import network.crypta.platform.appdist.TrustedAppKeys;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.AppInstallVerificationPolicy;
 import network.crypta.platform.apphost.manifest.AppManifestParser;
 import network.crypta.platform.apphost.runtime.LocalProcessAppHost;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -28,6 +36,7 @@ class PlatformApiAppsIntegrationTest {
   private static final String APP_ID = "demo-app";
   private static final String APP_NAME = "Demo App";
   private static final String APP_VERSION = "1.2.3";
+  private static final String TRUSTED_KEY_ID = "local-dev";
   private static final String UI_ENTRY = "/";
 
   @TempDir private Path tempDir;
@@ -37,13 +46,10 @@ class PlatformApiAppsIntegrationTest {
 
   @BeforeEach
   void setUp() {
-    RuntimePorts runtimePorts = mock(RuntimePorts.class, Answers.RETURNS_DEEP_STUBS);
     appHostLayout =
         new AppHostLayout(
             tempDir.resolve("data"), tempDir.resolve("cache"), tempDir.resolve("run"));
-    AppHost appHost =
-        new LocalProcessAppHost(appHostLayout, Duration.ofSeconds(2), new SecureRandom());
-    router = new PlatformApiRouter(runtimePorts, appHost);
+    router = createRouter(allowUnsignedHost());
   }
 
   @Test
@@ -195,9 +201,85 @@ class PlatformApiAppsIntegrationTest {
     assertTrue(repeatedStartResponse.body().contains("\"code\":\"app_conflict\""));
   }
 
+  @Test
+  void route_whenProductionPolicyReceivesUnsignedBundle_expectInvalidAppBundle() throws Exception {
+    PlatformApiRouter productionRouter =
+        createRouter(
+            new LocalProcessAppHost(appHostLayout, Duration.ofSeconds(2), new SecureRandom()));
+    Path stagedDir = stageApp();
+
+    PlatformApiResponse response =
+        productionRouter.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(400, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_app_bundle\",\"message\":\"Staged app bundle must pass"
+            + " trusted signature verification.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenProductionPolicyReceivesSignedBundle_expectInstallAndUpdateSuccess()
+      throws Exception {
+    KeyPair keyPair =
+        KeyPairGenerator.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM).generateKeyPair();
+    TrustedAppKeys trustedKeys =
+        TrustedAppKeys.of(
+            new TrustedAppKey(
+                TRUSTED_KEY_ID, AppBundleSignature.SIGNATURE_ALGORITHM, keyPair.getPublic()));
+    PlatformApiRouter productionRouter = createRouter(signedHost(trustedKeys));
+    Path stagedV1 = stageSignedApp("signed-v1", "1.0.0", keyPair);
+    Path stagedV2 = stageSignedApp("signed-v2", "9.9.9", keyPair);
+
+    PlatformApiResponse installResponse =
+        productionRouter.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedV1.toString()))));
+    assertEquals(201, installResponse.statusCode());
+    assertTrue(installResponse.body().contains("\"version\":\"1.0.0\""));
+
+    PlatformApiResponse updateResponse =
+        productionRouter.route(
+            request(
+                "POST",
+                List.of("apps", APP_ID, "update"),
+                Map.of("stagedDir", List.of(stagedV2.toString()))));
+
+    assertEquals(200, updateResponse.statusCode());
+    assertTrue(updateResponse.body().contains("\"version\":\"9.9.9\""));
+  }
+
   private PlatformApiRequest request(
       String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
     return new PlatformApiRequest(method, pathSegments, queryParameters);
+  }
+
+  private PlatformApiRouter createRouter(AppHost appHost) {
+    RuntimePorts runtimePorts = mock(RuntimePorts.class, Answers.RETURNS_DEEP_STUBS);
+    return new PlatformApiRouter(runtimePorts, appHost);
+  }
+
+  private AppHost allowUnsignedHost() {
+    return new LocalProcessAppHost(
+        appHostLayout,
+        Duration.ofSeconds(2),
+        new SecureRandom(),
+        AppInstallVerificationPolicy.allowUnsignedForDevelopmentOnly());
+  }
+
+  private AppHost signedHost(TrustedAppKeys trustedKeys) {
+    return new LocalProcessAppHost(
+        appHostLayout,
+        Duration.ofSeconds(2),
+        new SecureRandom(),
+        AppInstallVerificationPolicy.requireSigned(
+            copiedBundleDirectory -> AppBundleVerifier.verify(copiedBundleDirectory, trustedKeys)));
   }
 
   private Path stageApp() throws Exception {
@@ -229,6 +311,13 @@ class PlatformApiAppsIntegrationTest {
         """
             .formatted(APP_ID, APP_NAME, appVersion, scriptName, UI_ENTRY),
         StandardCharsets.UTF_8);
+    return stagedDir;
+  }
+
+  private Path stageSignedApp(String stagedDirectoryName, String appVersion, KeyPair keyPair)
+      throws Exception {
+    Path stagedDir = stageApp(stagedDirectoryName, appVersion);
+    AppBundleSigner.sign(stagedDir, TRUSTED_KEY_ID, keyPair.getPrivate());
     return stagedDir;
   }
 

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import network.crypta.platform.api.json.PlatformApiJsonWriter;
+import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostConfigurationException;
 import network.crypta.platform.apphost.AppHostException;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
@@ -2305,6 +2307,52 @@ class PlatformApiRouterTest {
             new AppHostException(
                 "installedAppsDir must not be a symlink, reparse point, or alias:"
                     + " /srv/node/apps/installed"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(500, response.statusCode());
+    assertEquals("Internal Server Error", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"internal_error\",\"message\":\"Failed to install app.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAppInstallSignatureVerificationFails_expectSanitizedBadRequestJson()
+      throws Exception {
+    Path stagedDir = stageApp();
+    when(appHost.describe(APP_ID)).thenAnswer(_ -> Optional.empty());
+    when(appHost.installFromDirectory(stagedDir))
+        .thenThrow(
+            new AppBundleVerificationException(
+                "signature sidecar missing in copied bundle: /srv/node/apps/installed/demo-app"));
+
+    PlatformApiResponse response =
+        router.route(
+            request(
+                "POST",
+                List.of("apps", "install"),
+                Map.of("stagedDir", List.of(stagedDir.toString()))));
+
+    assertEquals(400, response.statusCode());
+    assertEquals("Bad Request", response.reasonPhrase());
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_app_bundle\",\"message\":\"Staged app bundle must pass"
+            + " trusted signature verification.\"}}",
+        response.body());
+  }
+
+  @Test
+  void route_whenAppInstallTrustConfigurationFails_expectInternalErrorJson() throws Exception {
+    Path stagedDir = stageApp();
+    when(appHost.describe(APP_ID)).thenAnswer(_ -> Optional.empty());
+    when(appHost.installFromDirectory(stagedDir))
+        .thenThrow(new AppHostConfigurationException("Failed to load trusted app keys file."));
 
     PlatformApiResponse response =
         router.route(


### PR DESCRIPTION
## Summary
- Add the new `:platform-appdist` module for deterministic local app bundle digests, Ed25519 signatures, trusted-key registries, and a local signing/verification CLI.
- Integrate signed-bundle verification into AppHost install/update flows and Platform API error handling, while keeping explicit development-only unsigned policy paths for tests/local workflows.
- Add first-party app Gradle signing/verification tasks plus documentation for local signed staged bundles, trust configuration, and private-key handling.
- Add focused coverage for digest determinism, signature verification, tamper detection, manifest/launch validation, trust-configuration failures, API error mapping, and signed install/update behavior.

## How to test
- `./gradlew spotlessApply`
- `./gradlew test`

## Base
- Opened against `develop`.