### PR TITLE
feat(apphost): Harden app runtime boundary

### DIFF
--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -1,5 +1,6 @@
 package network.crypta.clients.http;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -12,6 +13,10 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeState;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
@@ -583,6 +588,43 @@ class AppUiToadletTest {
     @Override
     public List<RunningAppSnapshot> listRunning() {
       return List.of();
+    }
+
+    @Override
+    public AppRuntimeStatusSnapshot runtimeStatus(String appId) throws IOException {
+      if (!snapshots.containsKey(appId)) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      return new AppRuntimeStatusSnapshot(
+          appId, AppRuntimeState.STOPPED, false, null, null, null, null, 0, 0, false, null);
+    }
+
+    @Override
+    public List<AppRuntimeStatusSnapshot> listRuntimeStatus() {
+      return snapshots.keySet().stream()
+          .map(
+              appId ->
+                  new AppRuntimeStatusSnapshot(
+                      appId,
+                      AppRuntimeState.STOPPED,
+                      false,
+                      null,
+                      null,
+                      null,
+                      null,
+                      0,
+                      0,
+                      false,
+                      null))
+          .toList();
+    }
+
+    @Override
+    public AppProcessLogSnapshot readProcessLogTail(String appId, int maxBytes) throws IOException {
+      if (!snapshots.containsKey(appId)) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      return new AppProcessLogSnapshot(appId, false, false, maxBytes, 0L, "", null);
     }
   }
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -71,6 +71,17 @@ paths. Static UI remains same-origin with the local admin UI and Platform API, s
 entries are rejected and route responses use conservative CSP, `nosniff`, no-referrer, and
 non-public no-cache headers.
 
+AppHost process launches are process isolation, not sandboxing. AppHost starts a local child
+process with the installed bundle root as its working directory, a minimal environment, per-app
+data/cache/run directories, and a per-launch `CRYPTAD_APP_TOKEN` for app-originated Platform API
+authentication. It does not currently provide containers, WASM isolation, seccomp, chroot, jails,
+Windows Job Object restrictions, network isolation, or browser-scoped app sessions.
+
+Runtime status and process-log Platform API responses must remain token-free and path-free. Log
+tail responses redact the current launch token and obvious `CRYPTAD_APP_TOKEN=...` text before
+returning app output to the Web Shell. This is defense in depth for operator visibility; it is not a
+general secret scanner for arbitrary app output.
+
 First-party static app UIs can fetch `/apps/{appId}/.well-known/cryptad-bootstrap.json` to discover
 local route roots and the existing local-admin form password used for mutating Platform API calls.
 That bootstrap is host/operator scoped. It must not contain `CRYPTAD_APP_TOKEN`, AppHost launch
@@ -81,3 +92,6 @@ JavaScript as having local admin browser-origin access.
 Treat a bypass that serves host files, follows symlink escapes, executes JavaScript while the admin
 UI has JavaScript disabled, exposes AppHost launch tokens to browser code, or allows bundled UI to
 exfiltrate operator-entered data off-node as security-relevant.
+
+For the detailed runtime boundary, exposed environment variables, restart policy semantics, and
+remaining limitations, see [apphost-runtime-hardening.md](apphost-runtime-hardening.md).

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -73,6 +73,27 @@ bootstrap JSON, static asset security boundary, and API summary fields. See
 [platform-sdk-js.md](platform-sdk-js.md) for the staged browser SDK used by first-party static UI
 bundles.
 
+## Runtime Manifest Fields
+
+App bundles can declare a minimal restart policy:
+
+```properties
+app.restart.policy=never|on-failure
+app.restart.maxAttempts=0
+app.restart.backoff.ms=0
+```
+
+All fields are optional. The default policy is `never`, with no automatic restart attempts. When a
+bundle opts in to `on-failure`, AppHost restarts only after a non-zero process exit, only within the
+current daemon session, and only up to `app.restart.maxAttempts`. Explicit operator stop suppresses
+automatic restart. Each restart receives a fresh `CRYPTAD_APP_TOKEN`.
+
+`app.restart.maxAttempts` and `app.restart.backoff.ms` must be non-negative integers. AppHost does
+not persist restart state across daemon restarts and does not run app-provided health checks.
+
+See [apphost-runtime-hardening.md](apphost-runtime-hardening.md) for the process boundary, runtime
+status, process-log tailing, token redaction, and remaining sandbox limitations.
+
 ## Gradle Tasks
 
 Per app:

--- a/docs/app-owned-ui.md
+++ b/docs/app-owned-ui.md
@@ -158,6 +158,21 @@ Shell-panel apps preserve their existing local route:
 
 Apps without a UI use `uiMode=none`, `uiEntry=null`, and `uiUrl=null`.
 
+Runtime hardening APIs are separate from the app summary:
+
+```text
+GET /api/v1/apps/{appId}/runtime
+GET /api/v1/apps/{appId}/logs?maxBytes=65536
+```
+
+The runtime endpoint reports process state, PID, start time, last exit metadata, restart attempt
+counts, and process-log availability. The logs endpoint returns a bounded, token-redacted tail of
+the app's combined stdout/stderr log. Neither endpoint exposes `CRYPTAD_APP_TOKEN` or absolute
+installed/data/cache/run filesystem paths.
+
+The Web Shell uses those endpoints for operator visibility. Static app UIs must not treat the
+runtime endpoint as proof of app-level health; it is process status only.
+
 ## Examples
 
 Static UI bundle:

--- a/docs/apphost-runtime-hardening.md
+++ b/docs/apphost-runtime-hardening.md
@@ -1,0 +1,126 @@
+# AppHost runtime hardening
+
+This document describes the current AppHost runtime boundary for local out-of-process apps.
+
+## Scope
+
+AppHost runs installed apps as local child processes. The current hardening layer makes launch
+behavior explicit and adds operator visibility, but it does not add an operating-system sandbox.
+
+The current boundary provides:
+
+- signed bundle and catalog verification before install and update;
+- per-app install, data, cache, and run directories;
+- a minimal launch environment with AppHost variables only;
+- combined stdout/stderr capture in an app-owned `process.log`;
+- token-redacted runtime status and bounded process-log tail APIs;
+- best-effort owner-only permissions on POSIX app data, cache, run, and process-log files;
+- bounded in-session restart attempts when a manifest opts in to `on-failure`.
+
+The current boundary does not provide containers, WASM isolation, seccomp, chroot, jails, Windows
+Job Object restrictions, per-app browser sessions, or network isolation. A third-party app still
+runs as a local process under the same operating-system user as the daemon.
+
+## Launch environment
+
+AppHost clears the inherited environment before launch and rebuilds a small environment. Unix
+launches get a deterministic base `PATH`. Windows launches keep the system root, command
+interpreter, safe base `PATH`, and temporary-directory variables needed by common tools.
+
+Every app launch receives:
+
+```text
+CRYPTAD_APP_ID
+CRYPTAD_APP_NAME
+CRYPTAD_APP_VERSION
+CRYPTAD_APP_DATA_DIR
+CRYPTAD_APP_CACHE_DIR
+CRYPTAD_APP_RUN_DIR
+CRYPTAD_APP_TOKEN
+CRYPTAD_APP_PERMISSIONS
+CRYPTAD_APP_UI_MODE
+CRYPTAD_APP_UI_ENTRY   # only when the manifest declares a UI entry
+```
+
+`CRYPTAD_APP_TOKEN` is for app-originated Platform API authentication. It is injected only into the
+child process environment. It is not exposed to static browser UI, Web Shell bootstrap JSON, app
+API summaries, runtime status JSON, or process-log tail responses.
+
+AppHost does not inject daemon datastore paths, trusted-key files, catalog roots, signing material,
+or the daemon's current working directory. The child process working directory is the installed app
+bundle root.
+
+## Runtime files
+
+The layout keeps app state separated by purpose:
+
+| Area | Purpose |
+| --- | --- |
+| installed bundle | Immutable copied app files verified at install/update time. |
+| data directory | Persistent mutable app data. |
+| cache directory | Rebuildable mutable app cache. |
+| run directory | Session-scoped runtime files such as `process.log`. |
+
+Platform APIs describe these locations conceptually only. API responses must not include absolute
+installed, data, cache, or run paths.
+
+On POSIX filesystems, AppHost applies owner-only permissions where practical:
+
+- directories: `rwx------`;
+- sensitive files such as `process.log`: `rw-------`.
+
+On filesystems without POSIX attributes, AppHost falls back to the platform default and continues
+running. That fallback is not a security boundary.
+
+## Runtime status and logs
+
+The Platform API exposes process-level status:
+
+```text
+GET /api/v1/apps/{appId}/runtime
+GET /api/v1/apps/{appId}/logs?maxBytes=65536
+```
+
+Runtime status reports `STOPPED`, `RUNNING`, `EXITED`, `CRASHED`, or `RESTARTING`, plus process id,
+start time, last exit code/time, restart attempt counters, and log availability when known.
+
+Process-log tailing is bounded. The default is small, and AppHost clamps oversized requests to its
+hard maximum. Missing logs return a stable unavailable snapshot. Log responses include text and
+metadata only; they do not include the runtime log path.
+
+Before returning process-log text, AppHost redacts:
+
+- the exact current launch token when the app is running;
+- obvious `CRYPTAD_APP_TOKEN=...` or `CRYPTAD_APP_TOKEN:...` assignments printed by the app.
+
+Apps can still write secrets to their own files or to other process output. Log redaction is a
+defense-in-depth measure, not a general secret scanner.
+
+## Restart policy
+
+App manifests can declare:
+
+```properties
+app.restart.policy=never|on-failure
+app.restart.maxAttempts=0
+app.restart.backoff.ms=0
+```
+
+Defaults preserve existing behavior: `policy=never`, `maxAttempts=0`, and `backoff.ms=0`.
+
+When `policy=on-failure`, AppHost restarts only after a non-zero process exit, only within the
+current daemon session, and only up to `app.restart.maxAttempts`. Each restart gets a fresh launch
+token. Explicit operator stop suppresses automatic restart.
+
+This is minimal restart plumbing, not a persistent supervisor. AppHost does not recover restart
+state across daemon restarts, does not run app-provided health checks, and does not retry forever.
+
+## Remaining risks
+
+Third-party apps remain trusted local code. They can consume CPU, memory, disk, and network
+resources available to the daemon user unless the operating system or operator environment limits
+them outside AppHost.
+
+Future sandbox work may add stronger platform-specific controls such as process containment,
+network restrictions, syscall filters, browser isolation, or capability-specific app sessions.
+Those are out of scope for the current runtime hardening layer.

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -70,7 +70,7 @@ parameter; check the handler and tests when adding or changing a specific contra
 | Wizard/welcome | `GET /api/v1/wizard/first-time` exposes the detached first-time setup snapshot. `POST /api/v1/wizard/first-time/apply` submits the shell-native onboarding/reset model. There is no separate `/welcome` Platform API family in Phase 3; welcome-page fallback behavior remains on the legacy/admin side. |
 | Alerts | `GET /api/v1/alerts` lists current alerts. `POST /api/v1/alerts/{alertId}/dismiss` dismisses one alert by detached identifier. |
 | Diagnostics | `GET /api/v1/diagnostics` exposes the ordered diagnostic snapshot and plain-text export. When served through the legacy HTTP bridge, it also includes process-local `legacyAdmin.surfaces[]` counters for legacy admin retirement planning. |
-| Apps | `GET /api/v1/apps` lists installed apps when `AppHost` is wired into the router. The family also covers local staged-bundle install, app lookup, start, stop, update, and uninstall. |
+| Apps | `GET /api/v1/apps` lists installed apps when `AppHost` is wired into the router. The family also covers local staged-bundle install, app lookup, start, stop, update, uninstall, token-free runtime status at `GET /api/v1/apps/{appId}/runtime`, and bounded token-redacted process logs at `GET /api/v1/apps/{appId}/logs`. |
 | App catalogs | `GET /api/v1/app-catalogs` lists configured signed catalogs when catalog support is wired into the router. The family also covers source add/remove, refresh, catalog app listing/detail, and install/update from a verified catalog artifact. |
 
 ## Web Shell relationship

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -521,15 +521,39 @@ public final class PlatformApiRouter {
   private PlatformApiResponse routeAppsAction(
       String appId, String action, PlatformApiRequest request) {
     String method = request.method();
-    if (!"POST".equals(method)) {
-      return methodNotAllowed("POST", POST_ONLY_MESSAGE);
-    }
     return switch (action) {
-      case "start" -> PlatformApiResponse.ok(envelope("app", appsApiHandler.start(appId)));
-      case "stop" -> PlatformApiResponse.ok(envelope("app", appsApiHandler.stop(appId)));
-      case "update" ->
-          PlatformApiResponse.ok(
-              envelope("app", appsApiHandler.update(appId, request.queryParameters())));
+      case "runtime" -> {
+        if (!"GET".equals(method)) {
+          yield methodNotAllowed("GET", GET_ONLY_MESSAGE);
+        }
+        yield PlatformApiResponse.ok(envelope("runtime", appsApiHandler.runtime(appId)));
+      }
+      case "logs" -> {
+        if (!"GET".equals(method)) {
+          yield methodNotAllowed("GET", GET_ONLY_MESSAGE);
+        }
+        yield PlatformApiResponse.ok(
+            envelope("logs", appsApiHandler.logs(appId, request.queryParameters())));
+      }
+      case "start" -> {
+        if (!"POST".equals(method)) {
+          yield methodNotAllowed("POST", POST_ONLY_MESSAGE);
+        }
+        yield PlatformApiResponse.ok(envelope("app", appsApiHandler.start(appId)));
+      }
+      case "stop" -> {
+        if (!"POST".equals(method)) {
+          yield methodNotAllowed("POST", POST_ONLY_MESSAGE);
+        }
+        yield PlatformApiResponse.ok(envelope("app", appsApiHandler.stop(appId)));
+      }
+      case "update" -> {
+        if (!"POST".equals(method)) {
+          yield methodNotAllowed("POST", POST_ONLY_MESSAGE);
+        }
+        yield PlatformApiResponse.ok(
+            envelope("app", appsApiHandler.update(appId, request.queryParameters())));
+      }
       default -> throw new PlatformApiException(404, "not_found", "Platform API route not found.");
     };
   }

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +15,8 @@ import network.crypta.platform.api.PlatformApiParameters;
 import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
@@ -51,6 +54,11 @@ public final class AppsApiHandler {
   private static final String APP_ALREADY_INSTALLED_PREFIX = "app already installed: ";
   private static final String APP_NOT_INSTALLED_PREFIX = "app is not installed: ";
   private static final String CANNOT_UPDATE_RUNNING_APP_PREFIX = "cannot update a running app: ";
+  private static final String FIELD_APP_ID = "appId";
+  private static final String FIELD_RUNNING = "running";
+  private static final String FIELD_STARTED_AT = "startedAt";
+  private static final String MAX_BYTES_POSITIVE_INTEGER_MESSAGE =
+      "Query parameter 'maxBytes' must be a positive integer.";
   private static final String SIGNED_BUNDLE_FAILURE_MESSAGE =
       "Staged app bundle must pass trusted signature verification.";
 
@@ -108,6 +116,48 @@ public final class AppsApiHandler {
     String normalizedAppId = normalizeAppId(appId);
     InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
     return summarize(installed.manifest(), true, appHost.status(normalizedAppId).orElse(null));
+  }
+
+  /**
+   * Returns token-free process runtime status for one installed app.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @return JSON-compatible runtime status summary
+   */
+  public Map<String, Object> runtime(String appId) {
+    String normalizedAppId = normalizeAppId(appId);
+    try {
+      return summarizeRuntime(appHost.runtimeStatus(normalizedAppId));
+    } catch (AppHostException e) {
+      if (isMissingAppFailure(e)) {
+        throw appNotFound();
+      }
+      throw internalError("Failed to read app runtime status.");
+    } catch (IOException _) {
+      throw internalError("Failed to read app runtime status.");
+    }
+  }
+
+  /**
+   * Returns a bounded, token-redacted process-log tail for one installed app.
+   *
+   * @param appId stable application identifier extracted from the request path
+   * @param queryParameters decoded query parameters for the current request
+   * @return JSON-compatible process-log snapshot
+   */
+  public Map<String, Object> logs(String appId, Map<String, List<String>> queryParameters) {
+    String normalizedAppId = normalizeAppId(appId);
+    int maxBytes = parseMaxBytes(queryParameters);
+    try {
+      return summarizeProcessLog(appHost.readProcessLogTail(normalizedAppId, maxBytes));
+    } catch (AppHostException e) {
+      if (isMissingAppFailure(e)) {
+        throw appNotFound();
+      }
+      throw internalError("Failed to read app process log.");
+    } catch (IOException _) {
+      throw internalError("Failed to read app process log.");
+    }
   }
 
   /**
@@ -208,12 +258,14 @@ public final class AppsApiHandler {
   }
 
   /**
-   * Stops one running app and returns the installed summary.
+   * Stops one running app or cancels one pending automatic restart and returns the installed
+   * summary.
    *
    * <p>This path anchors on the live {@link RunningAppSnapshot} first, which allows callers to stop
-   * a damaged-but-running app even if its installed manifest can no longer be read safely. When no
-   * live process exists, the method still distinguishes "not running" from "not installed" so
-   * callers receive the stable conflict or not-found contract instead of a generic internal error.
+   * a damaged-but-running app even if its installed manifest can no longer be read safely. The
+   * method delegates to AppHost before reading an installed summary on the non-running path so a
+   * pending {@code RESTARTING} backoff can still be canceled when the installed manifest is damaged
+   * or temporarily unreadable.
    *
    * @param appId stable application identifier extracted from the request path
    * @return JSON-compatible app summary after the app has stopped
@@ -221,19 +273,22 @@ public final class AppsApiHandler {
   public Map<String, Object> stop(String appId) {
     String normalizedAppId = normalizeAppId(appId);
     RunningAppSnapshot running = appHost.status(normalizedAppId).orElse(null);
-    if (running == null) {
-      requireInstalled(normalizedAppId);
-      throw conflict("app is not running: " + normalizedAppId);
-    }
 
     try {
       if (!appHost.stop(normalizedAppId)) {
+        requireInstalled(normalizedAppId);
         throw conflict("app is not running: " + normalizedAppId);
       }
-      return summarize(running.manifest(), true, null);
     } catch (IOException _) {
       throw internalError("Failed to stop app.");
     }
+    if (running != null) {
+      return summarize(running.manifest(), true, null);
+    }
+    InstalledAppSnapshot installed = describeForStopSummary(normalizedAppId);
+    return installed == null
+        ? summarizeUnknown(normalizedAppId, true)
+        : summarize(installed.manifest(), true, null);
   }
 
   /**
@@ -259,7 +314,7 @@ public final class AppsApiHandler {
       appHost.uninstall(normalizedAppId);
       return installed != null
           ? summarize(installed.manifest(), false, null)
-          : summarizeUnknown(normalizedAppId);
+          : summarizeUnknown(normalizedAppId, false);
     } catch (AppHostException e) {
       throw uninstallFailure(normalizedAppId, e);
     } catch (IOException _) {
@@ -306,6 +361,24 @@ public final class AppsApiHandler {
    * @return installed snapshot when it can be read safely, otherwise {@code null}
    */
   private InstalledAppSnapshot describeForUninstallSummary(String appId) {
+    try {
+      return appHost.describe(appId).orElse(null);
+    } catch (IOException _) {
+      return null;
+    }
+  }
+
+  /**
+   * Attempts to read the installed snapshot for stop response shaping.
+   *
+   * <p>Stop remains callable for pending restart cancellation even when the installed manifest is
+   * unreadable. This helper therefore treats read failures as "summary unavailable" after the
+   * stop/cancel operation has already succeeded.
+   *
+   * @param appId stable application identifier
+   * @return installed snapshot when it can be read safely, otherwise {@code null}
+   */
+  private InstalledAppSnapshot describeForStopSummary(String appId) {
     try {
       return appHost.describe(appId).orElse(null);
     } catch (IOException _) {
@@ -376,7 +449,7 @@ public final class AppsApiHandler {
   private static Map<String, Object> summarize(
       AppManifest manifest, boolean installed, RunningAppSnapshot running) {
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(12);
-    json.put("appId", manifest.appId());
+    json.put(FIELD_APP_ID, manifest.appId());
     json.put("name", manifest.appName());
     json.put("version", manifest.appVersion());
     json.put("uiMode", manifest.uiMode().manifestValue());
@@ -385,10 +458,54 @@ public final class AppsApiHandler {
     json.put("permissions", manifest.permissions());
     json.put("quota", quota(manifest));
     json.put("installed", installed);
-    json.put("running", running != null);
+    json.put(FIELD_RUNNING, running != null);
     json.put("pid", running == null ? null : running.pid());
-    json.put("startedAt", running == null ? null : running.startedAt().toString());
+    json.put(FIELD_STARTED_AT, running == null ? null : running.startedAt().toString());
     return json;
+  }
+
+  /**
+   * Builds one JSON-friendly runtime status object.
+   *
+   * @param snapshot token-free AppHost runtime status snapshot
+   * @return ordered JSON-compatible runtime status map
+   */
+  private static Map<String, Object> summarizeRuntime(AppRuntimeStatusSnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(11);
+    json.put(FIELD_APP_ID, snapshot.appId());
+    json.put("state", snapshot.state().name());
+    json.put(FIELD_RUNNING, snapshot.running());
+    json.put("pid", snapshot.pid());
+    json.put(FIELD_STARTED_AT, instantText(snapshot.startedAt()));
+    json.put("lastExitAt", instantText(snapshot.lastExitAt()));
+    json.put("lastExitCode", snapshot.lastExitCode());
+    json.put("restartCount", snapshot.restartCount());
+    json.put("currentRestartAttempt", snapshot.currentRestartAttempt());
+    json.put("logAvailable", snapshot.logAvailable());
+    json.put("logSizeBytes", snapshot.logSizeBytes());
+    return json;
+  }
+
+  /**
+   * Builds one JSON-friendly process-log object.
+   *
+   * @param snapshot bounded redacted AppHost process-log snapshot
+   * @return ordered JSON-compatible process-log map
+   */
+  private static Map<String, Object> summarizeProcessLog(AppProcessLogSnapshot snapshot) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    json.put(FIELD_APP_ID, snapshot.appId());
+    json.put("available", snapshot.available());
+    json.put("truncated", snapshot.truncated());
+    json.put("maxBytes", snapshot.maxBytes());
+    json.put("sizeBytes", snapshot.sizeBytes());
+    json.put("text", snapshot.text());
+    json.put("lastModifiedAt", instantText(snapshot.lastModifiedAt()));
+    return json;
+  }
+
+  private static String instantText(Instant instant) {
+    return instant == null ? null : instant.toString();
   }
 
   /**
@@ -400,9 +517,9 @@ public final class AppsApiHandler {
    * @param appId normalized application identifier
    * @return ordered JSON-compatible summary map with unknown manifest fields set to {@code null}
    */
-  private static Map<String, Object> summarizeUnknown(String appId) {
+  private static Map<String, Object> summarizeUnknown(String appId, boolean installed) {
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(12);
-    json.put("appId", appId);
+    json.put(FIELD_APP_ID, appId);
     json.put("name", null);
     json.put("version", null);
     json.put("uiMode", "none");
@@ -410,10 +527,10 @@ public final class AppsApiHandler {
     json.put("uiUrl", null);
     json.put("permissions", List.of());
     json.put("quota", unknownQuota());
-    json.put("installed", false);
-    json.put("running", false);
+    json.put("installed", installed);
+    json.put(FIELD_RUNNING, false);
     json.put("pid", null);
-    json.put("startedAt", null);
+    json.put(FIELD_STARTED_AT, null);
     return json;
   }
 
@@ -435,6 +552,25 @@ public final class AppsApiHandler {
     json.put("dataBytes", null);
     json.put("cacheBytes", null);
     return json;
+  }
+
+  private static int parseMaxBytes(Map<String, List<String>> queryParameters) {
+    String rawMaxBytes = PlatformApiParameters.readOptionalString(queryParameters, "maxBytes");
+    if (rawMaxBytes == null) {
+      return AppHost.DEFAULT_PROCESS_LOG_TAIL_BYTES;
+    }
+    if (rawMaxBytes.isBlank()) {
+      throw invalidQuery(MAX_BYTES_POSITIVE_INTEGER_MESSAGE);
+    }
+    try {
+      int parsed = Integer.parseInt(rawMaxBytes);
+      if (parsed <= 0) {
+        throw invalidQuery(MAX_BYTES_POSITIVE_INTEGER_MESSAGE);
+      }
+      return Math.min(parsed, AppHost.MAX_PROCESS_LOG_TAIL_BYTES);
+    } catch (NumberFormatException _) {
+      throw invalidQuery(MAX_BYTES_POSITIVE_INTEGER_MESSAGE);
+    }
   }
 
   /**

--- a/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
@@ -13,6 +13,9 @@ import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostConfigurationException;
 import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeState;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
@@ -27,6 +30,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @SuppressWarnings("java:S100")
 class AppsApiHandlerTest {
   private static final String APP_ID = "demo-app";
+  private static final String ERROR_INVALID_APP_BUNDLE = "invalid_app_bundle";
+  private static final String FIELD_MAX_BYTES = "maxBytes";
+  private static final String FIELD_RUNNING = "running";
+  private static final String FIELD_UI_ENTRY = "uiEntry";
+  private static final String FIELD_UI_MODE = "uiMode";
+  private static final String FIELD_UI_URL = "uiUrl";
+  private static final String SAMPLE_INSTANT_TEXT = "2024-01-02T03:04:05Z";
+  private static final String SHELL_PANEL_ENTRY = "/app/node/#queue";
   private static final String SIGNED_BUNDLE_FAILURE_MESSAGE =
       "Staged app bundle must pass trusted signature verification.";
   private static final String STAGED_DIR_PARAMETER = "stagedDir";
@@ -50,7 +61,7 @@ class AppsApiHandlerTest {
             PlatformApiException.class, () -> handler.install(installParameters));
 
     assertEquals(400, exception.statusCode());
-    assertEquals("invalid_app_bundle", exception.errorCode());
+    assertEquals(ERROR_INVALID_APP_BUNDLE, exception.errorCode());
     assertEquals(SIGNED_BUNDLE_FAILURE_MESSAGE, exception.getMessage());
   }
 
@@ -71,7 +82,7 @@ class AppsApiHandlerTest {
             PlatformApiException.class, () -> handler.update(APP_ID, updateParameters));
 
     assertEquals(400, exception.statusCode());
-    assertEquals("invalid_app_bundle", exception.errorCode());
+    assertEquals(ERROR_INVALID_APP_BUNDLE, exception.errorCode());
     assertEquals(SIGNED_BUNDLE_FAILURE_MESSAGE, exception.getMessage());
   }
 
@@ -91,7 +102,7 @@ class AppsApiHandlerTest {
             PlatformApiException.class, () -> handler.install(installParameters));
 
     assertEquals(400, exception.statusCode());
-    assertEquals("invalid_app_bundle", exception.errorCode());
+    assertEquals(ERROR_INVALID_APP_BUNDLE, exception.errorCode());
     assertEquals(
         "app.ui.entry does not resolve to a file in copied bundle: static/index.html",
         exception.getMessage());
@@ -112,7 +123,7 @@ class AppsApiHandlerTest {
             PlatformApiException.class, () -> handler.update(APP_ID, updateParameters));
 
     assertEquals(400, exception.statusCode());
-    assertEquals("invalid_app_bundle", exception.errorCode());
+    assertEquals(ERROR_INVALID_APP_BUNDLE, exception.errorCode());
     assertEquals("app.ui.entry must not traverse links in copied bundle", exception.getMessage());
   }
 
@@ -142,21 +153,21 @@ class AppsApiHandlerTest {
 
     Map<String, Object> summary = handler.get(APP_ID);
 
-    assertEquals("static", summary.get("uiMode"));
-    assertEquals("static/index.html", summary.get("uiEntry"));
-    assertEquals("/apps/demo-app/static/", summary.get("uiUrl"));
+    assertEquals("static", summary.get(FIELD_UI_MODE));
+    assertEquals("static/index.html", summary.get(FIELD_UI_ENTRY));
+    assertEquals("/apps/demo-app/static/", summary.get(FIELD_UI_URL));
   }
 
   @Test
   void get_whenShellPanelAppInstalled_expectShellPanelUrlPreserved() {
     AppsApiHandler handler =
-        new AppsApiHandler(new SingleAppHost(snapshot(AppUiMode.SHELL_PANEL, "/app/node/#queue")));
+        new AppsApiHandler(new SingleAppHost(snapshot(AppUiMode.SHELL_PANEL, SHELL_PANEL_ENTRY)));
 
     Map<String, Object> summary = handler.get(APP_ID);
 
-    assertEquals("shell-panel", summary.get("uiMode"));
-    assertEquals("/app/node/#queue", summary.get("uiEntry"));
-    assertEquals("/app/node/#queue", summary.get("uiUrl"));
+    assertEquals("shell-panel", summary.get(FIELD_UI_MODE));
+    assertEquals(SHELL_PANEL_ENTRY, summary.get(FIELD_UI_ENTRY));
+    assertEquals(SHELL_PANEL_ENTRY, summary.get(FIELD_UI_URL));
   }
 
   @Test
@@ -165,9 +176,104 @@ class AppsApiHandlerTest {
 
     Map<String, Object> summary = handler.get(APP_ID);
 
-    assertEquals("none", summary.get("uiMode"));
-    assertNull(summary.get("uiEntry"));
-    assertNull(summary.get("uiUrl"));
+    assertEquals("none", summary.get(FIELD_UI_MODE));
+    assertNull(summary.get(FIELD_UI_ENTRY));
+    assertNull(summary.get(FIELD_UI_URL));
+  }
+
+  @Test
+  void runtime_whenAppRunning_expectTokenFreeRuntimeStatus() {
+    SingleAppHost appHost = new SingleAppHost(snapshot(AppUiMode.NONE, null));
+    appHost.runtimeStatus =
+        new AppRuntimeStatusSnapshot(
+            APP_ID,
+            AppRuntimeState.RUNNING,
+            true,
+            4242L,
+            java.time.Instant.parse(SAMPLE_INSTANT_TEXT),
+            null,
+            null,
+            1,
+            1,
+            true,
+            128L);
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+
+    Map<String, Object> runtime = handler.runtime(APP_ID);
+
+    assertEquals("RUNNING", runtime.get("state"));
+    assertEquals(true, runtime.get(FIELD_RUNNING));
+    assertEquals(4242L, runtime.get("pid"));
+    assertEquals(SAMPLE_INSTANT_TEXT, runtime.get("startedAt"));
+    org.junit.jupiter.api.Assertions.assertFalse(runtime.toString().contains("token"));
+  }
+
+  @Test
+  void logs_whenAppLogExists_expectTokenFreeProcessLog() {
+    SingleAppHost appHost = new SingleAppHost(snapshot(AppUiMode.NONE, null));
+    appHost.processLog =
+        new AppProcessLogSnapshot(
+            APP_ID,
+            true,
+            true,
+            16,
+            64L,
+            "CRYPTAD_APP_TOKEN=[REDACTED]\nready\n",
+            java.time.Instant.parse(SAMPLE_INSTANT_TEXT));
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+
+    Map<String, Object> logs = handler.logs(APP_ID, Map.of(FIELD_MAX_BYTES, List.of("16")));
+
+    assertEquals(true, logs.get("available"));
+    assertEquals(true, logs.get("truncated"));
+    assertEquals(16, logs.get(FIELD_MAX_BYTES));
+    assertEquals("CRYPTAD_APP_TOKEN=[REDACTED]\nready\n", logs.get("text"));
+    org.junit.jupiter.api.Assertions.assertFalse(logs.toString().contains("secret-token"));
+  }
+
+  @Test
+  void logs_whenMaxBytesMalformed_expectInvalidQueryParameter() {
+    AppsApiHandler handler = new AppsApiHandler(new SingleAppHost(snapshot(AppUiMode.NONE, null)));
+    Map<String, List<String>> queryParameters = Map.of(FIELD_MAX_BYTES, List.of("0"));
+
+    PlatformApiException exception =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            PlatformApiException.class, () -> handler.logs(APP_ID, queryParameters));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_query_parameter", exception.errorCode());
+  }
+
+  @Test
+  void stop_whenAppIsRestarting_expectDelegatesStopAndReturnsInstalledSummary() {
+    SingleAppHost appHost = new SingleAppHost(snapshot(AppUiMode.NONE, null));
+    appHost.runtimeStatus =
+        new AppRuntimeStatusSnapshot(
+            APP_ID, AppRuntimeState.RESTARTING, false, null, null, null, 7, 0, 1, true, 64L);
+    appHost.stopResult = true;
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+
+    Map<String, Object> summary = handler.stop(APP_ID);
+
+    assertEquals(APP_ID, summary.get("appId"));
+    assertEquals(false, summary.get(FIELD_RUNNING));
+    assertEquals(1, appHost.stopCalls);
+  }
+
+  @Test
+  void stop_whenRestartingAppManifestUnreadable_expectCancelsRestartAndReturnsFallbackSummary() {
+    SingleAppHost appHost = new SingleAppHost(snapshot(AppUiMode.NONE, null));
+    appHost.describeFailure = new IOException("manifest unreadable");
+    appHost.stopResult = true;
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+
+    Map<String, Object> summary = handler.stop(APP_ID);
+
+    assertEquals(APP_ID, summary.get("appId"));
+    assertNull(summary.get("name"));
+    assertEquals(true, summary.get("installed"));
+    assertEquals(false, summary.get(FIELD_RUNNING));
+    assertEquals(1, appHost.stopCalls);
   }
 
   private Path stageApp(Path stagedDir) throws IOException {
@@ -262,11 +368,30 @@ class AppsApiHandlerTest {
     public List<RunningAppSnapshot> listRunning() {
       return List.of();
     }
+
+    @Override
+    public AppRuntimeStatusSnapshot runtimeStatus(String appId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<AppRuntimeStatusSnapshot> listRuntimeStatus() {
+      return List.of();
+    }
+
+    @Override
+    public AppProcessLogSnapshot readProcessLogTail(String appId, int maxBytes) {
+      throw new UnsupportedOperationException();
+    }
   }
 
-  @SuppressWarnings("ClassCanBeRecord")
   private static final class SingleAppHost implements AppHost {
     private final InstalledAppSnapshot snapshot;
+    private AppRuntimeStatusSnapshot runtimeStatus;
+    private AppProcessLogSnapshot processLog;
+    private IOException describeFailure;
+    private boolean stopResult;
+    private int stopCalls;
 
     private SingleAppHost(InstalledAppSnapshot snapshot) {
       this.snapshot = snapshot;
@@ -293,7 +418,10 @@ class AppsApiHandlerTest {
     }
 
     @Override
-    public Optional<InstalledAppSnapshot> describe(String appId) {
+    public Optional<InstalledAppSnapshot> describe(String appId) throws IOException {
+      if (describeFailure != null) {
+        throw describeFailure;
+      }
       return APP_ID.equals(appId) ? Optional.of(snapshot) : Optional.empty();
     }
 
@@ -304,7 +432,8 @@ class AppsApiHandlerTest {
 
     @Override
     public boolean stop(String appId) {
-      throw new UnsupportedOperationException();
+      stopCalls++;
+      return stopResult;
     }
 
     @Override
@@ -315,6 +444,33 @@ class AppsApiHandlerTest {
     @Override
     public List<RunningAppSnapshot> listRunning() {
       return List.of();
+    }
+
+    @Override
+    public AppRuntimeStatusSnapshot runtimeStatus(String appId) throws IOException {
+      if (!APP_ID.equals(appId)) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      if (runtimeStatus != null) {
+        return runtimeStatus;
+      }
+      return new AppRuntimeStatusSnapshot(
+          appId, AppRuntimeState.STOPPED, false, null, null, null, null, 0, 0, false, null);
+    }
+
+    @Override
+    public List<AppRuntimeStatusSnapshot> listRuntimeStatus() throws IOException {
+      return List.of(runtimeStatus(APP_ID));
+    }
+
+    @Override
+    public AppProcessLogSnapshot readProcessLogTail(String appId, int maxBytes) throws IOException {
+      if (!APP_ID.equals(appId)) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      return processLog == null
+          ? new AppProcessLogSnapshot(appId, false, false, maxBytes, 0L, "", null)
+          : processLog;
     }
   }
 }

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppStaticAssetServiceTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppStaticAssetServiceTest.java
@@ -9,6 +9,10 @@ import java.util.Map;
 import java.util.Optional;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeState;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
@@ -273,6 +277,44 @@ class AppStaticAssetServiceTest {
     @Override
     public List<RunningAppSnapshot> listRunning() {
       return List.of();
+    }
+
+    @Override
+    public AppRuntimeStatusSnapshot runtimeStatus(String appId) throws IOException {
+      InstalledAppSnapshot snapshot = snapshots.get(appId);
+      if (snapshot == null) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      return new AppRuntimeStatusSnapshot(
+          appId, AppRuntimeState.STOPPED, false, null, null, null, null, 0, 0, false, null);
+    }
+
+    @Override
+    public List<AppRuntimeStatusSnapshot> listRuntimeStatus() {
+      return snapshots.keySet().stream()
+          .map(
+              appId ->
+                  new AppRuntimeStatusSnapshot(
+                      appId,
+                      AppRuntimeState.STOPPED,
+                      false,
+                      null,
+                      null,
+                      null,
+                      null,
+                      0,
+                      0,
+                      false,
+                      null))
+          .toList();
+    }
+
+    @Override
+    public AppProcessLogSnapshot readProcessLogTail(String appId, int maxBytes) throws IOException {
+      if (!snapshots.containsKey(appId)) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      return new AppProcessLogSnapshot(appId, false, false, maxBytes, 0L, "", null);
     }
   }
 }

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapServiceTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapServiceTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.appui;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -7,6 +8,10 @@ import java.util.Map;
 import java.util.Optional;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeState;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
@@ -182,6 +187,44 @@ class AppUiBootstrapServiceTest {
     @Override
     public List<RunningAppSnapshot> listRunning() {
       return List.of();
+    }
+
+    @Override
+    public AppRuntimeStatusSnapshot runtimeStatus(String appId) throws IOException {
+      InstalledAppSnapshot snapshot = snapshots.get(appId);
+      if (snapshot == null) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      return new AppRuntimeStatusSnapshot(
+          appId, AppRuntimeState.STOPPED, false, null, null, null, null, 0, 0, false, null);
+    }
+
+    @Override
+    public List<AppRuntimeStatusSnapshot> listRuntimeStatus() {
+      return snapshots.keySet().stream()
+          .map(
+              appId ->
+                  new AppRuntimeStatusSnapshot(
+                      appId,
+                      AppRuntimeState.STOPPED,
+                      false,
+                      null,
+                      null,
+                      null,
+                      null,
+                      0,
+                      0,
+                      false,
+                      null))
+          .toList();
+    }
+
+    @Override
+    public AppProcessLogSnapshot readProcessLogTail(String appId, int maxBytes) throws IOException {
+      if (!snapshots.containsKey(appId)) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      return new AppProcessLogSnapshot(appId, false, false, maxBytes, 0L, "", null);
     }
   }
 }

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifest.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifest.java
@@ -32,6 +32,9 @@ import java.util.regex.Pattern;
  * @param permissions normalized permission strings declared by the app manifest
  * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
  * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+ * @param restartPolicy normalized process restart policy
+ * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
+ * @param restartBackoffMillis delay before an automatic restart attempt
  */
 public record AppBundleManifest(
     int manifestVersion,
@@ -43,7 +46,10 @@ public record AppBundleManifest(
     String uiEntry,
     List<String> permissions,
     Long dataQuotaBytes,
-    Long cacheQuotaBytes) {
+    Long cacheQuotaBytes,
+    AppRestartPolicy restartPolicy,
+    int restartMaxAttempts,
+    long restartBackoffMillis) {
   private static final Pattern APP_ID_PATTERN =
       Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
   private static final Pattern WINDOWS_DRIVE_PREFIX_PATTERN = Pattern.compile("^[a-zA-Z]:.*");
@@ -67,6 +73,9 @@ public record AppBundleManifest(
    * @param permissions normalized permission strings declared by the app manifest
    * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
    * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+   * @param restartPolicy normalized process restart policy
+   * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
+   * @param restartBackoffMillis delay before an automatic restart attempt
    * @throws IllegalArgumentException if any value cannot represent a valid v1 app manifest
    */
   public AppBundleManifest {
@@ -83,6 +92,51 @@ public record AppBundleManifest(
     permissions = List.copyOf(Objects.requireNonNull(permissions, "permissions"));
     dataQuotaBytes = normalizeQuota(dataQuotaBytes, "quota.data.bytes");
     cacheQuotaBytes = normalizeQuota(cacheQuotaBytes, "quota.cache.bytes");
+    Objects.requireNonNull(restartPolicy, "restartPolicy");
+    requireValidRestartMaxAttempts(restartMaxAttempts);
+    requireValidRestartBackoffMillis(restartBackoffMillis);
+  }
+
+  /**
+   * Creates a manifest with the default restart policy.
+   *
+   * @param manifestVersion manifest schema version, currently required to be {@code 1}
+   * @param appId stable lower-case application identifier safe for managed bundle paths
+   * @param appName human-readable application name shown by host and API surfaces
+   * @param appVersion display version string recorded in installed app summaries
+   * @param execPathText executable path relative to the bundle root, using normalized separators
+   * @param uiMode normalized browser UI ownership mode declared or inferred from the manifest
+   * @param uiEntry optional UI entry path, or {@code null} when the app has no bundled UI surface
+   * @param permissions normalized permission strings declared by the app manifest
+   * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
+   * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+   */
+  @SuppressWarnings("unused")
+  public AppBundleManifest(
+      int manifestVersion,
+      String appId,
+      String appName,
+      String appVersion,
+      String execPathText,
+      AppUiMode uiMode,
+      String uiEntry,
+      List<String> permissions,
+      Long dataQuotaBytes,
+      Long cacheQuotaBytes) {
+    this(
+        manifestVersion,
+        appId,
+        appName,
+        appVersion,
+        execPathText,
+        uiMode,
+        uiEntry,
+        permissions,
+        dataQuotaBytes,
+        cacheQuotaBytes,
+        AppRestartPolicy.NEVER,
+        0,
+        0L);
   }
 
   /**
@@ -121,7 +175,10 @@ public record AppBundleManifest(
         uiEntry,
         permissions,
         dataQuotaBytes,
-        cacheQuotaBytes);
+        cacheQuotaBytes,
+        AppRestartPolicy.NEVER,
+        0,
+        0L);
   }
 
   /**
@@ -282,6 +339,18 @@ public record AppBundleManifest(
       throw new IllegalArgumentException(fieldName + " must be >= 0");
     }
     return quota;
+  }
+
+  private static void requireValidRestartMaxAttempts(int maxAttempts) {
+    if (maxAttempts < 0) {
+      throw new IllegalArgumentException("app.restart.maxAttempts must be >= 0");
+    }
+  }
+
+  private static void requireValidRestartBackoffMillis(long backoffMillis) {
+    if (backoffMillis < 0L) {
+      throw new IllegalArgumentException("app.restart.backoff.ms must be >= 0");
+    }
   }
 
   private static String requireNonBlank(String value, String fieldName) {

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
@@ -266,6 +266,9 @@ public final class AppBundleManifestParser {
     List<String> permissions = parsePermissions(optional(properties, "app.permissions"));
     Long dataQuotaBytes = parseOptionalLong(properties, "quota.data.bytes");
     Long cacheQuotaBytes = parseOptionalLong(properties, "quota.cache.bytes");
+    AppRestartPolicy restartPolicy = parseRestartPolicy(optional(properties, "app.restart.policy"));
+    int restartMaxAttempts = parseRestartMaxAttempts(properties);
+    long restartBackoffMillis = parseRestartBackoffMillis(properties);
     try {
       return new AppBundleManifest(
           manifestVersion,
@@ -277,7 +280,19 @@ public final class AppBundleManifestParser {
           uiEntry,
           permissions,
           dataQuotaBytes,
-          cacheQuotaBytes);
+          cacheQuotaBytes,
+          restartPolicy,
+          restartMaxAttempts,
+          restartBackoffMillis);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(exception.getMessage(), exception);
+    }
+  }
+
+  private static AppRestartPolicy parseRestartPolicy(String rawValue)
+      throws AppDistributionException {
+    try {
+      return AppRestartPolicy.parseManifestValue(rawValue);
     } catch (IllegalArgumentException exception) {
       throw new AppDistributionException(exception.getMessage(), exception);
     }
@@ -393,6 +408,42 @@ public final class AppBundleManifestParser {
     }
     try {
       return Long.parseLong(value);
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException("invalid " + key + ": " + value, exception);
+    }
+  }
+
+  private static int parseRestartMaxAttempts(Properties properties)
+      throws AppDistributionException {
+    String key = "app.restart.maxAttempts";
+    String value = optional(properties, key);
+    if (value == null) {
+      return 0;
+    }
+    try {
+      int parsed = Integer.parseInt(value);
+      if (parsed < 0) {
+        throw new AppDistributionException(key + " must be >= 0");
+      }
+      return parsed;
+    } catch (NumberFormatException exception) {
+      throw new AppDistributionException("invalid " + key + ": " + value, exception);
+    }
+  }
+
+  private static long parseRestartBackoffMillis(Properties properties)
+      throws AppDistributionException {
+    String key = "app.restart.backoff.ms";
+    String value = optional(properties, key);
+    if (value == null) {
+      return 0L;
+    }
+    try {
+      long parsed = Long.parseLong(value);
+      if (parsed < 0L) {
+        throw new AppDistributionException(key + " must be >= 0");
+      }
+      return parsed;
     } catch (NumberFormatException exception) {
       throw new AppDistributionException("invalid " + key + ": " + value, exception);
     }

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppRestartPolicy.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppRestartPolicy.java
@@ -1,0 +1,79 @@
+package network.crypta.platform.appdist;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Restart policy declared by an app bundle manifest.
+ *
+ * <p>The policy is intentionally small for the local AppHost runtime. It is signed as part of the
+ * bundle manifest, parsed by appdist, and consumed by AppHost after installation. The value does
+ * not describe a service manager, operating-system sandbox, or durable supervisor. It only tells
+ * the current daemon session whether a failed child process may be relaunched automatically.
+ *
+ * <p>Restart limits and backoff are carried as separate manifest fields so policy selection remains
+ * easy to audit in signed bundle metadata. Existing apps default to {@link #NEVER}, which preserves
+ * the pre-hardening behavior unless an app author explicitly opts into bounded failure restarts.
+ */
+public enum AppRestartPolicy {
+  /**
+   * Never restart the app automatically after process exit.
+   *
+   * <p>This is the default for manifests that omit {@code app.restart.policy}. It keeps operator
+   * control simple: a clean exit, crash, explicit stop, or accepted update leaves the app stopped
+   * until a caller starts it again.
+   */
+  NEVER("never"),
+
+  /**
+   * Restart only after a non-zero process exit, up to the declared attempt limit.
+   *
+   * <p>This policy is process based. It does not perform HTTP health checks or app-defined probes,
+   * and it never restarts after a clean zero exit or an explicit operator stop.
+   */
+  ON_FAILURE("on-failure");
+
+  private final String manifestValue;
+
+  AppRestartPolicy(String manifestValue) {
+    this.manifestValue = manifestValue;
+  }
+
+  /**
+   * Returns the manifest value for this policy.
+   *
+   * <p>The returned string is the canonical token stored in {@code cryptad-app.properties}. It is
+   * lower-case ASCII and stable for signing, manifest generation, and diagnostics.
+   *
+   * @return lower-case manifest policy value suitable for serialized bundle metadata
+   */
+  @SuppressWarnings("unused")
+  public String manifestValue() {
+    return manifestValue;
+  }
+
+  /**
+   * Parses an optional manifest policy value.
+   *
+   * <p>The parser accepts surrounding whitespace and case differences but does not accept aliases.
+   * A missing value maps to {@link #NEVER}, matching the runtime default for existing apps. Invalid
+   * values fail during manifest parsing so unsigned or misspelled restart behavior cannot be
+   * silently interpreted later by AppHost.
+   *
+   * @param rawValue raw manifest value, or {@code null} when the manifest omits the field
+   * @return parsed restart policy used by appdist and AppHost runtime code
+   * @throws IllegalArgumentException if the value is not one of the supported policy tokens
+   */
+  public static AppRestartPolicy parseManifestValue(String rawValue) {
+    if (rawValue == null) {
+      return NEVER;
+    }
+    String normalized =
+        Objects.requireNonNull(rawValue, "rawValue").trim().toLowerCase(Locale.ROOT);
+    return switch (normalized) {
+      case "never" -> NEVER;
+      case "on-failure" -> ON_FAILURE;
+      default -> throw new IllegalArgumentException("unsupported app.restart.policy: " + rawValue);
+    };
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
@@ -29,6 +29,37 @@ class AppBundleManifestParserTest {
 
     assertEquals(AppUiMode.NONE, manifest.uiMode());
     assertNull(manifest.uiEntry());
+    assertEquals(AppRestartPolicy.NEVER, manifest.restartPolicy());
+    assertEquals(0, manifest.restartMaxAttempts());
+    assertEquals(0L, manifest.restartBackoffMillis());
+  }
+
+  @Test
+  void parseContent_whenRestartPolicyDeclared_expectRestartFields() throws Exception {
+    AppBundleManifest manifest =
+        AppBundleManifestParser.parseContent(
+            minimalManifest(
+                """
+                app.restart.policy=on-failure
+                app.restart.maxAttempts=3
+                app.restart.backoff.ms=250
+                """));
+
+    assertEquals(AppRestartPolicy.ON_FAILURE, manifest.restartPolicy());
+    assertEquals(3, manifest.restartMaxAttempts());
+    assertEquals(250L, manifest.restartBackoffMillis());
+  }
+
+  @Test
+  void parseContent_whenRestartAttemptsNegative_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppBundleManifestParser.parseContent(
+                    minimalManifest("app.restart.maxAttempts=-1\n")));
+
+    assertEquals("app.restart.maxAttempts must be >= 0", exception.getMessage());
   }
 
   @Test

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHost.java
@@ -21,6 +21,12 @@ import java.util.Optional;
  * newer filesystem or process state than an earlier snapshot.
  */
 public interface AppHost {
+  /** Default number of process-log bytes returned by bounded log-tail APIs. */
+  int DEFAULT_PROCESS_LOG_TAIL_BYTES = 64 * 1024;
+
+  /** Hard maximum number of process-log bytes returned by bounded log-tail APIs. */
+  int MAX_PROCESS_LOG_TAIL_BYTES = 1024 * 1024;
+
   /**
    * Installs one app from a local staging directory.
    *
@@ -148,4 +154,38 @@ public interface AppHost {
    * @return immutable list of running snapshots sorted by app id
    */
   List<RunningAppSnapshot> listRunning();
+
+  /**
+   * Returns token-free process runtime status for one installed app.
+   *
+   * <p>The status is process-observed only. It does not perform app-provided HTTP health checks or
+   * expose launch tokens, data/cache/run paths, or other host filesystem locations.
+   *
+   * @param appId stable application identifier
+   * @return token-free runtime status snapshot
+   * @throws IOException if the app is not installed or the host cannot inspect its runtime files
+   */
+  AppRuntimeStatusSnapshot runtimeStatus(String appId) throws IOException;
+
+  /**
+   * Lists token-free runtime status for all installed apps.
+   *
+   * @return immutable runtime status snapshots sorted by app id
+   * @throws IOException if the installed-app tree cannot be scanned
+   */
+  @SuppressWarnings("unused")
+  List<AppRuntimeStatusSnapshot> listRuntimeStatus() throws IOException;
+
+  /**
+   * Returns a bounded, token-redacted tail of one app's combined process output log.
+   *
+   * <p>Implementations must clamp the requested byte bound to {@link #MAX_PROCESS_LOG_TAIL_BYTES},
+   * redact launch tokens from returned text, and avoid exposing the runtime log path.
+   *
+   * @param appId stable application identifier
+   * @param maxBytes requested maximum bytes to read before clamping
+   * @return token-redacted process-log snapshot
+   * @throws IOException if the app is not installed or the log cannot be inspected safely
+   */
+  AppProcessLogSnapshot readProcessLogTail(String appId, int maxBytes) throws IOException;
 }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostTokenRedactor.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostTokenRedactor.java
@@ -1,0 +1,192 @@
+package network.crypta.platform.apphost;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Redacts AppHost launch tokens from diagnostic strings and process-log tails.
+ *
+ * <p>The helper handles the leak shapes AppHost can reasonably recognize: the exact current launch
+ * token, environment-style {@code CRYPTAD_APP_TOKEN=...} assignments printed by child processes,
+ * and known AppHost-owned filesystem paths for the displayed app.
+ *
+ * <p>This class is deliberately a display-surface guard, not a parser for arbitrary untrusted log
+ * formats. Callers should apply it immediately before exposing runtime diagnostics through APIs, UI
+ * text, or log-tail snapshots. The redactor keeps replacement text stable so tests and operator
+ * views can distinguish hidden tokens from hidden path roles without learning the underlying secret
+ * or host filesystem layout.
+ *
+ * <p>Bounded log tails need special handling because the requested suffix may begin in the middle
+ * of a token or path. Use {@link #redactionOverlapBytes(String, InstalledAppPaths)} to read enough
+ * context before redaction, then apply the final display bound after sensitive text has been
+ * replaced.
+ */
+public final class AppHostTokenRedactor {
+  /**
+   * Stable replacement used wherever launch tokens are hidden from display surfaces.
+   *
+   * <p>The placeholder is intentionally generic. It confirms that sensitive text was removed while
+   * avoiding hints about token length, encoding, or how many distinct token values appeared in the
+   * original diagnostic text.
+   */
+  public static final String REDACTED = "[REDACTED]";
+
+  private static final String APP_INSTALL_DIR_PLACEHOLDER = "[APP_INSTALL_DIR]";
+  private static final String APP_DATA_DIR_PLACEHOLDER = "[APP_DATA_DIR]";
+  private static final String APP_CACHE_DIR_PLACEHOLDER = "[APP_CACHE_DIR]";
+  private static final String APP_RUN_DIR_PLACEHOLDER = "[APP_RUN_DIR]";
+  private static final String APP_PROCESS_LOG_PLACEHOLDER = "[APP_PROCESS_LOG]";
+  private static final String TOKEN_ASSIGNMENT_PREFIX = "CRYPTAD_APP_TOKEN=";
+  private static final int APPHOST_TOKEN_HEX_CHARS = 64;
+  private static final int UNKNOWN_TOKEN_ASSIGNMENT_BYTES =
+      TOKEN_ASSIGNMENT_PREFIX.length() + APPHOST_TOKEN_HEX_CHARS;
+  private static final Pattern TOKEN_ASSIGNMENT_PATTERN =
+      Pattern.compile("(CRYPTAD_APP_TOKEN\\s*[:=]\\s*)([^\\s,;\"'\\]}]+)");
+
+  private AppHostTokenRedactor() {}
+
+  /**
+   * Redacts obvious AppHost token assignments from text.
+   *
+   * <p>This overload is useful when the exact launch token is unavailable, such as after daemon
+   * restart while an older {@code process.log} remains on disk. It still recognizes common
+   * environment-assignment shapes, including {@code CRYPTAD_APP_TOKEN=value} and {@code
+   * CRYPTAD_APP_TOKEN: value}. It does not attempt to guess unrelated free-form secrets.
+   *
+   * @param text source diagnostic text to filter before display
+   * @return text with recognizable token assignments redacted
+   */
+  @SuppressWarnings("unused")
+  public static String redact(String text) {
+    return redact(text, null);
+  }
+
+  /**
+   * Redacts obvious AppHost token assignments and the exact current token from text.
+   *
+   * <p>The exact-token replacement covers cases where an app prints the token outside an
+   * environment-assignment form, for example inside a custom debug line. Passing a blank or {@code
+   * null} token falls back to assignment-pattern redaction only, which keeps stopped-app log reads
+   * possible even when no current launch snapshot exists.
+   *
+   * @param text source diagnostic text to filter before display
+   * @param token exact current or retained launch token, or {@code null} when unavailable
+   * @return text with launch tokens redacted where they can be recognized
+   */
+  public static String redact(String text, String token) {
+    Objects.requireNonNull(text, "text");
+    String redacted =
+        TOKEN_ASSIGNMENT_PATTERN.matcher(text).replaceAll(match -> match.group(1) + REDACTED);
+    if (token == null || token.isBlank()) {
+      return redacted;
+    }
+    return redacted.replace(token, REDACTED);
+  }
+
+  /**
+   * Redacts launch tokens and known AppHost-owned filesystem paths from text.
+   *
+   * <p>This is intended for process-log display surfaces where an app may have printed its
+   * environment or working directory. Replacements preserve the conceptual directory role without
+   * exposing the daemon's absolute filesystem layout. The method removes the installed bundle root,
+   * mutable data/cache/run directories, and the conventional process-log file path for the app
+   * represented by {@code paths}.
+   *
+   * @param text source diagnostic text to filter before display
+   * @param token exact current or retained launch token, or {@code null} when unavailable
+   * @param paths AppHost-owned paths for the app whose diagnostic text is being displayed
+   * @return text with launch tokens and known AppHost paths redacted
+   */
+  public static String redact(String text, String token, InstalledAppPaths paths) {
+    Objects.requireNonNull(paths, "paths");
+    return redactPaths(redact(text, token), paths);
+  }
+
+  /**
+   * Returns the byte overlap needed to redact a bounded log tail safely.
+   *
+   * <p>A caller that wants the last {@code maxBytes} of a log should read this many extra bytes
+   * before that suffix, redact the expanded text, and then apply the final bound. That ensures the
+   * redactor can still see a complete token, recognizable token assignment, or known path when the
+   * requested suffix starts in the middle of it.
+   *
+   * <p>The returned value is based on UTF-8 byte length, because process logs are tailed by bytes
+   * before they are decoded for display. The calculation includes a fixed allowance for a
+   * 64-character AppHost token assignment even when the exact token is unavailable, plus every
+   * known AppHost path spelling that this redactor can replace.
+   *
+   * @param token exact current or last launch token, or {@code null} when unavailable
+   * @param paths AppHost-owned paths for the app whose log is being tailed
+   * @return extra bytes to read before the requested suffix before redaction and final trimming
+   */
+  public static int redactionOverlapBytes(String token, InstalledAppPaths paths) {
+    Objects.requireNonNull(paths, "paths");
+    int maxSensitiveBytes = UNKNOWN_TOKEN_ASSIGNMENT_BYTES;
+    if (token != null && !token.isBlank()) {
+      maxSensitiveBytes = Math.max(maxSensitiveBytes, utf8Length(token));
+    }
+    for (String pathText : allPathTexts(paths)) {
+      maxSensitiveBytes = Math.max(maxSensitiveBytes, utf8Length(pathText));
+    }
+    return maxSensitiveBytes - 1;
+  }
+
+  private static String redactPaths(String text, InstalledAppPaths paths) {
+    List<PathReplacement> replacements = new ArrayList<>();
+    addPathReplacement(replacements, paths.processLogFile(), APP_PROCESS_LOG_PLACEHOLDER);
+    addPathReplacement(replacements, paths.installedRoot(), APP_INSTALL_DIR_PLACEHOLDER);
+    addPathReplacement(replacements, paths.dataDir(), APP_DATA_DIR_PLACEHOLDER);
+    addPathReplacement(replacements, paths.cacheDir(), APP_CACHE_DIR_PLACEHOLDER);
+    addPathReplacement(replacements, paths.runDir(), APP_RUN_DIR_PLACEHOLDER);
+    replacements.sort(
+        Comparator.comparingInt((PathReplacement replacement) -> replacement.text().length())
+            .reversed());
+    String redacted = text;
+    for (PathReplacement replacement : replacements) {
+      redacted = redacted.replace(replacement.text(), replacement.placeholder());
+    }
+    return redacted;
+  }
+
+  private static void addPathReplacement(
+      List<PathReplacement> replacements, Path path, String placeholder) {
+    for (String pathText : pathTexts(path)) {
+      addPathText(replacements, pathText, placeholder);
+    }
+  }
+
+  private static void addPathText(
+      List<PathReplacement> replacements, String text, String placeholder) {
+    if (!text.isBlank()) {
+      replacements.add(new PathReplacement(text, placeholder));
+    }
+  }
+
+  private static List<String> allPathTexts(InstalledAppPaths paths) {
+    List<String> pathTexts = new ArrayList<>();
+    pathTexts.addAll(pathTexts(paths.processLogFile()));
+    pathTexts.addAll(pathTexts(paths.installedRoot()));
+    pathTexts.addAll(pathTexts(paths.dataDir()));
+    pathTexts.addAll(pathTexts(paths.cacheDir()));
+    pathTexts.addAll(pathTexts(paths.runDir()));
+    return pathTexts;
+  }
+
+  private static List<String> pathTexts(Path path) {
+    return List.of(
+        path.toString(),
+        path.toAbsolutePath().normalize().toString(),
+        path.toString().replace('\\', '/'));
+  }
+
+  private static int utf8Length(String text) {
+    return text.getBytes(StandardCharsets.UTF_8).length;
+  }
+
+  private record PathReplacement(String text, String placeholder) {}
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostTokenRedactor.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppHostTokenRedactor.java
@@ -41,12 +41,24 @@ public final class AppHostTokenRedactor {
   private static final String APP_CACHE_DIR_PLACEHOLDER = "[APP_CACHE_DIR]";
   private static final String APP_RUN_DIR_PLACEHOLDER = "[APP_RUN_DIR]";
   private static final String APP_PROCESS_LOG_PLACEHOLDER = "[APP_PROCESS_LOG]";
-  private static final String TOKEN_ASSIGNMENT_PREFIX = "CRYPTAD_APP_TOKEN=";
+  private static final String TOKEN_ENVIRONMENT_NAME = "CRYPTAD_APP_TOKEN";
+  private static final int TOKEN_ASSIGNMENT_SEPARATOR_BYTES = 1;
+  private static final int TOKEN_ASSIGNMENT_MAX_WHITESPACE_BYTES = 16;
   private static final int APPHOST_TOKEN_HEX_CHARS = 64;
   private static final int UNKNOWN_TOKEN_ASSIGNMENT_BYTES =
-      TOKEN_ASSIGNMENT_PREFIX.length() + APPHOST_TOKEN_HEX_CHARS;
+      TOKEN_ENVIRONMENT_NAME.length()
+          + TOKEN_ASSIGNMENT_SEPARATOR_BYTES
+          + (TOKEN_ASSIGNMENT_MAX_WHITESPACE_BYTES * 2)
+          + APPHOST_TOKEN_HEX_CHARS;
   private static final Pattern TOKEN_ASSIGNMENT_PATTERN =
-      Pattern.compile("(CRYPTAD_APP_TOKEN\\s*[:=]\\s*)([^\\s,;\"'\\]}]+)");
+      Pattern.compile(
+          "("
+              + TOKEN_ENVIRONMENT_NAME
+              + "[ \\t]{0,"
+              + TOKEN_ASSIGNMENT_MAX_WHITESPACE_BYTES
+              + "}[:=][ \\t]{0,"
+              + TOKEN_ASSIGNMENT_MAX_WHITESPACE_BYTES
+              + "})([^\\s,;\"'\\]}]+)");
 
   private AppHostTokenRedactor() {}
 
@@ -56,7 +68,9 @@ public final class AppHostTokenRedactor {
    * <p>This overload is useful when the exact launch token is unavailable, such as after daemon
    * restart while an older {@code process.log} remains on disk. It still recognizes common
    * environment-assignment shapes, including {@code CRYPTAD_APP_TOKEN=value} and {@code
-   * CRYPTAD_APP_TOKEN: value}. It does not attempt to guess unrelated free-form secrets.
+   * CRYPTAD_APP_TOKEN: value}. Optional spacing around the separator is intentionally bounded so
+   * log-tail callers can reserve enough overlap to redact a split assignment deterministically. It
+   * does not attempt to guess unrelated free-form secrets.
    *
    * @param text source diagnostic text to filter before display
    * @return text with recognizable token assignments redacted
@@ -117,8 +131,9 @@ public final class AppHostTokenRedactor {
    *
    * <p>The returned value is based on UTF-8 byte length, because process logs are tailed by bytes
    * before they are decoded for display. The calculation includes a fixed allowance for a
-   * 64-character AppHost token assignment even when the exact token is unavailable, plus every
-   * known AppHost path spelling that this redactor can replace.
+   * 64-character AppHost token assignment, including the longest bounded spacing form accepted by
+   * the assignment redactor, even when the exact token is unavailable. It also covers every known
+   * AppHost path spelling that this redactor can replace.
    *
    * @param token exact current or last launch token, or {@code null} when unavailable
    * @param paths AppHost-owned paths for the app whose log is being tailed

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppProcessLogSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppProcessLogSnapshot.java
@@ -1,0 +1,67 @@
+package network.crypta.platform.apphost;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Bounded, token-redacted process-log tail for one app.
+ *
+ * <p>The snapshot contains log content and metadata only. It does not expose the underlying runtime
+ * directory or process-log filesystem path. AppHost produces this model for operator-facing API and
+ * Web Shell surfaces that need to inspect combined stdout/stderr without granting filesystem access
+ * to the daemon's run directories.
+ *
+ * <p>The {@code text} value is display text, not trusted structured data. Runtime code redacts the
+ * launch token and known AppHost paths before constructing this record, and UI callers must render
+ * the text as escaped text rather than HTML. {@code maxBytes} describes the caller's requested
+ * bound before implementation clamping; {@code sizeBytes} describes the full log file size when a
+ * regular process log is available.
+ *
+ * <p>Unavailable logs are represented as stable empty snapshots with {@code available == false},
+ * {@code sizeBytes == 0}, and empty text. This keeps missing files, stopped apps, and platforms
+ * without a readable log from surfacing raw filesystem exceptions through the API boundary.
+ *
+ * @param appId stable application identifier normalized by {@link InstalledAppPaths#normalizeAppId}
+ * @param available whether a process log was available as a readable regular file
+ * @param truncated whether older bytes were omitted because of the requested bound
+ * @param maxBytes requested maximum number of bytes before implementation clamping
+ * @param sizeBytes full process-log size in bytes, or {@code 0} when unavailable
+ * @param text redacted UTF-8 log tail text safe for escaped display
+ * @param lastModifiedAt process-log modification time, if available from the filesystem
+ */
+public record AppProcessLogSnapshot(
+    String appId,
+    boolean available,
+    boolean truncated,
+    int maxBytes,
+    long sizeBytes,
+    String text,
+    Instant lastModifiedAt) {
+  /**
+   * Creates a validated process-log snapshot.
+   *
+   * <p>The constructor performs value checks shared by AppHost runtime code and tests. It
+   * normalizes the app id, requires a positive requested byte bound, rejects negative file sizes,
+   * and requires a non-null text value. It does not perform redaction itself; callers must pass
+   * text that has already gone through {@link AppHostTokenRedactor} when the snapshot leaves
+   * internal runtime code.
+   *
+   * @param appId stable application identifier accepted by AppHost path normalization
+   * @param available whether a process log was available as a readable regular file
+   * @param truncated whether older bytes were omitted because of the requested bound
+   * @param maxBytes requested maximum number of bytes before implementation clamping
+   * @param sizeBytes full process-log size in bytes, or {@code 0} when unavailable
+   * @param text redacted UTF-8 log tail text, never {@code null}
+   * @param lastModifiedAt process-log modification time, if available from the filesystem
+   */
+  public AppProcessLogSnapshot {
+    appId = InstalledAppPaths.normalizeAppId(appId);
+    if (maxBytes <= 0) {
+      throw new IllegalArgumentException("maxBytes must be positive");
+    }
+    if (sizeBytes < 0L) {
+      throw new IllegalArgumentException("sizeBytes must be non-negative");
+    }
+    Objects.requireNonNull(text, "text");
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppRuntimeState.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppRuntimeState.java
@@ -1,0 +1,56 @@
+package network.crypta.platform.apphost;
+
+/**
+ * Process-level runtime state for an installed AppHost application.
+ *
+ * <p>The state is intentionally limited to host-observed process lifecycle. It does not imply an
+ * application-level health check, a browser session state, or an operating-system sandbox. AppHost
+ * derives these values from the managed child process, retained exit metadata, and pending bounded
+ * restart attempts.
+ *
+ * <p>Callers should treat the enum as an operator diagnostic signal. {@link #RUNNING} means the
+ * host has a representative process handle, not that the app is ready to serve requests. {@link
+ * #EXITED} and {@link #CRASHED} describe the last observed managed process result in this daemon
+ * session. {@link #RESTARTING} is transient and remains cancellable by an explicit stop request.
+ */
+public enum AppRuntimeState {
+  /**
+   * The app is installed but has no live or recently failed managed process.
+   *
+   * <p>This state is the stable baseline for newly installed apps, apps stopped by an operator, and
+   * apps whose previous runtime metadata is no longer retained by the current daemon session.
+   */
+  STOPPED,
+
+  /**
+   * The app has a live managed process.
+   *
+   * <p>The reported process id is the host's representative process for the app. The state does not
+   * assert that the app has completed startup or that any app-owned HTTP endpoint is healthy.
+   */
+  RUNNING,
+
+  /**
+   * The app's last managed process exited with status code {@code 0}.
+   *
+   * <p>A clean exit is terminal for the current process run. It does not trigger an {@code
+   * on-failure} restart policy because the app reported successful completion.
+   */
+  EXITED,
+
+  /**
+   * The app's last managed process exited with a non-zero status code or unknown failed outcome.
+   *
+   * <p>This state is used for crash diagnostics and for deciding whether a bounded {@code
+   * on-failure} restart may be scheduled, subject to the app's manifest limits.
+   */
+  CRASHED,
+
+  /**
+   * The host has scheduled a bounded automatic restart attempt.
+   *
+   * <p>The app is not currently running during the backoff window, but AppHost still considers it
+   * managed so a stop or update request can cancel the pending relaunch before it starts.
+   */
+  RESTARTING
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppRuntimeStatusSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppRuntimeStatusSnapshot.java
@@ -1,0 +1,85 @@
+package network.crypta.platform.apphost;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Token-free process status snapshot for one installed app.
+ *
+ * <p>This read model is safe for operator-facing APIs: it reports process lifecycle metadata and
+ * log availability, but it intentionally omits launch tokens and host filesystem paths. {@code
+ * LocalProcessAppHost} builds snapshots from live process handles and retained runtime records,
+ * then Platform API and Web Shell callers serialize the result without needing access to internal
+ * launch state.
+ *
+ * <p>The model is process-scoped. A running value means AppHost still observes a managed process;
+ * it does not imply application-level readiness or successful API authentication. Exit fields
+ * describe the last managed process result known to the current daemon session. Restart counters
+ * are best-effort diagnostics for bounded automatic restarts and reset when the app is started
+ * manually in a new managed run.
+ *
+ * <p>Log metadata mirrors the process-log tail API without exposing the log path. Callers can use
+ * {@code logAvailable} and {@code logSizeBytes} to decide whether to show a log action while still
+ * keeping run directories and token-bearing launch details outside the public response shape.
+ *
+ * @param appId stable application identifier normalized by {@link InstalledAppPaths#normalizeAppId}
+ * @param state current host-observed runtime state for the installed app
+ * @param running whether a managed process is currently live according to AppHost
+ * @param pid representative process id when running, otherwise {@code null}
+ * @param startedAt process start time when running, otherwise {@code null}
+ * @param lastExitAt last managed process exit time retained by this daemon, if known
+ * @param lastExitCode last managed process exit code retained by this daemon, if known
+ * @param restartCount completed automatic restart launches in this daemon-managed run
+ * @param currentRestartAttempt current or pending automatic restart attempt number
+ * @param logAvailable whether the process log can currently be read as a regular file
+ * @param logSizeBytes process log size in bytes, if known without exposing the path
+ */
+public record AppRuntimeStatusSnapshot(
+    String appId,
+    AppRuntimeState state,
+    boolean running,
+    Long pid,
+    Instant startedAt,
+    Instant lastExitAt,
+    Integer lastExitCode,
+    int restartCount,
+    int currentRestartAttempt,
+    boolean logAvailable,
+    Long logSizeBytes) {
+  /**
+   * Creates a validated runtime status snapshot.
+   *
+   * <p>The constructor normalizes the app id and rejects values that cannot represent a valid
+   * status response. It deliberately allows nullable timestamps, process ids, exit codes, and log
+   * sizes because those facts may be unknown for stopped apps, unavailable logs, or older runtime
+   * records retained only for crash diagnostics.
+   *
+   * @param appId stable application identifier accepted by AppHost path normalization
+   * @param state current host-observed runtime state for the installed app
+   * @param running whether a managed process is currently live according to AppHost
+   * @param pid representative process id when running, otherwise {@code null}
+   * @param startedAt process start time when running, otherwise {@code null}
+   * @param lastExitAt last managed process exit time retained by this daemon, if known
+   * @param lastExitCode last managed process exit code retained by this daemon, if known
+   * @param restartCount completed automatic restart launches in this daemon-managed run
+   * @param currentRestartAttempt current or pending automatic restart attempt number
+   * @param logAvailable whether the process log can currently be read as a regular file
+   * @param logSizeBytes process log size in bytes, if known without exposing the path
+   */
+  public AppRuntimeStatusSnapshot {
+    appId = InstalledAppPaths.normalizeAppId(appId);
+    Objects.requireNonNull(state, "state");
+    if (pid != null && pid <= 0L) {
+      throw new IllegalArgumentException("pid must be positive when present");
+    }
+    if (restartCount < 0) {
+      throw new IllegalArgumentException("restartCount must be non-negative");
+    }
+    if (currentRestartAttempt < 0) {
+      throw new IllegalArgumentException("currentRestartAttempt must be non-negative");
+    }
+    if (logSizeBytes != null && logSizeBytes < 0L) {
+      throw new IllegalArgumentException("logSizeBytes must be non-negative when present");
+    }
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/InstalledAppPaths.java
@@ -122,6 +122,9 @@ public record InstalledAppPaths(
     ensureMutableDirectory(dataDir, "dataDir");
     ensureMutableDirectory(cacheDir, "cacheDir");
     ensureMutableDirectory(runDir, "runDir");
+    OwnerOnlyFilePermissions.hardenDirectory(dataDir);
+    OwnerOnlyFilePermissions.hardenDirectory(cacheDir);
+    OwnerOnlyFilePermissions.hardenDirectory(runDir);
   }
 
   /**
@@ -134,7 +137,7 @@ public record InstalledAppPaths(
    */
   @SuppressWarnings("unused")
   public void ensureInstallParentDirectory() throws IOException {
-    Files.createDirectories(parentOrThrow(installedRoot, "installedRoot"));
+    Files.createDirectories(installedRootParentOrThrow(installedRoot));
   }
 
   /**
@@ -209,10 +212,10 @@ public record InstalledAppPaths(
     return !actualRealPath.equals(expectedRealPath);
   }
 
-  private static Path parentOrThrow(Path path, String label) throws AppHostException {
-    Path parent = path.getParent();
+  private static Path installedRootParentOrThrow(Path installedRoot) throws AppHostException {
+    Path parent = installedRoot.getParent();
     if (parent == null) {
-      throw new AppHostException(label + " must not be a filesystem root: " + path);
+      throw new AppHostException("installedRoot must not be a filesystem root: " + installedRoot);
     }
     return parent;
   }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/OwnerOnlyFilePermissions.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/OwnerOnlyFilePermissions.java
@@ -1,0 +1,127 @@
+package network.crypta.platform.apphost;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+/**
+ * Best-effort owner-only permission hardening for AppHost-owned runtime state.
+ *
+ * <p>POSIX filesystems receive explicit owner-only modes. Platforms or filesystems without a POSIX
+ * attribute view are treated as a supported fallback and do not fail solely because those
+ * permissions are unavailable.
+ *
+ * <p>This helper is part of AppHost runtime hygiene, not an operating-system sandbox. It reduces
+ * accidental exposure of app data directories, cache directories, run directories, tokens, and log
+ * files on filesystems where Java can set POSIX permissions. It does not isolate processes, prevent
+ * network access, or override platform account policy.
+ *
+ * <p>When possible, permissions are applied through a parent {@link SecureDirectoryStream} with
+ * {@link LinkOption#NOFOLLOW_LINKS} so the checked entry and the modified entry are the same
+ * directory entry. On providers without secure directory streams, the fallback still asks for a
+ * no-follow POSIX view and refuses symbolic links before applying permissions.
+ */
+public final class OwnerOnlyFilePermissions {
+  private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS =
+      Set.of(
+          PosixFilePermission.OWNER_READ,
+          PosixFilePermission.OWNER_WRITE,
+          PosixFilePermission.OWNER_EXECUTE);
+  private static final Set<PosixFilePermission> SENSITIVE_FILE_PERMISSIONS =
+      Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+
+  private enum PermissionAttemptResult {
+    APPLIED,
+    UNSUPPORTED,
+    UNAVAILABLE
+  }
+
+  private OwnerOnlyFilePermissions() {}
+
+  /**
+   * Applies {@code rwx------} to a directory when POSIX permissions are supported.
+   *
+   * <p>The mode gives the owning user read, write, and execute access and removes group and other
+   * access bits. AppHost uses this for mutable app-owned directories such as data, cache, and run
+   * roots. A {@code false} return means the filesystem does not expose POSIX permissions through
+   * Java; callers should continue with the platform fallback behavior already documented for the
+   * runtime.
+   *
+   * @param directory directory path to harden without following symbolic links
+   * @return {@code true} when POSIX permissions were applied, {@code false} on non-POSIX fallback
+   * @throws IOException if POSIX permissions are supported but cannot be applied safely
+   */
+  public static boolean hardenDirectory(Path directory) throws IOException {
+    return setPermissionsIfSupported(directory, DIRECTORY_PERMISSIONS);
+  }
+
+  /**
+   * Applies {@code rw-------} to a sensitive file when POSIX permissions are supported.
+   *
+   * <p>The mode gives the owning user read/write access and removes all group and other access
+   * bits. AppHost uses this for files that may contain runtime-sensitive content, including process
+   * logs after creation. The method is intentionally best-effort across platforms, but it does fail
+   * on POSIX providers when permissions cannot be applied to the requested non-link entry.
+   *
+   * @param file sensitive file path to harden without following symbolic links
+   * @return {@code true} when POSIX permissions were applied, {@code false} on non-POSIX fallback
+   * @throws IOException if POSIX permissions are supported but cannot be applied safely
+   */
+  public static boolean hardenSensitiveFile(Path file) throws IOException {
+    return setPermissionsIfSupported(file, SENSITIVE_FILE_PERMISSIONS);
+  }
+
+  private static boolean setPermissionsIfSupported(Path path, Set<PosixFilePermission> permissions)
+      throws IOException {
+    PermissionAttemptResult secureResult =
+        setPermissionsWithSecureParentIfAvailable(path, permissions);
+    if (secureResult != PermissionAttemptResult.UNAVAILABLE) {
+      return secureResult == PermissionAttemptResult.APPLIED;
+    }
+    return setPermissionsWithPathView(path, permissions);
+  }
+
+  private static PermissionAttemptResult setPermissionsWithSecureParentIfAvailable(
+      Path path, Set<PosixFilePermission> permissions) throws IOException {
+    Path normalized = path.toAbsolutePath().normalize();
+    Path parent = normalized.getParent();
+    Path fileName = normalized.getFileName();
+    if (parent == null || fileName == null) {
+      return PermissionAttemptResult.UNAVAILABLE;
+    }
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(parent)) {
+      if (!(stream instanceof SecureDirectoryStream<?>)) {
+        return PermissionAttemptResult.UNAVAILABLE;
+      }
+      SecureDirectoryStream<Path> secureStream = (SecureDirectoryStream<Path>) stream;
+      PosixFileAttributeView view =
+          secureStream.getFileAttributeView(
+              fileName, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+      if (view == null) {
+        return PermissionAttemptResult.UNSUPPORTED;
+      }
+      view.setPermissions(permissions);
+      return PermissionAttemptResult.APPLIED;
+    }
+  }
+
+  private static boolean setPermissionsWithPathView(Path path, Set<PosixFilePermission> permissions)
+      throws IOException {
+    if (Files.isSymbolicLink(path)) {
+      throw new IOException("refusing to harden symbolic link: " + path);
+    }
+    PosixFileAttributeView view =
+        Files.getFileAttributeView(path, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+    if (view == null) {
+      return false;
+    }
+    view.setPermissions(permissions);
+    return true;
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
@@ -3,6 +3,7 @@ package network.crypta.platform.apphost;
 import java.time.Instant;
 import java.util.Objects;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Immutable snapshot of one running child process.
@@ -56,5 +57,22 @@ public record RunningAppSnapshot(
    */
   public String appId() {
     return manifest.appId();
+  }
+
+  /**
+   * Returns a diagnostic string that never includes the launch token or filesystem paths.
+   *
+   * @return redacted diagnostic representation
+   */
+  @Override
+  public @NotNull String toString() {
+    return "RunningAppSnapshot[appId=%s, name=%s, version=%s, token=%s, pid=%d, startedAt=%s]"
+        .formatted(
+            manifest.appId(),
+            manifest.appName(),
+            manifest.appVersion(),
+            AppHostTokenRedactor.REDACTED,
+            pid,
+            startedAt);
   }
 }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppRestartPolicy;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.InstalledAppPaths;
 
@@ -31,6 +32,9 @@ import network.crypta.platform.apphost.InstalledAppPaths;
  * @param permissions normalized permission strings
  * @param dataQuotaBytes optional data quota metadata, or {@code null}
  * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+ * @param restartPolicy normalized process restart policy
+ * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
+ * @param restartBackoffMillis delay before an automatic restart attempt
  */
 public record AppManifest(
     int manifestVersion,
@@ -42,7 +46,10 @@ public record AppManifest(
     String uiEntry,
     List<String> permissions,
     Long dataQuotaBytes,
-    Long cacheQuotaBytes) {
+    Long cacheQuotaBytes,
+    AppRestartPolicy restartPolicy,
+    int restartMaxAttempts,
+    long restartBackoffMillis) {
   /**
    * Creates a validated manifest snapshot.
    *
@@ -56,6 +63,9 @@ public record AppManifest(
    * @param permissions normalized permission strings
    * @param dataQuotaBytes optional data quota metadata, or {@code null}
    * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+   * @param restartPolicy normalized process restart policy
+   * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
+   * @param restartBackoffMillis delay before an automatic restart attempt
    */
   public AppManifest {
     AppBundleManifest normalized =
@@ -69,7 +79,10 @@ public record AppManifest(
             uiEntry,
             permissions,
             dataQuotaBytes,
-            cacheQuotaBytes);
+            cacheQuotaBytes,
+            restartPolicy,
+            restartMaxAttempts,
+            restartBackoffMillis);
     manifestVersion = normalized.manifestVersion();
     appId = normalized.appId();
     appName = normalized.appName();
@@ -80,6 +93,50 @@ public record AppManifest(
     permissions = normalized.permissions();
     dataQuotaBytes = normalized.dataQuotaBytes();
     cacheQuotaBytes = normalized.cacheQuotaBytes();
+    restartPolicy = normalized.restartPolicy();
+    restartMaxAttempts = normalized.restartMaxAttempts();
+    restartBackoffMillis = normalized.restartBackoffMillis();
+  }
+
+  /**
+   * Creates a manifest with the default restart policy.
+   *
+   * @param manifestVersion manifest schema version
+   * @param appId stable path-safe app identifier
+   * @param appName human-readable application name
+   * @param appVersion display version string
+   * @param execPathText executable path relative to the installed app root
+   * @param uiMode normalized browser UI ownership mode declared or inferred from the manifest
+   * @param uiEntry optional UI entry path, or {@code null}
+   * @param permissions normalized permission strings
+   * @param dataQuotaBytes optional data quota metadata, or {@code null}
+   * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+   */
+  public AppManifest(
+      int manifestVersion,
+      String appId,
+      String appName,
+      String appVersion,
+      String execPathText,
+      AppUiMode uiMode,
+      String uiEntry,
+      List<String> permissions,
+      Long dataQuotaBytes,
+      Long cacheQuotaBytes) {
+    this(
+        manifestVersion,
+        appId,
+        appName,
+        appVersion,
+        execPathText,
+        uiMode,
+        uiEntry,
+        permissions,
+        dataQuotaBytes,
+        cacheQuotaBytes,
+        AppRestartPolicy.NEVER,
+        0,
+        0L);
   }
 
   /**
@@ -133,7 +190,10 @@ public record AppManifest(
         manifest.uiEntry(),
         manifest.permissions(),
         manifest.dataQuotaBytes(),
-        manifest.cacheQuotaBytes());
+        manifest.cacheQuotaBytes(),
+        manifest.restartPolicy(),
+        manifest.restartMaxAttempts(),
+        manifest.restartBackoffMillis());
   }
 
   /**

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
@@ -59,6 +59,9 @@ public final class AppManifestParser {
         manifest.uiEntry(),
         manifest.permissions(),
         manifest.dataQuotaBytes(),
-        manifest.cacheQuotaBytes());
+        manifest.cacheQuotaBytes(),
+        manifest.restartPolicy(),
+        manifest.restartMaxAttempts(),
+        manifest.restartBackoffMillis());
   }
 }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -13,6 +13,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.SecureRandom;
 import java.time.Duration;
@@ -34,13 +35,19 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import network.crypta.fs.AppEnv;
+import network.crypta.platform.appdist.AppRestartPolicy;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
 import network.crypta.platform.apphost.AppHostLayout;
+import network.crypta.platform.apphost.AppHostTokenRedactor;
 import network.crypta.platform.apphost.AppInstallVerificationPolicy;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeState;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.OwnerOnlyFilePermissions;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.manifest.AppManifestException;
@@ -69,6 +76,7 @@ public final class LocalProcessAppHost implements AppHost {
   private static final String INSTALLED_APPS_DIR_LABEL = "installedAppsDir";
   private static final String WINDOWS_SYSTEM32_DIRECTORY = "System32";
   private static final String PROC_ROOT = "/proc";
+  private static final String APP_NOT_INSTALLED_PREFIX = "app is not installed: ";
   private static final List<String> WINDOWS_ROOT_ENVIRONMENT_NAMES =
       List.of("SystemRoot", "SYSTEMROOT", "WINDIR");
   private static final int MAX_SHEBANG_PROBE_BYTES = 4096;
@@ -115,6 +123,8 @@ public final class LocalProcessAppHost implements AppHost {
   private final ManagedTreeDeleter managedTreeDeleter;
   private final AppInstallVerificationPolicy installVerificationPolicy;
   private final Map<String, RunningProcess> runningApps = new ConcurrentHashMap<>();
+  private final Map<String, RuntimeRecord> runtimeRecords = new ConcurrentHashMap<>();
+  private final Set<String> explicitStopRequests = ConcurrentHashMap.newKeySet();
 
   /**
    * Creates a host bound to the supplied layout.
@@ -362,7 +372,7 @@ public final class LocalProcessAppHost implements AppHost {
       throw new AppHostException("cannot update a running app: " + normalizedAppId);
     }
     if (!Files.isDirectory(paths.installedRoot(), LinkOption.NOFOLLOW_LINKS)) {
-      throw new AppHostException("app is not installed: " + normalizedAppId);
+      throw new AppHostException(APP_NOT_INSTALLED_PREFIX + normalizedAppId);
     }
     validateManagedMutableDirectories(paths);
     paths.ensureMutableDirectories();
@@ -376,6 +386,7 @@ public final class LocalProcessAppHost implements AppHost {
       AppManifest manifest = validateCopiedBundle(temporaryInstallRoot);
       requireMatchingUpdateTarget(normalizedAppId, manifest);
       replaceInstalledBundle(paths.installedRoot(), temporaryInstallRoot, backupInstallRoot);
+      cancelPendingRestartAfterAcceptedUpdate(normalizedAppId);
       return new InstalledAppSnapshot(manifest, paths);
     } catch (IOException | RuntimeException e) {
       deleteScratchTreeIfPresent(temporaryInstallRoot);
@@ -401,13 +412,15 @@ public final class LocalProcessAppHost implements AppHost {
       throw new AppHostException("cannot uninstall a running app: " + appId);
     }
     if (!Files.exists(paths.installedRoot())) {
-      throw new AppHostException("app is not installed: " + appId);
+      throw new AppHostException(APP_NOT_INSTALLED_PREFIX + appId);
     }
 
     deleteRecursively(paths.installedRoot());
     deleteRecursively(paths.dataDir());
     deleteRecursively(paths.cacheDir());
     deleteRecursively(paths.runDir());
+    runtimeRecords.remove(paths.appId());
+    explicitStopRequests.remove(paths.appId());
   }
 
   /**
@@ -480,14 +493,22 @@ public final class LocalProcessAppHost implements AppHost {
     if (liveRunningProcess(normalizedAppId) != null) {
       throw new AppHostException("app is already running: " + appId);
     }
+    explicitStopRequests.remove(normalizedAppId);
 
     InstalledAppSnapshot installation =
         describe(normalizedAppId)
-            .orElseThrow(() -> new AppHostException("app is not installed: " + appId));
+            .orElseThrow(() -> new AppHostException(APP_NOT_INSTALLED_PREFIX + appId));
+    return launchInstalledApp(installation, 0, 0);
+  }
+
+  private RunningAppSnapshot launchInstalledApp(
+      InstalledAppSnapshot installation, int restartCount, int currentRestartAttempt)
+      throws IOException {
+    String normalizedAppId = installation.appId();
     InstalledAppPaths paths = installation.paths();
     validateManagedMutableDirectories(paths);
     paths.ensureMutableDirectories();
-    Files.deleteIfExists(paths.processLogFile());
+    prepareProcessLogFile(paths);
 
     Path executable =
         resolveBundleEntry(
@@ -507,20 +528,23 @@ public final class LocalProcessAppHost implements AppHost {
 
     Instant startedAt = Instant.now();
     Process process = builder.start();
-    discardChildInput(process, appId);
+    discardChildInput(process, normalizedAppId);
     List<ProcessHandle> startupProcessTree = observeStartupProcessTree(process, normalizedAppId);
     if (startupProcessTree.isEmpty()) {
-      startupProcessTree =
-          recoverTrackedProcesses(
-              installation.manifest(),
-              paths,
-              token,
-              startedAt,
-              List.of(process.toHandle()),
-              ProcessHandle.allProcesses().toList());
+      startupProcessTree = recoverStartupProcessTree(installation, token, startedAt, process);
     }
     if (startupProcessTree.isEmpty()) {
-      throw startupFailure(appId, process);
+      recordProcessExit(
+          normalizedAppId,
+          new ProcessExitRecord(
+              paths,
+              processExitCode(process),
+              Instant.now(),
+              restartCount,
+              currentRestartAttempt,
+              token,
+              false));
+      throw startupFailure(normalizedAppId, process);
     }
     RunningAppSnapshot snapshot =
         new RunningAppSnapshot(
@@ -534,12 +558,22 @@ public final class LocalProcessAppHost implements AppHost {
             startedAt);
     CompletableFuture<Void> exitCleanup = new CompletableFuture<>();
     RunningProcess runningProcess =
-        new RunningProcess(process, snapshot, exitCleanup, startupProcessTree);
+        new RunningProcess(
+            process,
+            snapshot,
+            exitCleanup,
+            startupProcessTree,
+            restartCount,
+            currentRestartAttempt);
     runningApps.put(normalizedAppId, runningProcess);
+    runtimeRecords.compute(
+        normalizedAppId,
+        (_, previousRecord) ->
+            RuntimeRecord.running(snapshot, restartCount, currentRestartAttempt, previousRecord));
     startTrackedProcessTreeObserver(normalizedAppId, process, exitCleanup);
     RunningProcess liveRunningProcess = liveRunningProcess(normalizedAppId);
     if (liveRunningProcess == null) {
-      throw startupFailure(appId, process);
+      throw startupFailure(normalizedAppId, process);
     }
     return liveRunningProcess.snapshot();
   }
@@ -562,8 +596,15 @@ public final class LocalProcessAppHost implements AppHost {
     String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
     RunningProcess runningProcess = liveRunningProcess(normalizedAppId);
     if (runningProcess == null) {
+      RuntimeRecord restartRecord = runtimeRecords.get(normalizedAppId);
+      if (restartRecord != null && restartRecord.state() == AppRuntimeState.RESTARTING) {
+        explicitStopRequests.add(normalizedAppId);
+        runtimeRecords.put(normalizedAppId, restartRecord.stopped());
+        return true;
+      }
       return false;
     }
+    explicitStopRequests.add(normalizedAppId);
 
     RunningProcess trackedRunningProcess =
         trackRunningProcessForStop(normalizedAppId, runningProcess);
@@ -575,6 +616,7 @@ public final class LocalProcessAppHost implements AppHost {
       return true;
     }
     completeStop(normalizedAppId, appId, trackedRunningProcess);
+    runtimeRecords.put(normalizedAppId, RuntimeRecord.stopped(trackedRunningProcess));
     return true;
   }
 
@@ -614,6 +656,213 @@ public final class LocalProcessAppHost implements AppHost {
       }
     }
     return List.copyOf(running);
+  }
+
+  /**
+   * Returns token-free runtime status for one installed app.
+   *
+   * @param appId stable application identifier
+   * @return process-level runtime status snapshot
+   * @throws IOException if the app is not installed or managed files cannot be inspected
+   */
+  @Override
+  public synchronized AppRuntimeStatusSnapshot runtimeStatus(String appId) throws IOException {
+    String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
+    RunningProcess runningProcess = liveRunningProcess(normalizedAppId);
+    if (runningProcess != null) {
+      RuntimeRecord previousRecord = runtimeRecords.get(normalizedAppId);
+      return statusSnapshot(normalizedAppId, RuntimeRecord.running(runningProcess, previousRecord));
+    }
+    InstalledAppSnapshot installed =
+        describe(normalizedAppId)
+            .orElseThrow(() -> new AppHostException(APP_NOT_INSTALLED_PREFIX + appId));
+    RuntimeRecord runtimeRecord = runtimeRecords.get(normalizedAppId);
+    if (runtimeRecord == null) {
+      runtimeRecord = RuntimeRecord.stopped(installed.paths());
+    }
+    return statusSnapshot(normalizedAppId, runtimeRecord.withoutRunningProcess(installed.paths()));
+  }
+
+  /**
+   * Lists token-free runtime status for installed apps.
+   *
+   * @return runtime status snapshots sorted by app id
+   * @throws IOException if the installed-app tree cannot be read safely
+   */
+  @Override
+  public synchronized List<AppRuntimeStatusSnapshot> listRuntimeStatus() throws IOException {
+    List<AppRuntimeStatusSnapshot> statuses = new ArrayList<>();
+    for (InstalledAppSnapshot installed : listInstalled()) {
+      statuses.add(runtimeStatus(installed.appId()));
+    }
+    return List.copyOf(statuses);
+  }
+
+  /**
+   * Reads a bounded, token-redacted tail of one app's process log.
+   *
+   * @param appId stable application identifier
+   * @param maxBytes requested maximum bytes before clamping
+   * @return redacted process-log tail snapshot
+   * @throws IOException if the app is not installed or the log cannot be inspected safely
+   */
+  @Override
+  public synchronized AppProcessLogSnapshot readProcessLogTail(String appId, int maxBytes)
+      throws IOException {
+    String normalizedAppId = InstalledAppPaths.normalizeAppId(appId);
+    int boundedMaxBytes = boundedLogTailBytes(maxBytes);
+    RunningProcess runningProcess = liveRunningProcess(normalizedAppId);
+    InstalledAppPaths paths =
+        runningProcess == null
+            ? describe(normalizedAppId)
+                .orElseThrow(() -> new AppHostException(APP_NOT_INSTALLED_PREFIX + appId))
+                .paths()
+            : runningProcess.snapshot().paths();
+    String token = runningProcess == null ? null : runningProcess.snapshot().token();
+    RuntimeRecord runtimeRecord =
+        runningProcess == null ? runtimeRecords.get(normalizedAppId) : null;
+    if (token == null && runtimeRecord != null) {
+      token = runtimeRecord.lastLaunchToken();
+    }
+    return readProcessLogTail(normalizedAppId, paths, token, boundedMaxBytes);
+  }
+
+  private void prepareProcessLogFile(InstalledAppPaths paths) throws IOException {
+    Files.deleteIfExists(paths.processLogFile());
+    Files.createFile(paths.processLogFile());
+    OwnerOnlyFilePermissions.hardenSensitiveFile(paths.processLogFile());
+  }
+
+  private AppRuntimeStatusSnapshot statusSnapshot(String appId, RuntimeRecord runtimeRecord)
+      throws IOException {
+    LogMetadata log = logMetadata(runtimeRecord.paths());
+    return new AppRuntimeStatusSnapshot(
+        appId,
+        runtimeRecord.state(),
+        runtimeRecord.running(),
+        runtimeRecord.pid(),
+        runtimeRecord.startedAt(),
+        runtimeRecord.lastExitAt(),
+        runtimeRecord.lastExitCode(),
+        runtimeRecord.restartCount(),
+        runtimeRecord.currentRestartAttempt(),
+        log.available(),
+        log.sizeBytes());
+  }
+
+  private static int boundedLogTailBytes(int maxBytes) {
+    if (maxBytes <= 0) {
+      throw new IllegalArgumentException("maxBytes must be positive");
+    }
+    return Math.min(maxBytes, AppHost.MAX_PROCESS_LOG_TAIL_BYTES);
+  }
+
+  private AppProcessLogSnapshot readProcessLogTail(
+      String appId, InstalledAppPaths paths, String token, int maxBytes) throws IOException {
+    Path logFile = paths.processLogFile();
+    BasicFileAttributes attributes = processLogAttributes(logFile);
+    if (attributes == null) {
+      return new AppProcessLogSnapshot(appId, false, false, maxBytes, 0L, "", null);
+    }
+    long sizeBytes = attributes.size();
+    int overlapBytes = AppHostTokenRedactor.redactionOverlapBytes(token, paths);
+    int bytesToRead = logTailReadBytes(sizeBytes, maxBytes, overlapBytes);
+    long startOffset = sizeBytes - bytesToRead;
+    ByteBuffer buffer = ByteBuffer.allocate(bytesToRead);
+    try (SeekableByteChannel channel =
+        Files.newByteChannel(logFile, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
+      channel.position(startOffset);
+      while (buffer.hasRemaining()) {
+        if (channel.read(buffer) < 0) {
+          break;
+        }
+      }
+    }
+    buffer.flip();
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.get(bytes);
+    String redactedText =
+        AppHostTokenRedactor.redact(new String(bytes, StandardCharsets.UTF_8), token, paths);
+    String text = boundedUtf8Tail(redactedText, maxBytes);
+    return new AppProcessLogSnapshot(
+        appId,
+        true,
+        sizeBytes > maxBytes,
+        maxBytes,
+        sizeBytes,
+        text,
+        attributes.lastModifiedTime().toInstant());
+  }
+
+  private static int logTailReadBytes(long sizeBytes, int maxBytes, int overlapBytes) {
+    long requestedBytes = Math.min(sizeBytes, (long) maxBytes + overlapBytes);
+    return Math.toIntExact(Math.min(requestedBytes, Integer.MAX_VALUE));
+  }
+
+  private static String boundedUtf8Tail(String text, int maxBytes) {
+    byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+    if (bytes.length <= maxBytes) {
+      return text;
+    }
+    return new String(bytes, bytes.length - maxBytes, maxBytes, StandardCharsets.UTF_8);
+  }
+
+  private static LogMetadata logMetadata(InstalledAppPaths paths) throws IOException {
+    BasicFileAttributes attributes = processLogAttributes(paths.processLogFile());
+    if (attributes == null) {
+      return new LogMetadata(false, null);
+    }
+    return new LogMetadata(true, attributes.size());
+  }
+
+  private static BasicFileAttributes processLogAttributes(Path logFile) throws IOException {
+    if (!Files.exists(logFile, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(logFile)) {
+      return null;
+    }
+    BasicFileAttributes attributes =
+        Files.readAttributes(logFile, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+    return attributes.isRegularFile() ? attributes : null;
+  }
+
+  private void recordProcessExit(String appId, ProcessExitRecord exitRecord) {
+    runtimeRecords.put(
+        appId,
+        new RuntimeRecord(
+            exitRecord.paths(),
+            exitState(exitRecord.exitCode(), exitRecord.explicitStop()),
+            false,
+            null,
+            null,
+            exitRecord.exitAt(),
+            exitRecord.exitCode(),
+            exitRecord.lastLaunchToken(),
+            exitRecord.restartCount(),
+            exitRecord.currentRestartAttempt()));
+  }
+
+  private static AppRuntimeState exitState(Integer exitCode, boolean explicitStop) {
+    if (explicitStop) {
+      return AppRuntimeState.STOPPED;
+    }
+    if (exitCode != null && exitCode == 0) {
+      return AppRuntimeState.EXITED;
+    }
+    return AppRuntimeState.CRASHED;
+  }
+
+  private static Integer processExitCode(Process process) {
+    try {
+      return process.exitValue();
+    } catch (IllegalThreadStateException _) {
+      return null;
+    }
+  }
+
+  private static Integer trackedAppExitCode(RunningProcess runningProcess) {
+    if (runningProcess.isRepresentativeProcessHandoff()) {
+      return null;
+    }
+    return processExitCode(runningProcess.process());
   }
 
   private AppManifest readInstalledManifest(Path installedRoot) throws IOException {
@@ -702,9 +951,112 @@ public final class LocalProcessAppHost implements AppHost {
       runningApps.replace(appId, runningProcess, refreshedRunningProcess);
       return refreshedRunningProcess;
     }
+    recordExitAndScheduleRestartIfNeeded(appId, runningProcess);
     runningProcess.exitCleanup().join();
     runningApps.remove(appId, runningProcess);
     return null;
+  }
+
+  private void recordExitAndScheduleRestartIfNeeded(String appId, RunningProcess runningProcess) {
+    boolean explicitStop = explicitStopRequests.contains(appId);
+    Integer exitCode = trackedAppExitCode(runningProcess);
+    Instant exitAt = Instant.now();
+    if (shouldRestart(runningProcess, exitCode, explicitStop)) {
+      int nextAttempt = runningProcess.currentRestartAttempt() + 1;
+      runtimeRecords.put(
+          appId, RuntimeRecord.restarting(runningProcess, exitCode, exitAt, nextAttempt));
+      scheduleRestart(
+          appId,
+          nextAttempt,
+          Duration.ofMillis(runningProcess.snapshot().manifest().restartBackoffMillis()));
+      return;
+    }
+    recordProcessExit(
+        appId,
+        ProcessExitRecord.fromRunningProcess(runningProcess, exitCode, exitAt, explicitStop));
+  }
+
+  private void cancelPendingRestartAfterAcceptedUpdate(String appId) {
+    RuntimeRecord runtimeRecord = runtimeRecords.get(appId);
+    if (runtimeRecord != null && runtimeRecord.state() == AppRuntimeState.RESTARTING) {
+      runtimeRecords.put(appId, runtimeRecord.stopped());
+    }
+  }
+
+  private static boolean shouldRestart(
+      RunningProcess runningProcess, Integer exitCode, boolean explicitStop) {
+    AppManifest manifest = runningProcess.snapshot().manifest();
+    return !explicitStop
+        && isFailureExit(exitCode)
+        && manifest.restartPolicy() == AppRestartPolicy.ON_FAILURE
+        && runningProcess.currentRestartAttempt() < manifest.restartMaxAttempts();
+  }
+
+  private static boolean isFailureExit(Integer exitCode) {
+    return exitCode == null || exitCode != 0;
+  }
+
+  private void scheduleRestart(String appId, int restartAttempt, Duration backoff) {
+    Thread.ofVirtual()
+        .name("apphost-restart-", 0)
+        .start(
+            () -> {
+              try {
+                sleepBeforeRestart(backoff);
+                restartIfStillScheduled(appId, restartAttempt);
+              } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+              }
+            });
+  }
+
+  private static void sleepBeforeRestart(Duration backoff) throws InterruptedException {
+    long sleepMillis = restartBackoffSleepMillis(backoff);
+    if (sleepMillis == 0L) {
+      return;
+    }
+    TimeUnit.MILLISECONDS.sleep(sleepMillis);
+  }
+
+  static long restartBackoffSleepMillis(Duration backoff) {
+    if (backoff.isZero() || backoff.isNegative()) {
+      return 0L;
+    }
+    try {
+      return backoff.toMillis();
+    } catch (ArithmeticException _) {
+      return Long.MAX_VALUE;
+    }
+  }
+
+  private synchronized void restartIfStillScheduled(String appId, int restartAttempt) {
+    RuntimeRecord scheduledRecord = runtimeRecords.get(appId);
+    if (scheduledRecord == null
+        || scheduledRecord.state() != AppRuntimeState.RESTARTING
+        || scheduledRecord.currentRestartAttempt() != restartAttempt) {
+      return;
+    }
+    if (explicitStopRequests.contains(appId)) {
+      runtimeRecords.put(appId, scheduledRecord.stopped());
+      return;
+    }
+    if (liveRunningProcess(appId) != null) {
+      return;
+    }
+    try {
+      InstalledAppSnapshot installation =
+          describe(appId).orElseThrow(() -> new AppHostException(APP_NOT_INSTALLED_PREFIX + appId));
+      launchInstalledApp(installation, restartAttempt, restartAttempt);
+    } catch (IOException _) {
+      recordRestartLaunchFailureIfUnchanged(appId, scheduledRecord, Instant.now());
+    }
+  }
+
+  private void recordRestartLaunchFailureIfUnchanged(
+      String appId, RuntimeRecord scheduledRecord, Instant failedAt) {
+    if (scheduledRecord.equals(runtimeRecords.get(appId))) {
+      runtimeRecords.put(appId, scheduledRecord.failedRestart(failedAt));
+    }
   }
 
   private static Path normalizeExistingDirectory(Path directory) throws IOException {
@@ -967,17 +1319,50 @@ public final class LocalProcessAppHost implements AppHost {
                 observeTrackedProcessTreeUntilExit(appId, process);
               } finally {
                 try {
-                  runningApps.computeIfPresent(
-                      appId,
-                      (ignoredAppId, activeProcess) ->
-                          activeProcess.process() == process && !activeProcess.isAlive()
-                              ? null
-                              : activeProcess);
+                  recordObservedProcessExit(appId, process);
                 } finally {
                   exitCleanup.complete(null);
                 }
               }
             });
+  }
+
+  private List<ProcessHandle> recoverStartupProcessTree(
+      InstalledAppSnapshot installation, String token, Instant startedAt, Process process)
+      throws AppHostException {
+    long deadline = System.nanoTime() + timing.trackedProcessPostExitCaptureGracePeriod().toNanos();
+    while (true) {
+      List<ProcessHandle> recoveredHandles =
+          aliveHandles(
+              recoverTrackedProcesses(
+                  installation.manifest(),
+                  installation.paths(),
+                  token,
+                  startedAt,
+                  List.of(process.toHandle()),
+                  ProcessHandle.allProcesses().toList()));
+      if (!recoveredHandles.isEmpty() || System.nanoTime() >= deadline) {
+        return recoveredHandles;
+      }
+      try {
+        TimeUnit.NANOSECONDS.sleep(timing.startupProcessPollInterval().toNanos());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AppHostException("interrupted while starting app: " + installation.appId(), e);
+      }
+    }
+  }
+
+  private void recordObservedProcessExit(String appId, Process process) {
+    runningApps.computeIfPresent(
+        appId,
+        (ignoredAppId, runningProcess) -> {
+          if (runningProcess.process() != process || runningProcess.isAlive()) {
+            return runningProcess;
+          }
+          recordExitAndScheduleRestartIfNeeded(appId, runningProcess);
+          return null;
+        });
   }
 
   private void observeTrackedProcessTreeUntilExit(String appId, Process process) {
@@ -990,6 +1375,7 @@ public final class LocalProcessAppHost implements AppHost {
                 trackedProcessRefreshIntervalNanos(startupTrackingDeadline), TimeUnit.NANOSECONDS);
         if (exited) {
           capturePostExitProcessTreeHandoff(appId, process);
+          observeTrackedHandoffProcessTreeUntilExit(appId, process);
           break;
         }
       }
@@ -998,6 +1384,21 @@ public final class LocalProcessAppHost implements AppHost {
     } finally {
       refreshObservedProcessTree(appId, process);
     }
+  }
+
+  private void observeTrackedHandoffProcessTreeUntilExit(String appId, Process process)
+      throws InterruptedException {
+    while (observedProcessTreeStillAlive(appId, process)) {
+      TimeUnit.NANOSECONDS.sleep(timing.trackedProcessRefreshInterval().toNanos());
+      refreshObservedProcessTree(appId, process);
+    }
+  }
+
+  private boolean observedProcessTreeStillAlive(String appId, Process process) {
+    RunningProcess runningProcess = runningApps.get(appId);
+    return runningProcess != null
+        && runningProcess.process() == process
+        && runningProcess.isAlive();
   }
 
   private void capturePostExitProcessTreeHandoff(String appId, Process process)
@@ -1725,6 +2126,10 @@ public final class LocalProcessAppHost implements AppHost {
     List<ProcessHandle> processTree = runningProcess.processTree();
     RunningProcess trackedRunningProcess = runningProcess.tryWithProcessTree(processTree);
     if (trackedRunningProcess == null) {
+      recordProcessExit(
+          appId,
+          ProcessExitRecord.fromRunningProcess(
+              runningProcess, trackedAppExitCode(runningProcess), Instant.now(), true));
       runningProcess.exitCleanup().join();
       runningApps.remove(appId, runningProcess);
       return null;
@@ -1742,6 +2147,7 @@ public final class LocalProcessAppHost implements AppHost {
       runningApps.put(appId, refreshedRunningProcess);
       return refreshedRunningProcess;
     }
+    recordExitAndScheduleRestartIfNeeded(appId, runningProcess);
     runningProcess.exitCleanup().join();
     runningApps.remove(appId, runningProcess);
     return null;
@@ -2183,22 +2589,228 @@ public final class LocalProcessAppHost implements AppHost {
         .pid();
   }
 
+  private record ProcessExitRecord(
+      InstalledAppPaths paths,
+      Integer exitCode,
+      Instant exitAt,
+      int restartCount,
+      int currentRestartAttempt,
+      String lastLaunchToken,
+      boolean explicitStop) {
+    private static ProcessExitRecord fromRunningProcess(
+        RunningProcess runningProcess, Integer exitCode, Instant exitAt, boolean explicitStop) {
+      return new ProcessExitRecord(
+          runningProcess.snapshot().paths(),
+          exitCode,
+          exitAt,
+          runningProcess.restartCount(),
+          runningProcess.currentRestartAttempt(),
+          runningProcess.snapshot().token(),
+          explicitStop);
+    }
+  }
+
+  private record LogMetadata(boolean available, Long sizeBytes) {}
+
+  private record RuntimeRecord(
+      InstalledAppPaths paths,
+      AppRuntimeState state,
+      boolean running,
+      Long pid,
+      Instant startedAt,
+      Instant lastExitAt,
+      Integer lastExitCode,
+      String lastLaunchToken,
+      int restartCount,
+      int currentRestartAttempt) {
+    private static RuntimeRecord running(
+        RunningProcess runningProcess, RuntimeRecord previousRecord) {
+      return running(
+          runningProcess.snapshot(),
+          runningProcess.restartCount(),
+          runningProcess.currentRestartAttempt(),
+          previousRecord);
+    }
+
+    private static RuntimeRecord running(
+        RunningAppSnapshot snapshot,
+        int restartCount,
+        int currentRestartAttempt,
+        RuntimeRecord previousRecord) {
+      return new RuntimeRecord(
+          snapshot.paths(),
+          AppRuntimeState.RUNNING,
+          true,
+          snapshot.pid(),
+          snapshot.startedAt(),
+          previousRecord == null ? null : previousRecord.lastExitAt(),
+          previousRecord == null ? null : previousRecord.lastExitCode(),
+          snapshot.token(),
+          restartCount,
+          currentRestartAttempt);
+    }
+
+    private static RuntimeRecord restarting(
+        RunningProcess runningProcess, Integer exitCode, Instant exitAt, int restartAttempt) {
+      return new RuntimeRecord(
+          runningProcess.snapshot().paths(),
+          AppRuntimeState.RESTARTING,
+          false,
+          null,
+          null,
+          exitAt,
+          exitCode,
+          runningProcess.snapshot().token(),
+          runningProcess.restartCount(),
+          restartAttempt);
+    }
+
+    private static RuntimeRecord stopped(InstalledAppPaths paths) {
+      return new RuntimeRecord(
+          paths, AppRuntimeState.STOPPED, false, null, null, null, null, null, 0, 0);
+    }
+
+    private static RuntimeRecord stopped(RunningProcess runningProcess) {
+      return new RuntimeRecord(
+          runningProcess.snapshot().paths(),
+          AppRuntimeState.STOPPED,
+          false,
+          null,
+          null,
+          Instant.now(),
+          trackedAppExitCode(runningProcess),
+          runningProcess.snapshot().token(),
+          runningProcess.restartCount(),
+          runningProcess.currentRestartAttempt());
+    }
+
+    private RuntimeRecord stopped() {
+      return new RuntimeRecord(
+          paths,
+          AppRuntimeState.STOPPED,
+          false,
+          null,
+          null,
+          lastExitAt,
+          lastExitCode,
+          lastLaunchToken,
+          restartCount,
+          currentRestartAttempt);
+    }
+
+    private RuntimeRecord failedRestart(Instant failedAt) {
+      return new RuntimeRecord(
+          paths,
+          AppRuntimeState.CRASHED,
+          false,
+          null,
+          null,
+          failedAt,
+          lastExitCode,
+          lastLaunchToken,
+          restartCount,
+          currentRestartAttempt);
+    }
+
+    private RuntimeRecord withoutRunningProcess(InstalledAppPaths installedPaths) {
+      if (running) {
+        return new RuntimeRecord(
+            installedPaths,
+            AppRuntimeState.STOPPED,
+            false,
+            null,
+            null,
+            lastExitAt,
+            lastExitCode,
+            lastLaunchToken,
+            restartCount,
+            currentRestartAttempt);
+      }
+      return paths.equals(installedPaths) ? this : withPaths(installedPaths);
+    }
+
+    private RuntimeRecord withPaths(InstalledAppPaths installedPaths) {
+      return new RuntimeRecord(
+          installedPaths,
+          state,
+          running,
+          pid,
+          startedAt,
+          lastExitAt,
+          lastExitCode,
+          lastLaunchToken,
+          restartCount,
+          currentRestartAttempt);
+    }
+
+    @Override
+    public @NotNull String toString() {
+      return "RuntimeRecord[paths="
+          + paths
+          + ", state="
+          + state
+          + ", running="
+          + running
+          + ", pid="
+          + pid
+          + ", startedAt="
+          + startedAt
+          + ", lastExitAt="
+          + lastExitAt
+          + ", lastExitCode="
+          + lastExitCode
+          + ", lastLaunchToken="
+          + (lastLaunchToken == null ? null : AppHostTokenRedactor.REDACTED)
+          + ", restartCount="
+          + restartCount
+          + ", currentRestartAttempt="
+          + currentRestartAttempt
+          + ']';
+    }
+  }
+
   @SuppressWarnings("ClassCanBeRecord")
   private static final class RunningProcess {
     private final Process process;
     private final RunningAppSnapshot snapshot;
     private final CompletableFuture<Void> exitCleanup;
     private final List<ProcessHandle> trackedHandles;
+    private final int restartCount;
+    private final int currentRestartAttempt;
+    private final boolean representativeProcessHandoff;
 
     private RunningProcess(
         Process process,
         RunningAppSnapshot snapshot,
         CompletableFuture<Void> exitCleanup,
-        List<ProcessHandle> trackedHandles) {
+        List<ProcessHandle> trackedHandles,
+        int restartCount,
+        int currentRestartAttempt) {
+      this(
+          process,
+          snapshot,
+          exitCleanup,
+          trackedHandles,
+          restartCount,
+          currentRestartAttempt,
+          false);
+    }
+
+    private RunningProcess(
+        Process process,
+        RunningAppSnapshot snapshot,
+        CompletableFuture<Void> exitCleanup,
+        List<ProcessHandle> trackedHandles,
+        int restartCount,
+        int currentRestartAttempt,
+        boolean representativeProcessHandoff) {
       this.process = Objects.requireNonNull(process, "process");
       this.snapshot = Objects.requireNonNull(snapshot, "snapshot");
       this.exitCleanup = Objects.requireNonNull(exitCleanup, "exitCleanup");
       this.trackedHandles = List.copyOf(Objects.requireNonNull(trackedHandles, "trackedHandles"));
+      this.restartCount = restartCount;
+      this.currentRestartAttempt = currentRestartAttempt;
+      this.representativeProcessHandoff = representativeProcessHandoff;
     }
 
     private Process process() {
@@ -2211,6 +2823,18 @@ public final class LocalProcessAppHost implements AppHost {
 
     private CompletableFuture<Void> exitCleanup() {
       return exitCleanup;
+    }
+
+    private int restartCount() {
+      return restartCount;
+    }
+
+    private int currentRestartAttempt() {
+      return currentRestartAttempt;
+    }
+
+    private boolean isRepresentativeProcessHandoff() {
+      return representativeProcessHandoff;
     }
 
     private boolean isAlive() {
@@ -2233,7 +2857,7 @@ public final class LocalProcessAppHost implements AppHost {
       if (currentProcessTree.isEmpty()) {
         return null;
       }
-      return tryWithProcessTree(currentProcessTree);
+      return tryWithAliveProcessTree(currentProcessTree);
     }
 
     private RunningProcess tryWithProcessTree(List<ProcessHandle> newProcessTree) {
@@ -2241,6 +2865,20 @@ public final class LocalProcessAppHost implements AppHost {
       if (aliveProcessTree.isEmpty()) {
         return null;
       }
+      return tryWithAliveProcessTree(aliveProcessTree);
+    }
+
+    private RunningProcess tryWithAliveProcessTree(List<ProcessHandle> aliveProcessTree) {
+      boolean rootProcessExited = rootProcessExited(aliveProcessTree);
+      if (!rootProcessExited && !isEffectivelyAlive(process.toHandle())) {
+        aliveProcessTree = withoutRootProcess(aliveProcessTree);
+        if (aliveProcessTree.isEmpty()) {
+          return null;
+        }
+        rootProcessExited = true;
+      }
+      boolean updatedRepresentativeProcessHandoff =
+          representativeProcessHandoff || rootProcessExited;
       long updatedPid = representativePid(aliveProcessTree, snapshot.pid(), false);
       RunningAppSnapshot updatedSnapshot =
           updatedPid == snapshot.pid()
@@ -2252,10 +2890,28 @@ public final class LocalProcessAppHost implements AppHost {
                   updatedPid,
                   snapshot.startedAt());
       if (trackedHandlePids().equals(handlePids(aliveProcessTree))
-          && updatedPid == snapshot.pid()) {
+          && updatedPid == snapshot.pid()
+          && updatedRepresentativeProcessHandoff == representativeProcessHandoff) {
         return this;
       }
-      return new RunningProcess(process, updatedSnapshot, exitCleanup, aliveProcessTree);
+      return new RunningProcess(
+          process,
+          updatedSnapshot,
+          exitCleanup,
+          aliveProcessTree,
+          restartCount,
+          currentRestartAttempt,
+          updatedRepresentativeProcessHandoff);
+    }
+
+    private boolean rootProcessExited(List<ProcessHandle> aliveProcessTree) {
+      long rootPid = process.pid();
+      return aliveProcessTree.stream().noneMatch(processHandle -> processHandle.pid() == rootPid);
+    }
+
+    private List<ProcessHandle> withoutRootProcess(List<ProcessHandle> processTree) {
+      long rootPid = process.pid();
+      return processTree.stream().filter(processHandle -> processHandle.pid() != rootPid).toList();
     }
 
     private List<Long> trackedHandlePids() {

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/AppRuntimeSnapshotsTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/AppRuntimeSnapshotsTest.java
@@ -1,0 +1,225 @@
+package network.crypta.platform.apphost;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AppRuntimeSnapshotsTest {
+  private static final Instant STARTED_AT = Instant.parse("2026-04-26T10:15:30Z");
+  private static final Instant EXITED_AT = Instant.parse("2026-04-26T10:16:30Z");
+  private static final Instant LOG_MODIFIED_AT = Instant.parse("2026-04-26T10:17:30Z");
+
+  @Test
+  void appProcessLogSnapshot_whenConstructed_expectNormalizedAppIdAndMetadata() {
+    AppProcessLogSnapshot snapshot =
+        new AppProcessLogSnapshot(" Mixed-App ", true, true, 512, 2048L, "tail", LOG_MODIFIED_AT);
+
+    assertEquals("mixed-app", snapshot.appId());
+    assertTrue(snapshot.available());
+    assertTrue(snapshot.truncated());
+    assertEquals(512, snapshot.maxBytes());
+    assertEquals(2048L, snapshot.sizeBytes());
+    assertEquals("tail", snapshot.text());
+    assertEquals(LOG_MODIFIED_AT, snapshot.lastModifiedAt());
+  }
+
+  @Test
+  void appProcessLogSnapshot_whenLogIsUnavailable_expectOptionalMetadataAllowed() {
+    AppProcessLogSnapshot snapshot =
+        new AppProcessLogSnapshot("sample-app", false, false, 1, 0L, "", null);
+
+    assertFalse(snapshot.available());
+    assertFalse(snapshot.truncated());
+    assertEquals("", snapshot.text());
+    assertNull(snapshot.lastModifiedAt());
+  }
+
+  @Test
+  void appProcessLogSnapshot_whenMaxBytesIsNonPositive_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new AppProcessLogSnapshot("sample-app", true, false, 0, 0L, "", null));
+
+    assertEquals("maxBytes must be positive", exception.getMessage());
+  }
+
+  @Test
+  void appProcessLogSnapshot_whenSizeBytesIsNegative_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new AppProcessLogSnapshot("sample-app", true, false, 1, -1L, "", null));
+
+    assertEquals("sizeBytes must be non-negative", exception.getMessage());
+  }
+
+  @Test
+  void appProcessLogSnapshot_whenTextIsNull_expectFailure() {
+    NullPointerException exception =
+        assertThrows(
+            NullPointerException.class,
+            () -> new AppProcessLogSnapshot("sample-app", true, false, 1, 0L, null, null));
+
+    assertEquals("text", exception.getMessage());
+  }
+
+  @Test
+  void appRuntimeStatusSnapshot_whenConstructed_expectNormalizedAppIdAndMetadata() {
+    AppRuntimeStatusSnapshot snapshot =
+        new AppRuntimeStatusSnapshot(
+            " Mixed-App ",
+            AppRuntimeState.RESTARTING,
+            false,
+            null,
+            null,
+            EXITED_AT,
+            7,
+            2,
+            3,
+            true,
+            4096L);
+
+    assertEquals("mixed-app", snapshot.appId());
+    assertEquals(AppRuntimeState.RESTARTING, snapshot.state());
+    assertFalse(snapshot.running());
+    assertNull(snapshot.pid());
+    assertNull(snapshot.startedAt());
+    assertEquals(EXITED_AT, snapshot.lastExitAt());
+    assertEquals(7, snapshot.lastExitCode());
+    assertEquals(2, snapshot.restartCount());
+    assertEquals(3, snapshot.currentRestartAttempt());
+    assertTrue(snapshot.logAvailable());
+    assertEquals(4096L, snapshot.logSizeBytes());
+  }
+
+  @Test
+  void appRuntimeStatusSnapshot_whenRunning_expectProcessMetadataAllowed() {
+    AppRuntimeStatusSnapshot snapshot =
+        new AppRuntimeStatusSnapshot(
+            "sample-app",
+            AppRuntimeState.RUNNING,
+            true,
+            42L,
+            STARTED_AT,
+            null,
+            null,
+            0,
+            0,
+            false,
+            null);
+
+    assertTrue(snapshot.running());
+    assertEquals(42L, snapshot.pid());
+    assertEquals(STARTED_AT, snapshot.startedAt());
+    assertNull(snapshot.lastExitAt());
+    assertNull(snapshot.lastExitCode());
+    assertFalse(snapshot.logAvailable());
+    assertNull(snapshot.logSizeBytes());
+  }
+
+  @Test
+  void appRuntimeStatusSnapshot_whenStateIsNull_expectFailure() {
+    NullPointerException exception =
+        assertThrows(
+            NullPointerException.class,
+            () ->
+                new AppRuntimeStatusSnapshot(
+                    "sample-app", null, false, null, null, null, null, 0, 0, false, null));
+
+    assertEquals("state", exception.getMessage());
+  }
+
+  @Test
+  void appRuntimeStatusSnapshot_whenPidIsNonPositive_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new AppRuntimeStatusSnapshot(
+                    "sample-app",
+                    AppRuntimeState.RUNNING,
+                    true,
+                    0L,
+                    STARTED_AT,
+                    null,
+                    null,
+                    0,
+                    0,
+                    false,
+                    null));
+
+    assertEquals("pid must be positive when present", exception.getMessage());
+  }
+
+  @Test
+  void appRuntimeStatusSnapshot_whenRestartCountIsNegative_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new AppRuntimeStatusSnapshot(
+                    "sample-app",
+                    AppRuntimeState.CRASHED,
+                    false,
+                    null,
+                    null,
+                    EXITED_AT,
+                    1,
+                    -1,
+                    0,
+                    false,
+                    null));
+
+    assertEquals("restartCount must be non-negative", exception.getMessage());
+  }
+
+  @Test
+  void appRuntimeStatusSnapshot_whenCurrentRestartAttemptIsNegative_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new AppRuntimeStatusSnapshot(
+                    "sample-app",
+                    AppRuntimeState.RESTARTING,
+                    false,
+                    null,
+                    null,
+                    EXITED_AT,
+                    1,
+                    0,
+                    -1,
+                    false,
+                    null));
+
+    assertEquals("currentRestartAttempt must be non-negative", exception.getMessage());
+  }
+
+  @Test
+  void appRuntimeStatusSnapshot_whenLogSizeBytesIsNegative_expectFailure() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new AppRuntimeStatusSnapshot(
+                    "sample-app",
+                    AppRuntimeState.EXITED,
+                    false,
+                    null,
+                    null,
+                    EXITED_AT,
+                    0,
+                    0,
+                    0,
+                    true,
+                    -1L));
+
+    assertEquals("logSizeBytes must be non-negative when present", exception.getMessage());
+  }
+}

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/RunningAppSnapshotTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/RunningAppSnapshotTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.apphost;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
@@ -68,6 +69,15 @@ class RunningAppSnapshotTest {
   }
 
   @Test
+  void redact_whenTokenAssignmentUsesColonAndWhitespace_expectAssignmentRedacted() {
+    String token = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    String redacted = AppHostTokenRedactor.redact("CRYPTAD_APP_TOKEN \t: \t" + token + "\n", null);
+
+    assertEquals("CRYPTAD_APP_TOKEN \t: \t[REDACTED]\n", redacted);
+  }
+
+  @Test
   void redact_whenKnownAppHostPathsAppearInLogText_expectPathRolesRedacted() {
     InstalledAppPaths paths = paths();
 
@@ -106,10 +116,13 @@ class RunningAppSnapshotTest {
     InstalledAppPaths shortPaths =
         new InstalledAppPaths(
             SAMPLE_APP_ID, Path.of("i"), Path.of("d"), Path.of("c"), Path.of("r"));
+    String longestAcceptedAssignment =
+        "CRYPTAD_APP_TOKEN" + " ".repeat(16) + ":" + " ".repeat(16) + "0".repeat(64);
 
     int overlapBytes = AppHostTokenRedactor.redactionOverlapBytes(null, shortPaths);
 
-    assertTrue(overlapBytes >= "CRYPTAD_APP_TOKEN=".length() + 64 - 1);
+    assertTrue(
+        overlapBytes >= longestAcceptedAssignment.getBytes(StandardCharsets.UTF_8).length - 1);
   }
 
   private InstalledAppPaths paths() {

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/RunningAppSnapshotTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/RunningAppSnapshotTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RunningAppSnapshotTest {
   private static final String SAMPLE_APP_ID = "sample-app";
@@ -40,6 +42,74 @@ class RunningAppSnapshotTest {
             () -> new RunningAppSnapshot(SAMPLE_MANIFEST, paths, "token", 0L, Instant.EPOCH));
 
     assertEquals("pid must be positive", exception.getMessage());
+  }
+
+  @Test
+  void toString_whenSnapshotContainsTokenAndPaths_expectRedactedDiagnosticText() {
+    InstalledAppPaths paths = paths();
+    RunningAppSnapshot snapshot =
+        new RunningAppSnapshot(SAMPLE_MANIFEST, paths, "secret-token", 123L, Instant.EPOCH);
+
+    String text = snapshot.toString();
+
+    assertTrue(text.contains("token=[REDACTED]"));
+    assertFalse(text.contains("secret-token"));
+    assertFalse(text.contains(paths.installedRoot().toString()));
+    assertFalse(text.contains(paths.runDir().toString()));
+  }
+
+  @Test
+  void redact_whenTokenAppearsInLogText_expectAssignmentAndExactTokenRedacted() {
+    String redacted =
+        AppHostTokenRedactor.redact(
+            "CRYPTAD_APP_TOKEN=secret-token\nraw secret-token", "secret-token");
+
+    assertEquals("CRYPTAD_APP_TOKEN=[REDACTED]\nraw [REDACTED]", redacted);
+  }
+
+  @Test
+  void redact_whenKnownAppHostPathsAppearInLogText_expectPathRolesRedacted() {
+    InstalledAppPaths paths = paths();
+
+    String redacted =
+        AppHostTokenRedactor.redact(
+            """
+            cwd=%s
+            data=%s
+            cache=%s
+            run=%s
+            log=%s
+            """
+                .formatted(
+                    paths.installedRoot(),
+                    paths.dataDir(),
+                    paths.cacheDir(),
+                    paths.runDir(),
+                    paths.processLogFile()),
+            "token",
+            paths);
+
+    assertFalse(redacted.contains(paths.installedRoot().toString()));
+    assertFalse(redacted.contains(paths.dataDir().toString()));
+    assertFalse(redacted.contains(paths.cacheDir().toString()));
+    assertFalse(redacted.contains(paths.runDir().toString()));
+    assertFalse(redacted.contains(paths.processLogFile().toString()));
+    assertTrue(redacted.contains("cwd=[APP_INSTALL_DIR]"));
+    assertTrue(redacted.contains("data=[APP_DATA_DIR]"));
+    assertTrue(redacted.contains("cache=[APP_CACHE_DIR]"));
+    assertTrue(redacted.contains("run=[APP_RUN_DIR]"));
+    assertTrue(redacted.contains("log=[APP_PROCESS_LOG]"));
+  }
+
+  @Test
+  void redactionOverlapBytes_whenTokenUnknown_expectAssignmentOverlapReserved() {
+    InstalledAppPaths shortPaths =
+        new InstalledAppPaths(
+            SAMPLE_APP_ID, Path.of("i"), Path.of("d"), Path.of("c"), Path.of("r"));
+
+    int overlapBytes = AppHostTokenRedactor.redactionOverlapBytes(null, shortPaths);
+
+    assertTrue(overlapBytes >= "CRYPTAD_APP_TOKEN=".length() + 64 - 1);
   }
 
   private InstalledAppPaths paths() {

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 import network.crypta.fs.AppEnv;
+import network.crypta.platform.appdist.AppRestartPolicy;
 import network.crypta.platform.appdist.AppUiMode;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,9 @@ class AppManifestParserTest {
             app.permissions=network.read, ui.open
             quota.data.bytes=1048576
             quota.cache.bytes=2048
+            app.restart.policy=on-failure
+            app.restart.maxAttempts=2
+            app.restart.backoff.ms=50
             """);
 
     assertEquals(1, manifest.manifestVersion());
@@ -64,6 +68,9 @@ class AppManifestParserTest {
     assertEquals(java.util.List.of("network.read", "ui.open"), manifest.permissions());
     assertEquals(Long.valueOf(1048576L), manifest.dataQuotaBytes());
     assertEquals(Long.valueOf(2048L), manifest.cacheQuotaBytes());
+    assertEquals(AppRestartPolicy.ON_FAILURE, manifest.restartPolicy());
+    assertEquals(2, manifest.restartMaxAttempts());
+    assertEquals(50L, manifest.restartBackoffMillis());
   }
 
   @Test

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -1197,6 +1197,24 @@ class LocalProcessAppHostTest {
   }
 
   @Test
+  void processLogTail_whenUnknownTokenColonAssignmentIsSplit_expectAssignmentRedacted()
+      throws IOException {
+    AppHost host = allowUnsignedHost();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
+    String token = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    String assignment = "CRYPTAD_APP_TOKEN" + " ".repeat(16) + ":" + " ".repeat(16) + token;
+    Files.writeString(installation.paths().processLogFile(), assignment, StandardCharsets.UTF_8);
+
+    AppProcessLogSnapshot logTail = host.readProcessLogTail(RUNNER_APP_ID, 32);
+
+    assertTrue(logTail.available());
+    assertTrue(logTail.truncated());
+    assertTrue(logTail.text().contains("[REDACTED]"));
+    assertFalse(logTail.text().contains(token.substring(token.length() - 32)));
+    assertFalse(logTail.text().matches("(?s).*[0-9a-f]{8}.*"));
+  }
+
+  @Test
   void processLogTail_whenMaxBytesSmall_expectTailIsBoundedAndRedacted() throws IOException {
     AppEnv appEnv = new AppEnv();
     Assumptions.assumeFalse(appEnv.isWindows());

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -9,13 +9,18 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.time.Duration;
@@ -24,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -44,8 +50,12 @@ import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
 import network.crypta.platform.apphost.AppHostLayout;
 import network.crypta.platform.apphost.AppInstallVerificationPolicy;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeState;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.OwnerOnlyFilePermissions;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.manifest.AppManifestException;
@@ -73,12 +83,19 @@ class LocalProcessAppHostTest {
   private static final String NORMALIZED_MIXED_CASE_APP_ID = "mixedcase-app";
   private static final String PYTHON_DAEMON_APP_ID = "python-daemon-app";
   private static final String APP_VERSION = "2.0.0";
+  private static final String UPDATED_APP_VERSION = "3.0.0";
   private static final String DEFAULT_TOKEN = "token";
   private static final String CACHE_DIR_NAME = "cache";
   private static final String INSTALLED_DIR_NAME = "installed";
+  private static final String STAGE_UPDATE_DIR_NAME = "stage-update";
   private static final String INSTALLED_APPS_DIR_SYMLINK_MESSAGE =
       "installedAppsDir must not be a symlink";
   private static final String CONTENT_FILE_NAME = "content.txt";
+  private static final String NEW_BUNDLE_FILE_NAME = "new-bundle.txt";
+  private static final String NEW_BUNDLE_CONTENT = "new-bundle\n";
+  private static final String PROCESS_LOG_FILE_NAME = "process.log";
+  private static final String SIGNED_BUNDLE_REQUIRED_MESSAGE =
+      "signed app bundle verification is required";
   private static final String POSIX_LAUNCH_PATH = "bin/launch";
   private static final String STARTUP_EXIT_MESSAGE_PREFIX = "app exited during startup: ";
   private static final String WINDOWS_11 = "Windows 11";
@@ -117,6 +134,7 @@ class LocalProcessAppHostTest {
       TEST_TIMING.startupExitGracePeriod().plusMillis(25);
   private static final Duration TEST_POST_SPAWN_EXIT_DELAY = Duration.ofMillis(40);
   private static final Duration TEST_SHORT_EXIT_DELAY = Duration.ofMillis(50);
+  private static final Duration TEST_CLEAN_CHILD_EXIT_DELAY = Duration.ofMillis(500);
   private static final String TEST_LOOP_SLEEP_SECONDS = secondsLiteral(TEST_LOOP_SLEEP);
   private static final String TEST_DELAYED_WRAPPER_EXIT_SECONDS =
       secondsLiteral(TEST_DELAYED_WRAPPER_EXIT);
@@ -126,6 +144,8 @@ class LocalProcessAppHostTest {
   private static final String TEST_POST_SPAWN_EXIT_DELAY_SECONDS =
       secondsLiteral(TEST_POST_SPAWN_EXIT_DELAY);
   private static final String TEST_SHORT_EXIT_DELAY_SECONDS = secondsLiteral(TEST_SHORT_EXIT_DELAY);
+  private static final String TEST_CLEAN_CHILD_EXIT_DELAY_SECONDS =
+      secondsLiteral(TEST_CLEAN_CHILD_EXIT_DELAY);
   private static final String LATE_CHILD_APP_ID = "late-child-app";
   private static final String SHELL_NOEXEC_APP_ID = "shell-noexec-app";
   private static final String WRAPPER_SCRIPT =
@@ -284,6 +304,136 @@ class LocalProcessAppHostTest {
       exit 0
       """
           .formatted(TEST_SHORT_EXIT_DELAY_SECONDS);
+  private static final String WORKING_DIRECTORY_AND_TOKEN_LOG_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      pwd > "$CRYPTAD_APP_RUN_DIR/cwd.txt"
+      echo "cwd=$(pwd)"
+      echo "CRYPTAD_APP_DATA_DIR=$CRYPTAD_APP_DATA_DIR"
+      echo "CRYPTAD_APP_CACHE_DIR=$CRYPTAD_APP_CACHE_DIR"
+      echo "CRYPTAD_APP_RUN_DIR=$CRYPTAD_APP_RUN_DIR"
+      echo "process-log=$CRYPTAD_APP_RUN_DIR/%s"
+      echo "CRYPTAD_APP_TOKEN=$CRYPTAD_APP_TOKEN"
+      echo "raw-token=$CRYPTAD_APP_TOKEN"
+      while :; do
+        sleep %s
+      done
+      """
+          .formatted(PROCESS_LOG_FILE_NAME, TEST_LOOP_SLEEP_SECONDS);
+  private static final String IMMEDIATE_TOKEN_CRASH_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      echo "raw-token=$CRYPTAD_APP_TOKEN"
+      exit 7
+      """;
+  private static final String IMMEDIATE_CRASH_SCRIPT =
+      """
+      #!/bin/sh
+      exit 7
+      """;
+  private static final String RESTART_ON_FAILURE_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      count_file="$CRYPTAD_APP_RUN_DIR/restart-count.txt"
+      count=0
+      if [ -f "$count_file" ]; then
+        count="$(cat "$count_file")"
+      fi
+      count=$((count + 1))
+      printf '%%s\\n' "$count" > "$count_file"
+      if [ "$count" -eq 1 ]; then
+        sleep 0.500
+        exit 7
+      fi
+      trap 'exit 0' TERM INT
+      while :; do
+        sleep %s
+      done
+      """
+          .formatted(TEST_LOOP_SLEEP_SECONDS);
+  private static final String WAITING_WRAPPER_CLEAN_EXIT_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      count_file="$CRYPTAD_APP_RUN_DIR/wait-wrapper-run-count.txt"
+      count=0
+      if [ -f "$count_file" ]; then
+        count="$(cat "$count_file")"
+      fi
+      count=$((count + 1))
+      printf '%%s\\n' "$count" > "$count_file"
+      ./%s &
+      child=$!
+      echo "$child" > "$CRYPTAD_APP_RUN_DIR/%s"
+      wait "$child"
+      """
+          .formatted(CHILD_SCRIPT_PATH, CHILD_PID_FILE_NAME);
+  private static final String CLEAN_EXIT_CHILD_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      sleep %s
+      exit 0
+      """
+          .formatted(TEST_CLEAN_CHILD_EXIT_DELAY_SECONDS);
+  private static final String RESTART_ATTEMPT_STARTUP_FAILURE_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      count_file="$CRYPTAD_APP_RUN_DIR/restart-startup-failure-count.txt"
+      count=0
+      if [ -f "$count_file" ]; then
+        count="$(cat "$count_file")"
+      fi
+      count=$((count + 1))
+      printf '%s\\n' "$count" > "$count_file"
+      if [ "$count" -eq 1 ]; then
+        sleep 0.500
+        exit 7
+      fi
+      exit 9
+      """;
+  private static final String DAEMONIZED_RESTART_ON_FAILURE_CHILD_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      count_file="$CRYPTAD_APP_RUN_DIR/daemonized-restart-count.txt"
+      count=0
+      if [ -f "$count_file" ]; then
+        count="$(cat "$count_file")"
+      fi
+      count=$((count + 1))
+      printf '%%s\\n' "$count" > "$count_file"
+      if [ "$count" -eq 1 ]; then
+        sleep 0.500
+        exit 7
+      fi
+      trap 'exit 0' TERM INT
+      while :; do
+        sleep %s
+      done
+      """
+          .formatted(TEST_LOOP_SLEEP_SECONDS);
+  private static final String RESTART_STOP_SUPPRESSION_SCRIPT =
+      """
+      #!/bin/sh
+      set -eu
+      count_file="$CRYPTAD_APP_RUN_DIR/restart-count.txt"
+      count=0
+      if [ -f "$count_file" ]; then
+        count="$(cat "$count_file")"
+      fi
+      count=$((count + 1))
+      printf '%%s\\n' "$count" > "$count_file"
+      trap 'exit 7' TERM INT
+      while :; do
+        sleep %s
+      done
+      """
+          .formatted(TEST_LOOP_SLEEP_SECONDS);
 
   @TempDir private Path tempDir;
 
@@ -297,7 +447,7 @@ class LocalProcessAppHostTest {
         assertThrows(
             AppBundleVerificationException.class, () -> host.installFromDirectory(stagedApp));
 
-    assertEquals("signed app bundle verification is required", exception.getMessage());
+    assertEquals(SIGNED_BUNDLE_REQUIRED_MESSAGE, exception.getMessage());
     assertTrue(host.describe(SAMPLE_APP_ID).isEmpty());
     assertEquals(List.of(), host.listInstalled());
   }
@@ -310,8 +460,7 @@ class LocalProcessAppHostTest {
         requireSignedHost(
             copiedBundleDirectory -> {
               verifiedBundle.set(copiedBundleDirectory);
-              throw new AppBundleVerificationException(
-                  "signed app bundle verification is required");
+              throw new AppBundleVerificationException(SIGNED_BUNDLE_REQUIRED_MESSAGE);
             });
     Path stagedApp = stageInstalledApp(SAMPLE_APP_ID);
     Files.writeString(stagedApp.resolve(MANIFEST_FILE_NAME), "manifest.version=1\n");
@@ -321,7 +470,7 @@ class LocalProcessAppHostTest {
             AppBundleVerificationException.class, () -> host.installFromDirectory(stagedApp));
 
     Path copiedBundle = verifiedBundle.get();
-    assertEquals("signed app bundle verification is required", exception.getMessage());
+    assertEquals(SIGNED_BUNDLE_REQUIRED_MESSAGE, exception.getMessage());
     assertNotNull(copiedBundle);
     assertNotEquals(stagedApp.toAbsolutePath().normalize(), copiedBundle);
     assertTrue(copiedBundle.startsWith(layout().installedAppsDir()));
@@ -416,28 +565,28 @@ class LocalProcessAppHostTest {
     Path updatedStage =
         signBundle(
             stageInstalledAppAt(
-                tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
+                tempDir.resolve(STAGE_UPDATE_DIR_NAME).resolve(SAMPLE_APP_ID),
                 SAMPLE_APP_ID,
-                "3.0.0",
+                UPDATED_APP_VERSION,
                 """
                 #!/bin/sh
                 printf 'new\\n'
                 """,
-                Map.of("new-bundle.txt", "new-bundle\n")),
+                Map.of(NEW_BUNDLE_FILE_NAME, NEW_BUNDLE_CONTENT)),
             keyPair);
 
     InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
 
-    assertEquals("3.0.0", updated.manifest().appVersion());
+    assertEquals(UPDATED_APP_VERSION, updated.manifest().appVersion());
     assertEquals(installation.paths(), updated.paths());
     assertEquals("keep-data", Files.readString(dataSentinel, StandardCharsets.UTF_8));
     assertEquals("keep-cache", Files.readString(cacheSentinel, StandardCharsets.UTF_8));
     assertEquals("keep-run", Files.readString(runSentinel, StandardCharsets.UTF_8));
     assertFalse(Files.exists(updated.paths().installedRoot().resolve("bundle-only.txt")));
     assertEquals(
-        "new-bundle\n",
+        NEW_BUNDLE_CONTENT,
         Files.readString(
-            updated.paths().installedRoot().resolve("new-bundle.txt"), StandardCharsets.UTF_8));
+            updated.paths().installedRoot().resolve(NEW_BUNDLE_FILE_NAME), StandardCharsets.UTF_8));
     assertEquals(
         """
         #!/bin/sh
@@ -445,7 +594,8 @@ class LocalProcessAppHostTest {
         """,
         Files.readString(
             updated.paths().executablePath(updated.manifest()), StandardCharsets.UTF_8));
-    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(
+        UPDATED_APP_VERSION, host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
     assertEquals(List.of(updated), host.listInstalled());
   }
 
@@ -488,14 +638,13 @@ class LocalProcessAppHostTest {
         requireSignedHost(
             copiedBundleDirectory -> {
               verifiedBundle.set(copiedBundleDirectory);
-              throw new AppBundleVerificationException(
-                  "signed app bundle verification is required");
+              throw new AppBundleVerificationException(SIGNED_BUNDLE_REQUIRED_MESSAGE);
             });
     Path updatedStage =
         stageInstalledAppAt(
             tempDir.resolve("stage-update-unsigned").resolve(SAMPLE_APP_ID),
             SAMPLE_APP_ID,
-            "3.0.0",
+            UPDATED_APP_VERSION,
             scriptContent(new AppEnv()),
             Map.of());
     Files.writeString(updatedStage.resolve(MANIFEST_FILE_NAME), "manifest.version=1\n");
@@ -506,7 +655,7 @@ class LocalProcessAppHostTest {
             () -> host.updateFromDirectory(SAMPLE_APP_ID, updatedStage));
 
     Path copiedBundle = verifiedBundle.get();
-    assertEquals("signed app bundle verification is required", exception.getMessage());
+    assertEquals(SIGNED_BUNDLE_REQUIRED_MESSAGE, exception.getMessage());
     assertNotNull(copiedBundle);
     assertNotEquals(updatedStage.toAbsolutePath().normalize(), copiedBundle);
     assertTrue(copiedBundle.startsWith(layout().installedAppsDir()));
@@ -523,7 +672,7 @@ class LocalProcessAppHostTest {
         stageInstalledAppAt(
             tempDir.resolve("stage-repair").resolve(SAMPLE_APP_ID),
             SAMPLE_APP_ID,
-            "3.0.0",
+            UPDATED_APP_VERSION,
             """
             #!/bin/sh
             printf 'repaired\\n'
@@ -532,8 +681,9 @@ class LocalProcessAppHostTest {
 
     InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
 
-    assertEquals("3.0.0", updated.manifest().appVersion());
-    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(UPDATED_APP_VERSION, updated.manifest().appVersion());
+    assertEquals(
+        UPDATED_APP_VERSION, host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
     assertEquals(
         "repair-bundle\n",
         Files.readString(
@@ -547,9 +697,9 @@ class LocalProcessAppHostTest {
     host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Path mismatchedStage =
         stageInstalledAppAt(
-            tempDir.resolve("stage-update").resolve(DUPLICATE_APP_ID),
+            tempDir.resolve(STAGE_UPDATE_DIR_NAME).resolve(DUPLICATE_APP_ID),
             DUPLICATE_APP_ID,
-            "3.0.0",
+            UPDATED_APP_VERSION,
             scriptContent(new AppEnv()),
             Map.of());
 
@@ -582,22 +732,23 @@ class LocalProcessAppHostTest {
     Files.delete(installation.paths().manifestFile());
     Path updatedStage =
         stageInstalledAppAt(
-            tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
+            tempDir.resolve(STAGE_UPDATE_DIR_NAME).resolve(SAMPLE_APP_ID),
             SAMPLE_APP_ID,
-            "3.0.0",
+            UPDATED_APP_VERSION,
             scriptContent(new AppEnv()),
-            Map.of("new-bundle.txt", "new-bundle\n"));
+            Map.of(NEW_BUNDLE_FILE_NAME, NEW_BUNDLE_CONTENT));
 
     assertThrows(IOException.class, () -> host.describe(SAMPLE_APP_ID));
 
     InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
 
-    assertEquals("3.0.0", updated.manifest().appVersion());
-    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(UPDATED_APP_VERSION, updated.manifest().appVersion());
     assertEquals(
-        "new-bundle\n",
+        UPDATED_APP_VERSION, host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(
+        NEW_BUNDLE_CONTENT,
         Files.readString(
-            updated.paths().installedRoot().resolve("new-bundle.txt"), StandardCharsets.UTF_8));
+            updated.paths().installedRoot().resolve(NEW_BUNDLE_FILE_NAME), StandardCharsets.UTF_8));
   }
 
   @Test
@@ -613,16 +764,17 @@ class LocalProcessAppHostTest {
     host.installFromDirectory(stageInstalledApp(SAMPLE_APP_ID));
     Path updatedStage =
         stageInstalledAppAt(
-            tempDir.resolve("stage-update").resolve(SAMPLE_APP_ID),
+            tempDir.resolve(STAGE_UPDATE_DIR_NAME).resolve(SAMPLE_APP_ID),
             SAMPLE_APP_ID,
-            "3.0.0",
+            UPDATED_APP_VERSION,
             scriptContent(new AppEnv()),
-            Map.of("new-bundle.txt", "new-bundle\n"));
+            Map.of(NEW_BUNDLE_FILE_NAME, NEW_BUNDLE_CONTENT));
 
     InstalledAppSnapshot updated = host.updateFromDirectory(SAMPLE_APP_ID, updatedStage);
 
-    assertEquals("3.0.0", updated.manifest().appVersion());
-    assertEquals("3.0.0", host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
+    assertEquals(UPDATED_APP_VERSION, updated.manifest().appVersion());
+    assertEquals(
+        UPDATED_APP_VERSION, host.describe(SAMPLE_APP_ID).orElseThrow().manifest().appVersion());
     try (var entries = Files.list(updated.paths().installedRoot().getParent())) {
       assertTrue(
           entries.anyMatch(
@@ -653,6 +805,40 @@ class LocalProcessAppHostTest {
     } finally {
       host.stop(RUNNER_APP_ID);
     }
+  }
+
+  @Test
+  void updateFromDirectory_whenRestartPending_expectAcceptedUpdateCancelsRestart()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    Path stagedApp = stageInstalledRunnerApp(RESTART_ON_FAILURE_SCRIPT);
+    appendOnFailureRestartPolicy(stagedApp, 750);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    host.start(RUNNER_APP_ID);
+    waitForRuntimeState(host, AppRuntimeState.RESTARTING);
+    Path updatedRunMarker = installation.paths().runDir().resolve("updated-ran.txt");
+    Path updatedStage =
+        stageInstalledAppAt(
+            tempDir.resolve("stage-update-restarting").resolve(RUNNER_APP_ID),
+            RUNNER_APP_ID,
+            UPDATED_APP_VERSION,
+            """
+            #!/bin/sh
+            set -eu
+            printf 'updated\\n' > "$CRYPTAD_APP_RUN_DIR/updated-ran.txt"
+            exit 0
+            """,
+            Map.of());
+
+    InstalledAppSnapshot updated = host.updateFromDirectory(RUNNER_APP_ID, updatedStage);
+    LockSupport.parkNanos(Duration.ofSeconds(1).toNanos());
+
+    assertEquals(UPDATED_APP_VERSION, updated.manifest().appVersion());
+    assertFalse(Files.exists(updatedRunMarker));
+    assertEquals(AppRuntimeState.STOPPED, host.runtimeStatus(RUNNER_APP_ID).state());
   }
 
   @Test
@@ -893,6 +1079,49 @@ class LocalProcessAppHostTest {
   }
 
   @Test
+  void start_whenAppRuns_expectWorkingDirectoryRuntimeStatusAndRedactedLog() throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    InstalledAppSnapshot installation =
+        host.installFromDirectory(stageInstalledRunnerApp(WORKING_DIRECTORY_AND_TOKEN_LOG_SCRIPT));
+
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+
+    Path cwdFile = installation.paths().runDir().resolve("cwd.txt");
+    waitForFile(cwdFile);
+    waitForFile(installation.paths().processLogFile());
+    assertEquals(
+        installation.paths().installedRoot().toString(),
+        Files.readString(cwdFile, StandardCharsets.UTF_8).trim());
+
+    AppRuntimeStatusSnapshot status = host.runtimeStatus(RUNNER_APP_ID);
+    assertEquals(AppRuntimeState.RUNNING, status.state());
+    assertTrue(status.running());
+    assertNotNull(status.pid());
+    assertTrue(status.logAvailable());
+
+    AppProcessLogSnapshot logTail = host.readProcessLogTail(RUNNER_APP_ID, 4096);
+    assertTrue(logTail.available());
+    assertFalse(logTail.text().contains(running.token()));
+    assertFalse(logTail.text().contains(installation.paths().installedRoot().toString()));
+    assertFalse(logTail.text().contains(installation.paths().dataDir().toString()));
+    assertFalse(logTail.text().contains(installation.paths().cacheDir().toString()));
+    assertFalse(logTail.text().contains(installation.paths().runDir().toString()));
+    assertFalse(logTail.text().contains(installation.paths().processLogFile().toString()));
+    assertTrue(logTail.text().contains("cwd=[APP_INSTALL_DIR]"));
+    assertTrue(logTail.text().contains("CRYPTAD_APP_DATA_DIR=[APP_DATA_DIR]"));
+    assertTrue(logTail.text().contains("CRYPTAD_APP_CACHE_DIR=[APP_CACHE_DIR]"));
+    assertTrue(logTail.text().contains("CRYPTAD_APP_RUN_DIR=[APP_RUN_DIR]"));
+    assertTrue(logTail.text().contains("process-log=[APP_PROCESS_LOG]"));
+    assertTrue(logTail.text().contains("CRYPTAD_APP_TOKEN=[REDACTED]"));
+    assertTrue(logTail.text().contains("raw-token=[REDACTED]"));
+
+    assertTrue(host.stop(RUNNER_APP_ID));
+    assertEquals(AppRuntimeState.STOPPED, host.runtimeStatus(RUNNER_APP_ID).state());
+  }
+
+  @Test
   void start_whenInstalledProcessExitsImmediately_expectFailureAndNoRunningState()
       throws IOException {
     AppHost host = allowUnsignedHost();
@@ -907,6 +1136,233 @@ class LocalProcessAppHostTest {
     assertTrue(elapsed.compareTo(Duration.ofSeconds(3)) < 0);
     assertTrue(host.status(RUNNER_APP_ID).isEmpty());
     assertTrue(host.listRunning().isEmpty());
+    AppRuntimeStatusSnapshot status = host.runtimeStatus(RUNNER_APP_ID);
+    assertEquals(AppRuntimeState.EXITED, status.state());
+    assertEquals(0, status.lastExitCode());
+  }
+
+  @Test
+  void start_whenInstalledProcessCrashesImmediately_expectCrashedRuntimeStatus()
+      throws IOException {
+    AppHost host = allowUnsignedHost();
+    host.installFromDirectory(stageInstalledRunnerApp(IMMEDIATE_CRASH_SCRIPT));
+
+    AppHostException exception =
+        assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+
+    assertTrue(exception.getMessage().contains(STARTUP_EXIT_MESSAGE_PREFIX + RUNNER_APP_ID));
+    AppRuntimeStatusSnapshot status = host.runtimeStatus(RUNNER_APP_ID);
+    assertEquals(AppRuntimeState.CRASHED, status.state());
+    assertEquals(7, status.lastExitCode());
+  }
+
+  @Test
+  void processLogTail_whenExitedProcessPrintedRawToken_expectLastLaunchTokenRedacted()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    host.installFromDirectory(stageInstalledRunnerApp(IMMEDIATE_TOKEN_CRASH_SCRIPT));
+
+    assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
+
+    AppProcessLogSnapshot logTail = host.readProcessLogTail(RUNNER_APP_ID, 4096);
+    assertTrue(logTail.available());
+    assertTrue(logTail.text().contains("raw-token=[REDACTED]"));
+    assertFalse(logTail.text().matches("(?s).*raw-token=[0-9a-f]{64}.*"));
+    AppProcessLogSnapshot smallLogTail = host.readProcessLogTail(RUNNER_APP_ID, 12);
+    assertTrue(smallLogTail.available());
+    assertFalse(smallLogTail.text().matches("(?s).*[0-9a-f]{8}.*"));
+  }
+
+  @Test
+  void processLogTail_whenTailStartsInsideKnownPath_expectPathRedactedBeforeTrim()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    InstalledAppSnapshot installation = host.installFromDirectory(stageInstalledApp(RUNNER_APP_ID));
+    Files.writeString(
+        installation.paths().processLogFile(),
+        "path=" + installation.paths().dataDir() + "\n",
+        StandardCharsets.UTF_8);
+
+    AppProcessLogSnapshot logTail = host.readProcessLogTail(RUNNER_APP_ID, 16);
+
+    assertTrue(logTail.available());
+    assertTrue(logTail.truncated());
+    assertTrue(logTail.text().contains("[APP_DATA_DIR]"));
+    assertFalse(logTail.text().contains("/"));
+    assertFalse(logTail.text().contains(installation.paths().dataDir().toString()));
+  }
+
+  @Test
+  void processLogTail_whenMaxBytesSmall_expectTailIsBoundedAndRedacted() throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    InstalledAppSnapshot installation =
+        host.installFromDirectory(stageInstalledRunnerApp(WORKING_DIRECTORY_AND_TOKEN_LOG_SCRIPT));
+    RunningAppSnapshot running = host.start(RUNNER_APP_ID);
+    waitForFile(installation.paths().processLogFile());
+
+    AppProcessLogSnapshot logTail = host.readProcessLogTail(RUNNER_APP_ID, 24);
+
+    assertTrue(logTail.available());
+    assertTrue(logTail.truncated());
+    assertEquals(24, logTail.maxBytes());
+    assertFalse(logTail.text().contains(running.token()));
+    assertTrue(logTail.text().length() <= 64);
+    assertTrue(host.stop(RUNNER_APP_ID));
+  }
+
+  @Test
+  void restartPolicy_whenOnFailureConfigured_expectBoundedRestartAndVisibleAttempt()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    Path stagedApp = stageInstalledRunnerApp(RESTART_ON_FAILURE_SCRIPT);
+    appendOnFailureRestartPolicy(stagedApp, 10);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    host.start(RUNNER_APP_ID);
+
+    Path runCountFile = installation.paths().runDir().resolve("restart-count.txt");
+    waitForFileContent(runCountFile, "2\n");
+    AppRuntimeStatusSnapshot status = waitForRuntimeState(host, AppRuntimeState.RUNNING);
+    assertEquals(1, status.currentRestartAttempt());
+    assertEquals(1, status.restartCount());
+    assertEquals(7, status.lastExitCode());
+    assertNotNull(status.lastExitAt());
+
+    assertTrue(host.stop(RUNNER_APP_ID));
+  }
+
+  @Test
+  void restartPolicy_whenShellWrapperWaitsForCleanChildExit_expectNoFailureRestart()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            WAITING_WRAPPER_CLEAN_EXIT_SCRIPT,
+            Map.of(CHILD_SCRIPT_PATH, CLEAN_EXIT_CHILD_SCRIPT));
+    appendOnFailureRestartPolicy(stagedApp, 10);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    host.start(RUNNER_APP_ID);
+
+    Path runCountFile = installation.paths().runDir().resolve("wait-wrapper-run-count.txt");
+    waitForFileContent(runCountFile, "1\n");
+    AppRuntimeStatusSnapshot status = waitForRuntimeState(host, AppRuntimeState.EXITED);
+    assertEquals(0, status.lastExitCode());
+    assertEquals(0, status.currentRestartAttempt());
+    assertEquals(0, status.restartCount());
+    assertEquals("1\n", Files.readString(runCountFile, StandardCharsets.UTF_8));
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+  }
+
+  @Test
+  void restartPolicy_whenDaemonizedChildDisappears_expectUnknownExitRestarts() throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            DAEMONIZING_WRAPPER_IMMEDIATE_EXIT_SCRIPT,
+            Map.of(CHILD_SCRIPT_PATH, DAEMONIZED_RESTART_ON_FAILURE_CHILD_SCRIPT));
+    appendOnFailureRestartPolicy(stagedApp, 300);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    host.start(RUNNER_APP_ID);
+
+    Path runCountFile = installation.paths().runDir().resolve("daemonized-restart-count.txt");
+    waitForFileContent(runCountFile, "1\n");
+    waitForRuntimeState(host, AppRuntimeState.RESTARTING);
+    waitForFileContent(runCountFile, "2\n");
+    AppRuntimeStatusSnapshot status = waitForRuntimeState(host, AppRuntimeState.RUNNING);
+    assertEquals(1, status.currentRestartAttempt());
+    assertEquals(1, status.restartCount());
+
+    assertTrue(host.stop(RUNNER_APP_ID));
+  }
+
+  @Test
+  void restartPolicy_whenDaemonizedChildExitsWithoutPolling_expectObserverRestarts()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    Path stagedApp =
+        stageInstalledApp(
+            RUNNER_APP_ID,
+            DAEMONIZING_WRAPPER_IMMEDIATE_EXIT_SCRIPT,
+            Map.of(CHILD_SCRIPT_PATH, DAEMONIZED_RESTART_ON_FAILURE_CHILD_SCRIPT));
+    appendOnFailureRestartPolicy(stagedApp, 10);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    host.start(RUNNER_APP_ID);
+
+    Path runCountFile = installation.paths().runDir().resolve("daemonized-restart-count.txt");
+    waitForFileContent(runCountFile, "1\n");
+    waitForFileContent(runCountFile, "2\n");
+    assertTrue(host.stop(RUNNER_APP_ID));
+  }
+
+  @Test
+  void restartPolicy_whenRestartAttemptExitsDuringStartup_expectAttemptExitRecorded()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    Path stagedApp = stageInstalledRunnerApp(RESTART_ATTEMPT_STARTUP_FAILURE_SCRIPT);
+    appendOnFailureRestartPolicy(stagedApp, 10);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    host.start(RUNNER_APP_ID);
+
+    Path runCountFile = installation.paths().runDir().resolve("restart-startup-failure-count.txt");
+    waitForFileContent(runCountFile, "2\n");
+    AppRuntimeStatusSnapshot status = waitForRuntimeState(host, AppRuntimeState.CRASHED);
+    assertEquals(9, status.lastExitCode());
+    assertEquals(1, status.currentRestartAttempt());
+    assertEquals(1, status.restartCount());
+  }
+
+  @Test
+  void restartBackoffSleepMillis_whenManifestBackoffWouldOverflowNanos_expectMillisValue() {
+    long nanosOverflowingBackoffMillis = Long.MAX_VALUE / 1_000_000L + 1L;
+
+    assertEquals(
+        nanosOverflowingBackoffMillis,
+        LocalProcessAppHost.restartBackoffSleepMillis(
+            Duration.ofMillis(nanosOverflowingBackoffMillis)));
+    assertEquals(
+        Long.MAX_VALUE,
+        LocalProcessAppHost.restartBackoffSleepMillis(Duration.ofSeconds(Long.MAX_VALUE)));
+  }
+
+  @Test
+  void restartPolicy_whenOperatorStopsProcess_expectNoRestart() throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    AppHost host = allowUnsignedHost();
+    Path stagedApp = stageInstalledRunnerApp(RESTART_STOP_SUPPRESSION_SCRIPT);
+    appendOnFailureRestartPolicy(stagedApp, 10);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+
+    host.start(RUNNER_APP_ID);
+    Path runCountFile = installation.paths().runDir().resolve("restart-count.txt");
+    waitForFileContent(runCountFile, "1\n");
+    assertTrue(host.stop(RUNNER_APP_ID));
+    LockSupport.parkNanos(Duration.ofMillis(150).toNanos());
+
+    assertEquals("1\n", Files.readString(runCountFile, StandardCharsets.UTF_8));
+    assertEquals(AppRuntimeState.STOPPED, host.runtimeStatus(RUNNER_APP_ID).state());
   }
 
   @Test
@@ -1696,6 +2152,7 @@ class LocalProcessAppHostTest {
 
     environment.put("GITHUB_TOKEN", "secret");
     environment.put("AWS_SECRET_ACCESS_KEY", "top-secret");
+    environment.put("CRYPTAD_NODE_DATASTORE_DIR", "/srv/cryptad/datastore");
 
     LocalProcessAppHost.populateEnvironment(
         environment,
@@ -1706,6 +2163,7 @@ class LocalProcessAppHostTest {
 
     assertFalse(environment.containsKey("GITHUB_TOKEN"));
     assertFalse(environment.containsKey("AWS_SECRET_ACCESS_KEY"));
+    assertFalse(environment.containsKey("CRYPTAD_NODE_DATASTORE_DIR"));
     assertEquals(
         "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/local/sbin:"
             + "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin",
@@ -1749,6 +2207,77 @@ class LocalProcessAppHostTest {
     assertTrue(pathEntries.stream().anyMatch(entry -> entry.endsWith("/System32")));
     assertTrue(
         pathEntries.stream().anyMatch(entry -> entry.endsWith("/System32/WindowsPowerShell/v1.0")));
+  }
+
+  @Test
+  void ownerOnlyFilePermissions_whenPosixViewAvailable_expectOwnerOnlyModes() throws IOException {
+    Path directory = Files.createDirectories(tempDir.resolve("owner-only-dir"));
+    Path file =
+        Files.writeString(directory.resolve(PROCESS_LOG_FILE_NAME), "log", StandardCharsets.UTF_8);
+    Assumptions.assumeTrue(
+        Files.getFileAttributeView(directory, PosixFileAttributeView.class) != null);
+
+    assertTrue(OwnerOnlyFilePermissions.hardenDirectory(directory));
+    assertTrue(OwnerOnlyFilePermissions.hardenSensitiveFile(file));
+
+    assertEquals(
+        Set.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE),
+        Files.getPosixFilePermissions(directory));
+    assertEquals(
+        Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+        Files.getPosixFilePermissions(file));
+  }
+
+  @Test
+  void ownerOnlyFilePermissions_whenPathIsSymlink_expectTargetPermissionsUnchanged()
+      throws IOException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    Path target =
+        Files.writeString(tempDir.resolve("symlink-target.log"), "log", StandardCharsets.UTF_8);
+    Assumptions.assumeTrue(
+        Files.getFileAttributeView(target, PosixFileAttributeView.class) != null);
+    Set<PosixFilePermission> targetPermissions =
+        Set.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OTHERS_READ);
+    Files.setPosixFilePermissions(target, targetPermissions);
+    Path link = tempDir.resolve("symlink-process.log");
+    try {
+      Files.createSymbolicLink(link, target);
+    } catch (IOException | UnsupportedOperationException exception) {
+      Assumptions.assumeTrue(false, "symbolic links unavailable: " + exception.getMessage());
+    }
+
+    try {
+      OwnerOnlyFilePermissions.hardenSensitiveFile(link);
+    } catch (IOException _) {
+      // Some POSIX providers expose a no-follow symlink view but do not support chmod on symlinks.
+    }
+
+    assertEquals(targetPermissions, Files.getPosixFilePermissions(target));
+  }
+
+  @Test
+  void ownerOnlyFilePermissions_whenPosixViewUnavailable_expectFallbackWithoutFailure()
+      throws IOException {
+    Path zipFile = tempDir.resolve("non-posix.zip");
+    URI zipUri = URI.create("jar:" + zipFile.toUri());
+    try (FileSystem zipFs = FileSystems.newFileSystem(zipUri, Map.of("create", "true"))) {
+      Path directory = zipFs.getPath("/state");
+      Files.createDirectory(directory);
+      Path file =
+          Files.writeString(
+              directory.resolve(PROCESS_LOG_FILE_NAME), "log", StandardCharsets.UTF_8);
+
+      assertFalse(OwnerOnlyFilePermissions.hardenDirectory(directory));
+      assertFalse(OwnerOnlyFilePermissions.hardenSensitiveFile(file));
+    }
   }
 
   @Test
@@ -1875,7 +2404,7 @@ class LocalProcessAppHostTest {
         assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
 
     assertTrue(exception.getMessage().contains("runDir must not be a symlink"));
-    assertFalse(Files.exists(externalRun.resolve("process.log")));
+    assertFalse(Files.exists(externalRun.resolve(PROCESS_LOG_FILE_NAME)));
   }
 
   @Test
@@ -1894,7 +2423,8 @@ class LocalProcessAppHostTest {
         assertThrows(AppHostException.class, () -> host.start(RUNNER_APP_ID));
 
     assertTrue(exception.getMessage().contains("runDir must not be a symlink"));
-    assertFalse(Files.exists(externalRunAppsDir.resolve(RUNNER_APP_ID).resolve("process.log")));
+    assertFalse(
+        Files.exists(externalRunAppsDir.resolve(RUNNER_APP_ID).resolve(PROCESS_LOG_FILE_NAME)));
   }
 
   @Test
@@ -2088,6 +2618,20 @@ class LocalProcessAppHostTest {
     return stageInstalledApp(RUNNER_APP_ID, scriptContent, Map.of());
   }
 
+  private static void appendOnFailureRestartPolicy(Path stagedApp, long backoffMillis)
+      throws IOException {
+    Files.writeString(
+        stagedApp.resolve(MANIFEST_FILE_NAME),
+        """
+        app.restart.policy=%s
+        app.restart.maxAttempts=%d
+        app.restart.backoff.ms=%d
+        """
+            .formatted("on-failure", 1, backoffMillis),
+        StandardCharsets.UTF_8,
+        java.nio.file.StandardOpenOption.APPEND);
+  }
+
   private Path stageInstalledApp(String appId, String scriptContent, Map<String, String> extraFiles)
       throws IOException {
     Path stagedDir = tempDir.resolve(STAGE_DIR_NAME).resolve(appId);
@@ -2229,10 +2773,15 @@ class LocalProcessAppHostTest {
         Class.forName(LocalProcessAppHost.class.getName() + "$RunningProcess");
     Constructor<?> constructor =
         runningProcessClass.getDeclaredConstructor(
-            Process.class, RunningAppSnapshot.class, CompletableFuture.class, List.class);
+            Process.class,
+            RunningAppSnapshot.class,
+            CompletableFuture.class,
+            List.class,
+            int.class,
+            int.class);
     constructor.setAccessible(true);
     Object runningProcess =
-        constructor.newInstance(process, snapshot, exitCleanup, List.of(process.toHandle()));
+        constructor.newInstance(process, snapshot, exitCleanup, List.of(process.toHandle()), 0, 0);
     runningApps.put(appId, runningProcess);
   }
 
@@ -2442,6 +2991,19 @@ class LocalProcessAppHostTest {
     throw new AssertionError("timed out waiting for app to be running: " + appId);
   }
 
+  private static AppRuntimeStatusSnapshot waitForRuntimeState(AppHost host, AppRuntimeState state)
+      throws IOException {
+    long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (System.nanoTime() < deadline) {
+      AppRuntimeStatusSnapshot status = host.runtimeStatus(RUNNER_APP_ID);
+      if (status.state() == state) {
+        return status;
+      }
+      pausePolling("interrupted while waiting for app runtime state: " + RUNNER_APP_ID);
+    }
+    throw new AssertionError("timed out waiting for app runtime state: " + RUNNER_APP_ID);
+  }
+
   private static void waitForNotRunning(AppHost host) {
     long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
     while (System.nanoTime() < deadline) {
@@ -2468,6 +3030,18 @@ class LocalProcessAppHostTest {
       pausePolling("interrupted while waiting for app " + appId + " to report pid " + pid);
     }
     throw new AssertionError("timed out waiting for app " + appId + " to report pid " + pid);
+  }
+
+  private static void waitForFileContent(Path file, String expectedContent) throws IOException {
+    long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (Files.isRegularFile(file)
+          && expectedContent.equals(Files.readString(file, StandardCharsets.UTF_8))) {
+        return;
+      }
+      pausePolling("interrupted while waiting for file content: " + file);
+    }
+    throw new AssertionError("timed out waiting for file content: " + file);
   }
 
   private static void waitForProcessExit(long pid) throws IOException {

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -584,6 +584,12 @@ a {
   align-items: center;
 }
 
+.app-log-tail {
+  max-height: 280px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .diagnostics-lines,
 .diagnostics-export {
   margin: 0;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -883,6 +883,18 @@
     }
   }
 
+  function appRuntimePath(appId) {
+    return typeof appId === "string" && appId.length > 0
+      ? `apps/${encodeURIComponent(appId)}/runtime`
+      : null;
+  }
+
+  function appLogsPath(appId, maxBytes) {
+    return typeof appId === "string" && appId.length > 0
+      ? `apps/${encodeURIComponent(appId)}/logs?maxBytes=${encodeURIComponent(String(maxBytes))}`
+      : null;
+  }
+
   function catalogMutationPath(catalogId, appId, action) {
     if (typeof catalogId !== "string" || catalogId.length === 0) {
       return null;
@@ -977,6 +989,15 @@
   function renderAppCard(app) {
     const card = document.createElement("article");
     card.className = "app-card";
+    const runtime = app && app.runtime && typeof app.runtime === "object" ? app.runtime : null;
+    const logs = app && app.logs && typeof app.logs === "object" ? app.logs : null;
+    const runtimeError = typeof app.runtimeError === "string" ? app.runtimeError : "";
+    const runtimeState =
+      runtime && typeof runtime.state === "string" && runtime.state ? runtime.state : app.running ? "RUNNING" : "STOPPED";
+    const runtimeRunning = runtime ? !!runtime.running : !!app.running;
+    const runtimeStoppable = runtimeRunning || runtimeState === "RESTARTING";
+    const runtimePid = runtime ? runtime.pid : app.pid;
+    const runtimeStartedAt = runtime ? runtime.startedAt : app.startedAt;
 
     const header = document.createElement("div");
     header.className = "app-card-header";
@@ -990,7 +1011,7 @@
     const pills = document.createElement("div");
     pills.className = "app-card-pills";
     pills.append(createPill("Installed"));
-    pills.append(createPill(app.running ? "Running" : "Stopped", app.running ? "is-success" : "is-warning"));
+    pills.append(createPill(runtimeState, runtimeRunning ? "is-success" : "is-warning"));
     if (app.uiUrl || app.uiEntry) {
       pills.append(createPill(app.uiMode === "static" ? "Static UI" : "UI"));
     }
@@ -1005,17 +1026,31 @@
       ["UI mode", scalar(app.uiMode)],
       ["UI", uiEntryNode || scalar(app.uiUrl)],
       ["UI entry", scalar(app.uiEntry)],
-      ["Running", app.running ? "Yes" : "No"],
-      ["PID", app.running ? scalar(app.pid) : "Unavailable"],
-      ["Started at", app.running ? formatIsoTimestamp(app.startedAt) : "Unavailable"],
+      ["Runtime state", runtimeState],
+      ["Running", runtimeRunning ? "Yes" : "No"],
+      ["PID", runtimeRunning ? scalar(runtimePid) : "Unavailable"],
+      ["Started at", runtimeRunning ? formatIsoTimestamp(runtimeStartedAt) : "Unavailable"],
+      ["Last exit code", runtime && runtime.lastExitCode != null ? scalar(runtime.lastExitCode) : "Unavailable"],
+      ["Last exit at", runtime ? formatIsoTimestamp(runtime.lastExitAt) : "Unavailable"],
+      ["Restart attempts", runtime ? scalar(runtime.currentRestartAttempt) : "Unavailable"],
+      ["Process log", logs && logs.available ? `${scalar(logs.sizeBytes)} bytes` : "Unavailable"],
+      ["Runtime detail", runtimeError || (runtime ? "Available" : "Unavailable")],
     ];
     card.append(definitionList(entries));
+    const logDetails = appLogDetailsNode(logs, app.logsError);
+    if (logDetails) {
+      card.append(logDetails);
+    }
 
     const actions = document.createElement("div");
     actions.className = "app-card-actions";
     if (formPassword) {
-      const startForm = buildAppActionForm(app, app.running ? "stop" : "start", app.running ? "Stop" : "Start");
-      const uninstallForm = app.running
+      const startForm = buildAppActionForm(
+        app,
+        runtimeStoppable ? "stop" : "start",
+        runtimeStoppable ? "Stop" : "Start",
+      );
+      const uninstallForm = runtimeStoppable
         ? null
         : buildAppActionForm(app, "uninstall", "Uninstall");
       if (startForm) {
@@ -1030,6 +1065,30 @@
     }
 
     return card;
+  }
+
+  function appLogDetailsNode(logs, logsError) {
+    const details = document.createElement("details");
+    details.className = "json-details";
+    const summary = document.createElement("summary");
+    summary.textContent = "Runtime log tail";
+    details.append(summary);
+    if (logsError) {
+      details.append(text("p", "error-state", logsError));
+      return details;
+    }
+    if (!logs || !logs.available) {
+      details.append(text("p", "empty-state", "No process log is available."));
+      return details;
+    }
+    if (logs.truncated) {
+      details.append(text("p", "empty-state", `Showing the last ${scalar(logs.maxBytes)} bytes.`));
+    }
+    const pre = document.createElement("pre");
+    pre.className = "json-code app-log-tail";
+    pre.textContent = typeof logs.text === "string" ? logs.text : "";
+    details.append(pre);
+    return details;
   }
 
   function renderApps(data) {
@@ -2134,6 +2193,11 @@
     let installedSnapshot;
     try {
       installedSnapshot = await loadJson(apiUrl("apps"));
+      const apps =
+        installedSnapshot && Array.isArray(installedSnapshot.apps)
+          ? await Promise.all(installedSnapshot.apps.map(loadAppRuntimeDetails))
+          : [];
+      installedSnapshot = { ...installedSnapshot, apps };
     } catch (error) {
       if (loadGeneration !== appsLoadGeneration) {
         return;
@@ -2161,6 +2225,39 @@
       return;
     }
     renderApps({ ...installedSnapshot, catalogs, catalogError });
+  }
+
+  async function loadAppRuntimeDetails(app) {
+    if (!app || typeof app !== "object" || typeof app.appId !== "string" || app.appId.length === 0) {
+      return app;
+    }
+    const runtimePath = appRuntimePath(app.appId);
+    const logsPath = appLogsPath(app.appId, 65536);
+    let runtime = null;
+    let runtimeError = "";
+    let logs = null;
+    let logsError = "";
+    try {
+      const runtimeSnapshot = runtimePath ? await loadOptionalJson(apiUrl(runtimePath)) : null;
+      runtime =
+        runtimeSnapshot && runtimeSnapshot.runtime && typeof runtimeSnapshot.runtime === "object"
+          ? runtimeSnapshot.runtime
+          : runtimeSnapshot;
+    } catch (error) {
+      runtimeError =
+        error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
+    }
+    try {
+      const logsSnapshot = logsPath ? await loadOptionalJson(apiUrl(logsPath)) : null;
+      logs =
+        logsSnapshot && logsSnapshot.logs && typeof logsSnapshot.logs === "object"
+          ? logsSnapshot.logs
+          : logsSnapshot;
+    } catch (error) {
+      logsError =
+        error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
+    }
+    return { ...app, runtime, runtimeError, logs, logsError };
   }
 
   async function loadCatalogApps(catalog) {

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -99,6 +99,7 @@ class WebShellResourcesTest {
     assertTrue(stylesheet.contains("white-space: pre-wrap;"));
     assertTrue(stylesheet.contains(".app-card-list {"));
     assertTrue(stylesheet.contains(".app-card-actions {"));
+    assertTrue(stylesheet.contains(".app-log-tail {"));
     assertTrue(stylesheet.contains(".catalog-app-card {"));
     assertTrue(stylesheet.contains(".publisher-forms {"));
     assertTrue(stylesheet.contains(".publisher-result-actions {"));
@@ -323,11 +324,22 @@ class WebShellResourcesTest {
     assertTrue(script.contains("return `${url.pathname}${url.search}${url.hash}`;"));
     assertFalse(appUiEntryHelper.contains("const url = new URL(value, window.location.origin);"));
     assertTrue(script.contains("function appUiHref(app)"));
+    assertTrue(script.contains("function appRuntimePath(appId)"));
+    assertTrue(script.contains("function appLogsPath(appId, maxBytes)"));
+    assertTrue(script.contains("async function loadAppRuntimeDetails(app)"));
     assertTrue(script.contains("const explicitHref = normalizeAppUiEntryHref(app.uiUrl);"));
     assertTrue(
         script.contains(
             "return normalizeAppUiEntryHref(`/apps/${encodeURIComponent(app.appId)}/`);"));
     assertTrue(script.contains("function renderAppCard(app)"));
+    assertTrue(
+        script.contains(
+            "const runtimeStoppable = runtimeRunning || runtimeState === \"RESTARTING\";"));
+    assertTrue(script.contains("runtimeStoppable ? \"stop\" : \"start\""));
+    assertTrue(script.contains("runtimeStoppable ? \"Stop\" : \"Start\""));
+    assertTrue(script.contains("const uninstallForm = runtimeStoppable"));
+    assertTrue(script.contains("Runtime log tail"));
+    assertTrue(script.contains("app-log-tail"));
     assertTrue(script.contains("function renderApps(data)"));
     assertTrue(script.contains("function renderCatalogs(catalogs, catalogError)"));
     assertTrue(script.contains("Catalogs unavailable: ${catalogError}"));
@@ -342,6 +354,7 @@ class WebShellResourcesTest {
     assertTrue(script.contains("async function deleteForm(path, formData, unavailableMessage)"));
     assertTrue(script.contains("setAppsStatus(\"Refreshing installed apps and catalogs.\");"));
     assertTrue(script.contains("loadJson(apiUrl(\"apps\"))"));
+    assertTrue(script.contains("installedSnapshot.apps.map(loadAppRuntimeDetails)"));
     assertTrue(script.contains("loadOptionalJson(apiUrl(\"app-catalogs\"))"));
     assertTrue(script.contains("catalogsSnapshot.catalogs.map(loadCatalogApps)"));
     assertTrue(
@@ -350,6 +363,8 @@ class WebShellResourcesTest {
                 + " loadJson(apiUrl(`app-catalogs/${encodeURIComponent(catalog.catalogId)}/apps`));"));
     assertTrue(script.contains("return `apps/${encodedAppId}/${action}`;"));
     assertTrue(script.contains("return `apps/${encodedAppId}`;"));
+    assertTrue(script.contains("`apps/${encodeURIComponent(appId)}/runtime`"));
+    assertTrue(script.contains("`apps/${encodeURIComponent(appId)}/logs?maxBytes="));
     assertTrue(script.contains("return `app-catalogs/${encodedCatalogId}/refresh`;"));
     assertTrue(
         script.contains(

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -17,6 +17,9 @@ import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostConfigurationException;
 import network.crypta.platform.apphost.AppHostException;
+import network.crypta.platform.apphost.AppProcessLogSnapshot;
+import network.crypta.platform.apphost.AppRuntimeState;
+import network.crypta.platform.apphost.AppRuntimeStatusSnapshot;
 import network.crypta.platform.apphost.InstalledAppPaths;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
@@ -92,6 +95,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -2053,6 +2057,56 @@ class PlatformApiRouterTest {
   }
 
   @Test
+  void route_whenAppRuntimeRequested_expectRuntimeEnvelopeWithoutToken() throws Exception {
+    when(appHost.runtimeStatus(APP_ID))
+        .thenReturn(
+            new AppRuntimeStatusSnapshot(
+                APP_ID,
+                AppRuntimeState.RUNNING,
+                true,
+                APP_PID,
+                STARTED_AT,
+                null,
+                null,
+                1,
+                1,
+                true,
+                128L));
+
+    PlatformApiResponse response =
+        router.route(request("GET", List.of("apps", APP_ID, "runtime"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(PlatformApiJsonWriter.write(Map.of("runtime", runtimeSummary())), response.body());
+    assertFalse(response.body().contains("token"));
+  }
+
+  @Test
+  void route_whenAppLogsRequested_expectLogsEnvelopeWithoutToken() throws Exception {
+    when(appHost.readProcessLogTail(APP_ID, 32))
+        .thenReturn(
+            new AppProcessLogSnapshot(
+                APP_ID, true, true, 32, 128L, "CRYPTAD_APP_TOKEN=[REDACTED]\nready\n", STARTED_AT));
+
+    PlatformApiResponse response =
+        router.route(
+            request("GET", List.of("apps", APP_ID, "logs"), Map.of("maxBytes", List.of("32"))));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(PlatformApiJsonWriter.write(Map.of("logs", logsSummary())), response.body());
+    assertFalse(response.body().contains("secret"));
+  }
+
+  @Test
+  void route_whenAppRuntimePostRequested_expectMethodNotAllowedWithAllowGet() {
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "runtime"), Map.of()));
+
+    assertEquals(405, response.statusCode());
+    assertEquals(Map.of("Allow", "GET"), response.headers());
+  }
+
+  @Test
   void route_whenAppIdMatchesInstallRoute_expectDescribeJson() throws Exception {
     InstalledAppSnapshot installed = installedSnapshot(INSTALL_ROUTE_APP_ID);
     when(appHost.describe(INSTALL_ROUTE_APP_ID)).thenReturn(Optional.of(installed));
@@ -2506,6 +2560,23 @@ class PlatformApiRouterTest {
   }
 
   @Test
+  void route_whenAppStopRequestedDuringRestartBackoff_expectDelegatesStopAndReturnsSummary()
+      throws Exception {
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+    when(appHost.stop(APP_ID)).thenReturn(true);
+
+    PlatformApiResponse response =
+        router.route(request("POST", List.of("apps", APP_ID, "stop"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", summary(true, false, null, null))),
+        response.body());
+    verify(appHost).stop(APP_ID);
+  }
+
+  @Test
   void route_whenRunningAppManifestUnreadableDuringStop_expectStoppedSummaryJson()
       throws Exception {
     when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
@@ -2923,6 +2994,34 @@ class PlatformApiRouterTest {
   private static Map<String, Object> installRouteSummary(boolean installed) {
     return summaryFor(
         INSTALL_ROUTE_APP_ID, APP_NAME, APP_VERSION, APP_UI_ENTRY, installed, false, null, null);
+  }
+
+  private static Map<String, Object> runtimeSummary() {
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(11);
+    summary.put("appId", APP_ID);
+    summary.put("state", "RUNNING");
+    summary.put("running", true);
+    summary.put("pid", APP_PID);
+    summary.put("startedAt", STARTED_AT.toString());
+    summary.put("lastExitAt", null);
+    summary.put("lastExitCode", null);
+    summary.put("restartCount", 1);
+    summary.put("currentRestartAttempt", 1);
+    summary.put("logAvailable", true);
+    summary.put("logSizeBytes", 128L);
+    return summary;
+  }
+
+  private static Map<String, Object> logsSummary() {
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(7);
+    summary.put("appId", APP_ID);
+    summary.put("available", true);
+    summary.put("truncated", true);
+    summary.put("maxBytes", 32);
+    summary.put("sizeBytes", 128L);
+    summary.put("text", "CRYPTAD_APP_TOKEN=[REDACTED]\nready\n");
+    summary.put("lastModifiedAt", STARTED_AT.toString());
+    return summary;
   }
 
   private static Map<String, Object> summaryFor(


### PR DESCRIPTION
## Summary
- Harden local AppHost launches with installed-root working directories, minimal environment exposure, best-effort owner-only runtime/log permissions, and token/path redaction.
- Add process runtime status snapshots, bounded process-log tail snapshots, Platform API endpoints, and Web Shell runtime/log visibility without exposing launch tokens or filesystem paths.
- Add bounded `on-failure` restart-policy plumbing and document the process-isolation trust boundary, token handling, restart semantics, and remaining sandbox limitations.

## Testing
- `./gradlew spotlessApply`
- `./gradlew :platform-apphost:test --tests '*LocalProcessAppHostTest.restartPolicy_whenDaemonizedChildExitsWithoutPolling_expectObserverRestarts'`
- `./gradlew :platform-apphost:test --tests '*LocalProcessAppHostTest'`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java`
- `./gradlew test`

## Scope Notes
- This hardens and observes local out-of-process AppHost execution.
- It does not add containers, WASM, OS-level sandboxing, browser-scoped app sessions, or a public app store.