### PR TITLE
feat(admin): Add legacy admin retirement map

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/DiagnosticToadlet.java
@@ -54,6 +54,9 @@ public class DiagnosticToadlet extends Toadlet {
 
   private String render(DiagnosticReportSnapshot snapshot) {
     StringBuilder builder = new StringBuilder();
+    LegacyAdminRetirementRegistry.findById("diagnostic")
+        .flatMap(LegacyAdminRetirementNotice::renderPlainText)
+        .ifPresent(builder::append);
     for (DiagnosticSectionSnapshot section : snapshot.sections()) {
       builder.append(section.title()).append('\n');
       for (String line : section.lines()) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementNotice.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementNotice.java
@@ -1,0 +1,117 @@
+package network.crypta.clients.http;
+
+import java.util.Optional;
+import network.crypta.support.HTMLNode;
+
+/**
+ * Renders reusable fallback notices for replaced legacy admin pages.
+ *
+ * <p>The notice is intentionally non-blocking. It explains that the legacy page still exists for
+ * fallback and debug use, then links to the Web Shell or first-party app route that should be the
+ * primary operator path. Page builders can call this helper once near the top of a legacy page
+ * instead of embedding per-toadlet warning HTML, which keeps the wording, CSS classes, and fallback
+ * semantics aligned with {@link LegacyAdminRetirementRegistry}.
+ *
+ * <p>The helper is stateless and thread-safe. It does not decide whether a route is replaced; it
+ * trusts the supplied {@link LegacyAdminSurface}. HTML rendering uses existing {@link HTMLNode}
+ * primitives and same-origin URLs already validated by the surface model. Plain-text rendering uses
+ * fixed line-feed separators because legacy diagnostic exports are byte-for-byte HTTP payloads and
+ * should not vary by host operating system.
+ *
+ * <ul>
+ *   <li>HTML pages use {@link #render(LegacyAdminSurface)} or {@link #addTo(HTMLNode,
+ *       LegacyAdminSurface)}.
+ *   <li>Plain-text exports use {@link #renderPlainText(LegacyAdminSurface)}.
+ *   <li>Pending, retained, and infrastructure surfaces return an empty result by design.
+ * </ul>
+ */
+public final class LegacyAdminRetirementNotice {
+  private static final String CSS_CLASS_ATTRIBUTE = "class";
+  private static final String NOTICE_CLASS =
+      "infobox infobox-information legacy-admin-retirement-notice";
+  private static final String INFOBOX_HEADER_CLASS = "infobox-header";
+  private static final String INFOBOX_CONTENT_CLASS = "infobox-content";
+  private static final String NOTICE_HEADER = "Legacy fallback page";
+  private static final String FALLBACK_TEXT =
+      "This legacy page remains available as a fallback and debug view.";
+  private static final String PRIMARY_FLOW_PREFIX = "The primary flow is now in ";
+  private static final String PLAIN_TEXT_LINE_SEPARATOR = "\n";
+
+  private LegacyAdminRetirementNotice() {}
+
+  /**
+   * Builds a notice node for a replaced surface.
+   *
+   * <p>The method returns an empty value for {@code null}, retained, pending, fallback, or
+   * infrastructure surfaces. For replaced pages it creates a complete infobox node containing the
+   * standard fallback sentence and one replacement link. Callers own the returned node and can
+   * attach it to the page content tree without further mutation.
+   *
+   * @param surface registry metadata for the legacy surface being rendered; may be {@code null}
+   * @return notice HTML when the surface is primary-replaced, otherwise an empty optional
+   */
+  public static Optional<HTMLNode> render(LegacyAdminSurface surface) {
+    if (surface == null || !surface.rendersNotice()) {
+      return Optional.empty();
+    }
+
+    HTMLNode notice = new HTMLNode("div", CSS_CLASS_ATTRIBUTE, NOTICE_CLASS);
+    notice.addChild("div", CSS_CLASS_ATTRIBUTE, INFOBOX_HEADER_CLASS, NOTICE_HEADER);
+    HTMLNode content = notice.addChild("div", CSS_CLASS_ATTRIBUTE, INFOBOX_CONTENT_CLASS);
+    content.addChild("p", FALLBACK_TEXT);
+    HTMLNode primaryFlow = content.addChild("p");
+    primaryFlow.addChild("#", PRIMARY_FLOW_PREFIX);
+    primaryFlow.addChild("a", "href", surface.replacementUrl(), replacementLabel(surface));
+    primaryFlow.addChild("#", ".");
+    return Optional.of(notice);
+  }
+
+  /**
+   * Appends a notice for a replaced surface to an existing page content node.
+   *
+   * <p>This convenience method is suitable for shared page builders such as {@link PageMaker}. It
+   * leaves {@code parent} unchanged when the surface does not render a notice, so callers do not
+   * need to duplicate the retirement-state checks. The parent node must be the page content area
+   * where an infobox is valid.
+   *
+   * @param parent destination node that receives the generated notice when one exists
+   * @param surface registry metadata for the current legacy route; may be {@code null}
+   */
+  public static void addTo(HTMLNode parent, LegacyAdminSurface surface) {
+    render(surface).ifPresent(parent::addChild);
+  }
+
+  /**
+   * Builds a plain-text notice for non-HTML legacy exports.
+   *
+   * <p>The returned text mirrors the HTML notice wording and ends with a blank line so the caller
+   * can prepend it directly to an existing report. The format deliberately uses {@code \n} instead
+   * of {@link System#lineSeparator()} to keep HTTP diagnostic exports stable across Linux, macOS,
+   * and Windows hosts.
+   *
+   * @param surface registry metadata for the non-HTML legacy export; may be {@code null}
+   * @return plain-text notice when the surface is primary-replaced, otherwise an empty optional
+   */
+  public static Optional<String> renderPlainText(LegacyAdminSurface surface) {
+    if (surface == null || !surface.rendersNotice()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        NOTICE_HEADER
+            + PLAIN_TEXT_LINE_SEPARATOR
+            + FALLBACK_TEXT
+            + PLAIN_TEXT_LINE_SEPARATOR
+            + PRIMARY_FLOW_PREFIX
+            + replacementLabel(surface)
+            + ": "
+            + surface.replacementUrl()
+            + PLAIN_TEXT_LINE_SEPARATOR
+            + PLAIN_TEXT_LINE_SEPARATOR);
+  }
+
+  private static String replacementLabel(LegacyAdminSurface surface) {
+    return surface.replacementLabel() == null
+        ? surface.replacementUrl()
+        : surface.replacementLabel();
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java
@@ -1,0 +1,410 @@
+package network.crypta.clients.http;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import network.crypta.l10n.TranslationPaths;
+import network.crypta.platform.appui.AppUiPaths;
+import network.crypta.platform.webshell.routes.WebShellPaths;
+
+import static network.crypta.runtime.updater.UpdaterPaths.CORE_UPDATE_PATH;
+
+/**
+ * Authoritative retirement metadata for legacy admin HTTP surfaces.
+ *
+ * <p>The registry covers the admin/control-plane pages that are candidates for later retirement.
+ * Concrete FProxy browse routes remain outside this registry except where an admin-owned helper
+ * route directly supports a retained browse workflow. Matching is route-prefix based and uses the
+ * longest known prefix, which keeps configurable config and queue subpaths attributed to their
+ * parent surface without storing request parameters.
+ *
+ * <p>The list is intentionally static for PR-200. It gives notices, Web Shell fallback links, and
+ * usage diagnostics one shared source of truth while legacy pages continue to exist. Callers should
+ * treat the returned entries as policy metadata, not route registrations. The actual toadlet
+ * registration still lives in the legacy HTTP container, and app/UI replacements remain owned by
+ * their platform modules.
+ *
+ * <p>The registry is immutable after class initialization and is safe to read from request-handling
+ * threads. Any future change to a route's state should update this registry, the retirement-plan
+ * documentation, and the focused tests together so deletion decisions continue to be explainable.
+ *
+ * <ul>
+ *   <li>{@link #surfaces()} exposes the full administrative map.
+ *   <li>{@link #diagnosticSurfaces()} limits usage telemetry to user-facing tracked surfaces.
+ *   <li>{@link #webShellFallbackSurfaces()} feeds retained and pending links back to the shell.
+ *   <li>{@link #findByLegacyPath(String)} resolves request paths without storing query details.
+ * </ul>
+ */
+public final class LegacyAdminRetirementRegistry {
+  private static final String SHELL_PEERS_URL = WebShellPaths.SHELL_ROOT + "#peers";
+  private static final String SHELL_CONNECTIVITY_URL = WebShellPaths.SHELL_ROOT + "#connectivity";
+  private static final String SHELL_CONFIG_URL = WebShellPaths.SHELL_ROOT + "#config";
+  private static final String SHELL_SECURITY_URL = WebShellPaths.SHELL_ROOT + "#security";
+  private static final String SHELL_UPDATES_URL = WebShellPaths.SHELL_ROOT + "#updates";
+  private static final String SHELL_ALERTS_URL = WebShellPaths.SHELL_ROOT + "#alerts";
+  private static final String SHELL_DIAGNOSTICS_URL = WebShellPaths.SHELL_ROOT + "#diagnostics";
+  private static final String SHELL_WIZARD_URL = WebShellPaths.SHELL_ROOT + "#wizard";
+  private static final String WEB_SHELL_PEER_CONTROL_LABEL = "Web Shell peer control";
+  private static final String QUEUE_MANAGER_URL = AppUiPaths.APPS_ROOT + "queue-manager/";
+  private static final String PUBLISHER_URL = AppUiPaths.APPS_ROOT + "publisher/";
+  private static final String SEND_N2NTM_PATH = localPath("send_n2ntm");
+  private static final String CHAT_PATH = localPath("chat");
+  private static final String HELP_PATH = localPath("help");
+
+  private static final List<LegacyAdminSurface> SURFACES =
+      List.of(
+          infrastructure(
+              "web-shell",
+              "Web Shell bridge",
+              WebShellPaths.SHELL_ROOT,
+              "Hosts the replacement node-management shell."),
+          infrastructure(
+              "platform-api",
+              "Platform API bridge",
+              PlatformApiToadlet.MOUNT_PATH,
+              "Hosts the JSON control plane used by Web Shell and first-party apps."),
+          infrastructure(
+              "app-ui",
+              "App-owned static UI bridge",
+              AppUiPaths.APPS_ROOT,
+              "Hosts installed app-owned static UI routes."),
+          infrastructure(
+              "static-assets",
+              "Legacy static assets",
+              StaticToadlet.ROOT_URL,
+              "Serves shared legacy page assets while fallback pages remain."),
+          replaced(
+              "alerts",
+              "Alerts",
+              "/alerts/",
+              SHELL_ALERTS_URL,
+              "Web Shell alerts",
+              "Web Shell lists and dismisses alerts through Platform API v1."),
+          replaced(
+              "queue-downloads",
+              "Download queue",
+              QueueToadlet.PATH_DOWNLOADS,
+              QUEUE_MANAGER_URL,
+              "Queue Manager app",
+              "Queue Manager and the Web Shell queue panel are the primary transfer views."),
+          replaced(
+              "queue-uploads",
+              "Upload queue",
+              QueueToadlet.PATH_UPLOADS,
+              QUEUE_MANAGER_URL,
+              "Queue Manager app",
+              "Queue Manager and Publisher cover upload-queue monitoring and insert creation."),
+          replaced(
+              "file-insert",
+              "File insert wizard",
+              FileInsertWizardToadlet.PATH,
+              PUBLISHER_URL,
+              "Publisher app",
+              "Publisher is the primary first-party UI for local file and directory inserts."),
+          replaced(
+              "local-file-insert",
+              "Local upload file browser",
+              LocalFileInsertToadlet.INSERT_BROWSE_PATH,
+              PUBLISHER_URL,
+              "Publisher app",
+              "The route remains for legacy upload forms and operator fallback."),
+          replaced(
+              "friends",
+              "Friends",
+              LegacyHttpPaths.FRIENDS_PATH,
+              SHELL_PEERS_URL,
+              WEB_SHELL_PEER_CONTROL_LABEL,
+              "Web Shell peer control covers darknet peer roster and mutations."),
+          replaced(
+              "add-friend",
+              "Add friend",
+              DarknetAddRefToadlet.PATH,
+              SHELL_PEERS_URL,
+              WEB_SHELL_PEER_CONTROL_LABEL,
+              "Web Shell peer add handles the primary noderef import flow."),
+          replaced(
+              "strangers",
+              "Strangers",
+              "/strangers/",
+              SHELL_PEERS_URL,
+              WEB_SHELL_PEER_CONTROL_LABEL,
+              "Opennet peer visibility belongs with the shell peer control plane."),
+          replaced(
+              "connectivity",
+              "Connectivity",
+              ConnectivityToadlet.CONNECTIVITY_PATH,
+              SHELL_CONNECTIVITY_URL,
+              "Web Shell connectivity",
+              "Web Shell shows connectivity snapshots through Platform API v1."),
+          replaced(
+              "config",
+              "Configuration",
+              LegacyHttpPaths.CONFIG_PATH,
+              SHELL_CONFIG_URL,
+              "Web Shell config",
+              "Web Shell owns the operator config subset and persistence actions."),
+          replaced(
+              "security-levels",
+              "Security levels",
+              SecurityLevelsToadlet.PATH,
+              SHELL_SECURITY_URL,
+              "Web Shell security",
+              "Web Shell owns the primary security-level view and common mutations."),
+          replaced(
+              "core-update",
+              "Core update actions",
+              CORE_UPDATE_PATH,
+              SHELL_UPDATES_URL,
+              "Web Shell updates",
+              "Web Shell owns the primary updater state and download trigger."),
+          replaced(
+              "statistics",
+              "Statistics",
+              StatisticsToadlet.TOADLET_URL,
+              SHELL_DIAGNOSTICS_URL,
+              "Web Shell diagnostics",
+              "Diagnostics is the primary shell-native operator status surface."),
+          replaced(
+              "diagnostic",
+              "Diagnostic report",
+              DiagnosticToadlet.TOADLET_URL,
+              SHELL_DIAGNOSTICS_URL,
+              "Web Shell diagnostics",
+              "The plain-text export remains useful as fallback and debug output."),
+          pendingWizard(
+              "first-time-wizard",
+              "First-time wizard",
+              FirstTimeWizardToadlet.TOADLET_URL,
+              "The shell wizard exists, but startup routing still relies on the legacy wizard"
+                  + " gate."),
+          pendingWizard(
+              "first-time-wizard-js",
+              "JavaScript first-time wizard",
+              FirstTimeWizardNewToadlet.TOADLET_URL,
+              "The JavaScript wizard remains part of first-run fallback behavior."),
+          pending(
+              "node-to-node-message",
+              "Node-to-node messages",
+              SEND_N2NTM_PATH,
+              null,
+              null,
+              "No complete Web Shell or app replacement is established yet.",
+              true),
+          retained(
+              "chat",
+              "Chat and forums",
+              CHAT_PATH,
+              "On-network chat/forum discovery remains a retained legacy browse-adjacent page."),
+          retained(
+              "translation",
+              "Translation",
+              TranslationPaths.TOADLET_URL,
+              "Translation management has no shell-native replacement in this PR."),
+          retained(
+              "help",
+              "Help",
+              HELP_PATH,
+              "The simple help page remains a retained legacy support page."),
+          retained(
+              "content-filter",
+              "Content filter",
+              LegacyContentFilterSupport.CONTENT_FILTER_PATH,
+              "FProxy content filtering remains part of retained browse safety tooling."),
+          infrastructure(
+              "directory-browser",
+              "Local directory browser",
+              LocalDirectoryToadlet.basePath(),
+              "Supports legacy config, download, and insert forms."),
+          infrastructure(
+              "symlink-resolver",
+              "Toadlet symlink resolver",
+              "/sl/",
+              "Maintains legacy alias compatibility."));
+
+  private static final Map<String, LegacyAdminSurface> SURFACES_BY_ID = surfacesById();
+  private static final List<LegacyAdminSurface> MATCH_SURFACES =
+      SURFACES.stream()
+          .sorted(
+              Comparator.comparingInt((LegacyAdminSurface surface) -> surface.legacyPath().length())
+                  .reversed())
+          .toList();
+
+  private LegacyAdminRetirementRegistry() {}
+
+  /**
+   * Returns all known admin-surface retirement metadata in stable encounter order.
+   *
+   * <p>The returned list includes primary-replaced pages, retained pages, pending migration gaps,
+   * and infrastructure routes. Encounter order is the documentation order used by diagnostics and
+   * shell fallback views. Consumers must filter by state or inclusion flags rather than assuming
+   * every entry is user-facing.
+   *
+   * @return immutable list of registry entries in the maintained retirement-map order
+   */
+  public static List<LegacyAdminSurface> surfaces() {
+    return SURFACES;
+  }
+
+  /**
+   * Returns surfaces included in process-local usage diagnostics.
+   *
+   * <p>The diagnostics list excludes infrastructure bridges and helpers such as static assets,
+   * Platform API, Web Shell, and app UI mounts. It does include replaced, retained, and pending
+   * user-facing surfaces so later retirement PRs can see which fallback pages are still used after
+   * process start.
+   *
+   * @return immutable list of surfaces that should appear in diagnostics output
+   */
+  public static List<LegacyAdminSurface> diagnosticSurfaces() {
+    return SURFACES.stream().filter(LegacyAdminSurface::includeInUsageDiagnostics).toList();
+  }
+
+  /**
+   * Returns retained or pending legacy pages that the Web Shell may show as fallback links.
+   *
+   * <p>Primary-replaced pages are deliberately excluded because their normal entry points should be
+   * Web Shell panels or first-party apps. This list is for routes that remain retained or whose
+   * replacement is not complete enough to hide the legacy entry point.
+   *
+   * @return immutable list of Web Shell fallback-link surfaces in display order
+   */
+  public static List<LegacyAdminSurface> webShellFallbackSurfaces() {
+    return SURFACES.stream().filter(LegacyAdminSurface::includeInWebShellFallbackLinks).toList();
+  }
+
+  /**
+   * Resolves one surface by stable id.
+   *
+   * <p>Ids are stable machine-readable names used by diagnostics and tests. This method does not
+   * normalize input; callers should pass the exact registry id and handle an empty result for
+   * unknown or {@code null} values.
+   *
+   * @param id registry id to look up, usually a stable diagnostics surface id
+   * @return matching surface when present, otherwise an empty optional
+   */
+  public static Optional<LegacyAdminSurface> findById(String id) {
+    return Optional.ofNullable(SURFACES_BY_ID.get(id));
+  }
+
+  /**
+   * Resolves one surface by stable id and fails if the id is missing.
+   *
+   * <p>This is intended for tests and wiring code that must fail fast when a registry entry was
+   * renamed or removed. Request-handling paths should normally use {@link #findById(String)} or
+   * {@link #findByLegacyPath(String)} so unknown input can be ignored safely.
+   *
+   * @param id registry id to look up, using the exact value declared in the map
+   * @return matching surface for the supplied registry id
+   * @throws IllegalArgumentException if the id is unknown or not present in the map
+   */
+  public static LegacyAdminSurface require(String id) {
+    return findById(id).orElseThrow(() -> new IllegalArgumentException("Unknown surface: " + id));
+  }
+
+  /**
+   * Resolves the best matching surface for a request path using longest-prefix matching.
+   *
+   * <p>The matcher expects a local path with no query string, for example {@code /downloads/} or
+   * {@code /config/node}. Longest-prefix ordering prevents broad helper routes from masking more
+   * specific surfaces. The method returns empty for blank, {@code null}, unregistered, or
+   * browse-only paths, which lets usage diagnostics ignore traffic outside the retirement map.
+   *
+   * @param requestPath local same-origin request path without query string or fragment
+   * @return matching surface when the path belongs to a registered legacy-admin surface
+   */
+  public static Optional<LegacyAdminSurface> findByLegacyPath(String requestPath) {
+    if (requestPath == null || requestPath.isBlank()) {
+      return Optional.empty();
+    }
+    for (LegacyAdminSurface surface : MATCH_SURFACES) {
+      String legacyPath = surface.legacyPath();
+      if (requestPath.equals(legacyPath) || requestPath.startsWith(legacyPath)) {
+        return Optional.of(surface);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Map<String, LegacyAdminSurface> surfacesById() {
+    LinkedHashMap<String, LegacyAdminSurface> byId =
+        LinkedHashMap.newLinkedHashMap(SURFACES.size());
+    for (LegacyAdminSurface surface : SURFACES) {
+      LegacyAdminSurface previous = byId.put(surface.id(), surface);
+      if (previous != null) {
+        throw new IllegalStateException("Duplicate legacy-admin surface id: " + surface.id());
+      }
+    }
+    return Map.copyOf(byId);
+  }
+
+  private static String localPath(String segment) {
+    return "/" + segment + "/";
+  }
+
+  private static LegacyAdminSurface replaced(
+      String id,
+      String title,
+      String legacyPath,
+      String replacementUrl,
+      String replacementLabel,
+      String notes) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.PRIMARY_REPLACED,
+        replacementUrl,
+        replacementLabel,
+        notes,
+        true,
+        false);
+  }
+
+  private static LegacyAdminSurface pendingWizard(
+      String id, String title, String legacyPath, String notes) {
+    return pending(
+        id, title, legacyPath, SHELL_WIZARD_URL, "Web Shell first-time setup", notes, false);
+  }
+
+  private static LegacyAdminSurface pending(
+      String id,
+      String title,
+      String legacyPath,
+      String replacementUrl,
+      String replacementLabel,
+      String notes,
+      boolean includeInWebShellFallbackLinks) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.PENDING,
+        replacementUrl,
+        replacementLabel,
+        notes,
+        true,
+        includeInWebShellFallbackLinks);
+  }
+
+  private static LegacyAdminSurface retained(
+      String id, String title, String legacyPath, String notes) {
+    return new LegacyAdminSurface(
+        id, title, legacyPath, LegacyAdminRetirementState.RETAINED, null, null, notes, true, true);
+  }
+
+  private static LegacyAdminSurface infrastructure(
+      String id, String title, String legacyPath, String notes) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.INFRASTRUCTURE,
+        null,
+        null,
+        notes,
+        false,
+        false);
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementState.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementState.java
@@ -1,0 +1,69 @@
+package network.crypta.clients.http;
+
+/**
+ * Retirement state assigned to one legacy admin HTTP surface.
+ *
+ * <p>The values are intentionally conservative. They describe how operators should treat the legacy
+ * surface today; they do not delete routes or imply that a later PR can remove a page without
+ * checking diagnostics and remaining migration gaps.
+ *
+ * <p>States are used by three separate consumers: notice rendering, Web Shell fallback-link
+ * selection, and process-local diagnostics. A state therefore needs to describe current product
+ * ownership, not only implementation location. For example, a page can still exist in the legacy
+ * adapter while being marked {@link #PRIMARY_REPLACED} because Web Shell or a first-party app is
+ * now the expected operator entry point.
+ *
+ * <ul>
+ *   <li>Deletion decisions must be made in later PRs after usage counters and migration gaps are
+ *       reviewed.
+ *   <li>FProxy browse and browse-owned content rendering should remain {@link #RETAINED} or outside
+ *       this admin registry.
+ *   <li>{@link #INFRASTRUCTURE} entries support routing or hosting and are not user-facing
+ *       retirement candidates.
+ * </ul>
+ */
+public enum LegacyAdminRetirementState {
+  /**
+   * A Web Shell or first-party app route is now the primary user path.
+   *
+   * <p>The legacy page remains reachable for fallback, debug, or bookmarked access. Replaced pages
+   * normally render a retirement notice and are excluded from primary Web Shell legacy-link lists.
+   */
+  PRIMARY_REPLACED,
+
+  /**
+   * The page remains reachable as a fallback but is not the preferred path.
+   *
+   * <p>This state is reserved for pages that are still operational and expected to be reachable,
+   * but whose replacement status is softer than {@link #PRIMARY_REPLACED}. It lets future PRs
+   * describe transitional surfaces without showing a strong replacement warning by default.
+   */
+  FALLBACK,
+
+  /**
+   * The surface is intentionally kept as long-term functionality.
+   *
+   * <p>Retained surfaces are not deletion candidates for the current retirement plan. This state is
+   * appropriate for browse-adjacent tools, support pages, and other routes that remain legitimate
+   * endpoints even after Web Shell becomes the primary admin UI.
+   */
+  RETAINED,
+
+  /**
+   * A complete replacement is not available or has not been proven.
+   *
+   * <p>Pending surfaces should stay reachable and should not receive strong replacement notices.
+   * Use this state when coverage exists only partially, startup routing still depends on legacy
+   * behavior, or the replacement path needs more validation.
+   */
+  PENDING,
+
+  /**
+   * The route supports other pages and is not a standalone user-facing admin page.
+   *
+   * <p>Infrastructure entries include bridges, helpers, and static hosting routes. They can appear
+   * in the registry so matching remains explicit, but usage diagnostics and Web Shell fallback
+   * navigation normally exclude them.
+   */
+  INFRASTRUCTURE
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminSurface.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminSurface.java
@@ -1,0 +1,94 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+
+/**
+ * Immutable retirement metadata for one legacy admin HTTP surface.
+ *
+ * <p>The legacy path is the canonical route prefix used for notices, diagnostics, and Web Shell
+ * fallback-link decisions. Replacement fields are optional because pending, retained, and
+ * infrastructure routes may not have a shell-native successor.
+ *
+ * <p>The record carries route-level metadata only. It deliberately does not hold query strings,
+ * form fields, peer references, keys, filesystem paths, or request-specific values. This keeps the
+ * same object safe to use in page rendering, Web Shell bootstrap data, and process-local
+ * diagnostics. Instances are immutable, validate same-origin paths at construction time, and can be
+ * shared freely across request-handling threads.
+ *
+ * <p>Two boolean inclusion flags keep policy decisions explicit. A surface can be counted in
+ * diagnostics without appearing in the Web Shell fallback list, and infrastructure entries can be
+ * registered for matching while remaining excluded from both user-facing telemetry and navigation.
+ *
+ * @param id stable machine-readable identifier used by diagnostics and tests
+ * @param title human-readable surface title suitable for notices and link labels
+ * @param legacyPath canonical same-origin route prefix for the legacy surface
+ * @param state current retirement state that drives notices and navigation decisions
+ * @param replacementUrl primary same-origin Web Shell or app URL when known
+ * @param replacementLabel visible label for the replacement URL when present
+ * @param notes short maintainer note describing the classification and migration context
+ * @param includeInUsageDiagnostics whether process-local usage diagnostics should include this
+ *     surface
+ * @param includeInWebShellFallbackLinks whether the Web Shell should show this as a fallback link
+ */
+public record LegacyAdminSurface(
+    String id,
+    String title,
+    String legacyPath,
+    LegacyAdminRetirementState state,
+    String replacementUrl,
+    String replacementLabel,
+    String notes,
+    boolean includeInUsageDiagnostics,
+    boolean includeInWebShellFallbackLinks) {
+  /**
+   * Creates an immutable legacy-admin surface description.
+   *
+   * <p>Required text fields must be nonblank. Route fields must be same-origin absolute paths,
+   * which prevents notice rendering from introducing external or protocol-relative links. Optional
+   * replacement fields may be {@code null} for retained, pending, fallback, and infrastructure
+   * surfaces that do not have a declared primary successor.
+   *
+   * @throws NullPointerException if any required field is {@code null}
+   * @throws IllegalArgumentException if text fields are blank or a path is not same-origin
+   */
+  public LegacyAdminSurface {
+    requireText(id, "id");
+    requireText(title, "title");
+    requirePath(legacyPath, "legacyPath");
+    Objects.requireNonNull(state, "state");
+    if (replacementUrl != null) {
+      requirePath(replacementUrl, "replacementUrl");
+    }
+    if (replacementLabel != null) {
+      requireText(replacementLabel, "replacementLabel");
+    }
+    requireText(notes, "notes");
+  }
+
+  /**
+   * Returns whether this surface should render a retirement notice on legacy HTML pages.
+   *
+   * <p>Only primary-replaced surfaces with a concrete replacement URL render notices. Pending and
+   * retained pages intentionally stay quiet so operators are not pushed away from flows whose
+   * replacement is incomplete or intentionally out of scope.
+   *
+   * @return {@code true} when the surface has a primary replacement and replacement link
+   */
+  public boolean rendersNotice() {
+    return state == LegacyAdminRetirementState.PRIMARY_REPLACED && replacementUrl != null;
+  }
+
+  private static void requireText(String value, String label) {
+    Objects.requireNonNull(value, label);
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(label + " must not be blank");
+    }
+  }
+
+  private static void requirePath(String value, String label) {
+    requireText(value, label);
+    if (!value.startsWith("/") || value.startsWith("//")) {
+      throw new IllegalArgumentException(label + " must be a same-origin absolute path");
+    }
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminUsageRecorder.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminUsageRecorder.java
@@ -1,0 +1,150 @@
+package network.crypta.clients.http;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import network.crypta.runtime.spi.LegacyAdminSurfaceUsage;
+import network.crypta.runtime.spi.LegacyAdminUsagePort;
+import network.crypta.runtime.spi.LegacyAdminUsageSnapshot;
+
+/**
+ * Thread-safe process-local usage recorder for legacy admin HTTP surfaces.
+ *
+ * <p>The recorder is bounded by {@link LegacyAdminRetirementRegistry}. It only counts known surface
+ * ids and records the latest observation time. It does not persist data and does not store request
+ * parameters, bodies, peer references, URIs, filesystem paths, or remote addresses.
+ *
+ * <p>The legacy HTTP adapter records a visit only after a request has passed the container-level
+ * gates and produced an accepted response. This class assumes that policy decision has already
+ * happened; it only maps the supplied path or surface to a bounded counter. The resulting snapshot
+ * is useful for retirement planning because it answers which fallback pages are still exercised
+ * during the current process lifetime without becoming an audit log.
+ *
+ * <p>Instances are safe for concurrent request threads. Counts and timestamps are maintained with
+ * atomic fields, and snapshots include every diagnostic surface whether it has been observed or
+ * not. Counters are intentionally reset on process restart and are not written to disk.
+ *
+ * @see LegacyAdminUsagePort
+ * @see LegacyAdminUsageSnapshot
+ */
+public final class LegacyAdminUsageRecorder implements LegacyAdminUsagePort {
+  private static final LegacyAdminUsageRecorder DEFAULT =
+      new LegacyAdminUsageRecorder(Clock.systemUTC());
+
+  private final Clock clock;
+  private final ConcurrentMap<String, Counter> counters = new ConcurrentHashMap<>();
+
+  /**
+   * Creates a recorder using the supplied clock.
+   *
+   * <p>The constructor is package-private so focused tests can inject a fixed clock while
+   * production code uses {@link #defaultRecorder()}. The recorder does not retain request context;
+   * the clock is only sampled when a tracked observation is accepted.
+   *
+   * @param clock clock used to timestamp observations in epoch milliseconds
+   */
+  LegacyAdminUsageRecorder(Clock clock) {
+    this.clock = clock;
+  }
+
+  /**
+   * Returns the process-wide recorder used by the legacy HTTP adapter.
+   *
+   * <p>The shared recorder is intentionally process-local. All legacy admin requests in the current
+   * JVM contribute to this instance, and diagnostics reads expose its current counters. Restarting
+   * the node starts a fresh telemetry window.
+   *
+   * @return shared recorder instance for the running node process
+   */
+  public static LegacyAdminUsageRecorder defaultRecorder() {
+    return DEFAULT;
+  }
+
+  /**
+   * Records a visit by request path when the path belongs to a tracked legacy-admin surface.
+   *
+   * <p>The path should be the local request path after authorization decisions have completed and
+   * before any query string is considered. Unknown paths, blank input, retained infrastructure
+   * helpers, and registry entries excluded from diagnostics are ignored. Callers that already
+   * resolved a surface should prefer {@link #recordSurface(LegacyAdminSurface)} so internal
+   * redirects do not change the attribution.
+   *
+   * @param requestPath local request path without query string or fragment
+   */
+  public void recordPath(String requestPath) {
+    LegacyAdminRetirementRegistry.findByLegacyPath(requestPath).ifPresent(this::recordSurface);
+  }
+
+  /**
+   * Records a visit for one registry surface when diagnostics include that surface.
+   *
+   * <p>The method increments only surfaces whose metadata opts into usage diagnostics. It uses the
+   * stable surface id as the counter key, so multiple paths that resolve to the same surface are
+   * aggregated. Timestamps are monotonic with respect to the supplied clock value for each counter;
+   * concurrent observations cannot move a surface's latest-seen value backward.
+   *
+   * @param surface surface metadata resolved by the registry before recording
+   */
+  public void recordSurface(LegacyAdminSurface surface) {
+    if (!surface.includeInUsageDiagnostics()) {
+      return;
+    }
+    Counter counter = counters.computeIfAbsent(surface.id(), _ -> new Counter());
+    counter.increment(clock.millis());
+  }
+
+  /** Clears all counters. Intended for focused tests. */
+  void clear() {
+    counters.clear();
+  }
+
+  /**
+   * Returns a point-in-time view of all diagnostic legacy admin surfaces.
+   *
+   * <p>The snapshot preserves registry order and includes zero-count entries for surfaces that have
+   * not been observed. This keeps Platform API responses structurally stable and lets callers
+   * distinguish "known but unused since startup" from "not part of the retirement map."
+   *
+   * @return immutable snapshot containing one entry per diagnostic surface
+   */
+  @Override
+  public LegacyAdminUsageSnapshot snapshot() {
+    List<LegacyAdminSurfaceUsage> surfaces =
+        LegacyAdminRetirementRegistry.diagnosticSurfaces().stream()
+            .map(this::usageForSurface)
+            .toList();
+    return new LegacyAdminUsageSnapshot(surfaces);
+  }
+
+  private LegacyAdminSurfaceUsage usageForSurface(LegacyAdminSurface surface) {
+    Counter counter = counters.get(surface.id());
+    return new LegacyAdminSurfaceUsage(
+        surface.id(),
+        surface.title(),
+        surface.legacyPath(),
+        surface.state().name(),
+        surface.replacementUrl(),
+        counter == null ? 0L : counter.count(),
+        counter == null ? 0L : counter.lastSeenEpochMillis());
+  }
+
+  private static final class Counter {
+    private final AtomicLong count = new AtomicLong();
+    private final AtomicLong lastSeenEpochMillis = new AtomicLong();
+
+    void increment(long observedEpochMillis) {
+      count.incrementAndGet();
+      lastSeenEpochMillis.updateAndGet(previous -> Math.max(previous, observedEpochMillis));
+    }
+
+    long count() {
+      return count.get();
+    }
+
+    long lastSeenEpochMillis() {
+      return lastSeenEpochMillis.get();
+    }
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
@@ -1,11 +1,13 @@
 package network.crypta.clients.http;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import network.crypta.clients.http.utils.ClientSideLocalizationScript;
 import network.crypta.l10n.BaseL10n;
 import network.crypta.l10n.NodeL10n;
@@ -585,10 +587,8 @@ public final class PageMaker {
       return;
     }
     LegacyAdminSurface surface =
-        ctx.getUri() == null
-            ? surfaceForActiveToadlet(ctx)
-            : LegacyAdminRetirementRegistry.findByLegacyPath(ctx.getUri().getPath())
-                .orElseGet(() -> surfaceForActiveToadlet(ctx));
+        Optional.ofNullable(surfaceForActiveToadlet(ctx))
+            .orElseGet(() -> surfaceForRequestUri(ctx));
     LegacyAdminRetirementNotice.addTo(contentDiv, surface);
   }
 
@@ -598,6 +598,14 @@ public final class PageMaker {
       return null;
     }
     return LegacyAdminRetirementRegistry.findByLegacyPath(activeToadlet.path()).orElse(null);
+  }
+
+  private LegacyAdminSurface surfaceForRequestUri(ToadletContext ctx) {
+    URI uri = ctx.getUri();
+    if (uri == null) {
+      return null;
+    }
+    return LegacyAdminRetirementRegistry.findByLegacyPath(uri.getPath()).orElse(null);
   }
 
   private void addWebPushInputs(HTMLNode bodyNode, ToadletContext ctx, boolean webPushingEnabled) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
@@ -575,7 +575,29 @@ public final class PageMaker {
 
     topBarDiv.addChild("h1", title);
     renderNavigation(pageDiv, ctx, renderParameters, fullAccess, activePath);
-    return pageDiv.addChild(TAG_DIV, "id", "content");
+    HTMLNode contentDiv = pageDiv.addChild(TAG_DIV, "id", "content");
+    addLegacyAdminRetirementNotice(contentDiv, ctx);
+    return contentDiv;
+  }
+
+  private void addLegacyAdminRetirementNotice(HTMLNode contentDiv, ToadletContext ctx) {
+    if (ctx == null) {
+      return;
+    }
+    LegacyAdminSurface surface =
+        ctx.getUri() == null
+            ? surfaceForActiveToadlet(ctx)
+            : LegacyAdminRetirementRegistry.findByLegacyPath(ctx.getUri().getPath())
+                .orElseGet(() -> surfaceForActiveToadlet(ctx));
+    LegacyAdminRetirementNotice.addTo(contentDiv, surface);
+  }
+
+  private LegacyAdminSurface surfaceForActiveToadlet(ToadletContext ctx) {
+    Toadlet activeToadlet = ctx.activeToadlet();
+    if (activeToadlet == null) {
+      return null;
+    }
+    return LegacyAdminRetirementRegistry.findByLegacyPath(activeToadlet.path()).orElse(null);
   }
 
   private void addWebPushInputs(HTMLNode bodyNode, ToadletContext ctx, boolean webPushingEnabled) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -73,7 +73,9 @@ public final class PlatformApiToadlet extends Toadlet {
    * @param runtimePorts detached runtime ports exposed to the platform API leaf
    */
   public PlatformApiToadlet(RuntimePorts runtimePorts) {
-    this(new PlatformApiRouter(runtimePorts));
+    this(
+        new PlatformApiRouter(
+            runtimePorts, null, null, LegacyAdminUsageRecorder.defaultRecorder()));
   }
 
   /**
@@ -83,7 +85,9 @@ public final class PlatformApiToadlet extends Toadlet {
    * @param appHost detached AppHost exposed through the app-management control surface
    */
   public PlatformApiToadlet(RuntimePorts runtimePorts, AppHost appHost) {
-    this(new PlatformApiRouter(runtimePorts, appHost));
+    this(
+        new PlatformApiRouter(
+            runtimePorts, appHost, null, LegacyAdminUsageRecorder.defaultRecorder()));
   }
 
   /**
@@ -95,7 +99,9 @@ public final class PlatformApiToadlet extends Toadlet {
    */
   public PlatformApiToadlet(
       RuntimePorts runtimePorts, AppHost appHost, AppCatalogManager appCatalogManager) {
-    this(new PlatformApiRouter(runtimePorts, appHost, appCatalogManager));
+    this(
+        new PlatformApiRouter(
+            runtimePorts, appHost, appCatalogManager, LegacyAdminUsageRecorder.defaultRecorder()));
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -103,6 +103,8 @@ public final class ToadletContextImpl implements ToadletContext {
   private final BookmarkManagerHandle bookmarkManager;
   private final InetAddress remoteAddr;
   private Exception firstReplySendingException;
+  private int replyStatusCode = -1;
+  private boolean requestGateDenied;
   private final AtomicReference<Toadlet> activeToadlet = new AtomicReference<>();
 
   /** The unique id of the request */
@@ -433,6 +435,7 @@ public final class ToadletContextImpl implements ToadletContext {
             mvt,
             replyHeaders.forceDisableJavascript());
     sendReplyHeaders(sockOutputStream, resolvedHeaders, options);
+    replyStatusCode = resolvedHeaders.code();
   }
 
   /**
@@ -501,6 +504,7 @@ public final class ToadletContextImpl implements ToadletContext {
   public boolean checkFormPassword(HTTPRequest request, String redirectTo)
       throws ToadletContextClosedException, IOException {
     if (!hasFormPassword(request)) {
+      requestGateDenied = true;
       MultiValueTable<String, String> redirectHeaders =
           MultiValueTable.from("Location", redirectTo);
       sendReplyHeaders(302, "Found", redirectHeaders, null, 0);
@@ -529,6 +533,7 @@ public final class ToadletContextImpl implements ToadletContext {
     if (isAllowedFullAccess()) {
       return true;
     } else {
+      requestGateDenied = true;
       toadlet.sendUnauthorizedPage(this);
       return false;
     }
@@ -1086,6 +1091,8 @@ public final class ToadletContextImpl implements ToadletContext {
           IllegalAccessException,
           ToadletInvocationException {
     URI currentUri = uri;
+    LegacyAdminSurface usageSurface =
+        LegacyAdminRetirementRegistry.findByLegacyPath(uri.getPath()).orElse(null);
     boolean redirect;
     do {
       redirect = false;
@@ -1118,6 +1125,7 @@ public final class ToadletContextImpl implements ToadletContext {
 
         try {
           callToadletMethod(toadlet, method, currentUri, req, ctx, data, sock);
+          recordLegacyAdminUsageIfAccepted(usageSurface, ctx);
         } catch (RedirectException re) {
           currentUri = re.newuri;
           redirect = true;
@@ -1126,6 +1134,17 @@ public final class ToadletContextImpl implements ToadletContext {
         req.freeParts();
       }
     } while (redirect);
+  }
+
+  private static void recordLegacyAdminUsageIfAccepted(
+      LegacyAdminSurface usageSurface, ToadletContextImpl ctx) {
+    if (usageSurface != null && ctx.hasAcceptedLegacyAdminUsageResponse()) {
+      LegacyAdminUsageRecorder.defaultRecorder().recordSurface(usageSurface);
+    }
+  }
+
+  boolean hasAcceptedLegacyAdminUsageResponse() {
+    return !requestGateDenied && replyStatusCode >= 200 && replyStatusCode < 400;
   }
 
   private static FindToadletResult findToadlet(

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.l10n.NodeL10n;
@@ -1098,6 +1099,7 @@ public final class ToadletContextImpl implements ToadletContext {
       redirect = false;
       FindToadletResult toadletResult = findToadlet(container, ctx, currentUri);
       if (toadletResult.handled) {
+        recordLegacyAdminUsageIfAccepted(toadletResult.usageSurface(), ctx);
         return;
       }
       Toadlet toadlet = toadletResult.toadlet;
@@ -1152,11 +1154,21 @@ public final class ToadletContextImpl implements ToadletContext {
       throws IOException, ToadletContextClosedException {
     try {
       Toadlet toadlet = container.findToadlet(uri);
-      return new FindToadletResult(toadlet, false);
+      return new FindToadletResult(toadlet, false, null);
     } catch (PermanentRedirectException e) {
       Toadlet.writePermanentRedirect(ctx, "Found elsewhere", e.newuri.toASCIIString());
-      return new FindToadletResult(null, true);
+      return new FindToadletResult(
+          null, true, canonicalRedirectSurface(uri, e.newuri).orElse(null));
     }
+  }
+
+  private static Optional<LegacyAdminSurface> canonicalRedirectSurface(URI requestUri, URI newUri) {
+    String requestPath = requestUri.getPath();
+    String newPath = newUri.getPath();
+    if (requestPath == null || newPath == null || !newPath.equals(requestPath + "/")) {
+      return Optional.empty();
+    }
+    return LegacyAdminRetirementRegistry.findByLegacyPath(newPath);
   }
 
   private record DataReadResult(Bucket data, boolean continueProcessing) {
@@ -1175,7 +1187,8 @@ public final class ToadletContextImpl implements ToadletContext {
     }
   }
 
-  private record FindToadletResult(Toadlet toadlet, boolean handled) {}
+  private record FindToadletResult(
+      Toadlet toadlet, boolean handled, LegacyAdminSurface usageSurface) {}
 
   private static final class ToadletInvocationException extends Exception {
     ToadletInvocationException(Throwable cause) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
@@ -34,15 +34,6 @@ public final class WebShellToadlet extends Toadlet {
   /** Shared reason phrase for missing shell routes and shell-owned assets. */
   private static final String NOT_FOUND_REASON = "Not Found";
 
-  /** Leading and trailing separator reused when synthesizing stable legacy UI paths. */
-  private static final String ROOT_PATH_DELIMITER = "/";
-
-  /** Path segment for the legacy opennet peers page surfaced from the shell. */
-  private static final String STRANGERS_SEGMENT = "strangers";
-
-  /** Path segment for the legacy alerts page surfaced from the shell. */
-  private static final String ALERTS_SEGMENT = "alerts";
-
   /** Adapter-owned bootstrap payload injected into the rendered shell document. */
   private final WebShellBootstrap bootstrap;
 
@@ -115,21 +106,16 @@ public final class WebShellToadlet extends Toadlet {
   /**
    * Returns the default legacy deep links exposed by the Web Shell.
    *
-   * <p>The list stays adapter-owned because these routes are defined by the legacy HTTP surface and
-   * may include configuration-driven mount points.
+   * <p>The list is sourced from the retirement registry so primary-replaced legacy admin pages stop
+   * appearing as shell fallback links. Only retained or pending pages that still need a legacy
+   * entry point remain here.
    *
-   * @return ordered legacy links for friends, peers, downloads, status, and config pages
+   * @return ordered fallback links for retained or pending legacy pages
    */
-  private static List<WebShellBootstrap.LegacyLink> defaultLegacyLinks() {
-    return List.of(
-        legacyLink(LegacyHttpPaths.FRIENDS_PATH, "Friends"),
-        legacyLink(legacyPath(STRANGERS_SEGMENT), "Strangers"),
-        legacyLink(QueueToadlet.PATH_DOWNLOADS, "Downloads"),
-        legacyLink(ConnectivityToadlet.CONNECTIVITY_PATH, "Connectivity"),
-        legacyLink(SecurityLevelsToadlet.PATH, "Security levels"),
-        legacyLink(StatisticsToadlet.TOADLET_URL, "Statistics"),
-        legacyLink(legacyPath(ALERTS_SEGMENT), "Alerts"),
-        legacyLink(LegacyHttpPaths.CONFIG_PATH, "Config"));
+  static List<WebShellBootstrap.LegacyLink> defaultLegacyLinks() {
+    return LegacyAdminRetirementRegistry.webShellFallbackSurfaces().stream()
+        .map(surface -> legacyLink(surface.legacyPath(), surface.title()))
+        .toList();
   }
 
   /**
@@ -141,16 +127,6 @@ public final class WebShellToadlet extends Toadlet {
    */
   private static WebShellBootstrap.LegacyLink legacyLink(String path, String label) {
     return new WebShellBootstrap.LegacyLink(path, label);
-  }
-
-  /**
-   * Builds one stable legacy route path from a single path segment.
-   *
-   * @param pathSegment route segment without leading or trailing slashes
-   * @return canonical legacy route with a leading and trailing slash
-   */
-  private static String legacyPath(String pathSegment) {
-    return ROOT_PATH_DELIMITER + pathSegment + ROOT_PATH_DELIMITER;
   }
 
   /**

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementNoticeTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementNoticeTest.java
@@ -1,0 +1,48 @@
+package network.crypta.clients.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LegacyAdminRetirementNoticeTest {
+  @Test
+  void render_whenSurfacePrimaryReplaced_expectFallbackNoticeWithReplacementLink() {
+    String html =
+        LegacyAdminRetirementNotice.render(LegacyAdminRetirementRegistry.require("friends"))
+            .orElseThrow()
+            .generate();
+
+    assertTrue(html.contains("Legacy fallback page"));
+    assertTrue(html.contains("This legacy page remains available as a fallback and debug view."));
+    assertTrue(html.contains("The primary flow is now in"));
+    assertTrue(html.contains("href=\"/app/node/#peers\""));
+    assertTrue(html.contains("Web Shell peer control"));
+  }
+
+  @Test
+  void render_whenSurfaceRetained_expectNoNotice() {
+    assertFalse(
+        LegacyAdminRetirementNotice.render(LegacyAdminRetirementRegistry.require("help"))
+            .isPresent());
+  }
+
+  @Test
+  void renderPlainText_whenSurfacePrimaryReplaced_expectPlainFallbackNotice() {
+    String notice =
+        LegacyAdminRetirementNotice.renderPlainText(
+                LegacyAdminRetirementRegistry.require("diagnostic"))
+            .orElseThrow();
+
+    assertFalse(notice.contains("\r"));
+    assertTrue(
+        notice.startsWith(
+            """
+            Legacy fallback page
+            This legacy page remains available as a fallback and debug view.
+            The primary flow is now in Web Shell diagnostics: /app/node/#diagnostics
+
+            """));
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementRegistryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementRegistryTest.java
@@ -1,0 +1,62 @@
+package network.crypta.clients.http;
+
+import java.util.List;
+import network.crypta.platform.appui.AppUiPaths;
+import network.crypta.platform.webshell.routes.WebShellPaths;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LegacyAdminRetirementRegistryTest {
+  @Test
+  void require_whenQueueDownloadsRequested_expectPrimaryReplacementToQueueManager() {
+    LegacyAdminSurface surface = LegacyAdminRetirementRegistry.require("queue-downloads");
+
+    assertEquals(LegacyAdminRetirementState.PRIMARY_REPLACED, surface.state());
+    assertEquals(QueueToadlet.PATH_DOWNLOADS, surface.legacyPath());
+    assertEquals(AppUiPaths.APPS_ROOT + "queue-manager/", surface.replacementUrl());
+    assertTrue(surface.includeInUsageDiagnostics());
+    assertFalse(surface.includeInWebShellFallbackLinks());
+  }
+
+  @Test
+  void findByLegacyPath_whenConfigSubpageRequested_expectConfigSurface() {
+    LegacyAdminSurface surface =
+        LegacyAdminRetirementRegistry.findByLegacyPath(LegacyHttpPaths.CONFIG_PATH + "node")
+            .orElseThrow();
+
+    assertEquals("config", surface.id());
+    assertEquals(LegacyAdminRetirementState.PRIMARY_REPLACED, surface.state());
+    assertEquals(WebShellPaths.SHELL_ROOT + "#config", surface.replacementUrl());
+  }
+
+  @Test
+  void findByLegacyPath_whenPlatformApiRequested_expectInfrastructureSurface() {
+    LegacyAdminSurface surface =
+        LegacyAdminRetirementRegistry.findByLegacyPath(
+                PlatformApiToadlet.MOUNT_PATH + "diagnostics")
+            .orElseThrow();
+
+    assertEquals("platform-api", surface.id());
+    assertEquals(LegacyAdminRetirementState.INFRASTRUCTURE, surface.state());
+    assertFalse(surface.includeInUsageDiagnostics());
+  }
+
+  @Test
+  void webShellFallbackSurfaces_whenRequested_expectOnlyRetainedOrPendingLinks() {
+    List<String> fallbackIds =
+        LegacyAdminRetirementRegistry.webShellFallbackSurfaces().stream()
+            .map(LegacyAdminSurface::id)
+            .toList();
+
+    assertEquals(
+        List.of("node-to-node-message", "chat", "translation", "help", "content-filter"),
+        fallbackIds);
+    assertFalse(fallbackIds.contains("queue-downloads"));
+    assertFalse(fallbackIds.contains("friends"));
+    assertFalse(fallbackIds.contains("alerts"));
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminSurfaceTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminSurfaceTest.java
@@ -1,0 +1,112 @@
+package network.crypta.clients.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LegacyAdminSurfaceTest {
+  @Test
+  void constructor_whenIdBlank_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new LegacyAdminSurface(
+                " ",
+                "Queue",
+                "/downloads/",
+                LegacyAdminRetirementState.PRIMARY_REPLACED,
+                "/apps/queue-manager/",
+                "Queue Manager",
+                "notes",
+                true,
+                false));
+  }
+
+  @Test
+  void constructor_whenReplacementUrlExternal_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new LegacyAdminSurface(
+                "queue",
+                "Queue",
+                "/downloads/",
+                LegacyAdminRetirementState.PRIMARY_REPLACED,
+                "https://example.test/apps/queue-manager/",
+                "Queue Manager",
+                "notes",
+                true,
+                false));
+  }
+
+  @Test
+  void constructor_whenReplacementUrlProtocolRelative_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new LegacyAdminSurface(
+                "queue",
+                "Queue",
+                "/downloads/",
+                LegacyAdminRetirementState.PRIMARY_REPLACED,
+                "//example.test/apps/queue-manager/",
+                "Queue Manager",
+                "notes",
+                true,
+                false));
+  }
+
+  @Test
+  void rendersNotice_whenPrimaryReplacedWithReplacement_expectTrue() {
+    LegacyAdminSurface surface =
+        new LegacyAdminSurface(
+            "queue",
+            "Queue",
+            "/downloads/",
+            LegacyAdminRetirementState.PRIMARY_REPLACED,
+            "/apps/queue-manager/",
+            "Queue Manager",
+            "notes",
+            true,
+            false);
+
+    assertTrue(surface.rendersNotice());
+  }
+
+  @Test
+  void rendersNotice_whenPrimaryReplacedWithoutReplacement_expectFalse() {
+    LegacyAdminSurface surface =
+        new LegacyAdminSurface(
+            "queue",
+            "Queue",
+            "/downloads/",
+            LegacyAdminRetirementState.PRIMARY_REPLACED,
+            null,
+            null,
+            "notes",
+            true,
+            false);
+
+    assertFalse(surface.rendersNotice());
+  }
+
+  @Test
+  void rendersNotice_whenPendingWithReplacement_expectFalse() {
+    LegacyAdminSurface surface =
+        new LegacyAdminSurface(
+            "wizard",
+            "Wizard",
+            "/wizard/",
+            LegacyAdminRetirementState.PENDING,
+            "/app/node/#wizard",
+            "Web Shell wizard",
+            "notes",
+            true,
+            false);
+
+    assertFalse(surface.rendersNotice());
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminUsageRecorderTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminUsageRecorderTest.java
@@ -1,0 +1,51 @@
+package network.crypta.clients.http;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import network.crypta.runtime.spi.LegacyAdminSurfaceUsage;
+import network.crypta.runtime.spi.LegacyAdminUsageSnapshot;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("java:S100")
+class LegacyAdminUsageRecorderTest {
+  @Test
+  void recordPath_whenKnownSurfaceVisited_expectCountAndTimestampInSnapshot() {
+    LegacyAdminUsageRecorder recorder =
+        new LegacyAdminUsageRecorder(
+            Clock.fixed(Instant.ofEpochMilli(1_770_000_000_000L), ZoneOffset.UTC));
+
+    recorder.recordPath(QueueToadlet.PATH_DOWNLOADS);
+    recorder.recordPath(QueueToadlet.PATH_DOWNLOADS + "finished");
+
+    LegacyAdminSurfaceUsage usage = usage(recorder.snapshot(), "queue-downloads");
+    assertEquals(2L, usage.count());
+    assertEquals(1_770_000_000_000L, usage.lastSeenEpochMillis());
+    assertEquals(LegacyAdminRetirementState.PRIMARY_REPLACED.name(), usage.state());
+    assertEquals("/apps/queue-manager/", usage.replacementUrl());
+  }
+
+  @Test
+  void recordPath_whenInfrastructureOrUnknownVisited_expectNoDiagnosticCount() {
+    LegacyAdminUsageRecorder recorder =
+        new LegacyAdminUsageRecorder(
+            Clock.fixed(Instant.ofEpochMilli(1_770_000_000_000L), ZoneOffset.UTC));
+
+    recorder.recordPath(PlatformApiToadlet.MOUNT_PATH + "diagnostics");
+    recorder.recordPath("/not-a-legacy-admin-page/");
+
+    LegacyAdminSurfaceUsage diagnostic = usage(recorder.snapshot(), "diagnostic");
+    assertEquals(0L, diagnostic.count());
+    assertEquals(0L, diagnostic.lastSeenEpochMillis());
+  }
+
+  private static LegacyAdminSurfaceUsage usage(
+      LegacyAdminUsageSnapshot snapshot, String surfaceId) {
+    return snapshot.surfaces().stream()
+        .filter(surface -> surface.surfaceId().equals(surfaceId))
+        .findFirst()
+        .orElseThrow();
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/WebShellToadletBootstrapTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/WebShellToadletBootstrapTest.java
@@ -37,4 +37,22 @@ class WebShellToadletBootstrapTest {
             "/config-custom/"),
         bootstrap.legacyLinks().stream().map(WebShellBootstrap.LegacyLink::path).toList());
   }
+
+  @Test
+  void defaultLegacyLinks_whenBuilt_expectOnlyPendingOrRetainedFallbackPages() {
+    List<WebShellBootstrap.LegacyLink> links = WebShellToadlet.defaultLegacyLinks();
+
+    assertEquals(
+        List.of(
+            "/send_n2ntm/",
+            "/chat/",
+            "/translation/",
+            "/help/",
+            LegacyContentFilterSupport.CONTENT_FILTER_PATH),
+        links.stream().map(WebShellBootstrap.LegacyLink::path).toList());
+    assertEquals(
+        List.of(
+            "Node-to-node messages", "Chat and forums", "Translation", "Help", "Content filter"),
+        links.stream().map(WebShellBootstrap.LegacyLink::label).toList());
+  }
 }

--- a/docs/app-owned-ui.md
+++ b/docs/app-owned-ui.md
@@ -126,6 +126,10 @@ not an app permission token. The [Platform JavaScript SDK](platform-sdk-js.md) c
 bootstrap as route metadata and as the source of the existing `formPassword` mutation guard.
 Browser-issued app sessions and stronger app isolation remain later platform work.
 
+Queue Manager and Publisher are also the primary replacements for the legacy queue and insert
+admin pages in the current retirement map. The full map is maintained in
+[legacy-retirement-plan.md](legacy-retirement-plan.md).
+
 ## Platform API summary fields
 
 Installed app summaries expose UI metadata:

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -41,6 +41,11 @@ and `:platform-apphost`. The adapter owns `/apps/` route registration and respon
 the platform leaves own installed-app lookup, UI-mode interpretation, path normalization, content
 types, and static asset confinement.
 
+Legacy admin retirement metadata also stays in `:adapter-http-legacy-admin`. The registry records
+which admin pages are primary-replaced, pending, retained, or infrastructure, renders fallback
+notices for replaced pages, and feeds process-local usage counters into Platform API diagnostics.
+The retirement plan is documented in [legacy-retirement-plan.md](legacy-retirement-plan.md).
+
 Production code outside `:adapter-http-legacy-admin`, `:adapter-http-legacy-browse`, and
 `:bridge-http-runtime` should keep depending on runtime-owned seams, `:platform-api`, or
 `:platform-web-shell` instead of growing new direct dependencies on
@@ -48,6 +53,6 @@ Production code outside `:adapter-http-legacy-admin`, `:adapter-http-legacy-brow
 `src/main/java/network/crypta/runtime/bootstrap/DefaultNodeRuntimeBridgeFactories.java`, and the
 updater-action adapters remain in `:adapter-http-legacy-admin`.
 
-Future browse/FProxy decomposition or replacement remains a separate concern. This page documents
-the current admin/shared-shell, browse, and runtime boundary, and the concrete browse leaf remains
-out of scope for this closeout.
+Future browse/FProxy decomposition or replacement remains a separate concern. The concrete browse
+leaf is explicitly retained by the retirement plan and remains out of scope for legacy admin page
+removal.

--- a/docs/legacy-retirement-plan.md
+++ b/docs/legacy-retirement-plan.md
@@ -1,0 +1,116 @@
+# Legacy admin retirement plan
+
+This document maps Cryptad's legacy admin HTTP pages to their current Web Shell, Platform API, or
+first-party app replacements.
+
+## Scope
+
+PR-200 creates a retirement map. It does not delete legacy pages, remove FProxy browse, change FCP,
+or change network compatibility. Legacy admin pages remain reachable for fallback, debug, and deep
+links until later PRs prove that removal is safe.
+
+FProxy browse and content-rendering surfaces are explicitly retained. The browse split under
+`:adapter-http-legacy-browse` remains outside deletion scope for this plan.
+
+## Retirement states
+
+| State | Meaning |
+| --- | --- |
+| `PRIMARY_REPLACED` | Web Shell or a first-party app is now the primary user path. The legacy page remains as fallback or debug surface. |
+| `FALLBACK` | The legacy page is reachable and expected to work, but is not the preferred path. |
+| `RETAINED` | The legacy surface is intentionally kept as long-term functionality, such as FProxy browse or browse-adjacent tools. |
+| `PENDING` | No complete replacement is proven yet. Do not show a strong replacement notice. |
+| `INFRASTRUCTURE` | The route supports other pages and is not a standalone user-facing page. |
+
+## Current map
+
+| Legacy surface | Legacy path | State | Primary path or reason |
+| --- | --- | --- | --- |
+| Web Shell bridge | `/app/node/` | `INFRASTRUCTURE` | Hosts the replacement node-management UI. |
+| Platform API bridge | `/api/v1/` | `INFRASTRUCTURE` | Hosts the JSON control plane used by Web Shell and apps. |
+| App-owned static UI bridge | `/apps/{appId}/` | `INFRASTRUCTURE` | Hosts installed first-party and app-owned static UIs. |
+| Alerts | `/alerts/` | `PRIMARY_REPLACED` | Web Shell alerts at `/app/node/#alerts`. |
+| Download queue | `/downloads/` | `PRIMARY_REPLACED` | Queue Manager at `/apps/queue-manager/`; Web Shell queue remains a fallback panel. |
+| Upload queue | `/uploads/` | `PRIMARY_REPLACED` | Queue Manager at `/apps/queue-manager/`; Publisher covers insert creation. |
+| File insert wizard | `/insertfile/` | `PRIMARY_REPLACED` | Publisher at `/apps/publisher/`. |
+| Local upload file browser | `/insert-browse/` | `PRIMARY_REPLACED` | Publisher at `/apps/publisher/`; legacy route remains for old upload forms. |
+| Friends | `/friends/` | `PRIMARY_REPLACED` | Web Shell peer control at `/app/node/#peers`. |
+| Add friend | `/addfriend/` | `PRIMARY_REPLACED` | Web Shell peer control at `/app/node/#peers`. |
+| Strangers / opennet peers | `/strangers/` | `PRIMARY_REPLACED` | Web Shell peer control at `/app/node/#peers`. |
+| Connectivity | `/connectivity/` | `PRIMARY_REPLACED` | Web Shell connectivity at `/app/node/#connectivity`. |
+| Configuration | `/config/{section}` | `PRIMARY_REPLACED` | Web Shell config at `/app/node/#config`. |
+| Security levels | `/seclevels/` | `PRIMARY_REPLACED` | Web Shell security at `/app/node/#security`. |
+| Core update actions | `/core-update/` | `PRIMARY_REPLACED` | Web Shell updates at `/app/node/#updates`. |
+| Statistics | `/stats/` | `PRIMARY_REPLACED` | Web Shell diagnostics at `/app/node/#diagnostics`. |
+| Diagnostic report | `/diagnostic/` | `PRIMARY_REPLACED` | Web Shell diagnostics at `/app/node/#diagnostics`; plain-text export remains useful. |
+| First-time wizard | `/wizard/` and `/wiz/` | `PENDING` | Web Shell wizard exists at `/app/node/#wizard`, but startup routing still uses the legacy wizard gate. |
+| Node-to-node messages | `/send_n2ntm/` | `PENDING` | No complete Web Shell or app replacement is established. |
+| Chat and forums | `/chat/` | `RETAINED` | On-network browse-adjacent discovery remains retained. |
+| Translation management | `/translation/` | `RETAINED` | No shell-native replacement exists in this plan. |
+| Help | `/help/` | `RETAINED` | Kept as a simple support page. |
+| Content filter | `/filterfile/` | `RETAINED` | Part of retained FProxy browse safety tooling. |
+| FProxy browse root and key/content rendering | `/` and key routes | `RETAINED` | FProxy browse is intentionally kept out of admin-page retirement. |
+| Decode, external-link, bookmark, AJAX push, directory browser, symlink, and static helpers | Various support routes | `INFRASTRUCTURE` | Required by retained browse or fallback legacy pages. |
+
+The authoritative code map for admin pages lives in
+`LegacyAdminRetirementRegistry` under `:adapter-http-legacy-admin`. Browse-only routes remain owned
+by `:adapter-http-legacy-browse`.
+
+## Current Phase 4 status
+
+Web Shell is the primary local operator UI for node status, peers, queue and transfers, config,
+updates, alerts, diagnostics, installed apps, and first-time setup controls where startup state
+allows it. Queue Manager and Publisher are app-owned static UIs under `/apps/queue-manager/` and
+`/apps/publisher/`.
+
+Replaced legacy admin pages render a non-blocking notice that says the page remains available as a
+fallback/debug view and links to the Web Shell or first-party app replacement.
+
+Web Shell no longer treats replaced legacy admin pages as primary fallback links. Its legacy link
+panel is limited to retained or pending pages that still need a direct entry point.
+
+## Diagnostics
+
+Legacy admin page visits are counted in memory for known admin surfaces. The recorder stores only:
+
+- Surface id.
+- Legacy path.
+- Retirement state.
+- Replacement URL when one exists.
+- Process-local count.
+- Latest observed timestamp in epoch milliseconds.
+
+It does not store query strings, form data, tokens, peer references, Freenet/Crypta URIs,
+filesystem paths, request bodies, or remote addresses.
+
+`GET /api/v1/diagnostics` includes the counters when the legacy HTTP bridge is the host:
+
+```json
+{
+  "legacyAdmin": {
+    "surfaces": [
+      {
+        "id": "queue-downloads",
+        "path": "/downloads/",
+        "state": "PRIMARY_REPLACED",
+        "replacementUrl": "/apps/queue-manager/",
+        "count": 12,
+        "lastSeenEpochMillis": 1770000000000
+      }
+    ]
+  }
+}
+```
+
+The counters reset when the process restarts. They are intended to guide future removal PRs, not to
+act as persistent audit logs.
+
+## Future work before deletion
+
+Later PRs must use diagnostics and focused migration checks before deleting any legacy admin page:
+
+1. Confirm that retained FProxy browse routes are not affected.
+2. Prove that pending pages have complete Web Shell or app replacements.
+3. Keep fallback links or documented manual routes for any remaining debug-only workflows.
+4. Check packaged-node and upgrade behavior so bookmarked legacy URLs fail gracefully or redirect.
+5. Remove routes in small batches with targeted tests and release notes.

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -69,7 +69,7 @@ parameter; check the handler and tests when adding or changing a specific contra
 | Updates | `GET /api/v1/updates/core` reports core-updater availability. `POST /api/v1/updates/core/download` triggers the current package download flow. |
 | Wizard/welcome | `GET /api/v1/wizard/first-time` exposes the detached first-time setup snapshot. `POST /api/v1/wizard/first-time/apply` submits the shell-native onboarding/reset model. There is no separate `/welcome` Platform API family in Phase 3; welcome-page fallback behavior remains on the legacy/admin side. |
 | Alerts | `GET /api/v1/alerts` lists current alerts. `POST /api/v1/alerts/{alertId}/dismiss` dismisses one alert by detached identifier. |
-| Diagnostics | `GET /api/v1/diagnostics` exposes the ordered diagnostic snapshot and plain-text export. |
+| Diagnostics | `GET /api/v1/diagnostics` exposes the ordered diagnostic snapshot and plain-text export. When served through the legacy HTTP bridge, it also includes process-local `legacyAdmin.surfaces[]` counters for legacy admin retirement planning. |
 | Apps | `GET /api/v1/apps` lists installed apps when `AppHost` is wired into the router. The family also covers local staged-bundle install, app lookup, start, stop, update, and uninstall. |
 | App catalogs | `GET /api/v1/app-catalogs` lists configured signed catalogs when catalog support is wired into the router. The family also covers source add/remove, refresh, catalog app listing/detail, and install/update from a verified catalog artifact. |
 
@@ -91,6 +91,8 @@ The shell currently includes these first-party panels and surfaces:
 - Publisher local file/directory insert workflow and queue control remain available in the shell as
   fallback operator panels.
 - Legacy links for pages that remain fallback or debug surfaces.
+- Replaced legacy admin pages are not primary shell navigation targets; their current retirement
+  state is tracked in [legacy-retirement-plan.md](legacy-retirement-plan.md).
 
 The shell is hosted by `:adapter-http-legacy-admin`, but its route constants, HTML template, CSS,
 JavaScript, and bootstrap model are owned by `:platform-web-shell`.

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -17,6 +17,7 @@ import network.crypta.platform.api.updates.UpdatesApiHandler;
 import network.crypta.platform.api.wizard.FirstTimeWizardApiHandler;
 import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.runtime.spi.LegacyAdminUsagePort;
 import network.crypta.runtime.spi.RuntimePorts;
 
 /**
@@ -87,6 +88,7 @@ public final class PlatformApiRouter {
    * @param runtimePorts detached runtime-port aggregate used to resolve API requests
    * @throws NullPointerException if {@code runtimePorts} is {@code null}
    */
+  @SuppressWarnings("unused")
   public PlatformApiRouter(RuntimePorts runtimePorts) {
     this(runtimePorts, null, null);
   }
@@ -112,6 +114,24 @@ public final class PlatformApiRouter {
    */
   public PlatformApiRouter(
       RuntimePorts runtimePorts, AppHost appHost, AppCatalogManager appCatalogManager) {
+    this(runtimePorts, appHost, appCatalogManager, null);
+  }
+
+  /**
+   * Creates a router backed by runtime ports, AppHost, signed app catalogs, and optional
+   * legacy-admin usage diagnostics.
+   *
+   * @param runtimePorts detached runtime-port aggregate used to resolve API requests
+   * @param appHost detached AppHost used by app lifecycle and catalog install/update routes
+   * @param appCatalogManager signed catalog manager used by the catalog endpoint family
+   * @param legacyAdminUsage optional process-local legacy admin usage source
+   * @throws NullPointerException if {@code runtimePorts} is {@code null}
+   */
+  public PlatformApiRouter(
+      RuntimePorts runtimePorts,
+      AppHost appHost,
+      AppCatalogManager appCatalogManager,
+      LegacyAdminUsagePort legacyAdminUsage) {
     Objects.requireNonNull(runtimePorts, "runtimePorts");
     nodeApiHandler = new NodeApiHandler(runtimePorts.nodeInfo());
     peersApiHandler = new PeersApiHandler(runtimePorts.peer(), runtimePorts.darknetConnections());
@@ -131,7 +151,7 @@ public final class PlatformApiRouter {
             runtimePorts.queueSupport(),
             runtimePorts.queueCompletion());
     alertsApiHandler = new AlertsApiHandler(runtimePorts.alertFeed(), runtimePorts.alertMutation());
-    diagnosticsApiHandler = new DiagnosticsApiHandler(runtimePorts.diagnostic());
+    diagnosticsApiHandler = new DiagnosticsApiHandler(runtimePorts.diagnostic(), legacyAdminUsage);
     appsApiHandler = appHost == null ? null : new AppsApiHandler(appHost);
     appCatalogsApiHandler =
         appHost == null || appCatalogManager == null

--- a/platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java
@@ -7,6 +7,9 @@ import java.util.Objects;
 import network.crypta.runtime.spi.DiagnosticPort;
 import network.crypta.runtime.spi.DiagnosticReportSnapshot;
 import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
+import network.crypta.runtime.spi.LegacyAdminSurfaceUsage;
+import network.crypta.runtime.spi.LegacyAdminUsagePort;
+import network.crypta.runtime.spi.LegacyAdminUsageSnapshot;
 
 /**
  * Diagnostics endpoint family for Platform API v1.
@@ -27,6 +30,9 @@ public final class DiagnosticsApiHandler {
   /** Detached runtime diagnostic-report port. */
   private final DiagnosticPort diagnosticPort;
 
+  /** Optional process-local legacy admin usage source. */
+  private final LegacyAdminUsagePort legacyAdminUsagePort;
+
   /**
    * Creates a diagnostics API handler backed by the supplied detached runtime port.
    *
@@ -38,7 +44,21 @@ public final class DiagnosticsApiHandler {
    * @throws NullPointerException if {@code diagnosticPort} is {@code null}
    */
   public DiagnosticsApiHandler(DiagnosticPort diagnosticPort) {
+    this(diagnosticPort, null);
+  }
+
+  /**
+   * Creates a diagnostics API handler backed by the supplied detached runtime port and optional
+   * legacy-admin usage source.
+   *
+   * @param diagnosticPort detached runtime port used to read the current diagnostic report
+   * @param legacyAdminUsagePort optional process-local legacy admin usage source
+   * @throws NullPointerException if {@code diagnosticPort} is {@code null}
+   */
+  public DiagnosticsApiHandler(
+      DiagnosticPort diagnosticPort, LegacyAdminUsagePort legacyAdminUsagePort) {
     this.diagnosticPort = Objects.requireNonNull(diagnosticPort, "diagnosticPort");
+    this.legacyAdminUsagePort = legacyAdminUsagePort;
   }
 
   /**
@@ -57,10 +77,33 @@ public final class DiagnosticsApiHandler {
     List<Map<String, Object>> sections =
         snapshot.sections().stream().map(DiagnosticsApiHandler::toJson).toList();
 
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(4);
     json.put("sectionCount", sections.size());
     json.put("sections", sections);
     json.put("plainTextExport", render(snapshot));
+    if (legacyAdminUsagePort != null) {
+      json.put("legacyAdmin", legacyAdminUsageToJson(legacyAdminUsagePort.snapshot()));
+    }
+    return json;
+  }
+
+  private static Map<String, Object> legacyAdminUsageToJson(LegacyAdminUsageSnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(1);
+    json.put(
+        "surfaces",
+        snapshot.surfaces().stream().map(DiagnosticsApiHandler::legacySurfaceUsageToJson).toList());
+    return json;
+  }
+
+  private static Map<String, Object> legacySurfaceUsageToJson(LegacyAdminSurfaceUsage surface) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    json.put("id", surface.surfaceId());
+    json.put("title", surface.title());
+    json.put("path", surface.legacyPath());
+    json.put("state", surface.state());
+    json.put("replacementUrl", surface.replacementUrl());
+    json.put("count", surface.count());
+    json.put("lastSeenEpochMillis", surface.lastSeenEpochMillis());
     return json;
   }
 

--- a/platform-api/src/test/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandlerTest.java
@@ -4,12 +4,17 @@ import java.util.List;
 import java.util.Map;
 import network.crypta.runtime.spi.DiagnosticReportSnapshot;
 import network.crypta.runtime.spi.DiagnosticSectionSnapshot;
+import network.crypta.runtime.spi.LegacyAdminSurfaceUsage;
+import network.crypta.runtime.spi.LegacyAdminUsageSnapshot;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 @SuppressWarnings("java:S100")
 class DiagnosticsApiHandlerTest {
+  private static final String TITLE_FIELD = "title";
+
   @Test
   void snapshot_whenReportEmpty_expectEmptySectionsAndBlankPlainTextExport() {
     DiagnosticsApiHandler handler =
@@ -39,11 +44,60 @@ class DiagnosticsApiHandlerTest {
     assertEquals(2, response.get("sectionCount"));
     assertEquals(
         List.of(
-            Map.of("title", "System Information:", "lines", List.of("alpha", "", "beta")),
-            Map.of("title", "Queue:", "lines", List.of("Downloads Queued: 1", ""))),
+            Map.of(TITLE_FIELD, "System Information:", "lines", List.of("alpha", "", "beta")),
+            Map.of(TITLE_FIELD, "Queue:", "lines", List.of("Downloads Queued: 1", ""))),
         response.get("sections"));
     assertEquals(
         "System Information:\nalpha\n\nbeta\nQueue:\nDownloads Queued: 1\n\n",
         response.get("plainTextExport"));
+  }
+
+  @Test
+  void snapshot_whenLegacyAdminUsagePortProvided_expectLegacyAdminUsageSection() {
+    Map<String, Object> response = legacyAdminUsageResponse();
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> surfaces =
+        (List<Map<String, Object>>) legacyAdmin(response).get("surfaces");
+    assertEquals(
+        Map.of(
+            "id",
+            "queue-downloads",
+            TITLE_FIELD,
+            "Download queue",
+            "path",
+            "/downloads/",
+            "state",
+            "PRIMARY_REPLACED",
+            "replacementUrl",
+            "/apps/queue-manager/",
+            "count",
+            12L,
+            "lastSeenEpochMillis",
+            1_770_000_000_000L),
+        surfaces.getFirst());
+  }
+
+  private static Map<String, Object> legacyAdminUsageResponse() {
+    DiagnosticsApiHandler handler =
+        new DiagnosticsApiHandler(
+            () -> new DiagnosticReportSnapshot(List.of()),
+            () ->
+                new LegacyAdminUsageSnapshot(
+                    List.of(
+                        new LegacyAdminSurfaceUsage(
+                            "queue-downloads",
+                            "Download queue",
+                            "/downloads/",
+                            "PRIMARY_REPLACED",
+                            "/apps/queue-manager/",
+                            12L,
+                            1_770_000_000_000L))));
+    return handler.snapshot();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> legacyAdmin(Map<String, Object> response) {
+    return (Map<String, Object>) assertInstanceOf(Map.class, response.get("legacyAdmin"));
   }
 }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -651,10 +651,11 @@
       <section class="panel panel-wide" id="legacy-panel">
         <div class="panel-header">
           <p class="panel-kicker">Legacy tools</p>
-          <h2>Deep links back to existing admin pages</h2>
+          <h2>Fallback and retained legacy pages</h2>
         </div>
         <p class="panel-description">
-          Remaining legacy-only pages stay reachable here while queue control moves into the shell.
+          Retained browse-adjacent tools and pending migration gaps stay reachable here. Replaced
+          admin flows open from their Web Shell panels or first-party apps.
         </p>
         <ul class="legacy-links" id="legacy-links"></ul>
       </section>

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -28,6 +28,7 @@ class WebShellResourcesTest {
         "First-time setup",
         "Installed apps",
         "Publisher fallback panel",
+        "Fallback and retained legacy pages",
         "Installed apps JSON",
         "Alerts JSON",
         "Diagnostics JSON",

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminSurfaceUsage.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminSurfaceUsage.java
@@ -1,0 +1,64 @@
+package network.crypta.runtime.spi;
+
+import java.util.Objects;
+
+/**
+ * Detached usage counter for one legacy admin HTTP surface.
+ *
+ * <p>The record intentionally carries only route-level metadata. It does not include query strings,
+ * form fields, request bodies, Freenet/Crypta URIs, peer references, filesystem paths, or remote
+ * addresses. Platform API diagnostics can therefore expose this value without leaking sensitive
+ * request details from the legacy HTTP adapter.
+ *
+ * <p>The type lives in {@code runtime-spi} so transport-neutral diagnostics code can receive legacy
+ * admin usage data without importing HTTP toadlets or adapter classes. The {@code state} value is a
+ * string rather than an adapter enum for the same reason: higher layers display or serialize the
+ * current state, but they do not own the retirement policy.
+ *
+ * <p>Counts are process-local and monotonic for one node process. A {@code lastSeenEpochMillis}
+ * value of {@code 0} means the surface is known but has not been observed in the current process
+ * window. Consumers should treat the values as deletion-planning telemetry, not a durable audit
+ * trail.
+ *
+ * @param surfaceId stable identifier assigned by the legacy-admin retirement registry
+ * @param title user-facing page or surface title suitable for diagnostics output
+ * @param legacyPath canonical same-origin legacy route prefix without request parameters
+ * @param state retirement state name assigned to the surface by the HTTP adapter
+ * @param replacementUrl same-origin replacement Web Shell or app URL, or {@code null} when none is
+ *     declared
+ * @param count number of observed visits since process start
+ * @param lastSeenEpochMillis last observed visit timestamp in epoch milliseconds, or {@code 0} when
+ *     no visit has been recorded
+ */
+public record LegacyAdminSurfaceUsage(
+    String surfaceId,
+    String title,
+    String legacyPath,
+    String state,
+    String replacementUrl,
+    long count,
+    long lastSeenEpochMillis) {
+  /**
+   * Creates an immutable legacy-admin usage entry.
+   *
+   * <p>The constructor validates only structural invariants that are meaningful outside the legacy
+   * HTTP adapter. Required text fields must be present, while {@code replacementUrl} may be {@code
+   * null} for retained, pending, or infrastructure-like entries. Counts and timestamps cannot be
+   * negative because diagnostics clients treat them as unsigned process counters.
+   *
+   * @throws NullPointerException if any required text field is {@code null}
+   * @throws IllegalArgumentException if a count or timestamp is negative
+   */
+  public LegacyAdminSurfaceUsage {
+    Objects.requireNonNull(surfaceId, "surfaceId");
+    Objects.requireNonNull(title, "title");
+    Objects.requireNonNull(legacyPath, "legacyPath");
+    Objects.requireNonNull(state, "state");
+    if (count < 0) {
+      throw new IllegalArgumentException("count must not be negative");
+    }
+    if (lastSeenEpochMillis < 0) {
+      throw new IllegalArgumentException("lastSeenEpochMillis must not be negative");
+    }
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminUsagePort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminUsagePort.java
@@ -1,0 +1,33 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Supplies detached legacy-admin usage counters to diagnostics surfaces.
+ *
+ * <p>The port is optional for Platform API callers. Runtime-only test routers and non-HTTP hosts
+ * can omit it, while the legacy HTTP admin adapter can provide an implementation backed by its
+ * in-memory request recorder. The API shape stays JDK-only and deliberately exposes process-local
+ * counters rather than a persistent audit trail.
+ *
+ * <p>The interface is intentionally read-only. Implementations own the recording policy, including
+ * which requests count as accepted usage and which surfaces are safe to report. Diagnostics callers
+ * only ask for a snapshot and serialize it; they should not infer access decisions or try to record
+ * traffic through this SPI.
+ *
+ * <p>Implementations should return quickly and avoid blocking on disk or network I/O. The current
+ * legacy HTTP implementation is in-memory, and future implementations should preserve that
+ * expectation unless the diagnostics API is explicitly redesigned for persisted telemetry.
+ *
+ * @see LegacyAdminUsageSnapshot
+ */
+public interface LegacyAdminUsagePort {
+  /**
+   * Returns one point-in-time snapshot of process-local legacy-admin usage counters.
+   *
+   * <p>The snapshot should be safe for callers to retain after the method returns. Implementations
+   * may continue recording new observations concurrently, but those later observations should not
+   * mutate the returned object.
+   *
+   * @return immutable snapshot of known legacy admin surfaces and their observed counts
+   */
+  LegacyAdminUsageSnapshot snapshot();
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminUsageSnapshot.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminUsageSnapshot.java
@@ -1,0 +1,37 @@
+package network.crypta.runtime.spi;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detached process-local usage snapshot for legacy admin HTTP surfaces.
+ *
+ * <p>The snapshot is bounded by the legacy-admin retirement registry. It is not a request log and
+ * does not persist across process restarts. Consumers should use it to identify which fallback
+ * surfaces are still being exercised before planning later deletion work.
+ *
+ * <p>The ordered list is already detached from the recorder that produced it. Callers can serialize
+ * the snapshot or compare it in tests without coordinating with request threads that may continue
+ * to record new observations. Entries usually include zero-count surfaces so diagnostics can show
+ * the complete retirement map, not only the surfaces that have been used since startup.
+ *
+ * <p>This record does not define the registry or recording policy. It is a transport-neutral value
+ * object for Platform API handlers and other diagnostics consumers that need a stable, immutable
+ * view of the current process window.
+ *
+ * @param surfaces ordered usage entries for known legacy admin surfaces, copied on construction
+ */
+public record LegacyAdminUsageSnapshot(List<LegacyAdminSurfaceUsage> surfaces) {
+  /**
+   * Creates an immutable usage snapshot.
+   *
+   * <p>The constructor defensively copies the supplied list. Mutating the source list after
+   * construction does not affect the snapshot, and the accessor returns an unmodifiable list.
+   *
+   * @throws NullPointerException if {@code surfaces} is {@code null}
+   */
+  public LegacyAdminUsageSnapshot {
+    Objects.requireNonNull(surfaces, "surfaces");
+    surfaces = List.copyOf(surfaces);
+  }
+}

--- a/src/test/java/network/crypta/clients/http/DiagnosticToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/DiagnosticToadletTest.java
@@ -77,7 +77,17 @@ class DiagnosticToadletTest {
     toadlet.handleMethodGET(URI.create("http://localhost/diagnostic/"), request, ctx);
 
     assertEquals(
-        "Crypta Version:\n3.0\nSystem Information:\njava.version=25\n\n",
+        """
+        Legacy fallback page
+        This legacy page remains available as a fallback and debug view.
+        The primary flow is now in Web Shell diagnostics: /app/node/#diagnostics
+
+        Crypta Version:
+        3.0
+        System Information:
+        java.version=25
+
+        """,
         body.toString(StandardCharsets.UTF_8));
     verify(diagnostic).snapshot();
     verify(ctx)

--- a/src/test/java/network/crypta/clients/http/PageMakerTest.java
+++ b/src/test/java/network/crypta/clients/http/PageMakerTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http;
 
+import java.net.URI;
 import network.crypta.clients.http.utils.ClientSideLocalizationScript;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.spi.PageChromeSnapshot;
@@ -230,6 +231,45 @@ class PageMakerTest {
     assertTrue(html.contains("id=\"requestId\""));
     assertTrue(html.contains("value=\"req-push\""));
     assertTrue(html.contains(ClientSideLocalizationScript.getClientSideLocalizationScript()));
+  }
+
+  @Test
+  void getPageNode_whenRequestUriIsReplacedButActiveToadletIsInfrastructure_skipsNotice() {
+    PageMaker maker = newPageMaker();
+    stubPageRenderingContext(false);
+    Toadlet directoryBrowser = mock(Toadlet.class);
+    when(directoryBrowser.path()).thenReturn(LocalDirectoryToadlet.basePath());
+    when(context.activeToadlet()).thenReturn(directoryBrowser);
+    lenient().when(context.getUri()).thenReturn(URI.create(QueueToadlet.PATH_DOWNLOADS));
+
+    PageNode page =
+        maker.getPageNode(
+            "Directory",
+            context,
+            new PageMaker.RenderParameters().renderNavigationLinks(false).renderModeSwitch(false));
+
+    String html = page.generate();
+
+    assertFalse(html.contains("legacy-admin-retirement-notice"));
+    assertFalse(html.contains("Queue Manager app"));
+  }
+
+  @Test
+  void getPageNode_whenActiveToadletMissingAndRequestUriIsReplaced_rendersNotice() {
+    PageMaker maker = newPageMaker();
+    stubPageRenderingContext(false);
+    when(context.getUri()).thenReturn(URI.create(QueueToadlet.PATH_DOWNLOADS));
+
+    PageNode page =
+        maker.getPageNode(
+            "Downloads",
+            context,
+            new PageMaker.RenderParameters().renderNavigationLinks(false).renderModeSwitch(false));
+
+    String html = page.generate();
+
+    assertTrue(html.contains("legacy-admin-retirement-notice"));
+    assertTrue(html.contains("Queue Manager app"));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -198,6 +198,38 @@ class ToadletContextImplTest {
   }
 
   @Test
+  void handle_whenSlashlessLegacyRequestGetsCanonicalRedirect_recordsLegacyAdminUsage()
+      throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configurePermanentRedirect(URI.create(QueueToadlet.PATH_DOWNLOADS));
+      Socket socket = new FakeSocket(rawSlashlessDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(1L, queueDownloadsUsageCount());
+      assertEquals(
+          "301",
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8)).get("__status").getFirst());
+    }
+  }
+
+  @Test
+  void handle_whenLegacyRequestGetsNonCanonicalRedirect_doesNotRecordLegacyAdminUsage()
+      throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configurePermanentRedirect(URI.create(FirstTimeWizardToadlet.TOADLET_URL));
+      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(0L, queueDownloadsUsageCount());
+      assertEquals(
+          "301",
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8)).get("__status").getFirst());
+    }
+  }
+
+  @Test
   void handle_whenLegacyRequestRedirectsToHelper_recordsOriginalLegacySurface() throws Exception {
     try (var _ = clearedLegacyAdminUsage()) {
       URI helperUri = URI.create(LocalDirectoryToadlet.basePath() + QueueToadlet.PATH_DOWNLOADS);
@@ -427,8 +459,24 @@ class ToadletContextImplTest {
             });
   }
 
+  private void configurePermanentRedirect(URI newUri) throws Exception {
+    org.mockito.Mockito.when(container.getBucketFactory()).thenReturn(new ArrayBucketFactory());
+    org.mockito.Mockito.when(container.allowPosts()).thenReturn(true);
+    org.mockito.Mockito.when(container.generateUniqueID()).thenReturn(1L);
+    org.mockito.Mockito.when(container.findToadlet(org.mockito.ArgumentMatchers.any(URI.class)))
+        .thenThrow(new PermanentRedirectException(newUri));
+  }
+
   private static byte[] rawDownloadsGetRequest() {
-    return ("GET " + QueueToadlet.PATH_DOWNLOADS + " HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    return rawGetRequest(QueueToadlet.PATH_DOWNLOADS);
+  }
+
+  private static byte[] rawSlashlessDownloadsGetRequest() {
+    return rawGetRequest("/downloads");
+  }
+
+  private static byte[] rawGetRequest(String path) {
+    return ("GET " + path + " HTTP/1.1\r\nHost: localhost\r\n\r\n")
         .getBytes(StandardCharsets.US_ASCII);
   }
 

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -1,6 +1,9 @@
 package network.crypta.clients.http;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
@@ -19,6 +22,7 @@ import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.BucketFactory;
 import network.crypta.support.api.HTTPRequest;
+import network.crypta.support.io.ArrayBucketFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ToadletContextImplTest {
+  private static final String QUEUE_DOWNLOADS_SURFACE_ID = "queue-downloads";
+  private static final String WRONG_FORM_PASSWORD_BODY = "formPassword=wrong&confirm=true";
 
   @Mock private BucketFactory bucketFactory;
   @Mock private PageMaker pageMaker;
@@ -177,6 +183,57 @@ class ToadletContextImplTest {
     Map<String, List<String>> headers = parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
     assertEquals("302", headers.get("__status").getFirst());
     assertEquals("/redirect", headers.get("location").getFirst());
+  }
+
+  @Test
+  void handle_whenLegacyGetAccepted_recordsLegacyAdminUsage() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureDispatch(new DispatchTestToadlet(QueueToadlet.PATH_DOWNLOADS, 200));
+      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(1L, queueDownloadsUsageCount());
+    }
+  }
+
+  @Test
+  void handle_whenLegacyRequestRedirectsToHelper_recordsOriginalLegacySurface() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      URI helperUri = URI.create(LocalDirectoryToadlet.basePath() + QueueToadlet.PATH_DOWNLOADS);
+      configureRedirectDispatch(
+          new RedirectingToadlet(QueueToadlet.PATH_DOWNLOADS, helperUri),
+          new DispatchTestToadlet(LocalDirectoryToadlet.basePath(), 200));
+      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(1L, queueDownloadsUsageCount());
+    }
+  }
+
+  @Test
+  void handle_whenPostFormPasswordDenied_doesNotRecordLegacyAdminUsage() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureDispatch(new DispatchTestToadlet(QueueToadlet.PATH_DOWNLOADS, 200));
+      Socket socket = new FakeSocket(rawDeniedDownloadsPostRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(0L, queueDownloadsUsageCount());
+    }
+  }
+
+  @Test
+  void handle_whenFullAccessDenied_doesNotRecordLegacyAdminUsage() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureDispatch(new FullAccessCheckingToadlet(QueueToadlet.PATH_DOWNLOADS));
+      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(0L, queueDownloadsUsageCount());
+    }
   }
 
   @Test
@@ -339,19 +396,98 @@ class ToadletContextImplTest {
 
   private ToadletContextImpl newContext(MultiValueTable<String, String> headers) throws Exception {
     Socket socket = new FakeSocket(outputStream, InetAddress.getLoopbackAddress());
-    ToadletRequestServices services =
-        new ToadletRequestServices(container, pageMaker, alertManager, bookmarkManager);
     return new ToadletContextImpl(
-        socket, headers, bucketFactory, services, new URI("http://example.com/"), 1L);
+        socket, headers, bucketFactory, newRequestServices(), new URI("http://example.com/"), 1L);
+  }
+
+  private ToadletRequestServices newRequestServices() {
+    return new ToadletRequestServices(container, pageMaker, alertManager, bookmarkManager);
+  }
+
+  private void configureDispatch(Toadlet toadlet) throws Exception {
+    org.mockito.Mockito.when(container.getBucketFactory()).thenReturn(new ArrayBucketFactory());
+    org.mockito.Mockito.when(container.allowPosts()).thenReturn(true);
+    org.mockito.Mockito.when(container.generateUniqueID()).thenReturn(1L);
+    org.mockito.Mockito.when(container.findToadlet(org.mockito.ArgumentMatchers.any(URI.class)))
+        .thenReturn(toadlet);
+  }
+
+  private void configureRedirectDispatch(Toadlet originalToadlet, Toadlet helperToadlet)
+      throws Exception {
+    org.mockito.Mockito.when(container.getBucketFactory()).thenReturn(new ArrayBucketFactory());
+    org.mockito.Mockito.when(container.allowPosts()).thenReturn(true);
+    org.mockito.Mockito.when(container.generateUniqueID()).thenReturn(1L);
+    org.mockito.Mockito.when(container.findToadlet(org.mockito.ArgumentMatchers.any(URI.class)))
+        .thenAnswer(
+            invocation -> {
+              URI requestedUri = invocation.getArgument(0);
+              return requestedUri.getPath().startsWith(helperToadlet.path())
+                  ? helperToadlet
+                  : originalToadlet;
+            });
+  }
+
+  private static byte[] rawDownloadsGetRequest() {
+    return ("GET " + QueueToadlet.PATH_DOWNLOADS + " HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .getBytes(StandardCharsets.US_ASCII);
+  }
+
+  private static byte[] rawDeniedDownloadsPostRequest() {
+    return ("POST "
+            + QueueToadlet.PATH_DOWNLOADS
+            + " HTTP/1.1\r\nHost: localhost\r\nContent-Type: "
+            + "application/x-www-form-urlencoded; charset=UTF-8\r\nContent-Length: "
+            + WRONG_FORM_PASSWORD_BODY.length()
+            + "\r\n\r\n"
+            + WRONG_FORM_PASSWORD_BODY)
+        .getBytes(StandardCharsets.US_ASCII);
+  }
+
+  private static long queueDownloadsUsageCount() {
+    return LegacyAdminUsageRecorder.defaultRecorder().snapshot().surfaces().stream()
+        .filter(surface -> surface.surfaceId().equals(QUEUE_DOWNLOADS_SURFACE_ID))
+        .findFirst()
+        .orElseThrow()
+        .count();
+  }
+
+  private static LegacyAdminUsageScope clearedLegacyAdminUsage() {
+    return new LegacyAdminUsageScope();
+  }
+
+  private static final class LegacyAdminUsageScope implements AutoCloseable {
+    LegacyAdminUsageScope() {
+      LegacyAdminUsageRecorder.defaultRecorder().clear();
+    }
+
+    @Override
+    public void close() {
+      LegacyAdminUsageRecorder.defaultRecorder().clear();
+    }
   }
 
   private static class FakeSocket extends Socket {
+    private final ByteArrayInputStream is;
     private final ByteArrayOutputStream os;
     private final InetAddress inetAddress;
 
     FakeSocket(ByteArrayOutputStream os, InetAddress inetAddress) {
+      this(new byte[0], os, inetAddress);
+    }
+
+    FakeSocket(byte[] input, ByteArrayOutputStream os) {
+      this(input, os, InetAddress.getLoopbackAddress());
+    }
+
+    FakeSocket(byte[] input, ByteArrayOutputStream os, InetAddress inetAddress) {
+      this.is = new ByteArrayInputStream(input);
       this.os = os;
       this.inetAddress = inetAddress;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return is;
     }
 
     @Override
@@ -367,6 +503,70 @@ class ToadletContextImplTest {
     @Override
     public void close() {
       // no-op for tests
+    }
+  }
+
+  private static class DispatchTestToadlet extends Toadlet {
+    private final String path;
+    private final int replyCode;
+
+    DispatchTestToadlet(String path, int replyCode) {
+      this.path = path;
+      this.replyCode = replyCode;
+    }
+
+    @Override
+    public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
+        throws ToadletContextClosedException, IOException {
+      ctx.sendReplyHeaders(replyCode, replyCode == 200 ? "OK" : "Error", null, "text/plain", 0);
+    }
+
+    @SuppressWarnings({"UnusedMethod", "unused"})
+    public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx)
+        throws ToadletContextClosedException, IOException {
+      handleMethodGET(uri, request, ctx);
+    }
+
+    @Override
+    public String path() {
+      return path;
+    }
+  }
+
+  private static final class RedirectingToadlet extends Toadlet {
+    private final String path;
+    private final URI redirectUri;
+
+    RedirectingToadlet(String path, URI redirectUri) {
+      this.path = path;
+      this.redirectUri = redirectUri;
+    }
+
+    @Override
+    public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
+        throws RedirectException {
+      throw new RedirectException(redirectUri);
+    }
+
+    @Override
+    public String path() {
+      return path;
+    }
+  }
+
+  private static final class FullAccessCheckingToadlet extends DispatchTestToadlet {
+    FullAccessCheckingToadlet(String path) {
+      super(path, 200);
+    }
+
+    @Override
+    public void handleMethodGET(URI uri, HTTPRequest request, ToadletContext ctx)
+        throws ToadletContextClosedException, IOException {
+      if (!ctx.isAllowedFullAccess()) {
+        ctx.sendReplyHeaders(403, "Forbidden", null, "text/plain", 0);
+        return;
+      }
+      super.handleMethodGET(uri, request, ctx);
     }
   }
 }

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -50,6 +50,8 @@ import network.crypta.runtime.spi.FirstTimeWizardCurrentBandwidthLimits;
 import network.crypta.runtime.spi.FirstTimeWizardPort;
 import network.crypta.runtime.spi.FirstTimeWizardSnapshot;
 import network.crypta.runtime.spi.FirstTimeWizardSubmission;
+import network.crypta.runtime.spi.LegacyAdminSurfaceUsage;
+import network.crypta.runtime.spi.LegacyAdminUsageSnapshot;
 import network.crypta.runtime.spi.NodeFieldSet;
 import network.crypta.runtime.spi.NodeGreetingSnapshot;
 import network.crypta.runtime.spi.NodeInfoPort;
@@ -271,6 +273,38 @@ class PlatformApiRouterTest {
     assertEquals(
         "{\"sectionCount\":1,\"sections\":[{\"title\":\"System Information:\",\"lines\":[\"alpha\","
             + "\"\",\"beta\"]}],\"plainTextExport\":\"System Information:\\nalpha\\n\\nbeta\\n\"}",
+        response.body());
+  }
+
+  @Test
+  void route_whenDiagnosticsRouterHasLegacyAdminUsage_expectLegacyAdminUsageJson() {
+    PlatformApiRouter diagnosticsRouter =
+        new PlatformApiRouter(
+            runtimePorts,
+            appHost,
+            null,
+            () ->
+                new LegacyAdminUsageSnapshot(
+                    List.of(
+                        new LegacyAdminSurfaceUsage(
+                            "queue-downloads",
+                            "Download queue",
+                            "/downloads/",
+                            "PRIMARY_REPLACED",
+                            "/apps/queue-manager/",
+                            3L,
+                            1_770_000_000_000L))));
+    when(diagnosticPort.snapshot()).thenReturn(new DiagnosticReportSnapshot(List.of()));
+
+    PlatformApiResponse response =
+        diagnosticsRouter.route(request("GET", List.of("diagnostics"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "{\"sectionCount\":0,\"sections\":[],\"plainTextExport\":\"\",\"legacyAdmin\":{\"surfaces\""
+            + ":[{\"id\":\"queue-downloads\",\"title\":\"Download queue\",\"path\":\"/downloads/\","
+            + "\"state\":\"PRIMARY_REPLACED\",\"replacementUrl\":\"/apps/queue-manager/\","
+            + "\"count\":3,\"lastSeenEpochMillis\":1770000000000}]}}",
         response.body());
   }
 

--- a/src/test/java/network/crypta/runtime/spi/LegacyAdminUsageSnapshotTest.java
+++ b/src/test/java/network/crypta/runtime/spi/LegacyAdminUsageSnapshotTest.java
@@ -1,0 +1,67 @@
+package network.crypta.runtime.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class LegacyAdminUsageSnapshotTest {
+  @Test
+  void constructor_whenSourceListMutatedAfterCreation_expectDefensiveCopy() {
+    LegacyAdminSurfaceUsage usage = usage("queue-downloads", 1L, 1_770_000_000_000L);
+    ArrayList<LegacyAdminSurfaceUsage> source = new ArrayList<>();
+    source.add(usage);
+
+    LegacyAdminUsageSnapshot snapshot = new LegacyAdminUsageSnapshot(source);
+
+    source.clear();
+
+    assertEquals(List.of(usage), snapshot.surfaces());
+  }
+
+  @Test
+  void surfaces_whenSnapshotExposed_expectUnmodifiableList() {
+    LegacyAdminUsageSnapshot snapshot =
+        new LegacyAdminUsageSnapshot(List.of(usage("queue-downloads", 1L, 1L)));
+    List<LegacyAdminSurfaceUsage> surfaces = snapshot.surfaces();
+    LegacyAdminSurfaceUsage usageToAdd = usage("statistics", 2L, 2L);
+
+    assertThrows(UnsupportedOperationException.class, () -> surfaces.add(usageToAdd));
+  }
+
+  @Test
+  void surfaceUsageConstructor_whenCountNegative_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class, () -> usage("queue-downloads", -1L, 1_770_000_000_000L));
+  }
+
+  @Test
+  void surfaceUsageConstructor_whenTimestampNegative_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> usage("queue-downloads", 1L, -1L));
+  }
+
+  @Test
+  void surfaceUsageConstructor_whenReplacementUrlNull_expectAccepted() {
+    LegacyAdminSurfaceUsage usage =
+        new LegacyAdminSurfaceUsage("help", "Help", "/help/", "RETAINED", null, 0L, 0L);
+
+    assertEquals("help", usage.surfaceId());
+    assertNull(usage.replacementUrl());
+  }
+
+  private static LegacyAdminSurfaceUsage usage(
+      String surfaceId, long count, long lastSeenEpochMillis) {
+    return new LegacyAdminSurfaceUsage(
+        surfaceId,
+        "Download queue",
+        "/downloads/",
+        "PRIMARY_REPLACED",
+        "/apps/queue-manager/",
+        count,
+        lastSeenEpochMillis);
+  }
+}


### PR DESCRIPTION
## Summary
- Add an authoritative legacy admin retirement registry with immutable surface metadata, retirement states, reusable notices, and process-local usage counters.
- Render non-blocking replacement notices on primary-replaced legacy admin pages while keeping retained and pending surfaces reachable as fallback/debug flows.
- Expose legacy admin usage through `/api/v1/diagnostics` when the legacy HTTP bridge hosts the Platform API, without recording request parameters or sensitive request data.
- Update Web Shell fallback navigation so replaced legacy admin pages are no longer primary links, and document the retirement map in `docs/legacy-retirement-plan.md`.

## Retirement map
- `PRIMARY_REPLACED`: queue/downloads, uploads, insert flows, peer/admin connectivity, config, security, update, alerts, statistics, and diagnostic report surfaces now point to Web Shell or first-party app routes.
- `PENDING`: first-time wizard flows and node-to-node messages remain available without strong replacement warnings.
- `RETAINED`: FProxy browse-adjacent surfaces such as chat/forums, translation, help, and content filtering remain intentionally retained.
- `INFRASTRUCTURE`: Web Shell, Platform API, app UI, static assets, directory browser, and symlink helper routes remain helper surfaces.

## Tests
- `./gradlew spotlessApply`
- `./gradlew :adapter-http-legacy-admin:test :platform-api:test :platform-web-shell:test test`
- Focused SonarLint checks were also run during review cleanup for the touched registry, notice, diagnostics, usage snapshot, and context test files.

## Notes
- This PR does not delete legacy admin pages or FProxy browse routes.
- Usage counters are in-memory and reset on process restart; they are intended to guide later retirement PRs, not act as persistent audit logs.