### PR TITLE
feat(appcatalog): Add remote signed app catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ Cryptad now uses a partial multi-project Gradle build.
   Web Shell, application-UI, and remote update-channel work.
 - `:platform-appdist` owns the local app distribution tooling used to digest, sign, and verify
   staged AppHost bundles.
+- `:platform-appcatalog` owns signed app catalog parsing, signature verification, remote/local
+  catalog fetching, artifact digest checks, safe ZIP extraction, and verified staging for AppHost
+  install/update flows.
 - `:platform-web-shell` owns the first browser-facing Web Shell v1 under
   `network.crypta.platform.webshell`. It keeps the node-management shell's route constants,
   bootstrap payload, HTML renderer, and plain browser assets self-owned while staying separate
@@ -343,6 +346,10 @@ Common commands:
 ```
 
 Signed staged bundles add `cryptad-app.digests` and `cryptad-app.signature` at the bundle root. The digest uses deterministic SHA-256 file entries, and the signature uses Ed25519 over the exact digest sidecar bytes.
+
+Signed app catalogs add a verified source layer above signed bundles. See
+[`docs/app-catalogs.md`](docs/app-catalogs.md) for the `cryptad-app-catalog.properties` format,
+catalog signatures, trusted-key configuration, and `/api/v1/app-catalogs` install/update flow.
 
 Production-facing installs reject unsigned bundles by default. To install signed bundles through a
 live node, configure a trusted public key with `CRYPTAD_APPHOST_TRUSTED_KEY_ID` plus
@@ -814,8 +821,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
 - Local app lifecycle work is separate from CoreUpdater. The current platform can install, start,
   stop, uninstall, and replace an installed app bundle from a caller-supplied local staged
   directory through `:platform-apphost` and the Platform API v1. Signed local staged bundles are
-  now supported; remote catalogs, remote downloads, and background app-update fetching remain
-  future work.
+  supported. Signed local and HTTPS catalog sources can now install or update apps through the
+  same AppHost staged-directory semantics; background app-update fetching remains future work.
 
 ## Architecture Overview
 
@@ -972,7 +979,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `:platform-api` provides the transport-neutral Platform API v1 plus the minimal AppHost
   control-plane routes; `:platform-apphost` provides the transport-neutral out-of-process AppHost
   v1 core for installed local apps; `:platform-appdist` provides the local app bundle digest,
-  signing, and verification tooling;
+  signing, and verification tooling; `:platform-appcatalog` provides signed catalog source,
+  artifact verification, and safe ZIP staging support;
   `:platform-web-shell` provides the browser-facing Web Shell v1 node-management assets and
   bootstrap contract; `:runtime-node`
   provides the extracted daemon runtime body across the remaining cyclic/high-level

--- a/adapter-http-legacy-admin/build.gradle.kts
+++ b/adapter-http-legacy-admin/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   implementation(project(":kernel-routing"))
   implementation(project(":runtime-spi"))
   implementation(project(":platform-api"))
+  implementation(project(":platform-appcatalog"))
   implementation(project(":platform-apphost"))
   implementation(project(":platform-web-shell"))
   implementation(project(":runtime-alerts"))

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -306,7 +306,8 @@ final class FProxyRegistrar {
             ignored -> WebShellPaths.SHELL_ROOT.equals(server.primaryUiRoot())));
 
     PlatformApiToadlet platformApiToadlet =
-        new PlatformApiToadlet(runtimePorts, dependencies.appHost());
+        new PlatformApiToadlet(
+            runtimePorts, dependencies.appHost(), dependencies.appCatalogManager());
     server.register(
         platformApiToadlet,
         ToadletRegistration.basic(null, PlatformApiToadlet.MOUNT_PATH, true, true));

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrarDependencies.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.util.Objects;
 import network.crypta.config.Config;
+import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
@@ -21,6 +22,7 @@ import network.crypta.runtime.spi.RuntimePorts;
  *
  * @param runtimePorts detached runtime ports exposed to the HTTP shell
  * @param appHost shared AppHost instance exposed through the Platform API bridge
+ * @param appCatalogManager optional signed app-catalog manager exposed through the Platform API
  * @param config node configuration used to list sub-config toadlets
  * @param browseRoot prebuilt root browse toadlet handed to the registrar for root-path registration
  * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route publication
@@ -30,10 +32,40 @@ import network.crypta.runtime.spi.RuntimePorts;
 record FProxyRegistrarDependencies(
     RuntimePorts runtimePorts,
     AppHost appHost,
+    AppCatalogManager appCatalogManager,
     Config config,
     Toadlet browseRoot,
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
     InsertCompatibilityModes insertCompatibilityModes) {
+  /**
+   * Creates a dependency bundle for embeddings without signed app-catalog support.
+   *
+   * @param runtimePorts runtime-spi ports exposed to HTTP-layer toadlets and helper pages
+   * @param appHost shared AppHost instance exposed through the Platform API bridge
+   * @param config node configuration used to list and filter sub-config toadlets
+   * @param browseRoot prebuilt root browse toadlet that is registered at the HTTP root path
+   * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route
+   *     publication
+   * @param insertCompatibilityModes detached compatibility-mode choices used by queue and insert
+   *     forms
+   */
+  FProxyRegistrarDependencies(
+      RuntimePorts runtimePorts,
+      AppHost appHost,
+      Config config,
+      Toadlet browseRoot,
+      LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
+      InsertCompatibilityModes insertCompatibilityModes) {
+    this(
+        runtimePorts,
+        appHost,
+        null,
+        config,
+        browseRoot,
+        browseRouteRegistrar,
+        insertCompatibilityModes);
+  }
+
   /**
    * Creates a validated dependency bundle for {@link FProxyRegistrar}.
    *
@@ -43,6 +75,7 @@ record FProxyRegistrarDependencies(
    *
    * @param runtimePorts runtime-spi ports exposed to HTTP-layer toadlets and helper pages
    * @param appHost shared AppHost instance exposed through the Platform API bridge
+   * @param appCatalogManager optional signed app-catalog manager exposed through the Platform API
    * @param config node configuration used to list and filter sub-config toadlets
    * @param browseRoot prebuilt root browse toadlet that is registered at the HTTP root path
    * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/HttpShellRuntimeSupport.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.io.File;
 import network.crypta.config.Config;
+import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.spi.RuntimePorts;
@@ -16,7 +17,7 @@ import network.crypta.support.Ticker;
  * starts from the legacy node core. Implementations may expose old HTTP-local concepts such as
  * alerts, ticker access, and legacy bootstrap work, but the seam is not a new cross-module platform
  * abstraction. Its purpose is to keep shell behavior explicit, locally testable, and detached from
- * direct {@link network.crypta.node.NodeClientCore} field access inside the server itself.
+ * direct legacy node-core field access inside the server itself.
  */
 public interface HttpShellRuntimeSupport {
 
@@ -50,6 +51,17 @@ public interface HttpShellRuntimeSupport {
    * @return shared AppHost instance used by Platform API app-management routes
    */
   AppHost appHost();
+
+  /**
+   * Returns the long-lived signed app-catalog manager used by the platform control plane.
+   *
+   * <p>A {@code null} value means the current embedding exposes AppHost lifecycle routes but has
+   * not configured catalog source management. The Platform API router treats that state as the
+   * catalog endpoint family being unavailable rather than constructing a per-request manager.
+   *
+   * @return shared app-catalog manager, or {@code null} when catalog support is unavailable
+   */
+  AppCatalogManager appCatalogManager();
 
   /**
    * Creates the legacy push-data manager used by the shell's interval push flow.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminHttpRouteRegistrar.java
@@ -44,6 +44,7 @@ public final class LegacyAdminHttpRouteRegistrar implements LegacyHttpRouteRegis
         new FProxyRegistrarDependencies(
             context.runtimePorts(),
             context.appHost(),
+            context.appCatalogManager(),
             context.config(),
             context.browseRoot(),
             context.browseRouteRegistrar(),

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyHttpRouteRegistrarContext.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.util.Objects;
 import network.crypta.config.Config;
+import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
@@ -22,6 +23,7 @@ import network.crypta.runtime.spi.RuntimePorts;
  *
  * @param runtimePorts detached runtime-spi ports surfaced to HTTP routes and helper pages
  * @param appHost shared AppHost bridge that exposes the current Platform API runtime surface
+ * @param appCatalogManager optional signed app-catalog manager for catalog Platform API routes
  * @param config node configuration view used when listing or filtering sub-config toadlets
  * @param browseRoot prebuilt root browse toadlet that anchors the registration pass at the legacy
  *     browsing root
@@ -33,10 +35,40 @@ import network.crypta.runtime.spi.RuntimePorts;
 public record LegacyHttpRouteRegistrarContext(
     RuntimePorts runtimePorts,
     AppHost appHost,
+    AppCatalogManager appCatalogManager,
     Config config,
     Toadlet browseRoot,
     LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
     InsertCompatibilityModes insertCompatibilityModes) {
+
+  /**
+   * Creates a context for embeddings that have not configured signed app catalogs.
+   *
+   * @param runtimePorts detached runtime-spi ports exposed to the HTTP registrar
+   * @param appHost shared AppHost bridge made visible through HTTP-owned routes
+   * @param config node configuration view that registration may inspect for sub-config pages
+   * @param browseRoot prebuilt root browse toadlet registered at the browsing root
+   * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route
+   *     publication
+   * @param insertCompatibilityModes detached compatibility-mode choices used by queue and insert
+   *     forms
+   */
+  public LegacyHttpRouteRegistrarContext(
+      RuntimePorts runtimePorts,
+      AppHost appHost,
+      Config config,
+      Toadlet browseRoot,
+      LegacyHttpBrowseRouteRegistrar browseRouteRegistrar,
+      InsertCompatibilityModes insertCompatibilityModes) {
+    this(
+        runtimePorts,
+        appHost,
+        null,
+        config,
+        browseRoot,
+        browseRouteRegistrar,
+        insertCompatibilityModes);
+  }
 
   /**
    * Creates a validated route-registration context.
@@ -48,6 +80,7 @@ public record LegacyHttpRouteRegistrarContext(
    *
    * @param runtimePorts detached runtime-spi ports exposed to the HTTP registrar
    * @param appHost shared AppHost bridge made visible through HTTP-owned routes
+   * @param appCatalogManager optional signed app-catalog manager for catalog Platform API routes
    * @param config node configuration view that registration may inspect for sub-config pages
    * @param browseRoot prebuilt root browse toadlet registered at the browsing root
    * @param browseRouteRegistrar browse-neutral registrar seam used for browse-owned route

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -13,6 +13,7 @@ import network.crypta.platform.api.PlatformApiPaths;
 import network.crypta.platform.api.PlatformApiRequest;
 import network.crypta.platform.api.PlatformApiResponse;
 import network.crypta.platform.api.PlatformApiRouter;
+import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.MultiValueTable;
@@ -51,6 +52,7 @@ public final class PlatformApiToadlet extends Toadlet {
 
   private static final String DELETE_METHOD = "DELETE";
   private static final String ALERTS_SEGMENT = "alerts";
+  private static final String APP_CATALOGS_SEGMENT = "app-catalogs";
   private static final String FORM_PASSWORD_PARAMETER = "formPassword";
   private static final int MAX_PLATFORM_API_FORM_FIELD_LENGTH = QueueToadlet.MAX_KEY_LENGTH;
   private static final String CONFIG_SEGMENT = "config";
@@ -82,6 +84,18 @@ public final class PlatformApiToadlet extends Toadlet {
    */
   public PlatformApiToadlet(RuntimePorts runtimePorts, AppHost appHost) {
     this(new PlatformApiRouter(runtimePorts, appHost));
+  }
+
+  /**
+   * Creates a platform API toadlet backed by runtime ports, AppHost, and signed catalogs.
+   *
+   * @param runtimePorts detached runtime ports exposed to the platform API leaf
+   * @param appHost detached AppHost exposed through app lifecycle and catalog install routes
+   * @param appCatalogManager signed app-catalog manager exposed through catalog routes
+   */
+  public PlatformApiToadlet(
+      RuntimePorts runtimePorts, AppHost appHost, AppCatalogManager appCatalogManager) {
+    this(new PlatformApiRouter(runtimePorts, appHost, appCatalogManager));
   }
 
   /**
@@ -376,11 +390,40 @@ public final class PlatformApiToadlet extends Toadlet {
   private static boolean requiresNonAppFormPassword(String method, List<String> pathSegments) {
     return requiresQueueFormPassword(method, pathSegments)
         || requiresPeersFormPassword(method, pathSegments)
+        || requiresAppCatalogsFormPassword(method, pathSegments)
         || requiresConfigFormPassword(method, pathSegments)
         || requiresSecurityLevelsFormPassword(method, pathSegments)
         || requiresUpdatesFormPassword(method, pathSegments)
         || requiresAlertsFormPassword(method, pathSegments)
         || requiresWizardFormPassword(method, pathSegments);
+  }
+
+  /**
+   * Returns whether the current request targets a mutating signed app-catalog route.
+   *
+   * @param method HTTP method name forwarded into the router
+   * @param pathSegments decoded path segments beneath the Platform API mount point
+   * @return {@code true} when the request must present the legacy form password
+   */
+  private static boolean requiresAppCatalogsFormPassword(String method, List<String> pathSegments) {
+    if (pathSegments.isEmpty() || !APP_CATALOGS_SEGMENT.equals(pathSegments.getFirst())) {
+      return false;
+    }
+    if (DELETE_METHOD.equals(method)) {
+      return pathSegments.size() == 2;
+    }
+    if (!"POST".equals(method)) {
+      return false;
+    }
+    if (pathSegments.size() == 2) {
+      return "add".equals(pathSegments.get(1));
+    }
+    if (pathSegments.size() == 3) {
+      return "refresh".equals(pathSegments.get(2));
+    }
+    return pathSegments.size() == 5
+        && "apps".equals(pathSegments.get(2))
+        && ("install".equals(pathSegments.get(4)) || "update".equals(pathSegments.get(4)));
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -488,6 +488,7 @@ public final class SimpleToadletServer
         new LegacyHttpRouteRegistrarContext(
             runtimePorts,
             runtimeSupportRef.appHost(),
+            runtimeSupportRef.appCatalogManager(),
             runtimeSupportRef.config(),
             bootstrap.browseRoot(),
             bootstrap.browseRouteRegistrar(),

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.l10n.NodeL10n;
+import network.crypta.platform.api.PlatformApiPaths;
 import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.core.SSL;
 import network.crypta.support.HTMLEncoder;
@@ -88,7 +89,6 @@ public final class ToadletContextImpl implements ToadletContext {
    */
   private static final String METHODS_MUST_HAVE_DATA = "POST";
   private static final String METHODS_CANNOT_HAVE_DATA = "GET";
-  private static final String METHODS_RESTRICTED_MODE = "GET POST";
 
   private final MultiValueTable<String, String> headers;
   private ArrayList<ReceivedCookie>
@@ -911,7 +911,7 @@ public final class ToadletContextImpl implements ToadletContext {
     Bucket data = dataResult.data;
     try {
       if (!container.enableExtendedMethodHandling()
-          && !METHODS_RESTRICTED_MODE.contains(requestLine.method)) {
+          && !isMethodAllowedInRestrictedMode(requestLine.method, requestLine.uri)) {
         sendError(
             sock.getOutputStream(),
             403,
@@ -931,6 +931,20 @@ public final class ToadletContextImpl implements ToadletContext {
     } finally {
       if (data != null) data.free();
     }
+  }
+
+  static boolean isMethodAllowedInRestrictedMode(String method, URI uri) {
+    return switch (method) {
+      case "GET", "POST" -> true;
+      case "DELETE" -> isPlatformApiPath(uri);
+      default -> false;
+    };
+  }
+
+  private static boolean isPlatformApiPath(URI uri) {
+    return uri != null
+        && uri.getPath() != null
+        && uri.getPath().startsWith(PlatformApiPaths.API_V1_PREFIX);
   }
 
   private static RequestLine parseRequestLine(String firstLine, Socket sock)

--- a/bridge-http-runtime/build.gradle.kts
+++ b/bridge-http-runtime/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation(project(":foundation-crypto-keys"))
   implementation(project(":kernel-content"))
   implementation(project(":kernel-routing"))
+  implementation(project(":platform-appcatalog"))
   implementation(project(":platform-appdist"))
   implementation(project(":runtime-alerts"))
   implementation(project(":runtime-spi"))

--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -27,6 +27,8 @@ import network.crypta.node.RequestPriorityClasses;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.platform.appcatalog.AppCatalogManager;
+import network.crypta.platform.appcatalog.AppCatalogSourceStore;
 import network.crypta.platform.appdist.AppBundleVerifier;
 import network.crypta.platform.appdist.AppDistributionException;
 import network.crypta.platform.appdist.TrustedAppKey;
@@ -55,8 +57,10 @@ import org.slf4j.LoggerFactory;
  *
  * @param core daemon core that backs delegated shell services and browse bootstrap wiring
  * @param appHost shared AppHost instance used by the platform control plane
+ * @param appCatalogManager shared signed app-catalog manager used by the platform control plane
  */
-public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
+public record CoreHttpShellRuntimeSupport(
+    NodeClientCore core, AppHost appHost, AppCatalogManager appCatalogManager)
     implements network.crypta.runtime.http.HttpShellRuntimeSupport, HttpShellRuntimeSupport {
   private static final Logger LOG = LoggerFactory.getLogger(CoreHttpShellRuntimeSupport.class);
   private static final String APPHOST_ALLOW_UNSIGNED_PROPERTY = "cryptad.apphost.allowUnsigned";
@@ -86,7 +90,11 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
    * @throws NullPointerException if {@code core} is {@code null}
    */
   public CoreHttpShellRuntimeSupport(NodeClientCore core) {
-    this(core, createManagedAppHost(Objects.requireNonNull(core, "core")));
+    this(Objects.requireNonNull(core, "core"), createManagedAppServices(core));
+  }
+
+  private CoreHttpShellRuntimeSupport(NodeClientCore core, AppPlatformServices services) {
+    this(core, services.appHost(), services.appCatalogManager());
   }
 
   /**
@@ -97,8 +105,22 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
    * @throws NullPointerException if {@code core} or {@code appHost} is {@code null}
    */
   public CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost) {
+    this(core, appHost, null);
+  }
+
+  /**
+   * Creates a core-backed HTTP runtime adapter with explicit app platform services.
+   *
+   * @param core daemon core that supplies the shell-level runtime services
+   * @param appHost shared AppHost instance used by the platform control plane
+   * @param appCatalogManager shared app-catalog manager, or {@code null} when unavailable
+   * @throws NullPointerException if {@code core} or {@code appHost} is {@code null}
+   */
+  public CoreHttpShellRuntimeSupport(
+      NodeClientCore core, AppHost appHost, AppCatalogManager appCatalogManager) {
     this.core = Objects.requireNonNull(core, "core");
     this.appHost = Objects.requireNonNull(appHost, "appHost");
+    this.appCatalogManager = appCatalogManager;
   }
 
   @Override
@@ -244,10 +266,10 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
    * @param core daemon core that exposes the current node and temp-directory layout
    * @return managed AppHost instance rooted in the current node layout
    */
-  private static AppHost createManagedAppHost(NodeClientCore core) {
-    AppHost appHost = createAppHost(core);
-    SemiOrderedShutdownHook.get().addEarlyJob(createAppHostShutdownJob(appHost));
-    return appHost;
+  private static AppPlatformServices createManagedAppServices(NodeClientCore core) {
+    AppPlatformServices services = createAppPlatformServices(core);
+    SemiOrderedShutdownHook.get().addEarlyJob(createAppHostShutdownJob(services.appHost()));
+    return services;
   }
 
   /**
@@ -260,17 +282,24 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
    * @param core daemon core that exposes the current node and temp-directory layout
    * @return long-lived AppHost instance rooted in the current node layout
    */
-  private static AppHost createAppHost(NodeClientCore core) {
-    return new LocalProcessAppHost(
+  private static AppPlatformServices createAppPlatformServices(NodeClientCore core) {
+    AppHostLayout layout =
         new AppHostLayout(
             core.getNode().nodeDir().dir().toPath(),
             core.getPersistentTempDir().toPath(),
-            core.getNode().runDir().dir().toPath()),
-        createInstallVerificationPolicy());
+            core.getNode().runDir().dir().toPath());
+    AppHostTrustConfiguration trustConfiguration = readTrustConfiguration();
+    AppHost appHost =
+        new LocalProcessAppHost(layout, createInstallVerificationPolicy(trustConfiguration));
+    AppCatalogManager appCatalogManager =
+        new AppCatalogManager(
+            new AppCatalogSourceStore(layout.dataDir().resolve("apps").resolve("catalogs")),
+            () -> loadTrustedAppKeys(trustConfiguration));
+    return new AppPlatformServices(appHost, appCatalogManager);
   }
 
-  private static AppInstallVerificationPolicy createInstallVerificationPolicy() {
-    AppHostTrustConfiguration trustConfiguration = readTrustConfiguration();
+  private static AppInstallVerificationPolicy createInstallVerificationPolicy(
+      AppHostTrustConfiguration trustConfiguration) {
     AppInstallVerificationPolicy.CopiedBundleVerifier verifier =
         copiedBundleDirectory ->
             verifyBundleAgainstConfiguredTrust(copiedBundleDirectory, trustConfiguration);
@@ -401,6 +430,8 @@ public record CoreHttpShellRuntimeSupport(NodeClientCore core, AppHost appHost)
       String keyId,
       String publicKeyBase64,
       String publicKeyFile) {}
+
+  private record AppPlatformServices(AppHost appHost, AppCatalogManager appCatalogManager) {}
 
   /**
    * Creates the shutdown job that stops any AppHost-managed child processes on node exit.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ version = "3"
 val internalLeafProjects =
   listOf(
     project(":platform-appdist"),
+    project(":platform-appcatalog"),
     project(":foundation-support"),
     project(":foundation-store"),
     project(":foundation-store-contracts"),
@@ -100,6 +101,7 @@ dependencies {
   implementation(project(":kernel-routing"))
   implementation(project(":runtime-spi"))
   implementation(project(":platform-api"))
+  implementation(project(":platform-appcatalog"))
   implementation(project(":platform-apphost"))
   implementation(project(":platform-web-shell"))
   implementation(project(":runtime-alerts"))
@@ -148,6 +150,7 @@ dependencies {
   // testImplementation
   testImplementation(project(":launcher-desktop"))
   testImplementation(project(":platform-appdist"))
+  testImplementation(project(":platform-appcatalog"))
   testImplementation(libs.junitJupiterApi)
   testImplementation(libs.junitJupiterParams)
   testImplementation(libs.junitPlatformSuite)

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -1,0 +1,114 @@
+# Signed app catalogs
+
+This document describes Cryptad's signed app catalog format and the local install/update flow.
+
+## Scope
+
+Signed app catalogs are a Phase 4 app-platform control plane. They do not change peer protocols,
+wire formats, application sandboxing, or AppHost process launching. A catalog only tells the local
+node where to fetch a signed app bundle ZIP and which digest, size, app id, and version to expect.
+
+The runtime verifies data in this order:
+
+1. `cryptad-app-catalog.signature` over the exact bytes of `cryptad-app-catalog.properties`.
+2. The catalog entry's ZIP artifact size and lowercase SHA-256 digest.
+3. The extracted bundle's existing `cryptad-app.digests` and `cryptad-app.signature` through
+   `AppBundleVerifier`.
+4. The extracted manifest `app.id` and `app.version` against the catalog entry.
+
+## Catalog files
+
+A catalog source points at `cryptad-app-catalog.properties`. The matching signature is read from
+the sibling file `cryptad-app-catalog.signature`.
+
+Catalog properties use a deterministic `key=value` text sidecar:
+
+```properties
+catalog.version=1
+catalog.id=core
+catalog.name=Crypta Core Apps
+catalog.generatedAt=2026-04-21T18:22:40Z
+catalog.entries=queue-manager,publisher
+
+app.queue-manager.id=queue-manager
+app.queue-manager.name=Queue Manager
+app.queue-manager.version=1.0.0
+app.queue-manager.summary=Manage local Crypta transfer queues.
+app.queue-manager.bundle.uri=https://example.invalid/apps/queue-manager-1.0.0.zip
+app.queue-manager.bundle.sha256=<lowercase-hex-sha256-of-zip>
+app.queue-manager.bundle.size.bytes=12345
+app.queue-manager.bundle.type=zip
+app.queue-manager.permissions=queue.read,queue.write
+```
+
+The parser rejects duplicate keys, missing required fields, unsupported versions, unsupported
+artifact types, invalid app ids, blank names or versions, invalid SHA-256 text, negative sizes,
+unsafe artifact URIs, duplicate entries, and unknown properties.
+
+## Catalog signatures
+
+Catalog signatures use Ed25519 and the same trusted-key registry shape as signed app bundles:
+
+```properties
+catalog.signature.version=1
+catalog.signature.algorithm=Ed25519
+catalog.signature.key.id=<trusted-key-id>
+catalog.signature.payload=cryptad-app-catalog.properties
+catalog.signature.value.base64=<base64-signature-over-exact-catalog-properties-bytes>
+```
+
+The signature payload is the exact catalog-properties byte stream. Do not rewrite, sort, or
+re-serialize the catalog after signing.
+
+## Trusted keys
+
+Catalog verification reuses the trusted app key configuration already used for signed bundles:
+
+| Setting | Environment variable |
+| --- | --- |
+| `cryptad.apphost.trustedKeysFile` | `CRYPTAD_APPHOST_TRUSTED_KEYS_FILE` |
+| `cryptad.apphost.trustedKeyId` | `CRYPTAD_APPHOST_TRUSTED_KEY_ID` |
+| `cryptad.apphost.trustedPublicKeyBase64` | `CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_BASE64` |
+| `cryptad.apphost.trustedPublicKeyFile` | `CRYPTAD_APPHOST_TRUSTED_PUBLIC_KEY_FILE` |
+
+Unsigned catalogs are rejected. The local unsigned-bundle development bypass does not make remote
+catalogs or catalog artifacts trusted.
+
+## Source and artifact fetching
+
+Supported catalog sources:
+
+- Absolute local paths or `file:` URIs to `cryptad-app-catalog.properties`.
+- `https:` URIs.
+- `http:` URIs only for loopback hosts such as `localhost` or `127.0.0.1`.
+
+Remote fetches use the JDK HTTP client with finite timeouts, no automatic redirects, and size caps
+for catalog, signature, and artifact downloads. Artifact bytes are written to catalog-owned scratch
+storage, checked against the catalog size and SHA-256, then extracted into a separate staging
+directory. The extractor rejects absolute ZIP paths, `..`, Windows drive prefixes, backslash path
+separators, duplicate normalized entries, and rootless bundles.
+
+## Platform API flow
+
+Operators can manage catalogs through Platform API v1:
+
+```text
+GET    /api/v1/app-catalogs
+POST   /api/v1/app-catalogs/add?source=<uri-or-path>
+DELETE /api/v1/app-catalogs/{catalogId}
+POST   /api/v1/app-catalogs/{catalogId}/refresh
+GET    /api/v1/app-catalogs/{catalogId}/apps
+GET    /api/v1/app-catalogs/{catalogId}/apps/{appId}
+POST   /api/v1/app-catalogs/{catalogId}/apps/{appId}/install
+POST   /api/v1/app-catalogs/{catalogId}/apps/{appId}/update
+```
+
+Install and update endpoints prepare a verified temporary staged bundle, then delegate to
+`AppHost.installFromDirectory(...)` or `AppHost.updateFromDirectory(...)`. Existing local
+`/api/v1/apps/install?stagedDir=...` and `/api/v1/apps/{appId}/update?stagedDir=...` flows are
+unchanged.
+
+## Future work
+
+This PR does not add app-owned `/apps/{appId}/` static UI proxying, permission enforcement,
+container or WASM sandboxing, public app-store governance, or background app update scheduling.

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -57,6 +57,7 @@ parameter; check the handler and tests when adding or changing a specific contra
 | Alerts | `GET /api/v1/alerts` lists current alerts. `POST /api/v1/alerts/{alertId}/dismiss` dismisses one alert by detached identifier. |
 | Diagnostics | `GET /api/v1/diagnostics` exposes the ordered diagnostic snapshot and plain-text export. |
 | Apps | `GET /api/v1/apps` lists installed apps when `AppHost` is wired into the router. The family also covers local staged-bundle install, app lookup, start, stop, update, and uninstall. |
+| App catalogs | `GET /api/v1/app-catalogs` lists configured signed catalogs when catalog support is wired into the router. The family also covers source add/remove, refresh, catalog app listing/detail, and install/update from a verified catalog artifact. |
 
 ## Web Shell relationship
 
@@ -68,7 +69,7 @@ The shell currently includes these first-party panels and surfaces:
 
 - Overview and connectivity snapshots.
 - Alert queue and diagnostics.
-- Installed apps.
+- Installed apps and signed catalog app discovery.
 - Security levels, updater state, config controls, and first-time wizard controls.
 - Peer control plane.
 - Publisher local file/directory insert workflow.

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
   api(project(":runtime-spi"))
   api(project(":platform-apphost"))
+  api(project(":platform-appcatalog"))
 
   compileOnly(libs.jetbrainsAnnotations)
 

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import network.crypta.platform.api.alerts.AlertsApiHandler;
+import network.crypta.platform.api.appcatalogs.AppCatalogsApiHandler;
 import network.crypta.platform.api.apps.AppsApiHandler;
 import network.crypta.platform.api.config.ConfigApiHandler;
 import network.crypta.platform.api.connectivity.ConnectivityApiHandler;
@@ -14,6 +15,7 @@ import network.crypta.platform.api.queue.QueueApiHandler;
 import network.crypta.platform.api.security.SecurityLevelsApiHandler;
 import network.crypta.platform.api.updates.UpdatesApiHandler;
 import network.crypta.platform.api.wizard.FirstTimeWizardApiHandler;
+import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.runtime.spi.RuntimePorts;
 
@@ -34,6 +36,12 @@ public final class PlatformApiRouter {
 
   /** Shared 405 message for routes that only support POST. */
   private static final String POST_ONLY_MESSAGE = "Platform API v1 supports POST requests only.";
+
+  /** HTTP-style method name for DELETE routes. */
+  private static final String METHOD_DELETE = "DELETE";
+
+  /** Envelope key for one catalog summary. */
+  private static final String CATALOG_ENVELOPE_KEY = "catalog";
 
   /** Handler for the {@code /node/...} endpoint family. */
   private final NodeApiHandler nodeApiHandler;
@@ -69,13 +77,18 @@ public final class PlatformApiRouter {
   private final AppsApiHandler appsApiHandler;
 
   /**
+   * Handler for the {@code /app-catalogs/...} endpoint family, when catalog support is available.
+   */
+  private final AppCatalogsApiHandler appCatalogsApiHandler;
+
+  /**
    * Creates a router backed by the supplied runtime ports.
    *
    * @param runtimePorts detached runtime-port aggregate used to resolve API requests
    * @throws NullPointerException if {@code runtimePorts} is {@code null}
    */
   public PlatformApiRouter(RuntimePorts runtimePorts) {
-    this(runtimePorts, null);
+    this(runtimePorts, null, null);
   }
 
   /**
@@ -86,6 +99,19 @@ public final class PlatformApiRouter {
    * @throws NullPointerException if {@code runtimePorts} is {@code null}
    */
   public PlatformApiRouter(RuntimePorts runtimePorts, AppHost appHost) {
+    this(runtimePorts, appHost, null);
+  }
+
+  /**
+   * Creates a router backed by runtime ports, AppHost, and signed app catalogs.
+   *
+   * @param runtimePorts detached runtime-port aggregate used to resolve API requests
+   * @param appHost detached AppHost used by app lifecycle and catalog install/update routes
+   * @param appCatalogManager signed catalog manager used by the catalog endpoint family
+   * @throws NullPointerException if {@code runtimePorts} is {@code null}
+   */
+  public PlatformApiRouter(
+      RuntimePorts runtimePorts, AppHost appHost, AppCatalogManager appCatalogManager) {
     Objects.requireNonNull(runtimePorts, "runtimePorts");
     nodeApiHandler = new NodeApiHandler(runtimePorts.nodeInfo());
     peersApiHandler = new PeersApiHandler(runtimePorts.peer(), runtimePorts.darknetConnections());
@@ -107,6 +133,10 @@ public final class PlatformApiRouter {
     alertsApiHandler = new AlertsApiHandler(runtimePorts.alertFeed(), runtimePorts.alertMutation());
     diagnosticsApiHandler = new DiagnosticsApiHandler(runtimePorts.diagnostic());
     appsApiHandler = appHost == null ? null : new AppsApiHandler(appHost);
+    appCatalogsApiHandler =
+        appHost == null || appCatalogManager == null
+            ? null
+            : new AppCatalogsApiHandler(appCatalogManager, appHost);
   }
 
   /**
@@ -143,6 +173,9 @@ public final class PlatformApiRouter {
     }
 
     String firstSegment = segments.getFirst();
+    if ("app-catalogs".equals(firstSegment)) {
+      return routeAppCatalogsRequest(segments, request);
+    }
     if ("apps".equals(firstSegment)) {
       return routeAppsRequest(segments, request);
     }
@@ -168,11 +201,14 @@ public final class PlatformApiRouter {
       return routeAlertsRequest(segments, request);
     }
 
-    if (!"GET".equals(request.method())) {
-      return PlatformApiResponse.error(
-          405, Map.of("Allow", "GET"), "method_not_allowed", GET_ONLY_MESSAGE);
-    }
+    return routeGetOnlyRequest(segments, request, firstSegment);
+  }
 
+  private PlatformApiResponse routeGetOnlyRequest(
+      List<String> segments, PlatformApiRequest request, String firstSegment) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
     if ("node".equals(firstSegment)) {
       return routeNodeRequest(segments, request);
     }
@@ -182,7 +218,6 @@ public final class PlatformApiRouter {
     if ("diagnostics".equals(firstSegment) && segments.size() == 1) {
       return PlatformApiResponse.ok(diagnosticsApiHandler.snapshot());
     }
-
     throw new PlatformApiException(404, "not_found", "Platform API route not found.");
   }
 
@@ -433,7 +468,7 @@ public final class PlatformApiRouter {
     if ("GET".equals(method)) {
       return PlatformApiResponse.ok(envelope("app", appsApiHandler.get(appId)));
     }
-    if ("DELETE".equals(method)) {
+    if (METHOD_DELETE.equals(method)) {
       return PlatformApiResponse.ok(envelope("app", appsApiHandler.uninstall(appId)));
     }
     return methodNotAllowed(
@@ -452,7 +487,7 @@ public final class PlatformApiRouter {
    * @return {@code true} when the request should be treated as {@code /apps/{appId}}
    */
   private static boolean targetsInstalledAppResource(String method) {
-    return "GET".equals(method) || "DELETE".equals(method);
+    return "GET".equals(method) || METHOD_DELETE.equals(method);
   }
 
   /**
@@ -475,6 +510,104 @@ public final class PlatformApiRouter {
       case "update" ->
           PlatformApiResponse.ok(
               envelope("app", appsApiHandler.update(appId, request.queryParameters())));
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  /**
+   * Routes requests beneath the {@code /app-catalogs} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata, including query parameters
+   * @return JSON response for the selected catalog endpoint
+   */
+  private PlatformApiResponse routeAppCatalogsRequest(
+      List<String> segments, PlatformApiRequest request) {
+    if (appCatalogsApiHandler == null) {
+      throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    }
+    return switch (segments.size()) {
+      case 1 -> routeAppCatalogsCollection(request);
+      case 2 -> routeAppCatalogsResource(segments.get(1), request);
+      case 3 -> routeAppCatalogsActionOrApps(segments.get(1), segments.get(2), request);
+      case 4 -> routeAppCatalogApp(segments.get(1), segments.get(2), segments.get(3), request);
+      case 5 ->
+          routeAppCatalogAppAction(
+              segments.get(1), segments.get(2), segments.get(3), segments.get(4), request);
+      default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    };
+  }
+
+  private PlatformApiResponse routeAppCatalogsCollection(PlatformApiRequest request) {
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(envelope("catalogs", appCatalogsApiHandler.listCatalogs()));
+  }
+
+  private PlatformApiResponse routeAppCatalogsResource(
+      String resource, PlatformApiRequest request) {
+    if (METHOD_DELETE.equals(request.method())) {
+      return PlatformApiResponse.ok(
+          envelope(CATALOG_ENVELOPE_KEY, appCatalogsApiHandler.remove(resource)));
+    }
+    if ("add".equals(resource)) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.created(
+          envelope(CATALOG_ENVELOPE_KEY, appCatalogsApiHandler.add(request.queryParameters())));
+    }
+    return methodNotAllowed(METHOD_DELETE, "Platform API v1 supports DELETE requests only.");
+  }
+
+  private PlatformApiResponse routeAppCatalogsActionOrApps(
+      String catalogId, String action, PlatformApiRequest request) {
+    if ("refresh".equals(action)) {
+      if (!"POST".equals(request.method())) {
+        return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(
+          envelope(CATALOG_ENVELOPE_KEY, appCatalogsApiHandler.refresh(catalogId)));
+    }
+    if ("apps".equals(action)) {
+      if (!"GET".equals(request.method())) {
+        return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(envelope("apps", appCatalogsApiHandler.listApps(catalogId)));
+    }
+    throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+
+  private PlatformApiResponse routeAppCatalogApp(
+      String catalogId, String appsSegment, String appId, PlatformApiRequest request) {
+    if (!"apps".equals(appsSegment)) {
+      throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    }
+    if (!"GET".equals(request.method())) {
+      return methodNotAllowed("GET", GET_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(envelope("app", appCatalogsApiHandler.getApp(catalogId, appId)));
+  }
+
+  private PlatformApiResponse routeAppCatalogAppAction(
+      String catalogId,
+      String appsSegment,
+      String appId,
+      String action,
+      PlatformApiRequest request) {
+    if (!"apps".equals(appsSegment)) {
+      throw new PlatformApiException(404, "not_found", "Platform API route not found.");
+    }
+    if (!"POST".equals(request.method())) {
+      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
+    }
+    return switch (action) {
+      case "install" ->
+          PlatformApiResponse.created(
+              envelope("app", appCatalogsApiHandler.install(catalogId, appId)));
+      case "update" ->
+          PlatformApiResponse.ok(envelope("app", appCatalogsApiHandler.update(catalogId, appId)));
       default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
     };
   }

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
@@ -1,0 +1,420 @@
+package network.crypta.platform.api.appcatalogs;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.appcatalog.AppCatalogEntry;
+import network.crypta.platform.appcatalog.AppCatalogException;
+import network.crypta.platform.appcatalog.AppCatalogInstallPlan;
+import network.crypta.platform.appcatalog.AppCatalogManager;
+import network.crypta.platform.appcatalog.AppCatalogSourceSnapshot;
+import network.crypta.platform.apphost.AppBundleVerificationException;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.RunningAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
+
+/**
+ * Signed app-catalog endpoint family for Platform API v1.
+ *
+ * <p>The handler exposes catalog source management, catalog app listing, and install/update actions
+ * while preserving the existing local staged-directory app routes. Catalog install and update first
+ * obtain a verified temporary stage from {@link AppCatalogManager}, then call the same AppHost
+ * methods used by the local app API. That keeps bundle verification and mutable directory semantics
+ * centralized in AppHost.
+ *
+ * <p>Instances are transport-neutral. The router supplies decoded path and query values, and this
+ * class returns JSON-compatible maps and lists that the shared Platform API JSON writer can encode.
+ * Catalog failures stay expressed with stable machine-readable catalog codes, while AppHost
+ * failures are translated to the same app lifecycle contracts used by local install and update
+ * endpoints. The handler does not keep mutable request state; the shared {@link AppCatalogManager}
+ * and {@link AppHost} own persistence, staging, and lifecycle decisions.
+ */
+public final class AppCatalogsApiHandler {
+  private static final System.Logger LOG = System.getLogger(AppCatalogsApiHandler.class.getName());
+
+  private static final String APP_ALREADY_INSTALLED_PREFIX = "app already installed: ";
+  private static final String APP_NOT_INSTALLED_PREFIX = "app is not installed: ";
+  private static final String CANNOT_UPDATE_RUNNING_APP_PREFIX = "cannot update a running app: ";
+  private static final String INSTALL_FAILED_MESSAGE = "Failed to install catalog app.";
+  private static final String UPDATE_FAILED_MESSAGE = "Failed to update catalog app.";
+
+  private final AppCatalogManager catalogManager;
+  private final AppHost appHost;
+
+  /**
+   * Creates a handler backed by a catalog manager and shared AppHost.
+   *
+   * <p>The supplied catalog manager is expected to use the same trusted-key policy as the AppHost
+   * verification policy for PR-195. The handler performs no global lookup and does not cache
+   * trusted keys itself, which lets runtime composition reload key material between requests when
+   * configured to do so.
+   *
+   * @param catalogManager signed catalog manager owned by runtime composition
+   * @param appHost shared AppHost used for final install and update operations
+   */
+  public AppCatalogsApiHandler(AppCatalogManager catalogManager, AppHost appHost) {
+    this.catalogManager = Objects.requireNonNull(catalogManager, "catalogManager");
+    this.appHost = Objects.requireNonNull(appHost, "appHost");
+  }
+
+  /**
+   * Lists configured catalog sources.
+   *
+   * <p>Every stored catalog is re-read through the manager, which re-verifies the persisted catalog
+   * sidecars before exposing metadata. A corrupt or no-longer-trusted catalog therefore returns a
+   * catalog error instead of stale cached data.
+   *
+   * @return JSON-compatible catalog source summaries in manager-defined order
+   */
+  public List<Map<String, Object>> listCatalogs() {
+    try {
+      return catalogManager.listCatalogs().stream().map(this::summarizeCatalog).toList();
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to list app catalogs.");
+    }
+  }
+
+  /**
+   * Adds a signed catalog source and returns the verified catalog summary.
+   *
+   * <p>The {@code source} parameter may name a local file, a {@code file:} URI, an HTTPS URI, or a
+   * loopback HTTP URI accepted by the catalog source policy. Adding is intentionally eager: the
+   * source is fetched, its signature is checked, the catalog is parsed, and only then is the source
+   * persisted.
+   *
+   * @param queryParameters decoded request query or form parameters containing {@code source}
+   * @return JSON-compatible summary for the newly stored and verified catalog
+   */
+  public Map<String, Object> add(Map<String, List<String>> queryParameters) {
+    String source = PlatformApiParameters.requireString(queryParameters, "source");
+    try {
+      return summarizeCatalog(catalogManager.addSource(source));
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to add app catalog.");
+    }
+  }
+
+  /**
+   * Removes one configured catalog source.
+   *
+   * <p>Removal deletes the locally configured source record and cached catalog sidecars. It does
+   * not uninstall apps that were previously installed from that catalog, because installed app
+   * lifecycle remains owned by the app endpoints.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @return JSON-compatible removal summary containing the requested id and removal flag
+   */
+  public Map<String, Object> remove(String catalogId) {
+    try {
+      catalogManager.remove(catalogId);
+      LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+      json.put("catalogId", catalogId);
+      json.put("removed", true);
+      return json;
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to remove app catalog.");
+    }
+  }
+
+  /**
+   * Refreshes one configured catalog source.
+   *
+   * <p>Refresh reuses the stored source URI, fetches fresh catalog sidecars, verifies the
+   * signature, and rejects the result if the authenticated catalog id no longer matches the
+   * configured id. A failed refresh leaves the previous stored sidecars in place.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @return JSON-compatible summary for the refreshed catalog
+   */
+  public Map<String, Object> refresh(String catalogId) {
+    try {
+      return summarizeCatalog(catalogManager.refresh(catalogId));
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to refresh app catalog.");
+    }
+  }
+
+  /**
+   * Lists apps in one catalog.
+   *
+   * <p>The response preserves the catalog-declared app order and adds local AppHost state for each
+   * entry. Bundle URI, digest, and size metadata remain visible so operators can inspect what a
+   * catalog would download before installing or updating.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @return JSON-compatible app entries enriched with local installed/running state
+   */
+  public List<Map<String, Object>> listApps(String catalogId) {
+    try {
+      return catalogManager.listApps(catalogId).stream().map(this::summarizeEntry).toList();
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to list catalog apps.");
+    }
+  }
+
+  /**
+   * Describes one app in a catalog.
+   *
+   * <p>The app id is resolved through the verified catalog, not directly through AppHost. That
+   * keeps {@code app_not_found} distinct from an installed-app lookup failure and lets callers
+   * inspect a catalog entry even when the app is not installed locally.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   * @return JSON-compatible app entry enriched with local installed/running state
+   */
+  public Map<String, Object> getApp(String catalogId, String appId) {
+    try {
+      return summarizeEntry(catalogManager.getApp(catalogId, appId));
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to read catalog app.");
+    }
+  }
+
+  /**
+   * Installs one catalog app through AppHost.
+   *
+   * <p>The method first confirms that the catalog entry exists and that the app is not already
+   * installed. It then asks the manager to download, digest-check, extract, and verify the signed
+   * bundle before delegating the final copy into the managed app tree to AppHost. Scratch cleanup
+   * runs after the mutation and is logged if it fails so cleanup trouble does not mask a committed
+   * installation.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   * @return installed app summary without launch tokens or staging paths
+   */
+  public Map<String, Object> install(String catalogId, String appId) {
+    String normalizedAppId;
+    try {
+      AppCatalogEntry entry = catalogManager.getApp(catalogId, appId);
+      normalizedAppId = entry.appId();
+      if (appHost.describe(normalizedAppId).isPresent()) {
+        throw conflict(APP_ALREADY_INSTALLED_PREFIX + normalizedAppId);
+      }
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError(INSTALL_FAILED_MESSAGE);
+    }
+    AppCatalogInstallPlan plan = null;
+    try {
+      plan = catalogManager.prepareInstallPlan(catalogId, normalizedAppId);
+      InstalledAppSnapshot installed = appHost.installFromDirectory(plan.stagedBundleDirectory());
+      return summarizeInstalledApp(installed.manifest());
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (AppHostException exception) {
+      throw installFailure(exception);
+    } catch (IOException _) {
+      throw internalError(INSTALL_FAILED_MESSAGE);
+    } finally {
+      cleanUpPlan(plan);
+    }
+  }
+
+  /**
+   * Updates one installed app from a catalog entry through AppHost.
+   *
+   * <p>The update path refuses running apps before staging remote data and fails fast when the app
+   * is clearly not installed. If the installed manifest is unreadable, the method still lets
+   * AppHost attempt the update so a valid catalog bundle can repair a damaged installation. The
+   * staged bundle follows the same catalog digest, extraction, and signed-bundle verification path
+   * as install.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   * @return updated installed app summary without launch tokens or staging paths
+   */
+  public Map<String, Object> update(String catalogId, String appId) {
+    String normalizedAppId;
+    AppCatalogEntry entry;
+    try {
+      entry = catalogManager.getApp(catalogId, appId);
+      normalizedAppId = entry.appId();
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError(UPDATE_FAILED_MESSAGE);
+    }
+    if (appHost.status(normalizedAppId).isPresent()) {
+      throw conflict(CANNOT_UPDATE_RUNNING_APP_PREFIX + normalizedAppId);
+    }
+    try {
+      if (appHost.describe(normalizedAppId).isEmpty()) {
+        throw new PlatformApiException(404, "app_not_found", "App not found.");
+      }
+    } catch (IOException _) {
+      // Allow AppHost to repair installs whose manifest is unreadable.
+    }
+    AppCatalogInstallPlan plan = null;
+    try {
+      plan = catalogManager.prepareInstallPlan(catalogId, normalizedAppId);
+      InstalledAppSnapshot updated =
+          appHost.updateFromDirectory(entry.appId(), plan.stagedBundleDirectory());
+      return summarizeInstalledApp(updated.manifest());
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (AppHostException exception) {
+      throw updateFailure(normalizedAppId, exception);
+    } catch (IOException _) {
+      throw internalError(UPDATE_FAILED_MESSAGE);
+    } finally {
+      cleanUpPlan(plan);
+    }
+  }
+
+  private static void cleanUpPlan(AppCatalogInstallPlan plan) {
+    if (plan == null) {
+      return;
+    }
+    try {
+      plan.close();
+    } catch (IOException exception) {
+      LOG.log(
+          System.Logger.Level.WARNING, "Failed to clean catalog app scratch directory", exception);
+    }
+  }
+
+  private Map<String, Object> summarizeCatalog(AppCatalogSourceSnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    json.put("catalogId", snapshot.catalogId());
+    json.put("name", snapshot.name());
+    json.put("source", snapshot.sourceUri().toString());
+    json.put("generatedAt", snapshot.generatedAt().toString());
+    json.put("appCount", snapshot.appCount());
+    json.put("addedAt", snapshot.addedAt().toString());
+    json.put("refreshedAt", snapshot.refreshedAt().toString());
+    return json;
+  }
+
+  private Map<String, Object> summarizeEntry(AppCatalogEntry entry) {
+    InstalledAppSnapshot installed = installed(entry.appId());
+    RunningAppSnapshot running = appHost.status(entry.appId()).orElse(null);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(12);
+    json.put("appId", entry.appId());
+    json.put("name", entry.name());
+    json.put("version", entry.version());
+    json.put("summary", entry.summary());
+    json.put("permissions", entry.permissions());
+    json.put("bundle", summarizeBundle(entry));
+    json.put("installed", installed != null);
+    json.put("installedVersion", installed == null ? null : installed.manifest().appVersion());
+    json.put("running", running != null);
+    json.put("pid", running == null ? null : running.pid());
+    json.put("startedAt", running == null ? null : running.startedAt().toString());
+    return json;
+  }
+
+  private InstalledAppSnapshot installed(String appId) {
+    try {
+      return appHost.describe(appId).orElse(null);
+    } catch (IOException _) {
+      throw internalError("Failed to read installed apps.");
+    }
+  }
+
+  private static Map<String, Object> summarizeBundle(AppCatalogEntry entry) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(4);
+    json.put("uri", entry.bundleUri().toString());
+    json.put("type", entry.bundleType());
+    json.put("sizeBytes", entry.bundleSizeBytes());
+    json.put("sha256", entry.bundleSha256());
+    return json;
+  }
+
+  private static Map<String, Object> summarizeInstalledApp(AppManifest manifest) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(10);
+    json.put("appId", manifest.appId());
+    json.put("name", manifest.appName());
+    json.put("version", manifest.appVersion());
+    json.put("uiEntry", manifest.uiEntry());
+    json.put("permissions", manifest.permissions());
+    json.put("installed", true);
+    json.put("running", false);
+    json.put("pid", null);
+    json.put("startedAt", null);
+    return json;
+  }
+
+  private PlatformApiException catalogFailure(AppCatalogException exception) {
+    return switch (exception.errorCode()) {
+      case "catalog_not_found", "app_not_found" ->
+          new PlatformApiException(404, exception.errorCode(), exception.getMessage());
+      case "catalog_conflict" ->
+          new PlatformApiException(409, exception.errorCode(), exception.getMessage());
+      default -> new PlatformApiException(400, exception.errorCode(), exception.getMessage());
+    };
+  }
+
+  private PlatformApiException installFailure(AppHostException exception) {
+    if (isAlreadyInstalledFailure(exception)) {
+      return conflict(alreadyInstalledMessage(exception));
+    }
+    if (exception instanceof AppBundleVerificationException) {
+      return new PlatformApiException(
+          400, "invalid_app_bundle", "Catalog app bundle failed trusted verification.");
+    }
+    return internalError(INSTALL_FAILED_MESSAGE);
+  }
+
+  private PlatformApiException updateFailure(String appId, AppHostException exception) {
+    if (isRunningUpdateFailure(exception) || appHost.status(appId).isPresent()) {
+      return conflict(CANNOT_UPDATE_RUNNING_APP_PREFIX + appId);
+    }
+    if (isMissingAppFailure(exception)) {
+      return new PlatformApiException(404, "app_not_found", "App not found.");
+    }
+    if (exception instanceof AppBundleVerificationException) {
+      return new PlatformApiException(
+          400, "invalid_app_bundle", "Catalog app bundle failed trusted verification.");
+    }
+    return internalError(UPDATE_FAILED_MESSAGE);
+  }
+
+  private static boolean isAlreadyInstalledFailure(AppHostException failure) {
+    String message = failure.getMessage();
+    return message != null && message.startsWith(APP_ALREADY_INSTALLED_PREFIX);
+  }
+
+  private static boolean isRunningUpdateFailure(AppHostException failure) {
+    String message = failure.getMessage();
+    return message != null && message.startsWith(CANNOT_UPDATE_RUNNING_APP_PREFIX);
+  }
+
+  private static boolean isMissingAppFailure(AppHostException failure) {
+    String message = failure.getMessage();
+    return message != null && message.startsWith(APP_NOT_INSTALLED_PREFIX);
+  }
+
+  private static PlatformApiException conflict(String message) {
+    return new PlatformApiException(409, "app_conflict", message);
+  }
+
+  private static PlatformApiException internalError(String message) {
+    return new PlatformApiException(500, "internal_error", message);
+  }
+
+  private static String alreadyInstalledMessage(Throwable failure) {
+    String message = failure.getMessage();
+    return message == null || message.isBlank() ? "App already installed." : message;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Platform API handlers for signed app catalog source and catalog-app operations.
+ *
+ * <p>The package adapts the transport-neutral catalog manager to JSON-compatible response maps and
+ * delegates final app installation or update to AppHost. Existing local staged-directory app routes
+ * remain owned by {@code network.crypta.platform.api.apps}.
+ *
+ * <p>Routes in this package are the HTTP/API control surface for PR-195. They expose configured
+ * catalog sources, catalog app metadata, and catalog-backed install/update commands, but they do
+ * not fetch artifacts directly or manage app processes. The lower catalog module performs source
+ * fetch, signature verification, artifact digest checks, and safe ZIP staging. AppHost still owns
+ * the final install tree, update semantics, and running-process checks.
+ *
+ * <p>Error mapping is part of the package contract. Catalog-specific failures keep stable codes
+ * such as {@code invalid_catalog_signature}, {@code artifact_digest_mismatch}, and {@code
+ * invalid_app_bundle}; AppHost lifecycle conflicts continue to use the same app API codes as local
+ * staged-directory operations.
+ */
+package network.crypta.platform.api.appcatalogs;

--- a/platform-appcatalog/build.gradle.kts
+++ b/platform-appcatalog/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+  id("cryptad.java-kotlin-conventions")
+  id("cryptad.spotless")
+  `java-library`
+}
+
+version = rootProject.version
+
+val mainSourceSet = sourceSets.named("main")
+
+dependencies {
+  api(project(":platform-appdist"))
+
+  compileOnly(libs.jetbrainsAnnotations)
+
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(project(":platform-appdist"))
+  testImplementation(project(":platform-apphost"))
+  testImplementation(libs.junitJupiterApi)
+  testImplementation(libs.junitJupiterParams)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
+}

--- a/platform-appcatalog/gradle/owned-output-patterns.txt
+++ b/platform-appcatalog/gradle/owned-output-patterns.txt
@@ -1,0 +1,4 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :platform-appcatalog owns
+# them now.
+
+network/crypta/platform/appcatalog/**

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalog.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalog.java
@@ -1,0 +1,111 @@
+package network.crypta.platform.appcatalog;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import network.crypta.platform.appdist.AppBundleManifest;
+
+/**
+ * Verified v1 app catalog content.
+ *
+ * <p>The catalog preserves the deterministic entry order declared by {@code catalog.entries}. It is
+ * immutable after construction, and every entry is keyed by the normalized AppHost app id used by
+ * installation and update flows. Runtime code should treat an instance as a point-in-time view of
+ * one signed catalog payload, not as a live subscription to the source URI.
+ *
+ * <p>The constructor performs the same validation that the parser performs after signature
+ * verification, which makes the record safe for tests and controlled tooling to instantiate
+ * directly. Catalog ids use the signed-bundle app-id grammar so they can also serve as on-disk
+ * directory names and API path segments. Entry lists are copied, duplicate app ids are rejected,
+ * and no mutable collections from callers are retained.
+ *
+ * @param version catalog schema version, currently {@code 1}
+ * @param catalogId stable catalog identifier used by API paths and local storage
+ * @param name human-readable catalog name
+ * @param generatedAt timestamp declared by the catalog producer
+ * @param entries catalog entries in declared deterministic order
+ */
+public record AppCatalog(
+    int version,
+    String catalogId,
+    String name,
+    Instant generatedAt,
+    List<AppCatalogEntry> entries) {
+  /**
+   * Creates a validated immutable catalog.
+   *
+   * <p>The canonical constructor normalizes {@code catalogId}, trims and validates the display
+   * name, copies {@code entries}, and rejects duplicate normalized app ids. It does not verify
+   * signatures or artifact metadata; callers must only construct instances from already
+   * authenticated bytes or from trusted test/tooling fixtures.
+   *
+   * @param version catalog schema version, currently {@code 1}
+   * @param catalogId stable catalog identifier used by API paths and local storage
+   * @param name human-readable catalog name shown to operators
+   * @param generatedAt timestamp declared by the catalog producer
+   * @param entries catalog entries in declared deterministic order
+   * @throws AppCatalogException if the catalog header or entry set is invalid
+   */
+  public AppCatalog {
+    if (version != 1) {
+      throw AppCatalogSidecars.invalidEntry("unsupported catalog.version: " + version);
+    }
+    catalogId = normalizeCatalogId(catalogId);
+    name =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            name, "catalog.name", AppCatalogSidecars.INVALID_CATALOG_ENTRY);
+    Objects.requireNonNull(generatedAt, "generatedAt");
+    entries = List.copyOf(Objects.requireNonNull(entries, "entries"));
+    rejectDuplicateEntries(entries);
+  }
+
+  /**
+   * Finds one catalog entry by normalized app id.
+   *
+   * <p>The lookup accepts raw caller input and normalizes it with the same rules used for catalog
+   * parsing and AppHost installation. A syntactically invalid id is rejected before the entry list
+   * is scanned; a valid but absent id returns {@link Optional#empty()}.
+   *
+   * @param appId raw or normalized app identifier from a caller
+   * @return matching catalog entry, when present in the verified catalog
+   * @throws AppCatalogException if {@code appId} is not a valid AppHost id
+   */
+  public Optional<AppCatalogEntry> entry(String appId) throws AppCatalogException {
+    String normalizedAppId = AppCatalogEntry.normalizeAppId(appId);
+    return entries.stream().filter(entry -> entry.appId().equals(normalizedAppId)).findFirst();
+  }
+
+  /**
+   * Normalizes a catalog id using the same path-safe grammar as app ids.
+   *
+   * <p>Catalog ids are used as API path components and source-store directory names, so this method
+   * deliberately reuses the signed-bundle id grammar instead of accepting arbitrary catalog labels.
+   * The result is trimmed, lower-case, and safe to compare as a stable identifier.
+   *
+   * @param catalogId raw catalog identifier from a catalog or API path
+   * @return normalized lower-case catalog id
+   * @throws AppCatalogException if the id is not path-safe
+   */
+  public static String normalizeCatalogId(String catalogId) throws AppCatalogException {
+    try {
+      return AppBundleManifest.normalizeAppId(catalogId);
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.getMessage(), exception);
+    }
+  }
+
+  private static void rejectDuplicateEntries(List<AppCatalogEntry> entries)
+      throws AppCatalogException {
+    Map<String, AppCatalogEntry> byId = new LinkedHashMap<>();
+    for (AppCatalogEntry entry : entries) {
+      AppCatalogEntry previous = byId.putIfAbsent(entry.appId(), entry);
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry("duplicate catalog entry app id: " + entry.appId());
+      }
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogArtifactDownloader.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogArtifactDownloader.java
@@ -1,0 +1,220 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * Downloads one catalog artifact into a host-owned temporary file.
+ *
+ * <p>The downloader never writes directly into an installed app tree. It streams the artifact to a
+ * caller-supplied scratch directory, enforces the catalog-declared byte count and the absolute
+ * safety cap, and verifies the catalog-declared SHA-256 digest before returning the temporary ZIP
+ * path to the extractor.
+ *
+ * <p>Both local {@code file:} artifacts and remote HTTP(S) artifacts use the same size and digest
+ * gate. Remote requests use finite JDK {@link HttpClient} timeouts, do not follow redirects, and
+ * treat transport failures as catalog artifact failures rather than internal server errors. The
+ * caller owns the scratch directory and is expected to delete it after AppHost has copied the
+ * staged bundle into its managed installation tree.
+ */
+public final class AppCatalogArtifactDownloader {
+  private static final Duration REQUEST_TIMEOUT = Duration.ofMinutes(2);
+
+  private final HttpClient httpClient;
+
+  /**
+   * Creates a downloader backed by the default no-redirect JDK HTTP client.
+   *
+   * <p>The default client uses a ten-second connect timeout and rejects redirects. Source policy
+   * has already restricted artifact URIs to local files, HTTPS, or loopback HTTP, so this
+   * constructor is appropriate for normal runtime composition.
+   */
+  public AppCatalogArtifactDownloader() {
+    this(
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build());
+  }
+
+  /**
+   * Creates a downloader with an explicit HTTP client.
+   *
+   * <p>This overload exists for tests and controlled embeddings that need a custom transport. The
+   * downloader still sets per-request timeouts and performs response validation; callers should
+   * keep redirect handling disabled unless they also enforce equivalent redirect policy outside
+   * this class.
+   *
+   * @param httpClient client used for HTTP and HTTPS artifact retrieval
+   */
+  public AppCatalogArtifactDownloader(HttpClient httpClient) {
+    this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+  }
+
+  /**
+   * Downloads and verifies one entry artifact.
+   *
+   * <p>The returned path names a temporary ZIP in {@code scratchDirectory}. If downloading or
+   * verification fails, the partially written file is deleted before the original failure is
+   * rethrown. A successful return means the file byte count equals {@link
+   * AppCatalogEntry#bundleSizeBytes()} and its SHA-256 digest equals {@link
+   * AppCatalogEntry#bundleSha256()}.
+   *
+   * @param entry catalog entry whose ZIP artifact should be retrieved and checked
+   * @param scratchDirectory host-owned temporary directory for the artifact file
+   * @return path to the verified artifact ZIP inside the scratch directory
+   * @throws IOException if scratch directory creation or temporary-file deletion fails
+   */
+  public Path download(AppCatalogEntry entry, Path scratchDirectory) throws IOException {
+    AppCatalogEntry checkedEntry = Objects.requireNonNull(entry, "entry");
+    Path scratchRoot = Objects.requireNonNull(scratchDirectory, "scratchDirectory");
+    Files.createDirectories(scratchRoot);
+    Path artifact = Files.createTempFile(scratchRoot, "catalog-artifact-", ".zip");
+    try {
+      copyArtifact(checkedEntry, artifact);
+      return artifact;
+    } catch (RuntimeException exception) {
+      Files.deleteIfExists(artifact);
+      throw exception;
+    }
+  }
+
+  private void copyArtifact(AppCatalogEntry entry, Path destination) {
+    URI uri = entry.bundleUri();
+    String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+    if ("file".equals(scheme)) {
+      copyLocalArtifact(entry, uri, destination);
+      return;
+    }
+    copyRemoteArtifact(entry, destination);
+  }
+
+  private static void copyLocalArtifact(AppCatalogEntry entry, URI uri, Path destination) {
+    try {
+      copyAndVerify(entry, Files.newInputStream(Path.of(uri)), destination);
+    } catch (IOException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED,
+          "failed to read local artifact for app: " + entry.appId(),
+          exception);
+    }
+  }
+
+  private void copyRemoteArtifact(AppCatalogEntry entry, Path destination) {
+    HttpRequest request =
+        HttpRequest.newBuilder(entry.bundleUri())
+            .timeout(REQUEST_TIMEOUT)
+            .header("Accept", "application/zip, application/octet-stream")
+            .GET()
+            .build();
+    HttpResponse<InputStream> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+    } catch (IOException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED,
+          "failed to download artifact for app: " + entry.appId(),
+          exception);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED,
+          "interrupted while downloading artifact for app: " + entry.appId(),
+          exception);
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED,
+          "invalid artifact URI for app: " + entry.appId(),
+          exception);
+    }
+    try (InputStream input = response.body()) {
+      if (response.statusCode() != 200) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED,
+            "failed to download artifact for app "
+                + entry.appId()
+                + ": HTTP "
+                + response.statusCode());
+      }
+      validateContentLength(entry, response);
+      copyAndVerify(entry, input, destination);
+    } catch (IOException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED,
+          "failed to read artifact for app: " + entry.appId(),
+          exception);
+    }
+  }
+
+  private static void validateContentLength(
+      AppCatalogEntry entry, HttpResponse<InputStream> response) {
+    OptionalLong contentLength;
+    try {
+      contentLength = response.headers().firstValueAsLong("content-length");
+    } catch (NumberFormatException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED,
+          "artifact Content-Length is invalid for app: " + entry.appId(),
+          exception);
+    }
+    if (contentLength.isPresent()) {
+      rejectWrongContentLength(entry, contentLength.getAsLong());
+    }
+  }
+
+  private static void rejectWrongContentLength(AppCatalogEntry entry, long contentLength) {
+    if (contentLength != entry.bundleSizeBytes()) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DIGEST_MISMATCH,
+          "artifact size does not match catalog entry for app: " + entry.appId());
+    }
+  }
+
+  private static void copyAndVerify(AppCatalogEntry entry, InputStream input, Path destination)
+      throws IOException {
+    MessageDigest digest = AppCatalogSidecars.newArtifactSha256Digest();
+    long bytesCopied = 0L;
+    byte[] buffer = new byte[64 * 1024];
+    try (InputStream in = input;
+        OutputStream out = Files.newOutputStream(destination)) {
+      int bytesRead;
+      while ((bytesRead = in.read(buffer)) >= 0) {
+        if (bytesRead == 0) {
+          continue;
+        }
+        bytesCopied += bytesRead;
+        if (bytesCopied > entry.bundleSizeBytes()
+            || bytesCopied > AppCatalogSidecars.MAX_ARTIFACT_BYTES) {
+          throw new AppCatalogException(
+              AppCatalogSidecars.ARTIFACT_DIGEST_MISMATCH,
+              "artifact size exceeds catalog entry for app: " + entry.appId());
+        }
+        digest.update(buffer, 0, bytesRead);
+        out.write(buffer, 0, bytesRead);
+      }
+    }
+    if (bytesCopied != entry.bundleSizeBytes()) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DIGEST_MISMATCH,
+          "artifact size does not match catalog entry for app: " + entry.appId());
+    }
+    String actualSha256 = AppCatalogSidecars.lowercaseHex(digest.digest());
+    if (!entry.bundleSha256().equals(actualSha256)) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.ARTIFACT_DIGEST_MISMATCH,
+          "artifact digest does not match catalog entry for app: " + entry.appId());
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogArtifactDownloader.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogArtifactDownloader.java
@@ -33,6 +33,7 @@ public final class AppCatalogArtifactDownloader {
   private static final Duration REQUEST_TIMEOUT = Duration.ofMinutes(2);
 
   private final HttpClient httpClient;
+  private final ArtifactCleaner artifactCleaner;
 
   /**
    * Creates a downloader backed by the default no-redirect JDK HTTP client.
@@ -61,6 +62,12 @@ public final class AppCatalogArtifactDownloader {
    */
   public AppCatalogArtifactDownloader(HttpClient httpClient) {
     this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+    artifactCleaner = Files::deleteIfExists;
+  }
+
+  AppCatalogArtifactDownloader(HttpClient httpClient, ArtifactCleaner artifactCleaner) {
+    this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+    this.artifactCleaner = Objects.requireNonNull(artifactCleaner, "artifactCleaner");
   }
 
   /**
@@ -86,8 +93,16 @@ public final class AppCatalogArtifactDownloader {
       copyArtifact(checkedEntry, artifact);
       return artifact;
     } catch (RuntimeException exception) {
-      Files.deleteIfExists(artifact);
+      deleteArtifactAfterFailure(artifact, exception);
       throw exception;
+    }
+  }
+
+  private void deleteArtifactAfterFailure(Path artifact, RuntimeException originalException) {
+    try {
+      artifactCleaner.deleteIfExists(artifact);
+    } catch (IOException cleanupException) {
+      originalException.addSuppressed(cleanupException);
     }
   }
 
@@ -216,5 +231,10 @@ public final class AppCatalogArtifactDownloader {
           AppCatalogSidecars.ARTIFACT_DIGEST_MISMATCH,
           "artifact digest does not match catalog entry for app: " + entry.appId());
     }
+  }
+
+  @FunctionalInterface
+  interface ArtifactCleaner {
+    boolean deleteIfExists(Path artifact) throws IOException;
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractor.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractor.java
@@ -1,0 +1,496 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.LinkOption;
+import java.nio.file.NotDirectoryException;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipInputStream;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppBundleManifestParser;
+import network.crypta.platform.appdist.AppBundleVerifier;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appdist.TrustedAppKeys;
+
+/**
+ * Extracts a verified catalog ZIP artifact into a staged app bundle root.
+ *
+ * <p>The extractor rejects ZIP entries that can escape or alias the staging root before any bundle
+ * verifier sees the files. After extraction, it requires a root-level app manifest, verifies the
+ * existing signed-bundle sidecars with {@link AppBundleVerifier}, and checks that the signed
+ * manifest app id and version match the authenticated catalog entry.
+ *
+ * <p>This class is the last untrusted-input boundary before AppHost receives a staged directory. It
+ * never extracts into the final installation tree, rejects absolute paths, parent traversal,
+ * duplicate normalized names, unsupported ZIP64 central directory markers, and parent/file
+ * conflicts, and caps both entry count and extracted byte count. POSIX executable bits recorded by
+ * ZIP creators are restored when possible so the signed appdist digest can still verify bundles
+ * whose launch command is an executable file.
+ */
+public final class AppCatalogBundleExtractor {
+  private static final int COPY_BUFFER_BYTES = 64 * 1024;
+  private static final int MAX_ZIP_ENTRIES = 4096;
+  private static final long MAX_EXTRACTED_BYTES = AppCatalogSidecars.MAX_ARTIFACT_BYTES;
+  private static final int END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054B50;
+  private static final int CENTRAL_DIRECTORY_HEADER_SIGNATURE = 0x02014B50;
+  private static final int END_OF_CENTRAL_DIRECTORY_MIN_BYTES = 22;
+  private static final int ZIP_MAX_COMMENT_BYTES = 65_535;
+  private static final int CENTRAL_DIRECTORY_HEADER_BYTES = 46;
+  private static final int ZIP64_UNSIGNED_SHORT_MARKER = 0xFFFF;
+  private static final long ZIP64_UNSIGNED_INT_MARKER = 0xFFFF_FFFFL;
+  private static final int UNIX_HOST_PLATFORM = 3;
+  private static final int UNIX_MODE_SHIFT = 16;
+  private static final int UNIX_FILE_TYPE_MASK = 61440;
+  private static final int UNIX_DIRECTORY_TYPE = 16384;
+  private static final int UNIX_OWNER_EXECUTE = 64;
+  private static final int UNIX_GROUP_EXECUTE = 8;
+  private static final int UNIX_OTHER_EXECUTE = 1;
+  private static final int UNIX_EXECUTE_BITS =
+      UNIX_OWNER_EXECUTE | UNIX_GROUP_EXECUTE | UNIX_OTHER_EXECUTE;
+  private static final String PARENT_DIRECTORY_CONFLICT_MESSAGE =
+      "zip artifact parent directory conflicts with a file";
+
+  /**
+   * Creates a stateless bundle extractor.
+   *
+   * <p>All extraction state is allocated per {@link #extract(AppCatalogEntry, Path, Path,
+   * TrustedAppKeys)} call. A single instance can therefore be shared by a catalog manager without
+   * carrying path, trust, or artifact state between install and update operations.
+   */
+  public AppCatalogBundleExtractor() {
+    // The public constructor documents intentional stateless instantiation for doclint and tooling.
+  }
+
+  /**
+   * Extracts, verifies, and validates one downloaded ZIP artifact.
+   *
+   * <p>The method creates a new child directory under {@code scratchDirectory}, expands the ZIP
+   * into that directory, and then invokes {@link AppBundleVerifier} against the extracted root. If
+   * any extraction, bundle-verification, or manifest-matching check fails, the staged root is
+   * removed before the failure is propagated. The caller remains responsible for deleting the
+   * broader scratch directory after AppHost has copied the staged bundle.
+   *
+   * @param entry catalog entry that supplied the artifact metadata and expected manifest identity
+   * @param artifactZip downloaded and SHA-256-verified artifact ZIP
+   * @param scratchDirectory host-owned scratch directory used for extraction
+   * @param trustedKeys explicit trusted keys used for signed-bundle verification
+   * @return staged bundle root ready for AppHost installation or update
+   * @throws IOException if filesystem cleanup, extraction, or signed-bundle verification fails
+   */
+  public Path extract(
+      AppCatalogEntry entry, Path artifactZip, Path scratchDirectory, TrustedAppKeys trustedKeys)
+      throws IOException {
+    AppCatalogEntry checkedEntry = Objects.requireNonNull(entry, "entry");
+    Path zipPath = Objects.requireNonNull(artifactZip, "artifactZip").toAbsolutePath().normalize();
+    Path scratchRoot = Objects.requireNonNull(scratchDirectory, "scratchDirectory");
+    Files.createDirectories(scratchRoot);
+    Path stagedRoot = Files.createTempDirectory(scratchRoot, "catalog-bundle-");
+    try {
+      extractZip(zipPath, stagedRoot);
+      verifyExtractedBundle(checkedEntry, stagedRoot, trustedKeys);
+      return stagedRoot;
+    } catch (IOException | RuntimeException exception) {
+      deleteRecursively(stagedRoot);
+      throw exception;
+    }
+  }
+
+  // Archive expansion is safe here because every entry is path-normalized, duplicate-checked,
+  // rooted under the private staging directory, and bounded by entry-count and byte caps.
+  @SuppressWarnings("java:S5042")
+  private static void extractZip(Path zipPath, Path stagedRoot) throws IOException {
+    Path extractionRoot = stagedRoot.toAbsolutePath().normalize();
+    ExtractionState state = new ExtractionState();
+    Map<String, Integer> unixModesByPath = readCentralDirectoryUnixModes(zipPath);
+    try (InputStream fileInput = Files.newInputStream(zipPath);
+        ZipInputStream zipInput = new ZipInputStream(fileInput)) {
+      ZipEntry entry;
+      while ((entry = zipInput.getNextEntry()) != null) {
+        String normalizedName = normalizeZipEntryName(entry.getName(), entry.isDirectory());
+        state.recordEntry(normalizedName);
+        Path target = resolveZipEntryTarget(extractionRoot, normalizedName);
+        if (entry.isDirectory()) {
+          createDirectory(target);
+        } else {
+          createFile(zipInput, target, state, unixModesByPath.get(normalizedName));
+        }
+        zipInput.closeEntry();
+      }
+    } catch (ZipException exception) {
+      throw invalidBundle("zip artifact is corrupt", exception);
+    }
+  }
+
+  private static Path resolveZipEntryTarget(Path extractionRoot, String normalizedName) {
+    try {
+      Path target = extractionRoot.resolve(normalizedName).normalize();
+      if (!target.startsWith(extractionRoot)) {
+        throw invalidBundle("zip artifact entry escapes staged root: " + normalizedName);
+      }
+      return target;
+    } catch (InvalidPathException exception) {
+      throw invalidBundle(
+          "zip artifact contains an invalid entry name: " + normalizedName, exception);
+    }
+  }
+
+  private static void createDirectory(Path target) throws IOException {
+    Path parent = target.getParent();
+    if (parent != null) {
+      createParentDirectories(parent);
+    }
+    try {
+      if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)
+          && !Files.isDirectory(target, LinkOption.NOFOLLOW_LINKS)) {
+        throw invalidBundle("zip artifact directory conflicts with a file");
+      }
+      if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+        Files.createDirectory(target);
+      }
+    } catch (FileAlreadyExistsException | NotDirectoryException _) {
+      throw invalidBundle("zip artifact directory conflicts with a file");
+    }
+  }
+
+  private static void createFile(
+      ZipInputStream zipInput, Path target, ExtractionState state, Integer unixMode)
+      throws IOException {
+    Path parent = target.getParent();
+    if (parent == null) {
+      throw invalidBundle("zip artifact file has no parent directory");
+    }
+    createParentDirectories(parent);
+    if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+      throw invalidBundle("zip artifact overwrites an existing entry");
+    }
+    byte[] buffer = new byte[COPY_BUFFER_BYTES];
+    try (OutputStream output = Files.newOutputStream(target, StandardOpenOption.CREATE_NEW)) {
+      int bytesRead;
+      while ((bytesRead = zipInput.read(buffer)) >= 0) {
+        if (bytesRead == 0) {
+          continue;
+        }
+        state.recordExtractedBytes(bytesRead);
+        output.write(buffer, 0, bytesRead);
+      }
+    }
+    applyExecutableMode(target, unixMode);
+  }
+
+  private static void createParentDirectories(Path parent) throws IOException {
+    if (Files.exists(parent, LinkOption.NOFOLLOW_LINKS)) {
+      if (!Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+        throw invalidBundle(PARENT_DIRECTORY_CONFLICT_MESSAGE);
+      }
+      return;
+    }
+    rejectExistingFileAncestor(parent);
+    try {
+      Files.createDirectories(parent);
+    } catch (FileAlreadyExistsException | NotDirectoryException _) {
+      throw invalidBundle(PARENT_DIRECTORY_CONFLICT_MESSAGE);
+    }
+  }
+
+  private static void rejectExistingFileAncestor(Path path) {
+    Path current = path.getParent();
+    while (current != null && !Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+      current = current.getParent();
+    }
+    if (current != null && !Files.isDirectory(current, LinkOption.NOFOLLOW_LINKS)) {
+      throw invalidBundle(PARENT_DIRECTORY_CONFLICT_MESSAGE);
+    }
+  }
+
+  private static void applyExecutableMode(Path target, Integer unixMode) throws IOException {
+    if (unixMode == null || (unixMode & UNIX_EXECUTE_BITS) == 0) {
+      return;
+    }
+    if (Files.getFileStore(target).supportsFileAttributeView("posix")) {
+      Set<PosixFilePermission> permissions =
+          Files.getPosixFilePermissions(target, LinkOption.NOFOLLOW_LINKS);
+      setExecutablePermission(
+          permissions, PosixFilePermission.OWNER_EXECUTE, unixMode, UNIX_OWNER_EXECUTE);
+      setExecutablePermission(
+          permissions, PosixFilePermission.GROUP_EXECUTE, unixMode, UNIX_GROUP_EXECUTE);
+      setExecutablePermission(
+          permissions, PosixFilePermission.OTHERS_EXECUTE, unixMode, UNIX_OTHER_EXECUTE);
+      Files.setPosixFilePermissions(target, permissions);
+    } else {
+      boolean executableRestored = target.toFile().setExecutable(true, false);
+      if (!executableRestored && !Files.isExecutable(target)) {
+        throw invalidBundle("zip artifact executable mode could not be restored");
+      }
+    }
+  }
+
+  private static void setExecutablePermission(
+      Set<PosixFilePermission> permissions,
+      PosixFilePermission permission,
+      int unixMode,
+      int executeBit) {
+    if ((unixMode & executeBit) != 0) {
+      permissions.add(permission);
+    } else {
+      permissions.remove(permission);
+    }
+  }
+
+  private static Map<String, Integer> readCentralDirectoryUnixModes(Path zipPath)
+      throws IOException {
+    try (SeekableByteChannel channel = Files.newByteChannel(zipPath, StandardOpenOption.READ)) {
+      EndOfCentralDirectory endOfCentralDirectory = readEndOfCentralDirectory(channel);
+      Map<String, Integer> unixModesByPath = new HashMap<>();
+      channel.position(endOfCentralDirectory.centralDirectoryOffset());
+      long centralDirectoryEnd =
+          endOfCentralDirectory.centralDirectoryOffset()
+              + endOfCentralDirectory.centralDirectorySize();
+      for (int entryIndex = 0; entryIndex < endOfCentralDirectory.entryCount(); entryIndex++) {
+        CentralDirectoryEntry entry = readCentralDirectoryEntry(channel, centralDirectoryEnd);
+        if (entry.unixMode() != null && (entry.unixMode() & UNIX_EXECUTE_BITS) != 0) {
+          String normalizedName = normalizeZipEntryName(entry.name(), entry.directory());
+          unixModesByPath.putIfAbsent(normalizedName, entry.unixMode());
+        }
+      }
+      return Map.copyOf(unixModesByPath);
+    }
+  }
+
+  private static EndOfCentralDirectory readEndOfCentralDirectory(SeekableByteChannel channel)
+      throws IOException {
+    long zipSize = channel.size();
+    if (zipSize < END_OF_CENTRAL_DIRECTORY_MIN_BYTES) {
+      throw invalidBundle("zip artifact missing end-of-central-directory record");
+    }
+    int tailBytes =
+        (int) Math.min(zipSize, (long) END_OF_CENTRAL_DIRECTORY_MIN_BYTES + ZIP_MAX_COMMENT_BYTES);
+    ByteBuffer tail = ByteBuffer.allocate(tailBytes).order(ByteOrder.LITTLE_ENDIAN);
+    channel.position(zipSize - tailBytes);
+    readFully(channel, tail, "zip artifact end-of-central-directory record");
+    for (int offset = tailBytes - END_OF_CENTRAL_DIRECTORY_MIN_BYTES; offset >= 0; offset--) {
+      if (tail.getInt(offset) == END_OF_CENTRAL_DIRECTORY_SIGNATURE
+          && endOfCentralDirectoryRecordEndsAtTailEnd(tail, offset, tailBytes)) {
+        return readEndOfCentralDirectory(tail, offset, zipSize);
+      }
+    }
+    throw invalidBundle("zip artifact missing end-of-central-directory record");
+  }
+
+  private static boolean endOfCentralDirectoryRecordEndsAtTailEnd(
+      ByteBuffer tail, int offset, int tailBytes) {
+    int commentLength = unsignedShort(tail, offset + 20);
+    return offset + END_OF_CENTRAL_DIRECTORY_MIN_BYTES + commentLength == tailBytes;
+  }
+
+  private static EndOfCentralDirectory readEndOfCentralDirectory(
+      ByteBuffer tail, int offset, long zipSize) {
+    int diskNumber = unsignedShort(tail, offset + 4);
+    int centralDirectoryDisk = unsignedShort(tail, offset + 6);
+    int entriesOnDisk = unsignedShort(tail, offset + 8);
+    int totalEntries = unsignedShort(tail, offset + 10);
+    long centralDirectorySize = unsignedInt(tail, offset + 12);
+    long centralDirectoryOffset = unsignedInt(tail, offset + 16);
+    if (diskNumber != 0 || centralDirectoryDisk != 0 || entriesOnDisk != totalEntries) {
+      throw invalidBundle("zip artifact must not span multiple disks");
+    }
+    if (totalEntries == ZIP64_UNSIGNED_SHORT_MARKER
+        || centralDirectorySize == ZIP64_UNSIGNED_INT_MARKER
+        || centralDirectoryOffset == ZIP64_UNSIGNED_INT_MARKER) {
+      throw invalidBundle("zip64 catalog artifacts are not supported");
+    }
+    if (totalEntries > MAX_ZIP_ENTRIES) {
+      throw invalidBundle("zip artifact contains too many entries");
+    }
+    if (centralDirectoryOffset > zipSize
+        || centralDirectorySize > zipSize - centralDirectoryOffset) {
+      throw invalidBundle("zip artifact central directory escapes artifact");
+    }
+    return new EndOfCentralDirectory(totalEntries, centralDirectoryOffset, centralDirectorySize);
+  }
+
+  private static CentralDirectoryEntry readCentralDirectoryEntry(
+      SeekableByteChannel channel, long centralDirectoryEnd) throws IOException {
+    long headerOffset = channel.position();
+    if (headerOffset + CENTRAL_DIRECTORY_HEADER_BYTES > centralDirectoryEnd) {
+      throw invalidBundle("zip artifact central directory is truncated");
+    }
+    ByteBuffer header =
+        readBuffer(
+            channel, CENTRAL_DIRECTORY_HEADER_BYTES, "zip artifact central directory header");
+    if (header.getInt(0) != CENTRAL_DIRECTORY_HEADER_SIGNATURE) {
+      throw invalidBundle("zip artifact central directory is malformed");
+    }
+    int versionMadeBy = unsignedShort(header, 4);
+    int hostPlatform = (versionMadeBy >>> 8) & 0xFF;
+    int nameLength = unsignedShort(header, 28);
+    int extraLength = unsignedShort(header, 30);
+    int commentLength = unsignedShort(header, 32);
+    long externalAttributes = unsignedInt(header, 38);
+    long variableEnd = channel.position() + nameLength + extraLength + commentLength;
+    if (variableEnd > centralDirectoryEnd) {
+      throw invalidBundle("zip artifact central directory entry is truncated");
+    }
+    byte[] nameBytes = readBytes(channel, nameLength);
+    skip(channel, extraLength + commentLength);
+    String name = decodeZipEntryName(nameBytes);
+    Integer unixMode = null;
+    if (hostPlatform == UNIX_HOST_PLATFORM) {
+      unixMode = (int) ((externalAttributes >>> UNIX_MODE_SHIFT) & 0xFFFF);
+    }
+    return new CentralDirectoryEntry(name, unixMode);
+  }
+
+  private static String decodeZipEntryName(byte[] nameBytes) {
+    return new String(nameBytes, StandardCharsets.UTF_8);
+  }
+
+  private static ByteBuffer readBuffer(
+      SeekableByteChannel channel, int byteCount, String description) throws IOException {
+    ByteBuffer buffer = ByteBuffer.allocate(byteCount).order(ByteOrder.LITTLE_ENDIAN);
+    readFully(channel, buffer, description);
+    return buffer;
+  }
+
+  private static byte[] readBytes(SeekableByteChannel channel, int byteCount) throws IOException {
+    ByteBuffer buffer = readBuffer(channel, byteCount, "zip artifact central directory entry name");
+    byte[] bytes = new byte[byteCount];
+    buffer.get(bytes);
+    return bytes;
+  }
+
+  private static void readFully(SeekableByteChannel channel, ByteBuffer buffer, String description)
+      throws IOException {
+    while (buffer.hasRemaining()) {
+      if (channel.read(buffer) < 0) {
+        throw invalidBundle(description + " is truncated");
+      }
+    }
+    buffer.flip();
+  }
+
+  private static void skip(SeekableByteChannel channel, int byteCount) throws IOException {
+    channel.position(channel.position() + byteCount);
+  }
+
+  private static int unsignedShort(ByteBuffer buffer, int offset) {
+    return Short.toUnsignedInt(buffer.getShort(offset));
+  }
+
+  private static long unsignedInt(ByteBuffer buffer, int offset) {
+    return Integer.toUnsignedLong(buffer.getInt(offset));
+  }
+
+  private static String normalizeZipEntryName(String rawName, boolean directory) {
+    if (rawName == null || rawName.isBlank()) {
+      throw invalidBundle("zip artifact contains a blank entry name");
+    }
+    if (rawName.indexOf('\\') >= 0) {
+      throw invalidBundle("zip artifact entries must use '/' separators");
+    }
+    String name =
+        directory && rawName.endsWith("/") ? rawName.substring(0, rawName.length() - 1) : rawName;
+    if (name.startsWith("/") || startsWithWindowsDrive(name)) {
+      throw invalidBundle("zip artifact contains an absolute entry: " + rawName);
+    }
+    for (String segment : name.split("/", -1)) {
+      if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+        throw invalidBundle("zip artifact entry escapes staged root: " + rawName);
+      }
+    }
+    return name;
+  }
+
+  private static boolean startsWithWindowsDrive(String name) {
+    return name.length() >= 2 && Character.isLetter(name.charAt(0)) && name.charAt(1) == ':';
+  }
+
+  private static void verifyExtractedBundle(
+      AppCatalogEntry entry, Path stagedRoot, TrustedAppKeys trustedKeys) throws IOException {
+    Path manifestFile = stagedRoot.resolve(AppBundleManifestParser.MANIFEST_FILE_NAME);
+    if (!Files.isRegularFile(manifestFile, LinkOption.NOFOLLOW_LINKS)) {
+      throw invalidBundle("zip artifact must contain cryptad-app.properties at the root");
+    }
+    try {
+      AppBundleVerifier.verify(stagedRoot, Objects.requireNonNull(trustedKeys, "trustedKeys"));
+      AppBundleManifest manifest = AppBundleManifestParser.parse(manifestFile);
+      if (!entry.appId().equals(manifest.appId())) {
+        throw invalidBundle("catalog app id does not match extracted bundle manifest");
+      }
+      if (!entry.version().equals(manifest.appVersion())) {
+        throw invalidBundle("catalog app version does not match extracted bundle manifest");
+      }
+    } catch (AppDistributionException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_APP_BUNDLE, exception.getMessage(), exception);
+    }
+  }
+
+  static void deleteRecursively(Path root) throws IOException {
+    if (root == null || !Files.exists(root, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try (var stream = Files.walk(root)) {
+      for (Path path : stream.sorted(java.util.Comparator.reverseOrder()).toList()) {
+        Files.deleteIfExists(path);
+      }
+    }
+  }
+
+  private static AppCatalogException invalidBundle(String message) {
+    return new AppCatalogException(AppCatalogSidecars.INVALID_APP_BUNDLE, message);
+  }
+
+  private static AppCatalogException invalidBundle(String message, Throwable cause) {
+    return new AppCatalogException(AppCatalogSidecars.INVALID_APP_BUNDLE, message, cause);
+  }
+
+  private record EndOfCentralDirectory(
+      int entryCount, long centralDirectoryOffset, long centralDirectorySize) {}
+
+  private record CentralDirectoryEntry(String name, Integer unixMode) {
+    private boolean directory() {
+      return name.endsWith("/")
+          || (unixMode != null && (unixMode & UNIX_FILE_TYPE_MASK) == UNIX_DIRECTORY_TYPE);
+    }
+  }
+
+  private static final class ExtractionState {
+    private final Set<String> seenPaths = new HashSet<>();
+    private long extractedBytes;
+    private int entryCount;
+
+    void recordEntry(String normalizedName) {
+      entryCount++;
+      if (entryCount > MAX_ZIP_ENTRIES) {
+        throw invalidBundle("zip artifact contains too many entries");
+      }
+      if (!seenPaths.add(normalizedName)) {
+        throw invalidBundle("zip artifact contains duplicate entry: " + normalizedName);
+      }
+    }
+
+    void recordExtractedBytes(int bytesRead) {
+      extractedBytes += bytesRead;
+      if (extractedBytes > MAX_EXTRACTED_BYTES) {
+        throw invalidBundle("zip artifact exceeds extracted size cap");
+      }
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntry.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntry.java
@@ -1,0 +1,139 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import network.crypta.platform.appdist.AppBundleManifest;
+
+/**
+ * One app artifact advertised by a signed catalog.
+ *
+ * <p>The entry stores the normalized app identity, display metadata, permissions, and the exact ZIP
+ * artifact contract that must be satisfied before installation. Catalog installers use the declared
+ * size and SHA-256 digest as the first artifact gate, then verify the extracted signed bundle
+ * independently through {@code platform-appdist}.
+ *
+ * <p>Instances are immutable and safe to expose through the Platform API after the containing
+ * catalog has been signature-verified. The record validates that artifact URIs use an accepted
+ * local/remote scheme, that size is non-negative and below the catalog safety cap, and that only
+ * ZIP artifacts are accepted for this PR. Permission strings are normalized to lower case and
+ * deduplicated while preserving declaration order; they are descriptive hints until a later
+ * permissions-enforcement layer consumes them.
+ *
+ * @param appId normalized AppHost-compatible application identifier
+ * @param name human-readable application name
+ * @param version application version expected in the extracted bundle manifest
+ * @param summary short operator-facing description
+ * @param bundleUri absolute local or remote URI for the ZIP bundle artifact
+ * @param bundleSha256 lowercase SHA-256 digest of the ZIP artifact bytes
+ * @param bundleSizeBytes exact artifact size in bytes
+ * @param bundleType artifact type, currently {@code zip}
+ * @param permissions normalized catalog permission hints
+ */
+public record AppCatalogEntry(
+    String appId,
+    String name,
+    String version,
+    String summary,
+    URI bundleUri,
+    String bundleSha256,
+    long bundleSizeBytes,
+    String bundleType,
+    List<String> permissions) {
+  /** Artifact type supported by PR-195 catalog installs. */
+  public static final String ZIP_BUNDLE_TYPE = "zip";
+
+  private static final Pattern PERMISSION_PATTERN =
+      Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
+
+  /**
+   * Creates a validated catalog entry.
+   *
+   * <p>The canonical constructor applies the same validation used when parsing a signed catalog. It
+   * does not fetch or inspect the artifact; it only validates the catalog's authenticated metadata
+   * so later download and extraction stages can enforce that metadata deterministically.
+   *
+   * @param appId normalized AppHost-compatible application identifier
+   * @param name human-readable application name shown in catalog listings
+   * @param version application version expected in the extracted bundle manifest
+   * @param summary short operator-facing description from the catalog
+   * @param bundleUri absolute local or remote URI for the ZIP bundle artifact
+   * @param bundleSha256 lowercase SHA-256 digest of the ZIP artifact bytes
+   * @param bundleSizeBytes exact artifact size in bytes
+   * @param bundleType artifact type, currently {@code zip}
+   * @param permissions normalized catalog permission hints
+   * @throws AppCatalogException if the entry contains unsupported or unsafe metadata
+   */
+  public AppCatalogEntry {
+    appId = normalizeAppId(appId);
+    name = AppCatalogSidecars.requireNonBlankSingleLine(name, "app." + appId + ".name", code());
+    version =
+        AppCatalogSidecars.requireNonBlankSingleLine(version, "app." + appId + ".version", code());
+    summary =
+        AppCatalogSidecars.requireNonBlankSingleLine(summary, "app." + appId + ".summary", code());
+    bundleUri = AppCatalogSidecars.requireSafeArtifactUri(Objects.requireNonNull(bundleUri));
+    bundleSha256 =
+        AppCatalogSidecars.requireLowercaseSha256(bundleSha256, "app." + appId + ".bundle.sha256");
+    if (bundleSizeBytes < 0L) {
+      throw AppCatalogSidecars.invalidEntry("app." + appId + ".bundle.size.bytes must be >= 0");
+    }
+    if (bundleSizeBytes > AppCatalogSidecars.MAX_ARTIFACT_BYTES) {
+      throw AppCatalogSidecars.invalidEntry(
+          "app." + appId + ".bundle.size.bytes exceeds the safety cap");
+    }
+    bundleType =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+                bundleType, "app." + appId + ".bundle.type", code())
+            .toLowerCase(Locale.ROOT);
+    if (!ZIP_BUNDLE_TYPE.equals(bundleType)) {
+      throw AppCatalogSidecars.invalidEntry(
+          "unsupported app." + appId + ".bundle.type: " + bundleType);
+    }
+    permissions = normalizePermissions(permissions, appId);
+  }
+
+  /**
+   * Normalizes an app id using the signed-bundle manifest rules.
+   *
+   * <p>Catalog entries and extracted signed-bundle manifests must agree on this normalized value
+   * before AppHost receives a staged bundle. This keeps catalog routing, artifact matching, and
+   * local install paths aligned on one path-safe identifier grammar.
+   *
+   * @param appId raw catalog app identifier from metadata or a caller
+   * @return normalized AppHost-compatible identifier
+   * @throws AppCatalogException if the id is not supported by AppHost
+   */
+  public static String normalizeAppId(String appId) throws AppCatalogException {
+    try {
+      return AppBundleManifest.normalizeAppId(appId);
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.getMessage(), exception);
+    }
+  }
+
+  private static String code() {
+    return AppCatalogSidecars.INVALID_CATALOG_ENTRY;
+  }
+
+  private static List<String> normalizePermissions(List<String> permissions, String appId)
+      throws AppCatalogException {
+    Objects.requireNonNull(permissions, "permissions");
+    Set<String> normalized = new LinkedHashSet<>();
+    for (String permission : permissions) {
+      String value =
+          AppCatalogSidecars.requireNonBlankSingleLine(
+                  permission, "app." + appId + ".permissions", code())
+              .toLowerCase(Locale.ROOT);
+      if (!PERMISSION_PATTERN.matcher(value).matches()) {
+        throw AppCatalogSidecars.invalidEntry("invalid permission for app." + appId + ": " + value);
+      }
+      normalized.add(value);
+    }
+    return List.copyOf(normalized);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogException.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogException.java
@@ -1,0 +1,69 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Objects;
+
+/**
+ * Signals signed-catalog, artifact-download, or staged-bundle failures.
+ *
+ * <p>The exception carries a stable machine-readable error code in addition to the operator-facing
+ * message. Platform API handlers use that code to preserve explicit catalog failure contracts
+ * without forcing the lower catalog module to depend on the API response model.
+ *
+ * <p>The catalog package throws this unchecked exception for rejected input and policy failures,
+ * including malformed sidecars, untrusted signatures, disallowed artifact URIs, digest mismatches,
+ * and unsafe ZIP contents. Callers that expose user-facing APIs should map {@link #errorCode()} to
+ * stable response codes and keep the message as a concise diagnostic. Unexpected filesystem
+ * failures may still be reported as {@link java.io.IOException} by methods that declare it.
+ */
+public class AppCatalogException extends RuntimeException {
+  /**
+   * Stable machine-readable code used by API handlers and tests.
+   *
+   * <p>Codes are defined by {@link AppCatalogSidecars} and intentionally remain strings so the
+   * transport-independent catalog module does not depend on the Platform API response classes.
+   */
+  private final String errorCode;
+
+  /**
+   * Creates a catalog exception with a stable error code.
+   *
+   * <p>Use this constructor when the rejection is fully described by the catalog state and no lower
+   * exception needs to be retained. Both parameters are required so API adapters can always expose
+   * a stable code and a short message.
+   *
+   * @param errorCode machine-readable failure code exposed by API adapters
+   * @param message human-readable description of the rejected catalog or artifact state
+   */
+  public AppCatalogException(String errorCode, String message) {
+    super(Objects.requireNonNull(message, "message"));
+    this.errorCode = Objects.requireNonNull(errorCode, "errorCode");
+  }
+
+  /**
+   * Creates a catalog exception with a stable error code and underlying cause.
+   *
+   * <p>Use this constructor when preserving the lower cause helps logs or tests distinguish a
+   * parse, transport, filesystem, or cryptographic failure. API adapters should still use {@link
+   * #errorCode()} rather than inspecting the cause type.
+   *
+   * @param errorCode machine-readable failure code exposed by API adapters
+   * @param message human-readable description of the rejected catalog or artifact state
+   * @param cause parse, filesystem, network, or cryptographic failure that triggered rejection
+   */
+  public AppCatalogException(String errorCode, String message, Throwable cause) {
+    super(Objects.requireNonNull(message, "message"), cause);
+    this.errorCode = Objects.requireNonNull(errorCode, "errorCode");
+  }
+
+  /**
+   * Returns the stable error code for API and test assertions.
+   *
+   * <p>The returned value is intended for exact comparison by tests and API error mappers. It is
+   * not localized and should remain stable across wording changes in exception messages.
+   *
+   * @return machine-readable catalog failure code
+   */
+  public String errorCode() {
+    return errorCode;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetcher.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetcher.java
@@ -1,0 +1,126 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Fetches catalog properties and signature sidecars from local files or HTTP(S).
+ *
+ * <p>The fetcher uses finite JDK {@link HttpClient} timeouts, disables automatic redirects, and
+ * enforces separate byte limits for catalog and signature payloads. Plain HTTP is accepted only for
+ * loopback hosts by the source validation layer; non-local remote catalogs must use HTTPS.
+ *
+ * <p>A source points at {@code cryptad-app-catalog.properties}; the matching signature URI is
+ * resolved as its sibling {@code cryptad-app-catalog.signature}. This class fetches bytes only. It
+ * deliberately does not parse or verify the sidecars so callers can preserve the exact catalog
+ * bytes for signature verification and persistence.
+ */
+public final class AppCatalogFetcher {
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+  private final HttpClient httpClient;
+
+  /**
+   * Creates a fetcher with the default no-redirect JDK HTTP client.
+   *
+   * <p>The default client uses a ten-second connect timeout and rejects redirects. Per-request
+   * timeouts still apply to catalog and signature reads, which keeps a stalled remote source from
+   * blocking catalog operations indefinitely.
+   */
+  public AppCatalogFetcher() {
+    this(
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build());
+  }
+
+  /**
+   * Creates a fetcher with an explicit HTTP client.
+   *
+   * <p>This overload is mainly for deterministic tests and embeddings with already configured
+   * transport. The caller remains responsible for choosing a client whose redirect and proxy
+   * behavior matches the catalog source policy.
+   *
+   * @param httpClient client used for HTTP and HTTPS catalog retrieval
+   */
+  public AppCatalogFetcher(HttpClient httpClient) {
+    this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+  }
+
+  /**
+   * Fetches catalog properties and signature bytes for one source.
+   *
+   * <p>For local sources, both sidecars are read from the filesystem with symbolic-link rejection
+   * and size checks. For remote sources, each sidecar must return HTTP 200 and fit within its
+   * configured byte cap. Transport and response failures are reported as {@code
+   * invalid_catalog_source} so API callers can distinguish bad or unavailable sources from internal
+   * node faults.
+   *
+   * @param source validated catalog source descriptor
+   * @return fetched catalog sidecar bytes, defensively copied by {@link FetchedCatalog}
+   * @throws IOException if filesystem reads fail while checking local catalog sidecars
+   */
+  public FetchedCatalog fetch(AppCatalogSource source) throws IOException {
+    AppCatalogSource checkedSource = Objects.requireNonNull(source, "source");
+    return new FetchedCatalog(
+        fetchBytes(checkedSource.uri(), AppCatalogSidecars.MAX_CATALOG_BYTES, "catalog properties"),
+        fetchBytes(
+            checkedSource.signatureUri(),
+            AppCatalogSidecars.MAX_SIGNATURE_BYTES,
+            "catalog signature"));
+  }
+
+  private byte[] fetchBytes(URI uri, long maxBytes, String description) throws IOException {
+    String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+    if ("file".equals(scheme)) {
+      return AppCatalogSidecars.readRequiredBytes(
+          Path.of(uri), maxBytes, description, AppCatalogSidecars.INVALID_CATALOG_SOURCE);
+    }
+    return fetchRemoteBytes(uri, maxBytes, description);
+  }
+
+  private byte[] fetchRemoteBytes(URI uri, long maxBytes, String description) {
+    HttpRequest request =
+        HttpRequest.newBuilder(uri)
+            .timeout(REQUEST_TIMEOUT)
+            .header("Accept", "text/plain, application/octet-stream")
+            .GET()
+            .build();
+    HttpResponse<InputStream> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+    } catch (IOException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, "failed to fetch " + description, exception);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          "interrupted while fetching " + description,
+          exception);
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, "invalid catalog fetch URI", exception);
+    }
+    try (InputStream input = response.body()) {
+      if (response.statusCode() != 200) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+            "failed to fetch " + description + ": HTTP " + response.statusCode());
+      }
+      return AppCatalogSidecars.readLimitedCatalogSource(input, maxBytes, description);
+    } catch (IOException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, "failed to read " + description, exception);
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogInstallPlan.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogInstallPlan.java
@@ -1,0 +1,65 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Verified temporary staged bundle prepared from a catalog entry.
+ *
+ * <p>The plan owns a scratch directory that contains the downloaded artifact and extracted bundle.
+ * API handlers pass {@link #stagedBundleDirectory()} to AppHost, which copies the bundle into its
+ * managed installation tree. After AppHost returns, callers close the plan to remove catalog
+ * scratch data without affecting the installed copy.
+ *
+ * <p>Instances are returned only after catalog signature verification, artifact digest/size checks,
+ * safe ZIP extraction, signed-bundle verification, and manifest/catalog id matching have succeeded.
+ * The paths are normalized to absolute paths at construction time. The record is immutable, but the
+ * filesystem content it points at remains temporary and must not be exposed as a long-lived app
+ * location.
+ *
+ * @param catalogId catalog that supplied the entry
+ * @param entry catalog entry selected by the caller
+ * @param stagedBundleDirectory extracted signed-bundle root ready for AppHost
+ * @param scratchDirectory scratch directory removed when the plan is closed
+ */
+public record AppCatalogInstallPlan(
+    String catalogId, AppCatalogEntry entry, Path stagedBundleDirectory, Path scratchDirectory)
+    implements AutoCloseable {
+  /**
+   * Creates a verified installation plan.
+   *
+   * <p>The constructor normalizes the catalog id and path fields but does not perform bundle
+   * verification. Normal runtime callers receive plans from {@link AppCatalogManager}, which has
+   * already completed the full verification pipeline.
+   *
+   * @param catalogId catalog that supplied the entry
+   * @param entry catalog entry selected by the caller
+   * @param stagedBundleDirectory extracted signed-bundle root ready for AppHost
+   * @param scratchDirectory scratch directory removed when the plan is closed
+   */
+  public AppCatalogInstallPlan {
+    catalogId = AppCatalog.normalizeCatalogId(catalogId);
+    Objects.requireNonNull(entry, "entry");
+    stagedBundleDirectory =
+        Objects.requireNonNull(stagedBundleDirectory, "stagedBundleDirectory")
+            .toAbsolutePath()
+            .normalize();
+    scratchDirectory =
+        Objects.requireNonNull(scratchDirectory, "scratchDirectory").toAbsolutePath().normalize();
+  }
+
+  /**
+   * Removes the scratch tree associated with the plan.
+   *
+   * <p>Closing the plan is idempotent when the scratch tree has already been removed. A cleanup
+   * failure is reported to the caller so API adapters can log it without changing a successful
+   * install or update response after AppHost has already committed state.
+   *
+   * @throws IOException if the temporary catalog staging tree cannot be removed
+   */
+  @Override
+  public void close() throws IOException {
+    AppCatalogBundleExtractor.deleteRecursively(scratchDirectory);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
@@ -1,0 +1,283 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import network.crypta.platform.appdist.TrustedAppKeys;
+
+/**
+ * Coordinates signed catalog sources, refreshes, artifact staging, and bundle verification.
+ *
+ * <p>The manager owns no global state. Runtime composition supplies the file-backed store and a
+ * trusted-key provider, and API handlers call the manager for catalog operations. Install and
+ * update flows stop at {@link AppCatalogInstallPlan}; callers still delegate final installation to
+ * AppHost so existing staged-directory semantics and verification policies remain intact.
+ *
+ * <p>All public methods are synchronized because they read and update a shared source store and
+ * create scratch directories below the same root. The manager re-reads trusted keys for each
+ * operation through {@link TrustedKeyProvider}, which lets deployments rotate catalog/app signing
+ * keys without recreating the manager. It verifies stored sidecars before listing or selecting
+ * entries, and it never weakens the signed-bundle verification performed by {@code
+ * platform-appdist}.
+ */
+public final class AppCatalogManager {
+  private final AppCatalogSourceStore sourceStore;
+  private final TrustedKeyProvider trustedKeyProvider;
+  private final AppCatalogFetcher fetcher;
+  private final AppCatalogArtifactDownloader artifactDownloader;
+  private final AppCatalogBundleExtractor bundleExtractor;
+
+  /**
+   * Creates a manager with default JDK fetch and download helpers.
+   *
+   * <p>This constructor is the normal runtime entry point. It uses the default no-redirect fetcher,
+   * the default artifact downloader, and the standard ZIP extractor. The supplied store determines
+   * both persistent catalog state and the scratch root used during install/update staging.
+   *
+   * @param sourceStore file-backed catalog source store
+   * @param trustedKeyProvider provider for the current trusted app/catalog keys
+   */
+  public AppCatalogManager(
+      AppCatalogSourceStore sourceStore, TrustedKeyProvider trustedKeyProvider) {
+    this(
+        sourceStore,
+        trustedKeyProvider,
+        new AppCatalogFetcher(),
+        new AppCatalogArtifactDownloader(),
+        new AppCatalogBundleExtractor());
+  }
+
+  /**
+   * Creates a manager with explicit collaborators for tests and controlled embeddings.
+   *
+   * <p>Supplying collaborators keeps network and filesystem edges deterministic in unit tests while
+   * preserving the same orchestration order as production: fetch, verify catalog, download
+   * artifact, extract, verify bundle, then return a plan.
+   *
+   * @param sourceStore file-backed catalog source store
+   * @param trustedKeyProvider provider for the current trusted app/catalog keys
+   * @param fetcher catalog source fetcher
+   * @param artifactDownloader artifact downloader and digest checker
+   * @param bundleExtractor ZIP extractor and signed-bundle verifier
+   */
+  public AppCatalogManager(
+      AppCatalogSourceStore sourceStore,
+      TrustedKeyProvider trustedKeyProvider,
+      AppCatalogFetcher fetcher,
+      AppCatalogArtifactDownloader artifactDownloader,
+      AppCatalogBundleExtractor bundleExtractor) {
+    this.sourceStore = Objects.requireNonNull(sourceStore, "sourceStore");
+    this.trustedKeyProvider = Objects.requireNonNull(trustedKeyProvider, "trustedKeyProvider");
+    this.fetcher = Objects.requireNonNull(fetcher, "fetcher");
+    this.artifactDownloader = Objects.requireNonNull(artifactDownloader, "artifactDownloader");
+    this.bundleExtractor = Objects.requireNonNull(bundleExtractor, "bundleExtractor");
+  }
+
+  /**
+   * Lists all configured catalogs after re-verifying stored sidecars.
+   *
+   * <p>The returned snapshots are built from authenticated catalog bytes stored on disk. If a
+   * stored signature becomes invalid under the current trusted-key policy, the listing fails rather
+   * than returning stale metadata from a previous verification.
+   *
+   * @return source snapshots sorted by catalog id
+   * @throws IOException if stored catalog state cannot be read
+   */
+  public synchronized List<AppCatalogSourceSnapshot> listCatalogs() throws IOException {
+    TrustedAppKeys trustedKeys = trustedKeyProvider.trustedKeys();
+    return sourceStore.list().stream()
+        .map(stored -> snapshot(stored, trustedKeys))
+        .sorted(java.util.Comparator.comparing(AppCatalogSourceSnapshot::catalogId))
+        .toList();
+  }
+
+  /**
+   * Adds a catalog source and immediately verifies its signed catalog.
+   *
+   * <p>The source is fetched before it is persisted. A catalog id conflict is checked after
+   * signature verification so an attacker cannot reserve an id with unsigned or malformed content.
+   * Successful additions persist the exact fetched sidecar bytes, not a reserialized catalog model.
+   *
+   * @param rawSource operator-supplied source path or URI
+   * @return stored source snapshot for the new catalog
+   * @throws IOException if fetch, signature verification, or persistence fails
+   */
+  public synchronized AppCatalogSourceSnapshot addSource(String rawSource) throws IOException {
+    AppCatalogSource source = AppCatalogSource.parse(rawSource);
+    TrustedAppKeys trustedKeys = trustedKeyProvider.trustedKeys();
+    FetchedCatalog fetched = fetcher.fetch(source);
+    AppCatalog catalog =
+        AppCatalogVerifier.verify(fetched.catalogBytes(), fetched.signatureBytes(), trustedKeys);
+    if (sourceStore.exists(catalog.catalogId())) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.CATALOG_CONFLICT,
+          "Catalog already configured: " + catalog.catalogId());
+    }
+    Instant now = Instant.now();
+    sourceStore.write(catalog, source, fetched, now, now);
+    return AppCatalogSourceSnapshot.of(catalog, source, now, now);
+  }
+
+  /**
+   * Removes a configured catalog source.
+   *
+   * <p>Removal affects only the configured source and cached catalog sidecars. Apps already
+   * installed from the catalog are left in AppHost and must be managed through app lifecycle APIs.
+   *
+   * @param catalogId catalog id to remove
+   * @throws IOException if the source is missing or cannot be deleted
+   */
+  public synchronized void remove(String catalogId) throws IOException {
+    sourceStore.remove(normalizeCatalogIdForLookup(catalogId));
+  }
+
+  /**
+   * Refreshes one configured catalog source.
+   *
+   * <p>Refresh reuses the stored source URI and preserves the original local {@code addedAt}
+   * timestamp. The newly fetched catalog must authenticate to the same normalized catalog id;
+   * otherwise the refresh is rejected and the previous stored sidecars remain in place.
+   *
+   * @param catalogId catalog id to refresh
+   * @return updated source snapshot after successful verification
+   * @throws IOException if fetch, verification, or persistence fails
+   */
+  public synchronized AppCatalogSourceSnapshot refresh(String catalogId) throws IOException {
+    String normalizedCatalogId = normalizeCatalogIdForLookup(catalogId);
+    StoredCatalogSource stored = sourceStore.read(normalizedCatalogId);
+    TrustedAppKeys trustedKeys = trustedKeyProvider.trustedKeys();
+    FetchedCatalog fetched = fetcher.fetch(stored.source());
+    AppCatalog catalog =
+        AppCatalogVerifier.verify(fetched.catalogBytes(), fetched.signatureBytes(), trustedKeys);
+    if (!normalizedCatalogId.equals(catalog.catalogId())) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "refreshed catalog id does not match configured source: " + normalizedCatalogId);
+    }
+    Instant refreshedAt = Instant.now();
+    sourceStore.write(catalog, stored.source(), fetched, stored.addedAt(), refreshedAt);
+    return AppCatalogSourceSnapshot.of(catalog, stored.source(), stored.addedAt(), refreshedAt);
+  }
+
+  /**
+   * Lists apps from a configured catalog.
+   *
+   * <p>The catalog is read and verified on each call. The result preserves {@code catalog.entries}
+   * order so UI and API clients can display entries deterministically without re-sorting.
+   *
+   * @param catalogId catalog id to read
+   * @return entries in catalog-declared deterministic order
+   * @throws IOException if the catalog is missing or fails verification
+   */
+  public synchronized List<AppCatalogEntry> listApps(String catalogId) throws IOException {
+    return readVerifiedCatalog(catalogId).entries();
+  }
+
+  /**
+   * Returns one catalog app entry.
+   *
+   * <p>The app id is normalized using the same rules as signed app manifests. Missing catalogs and
+   * missing apps remain distinct error codes so API adapters can return stable {@code
+   * catalog_not_found} or {@code app_not_found} responses.
+   *
+   * @param catalogId catalog id to read
+   * @param appId app id to select
+   * @return selected catalog entry
+   * @throws IOException if catalog state cannot be read
+   */
+  public synchronized AppCatalogEntry getApp(String catalogId, String appId) throws IOException {
+    return readVerifiedCatalog(catalogId)
+        .entry(appId)
+        .orElseThrow(
+            () ->
+                new AppCatalogException(
+                    AppCatalogSidecars.APP_NOT_FOUND, "Catalog app not found."));
+  }
+
+  /**
+   * Downloads, extracts, and verifies one app bundle from a catalog.
+   *
+   * <p>The returned plan is the only output of the catalog install/update preparation path. The
+   * method verifies the catalog entry, downloads the declared artifact, checks size and SHA-256,
+   * extracts the ZIP safely, verifies the extracted signed bundle, and confirms manifest id/version
+   * match the catalog. If any step fails, the per-operation scratch tree is removed before the
+   * failure is rethrown.
+   *
+   * @param catalogId catalog id containing the app
+   * @param appId catalog app id to prepare
+   * @return temporary installation plan whose staged directory can be passed to AppHost
+   * @throws IOException if catalog lookup, download, extraction, or bundle verification fails
+   */
+  public synchronized AppCatalogInstallPlan prepareInstallPlan(String catalogId, String appId)
+      throws IOException {
+    String normalizedCatalogId = normalizeCatalogIdForLookup(catalogId);
+    AppCatalogEntry entry = getApp(normalizedCatalogId, appId);
+    Path stagingDirectory = sourceStore.stagingDirectory();
+    Files.createDirectories(stagingDirectory);
+    Path scratchRoot = Files.createTempDirectory(stagingDirectory, normalizedCatalogId + "-");
+    try {
+      Path artifactZip = artifactDownloader.download(entry, scratchRoot);
+      Path stagedBundle =
+          bundleExtractor.extract(
+              entry, artifactZip, scratchRoot, trustedKeyProvider.trustedKeys());
+      return new AppCatalogInstallPlan(normalizedCatalogId, entry, stagedBundle, scratchRoot);
+    } catch (IOException | RuntimeException exception) {
+      AppCatalogBundleExtractor.deleteRecursively(scratchRoot);
+      throw exception;
+    }
+  }
+
+  private AppCatalog readVerifiedCatalog(String catalogId) throws IOException {
+    StoredCatalogSource stored = sourceStore.read(normalizeCatalogIdForLookup(catalogId));
+    return verifyStoredCatalog(stored, trustedKeyProvider.trustedKeys());
+  }
+
+  private static AppCatalogSourceSnapshot snapshot(
+      StoredCatalogSource stored, TrustedAppKeys trustedKeys) {
+    AppCatalog catalog = verifyStoredCatalog(stored, trustedKeys);
+    return AppCatalogSourceSnapshot.of(
+        catalog, stored.source(), stored.addedAt(), stored.refreshedAt());
+  }
+
+  private static AppCatalog verifyStoredCatalog(
+      StoredCatalogSource stored, TrustedAppKeys trustedKeys) {
+    return AppCatalogVerifier.verify(
+        stored.fetchedCatalog().catalogBytes(),
+        stored.fetchedCatalog().signatureBytes(),
+        trustedKeys);
+  }
+
+  private static String normalizeCatalogIdForLookup(String catalogId) {
+    try {
+      return AppCatalog.normalizeCatalogId(catalogId);
+    } catch (AppCatalogException _) {
+      throw new AppCatalogException(AppCatalogSidecars.CATALOG_NOT_FOUND, "Catalog not found.");
+    }
+  }
+
+  /**
+   * Supplies the trusted keys used for catalog and bundle verification.
+   *
+   * <p>Runtime wiring can reload key files on each operation by implementing this provider as a
+   * small adapter over the same trusted-key configuration used by AppHost bundle verification.
+   * Implementations should be side-effect-light because the manager calls them while holding its
+   * monitor.
+   */
+  @FunctionalInterface
+  public interface TrustedKeyProvider {
+    /**
+     * Returns the current trusted app/catalog keys.
+     *
+     * <p>The returned registry is used for both catalog signature verification and extracted bundle
+     * verification. Returning an empty or stale registry makes signed catalog operations fail
+     * closed.
+     *
+     * @return immutable trusted-key registry
+     * @throws IOException if key material cannot be loaded from runtime configuration
+     */
+    TrustedAppKeys trustedKeys() throws IOException;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogParser.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogParser.java
@@ -1,0 +1,158 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Strict parser for {@code cryptad-app-catalog.properties}.
+ *
+ * <p>The parser accepts the deterministic key/value sidecar format used by app distribution
+ * metadata. It rejects duplicate keys, unsupported schema versions, missing fields, unknown
+ * properties, unsafe artifact URIs, invalid hashes, and out-of-order or duplicate entry
+ * declarations before any catalog entry can drive an artifact download.
+ *
+ * <p>The parser is intentionally not a general Java {@link java.util.Properties} reader. It keeps
+ * duplicate-key detection, preserves the order from {@code catalog.entries}, and fails closed on
+ * unknown fields until the catalog format grows explicit forward-compatibility rules. Signature
+ * verification happens outside this class; callers should parse only bytes that have already been
+ * authenticated by {@link AppCatalogVerifier}.
+ */
+public final class AppCatalogParser {
+  private AppCatalogParser() {}
+
+  /**
+   * Parses catalog properties from exact UTF-8 bytes.
+   *
+   * <p>The input bytes are decoded as UTF-8, parsed as strict {@code key=value} lines, and
+   * converted to immutable catalog records. Entry ids are normalized in the order declared by
+   * {@code catalog.entries}; each entry must then declare the same normalized id in its {@code
+   * app.*.id} field.
+   *
+   * @param catalogBytes bytes read from {@code cryptad-app-catalog.properties}
+   * @return validated immutable catalog content
+   * @throws AppCatalogException if the catalog is malformed or unsupported
+   */
+  public static AppCatalog parse(byte[] catalogBytes) throws AppCatalogException {
+    Map<String, String> properties =
+        AppCatalogSidecars.parseKeyValueSidecar(AppCatalogSidecars.utf8(catalogBytes), "catalog");
+    int version = parseVersion(removeRequired(properties, "catalog.version"));
+    String catalogId = removeRequired(properties, "catalog.id");
+    String catalogName = removeRequired(properties, "catalog.name");
+    Instant generatedAt = parseInstant(removeRequired(properties, "catalog.generatedAt"));
+    List<String> entryIds = parseEntryIds(removeRequired(properties, "catalog.entries"));
+    List<AppCatalogEntry> entries = new ArrayList<>(entryIds.size());
+    for (String appId : entryIds) {
+      entries.add(parseEntry(properties, appId));
+    }
+    if (!properties.isEmpty()) {
+      throw AppCatalogSidecars.invalidEntry(
+          "unsupported catalog property: " + properties.keySet().iterator().next());
+    }
+    return new AppCatalog(version, catalogId, catalogName, generatedAt, entries);
+  }
+
+  private static int parseVersion(String versionText) throws AppCatalogException {
+    try {
+      int version = Integer.parseInt(versionText);
+      if (version != 1) {
+        throw AppCatalogSidecars.invalidEntry("unsupported catalog.version: " + version);
+      }
+      return version;
+    } catch (NumberFormatException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid catalog.version: " + versionText,
+          exception);
+    }
+  }
+
+  private static Instant parseInstant(String text) throws AppCatalogException {
+    try {
+      return Instant.parse(text);
+    } catch (DateTimeParseException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid catalog.generatedAt: " + text,
+          exception);
+    }
+  }
+
+  private static List<String> parseEntryIds(String rawEntries) throws AppCatalogException {
+    if (rawEntries.isBlank()) {
+      return List.of();
+    }
+    Set<String> entryIds = new LinkedHashSet<>();
+    for (String token : rawEntries.split(",", -1)) {
+      String normalized = AppCatalogEntry.normalizeAppId(token);
+      if (!entryIds.add(normalized)) {
+        throw AppCatalogSidecars.invalidEntry("duplicate catalog.entries app id: " + normalized);
+      }
+    }
+    return List.copyOf(entryIds);
+  }
+
+  private static AppCatalogEntry parseEntry(Map<String, String> properties, String appId)
+      throws AppCatalogException {
+    String prefix = "app." + appId + ".";
+    String declaredId = removeRequired(properties, prefix + "id");
+    String normalizedDeclaredId = AppCatalogEntry.normalizeAppId(declaredId);
+    if (!appId.equals(normalizedDeclaredId)) {
+      throw AppCatalogSidecars.invalidEntry(
+          "catalog.entries id does not match app." + appId + ".id");
+    }
+    try {
+      return new AppCatalogEntry(
+          declaredId,
+          removeRequired(properties, prefix + "name"),
+          removeRequired(properties, prefix + "version"),
+          removeRequired(properties, prefix + "summary"),
+          URI.create(removeRequired(properties, prefix + "bundle.uri")),
+          removeRequired(properties, prefix + "bundle.sha256"),
+          parseSize(removeRequired(properties, prefix + "bundle.size.bytes"), appId),
+          removeRequired(properties, prefix + "bundle.type"),
+          parsePermissions(removeRequired(properties, prefix + "permissions")));
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid app." + appId + ".bundle.uri",
+          exception);
+    }
+  }
+
+  private static long parseSize(String sizeText, String appId) throws AppCatalogException {
+    try {
+      return Long.parseLong(sizeText);
+    } catch (NumberFormatException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid app." + appId + ".bundle.size.bytes: " + sizeText,
+          exception);
+    }
+  }
+
+  private static List<String> parsePermissions(String rawPermissions) {
+    if (rawPermissions.isBlank()) {
+      return List.of();
+    }
+    List<String> permissions = new ArrayList<>();
+    for (String permission : rawPermissions.split(",", -1)) {
+      permissions.add(permission.trim());
+    }
+    return permissions;
+  }
+
+  private static String removeRequired(Map<String, String> properties, String key)
+      throws AppCatalogException {
+    String value = properties.remove(key);
+    if (value == null) {
+      throw AppCatalogSidecars.invalidEntry("missing " + key);
+    }
+    return value;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
@@ -357,9 +357,14 @@ final class AppCatalogSidecars {
           return;
         }
       }
-      default -> throw new IllegalStateException("Unexpected value: " + normalizedScheme);
+      default -> throw unsupportedScheme(errorCode, fieldName, scheme);
     }
-    throw new AppCatalogException(errorCode, "unsupported " + fieldName + " scheme: " + scheme);
+    throw unsupportedScheme(errorCode, fieldName, scheme);
+  }
+
+  private static AppCatalogException unsupportedScheme(
+      String errorCode, String fieldName, String scheme) {
+    return new AppCatalogException(errorCode, "unsupported " + fieldName + " scheme: " + scheme);
   }
 
   /**

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
@@ -1,0 +1,490 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import network.crypta.platform.appdist.AppBundleDigest;
+
+/**
+ * Shared sidecar parsing, URI policy, digest, and error-code helpers for app catalogs.
+ *
+ * <p>This class keeps the low-level catalog format rules in one package-private place so parser,
+ * fetcher, verifier, downloader, and source-store code report the same stable error codes. It is
+ * not a generic properties or URI utility. The helpers are tuned for signed catalog sidecars and
+ * catalog artifacts: exact UTF-8 bytes, duplicate-key rejection, bounded reads, local-file
+ * restrictions, HTTPS by default, loopback-only HTTP, and lowercase SHA-256 artifact digests.
+ */
+final class AppCatalogSidecars {
+  /** Error code used when an operator-configured catalog source cannot be used safely. */
+  static final String INVALID_CATALOG_SOURCE = "invalid_catalog_source";
+
+  /** Error code used when catalog signature metadata or verification fails. */
+  static final String INVALID_CATALOG_SIGNATURE = "invalid_catalog_signature";
+
+  /** Error code used when authenticated catalog entry metadata is malformed. */
+  static final String INVALID_CATALOG_ENTRY = "invalid_catalog_entry";
+
+  /** Error code used when a catalog artifact cannot be retrieved or read. */
+  static final String ARTIFACT_DOWNLOAD_FAILED = "artifact_download_failed";
+
+  /** Error code used when artifact size or SHA-256 does not match catalog metadata. */
+  static final String ARTIFACT_DIGEST_MISMATCH = "artifact_digest_mismatch";
+
+  /** Error code used when an extracted artifact is not a valid signed app bundle. */
+  static final String INVALID_APP_BUNDLE = "invalid_app_bundle";
+
+  /** Error code used when a configured catalog id is not present in the source store. */
+  static final String CATALOG_NOT_FOUND = "catalog_not_found";
+
+  /** Error code used when adding a catalog whose authenticated id is already configured. */
+  static final String CATALOG_CONFLICT = "catalog_conflict";
+
+  /** Error code used when a verified catalog does not contain the requested app id. */
+  static final String APP_NOT_FOUND = "app_not_found";
+
+  /** Maximum accepted catalog properties sidecar size, in bytes. */
+  static final long MAX_CATALOG_BYTES = 1024L * 1024L;
+
+  /** Maximum accepted catalog signature sidecar size, in bytes. */
+  static final long MAX_SIGNATURE_BYTES = 64L * 1024L;
+
+  /** Maximum accepted ZIP artifact and extracted payload size, in bytes. */
+  static final long MAX_ARTIFACT_BYTES = 512L * 1024L * 1024L;
+
+  /** Optional UTF-8 byte-order mark accepted only at the start of text sidecars. */
+  private static final char UTF_8_BOM = '\uFEFF';
+
+  /** Strict lowercase hexadecimal SHA-256 digest grammar for catalog artifact metadata. */
+  private static final Pattern LOWERCASE_SHA256_PATTERN = Pattern.compile("[0-9a-f]{64}");
+
+  /** Prevents construction; all helpers are stateless and package-private. */
+  private AppCatalogSidecars() {}
+
+  /**
+   * Parses a strict key/value sidecar into insertion-ordered properties.
+   *
+   * <p>Blank lines and comment lines beginning with {@code #} or {@code !} are ignored. Every other
+   * line must contain a non-empty key before the first {@code =}. Duplicate keys are rejected so
+   * signature and catalog parsers cannot silently accept ambiguous metadata.
+   *
+   * @param content UTF-8 decoded sidecar content, optionally starting with a BOM
+   * @param description short sidecar name used in error messages
+   * @return insertion-ordered key/value map without duplicate keys
+   * @throws AppCatalogException if the sidecar line grammar is invalid
+   */
+  static Map<String, String> parseKeyValueSidecar(String content, String description)
+      throws AppCatalogException {
+    Objects.requireNonNull(content, "content");
+    Map<String, String> properties = new LinkedHashMap<>();
+    String[] lines = stripLeadingBom(content).split("\\R", -1);
+    for (String line : lines) {
+      if (line.isEmpty() || line.startsWith("#") || line.startsWith("!")) {
+        continue;
+      }
+      int separatorIndex = line.indexOf('=');
+      if (separatorIndex < 0) {
+        throw invalidEntry("invalid " + description + " line: " + line);
+      }
+      String key = line.substring(0, separatorIndex).trim();
+      if (key.isEmpty()) {
+        throw invalidEntry("invalid " + description + " line: " + line);
+      }
+      String value = line.substring(separatorIndex + 1);
+      String previous = properties.putIfAbsent(key, value);
+      if (previous != null) {
+        throw invalidEntry("duplicate " + description + " property: " + key);
+      }
+    }
+    return properties;
+  }
+
+  /**
+   * Reads a required local sidecar file after symlink, regular-file, and size checks.
+   *
+   * <p>The path is normalized before inspection, symbolic links are rejected, and the file must fit
+   * within the caller-provided byte limit. This protects catalog metadata reads from unexpectedly
+   * following host-owned links or consuming unbounded memory.
+   *
+   * @param file sidecar file path supplied by the fetcher or source store
+   * @param maxBytes maximum accepted byte length
+   * @param description short file description used in error messages
+   * @param errorCode catalog error code to attach to validation failures
+   * @return complete file contents
+   * @throws IOException if the file cannot be read after validation
+   */
+  static byte[] readRequiredBytes(Path file, long maxBytes, String description, String errorCode)
+      throws IOException {
+    Path normalized = Objects.requireNonNull(file, "file").toAbsolutePath().normalize();
+    if (Files.isSymbolicLink(normalized)) {
+      throw new AppCatalogException(errorCode, description + " must not be a symbolic link");
+    }
+    if (!Files.isRegularFile(normalized, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppCatalogException(errorCode, "missing " + description);
+    }
+    long size = Files.size(normalized);
+    if (size > maxBytes) {
+      throw new AppCatalogException(errorCode, description + " exceeds the allowed size");
+    }
+    return Files.readAllBytes(normalized);
+  }
+
+  /**
+   * Reads bounded sidecar bytes from a remote response stream.
+   *
+   * <p>The method consumes the stream incrementally and fails as soon as the configured byte cap is
+   * exceeded. It is used for catalog properties and signature sidecars, not for large ZIP
+   * artifacts.
+   *
+   * @param input response stream to consume
+   * @param maxBytes maximum accepted byte length
+   * @param description short payload description used in error messages
+   * @return bytes read from the stream
+   * @throws IOException if the stream cannot be read
+   */
+  static byte[] readLimitedCatalogSource(InputStream input, long maxBytes, String description)
+      throws IOException {
+    Objects.requireNonNull(input, "input");
+    byte[] buffer = new byte[64 * 1024];
+    try (var output = new ByteArrayOutputStream()) {
+      long totalBytes = 0L;
+      int bytesRead;
+      while ((bytesRead = input.read(buffer)) >= 0) {
+        if (bytesRead == 0) {
+          continue;
+        }
+        totalBytes += bytesRead;
+        if (totalBytes > maxBytes) {
+          throw new AppCatalogException(
+              INVALID_CATALOG_SOURCE, description + " exceeds the allowed size");
+        }
+        output.write(buffer, 0, bytesRead);
+      }
+      return output.toByteArray();
+    }
+  }
+
+  /**
+   * Decodes sidecar bytes as UTF-8 text.
+   *
+   * @param bytes exact sidecar bytes read from disk or network
+   * @return decoded UTF-8 string
+   */
+  static String utf8(byte[] bytes) {
+    return new String(Objects.requireNonNull(bytes, "bytes"), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Requires a non-blank single-line metadata value.
+   *
+   * <p>The returned value is trimmed, but embedded line breaks are rejected so sidecar fields
+   * cannot smuggle additional properties or multi-line display text into deterministic catalog
+   * files.
+   *
+   * @param value raw metadata value
+   * @param fieldName field name used in diagnostics
+   * @param errorCode catalog error code to attach to validation failures
+   * @return trimmed single-line value
+   * @throws AppCatalogException if the value is blank or multi-line
+   */
+  static String requireNonBlankSingleLine(String value, String fieldName, String errorCode)
+      throws AppCatalogException {
+    Objects.requireNonNull(value, fieldName);
+    if (value.isBlank()) {
+      throw new AppCatalogException(errorCode, fieldName + " must not be blank");
+    }
+    if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+      throw new AppCatalogException(errorCode, fieldName + " must be a single line");
+    }
+    return value.trim();
+  }
+
+  /**
+   * Requires a lowercase SHA-256 digest string.
+   *
+   * @param value raw digest text from catalog metadata
+   * @param fieldName field name used in diagnostics
+   * @return validated lowercase 64-character hexadecimal digest
+   * @throws AppCatalogException if the digest is missing or malformed
+   */
+  static String requireLowercaseSha256(String value, String fieldName) throws AppCatalogException {
+    String normalized = requireNonBlankSingleLine(value, fieldName, INVALID_CATALOG_ENTRY);
+    if (!LOWERCASE_SHA256_PATTERN.matcher(normalized).matches()) {
+      throw invalidEntry(fieldName + " must be lowercase SHA-256 hex");
+    }
+    return normalized;
+  }
+
+  /**
+   * Validates and normalizes a catalog source URI.
+   *
+   * @param uri source URI for {@code cryptad-app-catalog.properties}
+   * @return normalized source URI accepted by catalog fetch policy
+   * @throws AppCatalogException if the URI is not absolute or uses an unsupported scheme
+   */
+  static URI requireSafeCatalogSourceUri(URI uri) throws AppCatalogException {
+    URI normalized = normalizeUri(uri, INVALID_CATALOG_SOURCE, "catalog source URI");
+    requireSupportedScheme(normalized, INVALID_CATALOG_SOURCE, "catalog source URI");
+    return normalized;
+  }
+
+  /**
+   * Validates and normalizes an artifact URI from authenticated catalog metadata.
+   *
+   * @param uri bundle artifact URI from a catalog entry
+   * @return normalized artifact URI accepted by artifact download policy
+   * @throws AppCatalogException if the URI is not absolute or uses an unsupported scheme
+   */
+  static URI requireSafeArtifactUri(URI uri) throws AppCatalogException {
+    URI normalized = normalizeUri(uri, INVALID_CATALOG_ENTRY, "artifact URI");
+    requireSupportedScheme(normalized, INVALID_CATALOG_ENTRY, "artifact URI");
+    return normalized;
+  }
+
+  /**
+   * Creates an SHA-256 digest using the appdist digest algorithm constant.
+   *
+   * @return initialized digest for artifact streaming
+   * @throws AppCatalogException if the current JDK cannot provide SHA-256
+   */
+  static MessageDigest newArtifactSha256Digest() throws AppCatalogException {
+    try {
+      return MessageDigest.getInstance(AppBundleDigest.DIGEST_ALGORITHM);
+    } catch (NoSuchAlgorithmException exception) {
+      throw new AppCatalogException(
+          ARTIFACT_DIGEST_MISMATCH, "SHA-256 is not supported by the current JDK", exception);
+    }
+  }
+
+  /**
+   * Encodes bytes as lowercase hexadecimal text.
+   *
+   * @param bytes bytes to encode
+   * @return lowercase hexadecimal representation with two characters per byte
+   */
+  static String lowercaseHex(byte[] bytes) {
+    StringBuilder builder = new StringBuilder(bytes.length * 2);
+    for (byte value : bytes) {
+      builder.append(Character.forDigit((value >>> 4) & 0x0F, 16));
+      builder.append(Character.forDigit(value & 0x0F, 16));
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Creates an invalid-entry exception.
+   *
+   * @param message diagnostic message for the rejected catalog entry state
+   * @return catalog exception tagged with {@link #INVALID_CATALOG_ENTRY}
+   */
+  static AppCatalogException invalidEntry(String message) {
+    return new AppCatalogException(INVALID_CATALOG_ENTRY, message);
+  }
+
+  /**
+   * Creates an invalid-signature exception.
+   *
+   * @param message diagnostic message for the rejected signature state
+   * @return catalog exception tagged with {@link #INVALID_CATALOG_SIGNATURE}
+   */
+  static AppCatalogException invalidSignature(String message) {
+    return new AppCatalogException(INVALID_CATALOG_SIGNATURE, message);
+  }
+
+  /**
+   * Normalizes and checks URI invariants shared by source and artifact URIs.
+   *
+   * @param uri URI to normalize
+   * @param errorCode catalog error code for validation failures
+   * @param fieldName field name used in diagnostics
+   * @return normalized absolute URI without fragments or user info
+   * @throws AppCatalogException if the URI is not safe to store or fetch
+   */
+  private static URI normalizeUri(URI uri, String errorCode, String fieldName)
+      throws AppCatalogException {
+    Objects.requireNonNull(uri, fieldName);
+    if (!uri.isAbsolute()) {
+      throw new AppCatalogException(errorCode, fieldName + " must be absolute");
+    }
+    if (uri.getFragment() != null) {
+      throw new AppCatalogException(errorCode, fieldName + " must not include a fragment");
+    }
+    if (uri.getUserInfo() != null) {
+      throw new AppCatalogException(errorCode, fieldName + " must not include user info");
+    }
+    return uri.normalize();
+  }
+
+  /**
+   * Applies catalog transport scheme policy to a normalized URI.
+   *
+   * @param uri absolute URI to validate
+   * @param errorCode catalog error code for validation failures
+   * @param fieldName field name used in diagnostics
+   * @throws AppCatalogException if the URI scheme is unsupported or unsafe
+   */
+  private static void requireSupportedScheme(URI uri, String errorCode, String fieldName)
+      throws AppCatalogException {
+    String scheme = uri.getScheme();
+    if (scheme == null) {
+      throw new AppCatalogException(errorCode, fieldName + " must include a URI scheme");
+    }
+    String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
+    switch (normalizedScheme) {
+      case "https" -> {
+        requireRemoteHttpUri(uri, errorCode, fieldName);
+        return;
+      }
+      case "file" -> {
+        requireLocalFileUri(uri, errorCode, fieldName);
+        return;
+      }
+      case "http" -> {
+        requireRemoteHttpUri(uri, errorCode, fieldName);
+        if (isLocalhost(uri.getHost())) {
+          return;
+        }
+      }
+      default -> throw new IllegalStateException("Unexpected value: " + normalizedScheme);
+    }
+    throw new AppCatalogException(errorCode, "unsupported " + fieldName + " scheme: " + scheme);
+  }
+
+  /**
+   * Requires an HTTP(S) URI with a concrete authority host.
+   *
+   * @param uri URI whose scheme is {@code http} or {@code https}
+   * @param errorCode catalog error code for validation failures
+   * @param fieldName field name used in diagnostics
+   */
+  private static void requireRemoteHttpUri(URI uri, String errorCode, String fieldName) {
+    if (uri.isOpaque() || uri.getHost() == null || uri.getHost().isBlank()) {
+      throw new AppCatalogException(errorCode, fieldName + " must include a host");
+    }
+  }
+
+  /**
+   * Requires a hierarchical local {@code file:} URI that can be converted to a path.
+   *
+   * @param uri URI whose scheme is {@code file}
+   * @param errorCode catalog error code for validation failures
+   * @param fieldName field name used in diagnostics
+   * @throws AppCatalogException if the URI is opaque, remote, query-bearing, or path-invalid
+   */
+  private static void requireLocalFileUri(URI uri, String errorCode, String fieldName)
+      throws AppCatalogException {
+    if (uri.isOpaque()
+        || uri.getPath() == null
+        || uri.getPath().isBlank()
+        || uri.getAuthority() != null
+        || uri.getQuery() != null) {
+      throw new AppCatalogException(errorCode, fieldName + " must be a local file URI");
+    }
+    try {
+      Path localPath = Path.of(uri);
+      if (!localPath.isAbsolute()) {
+        throw new IllegalArgumentException("file URI path must be absolute");
+      }
+    } catch (IllegalArgumentException | FileSystemNotFoundException exception) {
+      throw new AppCatalogException(errorCode, fieldName + " must be a local file URI", exception);
+    }
+  }
+
+  /**
+   * Returns whether a host name is explicitly local enough for plaintext HTTP.
+   *
+   * @param host host component from a URI
+   * @return {@code true} for {@code localhost}, numeric IPv4 127/8, or IPv6 loopback literals
+   */
+  private static boolean isLocalhost(String host) {
+    if (host == null) {
+      return false;
+    }
+    String normalized = stripIpv6Brackets(host.toLowerCase(Locale.ROOT));
+    return "localhost".equals(normalized)
+        || isIpv4LoopbackLiteral(normalized)
+        || "::1".equals(normalized)
+        || "0:0:0:0:0:0:0:1".equals(normalized);
+  }
+
+  /**
+   * Removes square brackets from an IPv6 host literal when present.
+   *
+   * @param host lower-case host text
+   * @return host text without surrounding IPv6 brackets
+   */
+  private static String stripIpv6Brackets(String host) {
+    if (host.length() >= 2 && host.charAt(0) == '[' && host.charAt(host.length() - 1) == ']') {
+      return host.substring(1, host.length() - 1);
+    }
+    return host;
+  }
+
+  /**
+   * Checks for a dotted-decimal IPv4 loopback literal in 127/8.
+   *
+   * @param host lower-case host text without URI brackets
+   * @return {@code true} when all four octets are decimal and the first octet is {@code 127}
+   */
+  private static boolean isIpv4LoopbackLiteral(String host) {
+    String[] octets = host.split("\\.", -1);
+    if (octets.length != 4 || !"127".equals(octets[0])) {
+      return false;
+    }
+    for (String octet : octets) {
+      if (!isDecimalIpv4Octet(octet)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Validates one decimal IPv4 octet.
+   *
+   * @param octet octet text from a dotted IPv4 literal
+   * @return {@code true} when the octet is decimal and within {@code 0..255}
+   */
+  private static boolean isDecimalIpv4Octet(String octet) {
+    if (octet.isEmpty()) {
+      return false;
+    }
+    int value = 0;
+    for (int i = 0; i < octet.length(); i++) {
+      char digit = octet.charAt(i);
+      if (digit < '0' || digit > '9') {
+        return false;
+      }
+      value = value * 10 + digit - '0';
+      if (value > 255) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Removes one leading UTF-8 BOM character from decoded sidecar text.
+   *
+   * @param content decoded sidecar content
+   * @return content without a leading BOM, if one was present
+   */
+  private static String stripLeadingBom(String content) {
+    if (!content.isEmpty() && content.charAt(0) == UTF_8_BOM) {
+      return content.substring(1);
+    }
+    return content;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSignature.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSignature.java
@@ -1,0 +1,117 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Base64;
+import java.util.Objects;
+import network.crypta.platform.appdist.AppBundleSignature;
+
+/**
+ * Parsed or generated signature sidecar for a signed app catalog.
+ *
+ * <p>The signature authenticates the exact bytes of {@code cryptad-app-catalog.properties}. The
+ * catalog verifier checks this sidecar before parsing catalog entries, so a rewrite of either the
+ * entry metadata or the signer metadata fails before any artifact URL is trusted.
+ *
+ * <p>The sidecar format is intentionally small and deterministic. Version {@value
+ * #SIGNATURE_VERSION} supports Ed25519 only, identifies the trusted public key by {@code keyId},
+ * and requires the payload field to name the canonical catalog properties file. The record
+ * validates base64 syntax but does not verify the signature value; {@link AppCatalogVerifier}
+ * performs trust lookup and cryptographic verification against the exact catalog bytes.
+ *
+ * @param version signature schema version, currently {@code 1}
+ * @param algorithm signature algorithm, currently JDK {@code Ed25519}
+ * @param keyId stable trusted-key identifier used to select the public key
+ * @param payload payload filename authenticated by the signature
+ * @param valueBase64 base64-encoded signature bytes
+ */
+public record AppCatalogSignature(
+    int version, String algorithm, String keyId, String payload, String valueBase64) {
+  /**
+   * Canonical catalog properties filename.
+   *
+   * <p>The signature sidecar must name this file as its payload so verifiers never need to infer or
+   * accept alternate payload names.
+   */
+  public static final String CATALOG_FILE_NAME = "cryptad-app-catalog.properties";
+
+  /**
+   * Canonical catalog signature filename.
+   *
+   * <p>Catalog sources resolve this file as the sibling of {@link #CATALOG_FILE_NAME}.
+   */
+  public static final String SIGNATURE_FILE_NAME = "cryptad-app-catalog.signature";
+
+  /**
+   * Current catalog signature sidecar schema version.
+   *
+   * <p>Unsupported versions are rejected before key lookup or signature verification.
+   */
+  public static final int SIGNATURE_VERSION = 1;
+
+  /**
+   * Supported signature algorithm for catalog sidecars.
+   *
+   * <p>This matches signed app bundles so operators can reuse the same trusted-key configuration
+   * for catalog and bundle verification.
+   */
+  public static final String SIGNATURE_ALGORITHM = AppBundleSignature.SIGNATURE_ALGORITHM;
+
+  /**
+   * Creates a validated catalog signature snapshot.
+   *
+   * <p>Validation is structural. It checks the sidecar schema version, supported algorithm,
+   * non-blank key id, canonical payload filename, and base64 syntax. It intentionally does not
+   * consult trusted keys or verify the signature bytes so parsing can remain separate from policy.
+   *
+   * @param version signature schema version, currently {@code 1}
+   * @param algorithm signature algorithm, currently JDK {@code Ed25519}
+   * @param keyId stable trusted-key identifier used to select the public key
+   * @param payload payload filename authenticated by the signature
+   * @param valueBase64 base64-encoded signature bytes
+   * @throws AppCatalogException if the fields cannot describe a supported catalog signature
+   */
+  public AppCatalogSignature {
+    if (version != SIGNATURE_VERSION) {
+      throw AppCatalogSidecars.invalidSignature(
+          "unsupported catalog.signature.version: " + version);
+    }
+    if (!SIGNATURE_ALGORITHM.equals(Objects.requireNonNull(algorithm, "algorithm"))) {
+      throw AppCatalogSidecars.invalidSignature(
+          "unsupported catalog.signature.algorithm: " + algorithm);
+    }
+    keyId =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            keyId, "catalog.signature.key.id", AppCatalogSidecars.INVALID_CATALOG_SIGNATURE);
+    payload =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            payload, "catalog.signature.payload", AppCatalogSidecars.INVALID_CATALOG_SIGNATURE);
+    if (!CATALOG_FILE_NAME.equals(payload)) {
+      throw AppCatalogSidecars.invalidSignature(
+          "unsupported catalog.signature.payload: " + payload);
+    }
+    valueBase64 =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            valueBase64,
+            "catalog.signature.value.base64",
+            AppCatalogSidecars.INVALID_CATALOG_SIGNATURE);
+    try {
+      Base64.getDecoder().decode(valueBase64);
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SIGNATURE,
+          "invalid catalog.signature.value.base64",
+          exception);
+    }
+  }
+
+  /**
+   * Decodes the immutable base64 signature text.
+   *
+   * <p>A new array is returned on every call so verification code can pass the bytes to JDK crypto
+   * APIs without exposing mutable state from the record.
+   *
+   * @return fresh byte array containing the signature value
+   */
+  public byte[] signatureBytes() {
+    return Base64.getDecoder().decode(valueBase64);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSigner.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSigner.java
@@ -1,0 +1,94 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Writes deterministic Ed25519 catalog signature sidecars for tests and tooling.
+ *
+ * <p>The signer reads the catalog properties file as exact bytes and signs those bytes without
+ * reparsing or normalizing the catalog. Runtime verification uses the same byte-for-byte payload,
+ * so build tooling can create catalog fixtures that exercise the production trust path.
+ *
+ * <p>This class is intentionally small and does not manage key storage. Callers provide the private
+ * key and trusted-key id that operators will configure separately as a public trusted key. The
+ * generated sidecar uses the canonical file names and schema fields consumed by {@link
+ * AppCatalogVerifier}.
+ */
+public final class AppCatalogSigner {
+  private AppCatalogSigner() {}
+
+  /**
+   * Signs a catalog properties file and writes its sibling signature sidecar.
+   *
+   * <p>The catalog file must already contain the final bytes to authenticate. The method enforces
+   * the catalog sidecar size cap, signs the exact bytes, serializes signature metadata, and writes
+   * {@code cryptad-app-catalog.signature} beside the catalog file. Existing signature files are
+   * replaced by the write operation.
+   *
+   * @param catalogFile path to {@code cryptad-app-catalog.properties}
+   * @param keyId stable trusted-key identifier written into the sidecar
+   * @param privateKey Ed25519 private key used to sign the exact catalog bytes
+   * @return signature metadata written to disk
+   * @throws IOException if the catalog file cannot be read or the sidecar cannot be written
+   */
+  public static AppCatalogSignature sign(Path catalogFile, String keyId, PrivateKey privateKey)
+      throws IOException {
+    Path normalizedCatalogFile = Objects.requireNonNull(catalogFile).toAbsolutePath().normalize();
+    byte[] catalogBytes =
+        AppCatalogSidecars.readRequiredBytes(
+            normalizedCatalogFile,
+            AppCatalogSidecars.MAX_CATALOG_BYTES,
+            "catalog properties",
+            AppCatalogSidecars.INVALID_CATALOG_ENTRY);
+    AppCatalogSignature signature =
+        new AppCatalogSignature(
+            AppCatalogSignature.SIGNATURE_VERSION,
+            AppCatalogSignature.SIGNATURE_ALGORITHM,
+            keyId,
+            AppCatalogSignature.CATALOG_FILE_NAME,
+            Base64.getEncoder().encodeToString(signBytes(catalogBytes, privateKey)));
+    Files.writeString(
+        normalizedCatalogFile.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME),
+        serialize(signature));
+    return signature;
+  }
+
+  static String serialize(AppCatalogSignature signature) {
+    return "catalog.signature.version="
+        + signature.version()
+        + '\n'
+        + "catalog.signature.algorithm="
+        + signature.algorithm()
+        + '\n'
+        + "catalog.signature.key.id="
+        + signature.keyId()
+        + '\n'
+        + "catalog.signature.payload="
+        + signature.payload()
+        + '\n'
+        + "catalog.signature.value.base64="
+        + signature.valueBase64()
+        + '\n';
+  }
+
+  private static byte[] signBytes(byte[] catalogBytes, PrivateKey privateKey) {
+    try {
+      Signature signer = Signature.getInstance(AppCatalogSignature.SIGNATURE_ALGORITHM);
+      signer.initSign(Objects.requireNonNull(privateKey, "privateKey"));
+      signer.update(catalogBytes);
+      return signer.sign();
+    } catch (GeneralSecurityException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SIGNATURE,
+          "failed to sign catalog sidecar",
+          exception);
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSource.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSource.java
@@ -1,0 +1,115 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Operator-configured location for a signed app catalog.
+ *
+ * <p>A source identifies the catalog properties file. The matching signature is resolved as a
+ * sibling named {@code cryptad-app-catalog.signature}. Local filesystem paths are converted to
+ * {@code file:} URIs at construction time so the fetcher can apply one scheme-based policy for
+ * local, HTTPS, and loopback-HTTP sources.
+ *
+ * <p>The source model stores a URI, not raw operator input. Parsing accepts common local path
+ * forms, including Windows drive-letter paths, before falling back to URI handling. Remote
+ * non-loopback sources must use HTTPS. Plain HTTP is reserved for explicit loopback development and
+ * test sources after host validation in {@link AppCatalogSidecars}.
+ *
+ * @param uri absolute source URI for {@code cryptad-app-catalog.properties}
+ */
+public record AppCatalogSource(URI uri) {
+  private static final Pattern WINDOWS_DRIVE_PATH_PATTERN = Pattern.compile("[A-Za-z]:[\\\\/].*");
+
+  /**
+   * Creates a validated source descriptor.
+   *
+   * <p>The URI is normalized and checked for supported scheme, host, fragment, user-info, and local
+   * file restrictions. The constructor does not check that the target exists; fetching is
+   * responsible for reading the catalog and signature sidecars.
+   *
+   * @param uri absolute source URI for {@code cryptad-app-catalog.properties}
+   * @throws AppCatalogException if the URI uses an unsupported or unsafe scheme
+   */
+  public AppCatalogSource {
+    uri = AppCatalogSidecars.requireSafeCatalogSourceUri(uri);
+  }
+
+  /**
+   * Parses an operator-supplied source string.
+   *
+   * <p>Strings without a URI scheme are treated as local filesystem paths. Drive-letter paths are
+   * detected before URI parsing so {@code C:/...} is not mistaken for a one-letter URI scheme on
+   * Windows. Syntax that is neither a valid URI nor a valid local path is rejected with {@code
+   * invalid_catalog_source}.
+   *
+   * @param rawSource local path, {@code file:} URI, {@code https:} URI, or loopback {@code http:}
+   *     URI
+   * @return validated catalog source descriptor
+   * @throws AppCatalogException if the source cannot be parsed or is not allowed
+   */
+  public static AppCatalogSource parse(String rawSource) throws AppCatalogException {
+    String value =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            rawSource, "source", AppCatalogSidecars.INVALID_CATALOG_SOURCE);
+    if (WINDOWS_DRIVE_PATH_PATTERN.matcher(value).matches()) {
+      return parseLocalPathSource(value, null);
+    }
+    try {
+      URI parsed = new URI(value);
+      if (parsed.getScheme() == null) {
+        return parseLocalPathSource(value, null);
+      }
+      return new AppCatalogSource(parsed);
+    } catch (URISyntaxException exception) {
+      return parseLocalPathSource(value, exception);
+    }
+  }
+
+  private static AppCatalogSource parseLocalPathSource(
+      String value, URISyntaxException uriException) throws AppCatalogException {
+    try {
+      return new AppCatalogSource(Path.of(value).toAbsolutePath().normalize().toUri());
+    } catch (InvalidPathException pathException) {
+      if (uriException != null) {
+        uriException.addSuppressed(pathException);
+        throw invalidSource(value, uriException);
+      }
+      throw invalidSource(value, pathException);
+    }
+  }
+
+  private static AppCatalogException invalidSource(String value, Exception exception) {
+    return new AppCatalogException(
+        AppCatalogSidecars.INVALID_CATALOG_SOURCE, "invalid catalog source: " + value, exception);
+  }
+
+  /**
+   * Returns the sibling URI where the signature sidecar is expected.
+   *
+   * <p>The catalog format fixes signature placement beside the properties file. Callers should not
+   * derive alternate signature names or fetch a remote signature from an unrelated authority.
+   *
+   * @return sibling signature URI for this source
+   */
+  public URI signatureUri() {
+    return uri.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME);
+  }
+
+  /**
+   * Returns the source URI as a stable string for storage and API display.
+   *
+   * <p>The returned value is the normalized URI text persisted by the source store. It may expose a
+   * local file URI, so UI layers should avoid displaying it in contexts where host filesystem paths
+   * are sensitive.
+   *
+   * @return normalized URI text
+   */
+  public String displayUri() {
+    return Objects.toString(uri);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceSnapshot.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceSnapshot.java
@@ -1,0 +1,75 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * API-friendly snapshot of one configured catalog source.
+ *
+ * <p>The snapshot combines source configuration with the latest verified catalog metadata stored on
+ * disk. It intentionally exposes source URI text and catalog counts, but not trusted key material
+ * or any temporary filesystem paths used for artifact staging.
+ *
+ * <p>Snapshots are point-in-time values. Listing or refreshing catalogs may create newer snapshots,
+ * but an existing instance does not track later source-store writes. The record validates catalog
+ * id, source URI, timestamps, and app count so API handlers can serialize it directly without
+ * another normalization step.
+ *
+ * @param catalogId stable catalog identifier
+ * @param name human-readable catalog name
+ * @param sourceUri configured catalog properties URI
+ * @param generatedAt timestamp declared by the catalog producer
+ * @param appCount number of app entries currently available
+ * @param addedAt timestamp when the source was first configured locally
+ * @param refreshedAt timestamp when the stored catalog was last fetched and verified
+ */
+public record AppCatalogSourceSnapshot(
+    String catalogId,
+    String name,
+    URI sourceUri,
+    Instant generatedAt,
+    int appCount,
+    Instant addedAt,
+    Instant refreshedAt) {
+  /**
+   * Creates a validated source snapshot.
+   *
+   * <p>The constructor normalizes identifiers and URI policy to match the source store. It does not
+   * verify catalog signatures; callers should build snapshots only from catalogs that have already
+   * been authenticated by {@link AppCatalogVerifier}.
+   *
+   * @param catalogId stable catalog identifier
+   * @param name human-readable catalog name
+   * @param sourceUri configured catalog properties URI
+   * @param generatedAt timestamp declared by the catalog producer
+   * @param appCount number of app entries currently available
+   * @param addedAt timestamp when the source was first configured locally
+   * @param refreshedAt timestamp when the stored catalog was last fetched and verified
+   */
+  public AppCatalogSourceSnapshot {
+    catalogId = AppCatalog.normalizeCatalogId(catalogId);
+    name =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            name, "catalog.name", AppCatalogSidecars.INVALID_CATALOG_ENTRY);
+    sourceUri = AppCatalogSidecars.requireSafeCatalogSourceUri(Objects.requireNonNull(sourceUri));
+    Objects.requireNonNull(generatedAt, "generatedAt");
+    if (appCount < 0) {
+      throw AppCatalogSidecars.invalidEntry("appCount must be >= 0");
+    }
+    Objects.requireNonNull(addedAt, "addedAt");
+    Objects.requireNonNull(refreshedAt, "refreshedAt");
+  }
+
+  static AppCatalogSourceSnapshot of(
+      AppCatalog catalog, AppCatalogSource source, Instant addedAt, Instant refreshedAt) {
+    return new AppCatalogSourceSnapshot(
+        catalog.catalogId(),
+        catalog.name(),
+        source.uri(),
+        catalog.generatedAt(),
+        catalog.entries().size(),
+        addedAt,
+        refreshedAt);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
@@ -1,0 +1,304 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * File-backed store for configured app catalog sources and their verified sidecars.
+ *
+ * <p>The store keeps each catalog under a path-safe catalog id directory below a host-owned root.
+ * It persists the source URI and refresh timestamps in a strict key/value sidecar, while catalog
+ * properties and signature bytes are stored verbatim so later refreshes and reads can re-run
+ * signature verification against the same trusted-key policy.
+ *
+ * <p>The store is deliberately small and synchronous. It does not cache parsed catalogs, perform
+ * trust decisions, or manage installed apps. The manager owns synchronization around calls to this
+ * class. Scratch files for downloads and extraction live under {@code .staging}, a hidden name that
+ * is outside the catalog-id namespace and skipped by listing.
+ */
+@SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+public final class AppCatalogSourceStore {
+  private static final String SOURCE_FILE_NAME = "catalog-source.properties";
+  private static final String SOURCE_VERSION_KEY = "catalog.source.version";
+  private static final String CATALOG_ID_KEY = "catalog.id";
+  private static final String SOURCE_URI_KEY = "source.uri";
+  private static final String ADDED_AT_KEY = "source.addedAt";
+  private static final String REFRESHED_AT_KEY = "source.refreshedAt";
+
+  private final Path rootDirectory;
+
+  /**
+   * Creates a source store rooted at a host-owned directory.
+   *
+   * <p>The root path is converted to an absolute normalized path immediately. Directories are
+   * created lazily when a source is first written or when staging is needed for an
+   * installation/update operation.
+   *
+   * @param rootDirectory directory where source records and catalog sidecars are stored
+   */
+  public AppCatalogSourceStore(Path rootDirectory) {
+    this.rootDirectory =
+        Objects.requireNonNull(rootDirectory, "rootDirectory").toAbsolutePath().normalize();
+  }
+
+  /**
+   * Returns the root directory used for persistent catalog state.
+   *
+   * <p>Each configured catalog is stored below this directory using its normalized catalog id as
+   * the child directory name. Callers should treat the returned path as host-private operational
+   * state.
+   *
+   * @return absolute normalized store directory
+   */
+  @SuppressWarnings("unused")
+  public Path rootDirectory() {
+    return rootDirectory;
+  }
+
+  /**
+   * Returns the scratch root used for downloads and extraction.
+   *
+   * <p>The scratch root is named {@code .staging} so valid catalog ids cannot collide with
+   * temporary artifact state. The method returns the path only; callers create it when needed.
+   *
+   * @return scratch directory below the store root
+   */
+  public Path stagingDirectory() {
+    return rootDirectory.resolve(".staging");
+  }
+
+  /**
+   * Returns whether a catalog id is already stored.
+   *
+   * <p>The check looks for the source metadata sidecar rather than only the directory. This avoids
+   * treating incomplete or scratch directories as configured catalogs.
+   *
+   * @param catalogId catalog id to test
+   * @return {@code true} when source metadata exists for the id
+   */
+  public boolean exists(String catalogId) {
+    return Files.isRegularFile(sourceFile(catalogId), LinkOption.NOFOLLOW_LINKS);
+  }
+
+  /**
+   * Lists all stored catalog sources.
+   *
+   * <p>Only child directories containing valid source metadata are returned. The hidden staging
+   * directory is skipped even if it contains files from a failed or in-progress catalog operation.
+   * Records are sorted by directory name so API output is deterministic.
+   *
+   * @return stored source records sorted by catalog id
+   * @throws IOException if source metadata or sidecars cannot be read safely
+   */
+  List<StoredCatalogSource> list() throws IOException {
+    if (!Files.isDirectory(rootDirectory, LinkOption.NOFOLLOW_LINKS)) {
+      return List.of();
+    }
+    List<StoredCatalogSource> sources = new ArrayList<>();
+    try (var children = Files.list(rootDirectory)) {
+      for (Path child :
+          children.sorted(Comparator.comparing(path -> path.getFileName().toString())).toList()) {
+        if (!Files.isDirectory(child, LinkOption.NOFOLLOW_LINKS)
+            || child.equals(stagingDirectory())) {
+          continue;
+        }
+        sources.add(readByDirectory(child));
+      }
+    }
+    return List.copyOf(sources);
+  }
+
+  /**
+   * Reads one stored catalog source.
+   *
+   * <p>The metadata sidecar is parsed strictly and its catalog id must match the directory name.
+   * The catalog properties and signature sidecars are returned as exact bytes for later
+   * verification.
+   *
+   * @param catalogId catalog id to read
+   * @return stored source record and catalog sidecar bytes
+   * @throws IOException if the id is missing or its files cannot be read safely
+   */
+  StoredCatalogSource read(String catalogId) throws IOException {
+    Path sourceDirectory = catalogDirectory(catalogId);
+    if (!Files.isDirectory(sourceDirectory, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.CATALOG_NOT_FOUND, "Catalog not found: " + catalogId);
+    }
+    return readByDirectory(sourceDirectory);
+  }
+
+  /**
+   * Writes or replaces one stored source and its latest fetched sidecars.
+   *
+   * <p>The method writes source metadata, catalog bytes, and signature bytes below the catalog id
+   * directory. It stores the raw fetched sidecars rather than serializing {@code catalog},
+   * preserving the exact bytes that passed signature verification.
+   *
+   * @param catalog catalog content verified from {@code fetchedCatalog}
+   * @param source source descriptor used to fetch the catalog
+   * @param fetchedCatalog exact catalog and signature bytes to persist
+   * @param addedAt original local source creation timestamp
+   * @param refreshedAt latest successful refresh timestamp
+   * @throws IOException if the store files cannot be written safely
+   */
+  public void write(
+      AppCatalog catalog,
+      AppCatalogSource source,
+      FetchedCatalog fetchedCatalog,
+      Instant addedAt,
+      Instant refreshedAt)
+      throws IOException {
+    Files.createDirectories(rootDirectory);
+    Path directory = catalogDirectory(catalog.catalogId());
+    Files.createDirectories(directory);
+    Files.writeString(
+        directory.resolve(SOURCE_FILE_NAME),
+        serializeSource(catalog.catalogId(), source, addedAt, refreshedAt));
+    Files.write(
+        directory.resolve(AppCatalogSignature.CATALOG_FILE_NAME), fetchedCatalog.catalogBytes());
+    Files.write(
+        directory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
+        fetchedCatalog.signatureBytes());
+  }
+
+  /**
+   * Removes a stored catalog source and its cached sidecars.
+   *
+   * <p>Removal deletes only the catalog directory named by the normalized id. The shared staging
+   * directory and any installed apps are outside that directory and are not removed by this method.
+   *
+   * @param catalogId catalog id to remove
+   * @throws IOException if deletion fails
+   */
+  public void remove(String catalogId) throws IOException {
+    Path directory = catalogDirectory(catalogId);
+    if (!Files.exists(directory, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.CATALOG_NOT_FOUND, "Catalog not found: " + catalogId);
+    }
+    AppCatalogBundleExtractor.deleteRecursively(directory);
+  }
+
+  private StoredCatalogSource readByDirectory(Path directory) throws IOException {
+    Map<String, String> properties =
+        AppCatalogSidecars.parseKeyValueSidecar(
+            AppCatalogSidecars.utf8(
+                AppCatalogSidecars.readRequiredBytes(
+                    directory.resolve(SOURCE_FILE_NAME),
+                    AppCatalogSidecars.MAX_SIGNATURE_BYTES,
+                    "catalog source metadata",
+                    AppCatalogSidecars.INVALID_CATALOG_SOURCE)),
+            "catalog source metadata");
+    validateSourceVersion(properties.remove(SOURCE_VERSION_KEY));
+    String catalogId = removeRequired(properties, CATALOG_ID_KEY);
+    AppCatalog.normalizeCatalogId(catalogId);
+    if (!directory.getFileName().toString().equals(catalogId)) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          "catalog source metadata id does not match directory");
+    }
+    AppCatalogSource source = parseStoredSource(removeRequired(properties, SOURCE_URI_KEY));
+    Instant addedAt = parseInstant(removeRequired(properties, ADDED_AT_KEY), ADDED_AT_KEY);
+    Instant refreshedAt =
+        parseInstant(removeRequired(properties, REFRESHED_AT_KEY), REFRESHED_AT_KEY);
+    if (!properties.isEmpty()) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          "unsupported catalog source property: " + properties.keySet().iterator().next());
+    }
+    return new StoredCatalogSource(source, addedAt, refreshedAt, readFetchedCatalog(directory));
+  }
+
+  private FetchedCatalog readFetchedCatalog(Path directory) throws IOException {
+    return new FetchedCatalog(
+        AppCatalogSidecars.readRequiredBytes(
+            directory.resolve(AppCatalogSignature.CATALOG_FILE_NAME),
+            AppCatalogSidecars.MAX_CATALOG_BYTES,
+            "catalog properties",
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE),
+        AppCatalogSidecars.readRequiredBytes(
+            directory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
+            AppCatalogSidecars.MAX_SIGNATURE_BYTES,
+            "catalog signature",
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE));
+  }
+
+  private static AppCatalogSource parseStoredSource(String rawUri) {
+    try {
+      return new AppCatalogSource(URI.create(rawUri));
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          "invalid stored catalog source URI",
+          exception);
+    }
+  }
+
+  private Path catalogDirectory(String catalogId) {
+    return rootDirectory.resolve(AppCatalog.normalizeCatalogId(catalogId));
+  }
+
+  private Path sourceFile(String catalogId) {
+    return catalogDirectory(catalogId).resolve(SOURCE_FILE_NAME);
+  }
+
+  private static void validateSourceVersion(String versionText) {
+    if (!"1".equals(versionText)) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          versionText == null
+              ? "missing catalog.source.version"
+              : "unsupported catalog.source.version: " + versionText);
+    }
+  }
+
+  private static Instant parseInstant(String value, String key) {
+    try {
+      return Instant.parse(value);
+    } catch (DateTimeParseException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, "invalid " + key + ": " + value, exception);
+    }
+  }
+
+  private static String removeRequired(Map<String, String> properties, String key) {
+    String value = properties.remove(key);
+    if (value == null) {
+      throw new AppCatalogException(AppCatalogSidecars.INVALID_CATALOG_SOURCE, "missing " + key);
+    }
+    return value;
+  }
+
+  private static String serializeSource(
+      String catalogId, AppCatalogSource source, Instant addedAt, Instant refreshedAt) {
+    return SOURCE_VERSION_KEY
+        + "=1\n"
+        + CATALOG_ID_KEY
+        + "="
+        + catalogId
+        + "\n"
+        + SOURCE_URI_KEY
+        + "="
+        + source.displayUri()
+        + "\n"
+        + ADDED_AT_KEY
+        + "="
+        + addedAt
+        + "\n"
+        + REFRESHED_AT_KEY
+        + "="
+        + refreshedAt
+        + "\n";
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
@@ -2,9 +2,11 @@ package network.crypta.platform.appcatalog;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -109,7 +111,8 @@ public final class AppCatalogSourceStore {
       for (Path child :
           children.sorted(Comparator.comparing(path -> path.getFileName().toString())).toList()) {
         if (!Files.isDirectory(child, LinkOption.NOFOLLOW_LINKS)
-            || child.equals(stagingDirectory())) {
+            || child.equals(stagingDirectory())
+            || !Files.isRegularFile(child.resolve(SOURCE_FILE_NAME), LinkOption.NOFOLLOW_LINKS)) {
           continue;
         }
         sources.add(readByDirectory(child));
@@ -141,9 +144,11 @@ public final class AppCatalogSourceStore {
   /**
    * Writes or replaces one stored source and its latest fetched sidecars.
    *
-   * <p>The method writes source metadata, catalog bytes, and signature bytes below the catalog id
-   * directory. It stores the raw fetched sidecars rather than serializing {@code catalog},
-   * preserving the exact bytes that passed signature verification.
+   * <p>The method writes catalog bytes and signature bytes before the source metadata marker. The
+   * metadata file is the store's commit marker, so a failed add that writes only fetched sidecars
+   * is skipped by {@link #list()} and does not block retry as a configured catalog. It stores the
+   * raw fetched sidecars rather than serializing {@code catalog}, preserving the exact bytes that
+   * passed signature verification.
    *
    * @param catalog catalog content verified from {@code fetchedCatalog}
    * @param source source descriptor used to fetch the catalog
@@ -161,15 +166,25 @@ public final class AppCatalogSourceStore {
       throws IOException {
     Files.createDirectories(rootDirectory);
     Path directory = catalogDirectory(catalog.catalogId());
+    Path sourceFile = directory.resolve(SOURCE_FILE_NAME);
+    boolean sourceExisted = Files.isRegularFile(sourceFile, LinkOption.NOFOLLOW_LINKS);
     Files.createDirectories(directory);
-    Files.writeString(
-        directory.resolve(SOURCE_FILE_NAME),
-        serializeSource(catalog.catalogId(), source, addedAt, refreshedAt));
-    Files.write(
-        directory.resolve(AppCatalogSignature.CATALOG_FILE_NAME), fetchedCatalog.catalogBytes());
-    Files.write(
-        directory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
-        fetchedCatalog.signatureBytes());
+    try {
+      Files.write(
+          directory.resolve(AppCatalogSignature.CATALOG_FILE_NAME), fetchedCatalog.catalogBytes());
+      Files.write(
+          directory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
+          fetchedCatalog.signatureBytes());
+      writeSourceMetadata(
+          directory,
+          sourceFile,
+          serializeSource(catalog.catalogId(), source, addedAt, refreshedAt));
+    } catch (IOException exception) {
+      if (!sourceExisted) {
+        cleanupIncompleteAdd(directory, exception);
+      }
+      throw exception;
+    }
   }
 
   /**
@@ -251,6 +266,38 @@ public final class AppCatalogSourceStore {
 
   private Path sourceFile(String catalogId) {
     return catalogDirectory(catalogId).resolve(SOURCE_FILE_NAME);
+  }
+
+  private static void writeSourceMetadata(Path directory, Path sourceFile, String content)
+      throws IOException {
+    Path tempFile = Files.createTempFile(directory, ".catalog-source-", ".tmp");
+    boolean moved = false;
+    try {
+      Files.writeString(tempFile, content);
+      moveReplacing(tempFile, sourceFile);
+      moved = true;
+    } finally {
+      if (!moved) {
+        Files.deleteIfExists(tempFile);
+      }
+    }
+  }
+
+  private static void moveReplacing(Path source, Path target) throws IOException {
+    try {
+      Files.move(
+          source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    } catch (AtomicMoveNotSupportedException _) {
+      Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  private static void cleanupIncompleteAdd(Path directory, IOException originalException) {
+    try {
+      AppCatalogBundleExtractor.deleteRecursively(directory);
+    } catch (IOException cleanupException) {
+      originalException.addSuppressed(cleanupException);
+    }
   }
 
   private static void validateSourceVersion(String versionText) {

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
@@ -38,6 +38,7 @@ public final class AppCatalogSourceStore {
   private static final String REFRESHED_AT_KEY = "source.refreshedAt";
 
   private final Path rootDirectory;
+  private final SourceMetadataWriter sourceMetadataWriter;
 
   /**
    * Creates a source store rooted at a host-owned directory.
@@ -49,8 +50,14 @@ public final class AppCatalogSourceStore {
    * @param rootDirectory directory where source records and catalog sidecars are stored
    */
   public AppCatalogSourceStore(Path rootDirectory) {
+    this(rootDirectory, AppCatalogSourceStore::writeSourceMetadata);
+  }
+
+  AppCatalogSourceStore(Path rootDirectory, SourceMetadataWriter sourceMetadataWriter) {
     this.rootDirectory =
         Objects.requireNonNull(rootDirectory, "rootDirectory").toAbsolutePath().normalize();
+    this.sourceMetadataWriter =
+        Objects.requireNonNull(sourceMetadataWriter, "sourceMetadataWriter");
   }
 
   /**
@@ -167,7 +174,10 @@ public final class AppCatalogSourceStore {
     Files.createDirectories(rootDirectory);
     Path directory = catalogDirectory(catalog.catalogId());
     Path sourceFile = directory.resolve(SOURCE_FILE_NAME);
-    boolean sourceExisted = Files.isRegularFile(sourceFile, LinkOption.NOFOLLOW_LINKS);
+    FetchedCatalog previousFetchedCatalog =
+        Files.isRegularFile(sourceFile, LinkOption.NOFOLLOW_LINKS)
+            ? readFetchedCatalog(directory)
+            : null;
     Files.createDirectories(directory);
     try {
       Files.write(
@@ -175,13 +185,15 @@ public final class AppCatalogSourceStore {
       Files.write(
           directory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
           fetchedCatalog.signatureBytes());
-      writeSourceMetadata(
+      sourceMetadataWriter.write(
           directory,
           sourceFile,
           serializeSource(catalog.catalogId(), source, addedAt, refreshedAt));
     } catch (IOException exception) {
-      if (!sourceExisted) {
+      if (previousFetchedCatalog == null) {
         cleanupIncompleteAdd(directory, exception);
+      } else {
+        restoreFetchedCatalog(directory, previousFetchedCatalog, exception);
       }
       throw exception;
     }
@@ -206,15 +218,7 @@ public final class AppCatalogSourceStore {
   }
 
   private StoredCatalogSource readByDirectory(Path directory) throws IOException {
-    Map<String, String> properties =
-        AppCatalogSidecars.parseKeyValueSidecar(
-            AppCatalogSidecars.utf8(
-                AppCatalogSidecars.readRequiredBytes(
-                    directory.resolve(SOURCE_FILE_NAME),
-                    AppCatalogSidecars.MAX_SIGNATURE_BYTES,
-                    "catalog source metadata",
-                    AppCatalogSidecars.INVALID_CATALOG_SOURCE)),
-            "catalog source metadata");
+    Map<String, String> properties = readSourceMetadata(directory);
     validateSourceVersion(properties.remove(SOURCE_VERSION_KEY));
     String catalogId = removeRequired(properties, CATALOG_ID_KEY);
     AppCatalog.normalizeCatalogId(catalogId);
@@ -268,6 +272,25 @@ public final class AppCatalogSourceStore {
     return catalogDirectory(catalogId).resolve(SOURCE_FILE_NAME);
   }
 
+  private static Map<String, String> readSourceMetadata(Path directory) throws IOException {
+    try {
+      return AppCatalogSidecars.parseKeyValueSidecar(
+          AppCatalogSidecars.utf8(
+              AppCatalogSidecars.readRequiredBytes(
+                  directory.resolve(SOURCE_FILE_NAME),
+                  AppCatalogSidecars.MAX_SIGNATURE_BYTES,
+                  "catalog source metadata",
+                  AppCatalogSidecars.INVALID_CATALOG_SOURCE)),
+          "catalog source metadata");
+    } catch (AppCatalogException exception) {
+      if (AppCatalogSidecars.INVALID_CATALOG_ENTRY.equals(exception.errorCode())) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.getMessage(), exception);
+      }
+      throw exception;
+    }
+  }
+
   private static void writeSourceMetadata(Path directory, Path sourceFile, String content)
       throws IOException {
     Path tempFile = Files.createTempFile(directory, ".catalog-source-", ".tmp");
@@ -298,6 +321,24 @@ public final class AppCatalogSourceStore {
     } catch (IOException cleanupException) {
       originalException.addSuppressed(cleanupException);
     }
+  }
+
+  private static void restoreFetchedCatalog(
+      Path directory, FetchedCatalog fetchedCatalog, IOException originalException) {
+    try {
+      Files.write(
+          directory.resolve(AppCatalogSignature.CATALOG_FILE_NAME), fetchedCatalog.catalogBytes());
+      Files.write(
+          directory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
+          fetchedCatalog.signatureBytes());
+    } catch (IOException restoreException) {
+      originalException.addSuppressed(restoreException);
+    }
+  }
+
+  @FunctionalInterface
+  interface SourceMetadataWriter {
+    void write(Path directory, Path sourceFile, String content) throws IOException;
   }
 
   private static void validateSourceVersion(String versionText) {

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogVerifier.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogVerifier.java
@@ -1,0 +1,135 @@
+package network.crypta.platform.appcatalog;
+
+import java.security.GeneralSecurityException;
+import java.security.Signature;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.appdist.TrustedAppKey;
+import network.crypta.platform.appdist.TrustedAppKeys;
+
+/**
+ * Verifies signed catalog sidecars against explicit trusted keys.
+ *
+ * <p>Verification deliberately follows the same order as signed app bundles: first the signature
+ * over the exact catalog-properties bytes is checked, then the authenticated bytes are parsed into
+ * a catalog model. This prevents a normalized or reparsed catalog from becoming the signed payload
+ * and keeps remote catalog metadata fail-closed when sidecars are stale or tampered.
+ *
+ * <p>The verifier does not read files or fetch remote data. Callers pass the exact bytes retrieved
+ * by {@link AppCatalogFetcher} or loaded from {@link AppCatalogSourceStore}. Trusted keys are
+ * explicit inputs so runtime composition can choose whether catalog and bundle trust share the same
+ * key set without introducing global mutable state.
+ */
+public final class AppCatalogVerifier {
+  private AppCatalogVerifier() {}
+
+  /**
+   * Parses one catalog signature sidecar.
+   *
+   * <p>This method validates sidecar structure and supported signature metadata but does not verify
+   * the signature value against catalog bytes. Malformed signature sidecars are always classified
+   * as {@code invalid_catalog_signature}, even when the shared key/value parser detects the
+   * low-level line-format problem.
+   *
+   * @param signatureBytes exact UTF-8 bytes read from {@code cryptad-app-catalog.signature}
+   * @return parsed signature metadata
+   * @throws AppCatalogException if the sidecar is malformed or unsupported
+   */
+  public static AppCatalogSignature readSignature(byte[] signatureBytes)
+      throws AppCatalogException {
+    Map<String, String> properties = parseSignatureSidecar(signatureBytes);
+    String versionText = removeRequired(properties, "catalog.signature.version");
+    String algorithm = removeRequired(properties, "catalog.signature.algorithm");
+    String keyId = removeRequired(properties, "catalog.signature.key.id");
+    String payload = removeRequired(properties, "catalog.signature.payload");
+    String signatureValue = removeRequired(properties, "catalog.signature.value.base64");
+    if (!properties.isEmpty()) {
+      throw AppCatalogSidecars.invalidSignature(
+          "unsupported catalog signature property: " + properties.keySet().iterator().next());
+    }
+    try {
+      return new AppCatalogSignature(
+          Integer.parseInt(versionText), algorithm, keyId, payload, signatureValue);
+    } catch (NumberFormatException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SIGNATURE,
+          "invalid catalog.signature.version: " + versionText,
+          exception);
+    }
+  }
+
+  private static Map<String, String> parseSignatureSidecar(byte[] signatureBytes) {
+    try {
+      return AppCatalogSidecars.parseKeyValueSidecar(
+          AppCatalogSidecars.utf8(signatureBytes), "catalog signature");
+    } catch (AppCatalogException exception) {
+      if (AppCatalogSidecars.INVALID_CATALOG_ENTRY.equals(exception.errorCode())) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.INVALID_CATALOG_SIGNATURE, exception.getMessage(), exception);
+      }
+      throw exception;
+    }
+  }
+
+  /**
+   * Verifies a catalog and returns the authenticated parsed content.
+   *
+   * <p>The verifier reads the signature sidecar, selects the trusted public key by key id, checks
+   * the algorithm match, verifies Ed25519 over {@code catalogBytes}, and only then parses catalog
+   * entries. Unknown key ids, algorithm mismatches, and cryptographic failures all use the
+   * signature error code because no catalog entry should be trusted until this method returns.
+   *
+   * @param catalogBytes exact bytes from {@code cryptad-app-catalog.properties}
+   * @param signatureBytes exact bytes from {@code cryptad-app-catalog.signature}
+   * @param trustedKeys explicit trusted Ed25519 public keys
+   * @return authenticated catalog content in declared entry order
+   * @throws AppCatalogException if signature, trust, or catalog parsing fails
+   */
+  public static AppCatalog verify(
+      byte[] catalogBytes, byte[] signatureBytes, TrustedAppKeys trustedKeys)
+      throws AppCatalogException {
+    Objects.requireNonNull(catalogBytes, "catalogBytes");
+    Objects.requireNonNull(signatureBytes, "signatureBytes");
+    Objects.requireNonNull(trustedKeys, "trustedKeys");
+    AppCatalogSignature signature = readSignature(signatureBytes);
+    TrustedAppKey trustedKey =
+        trustedKeys
+            .find(signature.keyId())
+            .orElseThrow(
+                () ->
+                    new AppCatalogException(
+                        AppCatalogSidecars.INVALID_CATALOG_SIGNATURE,
+                        "unknown trusted catalog key id: " + signature.keyId()));
+    if (!signature.algorithm().equals(trustedKey.algorithm())) {
+      throw AppCatalogSidecars.invalidSignature(
+          "trusted key algorithm does not match catalog signature: " + signature.keyId());
+    }
+    verifySignature(catalogBytes, signature, trustedKey);
+    return AppCatalogParser.parse(catalogBytes);
+  }
+
+  private static void verifySignature(
+      byte[] catalogBytes, AppCatalogSignature signature, TrustedAppKey trustedKey) {
+    try {
+      Signature verifier = Signature.getInstance(signature.algorithm());
+      verifier.initVerify(trustedKey.publicKey());
+      verifier.update(catalogBytes);
+      if (!verifier.verify(signature.signatureBytes())) {
+        throw AppCatalogSidecars.invalidSignature("catalog signature does not match catalog bytes");
+      }
+    } catch (GeneralSecurityException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SIGNATURE,
+          "failed to verify catalog signature",
+          exception);
+    }
+  }
+
+  private static String removeRequired(Map<String, String> properties, String key) {
+    String value = properties.remove(key);
+    if (value == null) {
+      throw AppCatalogSidecars.invalidSignature("missing " + key);
+    }
+    return value;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/FetchedCatalog.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/FetchedCatalog.java
@@ -1,0 +1,59 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Objects;
+
+/**
+ * Holds the exact catalog sidecar bytes retrieved from one catalog source.
+ *
+ * <p>The catalog verifier signs and verifies the raw {@code cryptad-app-catalog.properties} bytes
+ * rather than a parsed or normalized representation, so callers must preserve these byte arrays
+ * exactly between fetch, persistence, and verification. Instances defensively copy input and output
+ * arrays so callers cannot mutate stored sidecar data after construction.
+ *
+ * <p>The type is intentionally a small class rather than a record because arrays are mutable. Its
+ * accessor methods return fresh copies and its constructor clones inputs immediately. That keeps
+ * cached sidecar bytes stable even when test fixtures or fetch buffers are reused by callers.
+ */
+@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
+public final class FetchedCatalog {
+  private final byte[] catalogBytes;
+  private final byte[] signatureBytes;
+
+  /**
+   * Creates a fetched catalog sidecar pair.
+   *
+   * <p>The provided arrays are copied immediately. Callers may safely reuse or clear their original
+   * buffers after construction without altering the bytes that will be verified or persisted.
+   *
+   * @param catalogBytes exact bytes of {@code cryptad-app-catalog.properties}
+   * @param signatureBytes exact bytes of {@code cryptad-app-catalog.signature}
+   */
+  public FetchedCatalog(byte[] catalogBytes, byte[] signatureBytes) {
+    this.catalogBytes = Objects.requireNonNull(catalogBytes, "catalogBytes").clone();
+    this.signatureBytes = Objects.requireNonNull(signatureBytes, "signatureBytes").clone();
+  }
+
+  /**
+   * Returns the exact fetched catalog properties bytes.
+   *
+   * <p>The returned array is a defensive copy. Modifying it does not affect this instance or any
+   * later signature verification using this instance.
+   *
+   * @return defensive copy of {@code cryptad-app-catalog.properties}
+   */
+  public byte[] catalogBytes() {
+    return catalogBytes.clone();
+  }
+
+  /**
+   * Returns the exact fetched catalog signature bytes.
+   *
+   * <p>The returned array is a defensive copy. Modifying it does not affect this instance or the
+   * source store when these bytes are persisted later.
+   *
+   * @return defensive copy of {@code cryptad-app-catalog.signature}
+   */
+  public byte[] signatureBytes() {
+    return signatureBytes.clone();
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/StoredCatalogSource.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/StoredCatalogSource.java
@@ -1,0 +1,19 @@
+package network.crypta.platform.appcatalog;
+
+import java.time.Instant;
+
+/**
+ * Source-store record containing configured source metadata and cached sidecar bytes.
+ *
+ * <p>The record is package-private because only {@link AppCatalogSourceStore} and {@link
+ * AppCatalogManager} need to exchange this persistence shape. It combines the operator-configured
+ * source URI, local lifecycle timestamps, and the exact fetched catalog/signature bytes that still
+ * need to be verified against the current trusted-key policy before exposure.
+ *
+ * @param source validated source URI used for refresh operations
+ * @param addedAt local timestamp when the source was first persisted
+ * @param refreshedAt local timestamp when sidecars were last fetched and verified
+ * @param fetchedCatalog exact catalog and signature bytes cached by the source store
+ */
+record StoredCatalogSource(
+    AppCatalogSource source, Instant addedAt, Instant refreshedAt, FetchedCatalog fetchedCatalog) {}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/package-info.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Signed app catalog parsing, fetching, artifact verification, and staging support.
+ *
+ * <p>This package is the distribution layer above local signed app bundles and below AppHost
+ * process orchestration. It verifies catalog sidecars, downloads or reads bundle artifacts, checks
+ * catalog-declared artifact size and SHA-256 metadata, safely extracts ZIP artifacts into
+ * host-owned staging directories, and then reuses {@code platform-appdist} bundle verification
+ * before callers install or update through AppHost. The package does not launch apps or own runtime
+ * lifecycle state.
+ *
+ * <p>The trust order is fixed:
+ *
+ * <ol>
+ *   <li>Verify {@code cryptad-app-catalog.signature} over the exact catalog properties bytes.
+ *   <li>Validate catalog metadata, source/artifact URI policy, artifact size, and artifact digest.
+ *   <li>Extract the ZIP into scratch space and verify the extracted signed app bundle.
+ * </ol>
+ *
+ * <p>All network and filesystem work uses JDK APIs only. JSON, HTTP, ZIP, crypto, and catalog
+ * parsing remain dependency-free in this leaf so it can serve as a narrow distribution primitive
+ * for Platform API and Web Shell integration without introducing runtime process orchestration
+ * here.
+ */
+package network.crypta.platform.appcatalog;

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -423,6 +423,28 @@ class AppCatalogManagerTest {
   }
 
   @Test
+  void download_whenArtifactValidationAndCleanupFail_expectCatalogErrorPreserved() {
+    CloseRecordingInputStream body = new CloseRecordingInputStream();
+    IOException cleanupFailure = new IOException("delete failed");
+    AppCatalogArtifactDownloader downloader =
+        new AppCatalogArtifactDownloader(
+            new FixedResponseHttpClient(new InputStreamResponse(200, body, contentLength("2"))),
+            _ -> {
+              throw cleanupFailure;
+            });
+    AppCatalogEntry entry = remoteEntry();
+    Path scratchDirectory = tempDir.resolve("scratch-cleanup-failure");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> downloader.download(entry, scratchDirectory));
+
+    assertEquals(AppCatalogSidecars.ARTIFACT_DIGEST_MISMATCH, exception.errorCode());
+    assertEquals(1, exception.getSuppressed().length);
+    assertEquals(cleanupFailure, exception.getSuppressed()[0]);
+    assertTrue(body.closed());
+  }
+
+  @Test
   void download_whenRemoteContentLengthIsMalformed_expectArtifactDownloadFailed() {
     CloseRecordingInputStream body = new CloseRecordingInputStream();
     AppCatalogArtifactDownloader downloader =

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -287,6 +287,7 @@ class AppCatalogManagerTest {
   @ValueSource(
       strings = {
         "http://127.example.com/cryptad-app-catalog.properties",
+        "ftp://example.invalid/cryptad-app-catalog.properties",
         "https:/cryptad-app-catalog.properties",
         "file:cryptad-app-catalog.properties",
         "file://localhost/tmp/cryptad-app-catalog.properties"
@@ -306,6 +307,7 @@ class AppCatalogManagerTest {
   @ValueSource(
       strings = {
         "http://127.example.com/queue-manager.zip",
+        "ftp://example.invalid/queue-manager.zip",
         "https:queue-manager.zip",
         "file:///tmp/queue-manager.zip?download=1"
       })

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -1,0 +1,880 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import network.crypta.platform.appdist.AppBundleManifestParser;
+import network.crypta.platform.appdist.AppBundleSignature;
+import network.crypta.platform.appdist.AppBundleSigner;
+import network.crypta.platform.appdist.TrustedAppKey;
+import network.crypta.platform.appdist.TrustedAppKeys;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AppCatalogManagerTest {
+  private static final String KEY_ID = "catalog-test";
+  private static final String CATALOG_ID = "core";
+  private static final String STAGING_CATALOG_ID = "staging";
+  private static final String APP_ID = "queue-manager";
+  private static final String APP_VERSION = "1.0.0";
+  private static final String ARTIFACT_ZIP = "queue-manager.zip";
+  private static final String EXECUTABLE_PATH = "bin/tool";
+  private static final int LOCAL_FILE_HEADER_SIGNATURE = 0x04034B50;
+  private static final int CENTRAL_DIRECTORY_HEADER_SIGNATURE = 0x02014B50;
+  private static final int END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054B50;
+  private static final int END_OF_CENTRAL_DIRECTORY_MIN_BYTES = 22;
+  private static final int UNIX_REGULAR_FILE_MODE = 32768;
+  private static final int UNIX_EXECUTABLE_FILE_MODE = UNIX_REGULAR_FILE_MODE | 448;
+  private static final Instant GENERATED_AT = Instant.parse("2026-04-21T18:22:40Z");
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void addSource_whenLocalSignedCatalogIsValid_expectListAndInstallPlan() throws Exception {
+    KeyPair keyPair = keyPair();
+    TrustedAppKeys trustedKeys = trustedKeys(keyPair);
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys);
+
+    AppCatalogSourceSnapshot snapshot = manager.addSource(catalog.toString());
+    List<AppCatalogEntry> entries = manager.listApps(CATALOG_ID);
+
+    assertEquals(CATALOG_ID, snapshot.catalogId());
+    assertEquals(1, snapshot.appCount());
+    assertEquals(APP_ID, entries.getFirst().appId());
+
+    try (AppCatalogInstallPlan plan = manager.prepareInstallPlan(CATALOG_ID, APP_ID)) {
+      assertTrue(Files.isDirectory(plan.stagedBundleDirectory()));
+      assertTrue(
+          Files.isRegularFile(
+              plan.stagedBundleDirectory().resolve(AppBundleManifestParser.MANIFEST_FILE_NAME)));
+    }
+  }
+
+  @Test
+  void addSource_whenCatalogBytesAreTampered_expectInvalidCatalogSignature() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    Files.writeString(
+        catalog, "\n# tampered\n", StandardCharsets.UTF_8, java.nio.file.StandardOpenOption.APPEND);
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    String catalogSource = catalog.toString();
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> manager.addSource(catalogSource));
+
+    assertEquals("invalid_catalog_signature", exception.errorCode());
+  }
+
+  @Test
+  void addSource_whenSignerIsUnknown_expectInvalidCatalogSignature() throws Exception {
+    KeyPair signingKeyPair = keyPair();
+    KeyPair trustedKeyPair = keyPair();
+    Path bundle = signedBundle(signingKeyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, signingKeyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(trustedKeyPair));
+    String catalogSource = catalog.toString();
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> manager.addSource(catalogSource));
+
+    assertEquals("invalid_catalog_signature", exception.errorCode());
+  }
+
+  @Test
+  void addSource_whenSignatureSidecarIsMalformed_expectInvalidCatalogSignature() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    Files.writeString(
+        catalog.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME),
+        "not-a-key-value-line\n",
+        StandardCharsets.UTF_8);
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    String catalogSource = catalog.toString();
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> manager.addSource(catalogSource));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SIGNATURE, exception.errorCode());
+  }
+
+  @Test
+  void prepareInstallPlan_whenArtifactDigestMismatches_expectArtifactDigestMismatch()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, "0".repeat(64), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    //noinspection resource
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> manager.prepareInstallPlan(CATALOG_ID, APP_ID));
+
+    assertEquals("artifact_digest_mismatch", exception.errorCode());
+  }
+
+  @Test
+  void prepareInstallPlan_whenZipContainsTraversal_expectInvalidAppBundle() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path artifact = traversalZip(tempDir.resolve("unsafe.zip"));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    //noinspection resource
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> manager.prepareInstallPlan(CATALOG_ID, APP_ID));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+    assertFalse(Files.exists(tempDir.resolve("evil.txt")));
+  }
+
+  @Test
+  void prepareInstallPlan_whenZipParentIsFile_expectInvalidAppBundle() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path artifact = parentConflictZip(tempDir.resolve("parent-conflict.zip"));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    //noinspection resource
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> manager.prepareInstallPlan(CATALOG_ID, APP_ID));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+  }
+
+  @Test
+  void prepareInstallPlan_whenZipDirectoryParentIsFile_expectInvalidAppBundle() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path artifact = directoryParentConflictZip(tempDir.resolve("directory-parent-conflict.zip"));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    //noinspection resource
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> manager.prepareInstallPlan(CATALOG_ID, APP_ID));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+  }
+
+  @Test
+  void prepareInstallPlan_whenZipPayloadIsCorrupt_expectInvalidAppBundle() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve("corrupt-payload.zip"));
+    corruptManifestZipEntryPayload(artifact);
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    //noinspection resource
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> manager.prepareInstallPlan(CATALOG_ID, APP_ID));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+  }
+
+  @Test
+  void prepareInstallPlan_whenZipEntryNameIsPathInvalid_expectInvalidAppBundle() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path artifact = invalidPathNameZip(tempDir.resolve("invalid-path-name.zip"));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    //noinspection resource
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> manager.prepareInstallPlan(CATALOG_ID, APP_ID));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+  }
+
+  @Test
+  void prepareInstallPlan_whenZipContainsTooManyEntries_expectInvalidAppBundle() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path artifact = manyEntriesZip(tempDir.resolve("too-many.zip"));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    //noinspection resource
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> manager.prepareInstallPlan(CATALOG_ID, APP_ID));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+  }
+
+  @Test
+  void prepareInstallPlan_whenSignedBundleRequiresExecutableBit_expectExecutableModePreserved()
+      throws Exception {
+    Assumptions.assumeTrue(
+        Files.getFileStore(tempDir).supportsFileAttributeView("posix"),
+        "POSIX executable mode preservation requires POSIX file attributes");
+    KeyPair keyPair = keyPair();
+    Path bundle = signedExecutableBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve("executable.zip"));
+    setExecutableZipUnixMode(artifact);
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    try (AppCatalogInstallPlan plan = manager.prepareInstallPlan(CATALOG_ID, APP_ID)) {
+      assertTrue(Files.isExecutable(plan.stagedBundleDirectory().resolve(EXECUTABLE_PATH)));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://127.example.com/cryptad-app-catalog.properties",
+        "https:/cryptad-app-catalog.properties",
+        "file:cryptad-app-catalog.properties",
+        "file://localhost/tmp/cryptad-app-catalog.properties"
+      })
+  void requireSafeCatalogSourceUri_whenUriIsUnsafe_expectInvalidCatalogSource(String sourceValue) {
+    URI source = URI.create(sourceValue);
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> AppCatalogSidecars.requireSafeCatalogSourceUri(source));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://127.example.com/queue-manager.zip",
+        "https:queue-manager.zip",
+        "file:///tmp/queue-manager.zip?download=1"
+      })
+  void requireSafeArtifactUri_whenUriIsUnsafe_expectInvalidCatalogEntry(String artifactValue) {
+    URI artifact = URI.create(artifactValue);
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> AppCatalogSidecars.requireSafeArtifactUri(artifact));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  @Test
+  void requireSafeArtifactUri_whenHttpHostIsNumeric127Loopback_expectAllowed() {
+    URI artifact = URI.create("http://127.0.0.2/queue-manager.zip");
+
+    assertEquals(artifact, AppCatalogSidecars.requireSafeArtifactUri(artifact));
+  }
+
+  @Test
+  void parse_whenWindowsDriveLetterCatalogPath_expectLocalFileSource() {
+    AppCatalogSource source =
+        AppCatalogSource.parse("C:/Cryptad/catalog/cryptad-app-catalog.properties");
+
+    assertEquals("file", source.uri().getScheme());
+  }
+
+  @Test
+  void fetch_whenRemoteStatusRejected_expectResponseBodyClosed() {
+    CloseRecordingInputStream body = new CloseRecordingInputStream();
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(new FixedResponseHttpClient(new InputStreamResponse(404, body)));
+    AppCatalogSource source =
+        new AppCatalogSource(URI.create("http://localhost/cryptad-app-catalog.properties"));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+    assertTrue(body.closed());
+  }
+
+  @Test
+  void fetch_whenRemoteTransportFails_expectInvalidCatalogSource() {
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(new FixedResponseHttpClient(new IOException("connect failed")));
+    AppCatalogSource source =
+        new AppCatalogSource(URI.create("http://localhost/cryptad-app-catalog.properties"));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  @Test
+  void download_whenRemoteStatusRejected_expectResponseBodyClosed() {
+    CloseRecordingInputStream body = new CloseRecordingInputStream();
+    AppCatalogArtifactDownloader downloader =
+        new AppCatalogArtifactDownloader(
+            new FixedResponseHttpClient(new InputStreamResponse(404, body)));
+    AppCatalogEntry entry = remoteEntry();
+    Path scratchDirectory = tempDir.resolve("scratch-status");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> downloader.download(entry, scratchDirectory));
+
+    assertEquals(AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED, exception.errorCode());
+    assertTrue(body.closed());
+  }
+
+  @Test
+  void download_whenRemoteTransportFails_expectArtifactDownloadFailed() {
+    AppCatalogArtifactDownloader downloader =
+        new AppCatalogArtifactDownloader(
+            new FixedResponseHttpClient(new IOException("connect failed")));
+    AppCatalogEntry entry = remoteEntry();
+    Path scratchDirectory = tempDir.resolve("scratch-transport");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> downloader.download(entry, scratchDirectory));
+
+    assertEquals(AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED, exception.errorCode());
+  }
+
+  @Test
+  void download_whenLocalArtifactIsMissing_expectArtifactDownloadFailed() {
+    AppCatalogArtifactDownloader downloader = new AppCatalogArtifactDownloader();
+    AppCatalogEntry entry = localEntry(tempDir.resolve("missing.zip"));
+    Path scratchDirectory = tempDir.resolve("scratch-missing");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> downloader.download(entry, scratchDirectory));
+
+    assertEquals(AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED, exception.errorCode());
+  }
+
+  @Test
+  void download_whenRemoteContentLengthRejected_expectResponseBodyClosed() {
+    CloseRecordingInputStream body = new CloseRecordingInputStream();
+    AppCatalogArtifactDownloader downloader =
+        new AppCatalogArtifactDownloader(
+            new FixedResponseHttpClient(new InputStreamResponse(200, body, contentLength("2"))));
+    AppCatalogEntry entry = remoteEntry();
+    Path scratchDirectory = tempDir.resolve("scratch-length");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> downloader.download(entry, scratchDirectory));
+
+    assertEquals(AppCatalogSidecars.ARTIFACT_DIGEST_MISMATCH, exception.errorCode());
+    assertTrue(body.closed());
+  }
+
+  @Test
+  void download_whenRemoteContentLengthIsMalformed_expectArtifactDownloadFailed() {
+    CloseRecordingInputStream body = new CloseRecordingInputStream();
+    AppCatalogArtifactDownloader downloader =
+        new AppCatalogArtifactDownloader(
+            new FixedResponseHttpClient(
+                new InputStreamResponse(200, body, contentLength("not-a-number"))));
+    AppCatalogEntry entry = remoteEntry();
+    Path scratchDirectory = tempDir.resolve("scratch-bad-length");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> downloader.download(entry, scratchDirectory));
+
+    assertEquals(AppCatalogSidecars.ARTIFACT_DOWNLOAD_FAILED, exception.errorCode());
+    assertTrue(body.closed());
+  }
+
+  @Test
+  void addSource_whenCatalogIdIsStaging_expectCatalogIsListedAndScratchUsesHiddenDirectory()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    TrustedAppKeys trustedKeys = trustedKeys(keyPair);
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog =
+        signedCatalog(
+            STAGING_CATALOG_ID, artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogSourceStore sourceStore = new AppCatalogSourceStore(tempDir.resolve("store"));
+    AppCatalogManager manager = new AppCatalogManager(sourceStore, () -> trustedKeys);
+
+    manager.addSource(catalog.toString());
+    List<AppCatalogSourceSnapshot> catalogs = manager.listCatalogs();
+
+    assertEquals(STAGING_CATALOG_ID, catalogs.getFirst().catalogId());
+    assertEquals(sourceStore.rootDirectory().resolve(".staging"), sourceStore.stagingDirectory());
+    try (AppCatalogInstallPlan plan = manager.prepareInstallPlan(STAGING_CATALOG_ID, APP_ID)) {
+      assertTrue(plan.scratchDirectory().startsWith(sourceStore.stagingDirectory()));
+    }
+  }
+
+  private AppCatalogManager manager(TrustedAppKeys trustedKeys) {
+    return new AppCatalogManager(
+        new AppCatalogSourceStore(tempDir.resolve("store")), () -> trustedKeys);
+  }
+
+  private Path signedBundle(KeyPair keyPair) throws IOException {
+    Path root = Files.createDirectories(tempDir.resolve("bundle").resolve(APP_ID));
+    Path bin = Files.createDirectories(root.resolve("bin"));
+    Files.writeString(bin.resolve("launch.sh"), "#!/bin/sh\nexit 0\n", StandardCharsets.UTF_8);
+    Files.writeString(
+        root.resolve(AppBundleManifestParser.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=Queue Manager
+        app.version=%s
+        app.exec=bin/launch.sh
+        app.permissions=queue.read,queue.write
+        """
+            .formatted(APP_ID, APP_VERSION),
+        StandardCharsets.UTF_8);
+    AppBundleSigner.sign(root, KEY_ID, keyPair.getPrivate());
+    return root;
+  }
+
+  private Path signedExecutableBundle(KeyPair keyPair) throws IOException {
+    Path root = Files.createDirectories(tempDir.resolve("bundle").resolve(APP_ID));
+    Files.createDirectories(root.resolve("bin"));
+    Path executable = root.resolve(EXECUTABLE_PATH);
+    Files.writeString(executable, "echo sample\n", StandardCharsets.UTF_8);
+    Files.setPosixFilePermissions(executable, PosixFilePermissions.fromString("rwx------"));
+    Files.writeString(
+        root.resolve(AppBundleManifestParser.MANIFEST_FILE_NAME),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=Queue Manager
+        app.version=%s
+        app.exec=%s
+        app.permissions=queue.read,queue.write
+        """
+            .formatted(APP_ID, APP_VERSION, EXECUTABLE_PATH),
+        StandardCharsets.UTF_8);
+    AppBundleSigner.sign(root, KEY_ID, keyPair.getPrivate());
+    return root;
+  }
+
+  private Path signedCatalog(
+      Path artifact, KeyPair keyPair, String artifactSha256, long artifactSize) throws IOException {
+    return signedCatalog(CATALOG_ID, artifact, keyPair, artifactSha256, artifactSize);
+  }
+
+  private Path signedCatalog(
+      String catalogId, Path artifact, KeyPair keyPair, String artifactSha256, long artifactSize)
+      throws IOException {
+    Path catalogDir = Files.createDirectories(tempDir.resolve("catalog-" + catalogId));
+    Path catalog = catalogDir.resolve(AppCatalogSignature.CATALOG_FILE_NAME);
+    Files.writeString(
+        catalog,
+        """
+        catalog.version=1
+        catalog.id=%s
+        catalog.name=Crypta Core Apps
+        catalog.generatedAt=%s
+        catalog.entries=%s
+        app.%s.id=%s
+        app.%s.name=Queue Manager
+        app.%s.version=%s
+        app.%s.summary=Manage local Crypta transfer queues.
+        app.%s.bundle.uri=%s
+        app.%s.bundle.sha256=%s
+        app.%s.bundle.size.bytes=%d
+        app.%s.bundle.type=zip
+        app.%s.permissions=queue.read,queue.write
+        """
+            .formatted(
+                catalogId,
+                GENERATED_AT,
+                APP_ID,
+                APP_ID,
+                APP_ID,
+                APP_ID,
+                APP_ID,
+                APP_VERSION,
+                APP_ID,
+                APP_ID,
+                artifact.toUri(),
+                APP_ID,
+                artifactSha256,
+                APP_ID,
+                artifactSize,
+                APP_ID,
+                APP_ID),
+        StandardCharsets.UTF_8);
+    AppCatalogSigner.sign(catalog, KEY_ID, keyPair.getPrivate());
+    return catalog;
+  }
+
+  private static Path zipDirectory(Path sourceRoot, Path targetZip) throws IOException {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip));
+        var paths = Files.walk(sourceRoot)) {
+      for (Path path : paths.sorted(Comparator.naturalOrder()).toList()) {
+        if (Files.isDirectory(path)) {
+          continue;
+        }
+        String relative = sourceRoot.relativize(path).toString().replace('\\', '/');
+        zip.putNextEntry(new ZipEntry(relative));
+        Files.copy(path, zip);
+        zip.closeEntry();
+      }
+    }
+    return targetZip;
+  }
+
+  private static Path traversalZip(Path targetZip) throws IOException {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip))) {
+      zip.putNextEntry(new ZipEntry("../evil.txt"));
+      zip.write("evil".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+    }
+    return targetZip;
+  }
+
+  private static Path parentConflictZip(Path targetZip) throws IOException {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip))) {
+      zip.putNextEntry(new ZipEntry("bin"));
+      zip.write("not-a-directory".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+      zip.putNextEntry(new ZipEntry(EXECUTABLE_PATH));
+      zip.write("echo sample\n".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+    }
+    return targetZip;
+  }
+
+  private static Path directoryParentConflictZip(Path targetZip) throws IOException {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip))) {
+      zip.putNextEntry(new ZipEntry("bin"));
+      zip.write("not-a-directory".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+      zip.putNextEntry(new ZipEntry(EXECUTABLE_PATH + "/"));
+      zip.closeEntry();
+    }
+    return targetZip;
+  }
+
+  private static Path manyEntriesZip(Path targetZip) throws IOException {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip))) {
+      for (int i = 0; i < 4097; i++) {
+        zip.putNextEntry(new ZipEntry("entry-" + i + ".txt"));
+        zip.write('x');
+        zip.closeEntry();
+      }
+    }
+    return targetZip;
+  }
+
+  private static Path invalidPathNameZip(Path targetZip) throws IOException {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip))) {
+      zip.putNextEntry(new ZipEntry("bad\0name"));
+      zip.write('x');
+      zip.closeEntry();
+    }
+    return targetZip;
+  }
+
+  private static void corruptManifestZipEntryPayload(Path targetZip) throws IOException {
+    byte[] zipBytes = Files.readAllBytes(targetZip);
+    ByteBuffer zip = ByteBuffer.wrap(zipBytes).order(ByteOrder.LITTLE_ENDIAN);
+    int centralDirectoryOffset = centralDirectoryOffset(zip);
+    while (centralDirectoryOffset < zip.limit()
+        && zip.getInt(centralDirectoryOffset) == CENTRAL_DIRECTORY_HEADER_SIGNATURE) {
+      int nameLength = Short.toUnsignedInt(zip.getShort(centralDirectoryOffset + 28));
+      int extraLength = Short.toUnsignedInt(zip.getShort(centralDirectoryOffset + 30));
+      int commentLength = Short.toUnsignedInt(zip.getShort(centralDirectoryOffset + 32));
+      int nameOffset = centralDirectoryOffset + 46;
+      String centralDirectoryName =
+          new String(zipBytes, nameOffset, nameLength, StandardCharsets.UTF_8);
+      if (AppBundleManifestParser.MANIFEST_FILE_NAME.equals(centralDirectoryName)) {
+        int compressedSize = zip.getInt(centralDirectoryOffset + 20);
+        int localHeaderOffset = zip.getInt(centralDirectoryOffset + 42);
+        int dataOffset = zipEntryDataOffset(zip, localHeaderOffset);
+        if (compressedSize <= 0 || dataOffset >= centralDirectoryOffset) {
+          throw new IOException(
+              "ZIP entry has no payload to corrupt: " + AppBundleManifestParser.MANIFEST_FILE_NAME);
+        }
+        zipBytes[dataOffset + Math.max(0, compressedSize / 2 - 1)] ^= 0x01;
+        Files.write(targetZip, zipBytes);
+        return;
+      }
+      centralDirectoryOffset = nameOffset + nameLength + extraLength + commentLength;
+    }
+    throw new IOException("ZIP entry not found: " + AppBundleManifestParser.MANIFEST_FILE_NAME);
+  }
+
+  private static int zipEntryDataOffset(ByteBuffer zip, int localHeaderOffset) throws IOException {
+    if (zip.getInt(localHeaderOffset) != LOCAL_FILE_HEADER_SIGNATURE) {
+      throw new IOException("ZIP local file header not found");
+    }
+    int nameLength = Short.toUnsignedInt(zip.getShort(localHeaderOffset + 26));
+    int extraLength = Short.toUnsignedInt(zip.getShort(localHeaderOffset + 28));
+    return localHeaderOffset + 30 + nameLength + extraLength;
+  }
+
+  private static void setExecutableZipUnixMode(Path targetZip) throws IOException {
+    byte[] zipBytes = Files.readAllBytes(targetZip);
+    ByteBuffer zip = ByteBuffer.wrap(zipBytes).order(ByteOrder.LITTLE_ENDIAN);
+    int centralDirectoryOffset = centralDirectoryOffset(zip);
+    while (centralDirectoryOffset < zip.limit()
+        && zip.getInt(centralDirectoryOffset) == CENTRAL_DIRECTORY_HEADER_SIGNATURE) {
+      int nameLength = Short.toUnsignedInt(zip.getShort(centralDirectoryOffset + 28));
+      int extraLength = Short.toUnsignedInt(zip.getShort(centralDirectoryOffset + 30));
+      int commentLength = Short.toUnsignedInt(zip.getShort(centralDirectoryOffset + 32));
+      int nameOffset = centralDirectoryOffset + 46;
+      String centralDirectoryName =
+          new String(zipBytes, nameOffset, nameLength, StandardCharsets.UTF_8);
+      if (EXECUTABLE_PATH.equals(centralDirectoryName)) {
+        zip.putShort(centralDirectoryOffset + 4, (short) 0x0314);
+        zip.putInt(centralDirectoryOffset + 38, UNIX_EXECUTABLE_FILE_MODE << 16);
+        Files.write(targetZip, zipBytes);
+        return;
+      }
+      centralDirectoryOffset = nameOffset + nameLength + extraLength + commentLength;
+    }
+    throw new IOException("ZIP entry not found: " + EXECUTABLE_PATH);
+  }
+
+  private static int centralDirectoryOffset(ByteBuffer zip) throws IOException {
+    for (int offset = zip.limit() - END_OF_CENTRAL_DIRECTORY_MIN_BYTES; offset >= 0; offset--) {
+      if (zip.getInt(offset) == END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+        return zip.getInt(offset + 16);
+      }
+    }
+    throw new IOException("ZIP end-of-central-directory record not found");
+  }
+
+  private static AppCatalogEntry remoteEntry() {
+    return new AppCatalogEntry(
+        APP_ID,
+        "Queue Manager",
+        APP_VERSION,
+        "Manage local Crypta transfer queues.",
+        URI.create("http://localhost/queue-manager.zip"),
+        "0".repeat(64),
+        1L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of("queue.read"));
+  }
+
+  private static AppCatalogEntry localEntry(Path artifact) {
+    return new AppCatalogEntry(
+        APP_ID,
+        "Queue Manager",
+        APP_VERSION,
+        "Manage local Crypta transfer queues.",
+        artifact.toUri(),
+        "0".repeat(64),
+        1L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of("queue.read"));
+  }
+
+  private static HttpHeaders contentLength(String value) {
+    return HttpHeaders.of(Map.of("content-length", List.of(value)), (_, _) -> true);
+  }
+
+  private static String sha256(Path path) throws IOException, NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    digest.update(Files.readAllBytes(path));
+    return HexFormat.of().formatHex(digest.digest());
+  }
+
+  private static KeyPair keyPair() throws NoSuchAlgorithmException {
+    return KeyPairGenerator.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM).generateKeyPair();
+  }
+
+  private static TrustedAppKeys trustedKeys(KeyPair keyPair) {
+    return TrustedAppKeys.of(
+        new TrustedAppKey(KEY_ID, AppBundleSignature.SIGNATURE_ALGORITHM, keyPair.getPublic()));
+  }
+
+  private static final class CloseRecordingInputStream extends ByteArrayInputStream {
+    private boolean closed;
+
+    private CloseRecordingInputStream() {
+      super(new byte[0]);
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    boolean closed() {
+      return closed;
+    }
+  }
+
+  private static final class FixedResponseHttpClient extends HttpClient {
+    private final HttpResponse<InputStream> response;
+    private final IOException sendFailure;
+
+    private FixedResponseHttpClient(HttpResponse<InputStream> response) {
+      this.response = response;
+      sendFailure = null;
+    }
+
+    private FixedResponseHttpClient(IOException sendFailure) {
+      response = null;
+      this.sendFailure = sendFailure;
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+      return Redirect.NEVER;
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+      return Optional.empty();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+      try {
+        return SSLContext.getDefault();
+      } catch (NoSuchAlgorithmException exception) {
+        throw new IllegalStateException(exception);
+      }
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+      return new SSLParameters();
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Version version() {
+      return Version.HTTP_1_1;
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+      return Optional.empty();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> HttpResponse<T> send(
+        HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) throws IOException {
+      if (sendFailure != null) {
+        throw sendFailure;
+      }
+      return (HttpResponse<T>) response;
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+        HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+      return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+        HttpRequest request,
+        HttpResponse.BodyHandler<T> responseBodyHandler,
+        HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+      return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+  }
+
+  private record InputStreamResponse(int statusCode, InputStream body, HttpHeaders headers)
+      implements HttpResponse<InputStream> {
+    private InputStreamResponse(int statusCode, InputStream body) {
+      this(statusCode, body, HttpHeaders.of(Collections.emptyMap(), (_, _) -> true));
+    }
+
+    @Override
+    public HttpRequest request() {
+      return HttpRequest.newBuilder(uri()).GET().build();
+    }
+
+    @Override
+    public Optional<HttpResponse<InputStream>> previousResponse() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<SSLSession> sslSession() {
+      return Optional.empty();
+    }
+
+    @Override
+    public URI uri() {
+      return URI.create("http://localhost/test");
+    }
+
+    @Override
+    public HttpClient.Version version() {
+      return HttpClient.Version.HTTP_1_1;
+    }
+  }
+}

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogParserTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogParserTest.java
@@ -1,0 +1,151 @@
+package network.crypta.platform.appcatalog;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AppCatalogParserTest {
+  private static final String GENERATED_AT = "2026-04-21T18:22:40Z";
+  private static final String SHA256 = "0".repeat(64);
+
+  @Test
+  void parse_whenCatalogIsValid_expectEntryOrderAndNormalizedFields() {
+    AppCatalog catalog =
+        AppCatalogParser.parse(
+            bytes(
+                """
+                catalog.version=1
+                catalog.id=Core
+                catalog.name=Crypta Core Apps
+                catalog.generatedAt=%s
+                catalog.entries=Publisher,queue-manager
+                app.publisher.id=Publisher
+                app.publisher.name=Publisher
+                app.publisher.version=1.0.0
+                app.publisher.summary=Publish local files.
+                app.publisher.bundle.uri=https://example.invalid/publisher.zip
+                app.publisher.bundle.sha256=%s
+                app.publisher.bundle.size.bytes=0
+                app.publisher.bundle.type=ZIP
+                app.publisher.permissions=QUEUE.READ,queue.write,queue.read
+                app.queue-manager.id=queue-manager
+                app.queue-manager.name=Queue Manager
+                app.queue-manager.version=1.0.0
+                app.queue-manager.summary=Manage transfer queues.
+                app.queue-manager.bundle.uri=https://example.invalid/queue-manager.zip
+                app.queue-manager.bundle.sha256=%s
+                app.queue-manager.bundle.size.bytes=0
+                app.queue-manager.bundle.type=zip
+                app.queue-manager.permissions=
+                """
+                    .formatted(GENERATED_AT, SHA256, SHA256)));
+
+    List<AppCatalogEntry> entries = catalog.entries();
+
+    assertEquals("core", catalog.catalogId());
+    assertEquals(
+        List.of("publisher", "queue-manager"),
+        entries.stream().map(AppCatalogEntry::appId).toList());
+    assertEquals(List.of("queue.read", "queue.write"), entries.getFirst().permissions());
+    assertTrue(entries.get(1).permissions().isEmpty());
+    assertEquals("zip", entries.getFirst().bundleType());
+  }
+
+  @Test
+  void parse_whenEntriesAreBlank_expectCatalogWithoutEntries() {
+    AppCatalog catalog =
+        AppCatalogParser.parse(
+            bytes(
+                """
+                catalog.version=1
+                catalog.id=core
+                catalog.name=Crypta Core Apps
+                catalog.generatedAt=%s
+                catalog.entries=
+                """
+                    .formatted(GENERATED_AT)));
+
+    assertTrue(catalog.entries().isEmpty());
+  }
+
+  @Test
+  void parse_whenCatalogHasDuplicateKey_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        """
+        catalog.version=1
+        catalog.id=core
+        catalog.name=Crypta Core Apps
+        catalog.name=Duplicate
+        catalog.generatedAt=%s
+        catalog.entries=
+        """
+            .formatted(GENERATED_AT));
+  }
+
+  @Test
+  void parse_whenCatalogHasUnknownProperty_expectInvalidCatalogEntry() {
+    assertInvalidEntry(validSingleEntryCatalog() + "catalog.future=value\n");
+  }
+
+  @Test
+  void parse_whenCatalogEntriesContainDuplicateId_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "catalog.entries=queue-manager", "catalog.entries=queue-manager,Queue-Manager"));
+  }
+
+  @Test
+  void parse_whenEntryIdDoesNotMatchDeclaredId_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace("app.queue-manager.id=queue-manager", "app.queue-manager.id=publisher"));
+  }
+
+  @Test
+  void parse_whenBundleSizeIsMalformed_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.size.bytes=0",
+                "app.queue-manager.bundle.size.bytes=NaN"));
+  }
+
+  private static void assertInvalidEntry(String catalogText) {
+    byte[] catalogBytes = bytes(catalogText);
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> AppCatalogParser.parse(catalogBytes));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  private static String validSingleEntryCatalog() {
+    return """
+    catalog.version=1
+    catalog.id=core
+    catalog.name=Crypta Core Apps
+    catalog.generatedAt=%s
+    catalog.entries=queue-manager
+    app.queue-manager.id=queue-manager
+    app.queue-manager.name=Queue Manager
+    app.queue-manager.version=1.0.0
+    app.queue-manager.summary=Manage transfer queues.
+    app.queue-manager.bundle.uri=https://example.invalid/queue-manager.zip
+    app.queue-manager.bundle.sha256=%s
+    app.queue-manager.bundle.size.bytes=0
+    app.queue-manager.bundle.type=zip
+    app.queue-manager.permissions=queue.read
+    """
+        .formatted(GENERATED_AT, SHA256);
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.appcatalog;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -91,6 +92,41 @@ class AppCatalogSourceStoreTest {
   }
 
   @Test
+  void write_whenExistingSourceMetadataWriteFails_expectPreviousSidecarsPreserved()
+      throws Exception {
+    Path rootDirectory = tempDir.resolve(STORE_DIRECTORY);
+    AppCatalogSourceStore store = new AppCatalogSourceStore(rootDirectory);
+    FetchedCatalog original = fetchedCatalog("core");
+    FetchedCatalog replacement =
+        new FetchedCatalog(
+            bytes("catalog.id=core\nreplacement=true\n"),
+            bytes("catalog.signature.key.id=replacement\n"));
+    store.write(catalog("core"), source("core"), original, ADDED_AT, REFRESHED_AT);
+    AppCatalogSourceStore.SourceMetadataWriter failingWriter =
+        (_, _, _) -> {
+          throw new IOException("metadata write failed");
+        };
+    AppCatalogSourceStore failingStore = new AppCatalogSourceStore(rootDirectory, failingWriter);
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                failingStore.write(
+                    catalog("core"),
+                    source("core"),
+                    replacement,
+                    ADDED_AT,
+                    REFRESHED_AT.plusSeconds(60)));
+    StoredCatalogSource stored = store.read("core");
+
+    assertEquals("metadata write failed", exception.getMessage());
+    assertEquals(REFRESHED_AT, stored.refreshedAt());
+    assertArrayEquals(original.catalogBytes(), stored.fetchedCatalog().catalogBytes());
+    assertArrayEquals(original.signatureBytes(), stored.fetchedCatalog().signatureBytes());
+  }
+
+  @Test
   void remove_whenCatalogExists_expectCatalogDeletedAndStagingPreserved() throws Exception {
     AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
     store.write(catalog("core"), source("core"), fetchedCatalog("core"), ADDED_AT, REFRESHED_AT);
@@ -119,6 +155,18 @@ class AppCatalogSourceStoreTest {
     Files.writeString(
         store.rootDirectory().resolve("core").resolve(SOURCE_FILE_NAME),
         sourceMetadata("other", source("core").displayUri()));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> store.read("core"));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  @Test
+  void read_whenSourceMetadataLineIsMalformed_expectInvalidCatalogSource() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    Path catalogDirectory = Files.createDirectories(store.rootDirectory().resolve("core"));
+    Files.writeString(catalogDirectory.resolve(SOURCE_FILE_NAME), "not-a-key-value-line\n");
 
     AppCatalogException exception =
         assertThrows(AppCatalogException.class, () -> store.read("core"));

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
@@ -69,6 +69,28 @@ class AppCatalogSourceStoreTest {
   }
 
   @Test
+  void listAndWrite_whenDirectoryHasSidecarsButNoSource_expectSkippedAndRetrySucceeds()
+      throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    Path catalogDirectory = Files.createDirectories(store.rootDirectory().resolve("core"));
+    Files.write(
+        catalogDirectory.resolve(AppCatalogSignature.CATALOG_FILE_NAME), bytes("partial catalog"));
+    Files.write(
+        catalogDirectory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
+        bytes("partial signature"));
+    FetchedCatalog fetchedCatalog = fetchedCatalog("core");
+
+    assertFalse(store.exists("core"));
+    assertTrue(store.list().isEmpty());
+
+    store.write(catalog("core"), source("core"), fetchedCatalog, ADDED_AT, REFRESHED_AT);
+    StoredCatalogSource stored = store.read("core");
+
+    assertArrayEquals(fetchedCatalog.catalogBytes(), stored.fetchedCatalog().catalogBytes());
+    assertArrayEquals(fetchedCatalog.signatureBytes(), stored.fetchedCatalog().signatureBytes());
+  }
+
+  @Test
   void remove_whenCatalogExists_expectCatalogDeletedAndStagingPreserved() throws Exception {
     AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
     store.write(catalog("core"), source("core"), fetchedCatalog("core"), ADDED_AT, REFRESHED_AT);

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
@@ -1,0 +1,148 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AppCatalogSourceStoreTest {
+  private static final String SOURCE_FILE_NAME = "catalog-source.properties";
+  private static final String STORE_DIRECTORY = "store";
+  private static final String ALPHA_CATALOG_ID = "alpha";
+  private static final Instant ADDED_AT = Instant.parse("2026-04-21T18:22:40Z");
+  private static final Instant REFRESHED_AT = Instant.parse("2026-04-21T19:22:40Z");
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void list_whenStoreDirectoryMissing_expectEmptyList() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve("missing"));
+
+    assertTrue(store.list().isEmpty());
+  }
+
+  @Test
+  void writeAndRead_whenSourcePersists_expectSidecarBytesAndTimestamps() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    FetchedCatalog fetchedCatalog = fetchedCatalog("core");
+    AppCatalogSource source = source("core");
+
+    store.write(catalog("core"), source, fetchedCatalog, ADDED_AT, REFRESHED_AT);
+    StoredCatalogSource stored = store.read("core");
+
+    assertEquals(source, stored.source());
+    assertEquals(ADDED_AT, stored.addedAt());
+    assertEquals(REFRESHED_AT, stored.refreshedAt());
+    assertArrayEquals(fetchedCatalog.catalogBytes(), stored.fetchedCatalog().catalogBytes());
+    assertArrayEquals(fetchedCatalog.signatureBytes(), stored.fetchedCatalog().signatureBytes());
+  }
+
+  @Test
+  void list_whenStagingDirectoryExists_expectStagingSkippedAndCatalogsSorted() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    store.write(catalog("zeta"), source("zeta"), fetchedCatalog("zeta"), ADDED_AT, REFRESHED_AT);
+    store.write(
+        catalog(ALPHA_CATALOG_ID),
+        source(ALPHA_CATALOG_ID),
+        fetchedCatalog(ALPHA_CATALOG_ID),
+        ADDED_AT,
+        REFRESHED_AT);
+    Files.createDirectories(store.stagingDirectory());
+    Files.writeString(store.stagingDirectory().resolve("scratch.tmp"), "scratch");
+
+    List<StoredCatalogSource> stored = store.list();
+
+    assertEquals(
+        List.of(source(ALPHA_CATALOG_ID).displayUri(), source("zeta").displayUri()),
+        stored.stream().map(source -> source.source().displayUri()).toList());
+  }
+
+  @Test
+  void remove_whenCatalogExists_expectCatalogDeletedAndStagingPreserved() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    store.write(catalog("core"), source("core"), fetchedCatalog("core"), ADDED_AT, REFRESHED_AT);
+    Files.createDirectories(store.stagingDirectory());
+
+    store.remove("core");
+
+    assertFalse(store.exists("core"));
+    assertTrue(Files.isDirectory(store.stagingDirectory()));
+  }
+
+  @Test
+  void remove_whenCatalogMissing_expectCatalogNotFound() {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> store.remove("missing"));
+
+    assertEquals(AppCatalogSidecars.CATALOG_NOT_FOUND, exception.errorCode());
+  }
+
+  @Test
+  void read_whenMetadataIdDoesNotMatchDirectory_expectInvalidCatalogSource() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    store.write(catalog("core"), source("core"), fetchedCatalog("core"), ADDED_AT, REFRESHED_AT);
+    Files.writeString(
+        store.rootDirectory().resolve("core").resolve(SOURCE_FILE_NAME),
+        sourceMetadata("other", source("core").displayUri()));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> store.read("core"));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  @Test
+  void read_whenStoredSourceUriIsMalformed_expectInvalidCatalogSource() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    Path catalogDirectory = Files.createDirectories(store.rootDirectory().resolve("core"));
+    Files.writeString(
+        catalogDirectory.resolve(SOURCE_FILE_NAME), sourceMetadata("core", "not a uri"));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> store.read("core"));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  private static AppCatalog catalog(String catalogId) {
+    return new AppCatalog(1, catalogId, "Catalog " + catalogId, REFRESHED_AT, List.of());
+  }
+
+  private static AppCatalogSource source(String catalogId) {
+    return new AppCatalogSource(
+        URI.create("https://example.invalid/" + catalogId + "/cryptad-app-catalog.properties"));
+  }
+
+  private static FetchedCatalog fetchedCatalog(String catalogId) {
+    return new FetchedCatalog(
+        bytes("catalog.id=" + catalogId + "\n"), bytes("catalog.signature.key.id=test\n"));
+  }
+
+  private static String sourceMetadata(String catalogId, String sourceUri) {
+    return """
+    catalog.source.version=1
+    catalog.id=%s
+    source.uri=%s
+    source.addedAt=%s
+    source.refreshedAt=%s
+    """
+        .formatted(catalogId, sourceUri, ADDED_AT, REFRESHED_AT);
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -110,6 +110,19 @@
           <p class="panel-description" hidden id="apps-readonly-hint">
             App lifecycle actions are unavailable in read-only mode.
           </p>
+          <form class="control-form" hidden id="catalog-source-form">
+            <div class="control-form-grid">
+              <label class="queue-field" for="catalog-source-input">
+                <span>Catalog source</span>
+                <input id="catalog-source-input" name="source" type="text" autocomplete="off">
+              </label>
+            </div>
+            <div class="control-form-actions">
+              <button class="button button-primary" id="catalog-source-submit" type="submit">
+                Add catalog
+              </button>
+            </div>
+          </form>
           <div class="panel-body" id="apps-body">
             <p class="loading">Loading installed apps...</p>
           </div>

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -561,6 +561,24 @@ a {
   display: flex;
 }
 
+.catalog-app-list {
+  display: grid;
+  gap: 10px;
+}
+
+.catalog-app-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.catalog-app-title {
+  margin: 0;
+}
+
 .app-ui-entry {
   display: inline-flex;
   align-items: center;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -1913,6 +1913,14 @@
     throw new Error(extractApiError(data, response));
   }
 
+  async function loadBestEffortOptionalJson(url) {
+    try {
+      return await loadOptionalJson(url);
+    } catch (error) {
+      return null;
+    }
+  }
+
   async function postForm(path, formData, unavailableMessage) {
     return submitFormMutation("POST", path, formData, unavailableMessage);
   }
@@ -2290,8 +2298,8 @@
 
     const snapshotRequest = loadJson(queuePageUrl());
     const countRequest =
-      queueState.page === "downloads" ? loadOptionalJson(queueCountUrl()) : Promise.resolve(null);
-    const keysRequest = queueState.keysVisible ? loadOptionalJson(queueKeysUrl()) : Promise.resolve(null);
+      queueState.page === "downloads" ? loadBestEffortOptionalJson(queueCountUrl()) : Promise.resolve(null);
+    const keysRequest = queueState.keysVisible ? loadBestEffortOptionalJson(queueKeysUrl()) : Promise.resolve(null);
 
     try {
       const snapshot = await snapshotRequest;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -14,6 +14,7 @@
   const legacyLinks = Array.isArray(bootstrap.legacyLinks) ? bootstrap.legacyLinks : [];
   const shellState = {
     alertsSnapshot: null,
+    appCatalogsSnapshot: null,
     appsSnapshot: null,
     configSnapshot: null,
     diagnosticsSnapshot: null,
@@ -87,6 +88,8 @@
   };
   const appsControls = {
     refreshButton: document.getElementById("apps-refresh-button"),
+    catalogSourceForm: document.getElementById("catalog-source-form"),
+    catalogSourceInput: document.getElementById("catalog-source-input"),
   };
   const publisherControls = {
     fileForm: document.getElementById("publisher-file-form"),
@@ -880,6 +883,27 @@
     }
   }
 
+  function catalogMutationPath(catalogId, appId, action) {
+    if (typeof catalogId !== "string" || catalogId.length === 0) {
+      return null;
+    }
+    const encodedCatalogId = encodeURIComponent(catalogId);
+    if (action === "refresh") {
+      return `app-catalogs/${encodedCatalogId}/refresh`;
+    }
+    if (action === "remove") {
+      return `app-catalogs/${encodedCatalogId}`;
+    }
+    if (typeof appId !== "string" || appId.length === 0) {
+      return null;
+    }
+    const encodedAppId = encodeURIComponent(appId);
+    if (action === "install" || action === "update") {
+      return `app-catalogs/${encodedCatalogId}/apps/${encodedAppId}/${action}`;
+    }
+    return null;
+  }
+
   function appUiEntryNode(app) {
     const href = normalizeAppUiEntryHref(app.uiEntry);
     if (!href) {
@@ -907,6 +931,29 @@
     form.dataset.appId = appId;
     form.dataset.appAction = action;
     form.dataset.appName = appDisplayName(app);
+
+    const submit = document.createElement("button");
+    submit.className = "button button-secondary";
+    submit.type = "submit";
+    submit.textContent = label;
+    form.append(submit);
+    return form;
+  }
+
+  function buildCatalogActionForm(catalog, app, action, label) {
+    const catalogId = typeof catalog.catalogId === "string" ? catalog.catalogId : "";
+    const appId = app && typeof app.appId === "string" ? app.appId : "";
+    const path = catalogMutationPath(catalogId, appId, action);
+    if (!path) {
+      return null;
+    }
+
+    const form = document.createElement("form");
+    form.className = "app-action-form";
+    form.dataset.catalogId = catalogId;
+    form.dataset.catalogAppId = appId;
+    form.dataset.catalogAction = action;
+    form.dataset.catalogAppName = app ? appDisplayName(app) : catalogId;
 
     const submit = document.createElement("button");
     submit.className = "button button-secondary";
@@ -974,30 +1021,133 @@
 
   function renderApps(data) {
     shellState.appsSnapshot = data;
+    shellState.appCatalogsSnapshot = Array.isArray(data.catalogs) ? data.catalogs : null;
     updateAppsToolbar();
     clear(sections.apps);
 
     const apps = Array.isArray(data.apps) ? data.apps : [];
+    const catalogs = Array.isArray(data.catalogs) ? data.catalogs : [];
+    const catalogError = typeof data.catalogError === "string" ? data.catalogError : "";
     const runningApps = apps.filter((app) => app && typeof app === "object" && app.running).length;
     const summaryEntries = [
       ["Installed apps", `${apps.length}`],
       ["Running apps", `${runningApps}`],
+      ["Catalogs", `${catalogs.length}`],
       ["Scope", formPassword ? "Shell-native" : "Read-only"],
-      ...topLevelFieldEntries(data, ["apps"]),
+      ...topLevelFieldEntries(data, ["apps", "catalogs"]),
     ];
     sections.apps.append(summaryCard("Apps summary", summaryEntries, apps.length ? "" : "is-warning"));
 
-    if (!apps.length) {
+    if (apps.length) {
+      const list = document.createElement("div");
+      list.className = "app-card-list";
+      apps.forEach((app) => {
+        list.append(renderAppCard(app && typeof app === "object" ? app : {}));
+      });
+      sections.apps.append(list);
+    } else {
       sections.apps.append(text("p", "empty-state", "No installed apps were returned."));
-      return;
     }
 
+    renderCatalogs(catalogs, catalogError);
+  }
+
+  function renderCatalogs(catalogs, catalogError) {
+    sections.apps.append(text("h3", "app-card-title", "Catalog apps"));
+    if (catalogError) {
+      sections.apps.append(text("p", "error-state", `Catalogs unavailable: ${catalogError}`));
+      return;
+    }
+    if (!Array.isArray(catalogs) || catalogs.length === 0) {
+      sections.apps.append(text("p", "empty-state", "No app catalogs were returned."));
+      return;
+    }
     const list = document.createElement("div");
     list.className = "app-card-list";
-    apps.forEach((app) => {
-      list.append(renderAppCard(app && typeof app === "object" ? app : {}));
+    catalogs.forEach((catalog) => {
+      list.append(renderCatalogCard(catalog && typeof catalog === "object" ? catalog : {}));
     });
     sections.apps.append(list);
+  }
+
+  function renderCatalogCard(catalog) {
+    const card = document.createElement("article");
+    card.className = "app-card";
+    const title = typeof catalog.name === "string" && catalog.name ? catalog.name : scalar(catalog.catalogId);
+    const header = document.createElement("div");
+    header.className = "app-card-header";
+    const heading = document.createElement("div");
+    heading.className = "app-card-heading";
+    heading.append(text("h3", "app-card-title", title), text("p", "app-card-subtitle", scalar(catalog.catalogId)));
+    const pills = document.createElement("div");
+    pills.className = "app-card-pills";
+    pills.append(createPill("Signed catalog"));
+    pills.append(createPill(`${Array.isArray(catalog.apps) ? catalog.apps.length : 0} apps`));
+    header.append(heading, pills);
+    card.append(header);
+    card.append(
+      definitionList([
+        ["Source", scalar(catalog.source)],
+        ["Generated", formatIsoTimestamp(catalog.generatedAt)],
+        ["Refreshed", formatIsoTimestamp(catalog.refreshedAt)],
+      ]),
+    );
+    if (formPassword) {
+      const actions = document.createElement("div");
+      actions.className = "app-card-actions";
+      const refreshForm = buildCatalogActionForm(catalog, null, "refresh", "Refresh");
+      const removeForm = buildCatalogActionForm(catalog, null, "remove", "Remove");
+      if (refreshForm) {
+        actions.append(refreshForm);
+      }
+      if (removeForm) {
+        actions.append(removeForm);
+      }
+      if (actions.childNodes.length) {
+        card.append(actions);
+      }
+    }
+
+    const apps = Array.isArray(catalog.apps) ? catalog.apps : [];
+    if (!apps.length) {
+      card.append(text("p", "empty-state", "No apps were returned for this catalog."));
+      return card;
+    }
+    const appList = document.createElement("div");
+    appList.className = "catalog-app-list";
+    apps.forEach((app) => {
+      appList.append(renderCatalogAppCard(catalog, app && typeof app === "object" ? app : {}));
+    });
+    card.append(appList);
+    return card;
+  }
+
+  function renderCatalogAppCard(catalog, app) {
+    const card = document.createElement("section");
+    card.className = "catalog-app-card";
+    card.append(text("h4", "catalog-app-title", appDisplayName(app)));
+    card.append(
+      definitionList([
+        ["App ID", scalar(app.appId)],
+        ["Version", scalar(app.version)],
+        ["Installed version", scalar(app.installedVersion)],
+        ["Summary", scalar(app.summary)],
+        ["Permissions", formatPermissions(app.permissions)],
+        ["Installed", app.installed ? "Yes" : "No"],
+        ["Running", app.running ? "Yes" : "No"],
+      ]),
+    );
+    if (formPassword) {
+      const actions = document.createElement("div");
+      actions.className = "app-card-actions";
+      const action = app.installed ? "update" : "install";
+      const form = buildCatalogActionForm(catalog, app, action, app.installed ? "Update" : "Install");
+      if (form) {
+        actions.append(form);
+        card.append(actions);
+      }
+    }
+    return card;
   }
 
   function getNestedValue(root, path) {
@@ -1227,6 +1377,9 @@
   }
 
   function updateAppsToolbar() {
+    if (appsControls.catalogSourceForm) {
+      appsControls.catalogSourceForm.hidden = !formPassword;
+    }
     if (sections.appsReadonlyHint) {
       sections.appsReadonlyHint.hidden = !!formPassword;
     }
@@ -1748,12 +1901,16 @@
     return data;
   }
 
-  async function loadOptionalJson(url) {
-    try {
-      return await loadJson(url);
-    } catch (error) {
+  async function loadOptionalJson(url, optionalStatuses = [404]) {
+    const response = await fetch(url, { headers: { Accept: "application/json" } });
+    const data = await response.json().catch(() => ({}));
+    if (response.ok) {
+      return data;
+    }
+    if (optionalStatuses.includes(response.status)) {
       return null;
     }
+    throw new Error(extractApiError(data, response));
   }
 
   async function postForm(path, formData, unavailableMessage) {
@@ -1948,22 +2105,49 @@
   async function loadAppsSection() {
     const loadGeneration = ++appsLoadGeneration;
     shellState.appsSnapshot = null;
+    shellState.appCatalogsSnapshot = null;
     clear(sections.apps);
-    sections.apps.append(text("p", "loading", "Loading installed apps..."));
+    sections.apps.append(text("p", "loading", "Loading installed apps and catalogs..."));
     updateAppsToolbar();
 
+    let installedSnapshot;
     try {
-      const snapshot = await loadJson(apiUrl("apps"));
-      if (loadGeneration !== appsLoadGeneration) {
-        return;
-      }
-      renderApps(snapshot);
+      installedSnapshot = await loadJson(apiUrl("apps"));
     } catch (error) {
       if (loadGeneration !== appsLoadGeneration) {
         return;
       }
       renderError(sections.apps, "apps", error);
+      return;
     }
+
+    let catalogs = [];
+    let catalogError = "";
+    try {
+      const catalogsSnapshot = await loadOptionalJson(apiUrl("app-catalogs"));
+      catalogs =
+        catalogsSnapshot && Array.isArray(catalogsSnapshot.catalogs)
+          ? await Promise.all(
+              catalogsSnapshot.catalogs.map(loadCatalogApps),
+            )
+          : [];
+    } catch (error) {
+      catalogError =
+        error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
+    }
+
+    if (loadGeneration !== appsLoadGeneration) {
+      return;
+    }
+    renderApps({ ...installedSnapshot, catalogs, catalogError });
+  }
+
+  async function loadCatalogApps(catalog) {
+    if (!catalog || typeof catalog !== "object" || typeof catalog.catalogId !== "string") {
+      return catalog;
+    }
+    const apps = await loadJson(apiUrl(`app-catalogs/${encodeURIComponent(catalog.catalogId)}/apps`));
+    return { ...catalog, apps: apps && Array.isArray(apps.apps) ? apps.apps : [] };
   }
 
   async function dismissAlert(form) {
@@ -2013,6 +2197,50 @@
       if (operation && operation !== action) {
         setAppsStatus(`App action completed: ${operation.replaceAll("_", " ")}.`, "is-success");
       }
+      await loadAppsSection();
+    } catch (error) {
+      setAppsStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  async function submitCatalogSource(event) {
+    event.preventDefault();
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+    if (typeof form.reportValidity === "function" && !form.reportValidity()) {
+      return;
+    }
+    try {
+      await postForm(
+        "app-catalogs/add",
+        new FormData(form),
+        "Catalog actions unavailable in read-only mode.",
+      );
+      form.reset();
+      setAppsStatus("Catalog source added.", "is-success");
+      await loadAppsSection();
+    } catch (error) {
+      setAppsStatus(error instanceof Error ? error.message : String(error), "is-error");
+    }
+  }
+
+  async function submitCatalogMutation(form, action) {
+    const catalogId = form.dataset.catalogId || "";
+    const appId = form.dataset.catalogAppId || "";
+    const path = catalogMutationPath(catalogId, appId, action);
+    if (!path) {
+      setAppsStatus("Catalog action unavailable for this entry.", "is-error");
+      return;
+    }
+    try {
+      if (action === "remove") {
+        await deleteForm(path, new FormData(form), "Catalog actions unavailable in read-only mode.");
+      } else {
+        await postForm(path, new FormData(form), "Catalog actions unavailable in read-only mode.");
+      }
+      setAppsStatus(`Catalog action completed: ${action}.`, "is-success");
       await loadAppsSection();
     } catch (error) {
       setAppsStatus(error instanceof Error ? error.message : String(error), "is-error");
@@ -2622,12 +2850,18 @@
 
   function bindAppsInteractions() {
     appsControls.refreshButton.addEventListener("click", () => {
-      setAppsStatus("Refreshing installed apps.");
+      setAppsStatus("Refreshing installed apps and catalogs.");
       loadAppsSection();
     });
     sections.apps.addEventListener("submit", async (event) => {
       const form = event.target;
       if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+      const catalogAction = form.dataset.catalogAction;
+      if (catalogAction) {
+        event.preventDefault();
+        await submitCatalogMutation(form, catalogAction);
         return;
       }
       const action = form.dataset.appAction;
@@ -2637,6 +2871,9 @@
       event.preventDefault();
       await submitAppMutation(form, action);
     });
+    if (appsControls.catalogSourceForm) {
+      appsControls.catalogSourceForm.addEventListener("submit", submitCatalogSource);
+    }
   }
 
   function bindPublisherInteractions() {

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -172,10 +172,12 @@ class WebShellResourcesTest {
         script.indexOf("renderError(sections.queue, \"queue\", error);", queueLoadIndex);
     int queueCountLoadIndex =
         script.indexOf(
-            "queueState.page === \"downloads\" ? loadOptionalJson(queueCountUrl()) :"
+            "queueState.page === \"downloads\" ? loadBestEffortOptionalJson(queueCountUrl()) :"
                 + " Promise.resolve(null);");
     int loadOptionalJsonIndex =
         script.indexOf("async function loadOptionalJson(url, optionalStatuses = [404])");
+    int loadBestEffortOptionalJsonIndex =
+        script.indexOf("async function loadBestEffortOptionalJson(url)");
     int snapshotAwaitIndex =
         script.indexOf("const snapshot = await snapshotRequest;", queueLoadIndex);
     int optionalAwaitIndex =
@@ -189,8 +191,10 @@ class WebShellResourcesTest {
     assertTrue(renderErrorIndex > errorGuardIndex);
     assertTrue(queueCountLoadIndex >= 0);
     assertTrue(loadOptionalJsonIndex >= 0);
+    assertTrue(loadBestEffortOptionalJsonIndex > loadOptionalJsonIndex);
     assertTrue(script.contains("optionalStatuses.includes(response.status)"));
     assertTrue(script.contains("throw new Error(extractApiError(data, response));"));
+    assertTrue(script.contains("return await loadOptionalJson(url);"));
     assertTrue(snapshotAwaitIndex > queueLoadIndex);
     assertTrue(optionalAwaitIndex > snapshotAwaitIndex);
   }

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -8,6 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class WebShellResourcesTest {
+  private static final String EVENT_PREVENT_DEFAULT = "event.preventDefault();";
+  private static final String CLEAR_WIZARD_BANDWIDTH_CHOICE_REQUIREMENT =
+      " clearWizardBandwidthChoiceRequirement);";
+
   @Test
   void readText_whenIndexResourceRequested_expectShellMarkup() {
     String html = WebShellResources.readText(WebShellPaths.INDEX_RESOURCE_PATH);
@@ -34,6 +38,9 @@ class WebShellResourcesTest {
         "id=\"apps\"",
         "id=\"apps-body\"",
         "id=\"apps-status\"",
+        "id=\"catalog-source-form\"",
+        "id=\"catalog-source-input\"",
+        "id=\"catalog-source-submit\"",
         "peer-create-form\" hidden",
         "name=\"referenceText\"",
         "id=\"peers-status\"",
@@ -91,6 +98,7 @@ class WebShellResourcesTest {
     assertTrue(stylesheet.contains("white-space: pre-wrap;"));
     assertTrue(stylesheet.contains(".app-card-list {"));
     assertTrue(stylesheet.contains(".app-card-actions {"));
+    assertTrue(stylesheet.contains(".catalog-app-card {"));
     assertTrue(stylesheet.contains(".publisher-forms {"));
     assertTrue(stylesheet.contains(".publisher-result-actions {"));
     assertTrue(stylesheet.contains(".status-pill.is-success::before {"));
@@ -137,7 +145,7 @@ class WebShellResourcesTest {
 
   private static void assertQueueMutationSubmissionOrder(String script) {
     int submitHandlerIndex = script.indexOf("const path = queueMutationPath(submitter.name);");
-    int preventDefaultIndex = script.indexOf("event.preventDefault();", submitHandlerIndex);
+    int preventDefaultIndex = script.indexOf(EVENT_PREVENT_DEFAULT, submitHandlerIndex);
     int awaitMutationIndex =
         script.indexOf("await submitQueueMutation(form, submitter, path);", submitHandlerIndex);
     int refreshFormPasswordIndex =
@@ -166,7 +174,8 @@ class WebShellResourcesTest {
         script.indexOf(
             "queueState.page === \"downloads\" ? loadOptionalJson(queueCountUrl()) :"
                 + " Promise.resolve(null);");
-    int loadOptionalJsonIndex = script.indexOf("async function loadOptionalJson(url)");
+    int loadOptionalJsonIndex =
+        script.indexOf("async function loadOptionalJson(url, optionalStatuses = [404])");
     int snapshotAwaitIndex =
         script.indexOf("const snapshot = await snapshotRequest;", queueLoadIndex);
     int optionalAwaitIndex =
@@ -180,6 +189,8 @@ class WebShellResourcesTest {
     assertTrue(renderErrorIndex > errorGuardIndex);
     assertTrue(queueCountLoadIndex >= 0);
     assertTrue(loadOptionalJsonIndex >= 0);
+    assertTrue(script.contains("optionalStatuses.includes(response.status)"));
+    assertTrue(script.contains("throw new Error(extractApiError(data, response));"));
     assertTrue(snapshotAwaitIndex > queueLoadIndex);
     assertTrue(optionalAwaitIndex > snapshotAwaitIndex);
   }
@@ -252,7 +263,7 @@ class WebShellResourcesTest {
     int bindPeersIndex = script.indexOf("function bindPeerInteractions()");
     int actionLookupIndex =
         script.indexOf("const action = form.dataset.peerAction;", bindPeersIndex);
-    int preventDefaultIndex = script.indexOf("event.preventDefault();", actionLookupIndex);
+    int preventDefaultIndex = script.indexOf(EVENT_PREVENT_DEFAULT, actionLookupIndex);
     int requiresForceRemovalIndex =
         script.indexOf(
             "const requiresForceRemoval = form.dataset.peerRequiresForceRemoval === \"true\";",
@@ -293,36 +304,64 @@ class WebShellResourcesTest {
     String appUiEntryHelper = script.substring(appUiEntryHelperIndex, legacyLinkHelperIndex);
 
     assertTrue(script.contains("appsSnapshot: null"));
+    assertTrue(script.contains("appCatalogsSnapshot: null"));
     assertTrue(script.contains("let appsLoadGeneration = 0;"));
     assertTrue(script.contains("apps: document.getElementById(\"apps-body\")"));
     assertTrue(script.contains("appsStatus: document.getElementById(\"apps-status\")"));
     assertTrue(
         script.contains("appsReadonlyHint: document.getElementById(\"apps-readonly-hint\")"));
     assertTrue(script.contains("const appsControls = {"));
+    assertTrue(
+        script.contains("catalogSourceForm: document.getElementById(\"catalog-source-form\")"));
     assertTrue(script.contains("function normalizeAppUiEntryHref(value)"));
     assertTrue(appUiEntryHelper.contains("const url = new URL(value, shellRootUrl);"));
     assertTrue(script.contains("return `${url.pathname}${url.search}${url.hash}`;"));
     assertFalse(appUiEntryHelper.contains("const url = new URL(value, window.location.origin);"));
     assertTrue(script.contains("function renderAppCard(app)"));
     assertTrue(script.contains("function renderApps(data)"));
+    assertTrue(script.contains("function renderCatalogs(catalogs, catalogError)"));
+    assertTrue(script.contains("Catalogs unavailable: ${catalogError}"));
+    assertTrue(script.contains("function renderCatalogCard(catalog)"));
+    assertTrue(script.contains("function renderCatalogAppCard(catalog, app)"));
+    assertTrue(script.contains("async function loadCatalogApps(catalog)"));
     assertTrue(script.contains("function appMutationPath(appId, action)"));
+    assertTrue(script.contains("function catalogMutationPath(catalogId, appId, action)"));
     assertTrue(script.contains("async function loadAppsSection()"));
+    assertTrue(script.contains("async function submitCatalogSource(event)"));
+    assertTrue(script.contains("async function submitCatalogMutation(form, action)"));
     assertTrue(script.contains("async function deleteForm(path, formData, unavailableMessage)"));
-    assertTrue(script.contains("setAppsStatus(\"Refreshing installed apps.\");"));
+    assertTrue(script.contains("setAppsStatus(\"Refreshing installed apps and catalogs.\");"));
     assertTrue(script.contains("loadJson(apiUrl(\"apps\"))"));
+    assertTrue(script.contains("loadOptionalJson(apiUrl(\"app-catalogs\"))"));
+    assertTrue(script.contains("catalogsSnapshot.catalogs.map(loadCatalogApps)"));
+    assertTrue(
+        script.contains(
+            "const apps = await"
+                + " loadJson(apiUrl(`app-catalogs/${encodeURIComponent(catalog.catalogId)}/apps`));"));
     assertTrue(script.contains("return `apps/${encodedAppId}/${action}`;"));
     assertTrue(script.contains("return `apps/${encodedAppId}`;"));
+    assertTrue(script.contains("return `app-catalogs/${encodedCatalogId}/refresh`;"));
+    assertTrue(
+        script.contains(
+            "return `app-catalogs/${encodedCatalogId}/apps/${encodedAppId}/${action}`;"));
     assertTrue(script.contains("action === \"uninstall\""));
     assertTrue(script.contains("App lifecycle actions unavailable in read-only mode."));
+    assertTrue(script.contains("Catalog actions unavailable in read-only mode."));
   }
 
   private static void assertAppsSubmissionOrder(String script) {
     int bindAppsIndex = script.indexOf("function bindAppsInteractions()");
     int actionLookupIndex = script.indexOf("const action = form.dataset.appAction;", bindAppsIndex);
-    int preventDefaultIndex = script.indexOf("event.preventDefault();", actionLookupIndex);
+    int preventDefaultIndex = script.indexOf(EVENT_PREVENT_DEFAULT, actionLookupIndex);
     int mutationIndex = script.indexOf("await submitAppMutation(form, action);", bindAppsIndex);
+    int catalogActionLookupIndex =
+        script.indexOf("const catalogAction = form.dataset.catalogAction;", bindAppsIndex);
+    int catalogMutationIndex =
+        script.indexOf("await submitCatalogMutation(form, catalogAction);", bindAppsIndex);
 
     assertTrue(bindAppsIndex >= 0);
+    assertTrue(catalogActionLookupIndex > bindAppsIndex);
+    assertTrue(catalogMutationIndex > catalogActionLookupIndex);
     assertTrue(actionLookupIndex > bindAppsIndex);
     assertTrue(preventDefaultIndex > actionLookupIndex);
     assertTrue(mutationIndex > preventDefaultIndex);
@@ -330,19 +369,31 @@ class WebShellResourcesTest {
 
   private static void assertAppsLoadSequencing(String script) {
     int loadAppsIndex = script.indexOf("const loadGeneration = ++appsLoadGeneration;");
-    int successGuardIndex =
-        script.indexOf("if (loadGeneration !== appsLoadGeneration) {", loadAppsIndex);
-    int renderAppsIndex = script.indexOf("renderApps(snapshot);", loadAppsIndex);
-    int errorGuardIndex =
-        script.indexOf("if (loadGeneration !== appsLoadGeneration) {", successGuardIndex + 1);
+    int installedAwaitIndex =
+        script.indexOf("installedSnapshot = await loadJson(apiUrl(\"apps\"));", loadAppsIndex);
+    int installedErrorGuardIndex =
+        script.indexOf("if (loadGeneration !== appsLoadGeneration) {", installedAwaitIndex);
     int renderErrorIndex =
-        script.indexOf("renderError(sections.apps, \"apps\", error);", loadAppsIndex);
+        script.indexOf("renderError(sections.apps, \"apps\", error);", installedErrorGuardIndex);
+    int catalogLoadIndex =
+        script.indexOf(
+            "const catalogsSnapshot = await loadOptionalJson(apiUrl(\"app-catalogs\"));",
+            renderErrorIndex);
+    int catalogErrorIndex = script.indexOf("catalogError =", catalogLoadIndex);
+    int successGuardIndex =
+        script.indexOf("if (loadGeneration !== appsLoadGeneration) {", catalogErrorIndex);
+    int renderAppsIndex =
+        script.indexOf(
+            "renderApps({ ...installedSnapshot, catalogs, catalogError });", successGuardIndex);
 
     assertTrue(loadAppsIndex >= 0);
-    assertTrue(successGuardIndex > loadAppsIndex);
+    assertTrue(installedAwaitIndex > loadAppsIndex);
+    assertTrue(installedErrorGuardIndex > installedAwaitIndex);
+    assertTrue(renderErrorIndex > installedErrorGuardIndex);
+    assertTrue(catalogLoadIndex > renderErrorIndex);
+    assertTrue(catalogErrorIndex > catalogLoadIndex);
+    assertTrue(successGuardIndex > catalogErrorIndex);
     assertTrue(renderAppsIndex > successGuardIndex);
-    assertTrue(errorGuardIndex > renderAppsIndex);
-    assertTrue(renderErrorIndex > errorGuardIndex);
   }
 
   private static void assertPublisherMarkersPresent(String script) {
@@ -554,15 +605,15 @@ class WebShellResourcesTest {
     assertTrue(
         script.contains(
             "wizardControls.downloadLimit.addEventListener(\"input\","
-                + " clearWizardBandwidthChoiceRequirement);"));
+                + CLEAR_WIZARD_BANDWIDTH_CHOICE_REQUIREMENT));
     assertTrue(
         script.contains(
             "wizardControls.uploadLimit.addEventListener(\"input\","
-                + " clearWizardBandwidthChoiceRequirement);"));
+                + CLEAR_WIZARD_BANDWIDTH_CHOICE_REQUIREMENT));
     assertTrue(
         script.contains(
             "wizardControls.monthlyLimit.addEventListener(\"input\","
-                + " clearWizardBandwidthChoiceRequirement);"));
+                + CLEAR_WIZARD_BANDWIDTH_CHOICE_REQUIREMENT));
     assertTrue(script.contains("await postForm(\"config/overrides\", formData"));
     assertTrue(script.contains("await postForm(\"updates/core/download\", new FormData()"));
     assertTrue(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ include(
   ":apps:queue-manager",
   ":apps:publisher",
   ":platform-appdist",
+  ":platform-appcatalog",
   ":foundation-support",
   ":foundation-store",
   ":foundation-store-contracts",

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import network.crypta.clients.http.bookmark.BookmarkManager;
+import network.crypta.platform.api.PlatformApiPaths;
 import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
@@ -88,6 +89,20 @@ class ToadletContextImplTest {
   void shouldDisconnectAfterHandled_http10WithoutHeader_returnsTrue() {
     MultiValueTable<String, String> headers = new MultiValueTable<>();
     assertTrue(invokeShouldDisconnectAfterHandled(true, headers));
+  }
+
+  @Test
+  void isMethodAllowedInRestrictedMode_whenDeleteTargetsPlatformApi_returnsTrue() {
+    URI uri = URI.create("http://localhost" + PlatformApiPaths.API_V1_PREFIX + "apps/alpha");
+
+    assertTrue(ToadletContextImpl.isMethodAllowedInRestrictedMode("DELETE", uri));
+  }
+
+  @Test
+  void isMethodAllowedInRestrictedMode_whenDeleteTargetsNonPlatformRoute_returnsFalse() {
+    URI uri = URI.create("http://localhost/downloads/");
+
+    assertFalse(ToadletContextImpl.isMethodAllowedInRestrictedMode("DELETE", uri));
   }
 
   @Test

--- a/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
@@ -5,11 +5,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 import network.crypta.fs.AppEnv;
+import network.crypta.platform.appcatalog.AppCatalogManager;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appcatalog.AppCatalogSigner;
+import network.crypta.platform.appcatalog.AppCatalogSourceStore;
 import network.crypta.platform.appdist.AppBundleSignature;
 import network.crypta.platform.appdist.AppBundleSigner;
 import network.crypta.platform.appdist.AppBundleVerifier;
@@ -38,6 +48,7 @@ class PlatformApiAppsIntegrationTest {
   private static final String APP_VERSION = "1.2.3";
   private static final String TRUSTED_KEY_ID = "local-dev";
   private static final String UI_ENTRY = "/";
+  private static final String CATALOG_ID = "core";
 
   @TempDir private Path tempDir;
 
@@ -255,6 +266,57 @@ class PlatformApiAppsIntegrationTest {
     assertTrue(updateResponse.body().contains("\"version\":\"9.9.9\""));
   }
 
+  @Test
+  void route_whenCatalogSourceInstalledAndUpdated_expectVerifiedCatalogFlow() throws Exception {
+    KeyPair keyPair =
+        KeyPairGenerator.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM).generateKeyPair();
+    TrustedAppKeys trustedKeys =
+        TrustedAppKeys.of(
+            new TrustedAppKey(
+                TRUSTED_KEY_ID, AppBundleSignature.SIGNATURE_ALGORITHM, keyPair.getPublic()));
+    PlatformApiRouter productionRouter =
+        createRouter(signedHost(trustedKeys), catalogManager(trustedKeys));
+    Path stagedV1 = stageSignedApp("catalog-v1", "1.0.0", keyPair);
+    Path artifactV1 = zipDirectory(stagedV1, tempDir.resolve("catalog-v1.zip"));
+    Path catalog = writeSignedCatalog(artifactV1, "1.0.0", keyPair);
+
+    PlatformApiResponse addResponse =
+        productionRouter.route(
+            request(
+                "POST",
+                List.of("app-catalogs", "add"),
+                Map.of("source", List.of(catalog.toString()))));
+    PlatformApiResponse listAppsResponse =
+        productionRouter.route(
+            request("GET", List.of("app-catalogs", CATALOG_ID, "apps"), Map.of()));
+    PlatformApiResponse installResponse =
+        productionRouter.route(
+            request(
+                "POST", List.of("app-catalogs", CATALOG_ID, "apps", APP_ID, "install"), Map.of()));
+
+    assertEquals(201, addResponse.statusCode());
+    assertEquals(200, listAppsResponse.statusCode());
+    assertTrue(listAppsResponse.body().contains("\"appId\":\"demo-app\""));
+    assertEquals(201, installResponse.statusCode());
+    assertTrue(installResponse.body().contains("\"version\":\"1.0.0\""));
+
+    Path stagedV2 = stageSignedApp("catalog-v2", "9.9.9", keyPair);
+    Path artifactV2 = zipDirectory(stagedV2, tempDir.resolve("catalog-v2.zip"));
+    writeSignedCatalog(artifactV2, "9.9.9", keyPair);
+
+    PlatformApiResponse refreshResponse =
+        productionRouter.route(
+            request("POST", List.of("app-catalogs", CATALOG_ID, "refresh"), Map.of()));
+    PlatformApiResponse updateResponse =
+        productionRouter.route(
+            request(
+                "POST", List.of("app-catalogs", CATALOG_ID, "apps", APP_ID, "update"), Map.of()));
+
+    assertEquals(200, refreshResponse.statusCode());
+    assertEquals(200, updateResponse.statusCode());
+    assertTrue(updateResponse.body().contains("\"version\":\"9.9.9\""));
+  }
+
   private PlatformApiRequest request(
       String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
     return new PlatformApiRequest(method, pathSegments, queryParameters);
@@ -263,6 +325,11 @@ class PlatformApiAppsIntegrationTest {
   private PlatformApiRouter createRouter(AppHost appHost) {
     RuntimePorts runtimePorts = mock(RuntimePorts.class, Answers.RETURNS_DEEP_STUBS);
     return new PlatformApiRouter(runtimePorts, appHost);
+  }
+
+  private PlatformApiRouter createRouter(AppHost appHost, AppCatalogManager appCatalogManager) {
+    RuntimePorts runtimePorts = mock(RuntimePorts.class, Answers.RETURNS_DEEP_STUBS);
+    return new PlatformApiRouter(runtimePorts, appHost, appCatalogManager);
   }
 
   private AppHost allowUnsignedHost() {
@@ -280,6 +347,11 @@ class PlatformApiAppsIntegrationTest {
         new SecureRandom(),
         AppInstallVerificationPolicy.requireSigned(
             copiedBundleDirectory -> AppBundleVerifier.verify(copiedBundleDirectory, trustedKeys)));
+  }
+
+  private AppCatalogManager catalogManager(TrustedAppKeys trustedKeys) {
+    return new AppCatalogManager(
+        new AppCatalogSourceStore(tempDir.resolve("catalog-store")), () -> trustedKeys);
   }
 
   private Path stageApp() throws Exception {
@@ -319,6 +391,74 @@ class PlatformApiAppsIntegrationTest {
     Path stagedDir = stageApp(stagedDirectoryName, appVersion);
     AppBundleSigner.sign(stagedDir, TRUSTED_KEY_ID, keyPair.getPrivate());
     return stagedDir;
+  }
+
+  private Path writeSignedCatalog(Path artifact, String appVersion, KeyPair keyPair)
+      throws Exception {
+    Path catalogDir = Files.createDirectories(tempDir.resolve("catalog"));
+    Path catalog = catalogDir.resolve(AppCatalogSignature.CATALOG_FILE_NAME);
+    Files.writeString(
+        catalog,
+        """
+        catalog.version=1
+        catalog.id=%s
+        catalog.name=Crypta Core Apps
+        catalog.generatedAt=%s
+        catalog.entries=%s
+        app.%s.id=%s
+        app.%s.name=%s
+        app.%s.version=%s
+        app.%s.summary=Manage local Crypta transfer queues.
+        app.%s.bundle.uri=%s
+        app.%s.bundle.sha256=%s
+        app.%s.bundle.size.bytes=%d
+        app.%s.bundle.type=zip
+        app.%s.permissions=queue.read,queue.write
+        """
+            .formatted(
+                CATALOG_ID,
+                Instant.parse("2026-04-21T18:22:40Z"),
+                APP_ID,
+                APP_ID,
+                APP_ID,
+                APP_ID,
+                APP_NAME,
+                APP_ID,
+                appVersion,
+                APP_ID,
+                APP_ID,
+                artifact.toUri(),
+                APP_ID,
+                sha256(artifact),
+                APP_ID,
+                Files.size(artifact),
+                APP_ID,
+                APP_ID),
+        StandardCharsets.UTF_8);
+    AppCatalogSigner.sign(catalog, TRUSTED_KEY_ID, keyPair.getPrivate());
+    return catalog;
+  }
+
+  private static Path zipDirectory(Path sourceRoot, Path targetZip) throws Exception {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip));
+        var paths = Files.walk(sourceRoot)) {
+      for (Path path : paths.sorted(Comparator.naturalOrder()).toList()) {
+        if (Files.isDirectory(path)) {
+          continue;
+        }
+        String relative = sourceRoot.relativize(path).toString().replace('\\', '/');
+        zip.putNextEntry(new ZipEntry(relative));
+        Files.copy(path, zip);
+        zip.closeEntry();
+      }
+    }
+    return targetZip;
+  }
+
+  private static String sha256(Path path) throws Exception {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    digest.update(Files.readAllBytes(path));
+    return HexFormat.of().formatHex(digest.digest());
   }
 
   private static String scriptContent(AppEnv appEnv) {

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import network.crypta.platform.api.json.PlatformApiJsonWriter;
+import network.crypta.platform.appcatalog.AppCatalogEntry;
+import network.crypta.platform.appcatalog.AppCatalogInstallPlan;
+import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostConfigurationException;
@@ -91,6 +94,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -1967,6 +1971,23 @@ class PlatformApiRouterTest {
   }
 
   @Test
+  void route_whenCatalogIdMatchesAddAndDeleteRequested_expectCatalogRemovedJson() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+
+    PlatformApiResponse response =
+        catalogRouter.route(request("DELETE", List.of("app-catalogs", "add"), Map.of()));
+
+    verify(catalogManager).remove("add");
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(
+            Map.of(
+                "catalog", orderedJson(Map.entry("catalogId", "add"), Map.entry("removed", true)))),
+        response.body());
+  }
+
+  @Test
   void route_whenAppsListRequested_expectAppsEnvelopeAndMergedRunningState() throws Exception {
     InstalledAppSnapshot installed = installedSnapshot();
     RunningAppSnapshot running = runningSnapshot();
@@ -2572,6 +2593,119 @@ class PlatformApiRouterTest {
         response.body());
   }
 
+  @Test
+  void route_whenCatalogInstallSucceedsAndCleanupFails_expectCreatedJson() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    AppCatalogInstallPlan plan = mock(AppCatalogInstallPlan.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    Path stagedDir = tempDir.resolve("catalog-install-stage");
+    InstalledAppSnapshot installed = installedSnapshot();
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry(APP_VERSION));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
+    when(appHost.installFromDirectory(stagedDir)).thenReturn(installed);
+    doThrow(new IOException("cleanup failed")).when(plan).close();
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "install"), Map.of()));
+
+    assertEquals(201, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", catalogSummary(APP_VERSION))), response.body());
+  }
+
+  @Test
+  void route_whenCatalogInstallRepeated_expectConflictWithoutPreparingPlan() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry(APP_VERSION));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "install"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app already installed: alpha\"}}",
+        response.body());
+    //noinspection resource
+    verify(catalogManager, never()).prepareInstallPlan(any(), any());
+    verify(appHost, never()).installFromDirectory(any());
+  }
+
+  @Test
+  void route_whenCatalogUpdateSucceedsAndCleanupFails_expectUpdatedJson() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    AppCatalogInstallPlan plan = mock(AppCatalogInstallPlan.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    Path stagedDir = tempDir.resolve("catalog-update-stage");
+    InstalledAppSnapshot updated = installedSnapshot(APP_ID, APP_NAME, "9.9.9", APP_UI_ENTRY);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry("9.9.9"));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
+    when(appHost.updateFromDirectory(APP_ID, stagedDir)).thenReturn(updated);
+    doThrow(new IOException("cleanup failed")).when(plan).close();
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", catalogSummary("9.9.9"))), response.body());
+  }
+
+  @Test
+  void route_whenCatalogUpdateTargetMissing_expectNotFoundWithoutPreparingPlan() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry("9.9.9"));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), Map.of()));
+
+    assertEquals(404, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+    //noinspection resource
+    verify(catalogManager, never()).prepareInstallPlan(any(), any());
+    verify(appHost, never()).updateFromDirectory(any(), any());
+  }
+
+  @Test
+  void route_whenCatalogUpdateInstalledManifestUnreadable_expectUpdatedJson() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    AppCatalogInstallPlan plan = mock(AppCatalogInstallPlan.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    Path stagedDir = tempDir.resolve("catalog-repair-stage");
+    InstalledAppSnapshot updated = installedSnapshot(APP_ID, APP_NAME, "9.9.9", APP_UI_ENTRY);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry("9.9.9"));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenThrow(new IOException("corrupt manifest"));
+    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
+    when(appHost.updateFromDirectory(APP_ID, stagedDir)).thenReturn(updated);
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", catalogSummary("9.9.9"))), response.body());
+    //noinspection resource
+    verify(catalogManager).prepareInstallPlan("core", APP_ID);
+    verify(appHost).updateFromDirectory(APP_ID, stagedDir);
+  }
+
   private static PlatformApiRequest request(
       String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
     return new PlatformApiRequest(method, pathSegments, queryParameters);
@@ -2664,10 +2798,37 @@ class PlatformApiRouterTest {
     return stagedDir;
   }
 
+  private AppCatalogEntry catalogEntry(String version) {
+    return new AppCatalogEntry(
+        APP_ID,
+        APP_NAME,
+        version,
+        "Catalog app summary",
+        tempDir.resolve("artifact.zip").toUri(),
+        "0".repeat(64),
+        0L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of("network.access"));
+  }
+
   private static Map<String, Object> summary(
       boolean installed, boolean running, Long pid, Instant startedAt) {
     return summaryFor(
         APP_ID, APP_NAME, APP_VERSION, APP_UI_ENTRY, installed, running, pid, startedAt);
+  }
+
+  private static Map<String, Object> catalogSummary(String appVersion) {
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(9);
+    summary.put("appId", APP_ID);
+    summary.put("name", APP_NAME);
+    summary.put("version", appVersion);
+    summary.put("uiEntry", APP_UI_ENTRY);
+    summary.put("permissions", List.of("network.access", "file.read"));
+    summary.put("installed", true);
+    summary.put("running", false);
+    summary.put("pid", null);
+    summary.put("startedAt", null);
+    return summary;
   }
 
   private static Map<String, Object> installRouteSummary(boolean installed) {


### PR DESCRIPTION
## Summary

Implements PR-195: Remote Signed App Catalog for Phase 4 / App Platform Maturity.

- Add `:platform-appcatalog` with signed catalog parsing, exact-byte Ed25519 signature verification, source persistence, local/remote catalog fetch, artifact download, SHA-256/size checks, safe ZIP extraction, and install/update plan staging.
- Wire `/api/v1/app-catalogs` into the Platform API and legacy HTTP runtime bridge, reusing the configured trusted app keys and preserving existing local staged-directory app install/update flows.
- Add Web Shell catalog management for listing configured catalogs, refreshing entries, and installing/updating catalog apps while keeping installed-app rendering isolated from catalog failures.
- Document the catalog and signature formats, trusted-key configuration, remote fetch behavior, security model, and API surface.

## API endpoints

- `GET /api/v1/app-catalogs`
- `POST /api/v1/app-catalogs/add?source=<uri-or-path>`
- `DELETE /api/v1/app-catalogs/{catalogId}`
- `POST /api/v1/app-catalogs/{catalogId}/refresh`
- `GET /api/v1/app-catalogs/{catalogId}/apps`
- `GET /api/v1/app-catalogs/{catalogId}/apps/{appId}`
- `POST /api/v1/app-catalogs/{catalogId}/apps/{appId}/install`
- `POST /api/v1/app-catalogs/{catalogId}/apps/{appId}/update`

## Security checks

- Reject unsigned, malformed, tampered, or unknown-key catalog sidecars by default.
- Validate catalog entries for supported versions, ids, artifact types, SHA-256 hex, sizes, and URI policy.
- Allow HTTPS remote sources/artifacts; allow plaintext HTTP only for loopback-safe hosts.
- Bound catalog and artifact download sizes and close rejected response bodies.
- Verify artifact size and SHA-256 before extraction.
- Extract ZIP artifacts only into host-owned scratch space, rejecting absolute paths, traversal, duplicate normalized paths, parent/file conflicts, malformed entry names, ZIP64 markers, oversized extraction, and corrupt ZIP streams.
- Preserve executable bits where available so signed appdist digests still verify executable app bundles.
- Re-run existing `AppBundleVerifier` checks and reject manifest/catalog app id or version mismatches before AppHost install/update.

## Test plan

- `./gradlew spotlessApply`
- `./gradlew :platform-appdist:test :platform-apphost:test :platform-api:test :platform-web-shell:test :platform-appcatalog:test`
- `./gradlew :platform-appcatalog:test`
- `./gradlew :platform-appcatalog:jacocoTestReport`
- `./gradlew test`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractor.java`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogParserTest.java`
- `git diff --check`

## Non-goals

- App-owned `/apps/{appId}/` static UI proxy remains future work.
- App permission enforcement/audit, sandboxing, public app-store governance, and peer/network/wire protocol changes remain future work.
- Queue Manager and Publisher routing migration remains future work.