### PR TITLE
feat(platform): Add browser SDK for app-owned UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ Cryptad now uses a partial multi-project Gradle build.
   `network.crypta.platform.appui`. It maps static app UI metadata to `/apps/{appId}/`, resolves
   installed-bundle assets, and enforces traversal, symlink, and content-type boundaries before the
   HTTP adapter streams files.
+- `:platform-sdk-js` owns the dependency-free browser SDK resource used by app-owned static UI
+  bundles. First-party app staging copies this SDK into staged `static/` assets so pages can use
+  the same bootstrap, Platform API, mutation, error, and fragment-sanitization helpers.
 - `:platform-appdist` owns the local app distribution tooling used to digest, sign, and verify
   staged AppHost bundles.
 - `:platform-appcatalog` owns signed app catalog parsing, signature verification, remote/local
@@ -361,7 +364,8 @@ Static UI bundles open at `/apps/{appId}/`; shell-panel bundles keep existing lo
 `/app/node/#queue`. See [`docs/app-owned-ui.md`](docs/app-owned-ui.md) for the route contract,
 first-party bootstrap JSON, security headers, and static asset boundary. The repo-owned Queue
 Manager and Publisher bundles now stage static UIs at `/apps/queue-manager/static/` and
-`/apps/publisher/static/`.
+`/apps/publisher/static/`, including the browser SDK described in
+[`docs/platform-sdk-js.md`](docs/platform-sdk-js.md).
 
 Production-facing installs reject unsigned bundles by default. To install signed bundles through a
 live node, configure a trusted public key with `CRYPTAD_APPHOST_TRUSTED_KEY_ID` plus
@@ -393,6 +397,7 @@ Key docs:
 - [Signed App Distribution](docs/app-distribution.md)
 - [Signed app catalogs](docs/app-catalogs.md)
 - [App-owned static UI](docs/app-owned-ui.md)
+- [Platform JavaScript SDK](docs/platform-sdk-js.md)
 
 ## Hyphanet Interop Gate
 
@@ -763,6 +768,8 @@ Root build also includes:
 - `:platform-app-ui`: app-owned static UI route and asset-resolution helpers used by the legacy
   HTTP admin adapter to serve `/apps/{appId}/` without exposing data/cache/run directories or
   traversal paths.
+- `:platform-sdk-js`: browser-native SDK resource for app-owned static UI bootstrap, Platform API
+  form/JSON helpers, error handling, and conservative legacy-fragment sanitization.
 - `:platform-appdist`: local app distribution tooling for deterministic bundle digests, Ed25519
   signatures, trusted-key verification, and the signing/verification CLI used by first-party app
   Gradle tasks.
@@ -1010,8 +1017,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   `:platform-api` provides the transport-neutral Platform API v1 plus the minimal AppHost
   control-plane routes; `:platform-apphost` provides the transport-neutral out-of-process AppHost
   v1 core for installed local apps; `:platform-app-ui` provides app-owned static UI route and
-  asset-resolution helpers; `:platform-appdist` provides the local app bundle digest, signing, and
-  verification tooling; `:platform-appcatalog` provides signed catalog source,
+  asset-resolution helpers; `:platform-sdk-js` provides the browser SDK resource for app-owned
+  static UI; `:platform-appdist` provides the local app bundle digest, signing, and verification
+  tooling; `:platform-appcatalog` provides signed catalog source,
   artifact verification, and safe ZIP staging support;
   `:platform-web-shell` provides the browser-facing Web Shell v1 node-management assets and
   bootstrap contract; `:runtime-node`

--- a/apps/publisher/build.gradle.kts
+++ b/apps/publisher/build.gradle.kts
@@ -19,6 +19,11 @@ val stageAppDir = layout.buildDirectory.dir("cryptad-app/$appId")
 val generatedManifestDir = layout.buildDirectory.dir("generated/stageApp")
 val stageAssetsDir = layout.projectDirectory.dir("src/staged")
 val manifestTemplateFile = stageAssetsDir.file("cryptad-app.properties.template")
+val platformSdkJsFile =
+  project(":platform-sdk-js")
+    .layout
+    .projectDirectory
+    .file("src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js")
 val launcherRelativePath = "bin/publisher.sh"
 val appDistPrivateKeyEnvironmentName = "CRYPTAD_APP_DIST_PRIVATE_KEY_BASE64"
 val stagedLauncher =
@@ -130,6 +135,7 @@ val stageApp by
     dependsOn(generateManifest)
     into(stageAppDir)
     from(stageAssetsDir) { exclude("cryptad-app.properties.template") }
+    from(platformSdkJsFile) { into("static") }
     from(generatedManifestDir)
     doLast {
       val launcher = stagedLauncher.get()

--- a/apps/publisher/src/staged/static/app.js
+++ b/apps/publisher/src/staged/static/app.js
@@ -4,7 +4,6 @@
   const appId = "publisher";
   const defaultCompatibilityMode = "COMPAT_CURRENT";
   const state = {
-    bootstrap: {},
     uploadQueueReversed: false,
     uploadQueueSortBy: null,
   };
@@ -22,11 +21,11 @@
   async function start() {
     bindControls();
     try {
-      state.bootstrap = await loadBootstrap();
+      await CryptaPlatform.bootstrap.load({ appId });
       initializeForm(elements.fileForm);
       initializeForm(elements.directoryForm);
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
     }
   }
 
@@ -36,17 +35,6 @@
     elements.uploadQueueButton.addEventListener("click", showUploadQueue);
     elements.result.addEventListener("click", interceptQueueClick);
     elements.result.addEventListener("submit", interceptQueueSubmit);
-  }
-
-  async function loadBootstrap() {
-    const response = await fetch(`/apps/${appId}/.well-known/cryptad-bootstrap.json`, {
-      headers: { Accept: "application/json" },
-    });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      throw new Error(apiError(data, response));
-    }
-    return data && typeof data === "object" ? data : {};
   }
 
   function initializeForm(form) {
@@ -65,15 +53,18 @@
     event.preventDefault();
     const form = event.currentTarget;
     const sourceType = sourceTypeFor(form);
-    const path = sourceType === "directory" ? "queue/inserts/directory" : "queue/inserts/file";
+    const insert =
+      sourceType === "directory"
+        ? CryptaPlatform.content.insertDirectory
+        : CryptaPlatform.content.insertFile;
     try {
-      const result = await postForm(path, buildInsertFormData(form));
+      const result = await insert(buildInsertFormData(form));
       setStatus("Insert queued.", "success");
       renderInsertResult(result);
       form.reset();
       initializeForm(form);
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
     }
   }
 
@@ -110,19 +101,15 @@
   async function showUploadQueue() {
     try {
       setStatus("Loading upload queue...");
-      const url = apiUrl("queue");
-      url.searchParams.set("page", "uploads");
-      if (state.uploadQueueSortBy) {
-        url.searchParams.set("sortBy", state.uploadQueueSortBy);
-      }
-      if (state.uploadQueueReversed) {
-        url.searchParams.set("reversed", "true");
-      }
-      const snapshot = await loadJson(url);
+      const snapshot = await CryptaPlatform.queue.snapshot({
+        page: "uploads",
+        sortBy: state.uploadQueueSortBy,
+        reversed: state.uploadQueueReversed,
+      });
       renderQueue(snapshot.contentHtml);
       setStatus(uploadQueueStatusMessage());
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
     }
   }
 
@@ -153,9 +140,7 @@
       elements.result.replaceChildren(container);
       return;
     }
-    const parsed = new DOMParser().parseFromString(contentHtml, "text/html");
-    sanitize(parsed.body);
-    container.replaceChildren(...Array.from(parsed.body.childNodes));
+    container.replaceChildren(CryptaPlatform.dom.sanitizeFragment(contentHtml));
     elements.result.replaceChildren(container);
   }
 
@@ -213,9 +198,9 @@
   async function exportUploadQueueKeys() {
     setStatus("Preparing upload key list...");
     try {
-      const url = apiUrl("queue/keys");
+      const url = CryptaPlatform.api.url("queue/keys");
       url.searchParams.set("page", "uploads");
-      const data = await loadJson(url);
+      const data = await CryptaPlatform.api.get(url);
       const keys = Array.isArray(data.keys)
         ? data.keys.filter((value) => typeof value === "string")
         : [];
@@ -223,72 +208,8 @@
       downloadTextFile("uploads-keys.txt", textBody);
       setStatus(`Exported ${keys.length} upload queue keys.`, "success");
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
     }
-  }
-
-  function sanitize(root) {
-    root
-      .querySelectorAll("script, style, template, iframe, frame, frameset, object, embed, link, meta, base")
-      .forEach((node) => node.remove());
-
-    root.querySelectorAll("*").forEach((element) => {
-      Array.from(element.attributes).forEach((attribute) => {
-        const name = attribute.name.toLowerCase();
-        if (name.startsWith("on") || name === "style" || name === "srcdoc") {
-          element.removeAttribute(attribute.name);
-          return;
-        }
-        if (
-          (name === "href" || name === "src" || name === "action" || name === "formaction") &&
-          !isSameOrigin(attribute.value)
-        ) {
-          element.removeAttribute(attribute.name);
-        }
-      });
-    });
-  }
-
-  async function postForm(path, formData) {
-    const password = typeof state.bootstrap.formPassword === "string" ? state.bootstrap.formPassword : "";
-    if (!password) {
-      throw new Error("Publisher actions are unavailable.");
-    }
-    const body = new URLSearchParams();
-    for (const [key, value] of formData.entries()) {
-      if (typeof value === "string") {
-        body.append(key, value);
-      }
-    }
-    body.set("formPassword", password);
-
-    const response = await fetch(apiUrl(path), {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-      },
-      body: body.toString(),
-    });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      throw new Error(apiError(data, response));
-    }
-    return data;
-  }
-
-  async function loadJson(url) {
-    const response = await fetch(url, { headers: { Accept: "application/json" } });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      throw new Error(apiError(data, response));
-    }
-    return data;
-  }
-
-  function apiUrl(path) {
-    const root = normalizeLocalRoot(state.bootstrap.platformApiRoot, "/api/v1/");
-    return new URL(path, new URL(root, window.location.origin));
   }
 
   function updateUploadQueueSort(rawHref) {
@@ -315,7 +236,7 @@
     }
     try {
       const url = new URL(href, window.location.href);
-      return url.origin === window.location.origin && url.pathname === "/uploads/listKeys.txt";
+      return CryptaPlatform.dom.sameOrigin(url.href) && url.pathname === "/uploads/listKeys.txt";
     } catch (error) {
       return false;
     }
@@ -331,36 +252,6 @@
     link.click();
     link.remove();
     window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
-  }
-
-  function normalizeLocalRoot(value, fallback) {
-    if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
-      return fallback;
-    }
-    try {
-      const url = new URL(value, window.location.origin);
-      if (url.origin !== window.location.origin || url.search || url.hash) {
-        return fallback;
-      }
-      return url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
-    } catch (error) {
-      return fallback;
-    }
-  }
-
-  function isSameOrigin(rawValue) {
-    const value = typeof rawValue === "string" ? rawValue.trim() : "";
-    if (!value || value.startsWith("#")) {
-      return true;
-    }
-    if (value.startsWith("//")) {
-      return false;
-    }
-    try {
-      return new URL(value, window.location.href).origin === window.location.origin;
-    } catch (error) {
-      return false;
-    }
   }
 
   function sourceTypeFor(form) {
@@ -409,14 +300,4 @@
     elements.status.className = `status ${tone || ""}`.trim();
   }
 
-  function apiError(data, response) {
-    if (data && data.error && typeof data.error.message === "string") {
-      return data.error.message;
-    }
-    return `${response.status} ${response.statusText}`;
-  }
-
-  function errorMessage(error) {
-    return error instanceof Error ? error.message : String(error);
-  }
 })();

--- a/apps/publisher/src/staged/static/index.html
+++ b/apps/publisher/src/staged/static/index.html
@@ -81,6 +81,7 @@
       <p class="empty">Submit a local file or directory insert to queue a persistent upload.</p>
     </section>
   </main>
-  <script src="app.js" defer></script>
+  <script src="./crypta-platform.js" defer></script>
+  <script src="./app.js" defer></script>
 </body>
 </html>

--- a/apps/publisher/src/test/java/network/crypta/apps/publisher/PublisherBundleStagingTest.java
+++ b/apps/publisher/src/test/java/network/crypta/apps/publisher/PublisherBundleStagingTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PublisherBundleStagingTest {
@@ -22,6 +23,18 @@ class PublisherBundleStagingTest {
   private static final String EXPECTED_UI_ENTRY = "static/index.html";
   private static final String EXPECTED_LAUNCHER_PATH = "bin/publisher.sh";
   private static final String EXPECTED_PERMISSIONS = "queue.read,queue.write,content.insert";
+  private static final Path PLATFORM_SDK_SOURCE_PATH =
+      Path.of(
+          "platform-sdk-js",
+          "src",
+          "main",
+          "resources",
+          "network",
+          "crypta",
+          "platform",
+          "sdk",
+          "js",
+          "crypta-platform.js");
 
   @Test
   void stagedBundle_whenManifestParsed_expectExpectedAppHostFields() throws Exception {
@@ -79,22 +92,99 @@ class PublisherBundleStagingTest {
   void stagedBundle_whenStaticUiStaged_expectEntryAssetsPresent() throws Exception {
     Path staticDirectory = stageDirectory().resolve("static");
 
+    verifyStaticAssetsPresent(staticDirectory);
+    verifySdkLoadsBeforeAppScript(Files.readString(staticDirectory.resolve("index.html")));
+    verifyStagedSdkScript(Files.readString(staticDirectory.resolve("crypta-platform.js")));
+    verifyPublisherAppScript(Files.readString(staticDirectory.resolve("app.js")));
+  }
+
+  private static void verifyStaticAssetsPresent(Path staticDirectory) {
     assertTrue(Files.isRegularFile(staticDirectory.resolve("index.html")));
     assertTrue(Files.isRegularFile(staticDirectory.resolve("app.js")));
     assertTrue(Files.isRegularFile(staticDirectory.resolve("app.css")));
+    assertTrue(Files.isRegularFile(staticDirectory.resolve("crypta-platform.js")));
     assertTrue(Files.notExists(staticDirectory.resolve("README.txt")));
-    String appScript = Files.readString(staticDirectory.resolve("app.js"));
-    assertTrue(appScript.contains("cryptad-bootstrap.json"));
-    assertTrue(appScript.contains("platformApiRoot"));
-    assertTrue(appScript.contains("formPassword"));
-    assertTrue(
-        appScript.contains("elements.result.addEventListener(\"submit\", interceptQueueSubmit);"));
-    assertTrue(appScript.contains("url.searchParams.set(\"sortBy\", state.uploadQueueSortBy);"));
-    assertTrue(appScript.contains("isUploadQueueKeyListLink"));
-    assertTrue(appScript.contains("queue/keys"));
-    assertTrue(appScript.contains("unsupportedQueueAction"));
-    assertTrue(appScript.contains("Queue actions are handled in Queue Manager."));
-    assertFalse(appScript.contains("CRYPTAD_APP_TOKEN"));
+  }
+
+  private static void verifySdkLoadsBeforeAppScript(String indexHtml) {
+    int sdkScriptIndex = indexHtml.indexOf("crypta-platform.js");
+    int appScriptIndex = indexHtml.indexOf("app.js");
+
+    assertTrue(sdkScriptIndex >= 0, "index.html must load the platform SDK.");
+    assertTrue(appScriptIndex > sdkScriptIndex, "index.html must load app.js after the SDK.");
+  }
+
+  private static void verifyStagedSdkScript(String sdkScript) throws Exception {
+    assertEquals(canonicalSdkScript(), sdkScript);
+    verifyContainsAll(
+        sdkScript,
+        "window.CryptaPlatform",
+        "bootstrap:",
+        "api:",
+        "queue:",
+        "content:",
+        "dom:",
+        "formPassword");
+    verifyContainsNone(sdkScript, "CRYPTAD_APP_TOKEN");
+  }
+
+  private static void verifyPublisherAppScript(String appScript) {
+    verifyContainsAll(
+        appScript,
+        "CryptaPlatform.bootstrap.load({ appId })",
+        "CryptaPlatform.content.insertFile",
+        "CryptaPlatform.content.insertDirectory",
+        "CryptaPlatform.queue.snapshot",
+        "CryptaPlatform.api.url(\"queue/keys\")",
+        "CryptaPlatform.api.get(url)",
+        "CryptaPlatform.dom.sanitizeFragment",
+        "CryptaPlatform.api.errorMessage",
+        "elements.result.addEventListener(\"submit\", interceptQueueSubmit);",
+        "sortBy: state.uploadQueueSortBy",
+        "reversed: state.uploadQueueReversed",
+        "isUploadQueueKeyListLink",
+        "queue/keys",
+        "unsupportedQueueAction",
+        "Queue actions are handled in Queue Manager.");
+    verifyContainsNone(
+        appScript,
+        "function loadBootstrap",
+        "function postForm",
+        "function loadJson",
+        "function normalizeLocalRoot",
+        "function apiError",
+        "function errorMessage",
+        "function sanitize(",
+        "CRYPTAD_APP_TOKEN");
+  }
+
+  private static void verifyContainsAll(String text, String... expectedFragments) {
+    for (String expectedFragment : expectedFragments) {
+      assertTrue(
+          text.contains(expectedFragment), () -> "Expected fragment missing: " + expectedFragment);
+    }
+  }
+
+  private static void verifyContainsNone(String text, String... forbiddenFragments) {
+    for (String forbiddenFragment : forbiddenFragments) {
+      assertFalse(
+          text.contains(forbiddenFragment),
+          () -> "Forbidden fragment present: " + forbiddenFragment);
+    }
+  }
+
+  private static String canonicalSdkScript() throws Exception {
+    return Files.readString(repoRoot().resolve(PLATFORM_SDK_SOURCE_PATH));
+  }
+
+  private static Path repoRoot() throws Exception {
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 
   private static Path stageDirectory() {

--- a/apps/queue-manager/build.gradle.kts
+++ b/apps/queue-manager/build.gradle.kts
@@ -19,6 +19,11 @@ val stageAppDir = layout.buildDirectory.dir("cryptad-app/$appId")
 val generatedManifestDir = layout.buildDirectory.dir("generated/stageApp")
 val stageAssetsDir = layout.projectDirectory.dir("src/staged")
 val manifestTemplateFile = stageAssetsDir.file("cryptad-app.properties.template")
+val platformSdkJsFile =
+  project(":platform-sdk-js")
+    .layout
+    .projectDirectory
+    .file("src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js")
 val launcherRelativePath = "bin/queue-manager.sh"
 val appDistPrivateKeyEnvironmentName = "CRYPTAD_APP_DIST_PRIVATE_KEY_BASE64"
 val stagedLauncher =
@@ -130,6 +135,7 @@ val stageApp by
     dependsOn(generateManifest)
     into(stageAppDir)
     from(stageAssetsDir) { exclude("cryptad-app.properties.template") }
+    from(platformSdkJsFile) { into("static") }
     from(generatedManifestDir)
     doLast {
       val launcher = stagedLauncher.get()

--- a/apps/queue-manager/src/staged/static/app.js
+++ b/apps/queue-manager/src/staged/static/app.js
@@ -3,7 +3,6 @@
 
   const appId = "queue-manager";
   const state = {
-    bootstrap: {},
     page: "downloads",
     reversed: false,
     sortBy: null,
@@ -24,10 +23,10 @@
   async function start() {
     bindControls();
     try {
-      state.bootstrap = await loadBootstrap();
+      await CryptaPlatform.bootstrap.load({ appId });
       await loadQueue();
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
       renderText("Queue Manager is not ready.");
     }
   }
@@ -39,17 +38,6 @@
     elements.directDownloadForm.addEventListener("submit", submitDirectDownload);
     elements.content.addEventListener("submit", interceptQueueSubmit);
     elements.content.addEventListener("click", interceptQueueClick);
-  }
-
-  async function loadBootstrap() {
-    const response = await fetch(`/apps/${appId}/.well-known/cryptad-bootstrap.json`, {
-      headers: { Accept: "application/json" },
-    });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      throw new Error(apiError(data, response));
-    }
-    return data && typeof data === "object" ? data : {};
   }
 
   async function selectPage(page) {
@@ -66,19 +54,15 @@
     renderText("Loading queue snapshot...");
     setStatus("");
     try {
-      const url = apiUrl("queue");
-      url.searchParams.set("page", state.page);
-      if (state.sortBy) {
-        url.searchParams.set("sortBy", state.sortBy);
-      }
-      if (state.reversed) {
-        url.searchParams.set("reversed", "true");
-      }
-      const snapshot = await loadJson(url);
+      const snapshot = await CryptaPlatform.queue.snapshot({
+        page: state.page,
+        sortBy: state.sortBy,
+        reversed: state.reversed,
+      });
       renderQueue(snapshot.contentHtml);
       setStatus(queueStatusMessage());
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
       renderText("Queue snapshot unavailable.");
     }
   }
@@ -93,32 +77,8 @@
       return;
     }
 
-    const parsed = new DOMParser().parseFromString(contentHtml, "text/html");
-    sanitize(parsed.body);
-    fragment.replaceChildren(...Array.from(parsed.body.childNodes));
+    fragment.replaceChildren(CryptaPlatform.dom.sanitizeFragment(contentHtml));
     elements.content.append(fragment);
-  }
-
-  function sanitize(root) {
-    root
-      .querySelectorAll("script, style, template, iframe, frame, frameset, object, embed, link, meta, base")
-      .forEach((node) => node.remove());
-
-    root.querySelectorAll("*").forEach((element) => {
-      Array.from(element.attributes).forEach((attribute) => {
-        const name = attribute.name.toLowerCase();
-        if (name.startsWith("on") || name === "style" || name === "srcdoc") {
-          element.removeAttribute(attribute.name);
-          return;
-        }
-        if (
-          (name === "href" || name === "src" || name === "action" || name === "formaction") &&
-          !isSameOrigin(attribute.value)
-        ) {
-          element.removeAttribute(attribute.name);
-        }
-      });
-    });
   }
 
   function interceptQueueClick(event) {
@@ -186,12 +146,12 @@
   async function submitQueueMutation(source, submitter, path) {
     const body = filterQueueFormData(source, submitter, path);
     try {
-      const result = await postForm(path, body);
+      const result = await CryptaPlatform.queue.mutate(path, body);
       const operation = result.operation || submitter.name || "queue action";
       setStatus(`Completed ${String(operation).replaceAll("_", " ")}.`, "success");
       await loadQueue();
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
     }
   }
 
@@ -256,7 +216,7 @@
   async function submitDirectDownload(event) {
     event.preventDefault();
     try {
-      await postForm("queue/downloads", new FormData(elements.directDownloadForm));
+      await CryptaPlatform.queue.directDownload(new FormData(elements.directDownloadForm));
       elements.directDownloadForm.reset();
       elements.directDownloadForm.querySelector('input[name="filterData"]').checked = true;
       setStatus("Direct download queued.", "success");
@@ -264,16 +224,16 @@
       updateTabs();
       await loadQueue();
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
     }
   }
 
   async function exportQueueKeys() {
     setStatus(`Preparing ${state.page} key list...`);
     try {
-      const url = apiUrl("queue/keys");
+      const url = CryptaPlatform.api.url("queue/keys");
       url.searchParams.set("page", state.page);
-      const data = await loadJson(url);
+      const data = await CryptaPlatform.api.get(url);
       const keys = Array.isArray(data.keys)
         ? data.keys.filter((value) => typeof value === "string")
         : [];
@@ -281,50 +241,8 @@
       downloadTextFile(`${state.page}-keys.txt`, textBody);
       setStatus(`Exported ${keys.length} ${state.page} queue keys.`, "success");
     } catch (error) {
-      setStatus(errorMessage(error), "error");
+      setStatus(CryptaPlatform.api.errorMessage(error), "error");
     }
-  }
-
-  async function postForm(path, formData) {
-    const password = typeof state.bootstrap.formPassword === "string" ? state.bootstrap.formPassword : "";
-    if (!password) {
-      throw new Error("Mutating queue actions are unavailable.");
-    }
-    const body = new URLSearchParams();
-    for (const [key, value] of formData.entries()) {
-      if (typeof value === "string") {
-        body.append(key, value);
-      }
-    }
-    body.set("formPassword", password);
-
-    const response = await fetch(apiUrl(path), {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-      },
-      body: body.toString(),
-    });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      throw new Error(apiError(data, response));
-    }
-    return data;
-  }
-
-  async function loadJson(url) {
-    const response = await fetch(url, { headers: { Accept: "application/json" } });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      throw new Error(apiError(data, response));
-    }
-    return data;
-  }
-
-  function apiUrl(path) {
-    const root = normalizeLocalRoot(state.bootstrap.platformApiRoot, "/api/v1/");
-    return new URL(path, new URL(root, window.location.origin));
   }
 
   function updateQueueSort(rawHref) {
@@ -352,7 +270,7 @@
     try {
       const url = new URL(href, window.location.href);
       return (
-        url.origin === window.location.origin &&
+        CryptaPlatform.dom.sameOrigin(url.href) &&
         (url.pathname === "/downloads/listKeys.txt" || url.pathname === "/uploads/listKeys.txt")
       );
     } catch (error) {
@@ -370,36 +288,6 @@
     link.click();
     link.remove();
     window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
-  }
-
-  function normalizeLocalRoot(value, fallback) {
-    if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
-      return fallback;
-    }
-    try {
-      const url = new URL(value, window.location.origin);
-      if (url.origin !== window.location.origin || url.search || url.hash) {
-        return fallback;
-      }
-      return url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
-    } catch (error) {
-      return fallback;
-    }
-  }
-
-  function isSameOrigin(rawValue) {
-    const value = typeof rawValue === "string" ? rawValue.trim() : "";
-    if (!value || value.startsWith("#")) {
-      return true;
-    }
-    if (value.startsWith("//")) {
-      return false;
-    }
-    try {
-      return new URL(value, window.location.href).origin === window.location.origin;
-    } catch (error) {
-      return false;
-    }
   }
 
   function updateTabs() {
@@ -434,14 +322,4 @@
     return node;
   }
 
-  function apiError(data, response) {
-    if (data && data.error && typeof data.error.message === "string") {
-      return data.error.message;
-    }
-    return `${response.status} ${response.statusText}`;
-  }
-
-  function errorMessage(error) {
-    return error instanceof Error ? error.message : String(error);
-  }
 })();

--- a/apps/queue-manager/src/staged/static/index.html
+++ b/apps/queue-manager/src/staged/static/index.html
@@ -50,6 +50,7 @@
       <p class="empty">Loading queue snapshot...</p>
     </section>
   </main>
-  <script src="app.js" defer></script>
+  <script src="./crypta-platform.js" defer></script>
+  <script src="./app.js" defer></script>
 </body>
 </html>

--- a/apps/queue-manager/src/test/java/network/crypta/apps/queuemanager/QueueManagerBundleStagingTest.java
+++ b/apps/queue-manager/src/test/java/network/crypta/apps/queuemanager/QueueManagerBundleStagingTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class QueueManagerBundleStagingTest {
@@ -22,6 +23,18 @@ class QueueManagerBundleStagingTest {
   private static final String EXPECTED_UI_ENTRY = "static/index.html";
   private static final String EXPECTED_LAUNCHER_PATH = "bin/queue-manager.sh";
   private static final String EXPECTED_PERMISSIONS = "queue.read,queue.write";
+  private static final Path PLATFORM_SDK_SOURCE_PATH =
+      Path.of(
+          "platform-sdk-js",
+          "src",
+          "main",
+          "resources",
+          "network",
+          "crypta",
+          "platform",
+          "sdk",
+          "js",
+          "crypta-platform.js");
 
   @Test
   void stagedBundle_whenManifestParsed_expectExpectedAppHostFields() throws Exception {
@@ -77,22 +90,99 @@ class QueueManagerBundleStagingTest {
   void stagedBundle_whenStaticUiStaged_expectEntryAssetsPresent() throws Exception {
     Path staticDirectory = stageDirectory().resolve("static");
 
+    verifyStaticAssetsPresent(staticDirectory);
+    verifySdkLoadsBeforeAppScript(Files.readString(staticDirectory.resolve("index.html")));
+    verifyStagedSdkScript(Files.readString(staticDirectory.resolve("crypta-platform.js")));
+    verifyQueueManagerAppScript(Files.readString(staticDirectory.resolve("app.js")));
+  }
+
+  private static void verifyStaticAssetsPresent(Path staticDirectory) {
     assertTrue(Files.isRegularFile(staticDirectory.resolve("index.html")));
     assertTrue(Files.isRegularFile(staticDirectory.resolve("app.js")));
     assertTrue(Files.isRegularFile(staticDirectory.resolve("app.css")));
+    assertTrue(Files.isRegularFile(staticDirectory.resolve("crypta-platform.js")));
     assertTrue(Files.notExists(staticDirectory.resolve("README.txt")));
-    String appScript = Files.readString(staticDirectory.resolve("app.js"));
-    assertTrue(appScript.contains("cryptad-bootstrap.json"));
-    assertTrue(appScript.contains("platformApiRoot"));
-    assertTrue(appScript.contains("formPassword"));
-    assertTrue(appScript.contains("url.searchParams.set(\"sortBy\", state.sortBy);"));
-    assertTrue(appScript.contains("url.searchParams.set(\"reversed\", \"true\");"));
-    assertTrue(appScript.contains("isQueueKeyListLink"));
-    assertTrue(appScript.contains("queue/keys"));
-    assertTrue(appScript.contains("downloadTextFile(`${state.page}-keys.txt`"));
-    assertTrue(appScript.contains("unsupportedQueueAction"));
-    assertTrue(appScript.contains("Queue action is not supported by Platform API yet."));
-    assertFalse(appScript.contains("CRYPTAD_APP_TOKEN"));
+  }
+
+  private static void verifySdkLoadsBeforeAppScript(String indexHtml) {
+    int sdkScriptIndex = indexHtml.indexOf("crypta-platform.js");
+    int appScriptIndex = indexHtml.indexOf("app.js");
+
+    assertTrue(sdkScriptIndex >= 0, "index.html must load the platform SDK.");
+    assertTrue(appScriptIndex > sdkScriptIndex, "index.html must load app.js after the SDK.");
+  }
+
+  private static void verifyStagedSdkScript(String sdkScript) throws Exception {
+    assertEquals(canonicalSdkScript(), sdkScript);
+    verifyContainsAll(
+        sdkScript,
+        "window.CryptaPlatform",
+        "bootstrap:",
+        "api:",
+        "queue:",
+        "content:",
+        "dom:",
+        "formPassword");
+    verifyContainsNone(sdkScript, "CRYPTAD_APP_TOKEN");
+  }
+
+  private static void verifyQueueManagerAppScript(String appScript) {
+    verifyContainsAll(
+        appScript,
+        "CryptaPlatform.bootstrap.load({ appId })",
+        "CryptaPlatform.queue.snapshot",
+        "CryptaPlatform.queue.directDownload",
+        "CryptaPlatform.queue.mutate",
+        "CryptaPlatform.api.url(\"queue/keys\")",
+        "CryptaPlatform.api.get(url)",
+        "CryptaPlatform.dom.sanitizeFragment",
+        "CryptaPlatform.api.errorMessage",
+        "sortBy: state.sortBy",
+        "reversed: state.reversed",
+        "isQueueKeyListLink",
+        "queue/keys",
+        "downloadTextFile(`${state.page}-keys.txt`",
+        "unsupportedQueueAction",
+        "Queue action is not supported by Platform API yet.");
+    verifyContainsNone(
+        appScript,
+        "function loadBootstrap",
+        "function postForm",
+        "function loadJson",
+        "function normalizeLocalRoot",
+        "function apiError",
+        "function errorMessage",
+        "function sanitize(",
+        "CRYPTAD_APP_TOKEN");
+  }
+
+  private static void verifyContainsAll(String text, String... expectedFragments) {
+    for (String expectedFragment : expectedFragments) {
+      assertTrue(
+          text.contains(expectedFragment), () -> "Expected fragment missing: " + expectedFragment);
+    }
+  }
+
+  private static void verifyContainsNone(String text, String... forbiddenFragments) {
+    for (String forbiddenFragment : forbiddenFragments) {
+      assertFalse(
+          text.contains(forbiddenFragment),
+          () -> "Forbidden fragment present: " + forbiddenFragment);
+    }
+  }
+
+  private static String canonicalSdkScript() throws Exception {
+    return Files.readString(repoRoot().resolve(PLATFORM_SDK_SOURCE_PATH));
+  }
+
+  private static Path repoRoot() throws Exception {
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
   }
 
   private static Path stageDirectory() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ val internalLeafProjects =
     project(":runtime-spi"),
     project(":platform-api"),
     project(":platform-apphost"),
+    project(":platform-sdk-js"),
     project(":platform-web-shell"),
     project(":runtime-alerts"),
     project(":runtime-node"),
@@ -105,6 +106,7 @@ dependencies {
   implementation(project(":platform-app-ui"))
   implementation(project(":platform-appcatalog"))
   implementation(project(":platform-apphost"))
+  implementation(project(":platform-sdk-js"))
   implementation(project(":platform-web-shell"))
   implementation(project(":runtime-alerts"))
   implementation(project(":runtime-node"))

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -14,8 +14,9 @@ Related but documented elsewhere:
 - Signed catalog sources and remote/local catalog artifact install/update:
   [app-catalogs.md](app-catalogs.md)
 - App-owned static UI routing for installed bundles: [app-owned-ui.md](app-owned-ui.md)
-- Public app store UI, browser-side bundle uploads, permission enforcement, SDK APIs, and app
-  sandboxing remain future platform work.
+- Browser SDK helpers for app-owned static UI: [platform-sdk-js.md](platform-sdk-js.md)
+- Public app store UI, browser-side bundle uploads, richer permission UX, and app sandboxing
+  remain future platform work.
 
 ## Bundle Files
 
@@ -68,7 +69,9 @@ The repo-owned Queue Manager and Publisher bundles use `app.ui.mode=static` and
 `/apps/publisher/static/`.
 
 See [app-owned-ui.md](app-owned-ui.md) for the `/apps/{appId}/` route contract, first-party
-bootstrap JSON, static asset security boundary, and API summary fields.
+bootstrap JSON, static asset security boundary, and API summary fields. See
+[platform-sdk-js.md](platform-sdk-js.md) for the staged browser SDK used by first-party static UI
+bundles.
 
 ## Gradle Tasks
 
@@ -192,6 +195,6 @@ Preferred local patterns:
 
 ## Future Work
 
-Public catalog governance, background app-update scheduling, richer permission UX, SDK APIs, and
-app sandboxing remain later platform work. Signed bundles now carry the manifest metadata needed by
-app-owned static UI routes.
+Public catalog governance, background app-update scheduling, richer permission UX, and app
+sandboxing remain later platform work. Signed bundles now carry the manifest metadata and staged
+browser assets needed by app-owned static UI routes.

--- a/docs/app-owned-ui.md
+++ b/docs/app-owned-ui.md
@@ -5,8 +5,10 @@ This document describes how installed AppHost bundles declare and serve app-owne
 
 ## Scope
 
-App-owned static UI is a local browser surface for installed apps. It does not add permission
-enforcement, a JavaScript SDK, sandboxing, container execution, or remote protocol changes.
+App-owned static UI is a local browser surface for installed apps. It does not add sandboxing,
+container execution, browser-scoped app sessions, or remote protocol changes. The
+[`CryptaPlatform` JavaScript SDK](platform-sdk-js.md) is only a browser convenience wrapper around
+the existing bootstrap and Platform API calls; permission enforcement remains server-side.
 
 The route serves immutable files from the installed app bundle only. It does not serve app data,
 cache, run directories, catalog scratch directories, or caller staging paths.
@@ -120,8 +122,9 @@ the same way the Web Shell does. Read-only requests do not need it.
 
 The bootstrap does not expose `CRYPTAD_APP_TOKEN`, AppHost launch tokens, signing keys, trusted-key
 material, installed-bundle filesystem paths, data/cache/run paths, or catalog scratch paths. It is
-not an app permission token and it is not the planned JavaScript SDK. Browser-issued app sessions,
-third-party SDK ergonomics, and stronger app isolation remain later platform work.
+not an app permission token. The [Platform JavaScript SDK](platform-sdk-js.md) consumes this
+bootstrap as route metadata and as the source of the existing `formPassword` mutation guard.
+Browser-issued app sessions and stronger app isolation remain later platform work.
 
 ## Platform API summary fields
 

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -24,6 +24,10 @@ metadata and the existing local-admin form password needed by mutating Platform 
 bootstrap is served by the app UI route, not by `/api/v1/apps`, and it does not expose
 `CRYPTAD_APP_TOKEN` or AppHost filesystem paths.
 
+The [Platform JavaScript SDK](platform-sdk-js.md) is a browser convenience layer over that
+bootstrap and the same-origin Platform API. It does not create a new authority boundary; server-side
+Platform API permission checks and app-origin audit remain authoritative.
+
 ## Response contract
 
 The router emits JSON responses. Successful reads generally return `200 OK`; create-style

--- a/docs/platform-sdk-js.md
+++ b/docs/platform-sdk-js.md
@@ -1,0 +1,176 @@
+# Platform JavaScript SDK
+
+This document describes the browser-side `CryptaPlatform` SDK for app-owned static UI bundles.
+
+## Scope
+
+The SDK is a small, dependency-free JavaScript file for static app pages served under
+`/apps/{appId}/`. It wraps the current same-origin bootstrap and Platform API conventions used by
+first-party apps. It is not a sandbox, an app-session system, or a new authorization boundary.
+
+Static app bundles should load the staged SDK before app-specific JavaScript:
+
+```html
+<script src="./crypta-platform.js" defer></script>
+<script src="./app.js" defer></script>
+```
+
+The first-party Queue Manager and Publisher bundles receive `crypta-platform.js` during their
+Gradle `stageApp` tasks. The canonical source lives in
+`platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js`.
+
+## Bootstrap
+
+Call `CryptaPlatform.bootstrap.load()` before using API helpers:
+
+```js
+await CryptaPlatform.bootstrap.load();
+```
+
+The SDK infers the app id from paths such as `/apps/queue-manager/static/`. Tests and unusual local
+mounts can pass an explicit app id:
+
+```js
+await CryptaPlatform.bootstrap.load({ appId: "queue-manager" });
+```
+
+Bootstrap data comes from:
+
+```text
+GET /apps/{appId}/.well-known/cryptad-bootstrap.json
+```
+
+The SDK keeps a sanitized in-memory copy of the bootstrap fields used by browser apps:
+`appId`, `name`, `uiRoot`, `assetRoot`, `platformApiRoot`, `shellRoot`, and `formPassword`.
+`CryptaPlatform.bootstrap.current()` returns the current cached copy, and
+`CryptaPlatform.app.currentId()` returns the current app id when it can be inferred or has been
+loaded.
+
+## Platform API reads
+
+`CryptaPlatform.api.url(path)` builds a same-origin URL beneath the bootstrap `platformApiRoot`,
+falling back to `/api/v1/` when the root is missing or invalid. Invalid roots such as external
+URLs, protocol-relative URLs, and roots with query strings or fragments are ignored.
+
+Use `CryptaPlatform.api.get(path, options)` for JSON reads:
+
+```js
+const snapshot = await CryptaPlatform.api.get("queue", {
+  params: { page: "downloads" },
+});
+```
+
+Queue-oriented static apps can use the convenience wrapper:
+
+```js
+const snapshot = await CryptaPlatform.queue.snapshot({
+  page: "downloads",
+  sortBy: "identifier",
+  reversed: true,
+});
+```
+
+The SDK sends `Accept: application/json` and normalizes common Platform API error bodies into
+readable `Error` messages.
+
+## Mutations
+
+Mutating helpers submit `application/x-www-form-urlencoded` bodies and add the current
+`formPassword` from app bootstrap. They refresh bootstrap before mutation so the submitted
+password tracks the local admin mutation guard.
+
+```js
+await CryptaPlatform.queue.directDownload(new FormData(form));
+await CryptaPlatform.queue.mutate("queue/requests/remove", formData);
+await CryptaPlatform.content.insertFile(formData);
+await CryptaPlatform.content.insertDirectory(formData);
+```
+
+`CryptaPlatform.api.postForm(path, formDataOrParams)` and
+`CryptaPlatform.api.deleteForm(path, formDataOrParams)` are available for other same-origin
+Platform API form mutations. If no `formPassword` is available, the SDK rejects the call before it
+sends a request. The password is placed in the form body, not in the query string.
+
+The helper accepts `FormData`, `URLSearchParams`, arrays of pairs, or plain objects. Non-string
+`FormData` entries such as `File` values are not submitted because the current Platform API bridge
+is text-form oriented.
+
+## Errors
+
+Use `CryptaPlatform.api.errorMessage(error)` when rendering failures:
+
+```js
+try {
+  await CryptaPlatform.queue.directDownload(new FormData(form));
+} catch (error) {
+  status.textContent = CryptaPlatform.api.errorMessage(error);
+}
+```
+
+The SDK recognizes these Platform API response shapes:
+
+```json
+{ "error": "message" }
+{ "error": { "message": "message" } }
+{ "message": "message" }
+{ "detail": "message" }
+```
+
+When the response body does not contain a message, the SDK falls back to the HTTP status and status
+text.
+
+## HTML fragments
+
+Some queue endpoints still return legacy HTML fragments in JSON. Use
+`CryptaPlatform.dom.sanitizeFragment(html)` before inserting those fragments into the page:
+
+```js
+const fragment = CryptaPlatform.dom.sanitizeFragment(snapshot.contentHtml);
+container.replaceChildren(fragment);
+```
+
+The sanitizer removes executable and document-control elements such as `script`, `style`,
+`template`, `iframe`, `object`, `embed`, `link`, `meta`, and `base`. It also removes event handler
+attributes, inline `style`, `srcdoc`, and cross-origin `href`, `src`, `action`, and `formaction`
+values. Relative links, hash links, query-only links, and same-origin absolute paths remain
+available for app-owned handlers.
+
+This sanitizer is intentionally small and deterministic. It is only meant for the daemon-provided
+legacy fragments used by app-owned UI, not as a general-purpose sanitizer for arbitrary untrusted
+HTML.
+
+## Security boundary
+
+The SDK runs in the same local browser origin as the app-owned UI and Platform API. It preserves
+the current local-admin model; it does not grant app permissions, isolate third-party JavaScript,
+or authenticate an app as an AppHost process.
+
+AppHost process launch tokens such as `CRYPTAD_APP_TOKEN` are not exposed to browser apps, SDK
+state, app summaries, or bootstrap JSON. Browser code only receives route metadata and the existing
+local-admin `formPassword` mutation guard. Permission enforcement and audit for app-originated API
+calls remain server-side Platform API behavior, not a browser SDK guarantee.
+
+Install static UI bundles only from sources trusted to run JavaScript in the local admin origin
+until stronger browser isolation exists.
+
+## First-party examples
+
+Queue Manager loads a snapshot and renders the sanitized legacy fragment:
+
+```js
+await CryptaPlatform.bootstrap.load({ appId: "queue-manager" });
+const snapshot = await CryptaPlatform.queue.snapshot({ page: "downloads" });
+queueContent.replaceChildren(CryptaPlatform.dom.sanitizeFragment(snapshot.contentHtml));
+```
+
+Publisher queues a local file insert with the same mutation guard used by the Web Shell:
+
+```js
+await CryptaPlatform.bootstrap.load({ appId: "publisher" });
+const formData = new FormData(fileForm);
+const result = await CryptaPlatform.content.insertFile(formData);
+```
+
+Both apps keep their own UI state, sort handling, key export behavior, and legacy form filtering.
+The SDK owns only bootstrap, same-origin API transport, mutation form submission, error parsing,
+and conservative fragment sanitization.

--- a/platform-sdk-js/build.gradle.kts
+++ b/platform-sdk-js/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+  id("cryptad.java-kotlin-conventions")
+  id("cryptad.spotless")
+  `java-library`
+}
+
+version = rootProject.version
+
+val mainSourceSet = sourceSets.named("main")
+
+dependencies {
+  testImplementation(mainSourceSet.map { it.output })
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
+}

--- a/platform-sdk-js/gradle/owned-output-patterns.txt
+++ b/platform-sdk-js/gradle/owned-output-patterns.txt
@@ -1,0 +1,4 @@
+# Aggregated main outputs that must be pruned on non-clean builds because :platform-sdk-js owns
+# them now.
+
+network/crypta/platform/sdk/js/**

--- a/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
+++ b/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
@@ -1,0 +1,492 @@
+(function (window) {
+  "use strict";
+
+  if (window.CryptaPlatform) {
+    return;
+  }
+
+  const defaultPlatformApiRoot = "/api/v1/";
+  const bootstrapResourcePath = ".well-known/cryptad-bootstrap.json";
+  const removedElementSelector =
+    "script, style, template, iframe, frame, frameset, object, embed, link, meta, base";
+  const urlAttributeNames = new Set(["href", "src", "action", "formaction"]);
+  const appIdPattern = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;
+
+  let currentBootstrap = null;
+  let currentAppId = null;
+  let loadingAppId = null;
+  let loadingBootstrap = null;
+
+  async function loadBootstrap(options) {
+    const rawAppId = explicitAppId(options) || inferAppId();
+    if (!rawAppId) {
+      throw new Error("Unable to determine the current Cryptad app id.");
+    }
+    const requestedAppId = normalizeAppId(rawAppId);
+
+    const force = !!(options && options.force);
+    if (!force && currentBootstrap && currentAppId === requestedAppId) {
+      return copyBootstrap(currentBootstrap);
+    }
+    if (!force && loadingBootstrap && loadingAppId === requestedAppId) {
+      return loadingBootstrap.then(copyBootstrap);
+    }
+
+    loadingAppId = requestedAppId;
+    loadingBootstrap = fetchBootstrap(requestedAppId)
+      .then((bootstrap) => {
+        currentBootstrap = bootstrap;
+        currentAppId = bootstrap.appId || requestedAppId;
+        return copyBootstrap(bootstrap);
+      })
+      .finally(() => {
+        loadingAppId = null;
+        loadingBootstrap = null;
+      });
+    return loadingBootstrap;
+  }
+
+  function current() {
+    return currentBootstrap ? copyBootstrap(currentBootstrap) : null;
+  }
+
+  function currentId() {
+    if (currentBootstrap && currentBootstrap.appId) {
+      return currentBootstrap.appId;
+    }
+    const inferredAppId = inferAppId();
+    return inferredAppId ? normalizeAppId(inferredAppId) : null;
+  }
+
+  async function fetchBootstrap(appId) {
+    const path = `/apps/${encodeURIComponent(appId)}/${bootstrapResourcePath}`;
+    const response = await fetch(path, { headers: { Accept: "application/json" } });
+    const data = await readJson(response);
+    if (!response.ok) {
+      throw new Error(responseErrorMessage(data, response));
+    }
+    const bootstrap = sanitizeBootstrap(data);
+    if (bootstrap.appId) {
+      bootstrap.appId = normalizeAppId(bootstrap.appId);
+    }
+    if (bootstrap.appId && bootstrap.appId !== appId) {
+      throw new Error("Bootstrap app id does not match the requested app.");
+    }
+    if (!bootstrap.appId) {
+      bootstrap.appId = appId;
+    }
+    return bootstrap;
+  }
+
+  async function apiGet(path, options) {
+    const requestOptions = options || {};
+    if (requestOptions.bootstrap !== false) {
+      await ensureBootstrap(requestOptions);
+    }
+    const url = apiUrl(path);
+    applySearchParams(url, requestOptions.params || requestOptions.searchParams || requestOptions.query);
+
+    const headers = jsonHeaders(requestOptions.headers);
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: requestOptions.signal,
+      credentials: "same-origin",
+    });
+    return readJsonOrThrow(response);
+  }
+
+  async function apiPostForm(path, formDataOrParams, options) {
+    return submitFormMutation("POST", path, formDataOrParams, options);
+  }
+
+  async function apiDeleteForm(path, formDataOrParams, options) {
+    return submitFormMutation("DELETE", path, formDataOrParams, options);
+  }
+
+  async function submitFormMutation(method, path, formDataOrParams, options) {
+    const requestOptions = options || {};
+    const bootstrap =
+      requestOptions.bootstrap === false
+        ? currentBootstrap || {}
+        : await refreshBootstrapForMutation(requestOptions);
+    const formPassword = requestOptions.formPassword || bootstrap.formPassword || "";
+    if (requestOptions.requireFormPassword !== false && !formPassword) {
+      throw new Error(
+        requestOptions.unavailableMessage ||
+          "Mutating Platform API calls require a bootstrap formPassword."
+      );
+    }
+
+    const body = toUrlSearchParams(formDataOrParams);
+    if (formPassword) {
+      body.set("formPassword", formPassword);
+    }
+
+    const headers = jsonHeaders(requestOptions.headers);
+    headers.set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
+    const response = await fetch(apiUrl(path), {
+      method,
+      headers,
+      body: body.toString(),
+      signal: requestOptions.signal,
+      credentials: "same-origin",
+    });
+    return readJsonOrThrow(response);
+  }
+
+  function apiUrl(path) {
+    const root = normalizeLocalRoot(
+      currentBootstrap && currentBootstrap.platformApiRoot,
+      defaultPlatformApiRoot
+    );
+    const rootUrl = new URL(root, window.location.origin);
+    const url = coerceApiUrl(path, rootUrl);
+    if (url.origin !== window.location.origin || !url.pathname.startsWith(rootUrl.pathname)) {
+      throw new Error("Platform API URL must stay under the same-origin API root.");
+    }
+    return url;
+  }
+
+  function queueSnapshot(options) {
+    const snapshotOptions = options || {};
+    const params = {
+      page: snapshotOptions.page || "downloads",
+    };
+    if (snapshotOptions.sortBy) {
+      params.sortBy = snapshotOptions.sortBy;
+    }
+    if (snapshotOptions.reversed) {
+      params.reversed = "true";
+    }
+    if (snapshotOptions.advancedMode != null) {
+      params.advancedMode = snapshotOptions.advancedMode ? "true" : "false";
+    }
+    return apiGet("queue", { params, signal: snapshotOptions.signal });
+  }
+
+  function directDownload(formDataOrParams, options) {
+    return apiPostForm("queue/downloads", formDataOrParams, options);
+  }
+
+  function queueMutate(path, formDataOrParams, options) {
+    if (typeof path !== "string" || !path.startsWith("queue/")) {
+      throw new Error("Queue mutation paths must start with queue/.");
+    }
+    return apiPostForm(path, formDataOrParams, options);
+  }
+
+  function insertFile(formDataOrParams, options) {
+    return apiPostForm("queue/inserts/file", formDataOrParams, options);
+  }
+
+  function insertDirectory(formDataOrParams, options) {
+    return apiPostForm("queue/inserts/directory", formDataOrParams, options);
+  }
+
+  function sanitizeFragment(html, options) {
+    const parser = new DOMParser();
+    const parsed = parser.parseFromString(typeof html === "string" ? html : "", "text/html");
+    sanitizeNode(parsed.body, options);
+    const fragment = document.createDocumentFragment();
+    fragment.append(...Array.from(parsed.body.childNodes));
+    return fragment;
+  }
+
+  function sanitizeNode(root, options) {
+    if (!root || typeof root.querySelectorAll !== "function") {
+      return;
+    }
+    root.querySelectorAll(removedElementSelector).forEach((node) => {
+      node.remove();
+    });
+
+    root.querySelectorAll("*").forEach((element) => {
+      Array.from(element.attributes).forEach((attribute) => {
+        const name = attribute.name.toLowerCase();
+        if (name.startsWith("on") || name === "style" || name === "srcdoc") {
+          element.removeAttribute(attribute.name);
+          return;
+        }
+        if (urlAttributeNames.has(name) && !sameOrigin(attribute.value, options)) {
+          element.removeAttribute(attribute.name);
+        }
+      });
+    });
+  }
+
+  function sameOrigin(rawValue) {
+    const value = typeof rawValue === "string" ? rawValue.trim() : "";
+    if (!value || value.startsWith("#")) {
+      return true;
+    }
+    if (value.startsWith("//")) {
+      return false;
+    }
+    try {
+      const url = new URL(value, window.location.href);
+      return (
+        (url.protocol === "http:" || url.protocol === "https:") &&
+        url.origin === window.location.origin
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function coerceApiUrl(path, rootUrl) {
+    if (path instanceof URL) {
+      return new URL(path.toString());
+    }
+
+    const value = path == null ? "" : String(path).trim();
+    if (value.startsWith("//")) {
+      throw new Error("Platform API paths must not be protocol-relative URLs.");
+    }
+
+    if (hasScheme(value)) {
+      return new URL(value);
+    }
+    if (value.startsWith("/")) {
+      return new URL(value, window.location.origin);
+    }
+    return new URL(value, rootUrl);
+  }
+
+  function normalizeLocalRoot(value, fallback) {
+    if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+      return fallback;
+    }
+    try {
+      const url = new URL(value, window.location.origin);
+      if (url.origin !== window.location.origin || url.search || url.hash) {
+        return fallback;
+      }
+      return url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+    } catch (error) {
+      return fallback;
+    }
+  }
+
+  function hasScheme(value) {
+    return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value);
+  }
+
+  function applySearchParams(url, params) {
+    if (!params) {
+      return;
+    }
+    appendParams(url.searchParams, params, true);
+  }
+
+  function toUrlSearchParams(source) {
+    const params = new URLSearchParams();
+    appendParams(params, source, false);
+    return params;
+  }
+
+  function appendParams(params, source, skipEmptyValues) {
+    if (!source) {
+      return;
+    }
+
+    if (typeof source.entries === "function") {
+      for (const [key, value] of source.entries()) {
+        appendParam(params, key, value, skipEmptyValues);
+      }
+      return;
+    }
+
+    if (Array.isArray(source)) {
+      source.forEach((entry) => {
+        if (Array.isArray(entry) && entry.length >= 2) {
+          appendParam(params, entry[0], entry[1], skipEmptyValues);
+        }
+      });
+      return;
+    }
+
+    if (typeof source === "object") {
+      Object.keys(source).forEach((key) => {
+        const value = source[key];
+        if (Array.isArray(value)) {
+          value.forEach((item) => appendParam(params, key, item, skipEmptyValues));
+        } else {
+          appendParam(params, key, value, skipEmptyValues);
+        }
+      });
+    }
+  }
+
+  function appendParam(params, key, value, skipEmptyValues) {
+    if (value == null || (skipEmptyValues && value === "")) {
+      return;
+    }
+    if (typeof value === "string") {
+      params.append(String(key), value);
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      params.append(String(key), String(value));
+    }
+  }
+
+  function jsonHeaders(headers) {
+    const result = new Headers(headers || {});
+    if (!result.has("Accept")) {
+      result.set("Accept", "application/json");
+    }
+    return result;
+  }
+
+  async function ensureBootstrap(options) {
+    if (currentBootstrap && !(options && options.force)) {
+      return currentBootstrap;
+    }
+    return loadBootstrap(options);
+  }
+
+  async function refreshBootstrapForMutation(options) {
+    if (options && options.refreshBootstrap === false) {
+      return ensureBootstrap(options);
+    }
+    const appId = explicitAppId(options) || currentAppId || inferAppId();
+    if (!appId) {
+      return ensureBootstrap(options);
+    }
+    return loadBootstrap(Object.assign({}, options, { appId, force: true }));
+  }
+
+  async function readJsonOrThrow(response) {
+    const data = await readJson(response);
+    if (!response.ok) {
+      throw new Error(responseErrorMessage(data, response));
+    }
+    return data;
+  }
+
+  async function readJson(response) {
+    return response.json().catch(() => ({}));
+  }
+
+  function responseErrorMessage(data, response) {
+    const bodyMessage = responseBodyMessage(data);
+    if (bodyMessage) {
+      return bodyMessage;
+    }
+    if (response) {
+      const status = response.status ? String(response.status) : "HTTP error";
+      return response.statusText ? `${status} ${response.statusText}` : status;
+    }
+    return "Unknown error";
+  }
+
+  function responseBodyMessage(data) {
+    if (!data || typeof data !== "object") {
+      return "";
+    }
+    if (typeof data.error === "string" && data.error.trim()) {
+      return data.error.trim();
+    }
+    if (data.error && typeof data.error.message === "string" && data.error.message.trim()) {
+      return data.error.message.trim();
+    }
+    if (typeof data.message === "string" && data.message.trim()) {
+      return data.message.trim();
+    }
+    if (typeof data.detail === "string" && data.detail.trim()) {
+      return data.detail.trim();
+    }
+    return "";
+  }
+
+  function errorMessage(error) {
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+    if (typeof error === "string" && error) {
+      return error;
+    }
+    const message = responseBodyMessage(error);
+    return message || "Unknown error";
+  }
+
+  function explicitAppId(options) {
+    const appId = options && typeof options.appId === "string" ? options.appId.trim() : "";
+    return appId || "";
+  }
+
+  function inferAppId() {
+    const segments = window.location.pathname.split("/");
+    if (segments.length < 3 || segments[1] !== "apps") {
+      return null;
+    }
+    try {
+      return decodeURIComponent(segments[2]);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function normalizeAppId(appId) {
+    if (typeof appId !== "string") {
+      throw new Error("Cryptad app id must be a string.");
+    }
+    const normalized = appId.trim().toLowerCase();
+    if (!appIdPattern.test(normalized)) {
+      throw new Error("Cryptad app id must be one normalized local path segment.");
+    }
+    return normalized;
+  }
+
+  function sanitizeBootstrap(data) {
+    const source = data && typeof data === "object" ? data : {};
+    const bootstrap = {};
+    copyStringField(source, bootstrap, "appId");
+    copyStringField(source, bootstrap, "name");
+    copyStringField(source, bootstrap, "uiRoot");
+    copyStringField(source, bootstrap, "assetRoot");
+    copyStringField(source, bootstrap, "platformApiRoot");
+    copyStringField(source, bootstrap, "shellRoot");
+    copyStringField(source, bootstrap, "formPassword");
+    return bootstrap;
+  }
+
+  function copyStringField(source, target, name) {
+    if (typeof source[name] === "string") {
+      target[name] = source[name];
+    }
+  }
+
+  function copyBootstrap(bootstrap) {
+    return Object.assign({}, bootstrap);
+  }
+
+  window.CryptaPlatform = Object.freeze({
+    bootstrap: Object.freeze({
+      load: loadBootstrap,
+      current,
+    }),
+    app: Object.freeze({
+      currentId,
+    }),
+    api: Object.freeze({
+      url: apiUrl,
+      get: apiGet,
+      postForm: apiPostForm,
+      deleteForm: apiDeleteForm,
+      errorMessage,
+    }),
+    queue: Object.freeze({
+      snapshot: queueSnapshot,
+      directDownload,
+      mutate: queueMutate,
+    }),
+    content: Object.freeze({
+      insertFile,
+      insertDirectory,
+    }),
+    dom: Object.freeze({
+      sanitizeFragment,
+      sameOrigin,
+    }),
+  });
+})(window);

--- a/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkBoundaryTest.java
+++ b/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkBoundaryTest.java
@@ -1,0 +1,58 @@
+package network.crypta.platform.sdk.js;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class CryptaPlatformSdkBoundaryTest {
+  private static final String MODULE_NAME = "platform-sdk-js";
+  private static final Path ROOT_SDK_RESOURCE_PACKAGE =
+      Path.of("src", "main", "resources", "network", "crypta", "platform", "sdk", "js");
+  private static final Path SDK_RESOURCE_PACKAGE =
+      Path.of(MODULE_NAME)
+          .resolve(
+              Path.of("src", "main", "resources", "network", "crypta", "platform", "sdk", "js"));
+  private static final Path SDK_SCRIPT = SDK_RESOURCE_PACKAGE.resolve("crypta-platform.js");
+  private static final Path OWNERSHIP_METADATA =
+      Path.of(MODULE_NAME, "gradle", "owned-output-patterns.txt");
+
+  @Test
+  void mainResourceLayout_whenCheckingSdkOwnership_expectLeafOwnsBrowserSdk() throws IOException {
+    Path repoRoot = repoRoot();
+
+    assertTrue(
+        Files.isRegularFile(repoRoot.resolve(SDK_SCRIPT)),
+        ":platform-sdk-js must own the browser SDK resource.");
+    assertFalse(
+        Files.exists(repoRoot.resolve(ROOT_SDK_RESOURCE_PACKAGE)),
+        "Root project must not own network/crypta/platform/sdk/js resources.");
+  }
+
+  @Test
+  void buildWiring_whenCheckingLeafMetadata_expectOwnedOutputPatternDeclared() throws IOException {
+    Path repoRoot = repoRoot();
+    String settings = Files.readString(repoRoot.resolve("settings.gradle.kts"));
+    String build = Files.readString(repoRoot.resolve("build.gradle.kts"));
+    String metadata = Files.readString(repoRoot.resolve(OWNERSHIP_METADATA));
+
+    assertTrue(settings.contains("\":platform-sdk-js\""));
+    assertTrue(build.contains("project(\":platform-sdk-js\")"));
+    assertTrue(metadata.contains("network/crypta/platform/sdk/js/**"));
+  }
+
+  private static Path repoRoot() throws IOException {
+    Path path = Path.of("");
+    Path directory = path.toAbsolutePath().normalize();
+    while (directory != null && !Files.isRegularFile(directory.resolve("settings.gradle.kts"))) {
+      directory = directory.getParent();
+    }
+    assertNotNull(directory, "Could not locate the repo root from " + path.toAbsolutePath());
+    return directory.toRealPath();
+  }
+}

--- a/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
+++ b/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
@@ -1,0 +1,60 @@
+package network.crypta.platform.sdk.js;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class CryptaPlatformSdkResourceTest {
+  private static final String SDK_RESOURCE_PATH =
+      "/network/crypta/platform/sdk/js/crypta-platform.js";
+
+  @Test
+  void classpathResource_whenSdkRequested_expectReadableBrowserScript() throws IOException {
+    String script = readSdkScript();
+
+    assertTrue(script.contains("window.CryptaPlatform"));
+    assertTrue(script.contains("bootstrap:"));
+    assertTrue(script.contains("api:"));
+    assertTrue(script.contains("queue:"));
+    assertTrue(script.contains("content:"));
+    assertTrue(script.contains("dom:"));
+    assertTrue(script.contains("sanitizeFragment"));
+    assertTrue(script.contains("formPassword"));
+    assertFalse(script.contains("CRYPTAD_APP_TOKEN"));
+  }
+
+  @Test
+  void classpathResource_whenAppIdCanonicalizationRequested_expectComparisonUsesNormalizedIds()
+      throws IOException {
+    String script = readSdkScript();
+
+    int requestedNormalization = script.indexOf("const requestedAppId = normalizeAppId(rawAppId);");
+    int fetchWithNormalizedId = script.indexOf("fetchBootstrap(requestedAppId)");
+    int bootstrapNormalization =
+        script.indexOf("bootstrap.appId = normalizeAppId(bootstrap.appId);");
+    int normalizedComparison = script.indexOf("bootstrap.appId && bootstrap.appId !== appId");
+
+    assertTrue(script.contains("const appIdPattern = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;"));
+    assertTrue(script.contains("const normalized = appId.trim().toLowerCase();"));
+    assertTrue(script.contains("const requestedAppId = normalizeAppId(rawAppId);"));
+    assertTrue(script.contains("bootstrap.appId = normalizeAppId(bootstrap.appId);"));
+    assertTrue(requestedNormalization >= 0);
+    assertTrue(fetchWithNormalizedId > requestedNormalization);
+    assertTrue(bootstrapNormalization >= 0);
+    assertTrue(normalizedComparison > bootstrapNormalization);
+  }
+
+  private static String readSdkScript() throws IOException {
+    try (InputStream stream =
+        CryptaPlatformSdkResourceTest.class.getResourceAsStream(SDK_RESOURCE_PATH)) {
+      assertNotNull(stream, "SDK resource must be available on the module classpath.");
+      return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ include(
   ":runtime-spi",
   ":platform-api",
   ":platform-apphost",
+  ":platform-sdk-js",
   ":platform-web-shell",
   ":runtime-alerts",
   ":runtime-node",


### PR DESCRIPTION
## Summary
- Add a dependency-free `:platform-sdk-js` module with the browser-native `window.CryptaPlatform` SDK for app-owned static UIs.
- Copy the canonical SDK into the Queue Manager and Publisher staged bundles, load it before each app script, and migrate duplicated bootstrap/API/form/error/sanitizer helpers to the shared SDK.
- Add SDK and first-party app staging tests, including app-id normalization coverage and checks that staged SDK copies match the canonical resource.
- Document SDK loading, bootstrap behavior, mutation handling with the local form guard, and the browser security boundary.

## Tests
- `./gradlew :platform-sdk-js:test :apps:queue-manager:test :apps:publisher:test`
- `./gradlew :apps:queue-manager:test :apps:publisher:test`
- `./gradlew :platform-web-shell:test :platform-api:test`
- `./gradlew test`
- `./gradlew buildJar`
- `git diff --check`