### PR TITLE
feat(apphost): Add sandbox runtime v1

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -63,7 +63,9 @@ local build, verification, install, and catalog-refresh flows.
 
 Catalog installs and updates verify the signed catalog, the advertised artifact size and SHA-256,
 and the extracted bundle signature before AppHost installs the app. Catalog fetches support local
-files, `https:`, and loopback-only `http:` sources.
+files, `https:`, and loopback-only `http:` sources. Catalog ZIP extraction drops macOS
+`__MACOSX/**` and AppleDouble `._*` metadata entries before verification; executable app payload
+still has to match the signed bundle digest.
 
 App-owned static UI routes serve files from the immutable installed bundle under `/apps/{appId}/`.
 They do not serve app data, cache, run directories, catalog scratch directories, or caller staging
@@ -71,11 +73,14 @@ paths. Static UI remains same-origin with the local admin UI and Platform API, s
 entries are rejected and route responses use conservative CSP, `nosniff`, no-referrer, and
 non-public no-cache headers.
 
-AppHost process launches are process isolation, not sandboxing. AppHost starts a local child
-process with the installed bundle root as its working directory, a minimal environment, per-app
-data/cache/run directories, and a per-launch `CRYPTAD_APP_TOKEN` for app-originated Platform API
-authentication. It does not currently provide containers, WASM isolation, seccomp, chroot, jails,
-Windows Job Object restrictions, network isolation, or browser origin isolation.
+AppHost process launches are process isolation, not hard sandboxing by default. AppHost starts a
+local child process with the installed bundle root as its working directory, a minimal environment,
+per-app data/cache/run directories, and a per-launch `CRYPTAD_APP_TOKEN` for app-originated
+Platform API authentication. App manifests can request `sandbox.mode=none`,
+`restricted-process`, or `wasm-preview`, and Platform API/Web Shell surfaces report the requested
+mode and actual support level. The default restricted-process provider is best-effort launch
+hygiene, not a container, WASM runtime, seccomp profile, chroot, jail, Windows Job Object policy,
+network isolation, or browser origin isolation.
 
 App-originated Platform API calls authenticate with the launch token in `X-Crypta-App-Token`.
 `Authorization: Bearer` is accepted only when the Bearer value matches a live app token; unrelated

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -86,7 +86,9 @@ Remote fetches use the JDK HTTP client with finite timeouts, no automatic redire
 for catalog, signature, and artifact downloads. Artifact bytes are written to catalog-owned scratch
 storage, checked against the catalog size and SHA-256, then extracted into a separate staging
 directory. The extractor rejects absolute ZIP paths, `..`, Windows drive prefixes, backslash path
-separators, duplicate normalized entries, and rootless bundles.
+separators, duplicate normalized entries, and rootless bundles. It drops macOS archive metadata
+entries such as `__MACOSX/**` and AppleDouble `._*` files before signed-bundle verification, so
+those files are not installed as app payload.
 
 ## Platform API flow
 

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -73,6 +73,24 @@ bootstrap JSON, static asset security boundary, and API summary fields. See
 [platform-sdk-js.md](platform-sdk-js.md) for the staged browser SDK used by first-party static UI
 bundles.
 
+## Sandbox Manifest Fields
+
+App bundles can declare the requested AppHost sandbox mode:
+
+```properties
+sandbox.mode=none|restricted-process|wasm-preview
+sandbox.required=false
+```
+
+Both fields are optional. Missing `sandbox.mode` defaults to `none`, and missing
+`sandbox.required` defaults to `false`. Unknown modes and malformed booleans fail manifest
+validation before a bundle is installed or launched.
+
+The `restricted-process` mode currently maps to AppHost's best-effort restricted local process
+provider. It preserves the existing sanitized environment, explicit working directory, and
+app-scoped mutable directories, but it is not a hard OS sandbox. The `wasm-preview` mode is reserved
+for a future provider and is unsupported by the default runtime.
+
 ## Runtime Manifest Fields
 
 App bundles can declare a minimal restart policy:

--- a/docs/app-permissions-and-audit.md
+++ b/docs/app-permissions-and-audit.md
@@ -7,8 +7,9 @@ recent app decisions.
 
 The app permission boundary applies to local AppHost child processes that authenticate with their
 current launch token and to app-owned static browser UIs that authenticate with browser app
-sessions. It does not add containers, WASM isolation, seccomp, chroot, browser origin isolation,
-FCP changes, wire-protocol changes, or persistent compliance-grade audit storage.
+sessions. It is separate from AppHost sandbox status. Permission checks do not add containers, WASM
+isolation, seccomp, chroot, browser origin isolation, FCP changes, wire-protocol changes, or
+persistent compliance-grade audit storage.
 
 Host/operator Web Shell requests keep the existing local-admin model. They do not need app
 permissions, and they are not recorded in the app audit log.

--- a/docs/apphost-runtime-hardening.md
+++ b/docs/apphost-runtime-hardening.md
@@ -5,7 +5,8 @@ This document describes the current AppHost runtime boundary for local out-of-pr
 ## Scope
 
 AppHost runs installed apps as local child processes. The current hardening layer makes launch
-behavior explicit and adds operator visibility, but it does not add an operating-system sandbox.
+behavior explicit and adds operator visibility. PR-206 adds a sandbox policy and reporting model,
+but the default providers still do not add a hard operating-system sandbox.
 
 The current boundary provides:
 
@@ -14,12 +15,44 @@ The current boundary provides:
 - a minimal launch environment with AppHost variables only;
 - combined stdout/stderr capture in an app-owned `process.log`;
 - token-redacted runtime status and bounded process-log tail APIs;
+- sandbox policy parsing, provider selection, and token-free sandbox status reporting;
 - best-effort owner-only permissions on POSIX app data, cache, run, and process-log files;
 - bounded in-session restart attempts when a manifest opts in to `on-failure`.
 
 The current boundary does not provide containers, WASM isolation, seccomp, chroot, jails, Windows
-Job Object restrictions, browser origin isolation, or network isolation. A third-party app still
-runs as a local process under the same operating-system user as the daemon.
+Job Object restrictions, browser origin isolation, or network isolation by default. A third-party
+app still runs as a local process under the same operating-system user as the daemon unless a future
+provider explicitly reports an enforced sandbox.
+
+## Sandbox policy
+
+App manifests may declare:
+
+```properties
+sandbox.mode=none|restricted-process|wasm-preview
+sandbox.required=false
+```
+
+Missing `sandbox.mode` defaults to `none`, and missing `sandbox.required` defaults to `false`.
+Unknown modes and malformed booleans fail manifest validation.
+
+`sandbox.mode=none` is the backward-compatible launch path. The app runs as it did before PR-206,
+and API/Shell surfaces report that no OS sandbox isolation is active.
+
+`sandbox.mode=restricted-process` requests the v1 restricted-process provider. The default provider
+is intentionally best-effort: it verifies AppHost's sanitized environment, explicit installed-bundle
+working directory, and app-scoped data/cache/run directories. It does not create a container,
+seccomp profile, chroot, jail, Windows Job Object policy, or network/filesystem mediation layer.
+Runtime status therefore reports `supportLevel=best-effort`, not `enforced`.
+
+`sandbox.mode=wasm-preview` is parsed as a reserved future mode. The default host has no WASM
+provider. If `sandbox.required=true`, starting such an app fails with `unsupported_sandbox`; if it
+is optional, AppHost may report the mode as unsupported instead of claiming isolation.
+
+`sandbox.required=true` means AppHost must reject launch when no provider can support the requested
+mode. It does not upgrade a best-effort provider into hard isolation. Operators should read the
+reported `supportLevel`, `provider`, `active`, and warnings fields to understand what actually
+happened on the current host.
 
 ## Launch environment
 
@@ -95,6 +128,8 @@ GET /api/v1/apps/{appId}/logs?maxBytes=65536
 
 Runtime status reports `STOPPED`, `RUNNING`, `EXITED`, `CRASHED`, or `RESTARTING`, plus process id,
 start time, last exit code/time, restart attempt counters, and log availability when known.
+It also reports a `sandbox` object containing the requested mode, whether the manifest requires it,
+the provider name, the support level, whether sandbox isolation is active, and token-free warnings.
 
 Process-log tailing is bounded. The default is small, and AppHost clamps oversized requests to its
 hard maximum. Missing logs return a stable unavailable snapshot. Log responses include text and
@@ -139,5 +174,5 @@ resources available to the daemon user unless the operating system or operator e
 them outside AppHost.
 
 Future sandbox work may add stronger platform-specific controls such as process containment,
-network restrictions, syscall filters, or browser origin isolation. Those are out of scope for the
-current runtime hardening layer.
+network restrictions, syscall filters, filesystem mediation, or real WASM execution. Those are out
+of scope for the current runtime hardening layer.

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -23,6 +23,10 @@ import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.manifest.AppManifestParser;
+import network.crypta.platform.apphost.sandbox.AppSandboxException;
+import network.crypta.platform.apphost.sandbox.AppSandboxPolicy;
+import network.crypta.platform.apphost.sandbox.AppSandboxProviders;
+import network.crypta.platform.apphost.sandbox.AppSandboxStatus;
 import network.crypta.platform.appui.AppUiPaths;
 
 /**
@@ -60,6 +64,7 @@ public final class AppsApiHandler {
   private static final String FIELD_PERMISSIONS = "permissions";
   private static final String FIELD_RECENT_DENIED_COUNT = "recentDeniedCount";
   private static final String FIELD_RUNNING = "running";
+  private static final String FIELD_SANDBOX = "sandbox";
   private static final String FIELD_STARTED_AT = "startedAt";
   private static final String MAX_BYTES_POSITIVE_INTEGER_MESSAGE =
       "Query parameter 'maxBytes' must be a positive integer.";
@@ -504,6 +509,7 @@ public final class AppsApiHandler {
     json.put("uiUrl", AppUiPaths.uiUrl(manifest));
     json.put(FIELD_PERMISSIONS, manifest.permissions());
     json.put("quota", quota(manifest));
+    json.put(FIELD_SANDBOX, summarizeSandbox(sandboxStatus(manifest, running)));
     json.put("installed", installed);
     json.put(FIELD_RUNNING, running != null);
     json.put("pid", running == null ? null : running.pid());
@@ -532,6 +538,7 @@ public final class AppsApiHandler {
     json.put("currentRestartAttempt", snapshot.currentRestartAttempt());
     json.put("logAvailable", snapshot.logAvailable());
     json.put("logSizeBytes", snapshot.logSizeBytes());
+    json.put(FIELD_SANDBOX, summarizeSandbox(snapshot.sandboxStatus()));
     return json;
   }
 
@@ -576,6 +583,9 @@ public final class AppsApiHandler {
     json.put("uiUrl", null);
     json.put(FIELD_PERMISSIONS, List.of());
     json.put("quota", unknownQuota());
+    json.put(
+        FIELD_SANDBOX,
+        summarizeSandbox(AppSandboxProviders.inactiveStatus(AppSandboxPolicy.defaults())));
     json.put("installed", installed);
     json.put(FIELD_RUNNING, false);
     json.put("pid", null);
@@ -627,6 +637,24 @@ public final class AppsApiHandler {
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
     json.put("dataBytes", null);
     json.put("cacheBytes", null);
+    return json;
+  }
+
+  private static AppSandboxStatus sandboxStatus(AppManifest manifest, RunningAppSnapshot running) {
+    return running == null
+        ? AppSandboxProviders.inactiveStatus(manifest.sandboxPolicy())
+        : running.sandboxStatus();
+  }
+
+  private static Map<String, Object> summarizeSandbox(AppSandboxStatus status) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    json.put("mode", status.mode().manifestValue());
+    json.put("required", status.required());
+    json.put("supportLevel", status.supportLevel().manifestValue());
+    json.put("provider", status.providerName());
+    json.put("active", status.active());
+    json.put("reason", status.reason());
+    json.put("warnings", status.warnings());
     return json;
   }
 
@@ -828,6 +856,9 @@ public final class AppsApiHandler {
    * @return structured Platform API exception
    */
   private PlatformApiException startFailure(String appId, AppHostException failure) {
+    if (failure instanceof AppSandboxException sandboxFailure) {
+      return new PlatformApiException(409, sandboxFailure.errorCode(), sandboxFailure.getMessage());
+    }
     if (appHost.status(appId).isPresent()) {
       return conflict("app is already running: " + appId);
     }

--- a/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
@@ -21,6 +21,7 @@ import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.manifest.AppManifestParser;
+import network.crypta.platform.apphost.sandbox.AppSandboxException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -156,6 +157,10 @@ class AppsApiHandlerTest {
     assertEquals("static", summary.get(FIELD_UI_MODE));
     assertEquals("static/index.html", summary.get(FIELD_UI_ENTRY));
     assertEquals("/apps/demo-app/static/", summary.get(FIELD_UI_URL));
+    Map<?, ?> sandbox = (Map<?, ?>) summary.get("sandbox");
+    assertEquals("none", sandbox.get("mode"));
+    assertEquals("none", sandbox.get("supportLevel"));
+    assertEquals("no-sandbox", sandbox.get("provider"));
   }
 
   @Test
@@ -205,7 +210,28 @@ class AppsApiHandlerTest {
     assertEquals(true, runtime.get(FIELD_RUNNING));
     assertEquals(4242L, runtime.get("pid"));
     assertEquals(SAMPLE_INSTANT_TEXT, runtime.get("startedAt"));
+    Map<?, ?> sandbox = (Map<?, ?>) runtime.get("sandbox");
+    assertEquals("none", sandbox.get("mode"));
+    assertEquals(false, sandbox.get("active"));
     org.junit.jupiter.api.Assertions.assertFalse(runtime.toString().contains("token"));
+  }
+
+  @Test
+  void start_whenRequiredSandboxUnsupported_expectUnsupportedSandboxError() {
+    SingleAppHost appHost = new SingleAppHost(snapshot(AppUiMode.NONE, null));
+    appHost.startFailure =
+        new AppSandboxException(
+            "unsupported_sandbox",
+            "App requires sandbox mode wasm-preview, but no provider can support it on this host");
+    AppsApiHandler handler = new AppsApiHandler(appHost);
+
+    PlatformApiException exception =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            PlatformApiException.class, () -> handler.start(APP_ID));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("unsupported_sandbox", exception.errorCode());
+    org.junit.jupiter.api.Assertions.assertFalse(exception.getMessage().contains("secret-token"));
   }
 
   @Test
@@ -390,6 +416,7 @@ class AppsApiHandlerTest {
     private AppRuntimeStatusSnapshot runtimeStatus;
     private AppProcessLogSnapshot processLog;
     private IOException describeFailure;
+    private IOException startFailure;
     private boolean stopResult;
     private int stopCalls;
 
@@ -426,7 +453,10 @@ class AppsApiHandlerTest {
     }
 
     @Override
-    public RunningAppSnapshot start(String appId) {
+    public RunningAppSnapshot start(String appId) throws IOException {
+      if (startFailure != null) {
+        throw startFailure;
+      }
       throw new UnsupportedOperationException();
     }
 

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractor.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractor.java
@@ -112,18 +112,28 @@ public final class AppCatalogBundleExtractor {
     }
   }
 
+  private static void extractZip(Path zipPath, Path stagedRoot) throws IOException {
+    extractZip(zipPath, stagedRoot, MAX_EXTRACTED_BYTES);
+  }
+
   // Archive expansion is safe here because every entry is path-normalized, duplicate-checked,
   // rooted under the private staging directory, and bounded by entry-count and byte caps.
   @SuppressWarnings("java:S5042")
-  private static void extractZip(Path zipPath, Path stagedRoot) throws IOException {
+  static void extractZip(Path zipPath, Path stagedRoot, long maxExtractedBytes) throws IOException {
     Path extractionRoot = stagedRoot.toAbsolutePath().normalize();
-    ExtractionState state = new ExtractionState();
+    ExtractionState state = new ExtractionState(maxExtractedBytes);
     Map<String, Integer> unixModesByPath = readCentralDirectoryUnixModes(zipPath);
     try (InputStream fileInput = Files.newInputStream(zipPath);
         ZipInputStream zipInput = new ZipInputStream(fileInput)) {
       ZipEntry entry;
       while ((entry = zipInput.getNextEntry()) != null) {
         String normalizedName = normalizeZipEntryName(entry.getName(), entry.isDirectory());
+        if (isIgnoredArchiveMetadata(normalizedName)) {
+          state.recordIgnoredEntry();
+          drainEntry(zipInput, state);
+          zipInput.closeEntry();
+          continue;
+        }
         state.recordEntry(normalizedName);
         Path target = resolveZipEntryTarget(extractionRoot, normalizedName);
         if (entry.isDirectory()) {
@@ -135,6 +145,18 @@ public final class AppCatalogBundleExtractor {
       }
     } catch (ZipException exception) {
       throw invalidBundle("zip artifact is corrupt", exception);
+    }
+  }
+
+  private static void drainEntry(ZipInputStream zipInput, ExtractionState state)
+      throws IOException {
+    byte[] buffer = new byte[COPY_BUFFER_BYTES];
+    int bytesRead;
+    while ((bytesRead = zipInput.read(buffer)) >= 0) {
+      if (bytesRead == 0) {
+        continue;
+      }
+      state.recordExtractedBytes(bytesRead);
     }
   }
 
@@ -266,6 +288,9 @@ public final class AppCatalogBundleExtractor {
         CentralDirectoryEntry entry = readCentralDirectoryEntry(channel, centralDirectoryEnd);
         if (entry.unixMode() != null && (entry.unixMode() & UNIX_EXECUTE_BITS) != 0) {
           String normalizedName = normalizeZipEntryName(entry.name(), entry.directory());
+          if (isIgnoredArchiveMetadata(normalizedName)) {
+            continue;
+          }
           unixModesByPath.putIfAbsent(normalizedName, entry.unixMode());
         }
       }
@@ -421,6 +446,15 @@ public final class AppCatalogBundleExtractor {
     return name.length() >= 2 && Character.isLetter(name.charAt(0)) && name.charAt(1) == ':';
   }
 
+  private static boolean isIgnoredArchiveMetadata(String normalizedName) {
+    for (String segment : normalizedName.split("/", -1)) {
+      if (segment.equals("__MACOSX") || segment.startsWith("._")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static void verifyExtractedBundle(
       AppCatalogEntry entry, Path stagedRoot, TrustedAppKeys trustedKeys) throws IOException {
     Path manifestFile = stagedRoot.resolve(AppBundleManifestParser.MANIFEST_FILE_NAME);
@@ -473,22 +507,38 @@ public final class AppCatalogBundleExtractor {
 
   private static final class ExtractionState {
     private final Set<String> seenPaths = new HashSet<>();
+    private final long maxExtractedBytes;
     private long extractedBytes;
     private int entryCount;
 
-    void recordEntry(String normalizedName) {
-      entryCount++;
-      if (entryCount > MAX_ZIP_ENTRIES) {
-        throw invalidBundle("zip artifact contains too many entries");
+    private ExtractionState(long maxExtractedBytes) {
+      if (maxExtractedBytes < 0L) {
+        throw new IllegalArgumentException("maxExtractedBytes must be non-negative");
       }
+      this.maxExtractedBytes = maxExtractedBytes;
+    }
+
+    void recordEntry(String normalizedName) {
+      recordEntryCount();
       if (!seenPaths.add(normalizedName)) {
         throw invalidBundle("zip artifact contains duplicate entry: " + normalizedName);
       }
     }
 
+    void recordIgnoredEntry() {
+      recordEntryCount();
+    }
+
+    private void recordEntryCount() {
+      entryCount++;
+      if (entryCount > MAX_ZIP_ENTRIES) {
+        throw invalidBundle("zip artifact contains too many entries");
+      }
+    }
+
     void recordExtractedBytes(int bytesRead) {
       extractedBytes += bytesRead;
-      if (extractedBytes > MAX_EXTRACTED_BYTES) {
+      if (extractedBytes > maxExtractedBytes) {
         throw invalidBundle("zip artifact exceeds extracted size cap");
       }
     }

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractorTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractorTest.java
@@ -1,0 +1,47 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class AppCatalogBundleExtractorTest {
+  private static final int IGNORED_METADATA_BYTES = 32;
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void extractZip_whenIgnoredAppleDoubleEntryExceedsExtractedCap_expectInvalidAppBundle()
+      throws Exception {
+    Path artifact = ignoredAppleDoubleZip(tempDir.resolve("appledouble-large.zip"));
+    Path stagedRoot = Files.createDirectory(tempDir.resolve("staged"));
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> AppCatalogBundleExtractor.extractZip(artifact, stagedRoot, 16L));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+    assertEquals("zip artifact exceeds extracted size cap", exception.getMessage());
+    assertFalse(Files.exists(stagedRoot.resolve("._cryptad-app.properties")));
+  }
+
+  private static Path ignoredAppleDoubleZip(Path targetZip) throws IOException {
+    byte[] payload = "x".repeat(IGNORED_METADATA_BYTES).getBytes(StandardCharsets.UTF_8);
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip))) {
+      zip.putNextEntry(new ZipEntry("._cryptad-app.properties"));
+      zip.write(payload);
+      zip.closeEntry();
+    }
+    return targetZip;
+  }
+}

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -183,6 +183,23 @@ class AppCatalogManagerTest {
   }
 
   @Test
+  void prepareInstallPlan_whenZipContainsAppleDoubleEntries_expectMetadataIgnored()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectoryWithAppleDouble(bundle, tempDir.resolve("appledouble.zip"));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    AppCatalogManager manager = manager(trustedKeys(keyPair));
+    manager.addSource(catalog.toString());
+
+    try (AppCatalogInstallPlan plan = manager.prepareInstallPlan(CATALOG_ID, APP_ID)) {
+      assertFalse(Files.exists(plan.stagedBundleDirectory().resolve("._cryptad-app.properties")));
+      assertFalse(Files.exists(plan.stagedBundleDirectory().resolve("__MACOSX")));
+      assertFalse(Files.exists(plan.stagedBundleDirectory().resolve("bin").resolve("._launch.sh")));
+    }
+  }
+
+  @Test
   void prepareInstallPlan_whenZipParentIsFile_expectInvalidAppBundle() throws Exception {
     KeyPair keyPair = keyPair();
     Path artifact = parentConflictZip(tempDir.resolve("parent-conflict.zip"));
@@ -594,6 +611,34 @@ class AppCatalogManagerTest {
         Files.copy(path, zip);
         zip.closeEntry();
       }
+    }
+    return targetZip;
+  }
+
+  private static Path zipDirectoryWithAppleDouble(Path sourceRoot, Path targetZip)
+      throws IOException {
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(targetZip));
+        var paths = Files.walk(sourceRoot)) {
+      for (Path path : paths.sorted(Comparator.naturalOrder()).toList()) {
+        if (Files.isDirectory(path)) {
+          continue;
+        }
+        String relative = sourceRoot.relativize(path).toString().replace('\\', '/');
+        zip.putNextEntry(new ZipEntry(relative));
+        Files.copy(path, zip);
+        zip.closeEntry();
+      }
+      zip.putNextEntry(new ZipEntry("._cryptad-app.properties"));
+      zip.write("finder metadata".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+      zip.putNextEntry(new ZipEntry("__MACOSX/"));
+      zip.closeEntry();
+      zip.putNextEntry(new ZipEntry("__MACOSX/._cryptad-app.properties"));
+      zip.write("finder metadata".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
+      zip.putNextEntry(new ZipEntry("bin/._launch.sh"));
+      zip.write("finder metadata".getBytes(StandardCharsets.UTF_8));
+      zip.closeEntry();
     }
     return targetZip;
   }

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifest.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifest.java
@@ -32,6 +32,8 @@ import java.util.regex.Pattern;
  * @param permissions normalized permission strings declared by the app manifest
  * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
  * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+ * @param sandboxMode requested process sandbox mode
+ * @param sandboxRequired whether launch must fail when the requested sandbox mode is unsupported
  * @param restartPolicy normalized process restart policy
  * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
  * @param restartBackoffMillis delay before an automatic restart attempt
@@ -47,6 +49,8 @@ public record AppBundleManifest(
     List<String> permissions,
     Long dataQuotaBytes,
     Long cacheQuotaBytes,
+    AppSandboxMode sandboxMode,
+    boolean sandboxRequired,
     AppRestartPolicy restartPolicy,
     int restartMaxAttempts,
     long restartBackoffMillis) {
@@ -73,6 +77,8 @@ public record AppBundleManifest(
    * @param permissions normalized permission strings declared by the app manifest
    * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
    * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+   * @param sandboxMode requested process sandbox mode
+   * @param sandboxRequired whether launch must fail when the requested sandbox mode is unsupported
    * @param restartPolicy normalized process restart policy
    * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
    * @param restartBackoffMillis delay before an automatic restart attempt
@@ -92,9 +98,63 @@ public record AppBundleManifest(
     permissions = List.copyOf(Objects.requireNonNull(permissions, "permissions"));
     dataQuotaBytes = normalizeQuota(dataQuotaBytes, "quota.data.bytes");
     cacheQuotaBytes = normalizeQuota(cacheQuotaBytes, "quota.cache.bytes");
+    sandboxMode = Objects.requireNonNullElse(sandboxMode, AppSandboxMode.NONE);
     Objects.requireNonNull(restartPolicy, "restartPolicy");
     requireValidRestartMaxAttempts(restartMaxAttempts);
     requireValidRestartBackoffMillis(restartBackoffMillis);
+  }
+
+  /**
+   * Creates a manifest with the default sandbox policy and explicit restart policy.
+   *
+   * <p>This overload preserves source compatibility for callers that construct signed-bundle
+   * manifests directly. Parsed manifests normally supply the sandbox fields explicitly.
+   *
+   * @param manifestVersion manifest schema version, currently required to be {@code 1}
+   * @param appId stable lower-case application identifier safe for managed bundle paths
+   * @param appName human-readable application name shown by host and API surfaces
+   * @param appVersion display version string recorded in installed app summaries
+   * @param execPathText executable path relative to the bundle root, using normalized separators
+   * @param uiMode normalized browser UI ownership mode declared or inferred from the manifest
+   * @param uiEntry optional UI entry path, or {@code null} when the app has no bundled UI surface
+   * @param permissions normalized permission strings declared by the app manifest
+   * @param dataQuotaBytes optional mutable data quota metadata in bytes, or {@code null}
+   * @param cacheQuotaBytes optional mutable cache quota metadata in bytes, or {@code null}
+   * @param restartPolicy normalized process restart policy
+   * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
+   * @param restartBackoffMillis delay before an automatic restart attempt
+   */
+  @SuppressWarnings("unused")
+  public AppBundleManifest(
+      int manifestVersion,
+      String appId,
+      String appName,
+      String appVersion,
+      String execPathText,
+      AppUiMode uiMode,
+      String uiEntry,
+      List<String> permissions,
+      Long dataQuotaBytes,
+      Long cacheQuotaBytes,
+      AppRestartPolicy restartPolicy,
+      int restartMaxAttempts,
+      long restartBackoffMillis) {
+    this(
+        manifestVersion,
+        appId,
+        appName,
+        appVersion,
+        execPathText,
+        uiMode,
+        uiEntry,
+        permissions,
+        dataQuotaBytes,
+        cacheQuotaBytes,
+        AppSandboxMode.NONE,
+        false,
+        restartPolicy,
+        restartMaxAttempts,
+        restartBackoffMillis);
   }
 
   /**
@@ -134,6 +194,8 @@ public record AppBundleManifest(
         permissions,
         dataQuotaBytes,
         cacheQuotaBytes,
+        AppSandboxMode.NONE,
+        false,
         AppRestartPolicy.NEVER,
         0,
         0L);
@@ -176,6 +238,8 @@ public record AppBundleManifest(
         permissions,
         dataQuotaBytes,
         cacheQuotaBytes,
+        AppSandboxMode.NONE,
+        false,
         AppRestartPolicy.NEVER,
         0,
         0L);

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppBundleManifestParser.java
@@ -266,6 +266,8 @@ public final class AppBundleManifestParser {
     List<String> permissions = parsePermissions(optional(properties, "app.permissions"));
     Long dataQuotaBytes = parseOptionalLong(properties, "quota.data.bytes");
     Long cacheQuotaBytes = parseOptionalLong(properties, "quota.cache.bytes");
+    AppSandboxMode sandboxMode = parseSandboxMode(optional(properties, "sandbox.mode"));
+    boolean sandboxRequired = parseSandboxRequired(properties);
     AppRestartPolicy restartPolicy = parseRestartPolicy(optional(properties, "app.restart.policy"));
     int restartMaxAttempts = parseRestartMaxAttempts(properties);
     long restartBackoffMillis = parseRestartBackoffMillis(properties);
@@ -281,6 +283,8 @@ public final class AppBundleManifestParser {
           permissions,
           dataQuotaBytes,
           cacheQuotaBytes,
+          sandboxMode,
+          sandboxRequired,
           restartPolicy,
           restartMaxAttempts,
           restartBackoffMillis);
@@ -301,6 +305,14 @@ public final class AppBundleManifestParser {
   private static AppUiMode parseUiMode(String rawValue) throws AppDistributionException {
     try {
       return AppUiMode.parseManifestValue(rawValue);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(exception.getMessage(), exception);
+    }
+  }
+
+  private static AppSandboxMode parseSandboxMode(String rawValue) throws AppDistributionException {
+    try {
+      return AppSandboxMode.parseManifestValue(rawValue);
     } catch (IllegalArgumentException exception) {
       throw new AppDistributionException(exception.getMessage(), exception);
     }
@@ -447,6 +459,23 @@ public final class AppBundleManifestParser {
     } catch (NumberFormatException exception) {
       throw new AppDistributionException("invalid " + key + ": " + value, exception);
     }
+  }
+
+  private static boolean parseSandboxRequired(Properties properties)
+      throws AppDistributionException {
+    String key = "sandbox.required";
+    String value = optional(properties, key);
+    if (value == null) {
+      return false;
+    }
+    String normalized = value.toLowerCase(Locale.ROOT);
+    if (normalized.equals("true")) {
+      return true;
+    }
+    if (normalized.equals("false")) {
+      return false;
+    }
+    throw new AppDistributionException("invalid " + key + ": " + value);
   }
 
   private static String required(Properties properties, String key)

--- a/platform-appdist/src/main/java/network/crypta/platform/appdist/AppSandboxMode.java
+++ b/platform-appdist/src/main/java/network/crypta/platform/appdist/AppSandboxMode.java
@@ -1,0 +1,102 @@
+package network.crypta.platform.appdist;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Process sandbox mode declared by an app bundle manifest.
+ *
+ * <p>The mode is signed as part of {@code cryptad-app.properties} so AppHost can make launch-time
+ * decisions from authenticated metadata. The values intentionally describe requested runtime
+ * policy, not a guarantee that a specific host can provide hard operating-system isolation. AppHost
+ * reports the actual support level separately at runtime through its sandbox status model.
+ *
+ * <p>This enum lives in {@code platform-appdist} because bundle signing and verification need to
+ * parse the manifest without depending on AppHost internals. The values are therefore stable
+ * manifest tokens rather than implementation classes. AppHost providers may support only a subset
+ * of the modes on a given host. Runtime status reports the actual outcome for operators: no
+ * isolation, best-effort launch hygiene, an unsupported mode, or a future enforced sandbox. Unknown
+ * values fail parsing so signed bundles cannot silently request behavior that this node does not
+ * understand.
+ */
+public enum AppSandboxMode {
+  /**
+   * Run the app with the normal local child-process launch path.
+   *
+   * <p>This is the default for existing manifests. It provides no operating-system sandbox
+   * isolation beyond AppHost's existing launch hygiene and token/path redaction boundaries. API and
+   * Shell surfaces should show this mode plainly as unsandboxed rather than presenting it as a
+   * security feature.
+   */
+  NONE("none"),
+
+  /**
+   * Request the AppHost restricted-process launch path.
+   *
+   * <p>The v1 implementation is conservative and best-effort. It can apply and report AppHost
+   * process-launch hygiene, but it must not be described as a container, chroot, jail, seccomp
+   * filter, or equivalent hard sandbox unless a future provider actually enforces those controls. A
+   * manifest can combine this mode with {@code sandbox.required=true} to require provider support,
+   * but the runtime status still distinguishes best-effort from enforced isolation.
+   */
+  RESTRICTED_PROCESS("restricted-process"),
+
+  /**
+   * Reserve a future WebAssembly runtime mode.
+   *
+   * <p>PR-206 parses this value so manifests can be validated consistently, but the default host
+   * has no WASM provider and therefore reports the mode as unsupported unless a future embedding
+   * supplies one explicitly. Keeping the token in the signed manifest grammar lets tooling reject
+   * misspellings now while leaving runtime execution to a later provider.
+   */
+  WASM_PREVIEW("wasm-preview");
+
+  private final String manifestValue;
+
+  AppSandboxMode(String manifestValue) {
+    this.manifestValue = manifestValue;
+  }
+
+  /**
+   * Returns the manifest/API spelling for this sandbox mode.
+   *
+   * <p>The returned value is the only spelling that should be written to {@code
+   * cryptad-app.properties} or exposed in Platform API JSON. It is intentionally lower-case and
+   * hyphenated so app manifests, catalog metadata, and operator-facing status output use the same
+   * vocabulary.
+   *
+   * @return lower-case stable manifest token for this sandbox mode
+   */
+  public String manifestValue() {
+    return manifestValue;
+  }
+
+  /**
+   * Parses an optional {@code sandbox.mode} value.
+   *
+   * <p>A missing value maps to {@link #NONE} for backward compatibility with existing app
+   * manifests. Present blank or unknown values fail manifest validation. Parsing is
+   * case-insensitive, but the normalized value returned by {@link #manifestValue()} remains the
+   * canonical spelling for signatures, API responses, and Web Shell display.
+   *
+   * @param rawValue raw manifest property value, or {@code null} when the key is absent
+   * @return parsed sandbox mode using {@link #NONE} for omitted manifest values
+   * @throws IllegalArgumentException if a present value is blank or not one of the supported tokens
+   */
+  public static AppSandboxMode parseManifestValue(String rawValue) {
+    if (rawValue == null) {
+      return NONE;
+    }
+    String normalized =
+        Objects.requireNonNull(rawValue, "rawValue").trim().toLowerCase(Locale.ROOT);
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException("sandbox.mode must not be blank");
+    }
+    for (AppSandboxMode mode : values()) {
+      if (Objects.equals(mode.manifestValue, normalized)) {
+        return mode;
+      }
+    }
+    throw new IllegalArgumentException("unsupported sandbox.mode: " + rawValue);
+  }
+}

--- a/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
+++ b/platform-appdist/src/test/java/network/crypta/platform/appdist/AppBundleManifestParserTest.java
@@ -3,8 +3,10 @@ package network.crypta.platform.appdist;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AppBundleManifestParserTest {
   @Test
@@ -29,9 +31,55 @@ class AppBundleManifestParserTest {
 
     assertEquals(AppUiMode.NONE, manifest.uiMode());
     assertNull(manifest.uiEntry());
+    assertEquals(AppSandboxMode.NONE, manifest.sandboxMode());
+    assertFalse(manifest.sandboxRequired());
     assertEquals(AppRestartPolicy.NEVER, manifest.restartPolicy());
     assertEquals(0, manifest.restartMaxAttempts());
     assertEquals(0L, manifest.restartBackoffMillis());
+  }
+
+  @Test
+  void parseContent_whenRestrictedSandboxDeclared_expectSandboxFields() throws Exception {
+    AppBundleManifest manifest =
+        AppBundleManifestParser.parseContent(
+            minimalManifest(
+                """
+                sandbox.mode=restricted-process
+                sandbox.required=true
+                """));
+
+    assertEquals(AppSandboxMode.RESTRICTED_PROCESS, manifest.sandboxMode());
+    assertTrue(manifest.sandboxRequired());
+  }
+
+  @Test
+  void parseContent_whenWasmPreviewSandboxDeclared_expectReservedModeParsed() throws Exception {
+    AppBundleManifest manifest =
+        AppBundleManifestParser.parseContent(minimalManifest("sandbox.mode=wasm-preview\n"));
+
+    assertEquals(AppSandboxMode.WASM_PREVIEW, manifest.sandboxMode());
+    assertFalse(manifest.sandboxRequired());
+  }
+
+  @Test
+  void parseContent_whenSandboxModeIsUnsupported_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> AppBundleManifestParser.parseContent(minimalManifest("sandbox.mode=docker\n")));
+
+    assertEquals("unsupported sandbox.mode: docker", exception.getMessage());
+  }
+
+  @Test
+  void parseContent_whenSandboxRequiredIsMalformed_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                AppBundleManifestParser.parseContent(minimalManifest("sandbox.required=maybe\n")));
+
+    assertEquals("invalid sandbox.required: maybe", exception.getMessage());
   }
 
   @Test

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/AppRuntimeStatusSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/AppRuntimeStatusSnapshot.java
@@ -2,6 +2,9 @@ package network.crypta.platform.apphost;
 
 import java.time.Instant;
 import java.util.Objects;
+import network.crypta.platform.apphost.sandbox.AppSandboxPolicy;
+import network.crypta.platform.apphost.sandbox.AppSandboxProviders;
+import network.crypta.platform.apphost.sandbox.AppSandboxStatus;
 
 /**
  * Token-free process status snapshot for one installed app.
@@ -21,6 +24,9 @@ import java.util.Objects;
  * <p>Log metadata mirrors the process-log tail API without exposing the log path. Callers can use
  * {@code logAvailable} and {@code logSizeBytes} to decide whether to show a log action while still
  * keeping run directories and token-bearing launch details outside the public response shape.
+ * Sandbox metadata is likewise coarse and token-free: it reports requested mode, support level,
+ * provider name, and warnings without exposing command lines, environment values, or filesystem
+ * paths.
  *
  * @param appId stable application identifier normalized by {@link InstalledAppPaths#normalizeAppId}
  * @param state current host-observed runtime state for the installed app
@@ -33,6 +39,7 @@ import java.util.Objects;
  * @param currentRestartAttempt current or pending automatic restart attempt number
  * @param logAvailable whether the process log can currently be read as a regular file
  * @param logSizeBytes process log size in bytes, if known without exposing the path
+ * @param sandboxStatus token-free sandbox status for this runtime snapshot
  */
 public record AppRuntimeStatusSnapshot(
     String appId,
@@ -45,7 +52,8 @@ public record AppRuntimeStatusSnapshot(
     int restartCount,
     int currentRestartAttempt,
     boolean logAvailable,
-    Long logSizeBytes) {
+    Long logSizeBytes,
+    AppSandboxStatus sandboxStatus) {
   /**
    * Creates a validated runtime status snapshot.
    *
@@ -65,10 +73,12 @@ public record AppRuntimeStatusSnapshot(
    * @param currentRestartAttempt current or pending automatic restart attempt number
    * @param logAvailable whether the process log can currently be read as a regular file
    * @param logSizeBytes process log size in bytes, if known without exposing the path
+   * @param sandboxStatus token-free sandbox status for this runtime snapshot
    */
   public AppRuntimeStatusSnapshot {
     appId = InstalledAppPaths.normalizeAppId(appId);
     Objects.requireNonNull(state, "state");
+    Objects.requireNonNull(sandboxStatus, "sandboxStatus");
     if (pid != null && pid <= 0L) {
       throw new IllegalArgumentException("pid must be positive when present");
     }
@@ -81,5 +91,50 @@ public record AppRuntimeStatusSnapshot(
     if (logSizeBytes != null && logSizeBytes < 0L) {
       throw new IllegalArgumentException("logSizeBytes must be non-negative when present");
     }
+  }
+
+  /**
+   * Creates a runtime snapshot with default no-sandbox status.
+   *
+   * <p>This overload preserves source compatibility for tests and alternate AppHost embeddings that
+   * construct snapshots directly.
+   *
+   * @param appId stable application identifier accepted by AppHost path normalization
+   * @param state current host-observed runtime state for the installed app
+   * @param running whether a managed process is currently live according to AppHost
+   * @param pid representative process id when running, otherwise {@code null}
+   * @param startedAt process start time when running, otherwise {@code null}
+   * @param lastExitAt last managed process exit time retained by this daemon, if known
+   * @param lastExitCode last managed process exit code retained by this daemon, if known
+   * @param restartCount completed automatic restart launches in this daemon-managed run
+   * @param currentRestartAttempt current or pending automatic restart attempt number
+   * @param logAvailable whether the process log can currently be read as a regular file
+   * @param logSizeBytes process log size in bytes, if known without exposing the path
+   */
+  public AppRuntimeStatusSnapshot(
+      String appId,
+      AppRuntimeState state,
+      boolean running,
+      Long pid,
+      Instant startedAt,
+      Instant lastExitAt,
+      Integer lastExitCode,
+      int restartCount,
+      int currentRestartAttempt,
+      boolean logAvailable,
+      Long logSizeBytes) {
+    this(
+        appId,
+        state,
+        running,
+        pid,
+        startedAt,
+        lastExitAt,
+        lastExitCode,
+        restartCount,
+        currentRestartAttempt,
+        logAvailable,
+        logSizeBytes,
+        AppSandboxProviders.inactiveStatus(AppSandboxPolicy.defaults()));
   }
 }

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/RunningAppSnapshot.java
@@ -3,6 +3,8 @@ package network.crypta.platform.apphost;
 import java.time.Instant;
 import java.util.Objects;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.apphost.sandbox.AppSandboxProviders;
+import network.crypta.platform.apphost.sandbox.AppSandboxStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -22,9 +24,15 @@ import org.jetbrains.annotations.NotNull;
  * @param token opaque per-start launch token
  * @param pid child-process id
  * @param startedAt launch timestamp
+ * @param sandboxStatus token-free sandbox status for this launch
  */
 public record RunningAppSnapshot(
-    AppManifest manifest, InstalledAppPaths paths, String token, long pid, Instant startedAt) {
+    AppManifest manifest,
+    InstalledAppPaths paths,
+    String token,
+    long pid,
+    Instant startedAt,
+    AppSandboxStatus sandboxStatus) {
   /**
    * Creates a validated running-app snapshot.
    *
@@ -33,18 +41,43 @@ public record RunningAppSnapshot(
    * @param token opaque per-start launch token
    * @param pid child-process id
    * @param startedAt launch timestamp
+   * @param sandboxStatus token-free sandbox status for this launch
    */
   public RunningAppSnapshot {
     Objects.requireNonNull(manifest, "manifest");
     Objects.requireNonNull(paths, "paths");
     Objects.requireNonNull(token, "token");
     Objects.requireNonNull(startedAt, "startedAt");
+    Objects.requireNonNull(sandboxStatus, "sandboxStatus");
     if (token.isBlank()) {
       throw new IllegalArgumentException("token must not be blank");
     }
     if (pid <= 0) {
       throw new IllegalArgumentException("pid must be positive");
     }
+  }
+
+  /**
+   * Creates a running snapshot with an inactive manifest-derived sandbox status.
+   *
+   * <p>This overload preserves compatibility for tests and embeddings that construct running
+   * snapshots directly without exercising the provider launch path.
+   *
+   * @param manifest parsed application manifest
+   * @param paths derived filesystem paths for the installed app
+   * @param token opaque per-start launch token
+   * @param pid child-process id
+   * @param startedAt launch timestamp
+   */
+  public RunningAppSnapshot(
+      AppManifest manifest, InstalledAppPaths paths, String token, long pid, Instant startedAt) {
+    this(
+        manifest,
+        paths,
+        token,
+        pid,
+        startedAt,
+        AppSandboxProviders.inactiveStatus(manifest.sandboxPolicy()));
   }
 
   /**

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifest.java
@@ -6,8 +6,10 @@ import java.util.Locale;
 import java.util.Objects;
 import network.crypta.platform.appdist.AppBundleManifest;
 import network.crypta.platform.appdist.AppRestartPolicy;
+import network.crypta.platform.appdist.AppSandboxMode;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.InstalledAppPaths;
+import network.crypta.platform.apphost.sandbox.AppSandboxPolicy;
 
 /**
  * Parsed v1 manifest for an installed application.
@@ -32,6 +34,7 @@ import network.crypta.platform.apphost.InstalledAppPaths;
  * @param permissions normalized permission strings
  * @param dataQuotaBytes optional data quota metadata, or {@code null}
  * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+ * @param sandboxPolicy requested process sandbox policy
  * @param restartPolicy normalized process restart policy
  * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
  * @param restartBackoffMillis delay before an automatic restart attempt
@@ -47,6 +50,7 @@ public record AppManifest(
     List<String> permissions,
     Long dataQuotaBytes,
     Long cacheQuotaBytes,
+    AppSandboxPolicy sandboxPolicy,
     AppRestartPolicy restartPolicy,
     int restartMaxAttempts,
     long restartBackoffMillis) {
@@ -63,6 +67,7 @@ public record AppManifest(
    * @param permissions normalized permission strings
    * @param dataQuotaBytes optional data quota metadata, or {@code null}
    * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+   * @param sandboxPolicy requested process sandbox policy
    * @param restartPolicy normalized process restart policy
    * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
    * @param restartBackoffMillis delay before an automatic restart attempt
@@ -80,6 +85,8 @@ public record AppManifest(
             permissions,
             dataQuotaBytes,
             cacheQuotaBytes,
+            Objects.requireNonNullElse(sandboxPolicy, AppSandboxPolicy.defaults()).mode(),
+            sandboxPolicy != null && sandboxPolicy.required(),
             restartPolicy,
             restartMaxAttempts,
             restartBackoffMillis);
@@ -93,9 +100,104 @@ public record AppManifest(
     permissions = normalized.permissions();
     dataQuotaBytes = normalized.dataQuotaBytes();
     cacheQuotaBytes = normalized.cacheQuotaBytes();
+    sandboxPolicy = new AppSandboxPolicy(normalized.sandboxMode(), normalized.sandboxRequired());
     restartPolicy = normalized.restartPolicy();
     restartMaxAttempts = normalized.restartMaxAttempts();
     restartBackoffMillis = normalized.restartBackoffMillis();
+  }
+
+  /**
+   * Creates a manifest with explicit restart policy and default no-sandbox policy.
+   *
+   * @param manifestVersion manifest schema version
+   * @param appId stable path-safe app identifier
+   * @param appName human-readable application name
+   * @param appVersion display version string
+   * @param execPathText executable path relative to the installed app root
+   * @param uiMode normalized browser UI ownership mode declared or inferred from the manifest
+   * @param uiEntry optional UI entry path, or {@code null}
+   * @param permissions normalized permission strings
+   * @param dataQuotaBytes optional data quota metadata, or {@code null}
+   * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+   * @param restartPolicy normalized process restart policy
+   * @param restartMaxAttempts maximum automatic restart attempts for one daemon-managed run
+   * @param restartBackoffMillis delay before an automatic restart attempt
+   */
+  public AppManifest(
+      int manifestVersion,
+      String appId,
+      String appName,
+      String appVersion,
+      String execPathText,
+      AppUiMode uiMode,
+      String uiEntry,
+      List<String> permissions,
+      Long dataQuotaBytes,
+      Long cacheQuotaBytes,
+      AppRestartPolicy restartPolicy,
+      int restartMaxAttempts,
+      long restartBackoffMillis) {
+    this(
+        manifestVersion,
+        appId,
+        appName,
+        appVersion,
+        execPathText,
+        uiMode,
+        uiEntry,
+        permissions,
+        dataQuotaBytes,
+        cacheQuotaBytes,
+        AppSandboxPolicy.defaults(),
+        restartPolicy,
+        restartMaxAttempts,
+        restartBackoffMillis);
+  }
+
+  /**
+   * Creates a manifest with explicit sandbox fields and the default restart policy.
+   *
+   * @param manifestVersion manifest schema version
+   * @param appId stable path-safe app identifier
+   * @param appName human-readable application name
+   * @param appVersion display version string
+   * @param execPathText executable path relative to the installed app root
+   * @param uiMode normalized browser UI ownership mode declared or inferred from the manifest
+   * @param uiEntry optional UI entry path, or {@code null}
+   * @param permissions normalized permission strings
+   * @param dataQuotaBytes optional data quota metadata, or {@code null}
+   * @param cacheQuotaBytes optional cache quota metadata, or {@code null}
+   * @param sandboxMode requested process sandbox mode
+   * @param sandboxRequired whether launch must fail when the requested sandbox mode is unsupported
+   */
+  public AppManifest(
+      int manifestVersion,
+      String appId,
+      String appName,
+      String appVersion,
+      String execPathText,
+      AppUiMode uiMode,
+      String uiEntry,
+      List<String> permissions,
+      Long dataQuotaBytes,
+      Long cacheQuotaBytes,
+      AppSandboxMode sandboxMode,
+      boolean sandboxRequired) {
+    this(
+        manifestVersion,
+        appId,
+        appName,
+        appVersion,
+        execPathText,
+        uiMode,
+        uiEntry,
+        permissions,
+        dataQuotaBytes,
+        cacheQuotaBytes,
+        new AppSandboxPolicy(sandboxMode, sandboxRequired),
+        AppRestartPolicy.NEVER,
+        0,
+        0L);
   }
 
   /**
@@ -134,6 +236,7 @@ public record AppManifest(
         permissions,
         dataQuotaBytes,
         cacheQuotaBytes,
+        AppSandboxPolicy.defaults(),
         AppRestartPolicy.NEVER,
         0,
         0L);
@@ -191,6 +294,7 @@ public record AppManifest(
         manifest.permissions(),
         manifest.dataQuotaBytes(),
         manifest.cacheQuotaBytes(),
+        new AppSandboxPolicy(manifest.sandboxMode(), manifest.sandboxRequired()),
         manifest.restartPolicy(),
         manifest.restartMaxAttempts(),
         manifest.restartBackoffMillis());

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/manifest/AppManifestParser.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import network.crypta.platform.appdist.AppBundleManifest;
 import network.crypta.platform.appdist.AppBundleManifestParser;
 import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.apphost.sandbox.AppSandboxPolicy;
 
 /**
  * Parser and validator for the v1 app-host manifest format.
@@ -60,6 +61,7 @@ public final class AppManifestParser {
         manifest.permissions(),
         manifest.dataQuotaBytes(),
         manifest.cacheQuotaBytes(),
+        new AppSandboxPolicy(manifest.sandboxMode(), manifest.sandboxRequired()),
         manifest.restartPolicy(),
         manifest.restartMaxAttempts(),
         manifest.restartBackoffMillis());

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -53,6 +53,10 @@ import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.manifest.AppManifestException;
 import network.crypta.platform.apphost.manifest.AppManifestParser;
+import network.crypta.platform.apphost.sandbox.AppSandboxLaunchContext;
+import network.crypta.platform.apphost.sandbox.AppSandboxLaunchPlan;
+import network.crypta.platform.apphost.sandbox.AppSandboxProviders;
+import network.crypta.platform.apphost.sandbox.AppSandboxStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -123,6 +127,7 @@ public final class LocalProcessAppHost implements AppHost {
   private final TimingConfig timing;
   private final ManagedTreeDeleter managedTreeDeleter;
   private final AppInstallVerificationPolicy installVerificationPolicy;
+  private final AppSandboxProviders sandboxProviders;
   private final Map<String, RunningProcess> runningApps = new ConcurrentHashMap<>();
   private final Map<String, RuntimeRecord> runtimeRecords = new ConcurrentHashMap<>();
   private final Set<String> explicitStopRequests = ConcurrentHashMap.newKeySet();
@@ -289,14 +294,35 @@ public final class LocalProcessAppHost implements AppHost {
       TimingConfig timing,
       ManagedTreeDeleter managedTreeDeleter,
       AppInstallVerificationPolicy installVerificationPolicy) {
+    this(
+        layout,
+        stopTimeout,
+        secureRandom,
+        appEnv,
+        timing,
+        new HostDependencies(
+            managedTreeDeleter, installVerificationPolicy, AppSandboxProviders.defaults()));
+  }
+
+  private LocalProcessAppHost(
+      AppHostLayout layout,
+      Duration stopTimeout,
+      SecureRandom secureRandom,
+      AppEnv appEnv,
+      TimingConfig timing,
+      HostDependencies dependencies) {
     this.layout = Objects.requireNonNull(layout, "layout");
     this.stopTimeout = Objects.requireNonNull(stopTimeout, "stopTimeout");
     this.secureRandom = Objects.requireNonNull(secureRandom, "secureRandom");
     this.appEnv = Objects.requireNonNull(appEnv, "appEnv");
     this.timing = Objects.requireNonNull(timing, "timing");
-    this.managedTreeDeleter = Objects.requireNonNull(managedTreeDeleter, "managedTreeDeleter");
+    HostDependencies normalized = Objects.requireNonNull(dependencies, "dependencies");
+    this.managedTreeDeleter =
+        Objects.requireNonNull(normalized.managedTreeDeleter(), "managedTreeDeleter");
     this.installVerificationPolicy =
-        Objects.requireNonNull(installVerificationPolicy, "installVerificationPolicy");
+        Objects.requireNonNull(normalized.installVerificationPolicy(), "installVerificationPolicy");
+    this.sandboxProviders =
+        Objects.requireNonNull(normalized.sandboxProviders(), "sandboxProviders");
     if (stopTimeout.isZero() || stopTimeout.isNegative()) {
       throw new IllegalArgumentException("stopTimeout must be positive");
     }
@@ -521,11 +547,28 @@ public final class LocalProcessAppHost implements AppHost {
 
     String token = generateToken();
     List<String> command = launchCommand(executable);
-    ProcessBuilder builder = new ProcessBuilder(command);
-    builder.directory(paths.installedRoot().toFile());
+    Map<String, String> launchEnvironment = new LinkedHashMap<>();
+    populateEnvironment(launchEnvironment, installation.manifest(), paths, token, appEnv);
+    AppSandboxLaunchPlan launchPlan =
+        sandboxProviders.prepareLaunch(
+            new AppSandboxLaunchContext(
+                normalizedAppId,
+                paths.installedRoot(),
+                paths.dataDir(),
+                paths.cacheDir(),
+                paths.runDir(),
+                paths.processLogFile().getParent(),
+                command,
+                launchEnvironment,
+                paths.installedRoot(),
+                installation.manifest().sandboxPolicy(),
+                appEnv));
+    ProcessBuilder builder = new ProcessBuilder(launchPlan.command());
+    builder.directory(launchPlan.workingDirectory().toFile());
     builder.redirectErrorStream(true);
     builder.redirectOutput(ProcessBuilder.Redirect.appendTo(paths.processLogFile().toFile()));
-    populateEnvironment(builder.environment(), installation.manifest(), paths, token, appEnv);
+    builder.environment().clear();
+    builder.environment().putAll(launchPlan.environment());
 
     Instant startedAt = Instant.now();
     Process process = builder.start();
@@ -544,6 +587,7 @@ public final class LocalProcessAppHost implements AppHost {
               restartCount,
               currentRestartAttempt,
               token,
+              launchPlan.sandboxStatus(),
               false));
       throw startupFailure(normalizedAppId, process);
     }
@@ -556,7 +600,8 @@ public final class LocalProcessAppHost implements AppHost {
                 startupProcessTree,
                 process.pid(),
                 preferDescendantPid(executable, startupProcessTree)),
-            startedAt);
+            startedAt,
+            launchPlan.sandboxStatus());
     CompletableFuture<Void> exitCleanup = new CompletableFuture<>();
     RunningProcess runningProcess =
         new RunningProcess(
@@ -703,9 +748,16 @@ public final class LocalProcessAppHost implements AppHost {
             .orElseThrow(() -> new AppHostException(APP_NOT_INSTALLED_PREFIX + appId));
     RuntimeRecord runtimeRecord = runtimeRecords.get(normalizedAppId);
     if (runtimeRecord == null) {
-      runtimeRecord = RuntimeRecord.stopped(installed.paths());
+      runtimeRecord =
+          RuntimeRecord.stopped(
+              installed.paths(),
+              AppSandboxProviders.inactiveStatus(installed.manifest().sandboxPolicy()));
     }
-    return statusSnapshot(normalizedAppId, runtimeRecord.withoutRunningProcess(installed.paths()));
+    return statusSnapshot(
+        normalizedAppId,
+        runtimeRecord.withoutRunningProcess(
+            installed.paths(),
+            AppSandboxProviders.inactiveStatus(installed.manifest().sandboxPolicy())));
   }
 
   /**
@@ -772,7 +824,8 @@ public final class LocalProcessAppHost implements AppHost {
         runtimeRecord.restartCount(),
         runtimeRecord.currentRestartAttempt(),
         log.available(),
-        log.sizeBytes());
+        log.sizeBytes(),
+        runtimeRecord.sandboxStatus());
   }
 
   private static int boundedLogTailBytes(int maxBytes) {
@@ -861,6 +914,7 @@ public final class LocalProcessAppHost implements AppHost {
             exitRecord.exitAt(),
             exitRecord.exitCode(),
             exitRecord.lastLaunchToken(),
+            exitRecord.sandboxStatus(),
             exitRecord.restartCount(),
             exitRecord.currentRestartAttempt()));
   }
@@ -2567,6 +2621,11 @@ public final class LocalProcessAppHost implements AppHost {
     void deleteRecursively(Path root) throws IOException;
   }
 
+  private record HostDependencies(
+      ManagedTreeDeleter managedTreeDeleter,
+      AppInstallVerificationPolicy installVerificationPolicy,
+      AppSandboxProviders sandboxProviders) {}
+
   record TimingConfig(
       Duration startupExitGracePeriod,
       Duration startupProcessCaptureWindow,
@@ -2621,6 +2680,7 @@ public final class LocalProcessAppHost implements AppHost {
       int restartCount,
       int currentRestartAttempt,
       String lastLaunchToken,
+      AppSandboxStatus sandboxStatus,
       boolean explicitStop) {
     private static ProcessExitRecord fromRunningProcess(
         RunningProcess runningProcess, Integer exitCode, Instant exitAt, boolean explicitStop) {
@@ -2631,6 +2691,7 @@ public final class LocalProcessAppHost implements AppHost {
           runningProcess.restartCount(),
           runningProcess.currentRestartAttempt(),
           runningProcess.snapshot().token(),
+          runningProcess.snapshot().sandboxStatus(),
           explicitStop);
     }
   }
@@ -2646,6 +2707,7 @@ public final class LocalProcessAppHost implements AppHost {
       Instant lastExitAt,
       Integer lastExitCode,
       String lastLaunchToken,
+      AppSandboxStatus sandboxStatus,
       int restartCount,
       int currentRestartAttempt) {
     private static RuntimeRecord running(
@@ -2671,6 +2733,7 @@ public final class LocalProcessAppHost implements AppHost {
           previousRecord == null ? null : previousRecord.lastExitAt(),
           previousRecord == null ? null : previousRecord.lastExitCode(),
           snapshot.token(),
+          snapshot.sandboxStatus(),
           restartCount,
           currentRestartAttempt);
     }
@@ -2686,13 +2749,14 @@ public final class LocalProcessAppHost implements AppHost {
           exitAt,
           exitCode,
           runningProcess.snapshot().token(),
+          runningProcess.snapshot().sandboxStatus(),
           runningProcess.restartCount(),
           restartAttempt);
     }
 
-    private static RuntimeRecord stopped(InstalledAppPaths paths) {
+    private static RuntimeRecord stopped(InstalledAppPaths paths, AppSandboxStatus sandboxStatus) {
       return new RuntimeRecord(
-          paths, AppRuntimeState.STOPPED, false, null, null, null, null, null, 0, 0);
+          paths, AppRuntimeState.STOPPED, false, null, null, null, null, null, sandboxStatus, 0, 0);
     }
 
     private static RuntimeRecord stopped(RunningProcess runningProcess) {
@@ -2705,6 +2769,7 @@ public final class LocalProcessAppHost implements AppHost {
           Instant.now(),
           trackedAppExitCode(runningProcess),
           runningProcess.snapshot().token(),
+          runningProcess.snapshot().sandboxStatus(),
           runningProcess.restartCount(),
           runningProcess.currentRestartAttempt());
     }
@@ -2719,6 +2784,7 @@ public final class LocalProcessAppHost implements AppHost {
           lastExitAt,
           lastExitCode,
           lastLaunchToken,
+          sandboxStatus,
           restartCount,
           currentRestartAttempt);
     }
@@ -2733,11 +2799,13 @@ public final class LocalProcessAppHost implements AppHost {
           failedAt,
           lastExitCode,
           lastLaunchToken,
+          sandboxStatus,
           restartCount,
           currentRestartAttempt);
     }
 
-    private RuntimeRecord withoutRunningProcess(InstalledAppPaths installedPaths) {
+    private RuntimeRecord withoutRunningProcess(
+        InstalledAppPaths installedPaths, AppSandboxStatus installedSandboxStatus) {
       if (running) {
         return new RuntimeRecord(
             installedPaths,
@@ -2748,13 +2816,17 @@ public final class LocalProcessAppHost implements AppHost {
             lastExitAt,
             lastExitCode,
             lastLaunchToken,
+            installedSandboxStatus,
             restartCount,
             currentRestartAttempt);
       }
-      return paths.equals(installedPaths) ? this : withPaths(installedPaths);
+      return paths.equals(installedPaths) && sandboxStatus.equals(installedSandboxStatus)
+          ? this
+          : withPathsAndSandboxStatus(installedPaths, installedSandboxStatus);
     }
 
-    private RuntimeRecord withPaths(InstalledAppPaths installedPaths) {
+    private RuntimeRecord withPathsAndSandboxStatus(
+        InstalledAppPaths installedPaths, AppSandboxStatus installedSandboxStatus) {
       return new RuntimeRecord(
           installedPaths,
           state,
@@ -2764,6 +2836,7 @@ public final class LocalProcessAppHost implements AppHost {
           lastExitAt,
           lastExitCode,
           lastLaunchToken,
+          installedSandboxStatus,
           restartCount,
           currentRestartAttempt);
     }
@@ -2786,6 +2859,8 @@ public final class LocalProcessAppHost implements AppHost {
           + lastExitCode
           + ", lastLaunchToken="
           + (lastLaunchToken == null ? null : AppHostTokenRedactor.REDACTED)
+          + ", sandboxStatus="
+          + sandboxStatus
           + ", restartCount="
           + restartCount
           + ", currentRestartAttempt="
@@ -2913,7 +2988,8 @@ public final class LocalProcessAppHost implements AppHost {
                   snapshot.paths(),
                   snapshot.token(),
                   updatedPid,
-                  snapshot.startedAt());
+                  snapshot.startedAt(),
+                  snapshot.sandboxStatus());
       if (trackedHandlePids().equals(handlePids(aliveProcessTree))
           && updatedPid == snapshot.pid()
           && updatedRepresentativeProcessHandoff == representativeProcessHandoff) {

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxException.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxException.java
@@ -1,0 +1,68 @@
+package network.crypta.platform.apphost.sandbox;
+
+import network.crypta.platform.apphost.AppHostException;
+
+/**
+ * Launch-time sandbox policy or provider failure.
+ *
+ * <p>{@code AppSandboxException} is the AppHost-facing error type for sandbox selection and launch
+ * planning failures. It carries a stable machine-readable code so Platform API can preserve the
+ * distinction between ordinary lifecycle conflicts and sandbox-specific rejection, while still
+ * returning a short message that is safe for operator-facing JSON and Web Shell surfaces.
+ *
+ * <p>Messages must not include launch tokens, process environment values, command lines, or
+ * host-private filesystem paths. Providers should use this exception for failures that a caller can
+ * classify from sandbox policy alone, such as an unsupported required mode or an invalid launch
+ * plan assembled by AppHost. Unexpected process I/O failures should remain ordinary {@link
+ * java.io.IOException} instances from the provider boundary.
+ */
+public class AppSandboxException extends AppHostException {
+  /** Stable machine-readable error token carried separately from the display message. */
+  private final String errorCode;
+
+  /**
+   * Creates a sandbox exception with a stable API error code.
+   *
+   * <p>The code is consumed by Platform API error mapping and should remain stable across wording
+   * changes to the human-readable message. Callers should pass messages that explain the policy
+   * failure without exposing runtime secrets or local paths.
+   *
+   * @param errorCode machine-readable Platform API error code for this sandbox failure
+   * @param message token-free failure message safe for API and Shell display
+   */
+  public AppSandboxException(String errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  /**
+   * Returns the stable machine-readable error code.
+   *
+   * <p>The value is intended for JSON error envelopes and audit-style classification. It is not a
+   * localized message and should not include dynamic identifiers beyond the fixed error token.
+   *
+   * @return API error code associated with this sandbox failure
+   */
+  public String errorCode() {
+    return errorCode;
+  }
+
+  /**
+   * Creates the standard unsupported-required sandbox failure.
+   *
+   * <p>This helper centralizes the message used when an app manifest declares {@code
+   * sandbox.required=true} but provider selection cannot produce a supported launch plan. The
+   * message includes only the manifest sandbox mode and deliberately omits provider internals,
+   * process tokens, and host paths.
+   *
+   * @param status unsupported sandbox status produced during provider selection
+   * @return checked AppHost sandbox exception using the {@code unsupported_sandbox} code
+   */
+  public static AppSandboxException unsupportedRequired(AppSandboxStatus status) {
+    return new AppSandboxException(
+        "unsupported_sandbox",
+        "App requires sandbox mode "
+            + status.mode().manifestValue()
+            + ", but no provider can support it on this host");
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxLaunchContext.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxLaunchContext.java
@@ -1,0 +1,104 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.fs.AppEnv;
+import network.crypta.platform.apphost.InstalledAppPaths;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Sensitive launch input passed from AppHost to a sandbox provider.
+ *
+ * <p>This record is the handoff point between {@code LocalProcessAppHost} and an {@link
+ * AppSandboxProvider}. It contains every value a provider may need to inspect or rewrite before
+ * process launch: app identity, immutable and mutable app directories, the command that AppHost
+ * would otherwise execute, the child environment, the requested policy, and platform detection
+ * state. The canonical constructor normalizes app ids and paths so providers can compare locations
+ * without repeating path cleanup.
+ *
+ * <p>The values are intentionally sensitive. The environment contains the per-launch app token, and
+ * paths reveal the host-owned app layout. Providers may return a rewritten launch plan, but logs,
+ * exceptions, and public status objects must never expose environment values, command text that may
+ * carry secrets, or private filesystem paths. The custom {@link #toString()} reports only coarse
+ * sizes and environment key names for diagnostics.
+ *
+ * @param appId normalized application identifier used for provider checks and status correlation
+ * @param installDir installed bundle root used as the immutable application directory
+ * @param dataDir app-scoped mutable data directory managed by AppHost
+ * @param cacheDir app-scoped mutable cache directory managed by AppHost
+ * @param runDir app-scoped runtime directory for process state and transient files
+ * @param logDir directory that contains the AppHost-managed process log
+ * @param command command AppHost would launch before provider rewriting or wrapping
+ * @param environment sanitized child environment, including the sensitive per-launch app token
+ * @param workingDirectory child working directory selected before provider rewriting
+ * @param policy manifest-derived sandbox policy requested for this launch
+ * @param appEnv host platform environment used for OS and architecture decisions
+ */
+public record AppSandboxLaunchContext(
+    String appId,
+    Path installDir,
+    Path dataDir,
+    Path cacheDir,
+    Path runDir,
+    Path logDir,
+    List<String> command,
+    Map<String, String> environment,
+    Path workingDirectory,
+    AppSandboxPolicy policy,
+    AppEnv appEnv) {
+  /**
+   * Creates a normalized launch context.
+   *
+   * <p>All directory arguments are converted to absolute normalized paths, the app id is canonical
+   * AppHost form, and collection inputs are defensively copied. The constructor rejects an empty
+   * command because providers must always return a concrete {@link ProcessBuilder} command in the
+   * corresponding {@link AppSandboxLaunchPlan}.
+   *
+   * @throws IllegalArgumentException if the app id is invalid or the command list is empty
+   * @throws NullPointerException if any required launch field is {@code null}
+   */
+  public AppSandboxLaunchContext {
+    appId = InstalledAppPaths.normalizeAppId(appId);
+    installDir = normalizePath(installDir, "installDir");
+    dataDir = normalizePath(dataDir, "dataDir");
+    cacheDir = normalizePath(cacheDir, "cacheDir");
+    runDir = normalizePath(runDir, "runDir");
+    logDir = normalizePath(logDir, "logDir");
+    command = List.copyOf(Objects.requireNonNull(command, "command"));
+    if (command.isEmpty()) {
+      throw new IllegalArgumentException("command must not be empty");
+    }
+    environment = Map.copyOf(Objects.requireNonNull(environment, "environment"));
+    workingDirectory = normalizePath(workingDirectory, "workingDirectory");
+    Objects.requireNonNull(policy, "policy");
+    Objects.requireNonNull(appEnv, "appEnv");
+  }
+
+  /**
+   * Returns a redacted diagnostic representation of the launch context.
+   *
+   * <p>The output deliberately omits command entries, environment values, and filesystem paths. It
+   * is suitable for local debugging of provider selection shape, but not for reconstructing a
+   * process launch.
+   *
+   * @return token-free summary containing app id, policy, command size, and environment keys
+   */
+  @Override
+  public @NotNull String toString() {
+    return "AppSandboxLaunchContext[appId="
+        + appId
+        + ", policy="
+        + policy
+        + ", commandSize="
+        + command.size()
+        + ", environmentKeys="
+        + environment.keySet()
+        + ']';
+  }
+
+  private static Path normalizePath(Path path, String label) {
+    return Objects.requireNonNull(path, label).toAbsolutePath().normalize();
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxLaunchPlan.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxLaunchPlan.java
@@ -1,0 +1,74 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provider-selected command, environment, working directory, and public sandbox status.
+ *
+ * <p>A provider returns this record after it has accepted an {@link AppSandboxLaunchContext}. The
+ * command, environment, and working directory are the exact values that AppHost should pass to
+ * {@link ProcessBuilder}. The status is the public, token-free description that AppHost retains for
+ * runtime summaries and Platform API responses.
+ *
+ * <p>Providers may leave the launch unchanged, minimize the environment further, wrap the command,
+ * or redirect to a future enforced runtime. Whatever they return must remain internally consistent:
+ * the command cannot be empty, the environment is copied, and the status must describe the actual
+ * level of support applied. The plan intentionally omits command text, environment values, and
+ * filesystem paths from {@link #toString()} because the environment carries the per-launch app
+ * token.
+ *
+ * @param command final command passed to {@link ProcessBuilder} for the child process
+ * @param environment final child process environment, copied before AppHost starts the process
+ * @param workingDirectory final child working directory used by the process builder
+ * @param sandboxStatus token-free public sandbox status for this launch plan
+ */
+public record AppSandboxLaunchPlan(
+    List<String> command,
+    Map<String, String> environment,
+    Path workingDirectory,
+    AppSandboxStatus sandboxStatus) {
+  /**
+   * Creates a validated launch plan.
+   *
+   * <p>Collection inputs are defensively copied so a provider cannot mutate a plan after AppHost
+   * accepts it. The working directory is normalized for stable comparison and process-builder use.
+   * The constructor does not inspect environment values because providers may need to pass opaque
+   * secrets such as the per-launch app token through to the child process.
+   *
+   * @throws IllegalArgumentException if the command list is empty
+   * @throws NullPointerException if any required plan field is {@code null}
+   */
+  public AppSandboxLaunchPlan {
+    command = List.copyOf(Objects.requireNonNull(command, "command"));
+    if (command.isEmpty()) {
+      throw new IllegalArgumentException("command must not be empty");
+    }
+    environment = Map.copyOf(Objects.requireNonNull(environment, "environment"));
+    workingDirectory = Objects.requireNonNull(workingDirectory, "workingDirectory").normalize();
+    Objects.requireNonNull(sandboxStatus, "sandboxStatus");
+  }
+
+  /**
+   * Returns a redacted diagnostic representation of the launch plan.
+   *
+   * <p>The output is intended for debugging provider behavior without exposing launch secrets. It
+   * reports the number of command elements, environment key names, and public sandbox status, but
+   * never includes command entries, environment values, or filesystem paths.
+   *
+   * @return token-free summary of the launch plan shape and sandbox status
+   */
+  @Override
+  public @NotNull String toString() {
+    return "AppSandboxLaunchPlan[commandSize="
+        + command.size()
+        + ", environmentKeys="
+        + environment.keySet()
+        + ", sandboxStatus="
+        + sandboxStatus
+        + ']';
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxPolicy.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxPolicy.java
@@ -1,0 +1,74 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.util.Objects;
+import network.crypta.platform.appdist.AppSandboxMode;
+
+/**
+ * Normalized sandbox policy requested by an app manifest.
+ *
+ * <p>The policy captures only the app author's request. Runtime support and whether any isolation
+ * is active are reported through {@link AppSandboxStatus} after provider selection.
+ *
+ * <p>AppHost derives this record from the signed bundle manifest fields {@code sandbox.mode} and
+ * {@code sandbox.required}. It is intentionally small: it does not include network, filesystem, or
+ * restart-policy hints that AppHost cannot enforce in PR-206. Provider selection uses the mode to
+ * choose a launch planner and the requirement to decide whether an unsupported mode may degrade to
+ * a warning or must reject launch. The record is immutable and safe to carry in installed-app
+ * snapshots, runtime records, and Platform API summaries.
+ *
+ * @param mode requested sandbox mode from the app manifest
+ * @param requirement whether unsupported requested modes must fail launch
+ */
+public record AppSandboxPolicy(AppSandboxMode mode, AppSandboxRequirement requirement) {
+  /**
+   * Creates a normalized sandbox policy.
+   *
+   * <p>Null values are normalized to the backward-compatible manifest defaults: {@link
+   * AppSandboxMode#NONE} and {@link AppSandboxRequirement#OPTIONAL}. That keeps older programmatic
+   * callers source-compatible while ensuring downstream provider logic never receives a null policy
+   * component.
+   */
+  public AppSandboxPolicy {
+    mode = Objects.requireNonNullElse(mode, AppSandboxMode.NONE);
+    requirement = Objects.requireNonNullElse(requirement, AppSandboxRequirement.OPTIONAL);
+  }
+
+  /**
+   * Creates a policy from manifest fields.
+   *
+   * <p>This overload mirrors the parsed manifest shape. It is useful at the boundary between {@code
+   * platform-appdist}, where {@code sandbox.required} is a boolean property, and AppHost, where the
+   * requirement is represented as a typed value.
+   *
+   * @param mode requested sandbox mode from {@code sandbox.mode}
+   * @param required manifest {@code sandbox.required} value after boolean validation
+   */
+  public AppSandboxPolicy(AppSandboxMode mode, boolean required) {
+    this(mode, AppSandboxRequirement.fromBoolean(required));
+  }
+
+  /**
+   * Returns the backward-compatible default policy.
+   *
+   * <p>Missing sandbox fields in existing manifests map to this value. It requests the normal local
+   * process launch path and allows launch to proceed without provider-enforced isolation.
+   *
+   * @return no-sandbox, optional policy used when manifest sandbox fields are absent
+   */
+  public static AppSandboxPolicy defaults() {
+    return new AppSandboxPolicy(AppSandboxMode.NONE, AppSandboxRequirement.OPTIONAL);
+  }
+
+  /**
+   * Returns whether unsupported sandbox support must fail launch.
+   *
+   * <p>This is a convenience bridge for existing code paths that only need the manifest boolean
+   * semantics. It does not indicate that a provider has enforced isolation; use {@link
+   * AppSandboxStatus#supportLevel()} for the runtime result.
+   *
+   * @return {@code true} when the app requires the requested sandbox mode to be supported
+   */
+  public boolean required() {
+    return requirement.required();
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxProvider.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxProvider.java
@@ -1,0 +1,58 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.io.IOException;
+
+/**
+ * Provider SPI that turns an AppHost launch context into a final process launch plan.
+ *
+ * <p>Implementations are the only place where AppHost sandbox policy becomes process-launch
+ * behavior. A provider receives a sensitive {@link AppSandboxLaunchContext}, decides whether it can
+ * honor the requested policy, and returns an {@link AppSandboxLaunchPlan} containing the exact
+ * command, environment, working directory, and public status AppHost should use.
+ *
+ * <p>The SPI is deliberately small for PR-206. Providers may implement no isolation, best-effort
+ * local launch hygiene, or future enforced runtimes, but they must report the actual support level
+ * honestly through {@link AppSandboxStatus}. Implementations must treat context values as secrets:
+ * do not log environment values, launch tokens, command details that can carry secrets, or
+ * host-private paths.
+ */
+public interface AppSandboxProvider {
+  /**
+   * Returns a stable provider identifier safe for API and Shell display.
+   *
+   * <p>The name should be short, deterministic, and independent of local filesystem state. It is
+   * exposed to operators in sandbox status, so it should describe the provider family rather than a
+   * transient platform detail.
+   *
+   * @return provider name used in token-free public sandbox status
+   */
+  @SuppressWarnings("unused")
+  String providerName();
+
+  /**
+   * Returns whether this provider can handle the requested policy.
+   *
+   * <p>This method is a cheap selector check. It should not mutate host state, inspect sensitive
+   * environment values, or allocate per-launch resources. Provider registries call it before {@link
+   * #prepareLaunch(AppSandboxLaunchContext)} to decide whether a policy is supported.
+   *
+   * @param policy requested sandbox policy from the app manifest
+   * @return {@code true} when {@link #prepareLaunch(AppSandboxLaunchContext)} may be called safely
+   */
+  boolean supports(AppSandboxPolicy policy);
+
+  /**
+   * Prepares the final process launch plan.
+   *
+   * <p>The returned plan is the process-launch contract AppHost will use. Providers can leave the
+   * command unchanged, rewrite environment entries, set a stricter working directory, or hand off
+   * to a future runtime wrapper. They should throw {@link AppSandboxException} for policy or
+   * validation failures and ordinary {@link IOException} for filesystem or process-preparation
+   * failures.
+   *
+   * @param context sensitive AppHost launch context for one app start attempt
+   * @return final launch plan containing process-builder inputs and public sandbox status
+   * @throws IOException if the provider cannot safely prepare the launch plan
+   */
+  AppSandboxLaunchPlan prepareLaunch(AppSandboxLaunchContext context) throws IOException;
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxProviders.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxProviders.java
@@ -1,0 +1,144 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.io.IOException;
+import java.util.Objects;
+import network.crypta.platform.appdist.AppSandboxMode;
+
+/**
+ * Provider registry and selector for AppHost sandbox launch planning.
+ *
+ * <p>The default registry supports the normal no-sandbox path, a conservative best-effort
+ * restricted-process path, and reports {@code wasm-preview} as unsupported.
+ *
+ * <p>{@code LocalProcessAppHost} uses this type as the narrow policy-to-provider boundary. The
+ * registry maps a manifest mode to one provider, asks that provider to prepare the launch, and
+ * converts missing optional providers into token-free unsupported status. Missing required
+ * providers become {@link AppSandboxException} failures so Platform API can return the {@code
+ * unsupported_sandbox} error instead of starting the app silently.
+ *
+ * <p>The default composition is intentionally conservative. It does not claim container, jail,
+ * seccomp, chroot, or WebAssembly isolation. Future embeddings can construct an explicit registry
+ * with additional providers without changing the manifest parser or AppHost status model.
+ */
+public final class AppSandboxProviders {
+  /** Provider used for the backward-compatible no-sandbox launch path. */
+  private final AppSandboxProvider noSandboxProvider;
+
+  /** Provider used for the v1 best-effort restricted-process launch path, when configured. */
+  private final AppSandboxProvider restrictedProcessProvider;
+
+  /** Optional provider reserved for a future WebAssembly runtime integration. */
+  private final AppSandboxProvider wasmPreviewProvider;
+
+  /**
+   * Creates the default provider registry.
+   *
+   * <p>The default registry always includes {@link NoSandboxProvider} and {@link
+   * RestrictedProcessSandboxProvider}. It deliberately leaves the WASM preview provider unset so
+   * {@code sandbox.mode=wasm-preview} reports unsupported unless a future embedding wires a
+   * concrete runtime.
+   */
+  public AppSandboxProviders() {
+    this(new NoSandboxProvider(), new RestrictedProcessSandboxProvider(), null);
+  }
+
+  /**
+   * Creates an explicit provider registry.
+   *
+   * <p>This constructor is primarily for tests and future host embeddings that need to replace or
+   * add providers. The no-sandbox provider is required because {@code sandbox.mode=none} is the
+   * backward-compatible manifest default. The other provider slots may be {@code null}; unsupported
+   * required policies will fail at launch time, while optional policies will report unsupported
+   * status and keep the original launch values.
+   *
+   * @param noSandboxProvider provider for {@code sandbox.mode=none}; must not be {@code null}
+   * @param restrictedProcessProvider provider for {@code sandbox.mode=restricted-process}, or
+   *     {@code null}
+   * @param wasmPreviewProvider optional future provider for {@code sandbox.mode=wasm-preview}
+   */
+  public AppSandboxProviders(
+      AppSandboxProvider noSandboxProvider,
+      AppSandboxProvider restrictedProcessProvider,
+      AppSandboxProvider wasmPreviewProvider) {
+    this.noSandboxProvider = Objects.requireNonNull(noSandboxProvider, "noSandboxProvider");
+    this.restrictedProcessProvider = restrictedProcessProvider;
+    this.wasmPreviewProvider = wasmPreviewProvider;
+  }
+
+  /**
+   * Returns a default provider registry.
+   *
+   * <p>This is the production factory used by AppHost when no embedding supplies an explicit
+   * registry. Each call returns a fresh stateless registry.
+   *
+   * @return default sandbox providers for local AppHost process launches
+   */
+  public static AppSandboxProviders defaults() {
+    return new AppSandboxProviders();
+  }
+
+  /**
+   * Selects a provider and prepares a launch plan for the supplied context.
+   *
+   * <p>Provider selection follows the manifest mode exactly. If the selected provider exists and
+   * reports support, its launch plan is returned. If no provider can support the mode, required
+   * policies fail with {@link AppSandboxException}; optional policies return the original command,
+   * environment, and working directory with an unsupported sandbox status. That behavior keeps
+   * third-party apps usable on hosts without a requested optional provider while still making the
+   * degradation visible.
+   *
+   * @param context sensitive AppHost launch context for one process start attempt
+   * @return final provider launch plan containing process inputs and public status
+   * @throws IOException when a required sandbox mode is unsupported or provider preparation fails
+   */
+  public AppSandboxLaunchPlan prepareLaunch(AppSandboxLaunchContext context) throws IOException {
+    AppSandboxLaunchContext checkedContext = Objects.requireNonNull(context, "context");
+    AppSandboxProvider provider = providerFor(checkedContext.policy().mode());
+    if (provider != null && provider.supports(checkedContext.policy())) {
+      return provider.prepareLaunch(checkedContext);
+    }
+    AppSandboxStatus unsupported = unsupportedStatus(checkedContext.policy());
+    if (checkedContext.policy().required()) {
+      throw AppSandboxException.unsupportedRequired(unsupported);
+    }
+    return new AppSandboxLaunchPlan(
+        checkedContext.command(),
+        checkedContext.environment(),
+        checkedContext.workingDirectory(),
+        unsupported);
+  }
+
+  /**
+   * Returns an inactive status for a policy using the default registry semantics.
+   *
+   * <p>Installed-but-stopped app summaries need to describe the requested policy before any process
+   * has been launched. This helper mirrors default registry behavior without constructing a process
+   * launch context or exposing launch secrets.
+   *
+   * @param policy requested sandbox policy from an installed manifest
+   * @return token-free status safe for installed and stopped app summaries
+   */
+  public static AppSandboxStatus inactiveStatus(AppSandboxPolicy policy) {
+    return AppSandboxStatus.inactive(policy);
+  }
+
+  private AppSandboxProvider providerFor(AppSandboxMode mode) {
+    return switch (mode) {
+      case NONE -> noSandboxProvider;
+      case RESTRICTED_PROCESS -> restrictedProcessProvider;
+      case WASM_PREVIEW -> wasmPreviewProvider;
+    };
+  }
+
+  private static AppSandboxStatus unsupportedStatus(AppSandboxPolicy policy) {
+    String reason =
+        switch (policy.mode()) {
+          case RESTRICTED_PROCESS -> "restricted-process sandbox is not available on this host";
+          case WASM_PREVIEW ->
+              "wasm-preview sandbox is reserved for a future provider and is not available on this"
+                  + " host";
+          case NONE -> "no-sandbox provider is not available on this host";
+        };
+    return AppSandboxStatus.unsupported(policy, reason);
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxRequirement.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxRequirement.java
@@ -1,0 +1,66 @@
+package network.crypta.platform.apphost.sandbox;
+
+/**
+ * Whether an app may run when its requested sandbox mode cannot be supported by this host.
+ *
+ * <p>The requirement is AppHost's typed representation of the manifest boolean {@code
+ * sandbox.required}. It does not describe the requested mode itself; that lives in {@link
+ * AppSandboxPolicy#mode()}. Provider selection combines both values to decide whether an
+ * unsupported mode becomes a visible warning or a launch-blocking error.
+ *
+ * <p>This distinction keeps third-party apps portable across hosts. An optional request can ask for
+ * better isolation where available without making the app unusable elsewhere. A required request is
+ * appropriate only when the app author or operator has decided that running without the requested
+ * sandbox mode is worse than refusing to start.
+ */
+public enum AppSandboxRequirement {
+  /**
+   * The host may warn and continue when the requested sandbox mode is unavailable.
+   *
+   * <p>Optional is the default for manifests that omit {@code sandbox.required}. AppHost still
+   * reports the unsupported mode in status so operators can see the degraded launch, but provider
+   * absence does not by itself block the process.
+   */
+  OPTIONAL(false),
+
+  /**
+   * The host must reject launch when the requested sandbox mode is unavailable.
+   *
+   * <p>Required requests turn unsupported provider selection into an {@link AppSandboxException}.
+   * Platform API maps that failure to the stable {@code unsupported_sandbox} error code.
+   */
+  REQUIRED(true);
+
+  /** Boolean form used by manifest parsing and compatibility call sites. */
+  private final boolean required;
+
+  AppSandboxRequirement(boolean required) {
+    this.required = required;
+  }
+
+  /**
+   * Returns whether launch must fail for unsupported sandbox modes.
+   *
+   * <p>This method intentionally mirrors the manifest boolean. It says nothing about whether a
+   * provider actually enforced a sandbox for a running process; callers should inspect {@link
+   * AppSandboxStatus#supportLevel()} for the runtime result.
+   *
+   * @return {@code true} when the manifest declared {@code sandbox.required=true}
+   */
+  public boolean required() {
+    return required;
+  }
+
+  /**
+   * Converts the manifest boolean into the typed requirement model.
+   *
+   * <p>The conversion is deterministic and has no validation step because boolean parsing happens
+   * before AppHost builds the policy model.
+   *
+   * @param required manifest boolean after {@code sandbox.required} validation
+   * @return matching requirement value used by provider selection
+   */
+  public static AppSandboxRequirement fromBoolean(boolean required) {
+    return required ? REQUIRED : OPTIONAL;
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxStatus.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxStatus.java
@@ -1,0 +1,179 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.util.List;
+import java.util.Objects;
+import network.crypta.platform.appdist.AppSandboxMode;
+
+/**
+ * Token-free, path-free sandbox status exposed through AppHost and Platform API.
+ *
+ * <p>The status deliberately separates requested mode from actual support level so operator
+ * surfaces can distinguish an unsandboxed app, a best-effort restricted launch, an unsupported
+ * required mode, and future enforced providers without overclaiming protection.
+ *
+ * <p>Instances of this record are safe to serialize in app list, app detail, and runtime status
+ * responses. They must not contain launch tokens, browser session tokens, command lines,
+ * environment values, or host-private paths. Providers should put only short, stable, operator
+ * facing explanations in {@code reason} and {@code warnings}. The status is a report of what the
+ * host did or can do; it is not a policy object and should not be used to authorize app API
+ * requests.
+ *
+ * <p>The {@code active} flag is intentionally separate from {@code supportLevel}. A stopped app can
+ * have a best-effort or unsupported status based on its manifest request, while a running app uses
+ * {@code active} to say whether the selected provider applied restrictions during that launch.
+ *
+ * @param mode requested manifest sandbox mode that AppHost parsed from the signed bundle
+ * @param required whether the manifest requires support for the requested mode
+ * @param supportLevel actual support level reported by provider selection or launch planning
+ * @param providerName stable provider name that produced this status
+ * @param active whether sandbox restrictions are active for the current process launch
+ * @param reason short human-readable status reason, or {@code null} when no reason is needed
+ * @param warnings token-free warnings safe for API and Web Shell display
+ */
+public record AppSandboxStatus(
+    AppSandboxMode mode,
+    boolean required,
+    AppSandboxSupportLevel supportLevel,
+    String providerName,
+    boolean active,
+    String reason,
+    List<String> warnings) {
+  /**
+   * Provider name used for the normal no-sandbox launch path.
+   *
+   * <p>This value appears in public status for {@code sandbox.mode=none}. It should remain stable
+   * so operators and tests can recognize the backward-compatible unsandboxed process path.
+   */
+  public static final String NO_SANDBOX_PROVIDER = "no-sandbox";
+
+  /**
+   * Provider name used when no provider exists for a requested mode.
+   *
+   * <p>This is a status placeholder, not a real launch provider. It lets app summaries and runtime
+   * responses report unavailable optional modes without inventing a provider identity.
+   */
+  public static final String UNSUPPORTED_PROVIDER = "unsupported";
+
+  /** Warning text used whenever AppHost reports the unsandboxed local-process path. */
+  private static final String NO_SANDBOX_WARNING = "App is running without OS sandbox isolation";
+
+  private static final String POLICY_PARAMETER = "policy";
+  private static final String PROVIDER_NAME_PARAMETER = "providerName";
+
+  /**
+   * Creates a validated sandbox status.
+   *
+   * <p>The constructor normalizes a null mode to {@link AppSandboxMode#NONE}, trims optional reason
+   * text, rejects a blank provider name, and defensively copies warning text. It does not inspect
+   * warning contents for secrets; callers that create status values remain responsible for keeping
+   * the public text token-free and path-free.
+   *
+   * @throws IllegalArgumentException if {@code providerName} is blank
+   * @throws NullPointerException if {@code supportLevel}, {@code providerName}, or {@code warnings}
+   *     is {@code null}
+   */
+  public AppSandboxStatus {
+    mode = Objects.requireNonNullElse(mode, AppSandboxMode.NONE);
+    Objects.requireNonNull(supportLevel, "supportLevel");
+    providerName = requireProviderName(providerName);
+    reason = normalizeOptional(reason);
+    warnings = List.copyOf(Objects.requireNonNull(warnings, "warnings"));
+  }
+
+  /**
+   * Returns a default status for the requested policy before a process is launched.
+   *
+   * <p>Installed and stopped apps still need sandbox metadata in API and Shell summaries. This
+   * method reports the expected default support for the policy without claiming that a process is
+   * running or that restrictions are active. {@code restricted-process} reports best-effort because
+   * the default host has a conservative provider; {@code wasm-preview} reports unsupported because
+   * no default WASM provider exists.
+   *
+   * @param policy requested manifest sandbox policy from an installed app
+   * @return inactive status suitable for installed-but-stopped app summaries
+   */
+  public static AppSandboxStatus inactive(AppSandboxPolicy policy) {
+    AppSandboxPolicy normalized = Objects.requireNonNull(policy, POLICY_PARAMETER);
+    return switch (normalized.mode()) {
+      case NONE -> noSandbox(normalized, false);
+      case RESTRICTED_PROCESS ->
+          new AppSandboxStatus(
+              normalized.mode(),
+              normalized.required(),
+              AppSandboxSupportLevel.BEST_EFFORT,
+              RestrictedProcessSandboxProvider.PROVIDER_NAME,
+              false,
+              "Restricted-process sandbox will use AppHost best-effort launch hygiene on start",
+              List.of(
+                  "restricted-process is best-effort in this host; it is not container, seccomp,"
+                      + " chroot, jail, or WASM isolation"));
+      case WASM_PREVIEW ->
+          unsupported(
+              normalized,
+              "wasm-preview sandbox is reserved for a future provider and is not available on this"
+                  + " host");
+    };
+  }
+
+  /**
+   * Returns a no-sandbox status for the normal launch path.
+   *
+   * <p>The support level is always {@link AppSandboxSupportLevel#NONE}. The warning is included in
+   * both {@code reason} and {@code warnings} so compact and detailed UI surfaces can both show that
+   * the app has no OS sandbox isolation.
+   *
+   * @param policy requested policy associated with the app or launch
+   * @param active whether sandbox restrictions are active; normally {@code false} for this status
+   * @return status reporting the no-sandbox provider and no OS sandbox isolation
+   */
+  public static AppSandboxStatus noSandbox(AppSandboxPolicy policy, boolean active) {
+    AppSandboxPolicy normalized = Objects.requireNonNull(policy, POLICY_PARAMETER);
+    return new AppSandboxStatus(
+        normalized.mode(),
+        normalized.required(),
+        AppSandboxSupportLevel.NONE,
+        NO_SANDBOX_PROVIDER,
+        active,
+        NO_SANDBOX_WARNING,
+        List.of(NO_SANDBOX_WARNING));
+  }
+
+  /**
+   * Returns an unsupported status for an unavailable requested mode.
+   *
+   * <p>Unsupported status is used both for optional degradation and for the status object attached
+   * to required-mode failures. The provider name is the stable {@link #UNSUPPORTED_PROVIDER}
+   * placeholder and {@code active} is always {@code false}.
+   *
+   * @param policy requested policy that could not be matched to a supporting provider
+   * @param reason token-free reason safe for public display
+   * @return unsupported sandbox status carrying the reason as its warning text
+   */
+  public static AppSandboxStatus unsupported(AppSandboxPolicy policy, String reason) {
+    AppSandboxPolicy normalized = Objects.requireNonNull(policy, POLICY_PARAMETER);
+    return new AppSandboxStatus(
+        normalized.mode(),
+        normalized.required(),
+        AppSandboxSupportLevel.UNSUPPORTED,
+        UNSUPPORTED_PROVIDER,
+        false,
+        reason,
+        List.of(reason));
+  }
+
+  private static String requireProviderName(String value) {
+    String trimmed = Objects.requireNonNull(value, PROVIDER_NAME_PARAMETER).trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException(PROVIDER_NAME_PARAMETER + " must not be blank");
+    }
+    return trimmed;
+  }
+
+  private static String normalizeOptional(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxSupportLevel.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/AppSandboxSupportLevel.java
@@ -1,0 +1,68 @@
+package network.crypta.platform.apphost.sandbox;
+
+/**
+ * Runtime support level actually applied for a requested app sandbox policy.
+ *
+ * <p>This enum is the main guard against overstating sandbox guarantees. The requested {@code
+ * sandbox.mode} comes from the manifest, while this value reports what the host can provide for a
+ * stopped app summary or a concrete process launch. API clients and Web Shell labels should display
+ * this value rather than inferring safety from the requested mode alone.
+ *
+ * <p>The values are ordered conceptually rather than by strength in code. {@link #BEST_EFFORT}
+ * means AppHost applied local launch hygiene but no hard containment; only {@link #ENFORCED} should
+ * be used by a provider that can point to real operating-system or runtime isolation.
+ */
+public enum AppSandboxSupportLevel {
+  /**
+   * No sandbox isolation is active.
+   *
+   * <p>This is the expected support level for {@code sandbox.mode=none}. Operators should read it
+   * as an explicit unsandboxed status, not as an error condition.
+   */
+  NONE("none"),
+
+  /**
+   * AppHost applied conservative process-launch hygiene but no hard OS containment.
+   *
+   * <p>The default restricted-process provider uses this level. It can report sanitized environment
+   * and app-scoped directory checks, but it must not be described as container, seccomp, chroot,
+   * jail, or WASM isolation.
+   */
+  BEST_EFFORT("best-effort"),
+
+  /**
+   * The requested sandbox mode is not supported by the current provider set.
+   *
+   * <p>Optional unsupported requests may still launch with this status and warnings. Required
+   * unsupported requests should fail before process start.
+   */
+  UNSUPPORTED("unsupported"),
+
+  /**
+   * A provider has applied real enforced sandbox controls.
+   *
+   * <p>PR-206 does not use this value in the default providers. Future providers should set it only
+   * when they can enforce concrete operating-system or runtime restrictions and document those
+   * restrictions separately.
+   */
+  ENFORCED("enforced");
+
+  /** Stable lower-case token exposed through Platform API JSON. */
+  private final String manifestValue;
+
+  AppSandboxSupportLevel(String manifestValue) {
+    this.manifestValue = manifestValue;
+  }
+
+  /**
+   * Returns the stable JSON/API spelling for this support level.
+   *
+   * <p>The returned value is intended for public status surfaces. It is lower-case and hyphenated
+   * where needed so app summaries, runtime status, and Web Shell labels share one vocabulary.
+   *
+   * @return lower-case support-level token for API and Shell status output
+   */
+  public String manifestValue() {
+    return manifestValue;
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/NoSandboxProvider.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/NoSandboxProvider.java
@@ -1,0 +1,77 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.util.Objects;
+import network.crypta.platform.appdist.AppSandboxMode;
+
+/**
+ * Provider for the backward-compatible AppHost local process launch path.
+ *
+ * <p>This provider intentionally performs no sandboxing and no command rewriting. It exists so the
+ * normal local child-process launch path goes through the same provider SPI as restricted and
+ * future runtime modes. That keeps AppHost launch planning observable without changing behavior for
+ * existing app manifests.
+ *
+ * <p>The returned status uses {@link AppSandboxSupportLevel#NONE}, provider name {@code
+ * no-sandbox}, and a warning that the app is running without OS sandbox isolation. UI and API
+ * callers should surface that warning plainly.
+ */
+public final class NoSandboxProvider implements AppSandboxProvider {
+  /**
+   * Stable provider name exposed through status APIs.
+   *
+   * <p>The value is shared with {@link AppSandboxStatus#NO_SANDBOX_PROVIDER} so direct provider
+   * references and status serialization use the same token.
+   */
+  public static final String PROVIDER_NAME = AppSandboxStatus.NO_SANDBOX_PROVIDER;
+
+  /**
+   * Creates the stateless no-sandbox provider.
+   *
+   * <p>Instances hold no mutable launch state and can be reused across app starts. A fresh instance
+   * is still cheap and is what the default registry creates.
+   */
+  public NoSandboxProvider() {
+    // Stateless provider; no per-instance launch state needs initialization.
+  }
+
+  /**
+   * Returns the stable no-sandbox provider name.
+   *
+   * @return {@code no-sandbox}, safe for public sandbox status output
+   */
+  @Override
+  public String providerName() {
+    return PROVIDER_NAME;
+  }
+
+  /**
+   * Returns whether the policy requests the backward-compatible no-sandbox mode.
+   *
+   * @param policy requested sandbox policy from the app manifest
+   * @return {@code true} only for {@link AppSandboxMode#NONE}
+   */
+  @Override
+  public boolean supports(AppSandboxPolicy policy) {
+    return Objects.requireNonNull(policy, "policy").mode() == AppSandboxMode.NONE;
+  }
+
+  /**
+   * Returns the unmodified local process launch plan with no-sandbox status.
+   *
+   * <p>The command, environment, and working directory are copied from the context. The environment
+   * may contain the launch token, so callers must continue to treat the returned plan as sensitive
+   * even though the public sandbox status is token-free.
+   *
+   * @param context sensitive AppHost launch context for one start attempt
+   * @return launch plan preserving process inputs and reporting no active sandbox isolation
+   */
+  @Override
+  public AppSandboxLaunchPlan prepareLaunch(AppSandboxLaunchContext context) {
+    AppSandboxLaunchContext checkedContext = Objects.requireNonNull(context, "context");
+    return new AppSandboxLaunchPlan(
+        checkedContext.command(),
+        checkedContext.environment(),
+        checkedContext.workingDirectory(),
+        AppSandboxStatus.noSandbox(checkedContext.policy(), false));
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/RestrictedProcessSandboxProvider.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/RestrictedProcessSandboxProvider.java
@@ -1,0 +1,143 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import network.crypta.platform.appdist.AppSandboxMode;
+
+/**
+ * Conservative v1 restricted-process provider.
+ *
+ * <p>This provider does not claim hard OS isolation. It verifies that AppHost is launching with the
+ * existing restricted local-process hygiene: explicit installed-bundle working directory, sanitized
+ * environment, and app-scoped mutable directories. The status is therefore {@link
+ * AppSandboxSupportLevel#BEST_EFFORT}, not {@link AppSandboxSupportLevel#ENFORCED}.
+ *
+ * <p>The provider is useful as a stable contract and observability point before platform-specific
+ * hardening exists. It lets manifests request {@code sandbox.mode=restricted-process}, lets AppHost
+ * reject malformed launch contexts, and reports clear warnings that the launch is not a container,
+ * seccomp profile, chroot, jail, or WASM runtime. Future providers can strengthen the
+ * implementation without changing the manifest grammar or Platform API status shape.
+ */
+public final class RestrictedProcessSandboxProvider implements AppSandboxProvider {
+  /**
+   * Stable provider name exposed through status APIs.
+   *
+   * <p>The value matches the manifest mode because this provider is the default implementation of
+   * {@code sandbox.mode=restricted-process}.
+   */
+  public static final String PROVIDER_NAME = "restricted-process";
+
+  /**
+   * Creates the stateless restricted-process provider.
+   *
+   * <p>The provider stores no mutable per-app state. Each launch is validated entirely from the
+   * supplied {@link AppSandboxLaunchContext}, which keeps provider instances safe to reuse.
+   */
+  public RestrictedProcessSandboxProvider() {
+    // Stateless provider; every launch is validated from its AppSandboxLaunchContext.
+  }
+
+  /**
+   * Returns the stable restricted-process provider name.
+   *
+   * @return {@code restricted-process}, safe for public sandbox status output
+   */
+  @Override
+  public String providerName() {
+    return PROVIDER_NAME;
+  }
+
+  /**
+   * Returns whether the policy requests the restricted-process mode.
+   *
+   * <p>This selector only checks the requested manifest mode. It does not decide whether launch
+   * hygiene can be validated; that happens in {@link #prepareLaunch(AppSandboxLaunchContext)}.
+   *
+   * @param policy requested sandbox policy from the app manifest
+   * @return {@code true} only for {@link AppSandboxMode#RESTRICTED_PROCESS}
+   */
+  @Override
+  public boolean supports(AppSandboxPolicy policy) {
+    return Objects.requireNonNull(policy, "policy").mode() == AppSandboxMode.RESTRICTED_PROCESS;
+  }
+
+  /**
+   * Validates the AppHost launch context and returns a best-effort restricted launch plan.
+   *
+   * <p>The current provider does not rewrite the command or environment. Instead, it checks the
+   * launch shape that AppHost already assembled: the working directory must be the installed
+   * bundle, mutable directories must be app-scoped, logs must remain under the run directory, and
+   * the sanitized AppHost environment must include the app id and launch token keys. The returned
+   * status reports {@link AppSandboxSupportLevel#BEST_EFFORT} and includes warnings that no hard OS
+   * containment is active.
+   *
+   * @param context sensitive AppHost launch context for one restricted-process start attempt
+   * @return launch plan preserving process inputs and reporting best-effort support
+   * @throws AppSandboxException if the policy is unsupported or launch hygiene cannot be validated
+   */
+  @Override
+  public AppSandboxLaunchPlan prepareLaunch(AppSandboxLaunchContext context)
+      throws AppSandboxException {
+    AppSandboxLaunchContext checkedContext = Objects.requireNonNull(context, "context");
+    if (!supports(checkedContext.policy())) {
+      throw new AppSandboxException(
+          "unsupported_sandbox",
+          "Provider restricted-process cannot handle sandbox mode "
+              + checkedContext.policy().mode().manifestValue());
+    }
+    validateRestrictedLaunchContext(checkedContext);
+    return new AppSandboxLaunchPlan(
+        checkedContext.command(),
+        checkedContext.environment(),
+        checkedContext.workingDirectory(),
+        bestEffortStatus(checkedContext.policy()));
+  }
+
+  private static void validateRestrictedLaunchContext(AppSandboxLaunchContext context)
+      throws AppSandboxException {
+    if (!context.workingDirectory().equals(context.installDir())) {
+      throw new AppSandboxException(
+          "invalid_sandbox_launch",
+          "restricted-process launch requires the installed bundle as working directory");
+    }
+    requireAppScopedDirectory(context.appId(), context.dataDir(), "dataDir");
+    requireAppScopedDirectory(context.appId(), context.cacheDir(), "cacheDir");
+    requireAppScopedDirectory(context.appId(), context.runDir(), "runDir");
+    if (!context.logDir().equals(context.runDir())) {
+      throw new AppSandboxException(
+          "invalid_sandbox_launch", "restricted-process launch requires logs under runDir");
+    }
+    if (!context.environment().containsKey("CRYPTAD_APP_ID")
+        || !context.environment().containsKey("CRYPTAD_APP_TOKEN")) {
+      throw new AppSandboxException(
+          "invalid_sandbox_launch",
+          "restricted-process launch requires the sanitized AppHost environment");
+    }
+  }
+
+  private static void requireAppScopedDirectory(String appId, java.nio.file.Path path, String label)
+      throws AppSandboxException {
+    java.nio.file.Path fileName = path.getFileName();
+    if (fileName == null || !appId.equals(fileName.toString())) {
+      throw new AppSandboxException(
+          "invalid_sandbox_launch", "restricted-process launch requires an app-scoped " + label);
+    }
+  }
+
+  private static AppSandboxStatus bestEffortStatus(AppSandboxPolicy policy) {
+    ArrayList<String> warnings = new ArrayList<>();
+    warnings.add(
+        "restricted-process is best-effort in this host; it is not container, seccomp, chroot,"
+            + " jail, or WASM isolation");
+    warnings.add("AppHost applied sanitized environment and app-scoped runtime directories");
+    return new AppSandboxStatus(
+        policy.mode(),
+        policy.required(),
+        AppSandboxSupportLevel.BEST_EFFORT,
+        PROVIDER_NAME,
+        true,
+        "Best-effort restricted local process launch active",
+        List.copyOf(warnings));
+  }
+}

--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/package-info.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/sandbox/package-info.java
@@ -1,0 +1,38 @@
+/**
+ * Sandbox policy, launch planning, and status reporting for AppHost child processes.
+ *
+ * <p>This package defines the PR-206 sandbox runtime abstraction. The v1 providers expose requested
+ * manifest policy and conservative launch-time status without claiming hard operating-system
+ * containment unless a provider can actually enforce it.
+ *
+ * <p>The package has three responsibilities:
+ *
+ * <ul>
+ *   <li>Represent the signed manifest request with {@link
+ *       network.crypta.platform.apphost.sandbox.AppSandboxPolicy AppSandboxPolicy} and {@link
+ *       network.crypta.platform.apphost.sandbox.AppSandboxRequirement AppSandboxRequirement}.
+ *   <li>Give AppHost a provider SPI through {@link
+ *       network.crypta.platform.apphost.sandbox.AppSandboxProvider AppSandboxProvider}, {@link
+ *       network.crypta.platform.apphost.sandbox.AppSandboxLaunchContext AppSandboxLaunchContext},
+ *       and {@link network.crypta.platform.apphost.sandbox.AppSandboxLaunchPlan
+ *       AppSandboxLaunchPlan}.
+ *   <li>Expose token-free runtime and inventory status through {@link
+ *       network.crypta.platform.apphost.sandbox.AppSandboxStatus AppSandboxStatus} and {@link
+ *       network.crypta.platform.apphost.sandbox.AppSandboxSupportLevel AppSandboxSupportLevel}.
+ * </ul>
+ *
+ * <p>Provider implementations must treat launch contexts as sensitive. They contain the child
+ * process environment, including the per-start app token, and host-owned filesystem paths. Public
+ * status objects in this package are the safe boundary for Platform API and Web Shell display: they
+ * should report requested mode, provider name, support level, and warnings without exposing command
+ * lines, environment values, browser session tokens, or private paths.
+ *
+ * <p>The default providers intentionally distinguish current behavior from future hardening. {@link
+ * network.crypta.platform.apphost.sandbox.NoSandboxProvider NoSandboxProvider} preserves the
+ * existing local process launch path and reports no active sandbox isolation. {@link
+ * network.crypta.platform.apphost.sandbox.RestrictedProcessSandboxProvider
+ * RestrictedProcessSandboxProvider} reports best-effort AppHost launch hygiene only. Future
+ * providers can add enforced OS or WASM isolation while reusing the same manifest and status
+ * contracts.
+ */
+package network.crypta.platform.apphost.sandbox;

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestParserTest.java
@@ -8,13 +8,16 @@ import java.nio.file.Path;
 import java.util.Properties;
 import network.crypta.fs.AppEnv;
 import network.crypta.platform.appdist.AppRestartPolicy;
+import network.crypta.platform.appdist.AppSandboxMode;
 import network.crypta.platform.appdist.AppUiMode;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AppManifestParserTest {
   private static final String MANIFEST_VERSION_PROPERTY = "manifest.version";
@@ -68,9 +71,49 @@ class AppManifestParserTest {
     assertEquals(java.util.List.of("network.read", "ui.open"), manifest.permissions());
     assertEquals(Long.valueOf(1048576L), manifest.dataQuotaBytes());
     assertEquals(Long.valueOf(2048L), manifest.cacheQuotaBytes());
+    assertEquals(AppSandboxMode.NONE, manifest.sandboxPolicy().mode());
+    assertFalse(manifest.sandboxPolicy().required());
     assertEquals(AppRestartPolicy.ON_FAILURE, manifest.restartPolicy());
     assertEquals(2, manifest.restartMaxAttempts());
     assertEquals(50L, manifest.restartBackoffMillis());
+  }
+
+  @Test
+  void parseContent_whenRestrictedSandboxDeclared_expectSandboxPolicy() throws Exception {
+    AppManifest manifest =
+        AppManifestParser.parseContent(
+            minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT)
+                + "sandbox.mode=restricted-process\n"
+                + "sandbox.required=true\n");
+
+    assertEquals(AppSandboxMode.RESTRICTED_PROCESS, manifest.sandboxPolicy().mode());
+    assertTrue(manifest.sandboxPolicy().required());
+  }
+
+  @Test
+  void parseContent_whenSandboxModeIsUnsupported_expectFailure() {
+    String invalidManifest =
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT)
+            + "sandbox.mode=docker\n";
+
+    AppManifestException exception =
+        assertThrows(
+            AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
+
+    assertEquals("unsupported sandbox.mode: docker", exception.getMessage());
+  }
+
+  @Test
+  void parseContent_whenSandboxRequiredIsMalformed_expectFailure() {
+    String invalidManifest =
+        minimalManifest(MANIFEST_VERSION, SAMPLE_APP_ID, SAMPLE_APP_NAME, START_SCRIPT)
+            + "sandbox.required=maybe\n";
+
+    AppManifestException exception =
+        assertThrows(
+            AppManifestException.class, () -> AppManifestParser.parseContent(invalidManifest));
+
+    assertEquals("invalid sandbox.required: maybe", exception.getMessage());
   }
 
   @Test

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/manifest/AppManifestTest.java
@@ -1,11 +1,14 @@
 package network.crypta.platform.apphost.manifest;
 
 import java.util.List;
+import network.crypta.platform.appdist.AppSandboxMode;
 import network.crypta.platform.appdist.AppUiMode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AppManifestTest {
   private static final String SAMPLE_APP_ID = "sample-app";
@@ -94,5 +97,45 @@ class AppManifestTest {
 
     assertEquals(
         "app.ui.entry must stay under the app root: ../index.html", exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenSandboxPolicyMissing_expectDefaultNoSandboxPolicy() {
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            SAMPLE_APP_ID,
+            SAMPLE_APP_NAME,
+            SAMPLE_APP_VERSION,
+            SAMPLE_EXEC_PATH,
+            AppUiMode.NONE,
+            null,
+            NO_PERMISSIONS,
+            null,
+            null);
+
+    assertEquals(AppSandboxMode.NONE, manifest.sandboxPolicy().mode());
+    assertFalse(manifest.sandboxPolicy().required());
+  }
+
+  @Test
+  void constructor_whenRestrictedSandboxProvided_expectPolicyPreserved() {
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            SAMPLE_APP_ID,
+            SAMPLE_APP_NAME,
+            SAMPLE_APP_VERSION,
+            SAMPLE_EXEC_PATH,
+            AppUiMode.NONE,
+            null,
+            NO_PERMISSIONS,
+            null,
+            null,
+            AppSandboxMode.RESTRICTED_PROCESS,
+            true);
+
+    assertEquals(AppSandboxMode.RESTRICTED_PROCESS, manifest.sandboxPolicy().mode());
+    assertTrue(manifest.sandboxPolicy().required());
   }
 }

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -60,6 +60,8 @@ import network.crypta.platform.apphost.OwnerOnlyFilePermissions;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.manifest.AppManifestException;
+import network.crypta.platform.apphost.sandbox.AppSandboxException;
+import network.crypta.platform.apphost.sandbox.AppSandboxSupportLevel;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assumptions;
@@ -2529,6 +2531,33 @@ class LocalProcessAppHostTest {
     assertTrue(exception.getMessage().contains("runDir must not be a symlink"));
     assertFalse(
         Files.exists(externalRunAppsDir.resolve(RUNNER_APP_ID).resolve(PROCESS_LOG_FILE_NAME)));
+  }
+
+  @Test
+  void start_whenRequiredWasmSandboxUnsupported_expectClearFailureAndUnsupportedStatus()
+      throws Exception {
+    LocalProcessAppHost host = allowUnsignedHost();
+    Path stagedApp = stageInstalledApp(RUNNER_APP_ID);
+    Files.writeString(
+        stagedApp.resolve(MANIFEST_FILE_NAME),
+        """
+        sandbox.mode=wasm-preview
+        sandbox.required=true
+        """,
+        StandardCharsets.UTF_8,
+        java.nio.file.StandardOpenOption.APPEND);
+    host.installFromDirectory(stagedApp);
+
+    AppSandboxException exception =
+        assertThrows(AppSandboxException.class, () -> host.start(RUNNER_APP_ID));
+
+    assertEquals("unsupported_sandbox", exception.errorCode());
+    assertTrue(exception.getMessage().contains("wasm-preview"));
+    assertFalse(exception.getMessage().contains("CRYPTAD_APP_TOKEN"));
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+    AppRuntimeStatusSnapshot status = host.runtimeStatus(RUNNER_APP_ID);
+    assertEquals(AppSandboxSupportLevel.UNSUPPORTED, status.sandboxStatus().supportLevel());
+    assertTrue(status.sandboxStatus().required());
   }
 
   @Test

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/sandbox/AppSandboxProvidersTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/sandbox/AppSandboxProvidersTest.java
@@ -1,0 +1,143 @@
+package network.crypta.platform.apphost.sandbox;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import network.crypta.fs.AppEnv;
+import network.crypta.platform.appdist.AppSandboxMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AppSandboxProvidersTest {
+  @TempDir private Path tempDir;
+
+  @Test
+  void noSandboxProvider_whenPreparingLaunch_expectDeterministicNoSandboxStatus() {
+    AppSandboxLaunchContext context = context(new AppSandboxPolicy(AppSandboxMode.NONE, false));
+
+    AppSandboxLaunchPlan plan = new NoSandboxProvider().prepareLaunch(context);
+
+    assertEquals(List.of("bin/launch.sh"), plan.command());
+    assertEquals(context.environment(), plan.environment());
+    assertEquals(context.workingDirectory(), plan.workingDirectory());
+    assertEquals(AppSandboxMode.NONE, plan.sandboxStatus().mode());
+    assertEquals(AppSandboxSupportLevel.NONE, plan.sandboxStatus().supportLevel());
+    assertEquals("no-sandbox", plan.sandboxStatus().providerName());
+    assertFalse(plan.sandboxStatus().active());
+  }
+
+  @Test
+  void restrictedProvider_whenPreparingLaunch_expectBestEffortStatus() throws Exception {
+    AppSandboxLaunchContext context =
+        context(new AppSandboxPolicy(AppSandboxMode.RESTRICTED_PROCESS, true));
+
+    AppSandboxLaunchPlan plan = new RestrictedProcessSandboxProvider().prepareLaunch(context);
+
+    assertEquals(AppSandboxMode.RESTRICTED_PROCESS, plan.sandboxStatus().mode());
+    assertEquals(AppSandboxSupportLevel.BEST_EFFORT, plan.sandboxStatus().supportLevel());
+    assertEquals("restricted-process", plan.sandboxStatus().providerName());
+    assertTrue(plan.sandboxStatus().active());
+    assertTrue(plan.sandboxStatus().warnings().toString().contains("best-effort"));
+  }
+
+  @Test
+  void providers_whenRequiredWasmPreviewRequested_expectUnsupportedSandboxFailure() {
+    AppSandboxLaunchContext context =
+        context(new AppSandboxPolicy(AppSandboxMode.WASM_PREVIEW, true));
+
+    AppSandboxException exception =
+        assertThrows(
+            AppSandboxException.class, () -> AppSandboxProviders.defaults().prepareLaunch(context));
+
+    assertEquals("unsupported_sandbox", exception.errorCode());
+    assertTrue(exception.getMessage().contains("wasm-preview"));
+  }
+
+  @Test
+  void providers_whenOptionalWasmPreviewRequested_expectUnsupportedLaunchPlan() throws Exception {
+    AppSandboxLaunchContext context =
+        context(new AppSandboxPolicy(AppSandboxMode.WASM_PREVIEW, false));
+
+    AppSandboxLaunchPlan plan = AppSandboxProviders.defaults().prepareLaunch(context);
+
+    assertEquals(context.command(), plan.command());
+    assertEquals(context.environment(), plan.environment());
+    assertEquals(context.workingDirectory(), plan.workingDirectory());
+    assertEquals(AppSandboxMode.WASM_PREVIEW, plan.sandboxStatus().mode());
+    assertEquals(AppSandboxSupportLevel.UNSUPPORTED, plan.sandboxStatus().supportLevel());
+    assertEquals("unsupported", plan.sandboxStatus().providerName());
+    assertFalse(plan.sandboxStatus().active());
+    assertTrue(plan.sandboxStatus().warnings().toString().contains("wasm-preview"));
+  }
+
+  @Test
+  void restrictedProvider_whenWorkingDirectoryDiffers_expectInvalidLaunchFailure() {
+    AppSandboxLaunchContext context =
+        context(
+            new AppSandboxPolicy(AppSandboxMode.RESTRICTED_PROCESS, true),
+            tempDir.resolve("elsewhere"));
+
+    AppSandboxException exception =
+        assertThrows(
+            AppSandboxException.class,
+            () -> new RestrictedProcessSandboxProvider().prepareLaunch(context));
+
+    assertEquals("invalid_sandbox_launch", exception.errorCode());
+    assertTrue(exception.getMessage().contains("installed bundle"));
+    assertFalse(exception.getMessage().contains("secret-token"));
+  }
+
+  @Test
+  void launchContextToString_whenEnvironmentContainsToken_expectTokenValueOmitted() {
+    AppSandboxLaunchContext context = context(new AppSandboxPolicy(AppSandboxMode.NONE, false));
+
+    String text = context.toString();
+
+    assertTrue(text.contains("CRYPTAD_APP_TOKEN"));
+    assertFalse(text.contains("secret-token"));
+    assertFalse(text.contains(tempDir.toString()));
+  }
+
+  @Test
+  void launchPlanToString_whenEnvironmentContainsToken_expectTokenValueOmitted() {
+    AppSandboxLaunchPlan plan =
+        new NoSandboxProvider()
+            .prepareLaunch(context(new AppSandboxPolicy(AppSandboxMode.NONE, false)));
+
+    String text = plan.toString();
+
+    assertTrue(text.contains("CRYPTAD_APP_TOKEN"));
+    assertFalse(text.contains("secret-token"));
+    assertFalse(text.contains("bin/launch.sh"));
+    assertFalse(text.contains(tempDir.toString()));
+  }
+
+  private AppSandboxLaunchContext context(AppSandboxPolicy policy) {
+    return context(policy, appRoot());
+  }
+
+  private AppSandboxLaunchContext context(AppSandboxPolicy policy, Path workingDirectory) {
+    Path root = appRoot();
+    return new AppSandboxLaunchContext(
+        "sample-app",
+        root,
+        tempDir.resolve("data").resolve("sample-app"),
+        tempDir.resolve("cache").resolve("sample-app"),
+        tempDir.resolve("run").resolve("sample-app"),
+        tempDir.resolve("run").resolve("sample-app"),
+        List.of("bin/launch.sh"),
+        Map.of("CRYPTAD_APP_ID", "sample-app", "CRYPTAD_APP_TOKEN", "secret-token"),
+        workingDirectory,
+        policy,
+        new AppEnv());
+  }
+
+  private Path appRoot() {
+    return tempDir.resolve("installed").resolve("sample-app");
+  }
+}

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -948,6 +948,58 @@
     return container;
   }
 
+  function appSandboxStatus(app, runtime) {
+    if (runtime && runtime.sandbox && typeof runtime.sandbox === "object") {
+      return runtime.sandbox;
+    }
+    if (app && app.sandbox && typeof app.sandbox === "object") {
+      return app.sandbox;
+    }
+    return null;
+  }
+
+  function sandboxLabel(status) {
+    if (!status || typeof status !== "object") {
+      return "Sandbox unavailable";
+    }
+    const mode = typeof status.mode === "string" ? status.mode : "";
+    const supportLevel = typeof status.supportLevel === "string" ? status.supportLevel : "";
+    if (supportLevel === "enforced") {
+      return "Enforced sandbox";
+    }
+    if (supportLevel === "best-effort") {
+      return "Best-effort restricted process";
+    }
+    if (supportLevel === "unsupported") {
+      return status.required ? "Unsupported required sandbox" : "Unsupported sandbox";
+    }
+    if (mode === "none" || supportLevel === "none") {
+      return "No sandbox";
+    }
+    return scalar(mode || supportLevel || "unknown");
+  }
+
+  function sandboxTone(status) {
+    if (!status || typeof status !== "object") {
+      return "is-warning";
+    }
+    const supportLevel = typeof status.supportLevel === "string" ? status.supportLevel : "";
+    if (supportLevel === "enforced") {
+      return "is-success";
+    }
+    if (supportLevel === "unsupported" && status.required) {
+      return "is-error";
+    }
+    return "is-warning";
+  }
+
+  function sandboxWarnings(status) {
+    if (!status || !Array.isArray(status.warnings) || status.warnings.length === 0) {
+      return "Unavailable";
+    }
+    return status.warnings.map((warning) => scalar(warning)).join("; ");
+  }
+
   function buildAppActionForm(app, action, label) {
     const appId = typeof app.appId === "string" ? app.appId : "";
     const path = appMutationPath(appId, action);
@@ -1005,6 +1057,7 @@
     const runtimeStoppable = runtimeRunning || runtimeState === "RESTARTING";
     const runtimePid = runtime ? runtime.pid : app.pid;
     const runtimeStartedAt = runtime ? runtime.startedAt : app.startedAt;
+    const sandbox = appSandboxStatus(app, runtime);
 
     const header = document.createElement("div");
     header.className = "app-card-header";
@@ -1019,6 +1072,7 @@
     pills.className = "app-card-pills";
     pills.append(createPill("Installed"));
     pills.append(createPill(runtimeState, runtimeRunning ? "is-success" : "is-warning"));
+    pills.append(createPill(sandboxLabel(sandbox), sandboxTone(sandbox)));
     if (app.uiUrl || app.uiEntry) {
       pills.append(createPill(app.uiMode === "static" ? "Static UI" : "UI"));
     }
@@ -1041,6 +1095,10 @@
       ["UI mode", scalar(app.uiMode)],
       ["UI", uiEntryNode || scalar(app.uiUrl)],
       ["UI entry", scalar(app.uiEntry)],
+      ["Sandbox", sandboxLabel(sandbox)],
+      ["Sandbox required", sandbox && sandbox.required ? "Yes" : "No"],
+      ["Sandbox provider", sandbox ? scalar(sandbox.provider) : "Unavailable"],
+      ["Sandbox warnings", sandboxWarnings(sandbox)],
       ["Runtime state", runtimeState],
       ["Running", runtimeRunning ? "Yes" : "No"],
       ["PID", runtimeRunning ? scalar(runtimePid) : "Unavailable"],

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -326,6 +326,10 @@ class WebShellResourcesTest {
     assertTrue(script.contains("return `${url.pathname}${url.search}${url.hash}`;"));
     assertFalse(appUiEntryHelper.contains("const url = new URL(value, window.location.origin);"));
     assertTrue(script.contains("function appUiHref(app)"));
+    assertTrue(script.contains("function appSandboxStatus(app, runtime)"));
+    assertTrue(script.contains("function sandboxLabel(status)"));
+    assertTrue(script.contains("Unsupported required sandbox"));
+    assertTrue(script.contains("[\"Sandbox\", sandboxLabel(sandbox)]"));
     assertTrue(script.contains("function appRuntimePath(appId)"));
     assertTrue(script.contains("function appLogsPath(appId, maxBytes)"));
     assertTrue(script.contains("function appAuditPath(appId)"));

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -3265,7 +3265,7 @@ class PlatformApiRouterTest {
   }
 
   private static Map<String, Object> runtimeSummary() {
-    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(11);
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(12);
     summary.put("appId", APP_ID);
     summary.put("state", "RUNNING");
     summary.put("running", true);
@@ -3277,6 +3277,7 @@ class PlatformApiRouterTest {
     summary.put("currentRestartAttempt", 1);
     summary.put("logAvailable", true);
     summary.put("logSizeBytes", 128L);
+    summary.put("sandbox", sandboxSummary());
     return summary;
   }
 
@@ -3301,7 +3302,7 @@ class PlatformApiRouterTest {
       boolean running,
       Long pid,
       Instant startedAt) {
-    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(14);
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(15);
     summary.put("appId", appId);
     summary.put("name", appName);
     summary.put("version", appVersion);
@@ -3313,6 +3314,7 @@ class PlatformApiRouterTest {
     quota.put("dataBytes", 4096L);
     quota.put("cacheBytes", 8192L);
     summary.put("quota", quota);
+    summary.put("sandbox", sandboxSummary());
     summary.put("installed", installed);
     summary.put("running", running);
     summary.put("pid", pid);
@@ -3323,7 +3325,7 @@ class PlatformApiRouterTest {
   }
 
   private static Map<String, Object> unknownSummary() {
-    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(14);
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(15);
     summary.put("appId", APP_ID);
     summary.put("name", null);
     summary.put("version", null);
@@ -3335,6 +3337,7 @@ class PlatformApiRouterTest {
     quota.put("dataBytes", null);
     quota.put("cacheBytes", null);
     summary.put("quota", quota);
+    summary.put("sandbox", sandboxSummary());
     summary.put("installed", false);
     summary.put("running", false);
     summary.put("pid", null);
@@ -3351,6 +3354,18 @@ class PlatformApiRouterTest {
     audit.put("recentDeniedCount", 0L);
     audit.put("events", List.of());
     return audit;
+  }
+
+  private static Map<String, Object> sandboxSummary() {
+    LinkedHashMap<String, Object> sandbox = LinkedHashMap.newLinkedHashMap(7);
+    sandbox.put("mode", "none");
+    sandbox.put("required", false);
+    sandbox.put("supportLevel", "none");
+    sandbox.put("provider", "no-sandbox");
+    sandbox.put("active", false);
+    sandbox.put("reason", "App is running without OS sandbox isolation");
+    sandbox.put("warnings", List.of("App is running without OS sandbox isolation"));
+    return sandbox;
   }
 
   private static String uiMode(String appUiEntry) {


### PR DESCRIPTION
## Summary
- Add signed manifest parsing for `sandbox.mode` and `sandbox.required`, plus AppHost sandbox policy/status/provider models.
- Route local process launches through sandbox launch plans with no-sandbox and best-effort restricted-process providers, including clear unsupported-required sandbox failures.
- Surface token-safe sandbox status through AppHost snapshots, Platform API app responses, and the Web Shell.
- Update runtime/security docs to distinguish no isolation, best-effort restrictions, unsupported modes, and future enforced providers.
- Count ignored AppleDouble ZIP metadata entries against catalog extraction caps and cover the behavior with a focused test.

## Test plan
- `./gradlew spotlessApply`
- `./gradlew :platform-apphost:test :platform-appdist:test :platform-appcatalog:test :platform-api:test :platform-web-shell:test`
- `./gradlew :test --tests '*PlatformApiRouterTest'`