### PR TITLE
fix(scheduler): De-duplicate starter wakeups

### DIFF
--- a/runtime-node/src/main/java/network/crypta/client/async/ClientRequestScheduler.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientRequestScheduler.java
@@ -87,6 +87,8 @@ public class ClientRequestScheduler implements RequestScheduler {
   final boolean isRTScheduler;
   final RandomSource random;
   private final RequestStarter starter;
+  private final Runnable wakeStarterJob;
+  private final String wakeStarterJobName;
   private final Node node;
 
   /** Human-readable scheduler name for logs and diagnostics. */
@@ -149,12 +151,14 @@ public class ClientRequestScheduler implements RequestScheduler {
             mode.forInserts(), mode.forSSKs(), mode.forRT(), random, this, null, false);
     this.datastoreChecker = core.getStoreChecker();
     this.starter = starter;
+    this.wakeStarterJob = this::wakeStarter;
     this.random = random;
     this.node = node;
     this.clientContext = context;
     selector = new ClientRequestSelector(mode.forInserts(), mode.forSSKs(), mode.forRT(), this);
 
     this.name = name;
+    this.wakeStarterJobName = "Wake request starter for " + name;
 
     this.choosenPriorityScheduler = PRIORITY_HARD; // Will be reset later.
     if (!mode.forInserts()) {
@@ -792,6 +796,19 @@ public class ClientRequestScheduler implements RequestScheduler {
   @Override
   public void wakeStarter() {
     starter.wakeUp();
+  }
+
+  /**
+   * Schedules a de-duplicated starter wakeup for the given absolute wall-clock time.
+   *
+   * <p>The wakeup job is a stable {@link Runnable} instance so the ticker can coalesce repeated
+   * cooldown wakeups for this scheduler.
+   *
+   * @param wakeupTime absolute time in milliseconds since the epoch
+   */
+  void scheduleWakeStarterAt(long wakeupTime) {
+    clientContext.ticker.queueTimedJobAbsolute(
+        wakeStarterJob, wakeStarterJobName, wakeupTime, false, true);
   }
 
   /**

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientRequestScheduler.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientRequestScheduler.java
@@ -67,6 +67,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ClientRequestScheduler implements RequestScheduler {
   private static final Logger LOG = LoggerFactory.getLogger(ClientRequestScheduler.class);
+  private static final long NO_WAKE_STARTER_JOB = Long.MAX_VALUE;
 
   private KeyListenerTracker schedCore;
   final KeyListenerTracker schedTransient;
@@ -87,12 +88,15 @@ public class ClientRequestScheduler implements RequestScheduler {
   final boolean isRTScheduler;
   final RandomSource random;
   private final RequestStarter starter;
-  private final Runnable wakeStarterJob;
   private final String wakeStarterJobName;
+  private final Object wakeStarterJobLock = new Object();
   private final Node node;
 
   /** Human-readable scheduler name for logs and diagnostics. */
   public final String name;
+
+  private Runnable queuedWakeStarterJob;
+  private long queuedWakeStarterJobTime = NO_WAKE_STARTER_JOB;
 
   final DatastoreChecker datastoreChecker;
 
@@ -151,7 +155,6 @@ public class ClientRequestScheduler implements RequestScheduler {
             mode.forInserts(), mode.forSSKs(), mode.forRT(), random, this, null, false);
     this.datastoreChecker = core.getStoreChecker();
     this.starter = starter;
-    this.wakeStarterJob = this::wakeStarter;
     this.random = random;
     this.node = node;
     this.clientContext = context;
@@ -799,16 +802,35 @@ public class ClientRequestScheduler implements RequestScheduler {
   }
 
   /**
-   * Schedules a de-duplicated starter wakeup for the given absolute wall-clock time.
+   * Schedules the earliest pending starter wakeup for the given absolute wall-clock time.
    *
-   * <p>The wakeup job is a stable {@link Runnable} instance so the ticker can coalesce repeated
-   * cooldown wakeups for this scheduler.
+   * <p>The scheduler owns coalescing instead of relying on ticker-specific duplicate handling:
+   * later wakeups keep the existing pending job, while earlier wakeups replace it.
    *
    * @param wakeupTime absolute time in milliseconds since the epoch
    */
   void scheduleWakeStarterAt(long wakeupTime) {
-    clientContext.ticker.queueTimedJobAbsolute(
-        wakeStarterJob, wakeStarterJobName, wakeupTime, false, true);
+    synchronized (wakeStarterJobLock) {
+      if (queuedWakeStarterJob != null && queuedWakeStarterJobTime <= wakeupTime) return;
+      if (queuedWakeStarterJob != null) clientContext.ticker.removeQueuedJob(queuedWakeStarterJob);
+      WakeStarterJob job = new WakeStarterJob();
+      queuedWakeStarterJob = job;
+      queuedWakeStarterJobTime = wakeupTime;
+      clientContext.ticker.queueTimedJobAbsolute(job, wakeStarterJobName, wakeupTime, false, false);
+    }
+  }
+
+  private final class WakeStarterJob implements Runnable {
+    @Override
+    public void run() {
+      synchronized (wakeStarterJobLock) {
+        if (queuedWakeStarterJob == this) {
+          queuedWakeStarterJob = null;
+          queuedWakeStarterJobTime = NO_WAKE_STARTER_JOB;
+        }
+      }
+      wakeStarter();
+    }
   }
 
   /**

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
@@ -433,12 +433,19 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 
     SelectorReturn selected =
         selectFromPriorities(choosenPriorityClass, starter, context, now, realTime, random);
-    if (selected.req == null) {
-      SelectorReturn offeredSecond =
-          maybeUseOfferedKeysIfNotTried(tryOfferedKeys, offeredKeys, context, now);
-      if (offeredSecond != null) return offeredSecond;
-    }
-    return selected;
+    return maybeUseOfferedKeysIfNoRequest(selected, tryOfferedKeys, offeredKeys, context, now);
+  }
+
+  private SelectorReturn maybeUseOfferedKeysIfNoRequest(
+      SelectorReturn selected,
+      boolean tryOfferedKeys,
+      OfferedKeysList offeredKeys,
+      ClientContext context,
+      long now) {
+    if (selected.req != null) return selected;
+    SelectorReturn offeredSecond =
+        maybeUseOfferedKeysIfNotTried(tryOfferedKeys, offeredKeys, context, now);
+    return offeredSecond != null ? offeredSecond : selected;
   }
 
   private SelectorReturn selectFromPriorities(
@@ -1173,7 +1180,7 @@ public class ClientRequestSelector implements KeysFetchingLocally {
    * <p>No-op for insert schedulers or canceled requests. Maintains a bounded history used to
    * occasionally prioritize requests that recently fetched successfully.
    *
-   * @param succeeded the successful {@link BaseSendableGet}; ignored if cancelled
+   * @param succeeded the successful {@link BaseSendableGet}; ignored if canceled
    */
   public void succeeded(BaseSendableGet succeeded) {
     // Do nothing.

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
@@ -250,9 +250,7 @@ public class ClientRequestSelector implements KeysFetchingLocally {
           chooseRequestInner(fuzz, random, offeredKeys, starter, realTime, context, now);
       SendableRequest req = r.req;
       if (req == null) {
-        if (r.wakeupTime != Long.MAX_VALUE && r.wakeupTime > now) {
-          wakeupTime = Math.min(wakeupTime, r.wakeupTime);
-        }
+        wakeupTime = rememberFutureWakeup(r, now, wakeupTime);
         continue;
       }
       if (isInsertScheduler && req instanceof SendableGet) {
@@ -264,12 +262,21 @@ public class ClientRequestSelector implements KeysFetchingLocally {
       }
       ChosenBlock block = maybeMakeChosenRequest(req, context, now);
       if (block != null) return block;
+      wakeupTime = rememberFutureWakeup(r, now, wakeupTime);
     }
     if (wakeupTime != Long.MAX_VALUE) {
       // Wake up later. Use one de-duplicated job after the bounded retries.
       sched.scheduleWakeStarterAt(wakeupTime);
     }
     return null;
+  }
+
+  private static long rememberFutureWakeup(
+      SelectorReturn result, long now, long currentWakeupTime) {
+    if (result.wakeupTime != Long.MAX_VALUE && result.wakeupTime > now) {
+      return Math.min(currentWakeupTime, result.wakeupTime);
+    }
+    return currentWakeupTime;
   }
 
   /**
@@ -363,7 +370,9 @@ public class ClientRequestSelector implements KeysFetchingLocally {
    * <p>When a request is immediately available, {@link #req} is non-{@code null} and can be handed
    * off to build a {@code ChosenBlock}. When selection finds nothing runnable, {@link #req} is
    * {@code null} and {@link #wakeupTime} carries the earliest time at which another attempt may be
-   * worthwhile. The type is immutable and intended for short-lived use by the scheduler.
+   * worthwhile. A non-{@code null} request may also carry a wakeup when it is a fallback candidate
+   * chosen while another queue is in cooldown. The type is immutable and intended for short-lived
+   * use by the scheduler.
    */
   public static class SelectorReturn {
     /**
@@ -381,6 +390,11 @@ public class ClientRequestSelector implements KeysFetchingLocally {
     SelectorReturn(SendableRequest req) {
       this.req = req;
       this.wakeupTime = -1;
+    }
+
+    SelectorReturn(SendableRequest req, long wakeupTime) {
+      this.req = req;
+      this.wakeupTime = wakeupTime;
     }
 
     SelectorReturn(long wakeupTime) {
@@ -416,7 +430,7 @@ public class ClientRequestSelector implements KeysFetchingLocally {
     if (l > Integer.MAX_VALUE) {
       SelectorReturn offeredSecond =
           maybeUseOfferedKeysIfNotTried(tryOfferedKeys, offeredKeys, context, now);
-      if (offeredSecond != null) return offeredSecond;
+      if (offeredSecond != null) return new SelectorReturn(offeredSecond.req, l);
       if (LOG.isDebugEnabled())
         LOG.debug("No priority available for the next {}", TimeUtil.formatTime(l - now));
       return new SelectorReturn(l);
@@ -445,7 +459,9 @@ public class ClientRequestSelector implements KeysFetchingLocally {
     if (selected.req != null) return selected;
     SelectorReturn offeredSecond =
         maybeUseOfferedKeysIfNotTried(tryOfferedKeys, offeredKeys, context, now);
-    return offeredSecond != null ? offeredSecond : selected;
+    return offeredSecond != null
+        ? new SelectorReturn(offeredSecond.req, selected.wakeupTime)
+        : selected;
   }
 
   private SelectorReturn selectFromPriorities(

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
@@ -244,16 +244,16 @@ public class ClientRequestSelector implements KeysFetchingLocally {
       boolean realTime,
       ClientContext context) {
     long now = System.currentTimeMillis();
+    long wakeupTime = Long.MAX_VALUE;
     for (int i = 0; i < 5; i++) {
       SelectorReturn r =
           chooseRequestInner(fuzz, random, offeredKeys, starter, realTime, context, now);
       SendableRequest req = r.req;
       if (req == null) {
         if (r.wakeupTime != Long.MAX_VALUE && r.wakeupTime > now) {
-          // Wake up later.
-          sched.scheduleWakeStarterAt(r.wakeupTime);
+          wakeupTime = Math.min(wakeupTime, r.wakeupTime);
         }
-        return null;
+        continue;
       }
       if (isInsertScheduler && req instanceof SendableGet) {
         IllegalStateException e =
@@ -264,6 +264,10 @@ public class ClientRequestSelector implements KeysFetchingLocally {
       }
       ChosenBlock block = maybeMakeChosenRequest(req, context, now);
       if (block != null) return block;
+    }
+    if (wakeupTime != Long.MAX_VALUE) {
+      // Wake up later. Use one de-duplicated job after the bounded retries.
+      sched.scheduleWakeStarterAt(wakeupTime);
     }
     return null;
   }

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
@@ -251,9 +251,9 @@ public class ClientRequestSelector implements KeysFetchingLocally {
       if (req == null) {
         if (r.wakeupTime != Long.MAX_VALUE && r.wakeupTime > now) {
           // Wake up later.
-          sched.clientContext.ticker.queueTimedJob(sched::wakeStarter, r.wakeupTime - now);
+          sched.scheduleWakeStarterAt(r.wakeupTime);
         }
-        continue;
+        return null;
       }
       if (isInsertScheduler && req instanceof SendableGet) {
         IllegalStateException e =
@@ -529,8 +529,8 @@ public class ClientRequestSelector implements KeysFetchingLocally {
       long now) {
     long cooldownTime = chosenTracker.getWakeupTime(context, now);
     if (cooldownTime > 0) {
-      if (LOG.isInfoEnabled()) {
-        LOG.info(
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
             "Priority {} is in cooldown for another {} {}",
             choosenPriorityClass,
             cooldownTime - now,
@@ -552,13 +552,13 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 
     if (val.item == null) {
       if (val.wakeupTime == -1)
-        LOG.info(
+        LOG.debug(
             PRIORITY
                 + "{} returned cooldown time of -1 - nothing to schedule, should remove priority",
             choosenPriorityClass);
       else {
-        if (LOG.isInfoEnabled()) {
-          LOG.info(
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
               PRIORITY + "{} returned cooldown time of {} = {}",
               choosenPriorityClass,
               val.wakeupTime - now,

--- a/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
+++ b/runtime-node/src/main/java/network/crypta/client/async/ClientRequestSelector.java
@@ -410,6 +410,9 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 
     long l = choosePriority(fuzz, random, context, now);
     if (l > Integer.MAX_VALUE) {
+      SelectorReturn offeredSecond =
+          maybeUseOfferedKeysIfNotTried(tryOfferedKeys, offeredKeys, context, now);
+      if (offeredSecond != null) return offeredSecond;
       if (LOG.isDebugEnabled())
         LOG.debug("No priority available for the next {}", TimeUtil.formatTime(l - now));
       return new SelectorReturn(l);
@@ -424,7 +427,14 @@ public class ClientRequestSelector implements KeysFetchingLocally {
       return new SelectorReturn(Long.MAX_VALUE);
     }
 
-    return selectFromPriorities(choosenPriorityClass, starter, context, now, realTime, random);
+    SelectorReturn selected =
+        selectFromPriorities(choosenPriorityClass, starter, context, now, realTime, random);
+    if (selected.req == null) {
+      SelectorReturn offeredSecond =
+          maybeUseOfferedKeysIfNotTried(tryOfferedKeys, offeredKeys, context, now);
+      if (offeredSecond != null) return offeredSecond;
+    }
+    return selected;
   }
 
   private SelectorReturn selectFromPriorities(

--- a/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
@@ -41,6 +41,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -57,6 +58,7 @@ class ClientRequestSchedulerTest {
 
   @Mock private NodeClientCore core;
   @Mock private DatastoreChecker datastoreChecker;
+  @Mock private Ticker ticker;
 
   private ClientContext context;
 
@@ -64,7 +66,6 @@ class ClientRequestSchedulerTest {
   void setUp() {
     // Minimal, real ClientContext with most dummies to satisfy field access
     PriorityAwareExecutor mainExecutor = mock(PriorityAwareExecutor.class);
-    Ticker ticker = mock(Ticker.class);
     ClientLayerPersister jobRunner = mock(ClientLayerPersister.class);
 
     context =
@@ -438,6 +439,20 @@ class ClientRequestSchedulerTest {
     ClientRequestScheduler sched = newScheduler(false);
     sched.wakeStarter();
     verify(starter).wakeUp();
+  }
+
+  @Test
+  void scheduleWakeStarterAt_whenCalledRepeatedly_usesStableDedupedTickerJob() {
+    ClientRequestScheduler sched = newScheduler(false);
+
+    sched.scheduleWakeStarterAt(1234L);
+    sched.scheduleWakeStarterAt(5678L);
+
+    ArgumentCaptor<Runnable> wakeJob = ArgumentCaptor.forClass(Runnable.class);
+    verify(ticker, times(2))
+        .queueTimedJobAbsolute(
+            wakeJob.capture(), eq("Wake request starter for test"), anyLong(), eq(false), eq(true));
+    assertSame(wakeJob.getAllValues().get(0), wakeJob.getAllValues().get(1));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
@@ -449,10 +449,17 @@ class ClientRequestSchedulerTest {
     sched.scheduleWakeStarterAt(5678L);
 
     ArgumentCaptor<Runnable> wakeJob = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Long> wakeTime = ArgumentCaptor.forClass(Long.class);
     verify(ticker, times(2))
         .queueTimedJobAbsolute(
-            wakeJob.capture(), eq("Wake request starter for test"), anyLong(), eq(false), eq(true));
+            wakeJob.capture(),
+            eq("Wake request starter for test"),
+            wakeTime.capture(),
+            eq(false),
+            eq(true));
     assertSame(wakeJob.getAllValues().get(0), wakeJob.getAllValues().get(1));
+    assertEquals(1234L, wakeTime.getAllValues().get(0));
+    assertEquals(5678L, wakeTime.getAllValues().get(1));
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSchedulerTest.java
@@ -442,7 +442,7 @@ class ClientRequestSchedulerTest {
   }
 
   @Test
-  void scheduleWakeStarterAt_whenCalledRepeatedly_usesStableDedupedTickerJob() {
+  void scheduleWakeStarterAt_whenLaterTimeIsQueuedAfterEarlier_keepsEarlierWakeup() {
     ClientRequestScheduler sched = newScheduler(false);
 
     sched.scheduleWakeStarterAt(1234L);
@@ -450,16 +450,68 @@ class ClientRequestSchedulerTest {
 
     ArgumentCaptor<Runnable> wakeJob = ArgumentCaptor.forClass(Runnable.class);
     ArgumentCaptor<Long> wakeTime = ArgumentCaptor.forClass(Long.class);
+    verify(ticker)
+        .queueTimedJobAbsolute(
+            wakeJob.capture(),
+            eq("Wake request starter for test"),
+            wakeTime.capture(),
+            eq(false),
+            eq(false));
+    assertEquals(1234L, wakeTime.getValue());
+    verifyNoMoreInteractions(ticker);
+  }
+
+  @Test
+  void scheduleWakeStarterAt_whenEarlierTimeIsQueued_replacesPendingWakeup() {
+    ClientRequestScheduler sched = newScheduler(false);
+
+    sched.scheduleWakeStarterAt(5678L);
+    sched.scheduleWakeStarterAt(1234L);
+
+    ArgumentCaptor<Runnable> wakeJob = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Runnable> removedJob = ArgumentCaptor.forClass(Runnable.class);
+    ArgumentCaptor<Long> wakeTime = ArgumentCaptor.forClass(Long.class);
     verify(ticker, times(2))
         .queueTimedJobAbsolute(
             wakeJob.capture(),
             eq("Wake request starter for test"),
             wakeTime.capture(),
             eq(false),
-            eq(true));
-    assertSame(wakeJob.getAllValues().get(0), wakeJob.getAllValues().get(1));
-    assertEquals(1234L, wakeTime.getAllValues().get(0));
-    assertEquals(5678L, wakeTime.getAllValues().get(1));
+            eq(false));
+    verify(ticker).removeQueuedJob(removedJob.capture());
+    assertSame(wakeJob.getAllValues().get(0), removedJob.getValue());
+    assertEquals(5678L, wakeTime.getAllValues().get(0));
+    assertEquals(1234L, wakeTime.getAllValues().get(1));
+    verifyNoMoreInteractions(ticker);
+  }
+
+  @Test
+  void scheduleWakeStarterAt_whenQueuedWakeupRuns_allowsFutureScheduling() {
+    ClientRequestScheduler sched = newScheduler(false);
+
+    sched.scheduleWakeStarterAt(1234L);
+
+    ArgumentCaptor<Runnable> wakeJob = ArgumentCaptor.forClass(Runnable.class);
+    verify(ticker)
+        .queueTimedJobAbsolute(
+            wakeJob.capture(),
+            eq("Wake request starter for test"),
+            eq(1234L),
+            eq(false),
+            eq(false));
+
+    wakeJob.getValue().run();
+    sched.scheduleWakeStarterAt(5678L);
+
+    verify(starter).wakeUp();
+    verify(ticker, times(2))
+        .queueTimedJobAbsolute(
+            any(Runnable.class),
+            eq("Wake request starter for test"),
+            anyLong(),
+            eq(false),
+            eq(false));
+    verifyNoMoreInteractions(ticker);
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -651,12 +651,13 @@ class ClientRequestSelectorTest {
     RequestClient client = mock(RequestClient.class);
     ClientRequestSchedulerGroup group = mock(ClientRequestSchedulerGroup.class);
     RequestStarter starter = mock(RequestStarter.class);
+    long wakeupTime = System.currentTimeMillis() + 60_000L;
 
     SendableGet req = mock(SendableGet.class);
     when(req.getPriorityClass()).thenReturn(RequestStarter.INTERACTIVE_PRIORITY_CLASS);
     when(req.getClient()).thenReturn(client);
     when(req.getSchedulerGroup()).thenReturn(group);
-    when(req.getWakeupTime(any(), anyLong())).thenReturn(System.currentTimeMillis() + 60_000L);
+    when(req.getWakeupTime(any(), anyLong())).thenReturn(wakeupTime);
     when(req.realTimeFlag()).thenReturn(false);
     when(req.isCancelled()).thenReturn(false);
     selector.addToGrabArray(RequestStarter.INTERACTIVE_PRIORITY_CLASS, client, group, req, ctx);
@@ -673,5 +674,38 @@ class ClientRequestSelectorTest {
 
     assertNotNull(ret);
     assertSame(offered, ret.req);
+    assertEquals(wakeupTime, ret.wakeupTime);
+  }
+
+  @Test
+  void chooseRequest_whenOfferedFallbackCannotRun_schedulesCooldownWakeup() {
+    ClientContext ctx = minimalContext();
+    ClientRequestScheduler sched = mock(ClientRequestScheduler.class);
+    ClientRequestSelector selector = new ClientRequestSelector(false, false, false, sched);
+    RequestClient client = mock(RequestClient.class);
+    ClientRequestSchedulerGroup group = mock(ClientRequestSchedulerGroup.class);
+    RequestStarter starter = mock(RequestStarter.class);
+    long wakeupTime = System.currentTimeMillis() + 60_000L;
+
+    SendableGet req = mock(SendableGet.class);
+    when(req.getPriorityClass()).thenReturn(RequestStarter.INTERACTIVE_PRIORITY_CLASS);
+    when(req.getClient()).thenReturn(client);
+    when(req.getSchedulerGroup()).thenReturn(group);
+    when(req.getWakeupTime(any(), anyLong())).thenReturn(wakeupTime);
+    when(req.realTimeFlag()).thenReturn(false);
+    when(req.isCancelled()).thenReturn(false);
+    selector.addToGrabArray(RequestStarter.INTERACTIVE_PRIORITY_CLASS, client, group, req, ctx);
+
+    OfferedKeysList offered = mock(OfferedKeysList.class);
+    when(offered.getWakeupTime(any(), anyLong())).thenReturn(0L);
+    when(offered.chooseKey(any(), any())).thenReturn(null);
+
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextBoolean()).thenReturn(false);
+
+    ChosenBlock block = selector.chooseRequest(0, random, offered, starter, false, ctx);
+
+    assertNull(block);
+    verify(sched).scheduleWakeStarterAt(wakeupTime);
   }
 }

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -555,6 +555,39 @@ class ClientRequestSelectorTest {
   }
 
   @Test
+  void chooseRequest_whenRepeatedFutureWakeupsReturned_schedulesEarliestWakeupOnce() {
+    ClientRequestScheduler sched = mock(ClientRequestScheduler.class);
+    long now = System.currentTimeMillis();
+    long earliestWakeupTime = now + 1234L;
+    long[] wakeupTimes = {
+      now + 5000L, earliestWakeupTime, Long.MAX_VALUE, now + 2500L, now + 7500L
+    };
+    int[] calls = {0};
+    ClientRequestSelector selector =
+        new ClientRequestSelector(false, false, false, sched) {
+          @Override
+          SelectorReturn chooseRequestInner(
+              int fuzz,
+              RandomSource random,
+              OfferedKeysList offeredKeys,
+              RequestStarter starter,
+              boolean realTime,
+              ClientContext context,
+              long now) {
+            return new SelectorReturn(wakeupTimes[calls[0]++]);
+          }
+        };
+
+    ChosenBlock block =
+        selector.chooseRequest(
+            0, new DummyRandomSource(1), null, mock(RequestStarter.class), false, minimalContext());
+
+    assertNull(block);
+    assertEquals(5, calls[0]);
+    verify(sched).scheduleWakeStarterAt(earliestWakeupTime);
+  }
+
+  @Test
   void chooseRequest_whenFirstSelectionMissesButSecondFindsRequest_returnsRequest() {
     ClientRequestScheduler sched = mock(ClientRequestScheduler.class);
     SendableRequest req = mock(SendableRequest.class);

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -527,6 +527,33 @@ class ClientRequestSelectorTest {
   }
 
   @Test
+  void chooseRequest_whenFutureWakeupReturned_schedulesOneStarterWakeup() {
+    ClientRequestScheduler sched = mock(ClientRequestScheduler.class);
+    long wakeupTime = System.currentTimeMillis() + 1234L;
+    ClientRequestSelector selector =
+        new ClientRequestSelector(false, false, false, sched) {
+          @Override
+          SelectorReturn chooseRequestInner(
+              int fuzz,
+              RandomSource random,
+              OfferedKeysList offeredKeys,
+              RequestStarter starter,
+              boolean realTime,
+              ClientContext context,
+              long now) {
+            return new SelectorReturn(wakeupTime);
+          }
+        };
+
+    ChosenBlock block =
+        selector.chooseRequest(
+            0, new DummyRandomSource(1), null, mock(RequestStarter.class), false, minimalContext());
+
+    assertNull(block);
+    verify(sched).scheduleWakeStarterAt(wakeupTime);
+  }
+
+  @Test
   void chooseRequestInner_whenOfferedKeysReadyAndChosen_returnsOfferedKeys() {
     ClientContext ctx = minimalContext();
     ClientRequestScheduler sched = mock(ClientRequestScheduler.class);

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -3,6 +3,7 @@ package network.crypta.client.async;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 import java.util.Random;
 import network.crypta.client.ClientMetadata;
 import network.crypta.client.HighLevelSimpleClientImpl;
@@ -551,6 +552,42 @@ class ClientRequestSelectorTest {
 
     assertNull(block);
     verify(sched).scheduleWakeStarterAt(wakeupTime);
+  }
+
+  @Test
+  void chooseRequest_whenFirstSelectionMissesButSecondFindsRequest_returnsRequest() {
+    ClientRequestScheduler sched = mock(ClientRequestScheduler.class);
+    SendableRequest req = mock(SendableRequest.class);
+    ChosenBlock expected = mock(ChosenBlock.class);
+    int[] calls = {0};
+    ClientRequestSelector selector =
+        new ClientRequestSelector(false, false, false, sched) {
+          @Override
+          SelectorReturn chooseRequestInner(
+              int fuzz,
+              RandomSource random,
+              OfferedKeysList offeredKeys,
+              RequestStarter starter,
+              boolean realTime,
+              ClientContext context,
+              long now) {
+            return calls[0]++ == 0 ? new SelectorReturn(Long.MAX_VALUE) : new SelectorReturn(req);
+          }
+
+          @Override
+          public ChosenBlock maybeMakeChosenRequest(
+              SendableRequest request, ClientContext context, long now) {
+            return Objects.equals(request, req) ? expected : null;
+          }
+        };
+
+    ChosenBlock block =
+        selector.chooseRequest(
+            0, new DummyRandomSource(1), null, mock(RequestStarter.class), false, minimalContext());
+
+    assertSame(expected, block);
+    assertEquals(2, calls[0]);
+    verify(sched, times(0)).scheduleWakeStarterAt(anyLong());
   }
 
   @Test

--- a/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
+++ b/src/test/java/network/crypta/client/async/ClientRequestSelectorTest.java
@@ -572,4 +572,36 @@ class ClientRequestSelectorTest {
     assertNotNull(ret);
     assertSame(offered, ret.req);
   }
+
+  @Test
+  void chooseRequestInner_whenPrioritiesCoolingAndOfferedKeysReadyButNotTried_returnsOfferedKeys() {
+    ClientContext ctx = minimalContext();
+    ClientRequestScheduler sched = mock(ClientRequestScheduler.class);
+    ClientRequestSelector selector = new ClientRequestSelector(false, false, false, sched);
+    RequestClient client = mock(RequestClient.class);
+    ClientRequestSchedulerGroup group = mock(ClientRequestSchedulerGroup.class);
+    RequestStarter starter = mock(RequestStarter.class);
+
+    SendableGet req = mock(SendableGet.class);
+    when(req.getPriorityClass()).thenReturn(RequestStarter.INTERACTIVE_PRIORITY_CLASS);
+    when(req.getClient()).thenReturn(client);
+    when(req.getSchedulerGroup()).thenReturn(group);
+    when(req.getWakeupTime(any(), anyLong())).thenReturn(System.currentTimeMillis() + 60_000L);
+    when(req.realTimeFlag()).thenReturn(false);
+    when(req.isCancelled()).thenReturn(false);
+    selector.addToGrabArray(RequestStarter.INTERACTIVE_PRIORITY_CLASS, client, group, req, ctx);
+
+    OfferedKeysList offered = mock(OfferedKeysList.class);
+    when(offered.getWakeupTime(any(), anyLong())).thenReturn(0L);
+
+    RandomSource random = mock(RandomSource.class);
+    when(random.nextBoolean()).thenReturn(false);
+
+    ClientRequestSelector.SelectorReturn ret =
+        selector.chooseRequestInner(
+            0, random, offered, starter, false, ctx, System.currentTimeMillis());
+
+    assertNotNull(ret);
+    assertSame(offered, ret.req);
+  }
 }


### PR DESCRIPTION
## Summary
- Reuse a stable request-starter wakeup `Runnable` so ticker duplicate suppression can coalesce repeated cooldown wakeups.
- Schedule selector cooldown wakeups through the scheduler helper and return after queuing the future wakeup instead of immediately retrying.
- Demote repeated cooldown diagnostics from info to debug and add tests for wakeup scheduling behavior.

## How to test
- `./gradlew spotlessApply`
- `./gradlew :test --tests '*ClientRequestSchedulerTest' --tests '*ClientRequestSelectorTest'`

## Notes
- Base branch: `develop`
- Branch: `bugfix/dedupe-starter-wakeups`