### PR TITLE
fix(appdist): Reject blank UI entries

### DIFF
--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
@@ -420,12 +420,15 @@ public final class AppBundleManifestParser {
     return trimmed;
   }
 
-  private static String optionalUiEntry(Properties properties) {
+  private static String optionalUiEntry(Properties properties) throws AppDistributionException {
     String value = properties.getProperty("app.ui.entry");
     if (value == null) {
       return null;
     }
     String trimmed = value.trim();
-    return trimmed.isEmpty() ? null : trimmed;
+    if (trimmed.isEmpty()) {
+      throw new AppDistributionException("app.ui.entry must not be blank");
+    }
+    return trimmed;
   }
 }

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
@@ -50,6 +50,16 @@ class AppBundleManifestParserTest {
   }
 
   @Test
+  void parseContent_whenUiEntryValueIsBlank_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleManifestParser.parseContent(minimalManifest("app.ui.entry=\n")));
+
+    assertEquals("app.ui.entry must not be blank", exception.getMessage());
+  }
+
+  @Test
   void parseContent_whenStaticUiEntryIsAbsolute_expectFailure() {
     AppDistributionException exception =
         assertThrows(


### PR DESCRIPTION
## Summary
- Reject present-but-blank `app.ui.entry` values during app bundle manifest parsing instead of treating them as absent.
- Add a regression test for the blank UI entry path that previously inferred `app.ui.mode=none`.

## How to test
- `./gradlew spotlessApply`
- `./gradlew :platform-appdist:test`
- `git diff --check`

## Context
- Addresses review feedback from https://github.com/crypta-network/cryptad/pull/1290#discussion_r3133962052