### PR TITLE
ci(workflows): Run interop smoke independently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   interop-smoke:
-    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary
- Remove the `build` dependency from the `interop-smoke` GitHub Actions job.
- Let `interop-smoke` run in parallel with the reusable build workflow while still building its own runnable distribution before the smoke test.

## How to test
- `./gradlew spotlessApply`
- `actionlint .github/workflows/ci.yml`
- `git diff --check -- .github/workflows/ci.yml`
- `yq -e '.jobs["interop-smoke"] | has("needs") | not' .github/workflows/ci.yml`