### PR TITLE
docs(platform): Close Phase 3 platform work

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ data, and serves applications.
 - [Quick Start](#quick-start)
 - [Building](#building)
 - [Signed App Bundles](#signed-app-bundles)
+- [Platform Closeout & API Surface](#platform-closeout--api-surface)
+- [Hyphanet Interop Gate](#hyphanet-interop-gate)
 - [Testing](#testing)
 - [Code Quality](#code-quality)
 - [Running Your Build](#running-your-build)
@@ -235,15 +237,17 @@ Cryptad now uses a partial multi-project Gradle build.
   `UpdaterPaths`.
 - `:platform-api` owns the transport-neutral Platform API v1 under
   `network.crypta.platform.api`. It sits above `:runtime-spi`, exposes detached runtime snapshots
-  and the minimal local AppHost control surface as JSON-oriented responses, and is currently
-  mounted at `/api/v1/` through a thin legacy HTTP bridge in `:adapter-http-legacy-admin`. The
-  current surface covers node info, peers, config export, connectivity, security-level snapshots,
-  and local app install/start/stop/update/uninstall routes; `GET /api/v1/config` defaults to the
-  effective `CURRENT` section when `sections=` is omitted.
+  and local AppHost control operations as JSON-oriented responses, and is currently mounted at
+  `/api/v1/` through a thin legacy HTTP bridge in `:adapter-http-legacy-admin`. The current Phase
+  3 surface covers node, connectivity, queue, peers, config, security levels, updates,
+  wizard/welcome, alerts, diagnostics, and apps; `GET /api/v1/config` defaults to the effective
+  `CURRENT` section when `sections=` is omitted.
 - `:platform-apphost` owns the transport-neutral out-of-process AppHost v1 core under
   `network.crypta.platform.apphost`. It defines the local manifest, installed-app layout, process
   lifecycle, and per-start launch-token plumbing for local apps while staying separate from future
   Web Shell, application-UI, and remote update-channel work.
+- `:platform-appdist` owns the local app distribution tooling used to digest, sign, and verify
+  staged AppHost bundles.
 - `:platform-web-shell` owns the first browser-facing Web Shell v1 under
   `network.crypta.platform.webshell`. It keeps the node-management shell's route constants,
   bootstrap payload, HTML renderer, and plain browser assets self-owned while staying separate
@@ -350,6 +354,36 @@ Do not commit production private signing keys to this repository. Keep local dev
 outside the repo and pass them through Gradle properties or environment variables. Remote catalogs
 and remote downloads are future work. See [docs/app-distribution.md](docs/app-distribution.md) for
 the full workflow and exact signing inputs.
+
+## Platform Closeout & API Surface
+
+Phase 3 Platform Primacy makes `:platform-api`, `:platform-web-shell`, and `:platform-apphost` the
+primary local platform path for operator workflows and first-party apps. Legacy HTTP and FCP remain
+compatibility, bridge, debug, and fallback surfaces.
+
+Key docs:
+
+- [Phase 3 Platform Primacy closeout](docs/phase-3-platform-primacy-closeout.md)
+- [Platform API and Web Shell surface](docs/platform-api-surface.md)
+- [Signed App Distribution](docs/app-distribution.md)
+
+## Hyphanet Interop Gate
+
+The packaged-node Hyphanet interop smoke gate lives under `tools/interop/` and is wired into CI as
+the `interop-smoke` job. Local usage, baseline configuration, diagnostics, and follow-ups are
+documented in [tools/interop/README.md](tools/interop/README.md).
+
+Fast parser/client self-test:
+
+```bash
+python3 tools/interop/interop_smoke.py --self-test
+```
+
+Full gate when the local environment is prepared:
+
+```bash
+tools/interop/run-hyphanet-interop-smoke.sh
+```
 
 ## Testing
 
@@ -692,9 +726,14 @@ Root build also includes:
   path constants such as `ConnectivityPagePaths` and `UpdaterPaths`.
 - `:platform-api`: transport-neutral Platform API v1 built on top of `:runtime-spi` and
   `:platform-apphost`, currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
+  Its current family-level surface covers node, connectivity, queue, peers, config, security
+  levels, updates, wizard/welcome, alerts, diagnostics, and apps.
 - `:platform-apphost`: transport-neutral out-of-process AppHost v1 core for installed local apps.
   Local staged app updates now flow through this core; future Web Shell, app UI, and remote
   update-channel work remain separate and later.
+- `:platform-appdist`: local app distribution tooling for deterministic bundle digests, Ed25519
+  signatures, trusted-key verification, and the signing/verification CLI used by first-party app
+  Gradle tasks.
 - `:platform-web-shell`: browser-facing Web Shell v1 leaf owning the node-management shell route
   descriptors, bootstrap payload, and static browser assets that the legacy HTTP adapter mounts at
   `/app/node/`.
@@ -764,7 +803,7 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 ## Branching & Releases
 
 - Standard branching and release workflow: see `docs/standard-git-branching-and-release-workflow.md` (validated copy). The original wiki page is also available: https://github.com/crypta-network/cryptad/wiki/Standard-Git-Branching-and-Release-Workflow-for-Cryptad
-- [Release workflow and operations runbook](https://github.com/crypta-network/cryptad/wiki/Cryptad-Release-Workflow-and-Runbook)
+- [Release workflow and operations runbook](docs/cryptad-release-workflow-and-runbook.md)
 
 ## Update System
 
@@ -789,7 +828,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
     `:foundation-store-contracts`, `:foundation-crypto-keys`, `:interop-wire`,
     `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
     `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:runtime-alerts`,
-    `:platform-api`, `:platform-apphost`, `:platform-web-shell`, `:runtime-node`,
+    `:platform-api`, `:platform-apphost`, `:platform-appdist`, `:platform-web-shell`,
+    `:runtime-node`,
     `:adapter-fcp`, `:bridge-fcp-runtime`, `:bridge-http-runtime`,
     `:adapter-http-legacy-admin`, `:adapter-http-legacy-browse`, `:thirdparty-onion`,
     `:thirdparty-legacy`, and `:launcher-desktop`.
@@ -931,7 +971,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   feed/model subset plus the detached `UserAlertSurface`;
   `:platform-api` provides the transport-neutral Platform API v1 plus the minimal AppHost
   control-plane routes; `:platform-apphost` provides the transport-neutral out-of-process AppHost
-  v1 core for installed local apps;
+  v1 core for installed local apps; `:platform-appdist` provides the local app bundle digest,
+  signing, and verification tooling;
   `:platform-web-shell` provides the browser-facing Web Shell v1 node-management assets and
   bootstrap contract; `:runtime-node`
   provides the extracted daemon runtime body across the remaining cyclic/high-level

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -5,6 +5,9 @@ This document describes Cryptad's local signed staged app bundle workflow for fi
 ## Scope
 
 PR-192 adds signed local bundle sidecars and Gradle tasks for staging, signing, and verifying first-party apps.
+PR-194 treats staging, signing, and verification as Phase 3 release gates; see
+[phase-3-platform-primacy-closeout.md](phase-3-platform-primacy-closeout.md) and
+[cryptad-release-workflow-and-runbook.md](cryptad-release-workflow-and-runbook.md).
 
 Out of scope in this PR:
 

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -43,6 +43,15 @@
 - **Environment validation**: run smoke tests on each target OS using `build/jpackage/Crypta`, `build/distributions/`, or the staged Flatpak bundle. Ensure the installers launch and locate `cryptad-dist/` correctly.
 - **Dependency review**: verify updater metadata and package checksums are consistent with produced artifacts.
 
+## Phase 3 Release Gates
+Treat these as release blockers, in order:
+
+1. **Normal Gradle checks** - run the standard repository build and test path before any publish step. For release readiness, this means the usual Gradle verification path for the branch, including `./gradlew clean build` and any project-required test tasks used in CI.
+2. **First-party app staging** - stage repo-owned AppHost bundles with the app module tasks or `./gradlew stageFirstPartyApps`. The app workflow source of truth is [app-distribution.md](app-distribution.md).
+3. **First-party app signing and verification** - sign with the intended release or staging key inputs, then verify with the matching trusted public key inputs. Gate promotion on successful `./gradlew signFirstPartyApps` and `./gradlew verifyFirstPartyApps` runs. Keep private signing keys outside the repository.
+4. **Hyphanet interop smoke** - run the packaged-node compatibility smoke locally when the environment is prepared, or verify that the CI `interop-smoke` job passed. The gate is documented in [tools/interop/README.md](../tools/interop/README.md) and summarized in [phase-3-platform-primacy-closeout.md](phase-3-platform-primacy-closeout.md).
+5. **Interop failure artifacts** - if the interop gate fails, preserve `build/interop-smoke/` from the local run or the CI uploaded artifact before rerunning or cleaning the workspace.
+
 ## Build
 1. Clean build for deterministic artifacts:
    ```bash

--- a/docs/phase-3-platform-primacy-closeout.md
+++ b/docs/phase-3-platform-primacy-closeout.md
@@ -1,0 +1,146 @@
+# Phase 3 Platform Primacy Closeout
+
+This document records the Phase 3 Platform Primacy state after PR-194: what landed, which modules
+own the platform surfaces now, which release gates must pass, and which work stays deferred.
+
+## Status
+
+Phase 3 is complete as of PR-194, assuming the release gates below pass.
+
+PR-194 is a documentation and release-readiness closeout. It does not remove legacy HTTP or FCP,
+change AppHost runtime semantics, change signed-app cryptography, or change wire, routing, key, or
+persistent formats.
+
+## Goals
+
+Phase 3 made the platform path the primary local operator and first-party app path:
+
+- Shell-native control plane through Platform API v1 and Web Shell v1.
+- First-party AppHost apps for queue management and publishing workflows.
+- Signed local app distribution for staged first-party app bundles.
+- Hyphanet/Freenet compatibility coverage through the packaged-node interop gate.
+
+Legacy HTTP and FCP remain available. They are compatibility, bridge, debug, and fallback surfaces,
+not removed components.
+
+## PR map
+
+| PR | Area | Result |
+| --- | --- | --- |
+| PR-184 | Browse detach | Cleaned up the tail of the legacy browse detachment work and kept browse/FProxy concerns owned by the legacy browse adapter. |
+| PR-185 | Platform API mutation plumbing | Added the mutation plumbing needed for shell-native control-plane actions instead of read-only snapshots only. |
+| PR-186 | Queue control plane | Made queue snapshots, direct downloads, request mutations, cleanup, and queue key export reachable through Platform API and Web Shell surfaces. |
+| PR-187 | Peer control plane | Added Platform API and Web Shell peer roster, add, settings, note, and removal flows on top of detached runtime peer ports. |
+| PR-188 | Config, update, and wizard control plane | Brought config overrides/persistence, core-update download triggering, and first-time wizard submission into the platform path. |
+| PR-189 | Alerts and diagnostics surface | Added Platform API and Web Shell alert listing/dismissal plus diagnostics snapshots and text export. |
+| PR-190 | First-party app toolchain and Queue Manager app | Added first-party app staging/tooling and the Queue Manager app bundle that deep-links into the shell queue surface. |
+| PR-191 | Publisher first-party app | Added the Publisher app bundle and shell-native local file/directory insert workflow. |
+| PR-192 | Signed local app distribution | Added deterministic digest sidecars, Ed25519 signatures, Gradle signing/verification tasks, and AppHost trusted-key checks for local staged bundles. |
+| PR-193 | Hyphanet interop gate | Added the packaged-node Hyphanet interop smoke harness and CI gate under `tools/interop/`. |
+| PR-194 | Closeout and release readiness | Documents the completed Phase 3 state, release gates, Platform API/Web Shell surface, and Phase 4 candidates. |
+
+## Current platform architecture
+
+The Phase 3 platform path is split across focused modules:
+
+- `:runtime-spi` owns the detached runtime ports and DTOs used by the platform layer. It is the
+  JDK-only boundary between shell/API code and daemon-backed runtime implementations.
+- `:platform-api` owns the transport-neutral Platform API v1 router, JSON response/error helpers,
+  and endpoint handlers for node, connectivity, queue, peers, config, security levels, updates,
+  wizard, alerts, diagnostics, and apps.
+- `:platform-web-shell` owns the browser-facing Web Shell v1 page contract, bootstrap model, route
+  constants, and static browser assets. The current shell is mounted at `/app/node/`.
+- `:platform-apphost` owns the transport-neutral local AppHost core: manifest parsing, installed
+  app layout, process lifecycle, running-state snapshots, and launch-token plumbing.
+- `:platform-appdist` owns the local app distribution tooling used to digest, sign, and verify
+  staged bundles.
+- `apps/queue-manager` owns the Queue Manager first-party app bundle. Its `app.ui.entry` points to
+  `/app/node/#queue`.
+- `apps/publisher` owns the Publisher first-party app bundle. Its `app.ui.entry` points to
+  `/app/node/#publisher`.
+- `:adapter-fcp` owns the detached FCP protocol adapter surface. It remains a compatibility and
+  automation protocol, separate from Platform API.
+- `:bridge-fcp-runtime` owns the concrete runtime bindings for FCP.
+- `:adapter-http-legacy-admin` owns the shared legacy HTTP admin shell, admin toadlets, the
+  `/api/v1/` Platform API bridge, and the `/app/node/` Web Shell bridge.
+- `:adapter-http-legacy-browse` owns concrete legacy browse/FProxy routes and helpers.
+- `:bridge-http-runtime` owns concrete runtime bindings for legacy HTTP.
+- `tools/interop` owns the packaged-node Hyphanet interop smoke harness and checked-in baseline
+  defaults.
+
+The main production composition still starts from root-owned bootstrap code. The Phase 3 change is
+that routine local operator workflows now have a first-party platform path through Platform API and
+Web Shell, while the legacy adapters continue to host transport, auth, compatibility, and fallback
+behavior.
+
+## First-party apps and signed local distribution
+
+First-party app bundles are staged by their app modules and by root convenience tasks:
+
+- `./gradlew :apps:queue-manager:stageApp`
+- `./gradlew :apps:publisher:stageApp`
+- `./gradlew stageFirstPartyApps`
+
+Signing and verification are separate release gates:
+
+- `./gradlew signFirstPartyApps`
+- `./gradlew verifyFirstPartyApps`
+
+Signing inputs, trusted-key inputs, sidecar formats, and local install/update examples are
+documented in [app-distribution.md](app-distribution.md). The staged bundles are local bundles.
+Remote catalogs, remote bundle downloads, browser-side uploads, and app-owned static serving remain
+future work.
+
+## Platform API and Web Shell
+
+Platform API v1 is mounted at `/api/v1/` through the legacy HTTP admin bridge. The API is currently
+a local/internal control plane, not a declared stable remote public API.
+
+Web Shell v1 is mounted at `/app/node/` through the legacy HTTP admin bridge. It uses the Platform
+API for shell-native node management and still exposes legacy deep links for flows that remain
+fallback or debug surfaces.
+
+The current family-level surface is documented in
+[platform-api-surface.md](platform-api-surface.md).
+
+## Hyphanet interop gate
+
+PR-193 added the interop harness. It is present and should be treated as an existing release gate,
+not recreated:
+
+- `tools/interop/README.md`
+- `tools/interop/hyphanet-baseline.env`
+- `tools/interop/run-hyphanet-interop-smoke.sh`
+- `tools/interop/interop_smoke.py`
+
+CI runs the gate through the `interop-smoke` job in `.github/workflows/ci.yml` after building a
+runnable Cryptad distribution. Local usage and diagnostics are documented in
+[tools/interop/README.md](../tools/interop/README.md).
+
+## Release gates
+
+Treat these gates as blockers before promoting a Phase 3 release:
+
+1. Run the normal Gradle build/test gate for the release branch.
+2. Stage first-party apps.
+3. Sign first-party apps with the intended release or staging signing inputs.
+4. Verify first-party apps with the matching trusted public key inputs.
+5. Run the Hyphanet interop smoke gate locally or verify the CI `interop-smoke` job passed.
+6. Preserve `build/interop-smoke/` diagnostics when the interop smoke fails.
+
+The release runbook records the same gates in
+[cryptad-release-workflow-and-runbook.md](cryptad-release-workflow-and-runbook.md).
+
+## Deferred to Phase 4
+
+Phase 4 candidates are plans, not PR-194 implementation scope:
+
+- Remote signed app catalogs and remote bundle fetch.
+- App proxy/static serving for independent app UIs.
+- Broader first-party app catalog.
+- Better app permission enforcement and audit surfaces.
+- Legacy admin and browse retirement plan.
+- Longer USK and persistent-request interop soak tests.
+- Multi-OS interop matrix.
+- Opennet interop gate.
+- Performance and regression gates.

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -1,0 +1,95 @@
+# Platform API Surface
+
+This page documents the current local Platform API v1 and Web Shell surfaces after Phase 3.
+
+## Scope
+
+Platform API v1 is mounted at `/api/v1/`. The current transport-facing entrypoint is the legacy
+HTTP admin bridge in `:adapter-http-legacy-admin`, which converts legacy requests into
+`PlatformApiRequest` objects and delegates routing to `:platform-api`.
+
+The API is a local/internal control plane for the daemon and first-party shell. It is not yet a
+declared stable remote public API.
+
+Web Shell v1 is mounted separately at `/app/node/`. Its static assets are served beneath
+`/app/node/static/`, and its bootstrap payload points the browser at the Platform API root.
+
+## Response contract
+
+The router emits JSON responses. Successful reads generally return `200 OK`; create-style
+operations such as queueing a direct download or installing a local app can return `201 Created`.
+
+Errors use one JSON shape:
+
+```json
+{"error":{"code":"...","message":"..."}}
+```
+
+Current error handling uses HTTP-style status codes:
+
+| Status | Current use |
+| --- | --- |
+| `400 Bad Request` | Malformed paths, malformed percent-encoding, or invalid query/form values. |
+| `403 Forbidden` | The legacy bridge rejects a caller without full access. |
+| `404 Not Found` | Unknown routes or missing resources. |
+| `405 Method Not Allowed` | A known route was called with the wrong method; the response includes `Allow`. |
+| `409 Conflict` | Stateful conflicts, confirmation requirements, or temporarily unavailable control paths. |
+| `500 Internal Server Error` | Unexpected failures after routing. |
+
+Mutating routes still rely on the legacy admin bridge for full-access checks and the form-password
+guard. Current Web Shell mutations submit URL-encoded form data.
+
+## Endpoint families
+
+The table lists the current family-level surface. It avoids documenting every minor query
+parameter; check the handler and tests when adding or changing a specific contract.
+
+| Family | Current surface |
+| --- | --- |
+| Node | `GET /api/v1/node/greeting` and `GET /api/v1/node/reference` expose read-only node metadata and node-reference export. |
+| Connectivity | `GET /api/v1/connectivity` exposes the current connectivity snapshot. |
+| Queue | `GET /api/v1/queue` exposes the queue snapshot. The family also covers count and key-export views, direct downloads, local file/directory inserts, request removal/restart/priority changes, and finished upload/download cleanup. |
+| Peers | `GET /api/v1/peers` exposes raw peer lists or the shell summary view. The family also covers peer add, lookup, settings updates, private-note updates, and removal. |
+| Config | `GET /api/v1/config` exports config snapshots. `POST` actions apply overrides and persist the current config. |
+| Security levels | `GET /api/v1/security-levels` exposes threat-level state. The family also covers network warning lookup and current network/physical threat-level mutations, with confirmation-heavy flows still falling back to legacy pages when required. |
+| Updates | `GET /api/v1/updates/core` reports core-updater availability. `POST /api/v1/updates/core/download` triggers the current package download flow. |
+| Wizard/welcome | `GET /api/v1/wizard/first-time` exposes the detached first-time setup snapshot. `POST /api/v1/wizard/first-time/apply` submits the shell-native onboarding/reset model. There is no separate `/welcome` Platform API family in Phase 3; welcome-page fallback behavior remains on the legacy/admin side. |
+| Alerts | `GET /api/v1/alerts` lists current alerts. `POST /api/v1/alerts/{alertId}/dismiss` dismisses one alert by detached identifier. |
+| Diagnostics | `GET /api/v1/diagnostics` exposes the ordered diagnostic snapshot and plain-text export. |
+| Apps | `GET /api/v1/apps` lists installed apps when `AppHost` is wired into the router. The family also covers local staged-bundle install, app lookup, start, stop, update, and uninstall. |
+
+## Web Shell relationship
+
+The Web Shell uses the Platform API for node management, queue control, peer control, alerts,
+diagnostics, config, updater, security levels, wizard, installed-app lifecycle work, and the
+Publisher/Queue Manager first-party app surfaces.
+
+The shell currently includes these first-party panels and surfaces:
+
+- Overview and connectivity snapshots.
+- Alert queue and diagnostics.
+- Installed apps.
+- Security levels, updater state, config controls, and first-time wizard controls.
+- Peer control plane.
+- Publisher local file/directory insert workflow.
+- Queue control plane.
+- Legacy links for pages that remain fallback or debug surfaces.
+
+The shell is hosted by `:adapter-http-legacy-admin`, but its route constants, HTML template, CSS,
+JavaScript, and bootstrap model are owned by `:platform-web-shell`.
+
+## Legacy HTTP and FCP relationship
+
+Platform API v1 does not replace legacy HTTP or FCP in Phase 3.
+
+Legacy HTTP remains the current transport and authentication boundary for `/api/v1/` and
+`/app/node/`. The shared admin shell, admin toadlets, updater actions, and fallback pages remain in
+`:adapter-http-legacy-admin`; concrete browse/FProxy routes remain in
+`:adapter-http-legacy-browse`; concrete runtime HTTP bindings remain in `:bridge-http-runtime`.
+
+FCP remains a separate compatibility and automation protocol. The detached FCP protocol surface is
+owned by `:adapter-fcp`, and runtime bindings are owned by `:bridge-fcp-runtime`. The Platform API
+does not own FCP routing or compatibility behavior.
+
+The maintained boundary docs are [fcp-boundary.md](fcp-boundary.md) and
+[legacy-http-boundary.md](legacy-http-boundary.md).

--- a/tools/interop/README.md
+++ b/tools/interop/README.md
@@ -3,6 +3,11 @@
 Use this gate to verify that a packaged Cryptad node can interoperate with a pinned Hyphanet
 baseline over darknet peering and FCP content operations.
 
+PR-194 records this existing harness as a Phase 3 release gate. The closeout summary is in
+[docs/phase-3-platform-primacy-closeout.md](../../docs/phase-3-platform-primacy-closeout.md), and
+the release checklist is in
+[docs/cryptad-release-workflow-and-runbook.md](../../docs/cryptad-release-workflow-and-runbook.md).
+
 ## Scope
 
 The gate is Linux-only and runs two local nodes:


### PR DESCRIPTION
## Summary
- Add the Phase 3 Platform Primacy closeout doc for PR-194, including the PR-184 through PR-194 map, current module ownership, release gates, and Phase 4 candidates.
- Add a family-level Platform API/Web Shell surface doc covering the current `/api/v1/` and `/app/node/` relationships to legacy HTTP and FCP.
- Update README, release runbook, app distribution docs, and interop docs so signed first-party app verification and the existing Hyphanet interop gate are discoverable release-readiness checks.

This PR corrects the earlier assumption that interop tooling was missing: `tools/interop/` is present and documented here as part of the closeout and release gates. Phase 4 remains future work and is intentionally not implemented here.

## Validation
- `./gradlew spotlessApply`
- `git diff --check --staged`
- touched-doc local Markdown link check
- `./gradlew help`
- `python3 tools/interop/interop_smoke.py --self-test`
- `./gradlew :platform-api:test :platform-web-shell:test :platform-apphost:test :platform-appdist:test`

The full Hyphanet interop smoke was not run locally; it remains documented as `tools/interop/run-hyphanet-interop-smoke.sh` for prepared local environments and the CI `interop-smoke` job.