### PR TITLE
fix(updater): Delay recently failed retries

### DIFF
--- a/runtime-node/src/main/java/network/crypta/runtime/updater/NodeUpdater.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/updater/NodeUpdater.java
@@ -78,6 +78,9 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
   /** Maximum number of compressed bytes to read from the ZIP stream overall. */
   private static final long MAX_ZIP_SCAN_BYTES = 16L * 1024L * 1024L; // 16 MiB
 
+  /** Delay before retrying a fetch while the key is still in the recently-failed table. */
+  private static final long RECENTLY_FAILED_RETRY_DELAY_MILLIS = SECONDS.toMillis(1);
+
   private final FetchContext ctx;
   private ClientGetter cg;
   private FreenetURI uri;
@@ -702,13 +705,18 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 
     if (LOG.isDebugEnabled()) LOG.debug("onFailure({},{})", e, localCg);
     if (errorCode == FetchExceptionMode.CANCELLED || !e.isFatal()) {
-      LOG.info("Rescheduling new request");
-      ticker.queueTimedJob(this::maybeUpdate, 0);
+      long retryDelay = retryDelayForFailure(errorCode);
+      LOG.info("Rescheduling update request after {} with delay {} ms", errorCode, retryDelay);
+      ticker.queueTimedJob(this::maybeUpdate, retryDelay);
     } else {
       LOG.error("Canceling fetch : {}", e.getMessage());
       LOG.error("Unexpected error fetching update: {}", e.getMessage());
       // Fatal error: wait for the next version; do not reschedule now.
     }
+  }
+
+  private static long retryDelayForFailure(FetchExceptionMode errorCode) {
+    return errorCode == FetchExceptionMode.RECENTLY_FAILED ? RECENTLY_FAILED_RETRY_DELAY_MILLIS : 0;
   }
 
   /** Called before {@link #kill()} to mark the updater as stopping. Avoids taking locks. */

--- a/src/test/java/network/crypta/runtime/updater/NodeUpdaterTest.java
+++ b/src/test/java/network/crypta/runtime/updater/NodeUpdaterTest.java
@@ -5,6 +5,8 @@ import java.net.MalformedURLException;
 import java.nio.file.Path;
 import network.crypta.client.FetchContext;
 import network.crypta.client.FetchContextOptions;
+import network.crypta.client.FetchException.FetchExceptionMode;
+import network.crypta.client.FetchException;
 import network.crypta.client.FetchResult;
 import network.crypta.client.HighLevelSimpleClient;
 import network.crypta.client.async.USKManager;
@@ -25,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.eq;
@@ -134,6 +137,18 @@ class NodeUpdaterTest {
         updater.getUpdateKey().toString(false, false),
         recordedUri.getValue().toString(false, false));
     assertTrue(updater.getBlobFile(1434).exists());
+  }
+
+  @Test
+  void onFailure_whenRecentlyFailed_expectDelayedRetry() {
+    // Arrange
+    FetchException recentlyFailed = new FetchException(FetchExceptionMode.RECENTLY_FAILED);
+
+    // Act
+    updater.onFailure(recentlyFailed);
+
+    // Assert
+    verify(ticker).queueTimedJob(any(Runnable.class), eq(1000L));
   }
 
   private NodeUpdaterParams defaultParams() throws MalformedURLException {


### PR DESCRIPTION
## Summary
- Add a one-second retry delay when `NodeUpdater` receives `FetchExceptionMode.RECENTLY_FAILED`.
- Keep immediate retry behavior for other nonfatal updater fetch failures.
- Add regression coverage for recently-failed retry scheduling.

## How to test
- `./gradlew spotlessApply`
- `./gradlew :test --tests '*NodeUpdaterTest'`
