### PR TITLE
feat(apps): Add app store metadata UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,9 @@ local developer tooling; it does not add hot reload or a daemon-side install com
 
 `crypta-app catalog create` descriptors can author optional store metadata such as homepage,
 source, license, categories, advisory review status/note, permission rationales, screenshot URL
-metadata, changelog metadata, and advisory minimum Cryptad version. See
-[docs/app-dev-cli.md](docs/app-dev-cli.md) for descriptor fields.
+metadata, changelog metadata, and advisory minimum Cryptad version. Descriptors without those
+fields generate minimal `catalog.version=1` catalogs; descriptors with store metadata generate
+`catalog.version=2`. See [docs/app-dev-cli.md](docs/app-dev-cli.md) for descriptor fields.
 
 First-party apps can keep using `:apps:queue-manager` and `:apps:publisher` `stageApp`, `signApp`,
 and `verifyApp` tasks. See [docs/app-dev-cli.md](docs/app-dev-cli.md) for the standalone CLI flow

--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ Cryptad now uses a partial multi-project Gradle build.
 - `:platform-appdist` owns the local app distribution tooling used to digest, sign, and verify
   staged AppHost bundles.
 - `:platform-appcatalog` owns signed app catalog parsing, signature verification, remote/local
-  catalog fetching, artifact digest checks, safe ZIP extraction, and verified staging for AppHost
-  install/update flows.
+  catalog fetching, app-store metadata parsing, artifact digest checks, safe ZIP extraction, and
+  verified staging for AppHost install/update flows.
 - `:platform-web-shell` owns the first browser-facing Web Shell v1 under
   `network.crypta.platform.webshell`. It keeps the node-management shell's route constants,
   bootstrap payload, HTML renderer, and plain browser assets self-owned while staying separate
@@ -358,7 +358,9 @@ Signed staged bundles add `cryptad-app.digests` and `cryptad-app.signature` at t
 
 Signed app catalogs add a verified source layer above signed bundles. See
 [`docs/app-catalogs.md`](docs/app-catalogs.md) for the `cryptad-app-catalog.properties` format,
-catalog signatures, trusted-key configuration, and `/api/v1/app-catalogs` install/update flow.
+catalog signatures, trusted-key configuration, optional app-store metadata, and
+`/api/v1/app-catalogs` install/update flow. Catalog review metadata is advisory; signed catalog
+and signed bundle verification remain the trust source.
 
 Installed apps can also declare browser UI ownership with `app.ui.mode` and `app.ui.entry`.
 Static UI bundles open at `/apps/{appId}/`; shell-panel bundles keep existing local links such as
@@ -418,8 +420,12 @@ crypta-app verify \
 
 `crypta-app init` writes a standalone staged bundle directory, not a new Gradle subproject. Static
 scaffolds copy or vendor the browser SDK as `static/crypta-platform.js` when available. The CLI is
-local developer tooling; it does not add a remote app-store UI, hot reload, or daemon-side install
-command.
+local developer tooling; it does not add hot reload or a daemon-side install command.
+
+`crypta-app catalog create` descriptors can author optional store metadata such as homepage,
+source, license, categories, advisory review status/note, permission rationales, screenshot URL
+metadata, changelog metadata, and advisory minimum Cryptad version. See
+[docs/app-dev-cli.md](docs/app-dev-cli.md) for descriptor fields.
 
 First-party apps can keep using `:apps:queue-manager` and `:apps:publisher` `stageApp`, `signApp`,
 and `verifyApp` tasks. See [docs/app-dev-cli.md](docs/app-dev-cli.md) for the standalone CLI flow
@@ -431,10 +437,13 @@ Phase 3 Platform Primacy makes `:platform-api`, `:platform-web-shell`, and `:pla
 primary local platform path for operator workflows and first-party apps. Legacy HTTP and FCP remain
 compatibility, bridge, debug, and fallback surfaces.
 
-Current Phase 4 app-platform work extends that path with signed catalog sources, app-owned static
-UI routes, and independent first-party Queue Manager and Publisher UIs. Installed apps can be
-launched through `/app/node/` shell-panel links or through stable `/apps/{appId}/` routes when the
-signed bundle declares `app.ui.mode=static`.
+Current Phase 5 app-platform work extends that path with signed catalog sources, app-owned static
+UI routes, richer catalog review metadata, and independent first-party Queue Manager and Publisher
+UIs. Installed apps can be launched through `/app/node/` shell-panel links or through stable
+`/apps/{appId}/` routes when the signed bundle declares `app.ui.mode=static`. The Web Shell Apps
+section uses `/api/v1/app-catalogs` metadata to show source, license, category, review,
+permission-rationale, version-difference, compatibility, and changelog details before install or
+update.
 
 Key docs:
 
@@ -845,8 +854,9 @@ Root build also includes:
 - `:platform-appdist`: local app distribution tooling for deterministic bundle digests, Ed25519
   signatures, trusted-key verification, and the signing/verification CLI used by first-party app
   Gradle tasks.
-- `:platform-appcatalog`: signed catalog source parsing, signature verification, artifact digest
-  checks, safe ZIP extraction, and verified staging for AppHost install/update flows.
+- `:platform-appcatalog`: signed catalog source parsing, signature verification, app-store
+  metadata parsing, artifact digest checks, safe ZIP extraction, and verified staging for AppHost
+  install/update flows.
 - `:platform-web-shell`: browser-facing Web Shell v1 leaf owning the node-management shell route
   descriptors, bootstrap payload, and static browser assets that the legacy HTTP adapter mounts at
   `/app/node/`.
@@ -1091,8 +1101,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   v1 core for installed local apps; `:platform-app-ui` provides app-owned static UI route and
   asset-resolution helpers; `:platform-sdk-js` provides the browser SDK resource for app-owned
   static UI; `:platform-appdist` provides the local app bundle digest, signing, and verification
-  tooling; `:platform-appcatalog` provides signed catalog source,
-  artifact verification, and safe ZIP staging support;
+  tooling; `:platform-appcatalog` provides signed catalog source, app-store metadata, artifact
+  verification, and safe ZIP staging support;
   `:platform-web-shell` provides the browser-facing Web Shell v1 node-management assets and
   bootstrap contract; `:runtime-node`
   provides the extracted daemon runtime body across the remaining cyclic/high-level

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -4,9 +4,11 @@ This document describes Cryptad's signed app catalog format and the local instal
 
 ## Scope
 
-Signed app catalogs are a Phase 4 app-platform control plane. They do not change peer protocols,
-wire formats, application sandboxing, or AppHost process launching. A catalog only tells the local
-node where to fetch a signed app bundle ZIP and which digest, size, app id, and version to expect.
+Signed app catalogs are a Phase 5 app-platform control plane. They do not change peer protocols,
+wire formats, application sandboxing, or AppHost process launching. A catalog tells the local node
+where to fetch a signed app bundle ZIP and which digest, size, app id, and version to expect. It
+can also carry optional app-store display metadata for review, compatibility, source, license,
+permissions, screenshots, and changelog links.
 
 The runtime verifies data in this order:
 
@@ -15,6 +17,10 @@ The runtime verifies data in this order:
 3. The extracted bundle's existing `cryptad-app.digests` and `cryptad-app.signature` through
    `AppBundleVerifier`.
 4. The extracted manifest `app.id` and `app.version` against the catalog entry.
+
+Catalog review metadata is advisory. Signed catalog verification and signed bundle verification
+remain the trust source. A `review.status` or `review.note` value does not create cryptographic
+trust and does not weaken artifact or bundle checks.
 
 ## Catalog files
 
@@ -39,11 +45,54 @@ app.queue-manager.bundle.sha256=<lowercase-hex-sha256-of-zip>
 app.queue-manager.bundle.size.bytes=12345
 app.queue-manager.bundle.type=zip
 app.queue-manager.permissions=queue.read,queue.write
+app.queue-manager.homepage=https://example.invalid/apps/queue-manager
+app.queue-manager.source=https://example.invalid/src/queue-manager
+app.queue-manager.license=MIT
+app.queue-manager.categories=productivity,network
+app.queue-manager.minimumCryptaVersion=1481
+app.queue-manager.review.status=reviewed
+app.queue-manager.review.note=Reviewed for local operator safety.
+app.queue-manager.permissions.rationale.queue.read=Reads the local transfer queue.
+app.queue-manager.permissions.rationale.queue.write=Lets the app cancel or reprioritize requests.
+app.queue-manager.screenshot.1=https://example.invalid/assets/queue-manager-1.png
+app.queue-manager.changelog.summary=Adds queue retry controls.
+app.queue-manager.changelog.uri=https://example.invalid/apps/queue-manager-1.0.0-changelog.txt
 ```
 
 The parser rejects duplicate keys, missing required fields, unsupported versions, unsupported
 artifact types, invalid app ids, blank names or versions, invalid SHA-256 text, negative sizes,
 unsafe artifact URIs, duplicate entries, and unknown properties.
+
+Minimal catalogs that only provide the required fields still parse and install. The app-store
+metadata fields are optional and additive.
+
+## App-store metadata
+
+Catalog entries can include these optional fields:
+
+| Catalog property | Meaning |
+| --- | --- |
+| `app.<id>.homepage` | Operator-facing homepage URI. |
+| `app.<id>.source` | Source repository or source archive URI. |
+| `app.<id>.license` | Single-line license label, such as `MIT` or `GPL-3.0-or-later`. |
+| `app.<id>.categories` | Comma-separated category labels, normalized and deduplicated for display. |
+| `app.<id>.minimumCryptaVersion` | Advisory minimum Cryptad build/version string. Integer build numbers are the comparable form used by Platform API responses. |
+| `app.<id>.review.status` | Advisory human review state. Supported values are `unreviewed`, `reviewed`, `caution`, and `rejected`. |
+| `app.<id>.review.note` | Single-line advisory review note for operators. |
+| `app.<id>.permissions.rationale.<permission>` | Explanation for a declared permission, keyed by the normalized permission name. |
+| `app.<id>.screenshot.N` | Screenshot URI metadata, where `N` is a positive deterministic index. |
+| `app.<id>.changelog.summary` | Single-line summary of changes for the catalog version. |
+| `app.<id>.changelog.uri` | URI for full changelog text or release notes. |
+
+URI fields are metadata only. The Web Shell should show screenshot URIs as links or behind an
+operator-explicit preview control; it should not silently auto-fetch arbitrary remote images from a
+catalog entry. `minimumCryptaVersion` is advisory and should not block install/update by itself
+when comparison is unavailable or ambiguous. Platform API compatibility summaries compare numeric
+Cryptad build labels when possible.
+
+Permission rationales explain why the catalog version declares a permission. They do not grant
+permissions and do not replace the signed bundle manifest's permission list or server-side
+Platform API authorization checks.
 
 ## Developer CLI catalog flow
 
@@ -63,13 +112,26 @@ name=Hello Queue
 version=0.1.0
 permissions=queue.read,queue.write
 app.id=hello-queue
+homepage=https://example.invalid/apps/hello-queue
+source=https://example.invalid/src/hello-queue
+license=MIT
+categories=productivity,network
+minimumCryptaVersion=1481
+review.status=reviewed
+review.note=Reviewed for local operator safety.
+permissions.rationale.queue.read=Reads the local transfer queue.
+permissions.rationale.queue.write=Lets the app cancel or reprioritize requests.
+screenshot.1=https://example.invalid/assets/hello-queue-1.png
+changelog.summary=Adds queue retry controls.
+changelog.uri=https://example.invalid/apps/hello-queue-0.1.0-changelog.txt
 ```
 
 Only `artifact.path`, `bundle.uri`, and `summary` are required. The writer derives the catalog app
 id and version from the artifact's root `cryptad-app.properties`; descriptor `app.id` and `version`
 values are optional consistency checks and must match the artifact manifest. The `name` and
 `permissions` fields can override the display metadata and permission hints written to the catalog.
-It computes `bundle.sha256` and `bundle.size.bytes` from the local artifact bytes.
+Optional descriptor metadata uses the same names as catalog metadata without the `app.<id>.`
+prefix. The writer computes `bundle.sha256` and `bundle.size.bytes` from the local artifact bytes.
 
 Create, sign, and verify a catalog with:
 
@@ -168,8 +230,19 @@ semantics as local staged apps: missing or `0` quota fields are unlimited, and p
 enforced only for AppHost-managed app data/cache directories. See
 [app-owned-ui.md](app-owned-ui.md) for the static UI route and security boundary.
 
+Catalog app listing and detail responses expose optional store metadata, installed/running state,
+installed version, catalog version, advisory version-difference/update information, permission
+rationales, and permission deltas for install/update review. Responses do not expose trusted-key
+material, catalog scratch paths, or verified staging directories.
+
+The Web Shell Apps section uses the same API to show catalog details before install or update:
+review status and note, source/homepage/license/category metadata, permission explanations,
+installed-vs-catalog version difference, advisory compatibility hints, and changelog metadata when
+present. Review metadata remains separate from signed catalog trust.
+
 ## Future work
 
 Manifest permissions are enforced for app-process Platform API calls as described in
-[app-permissions-and-audit.md](app-permissions-and-audit.md). Container or WASM sandboxing, public
-app-store governance, and background app update scheduling remain future work.
+[app-permissions-and-audit.md](app-permissions-and-audit.md). Catalog distribution over Crypta
+keys, public app-store governance, background app update scheduling, and remote screenshot proxying
+remain future work.

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -30,7 +30,7 @@ the sibling file `cryptad-app-catalog.signature`.
 Catalog properties use a deterministic `key=value` text sidecar:
 
 ```properties
-catalog.version=1
+catalog.version=2
 catalog.id=core
 catalog.name=Crypta Core Apps
 catalog.generatedAt=2026-04-21T18:22:40Z
@@ -63,8 +63,13 @@ The parser rejects duplicate keys, missing required fields, unsupported versions
 artifact types, invalid app ids, blank names or versions, invalid SHA-256 text, negative sizes,
 unsafe artifact URIs, duplicate entries, and unknown properties.
 
-Minimal catalogs that only provide the required fields still parse and install. The app-store
-metadata fields are optional and additive.
+`catalog.version=1` is the minimal signed-catalog schema and contains only the required app,
+artifact, and permission fields. `catalog.version=2` adds the optional app-store metadata fields
+shown above. Current Cryptad nodes parse both versions. Older strict v1 nodes reject v2 catalogs
+rather than silently accepting unknown metadata fields.
+
+Minimal v1 catalogs that only provide the required fields still parse and install unchanged. The
+app-store metadata fields remain optional within the v2 schema.
 
 ## App-store metadata
 
@@ -132,6 +137,8 @@ values are optional consistency checks and must match the artifact manifest. The
 `permissions` fields can override the display metadata and permission hints written to the catalog.
 Optional descriptor metadata uses the same names as catalog metadata without the `app.<id>.`
 prefix. The writer computes `bundle.sha256` and `bundle.size.bytes` from the local artifact bytes.
+Descriptors that omit app-store metadata produce `catalog.version=1`; descriptors that include any
+app-store metadata produce `catalog.version=2`.
 
 Create, sign, and verify a catalog with:
 

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -201,7 +201,7 @@ id and version from the ZIP artifact's root `cryptad-app.properties`; descriptor
 and `permissions` fields can override the display metadata and permission hints written to the
 catalog.
 
-Descriptors can also author optional v1 app-store metadata:
+Descriptors can also author optional app-store metadata:
 
 | Descriptor property | Generated catalog property |
 | --- | --- |
@@ -217,12 +217,14 @@ Descriptors can also author optional v1 app-store metadata:
 | `changelog.summary` | `app.<id>.changelog.summary` |
 | `changelog.uri` | `app.<id>.changelog.uri` |
 
-These fields are optional and backward compatible. `homepage`, `source`, `screenshot.N`, and
-`changelog.uri` are URI metadata for operator display. `review.status` and `review.note` are
-advisory and do not replace signed catalog or signed bundle verification. `minimumCryptaVersion`
-is advisory and does not block install/update by itself; integer Cryptad build labels are the
-comparable form used by Platform API responses. Permission rationales explain declared permissions;
-they do not grant capabilities.
+These fields are optional. Descriptors that omit them generate a minimal `catalog.version=1`
+catalog; descriptors that include any app-store metadata generate `catalog.version=2` so strict v1
+catalog consumers reject the expanded schema cleanly instead of accepting unknown fields.
+`homepage`, `source`, `screenshot.N`, and `changelog.uri` are URI metadata for operator display.
+`review.status` and `review.note` are advisory and do not replace signed catalog or signed bundle
+verification. `minimumCryptaVersion` is advisory and does not block install/update by itself;
+integer Cryptad build labels are the comparable form used by Platform API responses. Permission
+rationales explain declared permissions; they do not grant capabilities.
 
 `artifact.path` is local authoring input and is not written to the public catalog. Do not change
 the ZIP after creating the catalog; the generated catalog records its size and lowercase SHA-256

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -10,9 +10,9 @@ projects. The command works on a staged bundle directory containing `cryptad-app
 launch files, and optional `static/` assets. The scaffold is a standalone staged bundle directory,
 not a new Gradle subproject.
 
-The CLI is offline filesystem tooling. It does not provide a remote app-store UI, hot reload, or a
-daemon-side install command. Install and update flows still go through the Platform API or signed
-catalog source handling described in [app-catalogs.md](app-catalogs.md).
+The CLI is offline filesystem tooling. It does not provide hot reload or a daemon-side install
+command. Install and update flows still go through the Platform API or signed catalog source
+handling described in [app-catalogs.md](app-catalogs.md).
 
 First-party repo apps can keep using their existing Gradle tasks. See
 [First-party Gradle workflow](#first-party-gradle-workflow).
@@ -181,15 +181,52 @@ name=Hello Queue
 version=0.1.0
 permissions=queue.read,queue.write
 app.id=hello-queue
+homepage=https://example.invalid/apps/hello-queue
+source=https://example.invalid/src/hello-queue
+license=MIT
+categories=productivity,network
+minimumCryptaVersion=1481
+review.status=reviewed
+review.note=Reviewed for local operator safety.
+permissions.rationale.queue.read=Reads the local transfer queue.
+permissions.rationale.queue.write=Lets the app cancel or reprioritize requests.
+screenshot.1=https://example.invalid/assets/hello-queue-1.png
+changelog.summary=Adds queue retry controls.
+changelog.uri=https://example.invalid/apps/hello-queue-0.1.0-changelog.txt
 ```
 
 Only `artifact.path`, `bundle.uri`, and `summary` are required. The writer derives the catalog app
 id and version from the ZIP artifact's root `cryptad-app.properties`; descriptor `app.id` and
 `version` values are optional consistency checks and must match the artifact manifest. The `name`
 and `permissions` fields can override the display metadata and permission hints written to the
-catalog. `artifact.path` is local authoring input and is not written to the public catalog. Do not
-change the ZIP after creating the catalog; the generated catalog records its size and lowercase
-SHA-256 digest.
+catalog.
+
+Descriptors can also author optional v1 app-store metadata:
+
+| Descriptor property | Generated catalog property |
+| --- | --- |
+| `homepage` | `app.<id>.homepage` |
+| `source` | `app.<id>.source` |
+| `license` | `app.<id>.license` |
+| `categories` | `app.<id>.categories` |
+| `minimumCryptaVersion` | `app.<id>.minimumCryptaVersion` |
+| `review.status` | `app.<id>.review.status` |
+| `review.note` | `app.<id>.review.note` |
+| `permissions.rationale.<permission>` | `app.<id>.permissions.rationale.<permission>` |
+| `screenshot.N` | `app.<id>.screenshot.N` |
+| `changelog.summary` | `app.<id>.changelog.summary` |
+| `changelog.uri` | `app.<id>.changelog.uri` |
+
+These fields are optional and backward compatible. `homepage`, `source`, `screenshot.N`, and
+`changelog.uri` are URI metadata for operator display. `review.status` and `review.note` are
+advisory and do not replace signed catalog or signed bundle verification. `minimumCryptaVersion`
+is advisory and does not block install/update by itself; integer Cryptad build labels are the
+comparable form used by Platform API responses. Permission rationales explain declared permissions;
+they do not grant capabilities.
+
+`artifact.path` is local authoring input and is not written to the public catalog. Do not change
+the ZIP after creating the catalog; the generated catalog records its size and lowercase SHA-256
+digest.
 
 Create the catalog properties file:
 

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -195,7 +195,8 @@ surface.
 Catalog entry descriptors accepted by `crypta-app catalog create` can include `homepage`,
 `source`, `license`, `categories`, `minimumCryptaVersion`, `review.status`, `review.note`,
 `permissions.rationale.<permission>`, `screenshot.N`, `changelog.summary`, and `changelog.uri`.
-The generated catalog writes those fields under `app.<id>.*`.
+The generated catalog writes those fields under `app.<id>.*` and uses `catalog.version=2`.
+Descriptors without store metadata continue to generate minimal `catalog.version=1` catalogs.
 
 These fields are display and review metadata. The catalog signature still authenticates the exact
 catalog bytes, and the app bundle signature still authenticates the bundle payload. Review notes,

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -16,8 +16,8 @@ Related but documented elsewhere:
   [app-catalogs.md](app-catalogs.md)
 - App-owned static UI routing for installed bundles: [app-owned-ui.md](app-owned-ui.md)
 - Browser SDK helpers for app-owned static UI: [platform-sdk-js.md](platform-sdk-js.md)
-- Public app store UI, browser-side bundle uploads, richer permission UX, and app sandboxing
-  remain future platform work.
+- Catalog distribution over Crypta keys, browser-side bundle uploads, and app sandboxing remain
+  future platform work.
 
 ## Bundle Files
 
@@ -185,6 +185,23 @@ is available. See [app-dev-cli.md](app-dev-cli.md) for the full scaffold, pack, 
 The CLI does not replace the first-party Gradle workflow. Queue Manager and Publisher can keep
 using `:apps:queue-manager` and `:apps:publisher` `stageApp`, `signApp`, and `verifyApp` tasks.
 
+## Catalog Store Metadata
+
+Signed bundle manifests remain the source for installed app id, version, launch settings, UI
+entry, sandbox mode, quota metadata, and declared permissions. Signed catalogs can add optional
+store metadata around those bundles so the Web Shell can show a richer install/update review
+surface.
+
+Catalog entry descriptors accepted by `crypta-app catalog create` can include `homepage`,
+`source`, `license`, `categories`, `minimumCryptaVersion`, `review.status`, `review.note`,
+`permissions.rationale.<permission>`, `screenshot.N`, `changelog.summary`, and `changelog.uri`.
+The generated catalog writes those fields under `app.<id>.*`.
+
+These fields are display and review metadata. The catalog signature still authenticates the exact
+catalog bytes, and the app bundle signature still authenticates the bundle payload. Review notes,
+permission rationales, screenshot URLs, changelog URLs, and compatibility hints do not grant trust
+or bypass AppHost verification.
+
 ## Gradle Tasks
 
 Per app:
@@ -307,6 +324,7 @@ Preferred local patterns:
 
 ## Future Work
 
-Public catalog governance, background app-update scheduling, richer permission UX, and app
-sandboxing remain later platform work. Signed bundles now carry the manifest metadata and staged
-browser assets needed by app-owned static UI routes.
+Catalog distribution over Crypta keys, public catalog governance, background app-update
+scheduling, remote screenshot proxying, and app sandboxing remain later platform work. Signed
+bundles now carry the manifest metadata and staged browser assets needed by app-owned static UI
+routes.

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -85,7 +85,33 @@ parameter; check the handler and tests when adding or changing a specific contra
 | Alerts | `GET /api/v1/alerts` lists current alerts. `POST /api/v1/alerts/{alertId}/dismiss` dismisses one alert by detached identifier. |
 | Diagnostics | `GET /api/v1/diagnostics` exposes the ordered diagnostic snapshot and plain-text export. When served through the legacy HTTP bridge, it also includes process-local `legacyAdmin.surfaces[]` counters for legacy admin retirement planning. |
 | Apps | `GET /api/v1/apps` lists installed apps when `AppHost` is wired into the router, including path-free quota usage, effective limits, process-log size/limit metadata, sandbox status, and recent audit summary data. The family also covers local staged-bundle install, app lookup, start, stop, update, uninstall, declared permissions at `GET /api/v1/apps/{appId}/permissions`, recent app audit at `GET /api/v1/apps/{appId}/audit`, token-free runtime status at `GET /api/v1/apps/{appId}/runtime`, and bounded token-redacted process logs at `GET /api/v1/apps/{appId}/logs`. |
-| App catalogs | `GET /api/v1/app-catalogs` lists configured signed catalogs when catalog support is wired into the router. The family also covers source add/remove, refresh, catalog app listing/detail, and install/update from a verified catalog artifact. |
+| App catalogs | `GET /api/v1/app-catalogs` lists configured signed catalogs when catalog support is wired into the router. The family also covers source add/remove, refresh, catalog app listing/detail, install/update from a verified catalog artifact, and app-store metadata for install/update review. |
+
+## App catalog response metadata
+
+Catalog app listing and detail responses expose signed-catalog metadata for the Web Shell Apps
+section. The response shape includes the existing app id, name, version, summary, bundle metadata,
+installed state, running state, and installed version. It also includes optional v1 store metadata
+when a catalog entry provides it:
+
+- `homepage`, `source`, `license`, and `categories`.
+- `review.status` and `review.note`.
+- `permissionRationales`, keyed by normalized permission name.
+- `compatibility.minimumCryptaVersion`, the current comparable Cryptad build/version string,
+  advisory status, and whether the comparison is satisfied when it can be evaluated.
+- `screenshots` as URI strings.
+- `changelog.summary` and `changelog.uri`.
+- Installed-vs-catalog version-difference fields and an advisory `updateAvailable` summary.
+- `permissionDelta` for install/update review, with added, removed, and unchanged permissions.
+
+Signed catalog verification remains the source of trust. Review metadata is advisory and does not
+create cryptographic trust. Compatibility metadata is advisory and does not block install/update by
+itself when version comparison is unavailable or ambiguous.
+
+The API must not expose trusted-key material, catalog scratch paths, verified staging directories,
+or AppHost filesystem paths through catalog responses. Screenshot fields are URL metadata for the
+operator; the Web Shell should show them as links or behind an explicit preview control rather than
+silently fetching arbitrary remote images.
 
 ## Web Shell relationship
 
@@ -98,7 +124,8 @@ The shell currently includes these first-party panels and surfaces:
 
 - Overview and connectivity snapshots.
 - Alert queue and diagnostics.
-- Installed apps and signed catalog app discovery.
+- Installed apps and signed catalog app discovery, including catalog detail review before
+  install/update.
 - Security levels, updater state, config controls, and first-time wizard controls.
 - Peer control plane.
 - Publisher and Queue Manager open as independent first-party app UIs when installed.

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -101,7 +101,10 @@ when a metadata-capable catalog entry provides it:
   advisory status, and whether the comparison is satisfied when it can be evaluated.
 - `screenshots` as URI strings.
 - `changelog.summary` and `changelog.uri`.
-- Installed-vs-catalog version-difference fields and an advisory `updateAvailable` summary.
+- Installed-vs-catalog version-difference fields and an advisory `updateAvailable` summary. A
+  version mismatch is reported separately through `versionDifferent`; `updateAvailable` is `true`
+  only when the catalog version compares newer than the installed version and is `null` when
+  ordering cannot be evaluated safely.
 - `permissionDelta` for install/update review, with added, removed, and unchanged permissions.
 
 Signed catalog verification remains the source of trust. Review metadata is advisory and does not

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -91,8 +91,8 @@ parameter; check the handler and tests when adding or changing a specific contra
 
 Catalog app listing and detail responses expose signed-catalog metadata for the Web Shell Apps
 section. The response shape includes the existing app id, name, version, summary, bundle metadata,
-installed state, running state, and installed version. It also includes optional v1 store metadata
-when a catalog entry provides it:
+installed state, running state, and installed version. It also includes optional store metadata
+when a metadata-capable catalog entry provides it:
 
 - `homepage`, `source`, `license`, and `categories`.
 - `review.status` and `review.note`.

--- a/platform-api/build.gradle.kts
+++ b/platform-api/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
 
   testImplementation(mainSourceSet.map { it.output })
   testImplementation(libs.junitJupiterApi)
+  testImplementation(libs.mockitoCore)
+  testImplementation(libs.mockitoJunitJupiter)
+  testImplementation(libs.mockitoInline)
   testRuntimeOnly(libs.junitJupiterEngine)
   testRuntimeOnly(libs.junitPlatformLauncher)
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -169,7 +169,7 @@ public final class PlatformApiRouter {
     appCatalogsApiHandler =
         appHost == null || appCatalogManager == null
             ? null
-            : new AppCatalogsApiHandler(appCatalogManager, appHost);
+            : new AppCatalogsApiHandler(appCatalogManager, appHost, this::currentCryptaVersion);
   }
 
   /**
@@ -274,6 +274,11 @@ public final class PlatformApiRouter {
     }
 
     return routeGetOnlyRequest(segments, request, firstSegment);
+  }
+
+  private String currentCryptaVersion() {
+    var greeting = nodeApiHandler.rawGreeting();
+    return greeting == null ? null : Integer.toString(greeting.buildNumber());
   }
 
   private PlatformApiResponse routeGetOnlyRequest(

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
@@ -476,9 +476,19 @@ public final class AppCatalogsApiHandler {
     return !catalogVersion.equals(installedVersion);
   }
 
-  private static boolean updateAvailable(
+  private static Boolean updateAvailable(
       String catalogVersion, String installedVersion, boolean installed) {
-    return versionDifferent(catalogVersion, installedVersion, installed);
+    if (!installed) {
+      return false;
+    }
+    if (catalogVersion == null || installedVersion == null) {
+      return null;
+    }
+    if (catalogVersion.equals(installedVersion)) {
+      return false;
+    }
+    Integer comparison = compareDottedNumericVersions(catalogVersion, installedVersion);
+    return comparison == null ? null : comparison > 0;
   }
 
   private static String versionStatus(

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
@@ -1,16 +1,24 @@
 package network.crypta.platform.api.appcatalogs;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
 import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.appcatalog.AppCatalogChangelog;
+import network.crypta.platform.appcatalog.AppCatalogCompatibilityMetadata;
 import network.crypta.platform.appcatalog.AppCatalogEntry;
 import network.crypta.platform.appcatalog.AppCatalogException;
 import network.crypta.platform.appcatalog.AppCatalogInstallPlan;
 import network.crypta.platform.appcatalog.AppCatalogManager;
+import network.crypta.platform.appcatalog.AppCatalogReviewMetadata;
 import network.crypta.platform.appcatalog.AppCatalogSourceSnapshot;
 import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
@@ -47,9 +55,19 @@ public final class AppCatalogsApiHandler {
   private static final String INVALID_APP_BUNDLE_ERROR_CODE = "invalid_app_bundle";
   private static final String APPHOST_BUNDLE_VALIDATION_MESSAGE =
       "Catalog app bundle failed AppHost validation.";
+  private static final String VERSION_STATUS_NOT_INSTALLED = "not_installed";
+  private static final String VERSION_STATUS_CURRENT = "current";
+  private static final String VERSION_STATUS_DIFFERENT = "different";
+  private static final String VERSION_STATUS_UNKNOWN = "unknown";
+  private static final String COMPATIBILITY_NOT_DECLARED = "not_declared";
+  private static final String COMPATIBILITY_SATISFIED = "satisfied";
+  private static final String COMPATIBILITY_NOT_SATISFIED = "not_satisfied";
+  private static final String COMPATIBILITY_UNKNOWN = "unknown";
+  private static final String SOURCE_FIELD = "source";
 
   private final AppCatalogManager catalogManager;
   private final AppHost appHost;
+  private final Supplier<String> currentCryptaVersionSupplier;
 
   /**
    * Creates a handler backed by a catalog manager and shared AppHost.
@@ -62,9 +80,30 @@ public final class AppCatalogsApiHandler {
    * @param catalogManager signed catalog manager owned by runtime composition
    * @param appHost shared AppHost used for final install and update operations
    */
+  @SuppressWarnings("unused")
   public AppCatalogsApiHandler(AppCatalogManager catalogManager, AppHost appHost) {
+    this(catalogManager, appHost, () -> null);
+  }
+
+  /**
+   * Creates a handler backed by a catalog manager, AppHost, and node-version supplier.
+   *
+   * <p>The version supplier is used only for advisory compatibility metadata in read responses. It
+   * is not involved in catalog signature verification, artifact staging, or install/update
+   * decisions.
+   *
+   * @param catalogManager signed catalog manager owned by runtime composition
+   * @param appHost shared AppHost used for final install and update operations
+   * @param currentCryptaVersionSupplier current node version supplier for compatibility display
+   */
+  public AppCatalogsApiHandler(
+      AppCatalogManager catalogManager,
+      AppHost appHost,
+      Supplier<String> currentCryptaVersionSupplier) {
     this.catalogManager = Objects.requireNonNull(catalogManager, "catalogManager");
     this.appHost = Objects.requireNonNull(appHost, "appHost");
+    this.currentCryptaVersionSupplier =
+        Objects.requireNonNull(currentCryptaVersionSupplier, "currentCryptaVersionSupplier");
   }
 
   /**
@@ -98,7 +137,7 @@ public final class AppCatalogsApiHandler {
    * @return JSON-compatible summary for the newly stored and verified catalog
    */
   public Map<String, Object> add(Map<String, List<String>> queryParameters) {
-    String source = PlatformApiParameters.requireString(queryParameters, "source");
+    String source = PlatformApiParameters.requireString(queryParameters, SOURCE_FIELD);
     try {
       return summarizeCatalog(catalogManager.addSource(source));
     } catch (AppCatalogException exception) {
@@ -302,7 +341,7 @@ public final class AppCatalogsApiHandler {
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
     json.put("catalogId", snapshot.catalogId());
     json.put("name", snapshot.name());
-    json.put("source", snapshot.sourceUri().toString());
+    json.put(SOURCE_FIELD, snapshot.sourceUri().toString());
     json.put("generatedAt", snapshot.generatedAt().toString());
     json.put("appCount", snapshot.appCount());
     json.put("addedAt", snapshot.addedAt().toString());
@@ -313,15 +352,31 @@ public final class AppCatalogsApiHandler {
   private Map<String, Object> summarizeEntry(AppCatalogEntry entry) {
     InstalledAppSnapshot installed = installed(entry.appId());
     RunningAppSnapshot running = appHost.status(entry.appId()).orElse(null);
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(12);
+    String installedVersion = installed == null ? null : installed.manifest().appVersion();
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(28);
     json.put("appId", entry.appId());
     json.put("name", entry.name());
     json.put("version", entry.version());
     json.put("summary", entry.summary());
+    json.put("homepage", entry.homepage().map(URI::toString).orElse(null));
+    json.put(SOURCE_FIELD, entry.source().map(URI::toString).orElse(null));
+    json.put("license", entry.license().orElse(null));
+    json.put("categories", entry.categories());
+    json.put("review", summarizeReview(entry.review()));
     json.put("permissions", entry.permissions());
+    json.put("permissionRationales", entry.permissionRationales());
+    json.put("compatibility", summarizeCompatibility(entry.compatibility()));
+    json.put("changelog", summarizeChangelog(entry.changelog()));
+    json.put("screenshots", entry.screenshots().stream().map(URI::toString).toList());
     json.put("bundle", summarizeBundle(entry));
     json.put("installed", installed != null);
-    json.put("installedVersion", installed == null ? null : installed.manifest().appVersion());
+    json.put("installedVersion", installedVersion);
+    json.put(
+        "versionDifferent", versionDifferent(entry.version(), installedVersion, installed != null));
+    json.put(
+        "updateAvailable", updateAvailable(entry.version(), installedVersion, installed != null));
+    json.put("versionStatus", versionStatus(entry.version(), installedVersion, installed != null));
+    json.put("permissionDelta", summarizePermissionDelta(entry.permissions(), installed));
     json.put("running", running != null);
     json.put("pid", running == null ? null : running.pid());
     json.put("startedAt", running == null ? null : running.startedAt().toString());
@@ -343,6 +398,153 @@ public final class AppCatalogsApiHandler {
     json.put("sizeBytes", entry.bundleSizeBytes());
     json.put("sha256", entry.bundleSha256());
     return json;
+  }
+
+  private static Map<String, Object> summarizeReview(AppCatalogReviewMetadata review) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put("status", review.status().catalogValue());
+    json.put("note", review.note().orElse(null));
+    json.put("advisory", true);
+    return json;
+  }
+
+  private Map<String, Object> summarizeCompatibility(
+      AppCatalogCompatibilityMetadata compatibility) {
+    String minimumVersion = compatibility.minimumCryptaVersion().orElse(null);
+    String currentVersion = currentCryptaVersion();
+    CompatibilityResult result = compatibilityResult(minimumVersion, currentVersion);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(6);
+    json.put("minimumCryptaVersion", minimumVersion);
+    json.put("currentCryptaVersion", currentVersion);
+    json.put(COMPATIBILITY_SATISFIED, result.satisfied());
+    json.put("advisory", true);
+    json.put("status", result.status());
+    return json;
+  }
+
+  private static Map<String, Object> summarizeChangelog(AppCatalogChangelog changelog) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("summary", changelog.summary().orElse(null));
+    json.put("uri", changelog.uri().map(URI::toString).orElse(null));
+    return json;
+  }
+
+  private static Map<String, Object> summarizePermissionDelta(
+      List<String> catalogPermissions, InstalledAppSnapshot installed) {
+    Set<String> catalog = new LinkedHashSet<>(catalogPermissions);
+    Set<String> local =
+        installed == null ? Set.of() : new LinkedHashSet<>(installed.manifest().permissions());
+    List<String> added = new ArrayList<>();
+    List<String> removed = new ArrayList<>();
+    List<String> unchanged = new ArrayList<>();
+    for (String permission : catalog) {
+      if (local.contains(permission)) {
+        unchanged.add(permission);
+      } else {
+        added.add(permission);
+      }
+    }
+    for (String permission : local) {
+      if (!catalog.contains(permission)) {
+        removed.add(permission);
+      }
+    }
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put("added", List.copyOf(added));
+    json.put("removed", List.copyOf(removed));
+    json.put("unchanged", List.copyOf(unchanged));
+    return json;
+  }
+
+  private String currentCryptaVersion() {
+    try {
+      String value = currentCryptaVersionSupplier.get();
+      return value == null || value.isBlank() ? null : value;
+    } catch (RuntimeException _) {
+      return null;
+    }
+  }
+
+  private static boolean versionDifferent(
+      String catalogVersion, String installedVersion, boolean installed) {
+    if (!installed) {
+      return false;
+    }
+    if (catalogVersion == null || installedVersion == null) {
+      return false;
+    }
+    return !catalogVersion.equals(installedVersion);
+  }
+
+  private static boolean updateAvailable(
+      String catalogVersion, String installedVersion, boolean installed) {
+    return versionDifferent(catalogVersion, installedVersion, installed);
+  }
+
+  private static String versionStatus(
+      String catalogVersion, String installedVersion, boolean installed) {
+    if (!installed) {
+      return VERSION_STATUS_NOT_INSTALLED;
+    }
+    if (catalogVersion == null || installedVersion == null) {
+      return VERSION_STATUS_UNKNOWN;
+    }
+    return versionDifferent(catalogVersion, installedVersion, true)
+        ? VERSION_STATUS_DIFFERENT
+        : VERSION_STATUS_CURRENT;
+  }
+
+  private static CompatibilityResult compatibilityResult(
+      String minimumVersion, String currentVersion) {
+    if (minimumVersion == null) {
+      return new CompatibilityResult(true, COMPATIBILITY_NOT_DECLARED);
+    }
+    if (currentVersion == null) {
+      return new CompatibilityResult(null, COMPATIBILITY_UNKNOWN);
+    }
+    Integer comparison = compareDottedNumericVersions(currentVersion, minimumVersion);
+    if (comparison == null) {
+      return new CompatibilityResult(null, COMPATIBILITY_UNKNOWN);
+    }
+    boolean satisfied = comparison >= 0;
+    return new CompatibilityResult(
+        satisfied, satisfied ? COMPATIBILITY_SATISFIED : COMPATIBILITY_NOT_SATISFIED);
+  }
+
+  private static Integer compareDottedNumericVersions(String left, String right) {
+    List<Integer> leftParts = parseDottedNumericVersion(left);
+    List<Integer> rightParts = parseDottedNumericVersion(right);
+    if (leftParts.isEmpty() || rightParts.isEmpty()) {
+      return null;
+    }
+    int count = Math.max(leftParts.size(), rightParts.size());
+    for (int index = 0; index < count; index++) {
+      int leftPart = index < leftParts.size() ? leftParts.get(index) : 0;
+      int rightPart = index < rightParts.size() ? rightParts.get(index) : 0;
+      if (leftPart != rightPart) {
+        return Integer.compare(leftPart, rightPart);
+      }
+    }
+    return 0;
+  }
+
+  private static List<Integer> parseDottedNumericVersion(String version) {
+    if (version == null || version.isBlank()) {
+      return List.of();
+    }
+    String[] tokens = version.trim().split("\\.", -1);
+    List<Integer> parts = new ArrayList<>(tokens.length);
+    for (String token : tokens) {
+      if (token.isBlank() || !token.chars().allMatch(Character::isDigit)) {
+        return List.of();
+      }
+      try {
+        parts.add(Integer.parseInt(token));
+      } catch (NumberFormatException _) {
+        return List.of();
+      }
+    }
+    return List.copyOf(parts);
   }
 
   private static Map<String, Object> summarizeInstalledApp(AppManifest manifest) {
@@ -448,4 +650,6 @@ public final class AppCatalogsApiHandler {
     String message = failure.getMessage();
     return message == null || message.isBlank() ? "App already installed." : message;
   }
+
+  private record CompatibilityResult(Boolean satisfied, String status) {}
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/node/NodeApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/node/NodeApiHandler.java
@@ -49,6 +49,18 @@ public final class NodeApiHandler {
   }
 
   /**
+   * Returns the raw greeting snapshot for other Platform API endpoint families.
+   *
+   * <p>This keeps shared display metadata, such as advisory app-catalog compatibility fields, on
+   * the same detached runtime port as the public {@code /node/greeting} response.
+   *
+   * @return current detached greeting snapshot
+   */
+  public NodeGreetingSnapshot rawGreeting() {
+    return nodeInfoPort.greeting();
+  }
+
+  /**
    * Returns one node-reference export as a nested JSON object.
    *
    * @param queryParameters decoded query parameters for the current request

--- a/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
@@ -1,0 +1,286 @@
+package network.crypta.platform.api.appcatalogs;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import network.crypta.platform.appcatalog.AppCatalogChangelog;
+import network.crypta.platform.appcatalog.AppCatalogCompatibilityMetadata;
+import network.crypta.platform.appcatalog.AppCatalogEntry;
+import network.crypta.platform.appcatalog.AppCatalogManager;
+import network.crypta.platform.appcatalog.AppCatalogReviewMetadata;
+import network.crypta.platform.appcatalog.AppCatalogReviewStatus;
+import network.crypta.platform.appdist.AppUiMode;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.InstalledAppPaths;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"java:S100", "unchecked"})
+class AppCatalogsApiHandlerTest {
+  private static final String APP_ID = "queue-manager";
+
+  @Mock private AppCatalogManager catalogManager;
+  @Mock private AppHost appHost;
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void listApps_whenEntryHasStoreMetadataAndInstalledAppDiffers_expectReviewMetadata()
+      throws Exception {
+    Map<String, Object> app = listRichInstalledCatalogApp();
+
+    assertEquals(APP_ID, app.get("appId"));
+    assertEquals("1.2.0", app.get("version"));
+    assertEquals("1.1.0", app.get("installedVersion"));
+    assertEquals(true, app.get("installed"));
+    assertEquals(true, app.get("versionDifferent"));
+    assertEquals(true, app.get("updateAvailable"));
+    assertEquals("different", app.get("versionStatus"));
+    assertEquals(List.of("productivity", "network"), app.get("categories"));
+    assertEquals("https://example.invalid/app", app.get("homepage"));
+    assertEquals("https://example.invalid/repo", app.get("source"));
+    assertEquals("MIT", app.get("license"));
+
+    Map<String, Object> review = (Map<String, Object>) app.get("review");
+    assertEquals("reviewed", review.get("status"));
+    assertEquals("Reviewed for local operator safety.", review.get("note"));
+    assertEquals(true, review.get("advisory"));
+
+    Map<String, Object> rationales = (Map<String, Object>) app.get("permissionRationales");
+    assertEquals("Reads the local transfer queue.", rationales.get("queue.read"));
+    assertEquals("Lets the app manage queue entries.", rationales.get("queue.write"));
+
+    Map<String, Object> compatibility = (Map<String, Object>) app.get("compatibility");
+    assertEquals("0.1.0", compatibility.get("minimumCryptaVersion"));
+    assertEquals("0.2.0", compatibility.get("currentCryptaVersion"));
+    assertEquals(true, compatibility.get("satisfied"));
+    assertEquals(true, compatibility.get("advisory"));
+    assertEquals("satisfied", compatibility.get("status"));
+
+    Map<String, Object> changelog = (Map<String, Object>) app.get("changelog");
+    assertEquals("Adds queue retry controls.", changelog.get("summary"));
+    assertEquals("https://example.invalid/changelog.txt", changelog.get("uri"));
+    assertEquals(List.of("https://example.invalid/shot-1.png"), app.get("screenshots"));
+  }
+
+  @Test
+  void listApps_whenEntryHasStoreMetadataAndInstalledAppDiffers_expectPermissionDelta()
+      throws Exception {
+    Map<String, Object> app = listRichInstalledCatalogApp();
+
+    Map<String, Object> delta = (Map<String, Object>) app.get("permissionDelta");
+    assertEquals(List.of("queue.write"), delta.get("added"));
+    assertEquals(List.of("network.access"), delta.get("removed"));
+    assertEquals(List.of("queue.read"), delta.get("unchanged"));
+  }
+
+  @Test
+  void listApps_whenMinimalCatalogEntryIsNotInstalled_expectBackwardCompatibleApiMetadata()
+      throws Exception {
+    AppCatalogsApiHandler handler = new AppCatalogsApiHandler(catalogManager, appHost, () -> null);
+    when(catalogManager.listApps("core")).thenReturn(List.of(minimalCatalogEntry()));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    Map<String, Object> app = handler.listApps("core").getFirst();
+
+    assertNull(app.get("homepage"));
+    assertNull(app.get("source"));
+    assertNull(app.get("license"));
+    assertEquals(List.of(), app.get("categories"));
+    assertFalse((Boolean) app.get("installed"));
+    assertEquals(false, app.get("versionDifferent"));
+    assertEquals(false, app.get("updateAvailable"));
+    assertEquals("not_installed", app.get("versionStatus"));
+
+    Map<String, Object> review = (Map<String, Object>) app.get("review");
+    assertEquals("unreviewed", review.get("status"));
+    assertNull(review.get("note"));
+    assertTrue((Boolean) review.get("advisory"));
+
+    Map<String, Object> compatibility = (Map<String, Object>) app.get("compatibility");
+    assertNull(compatibility.get("minimumCryptaVersion"));
+    assertNull(compatibility.get("currentCryptaVersion"));
+    assertEquals(true, compatibility.get("satisfied"));
+    assertEquals("not_declared", compatibility.get("status"));
+  }
+
+  @Test
+  void listApps_whenInstalledVersionAndPermissionsMatchCatalog_expectCurrentVersionReview()
+      throws Exception {
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(catalogManager, appHost, () -> "1.2.0");
+    when(catalogManager.listApps("core")).thenReturn(List.of(richCatalogEntry()));
+    when(appHost.describe(APP_ID))
+        .thenReturn(Optional.of(installedSnapshot("1.2.0", List.of("queue.read", "queue.write"))));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    Map<String, Object> app = handler.listApps("core").getFirst();
+
+    assertEquals(false, app.get("versionDifferent"));
+    assertEquals(false, app.get("updateAvailable"));
+    assertEquals("current", app.get("versionStatus"));
+
+    Map<String, Object> delta = (Map<String, Object>) app.get("permissionDelta");
+    assertEquals(List.of(), delta.get("added"));
+    assertEquals(List.of(), delta.get("removed"));
+    assertEquals(List.of("queue.read", "queue.write"), delta.get("unchanged"));
+  }
+
+  @Test
+  void listApps_whenMinimumVersionExceedsCurrentVersion_expectNotSatisfiedCompatibility()
+      throws Exception {
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(catalogManager, appHost, () -> "1.2.0");
+    when(catalogManager.listApps("core"))
+        .thenReturn(List.of(catalogEntryWithMinimumCryptaVersion("1.3.0")));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    Map<String, Object> app = handler.listApps("core").getFirst();
+
+    Map<String, Object> compatibility = (Map<String, Object>) app.get("compatibility");
+    assertEquals("1.3.0", compatibility.get("minimumCryptaVersion"));
+    assertEquals("1.2.0", compatibility.get("currentCryptaVersion"));
+    assertEquals(false, compatibility.get("satisfied"));
+    assertEquals("not_satisfied", compatibility.get("status"));
+  }
+
+  @Test
+  void listApps_whenCurrentVersionSupplierFails_expectUnknownCompatibility() throws Exception {
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(
+            catalogManager,
+            appHost,
+            () -> {
+              throw new IllegalStateException("runtime unavailable");
+            });
+    when(catalogManager.listApps("core"))
+        .thenReturn(List.of(catalogEntryWithMinimumCryptaVersion("1.0.0")));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    Map<String, Object> app = handler.listApps("core").getFirst();
+
+    Map<String, Object> compatibility = (Map<String, Object>) app.get("compatibility");
+    assertEquals("1.0.0", compatibility.get("minimumCryptaVersion"));
+    assertNull(compatibility.get("currentCryptaVersion"));
+    assertNull(compatibility.get("satisfied"));
+    assertEquals("unknown", compatibility.get("status"));
+  }
+
+  private Map<String, Object> listRichInstalledCatalogApp() throws Exception {
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(catalogManager, appHost, () -> "0.2.0");
+    when(catalogManager.listApps("core")).thenReturn(List.of(richCatalogEntry()));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    return handler.listApps("core").getFirst();
+  }
+
+  private AppCatalogEntry richCatalogEntry() {
+    return new AppCatalogEntry(
+        APP_ID,
+        "Queue Manager",
+        "1.2.0",
+        "Manage local Crypta transfer queues.",
+        Optional.of(URI.create("https://example.invalid/app")),
+        Optional.of(URI.create("https://example.invalid/repo")),
+        Optional.of("MIT"),
+        List.of("productivity", "network"),
+        new AppCatalogCompatibilityMetadata(Optional.of("0.1.0")),
+        new AppCatalogReviewMetadata(
+            AppCatalogReviewStatus.REVIEWED, Optional.of("Reviewed for local operator safety.")),
+        new AppCatalogChangelog(
+            Optional.of("Adds queue retry controls."),
+            Optional.of(URI.create("https://example.invalid/changelog.txt"))),
+        List.of(URI.create("https://example.invalid/shot-1.png")),
+        URI.create("https://example.invalid/apps/queue-manager.zip"),
+        "0".repeat(64),
+        0L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of("queue.read", "queue.write"),
+        Map.of(
+            "queue.read",
+            "Reads the local transfer queue.",
+            "queue.write",
+            "Lets the app manage queue entries."));
+  }
+
+  private AppCatalogEntry minimalCatalogEntry() {
+    return new AppCatalogEntry(
+        APP_ID,
+        "Queue Manager",
+        "1.2.0",
+        "Manage local Crypta transfer queues.",
+        URI.create("https://example.invalid/apps/queue-manager.zip"),
+        "0".repeat(64),
+        0L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of("queue.read"));
+  }
+
+  private AppCatalogEntry catalogEntryWithMinimumCryptaVersion(String minimumCryptaVersion) {
+    return new AppCatalogEntry(
+        APP_ID,
+        "Queue Manager",
+        "1.2.0",
+        "Manage local Crypta transfer queues.",
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        List.of(),
+        new AppCatalogCompatibilityMetadata(Optional.of(minimumCryptaVersion)),
+        AppCatalogReviewMetadata.EMPTY,
+        AppCatalogChangelog.EMPTY,
+        List.of(),
+        URI.create("https://example.invalid/apps/queue-manager.zip"),
+        "0".repeat(64),
+        0L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of("queue.read"),
+        Map.of());
+  }
+
+  private InstalledAppSnapshot installedSnapshot() {
+    return installedSnapshot("1.1.0", List.of("queue.read", "network.access"));
+  }
+
+  private InstalledAppSnapshot installedSnapshot(String version, List<String> permissions) {
+    AppManifest manifest =
+        new AppManifest(
+            1,
+            APP_ID,
+            "Queue Manager",
+            version,
+            "bin/launch.sh",
+            AppUiMode.STATIC,
+            "static/index.html",
+            permissions,
+            null,
+            null);
+    InstalledAppPaths paths =
+        new InstalledAppPaths(
+            APP_ID,
+            tempDir.resolve("installed").resolve(APP_ID),
+            tempDir.resolve("data").resolve(APP_ID),
+            tempDir.resolve("cache").resolve(APP_ID),
+            tempDir.resolve("run").resolve(APP_ID));
+    return new InstalledAppSnapshot(manifest, paths);
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
@@ -142,6 +142,38 @@ class AppCatalogsApiHandlerTest {
   }
 
   @Test
+  void listApps_whenInstalledVersionIsNewerThanCatalog_expectDifferenceWithoutUpdateAvailable()
+      throws Exception {
+    AppCatalogsApiHandler handler = new AppCatalogsApiHandler(catalogManager, appHost, () -> null);
+    when(catalogManager.listApps("core")).thenReturn(List.of(catalogEntryWithVersion("1.2.0")));
+    when(appHost.describe(APP_ID))
+        .thenReturn(Optional.of(installedSnapshot("1.3.0", List.of("queue.read"))));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    Map<String, Object> app = handler.listApps("core").getFirst();
+
+    assertEquals(true, app.get("versionDifferent"));
+    assertEquals(false, app.get("updateAvailable"));
+    assertEquals("different", app.get("versionStatus"));
+  }
+
+  @Test
+  void listApps_whenDifferingVersionsAreNotComparable_expectUnknownUpdateAvailable()
+      throws Exception {
+    AppCatalogsApiHandler handler = new AppCatalogsApiHandler(catalogManager, appHost, () -> null);
+    when(catalogManager.listApps("core")).thenReturn(List.of(catalogEntryWithVersion("1.2-beta")));
+    when(appHost.describe(APP_ID))
+        .thenReturn(Optional.of(installedSnapshot("1.1.0", List.of("queue.read"))));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    Map<String, Object> app = handler.listApps("core").getFirst();
+
+    assertEquals(true, app.get("versionDifferent"));
+    assertNull(app.get("updateAvailable"));
+    assertEquals("different", app.get("versionStatus"));
+  }
+
+  @Test
   void listApps_whenMinimumVersionExceedsCurrentVersion_expectNotSatisfiedCompatibility()
       throws Exception {
     AppCatalogsApiHandler handler =
@@ -223,10 +255,14 @@ class AppCatalogsApiHandlerTest {
   }
 
   private AppCatalogEntry minimalCatalogEntry() {
+    return catalogEntryWithVersion("1.2.0");
+  }
+
+  private AppCatalogEntry catalogEntryWithVersion(String version) {
     return new AppCatalogEntry(
         APP_ID,
         "Queue Manager",
-        "1.2.0",
+        version,
         "Manage local Crypta transfer queues.",
         URI.create("https://example.invalid/apps/queue-manager.zip"),
         "0".repeat(64),

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalog.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalog.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import network.crypta.platform.appdist.AppBundleManifest;
 
 /**
- * Verified v1 app catalog content.
+ * Verified app catalog content.
  *
  * <p>The catalog preserves the deterministic entry order declared by {@code catalog.entries}. It is
  * immutable after construction, and every entry is keyed by the normalized AppHost app id used by
@@ -22,7 +22,7 @@ import network.crypta.platform.appdist.AppBundleManifest;
  * directory names and API path segments. Entry lists are copied, duplicate app ids are rejected,
  * and no mutable collections from callers are retained.
  *
- * @param version catalog schema version, currently {@code 1}
+ * @param version catalog schema version
  * @param catalogId stable catalog identifier used by API paths and local storage
  * @param name human-readable catalog name
  * @param generatedAt timestamp declared by the catalog producer
@@ -34,6 +34,12 @@ public record AppCatalog(
     String name,
     Instant generatedAt,
     List<AppCatalogEntry> entries) {
+  /** Minimal signed-catalog schema. */
+  public static final int VERSION_MINIMAL = 1;
+
+  /** Signed-catalog schema that can carry optional app-store metadata. */
+  public static final int VERSION_STORE_METADATA = 2;
+
   /**
    * Creates a validated immutable catalog.
    *
@@ -42,7 +48,7 @@ public record AppCatalog(
    * signatures or artifact metadata; callers must only construct instances from already
    * authenticated bytes or from trusted test/tooling fixtures.
    *
-   * @param version catalog schema version, currently {@code 1}
+   * @param version catalog schema version
    * @param catalogId stable catalog identifier used by API paths and local storage
    * @param name human-readable catalog name shown to operators
    * @param generatedAt timestamp declared by the catalog producer
@@ -50,7 +56,7 @@ public record AppCatalog(
    * @throws AppCatalogException if the catalog header or entry set is invalid
    */
   public AppCatalog {
-    if (version != 1) {
+    if (!isSupportedVersion(version)) {
       throw AppCatalogSidecars.invalidEntry("unsupported catalog.version: " + version);
     }
     catalogId = normalizeCatalogId(catalogId);
@@ -60,6 +66,10 @@ public record AppCatalog(
     Objects.requireNonNull(generatedAt, "generatedAt");
     entries = List.copyOf(Objects.requireNonNull(entries, "entries"));
     rejectDuplicateEntries(entries);
+  }
+
+  static boolean isSupportedVersion(int version) {
+    return version == VERSION_MINIMAL || version == VERSION_STORE_METADATA;
   }
 
   /**

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogChangelog.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogChangelog.java
@@ -1,0 +1,80 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Optional changelog metadata displayed before app install or update.
+ *
+ * <p>A catalog entry may use this value to attach release information to the exact bundle version
+ * advertised by the signed catalog. The metadata is intentionally small: a single-line summary for
+ * card/detail views and an optional URI for longer release notes hosted by the publisher. Catalog
+ * verification authenticates that the publisher supplied these fields, but the fields remain
+ * advisory operator-facing text. They do not affect artifact download policy, bundle signature
+ * verification, install eligibility, or update ordering.
+ *
+ * <p>Instances are immutable and normalize their input during construction. Text is trimmed,
+ * bounded, and rejected if it spans multiple lines. The URI uses the catalog metadata URI policy,
+ * which permits HTTPS and loopback HTTP while rejecting fragments, user-info, local files, and
+ * arbitrary remote HTTP. The Web Shell can therefore render a link without turning the shell into a
+ * remote asset fetcher.
+ *
+ * @param summary optional single-line change summary for the catalog version
+ * @param uri optional public URI with detailed release notes for operators
+ * @see AppCatalogEntry#changelog()
+ * @see AppCatalogWriter#serialize(AppCatalog)
+ */
+public record AppCatalogChangelog(Optional<String> summary, Optional<URI> uri) {
+  private static final int MAX_CHANGELOG_SUMMARY_CHARS = 512;
+
+  /**
+   * Empty changelog metadata used by catalogs that do not declare release text.
+   *
+   * <p>Writers use this value when older descriptor files omit changelog properties. API responses
+   * still expose a stable changelog object, but both fields serialize as absent or {@code null}.
+   */
+  public static final AppCatalogChangelog EMPTY =
+      new AppCatalogChangelog(Optional.empty(), Optional.empty());
+
+  /**
+   * Creates validated changelog metadata.
+   *
+   * <p>The constructor performs all validation required by signed-catalog parsing and descriptor
+   * authoring. An absent summary or URI is valid, which keeps existing minimal catalogs compatible.
+   * A present summary must fit the display bound after trimming. A present URI must be safe
+   * metadata, not a fetchable artifact URI; catalog installers still rely only on bundle digest and
+   * signed-bundle verification.
+   *
+   * @param summary optional short summary associated with this catalog entry version
+   * @param uri optional HTTPS or loopback HTTP URI for longer release notes
+   * @throws NullPointerException if either optional wrapper is {@code null}
+   * @throws AppCatalogException if text is blank or multi-line, or URI metadata is unsafe
+   */
+  public AppCatalogChangelog {
+    Objects.requireNonNull(summary, "summary");
+    Objects.requireNonNull(uri, "uri");
+    summary =
+        summary.map(
+            rawSummary ->
+                AppCatalogSidecars.requireBoundedSingleLine(
+                    rawSummary,
+                    "changelog.summary",
+                    AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+                    MAX_CHANGELOG_SUMMARY_CHARS));
+    uri = uri.map(rawUri -> AppCatalogSidecars.requireSafeMetadataUri(rawUri, "changelog.uri"));
+  }
+
+  /**
+   * Returns whether the catalog omits all changelog metadata.
+   *
+   * <p>This helper lets writers decide whether a descriptor produced any changelog fields without
+   * inspecting the individual optionals at each call site. A summary-only or URI-only value is not
+   * empty; both shapes are valid for v1 catalogs.
+   *
+   * @return {@code true} when both optional changelog fields are absent
+   */
+  public boolean isEmpty() {
+    return summary.isEmpty() && uri.isEmpty();
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogChangelog.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogChangelog.java
@@ -70,7 +70,7 @@ public record AppCatalogChangelog(Optional<String> summary, Optional<URI> uri) {
    *
    * <p>This helper lets writers decide whether a descriptor produced any changelog fields without
    * inspecting the individual optionals at each call site. A summary-only or URI-only value is not
-   * empty; both shapes are valid for v1 catalogs.
+   * empty; both shapes are valid for metadata-capable catalogs.
    *
    * @return {@code true} when both optional changelog fields are absent
    */

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogCompatibilityMetadata.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogCompatibilityMetadata.java
@@ -6,11 +6,11 @@ import java.util.Optional;
 /**
  * Advisory compatibility metadata for a catalog app.
  *
- * <p>This record carries the v1 compatibility hint that a catalog publisher can attach to an app:
- * the minimum Cryptad build or version label the publisher expects operators to run. The field is
- * authenticated by the signed catalog sidecar, but it is not a trust decision, and it is not a
- * runtime gate. Install and update still depend on catalog signature verification, artifact digest
- * checks, signed-bundle verification, and AppHost validation.
+ * <p>This record carries the compatibility hint that a catalog publisher can attach to an app: the
+ * minimum Cryptad build or version label the publisher expects operators to run. The field is
+ * authenticated by the signed catalog sidecar when present, but it is not a trust decision, and it
+ * is not a runtime gate. Install and update still depend on catalog signature verification,
+ * artifact digest checks, signed-bundle verification, and AppHost validation.
  *
  * <p>Platform API responses compare this value with the local node's comparable version string when
  * the two values can be parsed safely. Integer Cryptad build labels are the preferred comparable

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogCompatibilityMetadata.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogCompatibilityMetadata.java
@@ -1,0 +1,65 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Advisory compatibility metadata for a catalog app.
+ *
+ * <p>This record carries the v1 compatibility hint that a catalog publisher can attach to an app:
+ * the minimum Cryptad build or version label the publisher expects operators to run. The field is
+ * authenticated by the signed catalog sidecar, but it is not a trust decision, and it is not a
+ * runtime gate. Install and update still depend on catalog signature verification, artifact digest
+ * checks, signed-bundle verification, and AppHost validation.
+ *
+ * <p>Platform API responses compare this value with the local node's comparable version string when
+ * the two values can be parsed safely. Integer Cryptad build labels are the preferred comparable
+ * form because Cryptad releases are build-numbered. Dotted numeric labels can still be reported for
+ * compatibility with early descriptors. Ambiguous values are preserved for display and produce an
+ * advisory {@code unknown} status rather than blocking the operator.
+ *
+ * <p>Instances are immutable. Construction trims present values, rejects blank or multi-line
+ * values, and bounds the length so catalog metadata cannot smuggle long free-form review text into
+ * the compatibility field.
+ *
+ * @param minimumCryptaVersion optional minimum Cryptad build or version label from the catalog
+ *     publisher
+ * @see AppCatalogEntry#compatibility()
+ */
+public record AppCatalogCompatibilityMetadata(Optional<String> minimumCryptaVersion) {
+  private static final int MAX_VERSION_CHARS = 96;
+
+  /**
+   * Empty compatibility metadata used by catalogs that do not declare a minimum version.
+   *
+   * <p>This value preserves backward compatibility with the original minimal catalog format. API
+   * clients should treat it as {@code not_declared}, not as evidence that every node version was
+   * reviewed by the publisher.
+   */
+  public static final AppCatalogCompatibilityMetadata EMPTY =
+      new AppCatalogCompatibilityMetadata(Optional.empty());
+
+  /**
+   * Creates validated compatibility metadata.
+   *
+   * <p>The constructor validates only the shape of the advisory metadata. It does not parse,
+   * compare, or normalize version ordering because comparison depends on the caller's current node
+   * version and may remain unavailable for non-numeric publisher labels. A present value is stored
+   * after trimming so writers and API responses use the same canonical text.
+   *
+   * @param minimumCryptaVersion optional minimum Cryptad build or version label to display
+   * @throws NullPointerException if the optional wrapper is {@code null}
+   * @throws AppCatalogException if the value is blank, multi-line, or too long
+   */
+  public AppCatalogCompatibilityMetadata {
+    Objects.requireNonNull(minimumCryptaVersion, "minimumCryptaVersion");
+    minimumCryptaVersion =
+        minimumCryptaVersion.map(
+            rawVersion ->
+                AppCatalogSidecars.requireBoundedSingleLine(
+                    rawVersion,
+                    "minimumCryptaVersion",
+                    AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+                    MAX_VERSION_CHARS));
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntry.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntry.java
@@ -1,10 +1,14 @@
 package network.crypta.platform.appcatalog;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import network.crypta.platform.appdist.AppBundleManifest;
@@ -13,9 +17,11 @@ import network.crypta.platform.appdist.AppBundleManifest;
  * One app artifact advertised by a signed catalog.
  *
  * <p>The entry stores the normalized app identity, display metadata, permissions, and the exact ZIP
- * artifact contract that must be satisfied before installation. Catalog installers use the declared
- * size and SHA-256 digest as the first artifact gate, then verify the extracted signed bundle
- * independently through {@code platform-appdist}.
+ * artifact contract that must be satisfied before installation. Optional store metadata such as
+ * homepage links, category tags, review notes, permission rationales, compatibility hints,
+ * screenshots, and changelog references is advisory display input for operators. Catalog installers
+ * use the declared size and SHA-256 digest as the first artifact gate, then verify the extracted
+ * signed bundle independently through {@code platform-appdist}.
  *
  * <p>Instances are immutable and safe to expose through the Platform API after the containing
  * catalog has been signature-verified. The record validates that artifact URIs use an accepted
@@ -28,27 +34,49 @@ import network.crypta.platform.appdist.AppBundleManifest;
  * @param name human-readable application name
  * @param version application version expected in the extracted bundle manifest
  * @param summary short operator-facing description
+ * @param homepage optional operator-facing project homepage URI
+ * @param source optional operator-facing source-code URI
+ * @param license optional license identifier or short license name
+ * @param categories normalized catalog category tags
+ * @param compatibility advisory compatibility metadata
+ * @param review advisory human-review metadata
+ * @param changelog optional change metadata for this catalog version
+ * @param screenshots optional screenshot URIs displayed as links
  * @param bundleUri absolute local or remote URI for the ZIP bundle artifact
  * @param bundleSha256 lowercase SHA-256 digest of the ZIP artifact bytes
  * @param bundleSizeBytes exact artifact size in bytes
  * @param bundleType artifact type, currently {@code zip}
  * @param permissions normalized catalog permission hints
+ * @param permissionRationales permission-keyed rationale text for install/update review
  */
 public record AppCatalogEntry(
     String appId,
     String name,
     String version,
     String summary,
+    Optional<URI> homepage,
+    Optional<URI> source,
+    Optional<String> license,
+    List<String> categories,
+    AppCatalogCompatibilityMetadata compatibility,
+    AppCatalogReviewMetadata review,
+    AppCatalogChangelog changelog,
+    List<URI> screenshots,
     URI bundleUri,
     String bundleSha256,
     long bundleSizeBytes,
     String bundleType,
-    List<String> permissions) {
+    List<String> permissions,
+    Map<String, String> permissionRationales) {
   /** Artifact type supported by PR-195 catalog installs. */
   public static final String ZIP_BUNDLE_TYPE = "zip";
 
   private static final Pattern PERMISSION_PATTERN =
       Pattern.compile("[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?");
+  private static final int MAX_LICENSE_CHARS = 128;
+  private static final int MAX_CATEGORY_CHARS = 64;
+  private static final int MAX_PERMISSION_RATIONALE_CHARS = 512;
+  private static final int MAX_SCREENSHOT_COUNT = 8;
 
   /**
    * Creates a validated catalog entry.
@@ -61,20 +89,45 @@ public record AppCatalogEntry(
    * @param name human-readable application name shown in catalog listings
    * @param version application version expected in the extracted bundle manifest
    * @param summary short operator-facing description from the catalog
+   * @param homepage optional operator-facing project homepage URI
+   * @param source optional operator-facing source-code URI
+   * @param license optional license identifier or short license name
+   * @param categories normalized catalog category tags
+   * @param compatibility advisory compatibility metadata
+   * @param review advisory human-review metadata
+   * @param changelog optional change metadata for this catalog version
+   * @param screenshots optional screenshot URIs displayed as links
    * @param bundleUri absolute local or remote URI for the ZIP bundle artifact
    * @param bundleSha256 lowercase SHA-256 digest of the ZIP artifact bytes
    * @param bundleSizeBytes exact artifact size in bytes
    * @param bundleType artifact type, currently {@code zip}
    * @param permissions normalized catalog permission hints
+   * @param permissionRationales permission-keyed rationale text for install/update review
    * @throws AppCatalogException if the entry contains unsupported or unsafe metadata
    */
   public AppCatalogEntry {
     appId = normalizeAppId(appId);
+    String fieldPrefix = "app." + appId + ".";
     name = AppCatalogSidecars.requireNonBlankSingleLine(name, "app." + appId + ".name", code());
     version =
         AppCatalogSidecars.requireNonBlankSingleLine(version, "app." + appId + ".version", code());
     summary =
         AppCatalogSidecars.requireNonBlankSingleLine(summary, "app." + appId + ".summary", code());
+    Objects.requireNonNull(homepage, "homepage");
+    homepage = homepage.map(rawUri -> normalizeMetadataUri(rawUri, fieldPrefix + "homepage"));
+    Objects.requireNonNull(source, "source");
+    source = source.map(rawUri -> normalizeMetadataUri(rawUri, fieldPrefix + "source"));
+    Objects.requireNonNull(license, "license");
+    license =
+        license.map(
+            rawValue ->
+                AppCatalogSidecars.requireBoundedSingleLine(
+                    rawValue, fieldPrefix + "license", code(), MAX_LICENSE_CHARS));
+    categories = normalizeCategories(categories, appId);
+    Objects.requireNonNull(compatibility, "compatibility");
+    Objects.requireNonNull(review, "review");
+    Objects.requireNonNull(changelog, "changelog");
+    screenshots = normalizeScreenshots(screenshots, appId);
     bundleUri = AppCatalogSidecars.requireSafeArtifactUri(Objects.requireNonNull(bundleUri));
     bundleSha256 =
         AppCatalogSidecars.requireLowercaseSha256(bundleSha256, "app." + appId + ".bundle.sha256");
@@ -94,6 +147,55 @@ public record AppCatalogEntry(
           "unsupported app." + appId + ".bundle.type: " + bundleType);
     }
     permissions = normalizePermissions(permissions, appId);
+    permissionRationales = normalizePermissionRationales(permissionRationales, permissions, appId);
+  }
+
+  /**
+   * Creates a catalog entry using the original minimal v1 metadata shape.
+   *
+   * <p>This constructor keeps existing tests and controlled callers source-compatible while the
+   * record grows optional store metadata. All optional fields default to absent or empty advisory
+   * metadata.
+   *
+   * @param appId normalized AppHost-compatible application identifier
+   * @param name human-readable application name shown in catalog listings
+   * @param version application version expected in the extracted bundle manifest
+   * @param summary short operator-facing description from the catalog
+   * @param bundleUri absolute local or remote URI for the ZIP bundle artifact
+   * @param bundleSha256 lowercase SHA-256 digest of the ZIP artifact bytes
+   * @param bundleSizeBytes exact artifact size in bytes
+   * @param bundleType artifact type, currently {@code zip}
+   * @param permissions normalized catalog permission hints
+   */
+  public AppCatalogEntry(
+      String appId,
+      String name,
+      String version,
+      String summary,
+      URI bundleUri,
+      String bundleSha256,
+      long bundleSizeBytes,
+      String bundleType,
+      List<String> permissions) {
+    this(
+        appId,
+        name,
+        version,
+        summary,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        List.of(),
+        AppCatalogCompatibilityMetadata.EMPTY,
+        AppCatalogReviewMetadata.EMPTY,
+        AppCatalogChangelog.EMPTY,
+        List.of(),
+        bundleUri,
+        bundleSha256,
+        bundleSizeBytes,
+        bundleType,
+        permissions,
+        Map.of());
   }
 
   /**
@@ -120,20 +222,92 @@ public record AppCatalogEntry(
     return AppCatalogSidecars.INVALID_CATALOG_ENTRY;
   }
 
+  private static URI normalizeMetadataUri(URI uri, String fieldName) {
+    return AppCatalogSidecars.requireSafeMetadataUri(uri, fieldName);
+  }
+
+  private static List<String> normalizeCategories(List<String> categories, String appId)
+      throws AppCatalogException {
+    Objects.requireNonNull(categories, "categories");
+    Set<String> normalized = new LinkedHashSet<>();
+    for (String category : categories) {
+      normalized.add(normalizeCategory(category, "app." + appId + ".categories"));
+    }
+    return List.copyOf(normalized);
+  }
+
+  static String normalizeCategory(String category, String fieldName) throws AppCatalogException {
+    String value =
+        AppCatalogSidecars.requireBoundedSingleLine(category, fieldName, code(), MAX_CATEGORY_CHARS)
+            .toLowerCase(Locale.ROOT);
+    if (!PERMISSION_PATTERN.matcher(value).matches()) {
+      throw AppCatalogSidecars.invalidEntry("invalid category for " + fieldName + ": " + value);
+    }
+    return value;
+  }
+
+  private static List<URI> normalizeScreenshots(List<URI> screenshots, String appId)
+      throws AppCatalogException {
+    Objects.requireNonNull(screenshots, "screenshots");
+    if (screenshots.size() > MAX_SCREENSHOT_COUNT) {
+      throw AppCatalogSidecars.invalidEntry(
+          "app." + appId + ".screenshot count exceeds the safety cap");
+    }
+    List<URI> normalized =
+        screenshots.stream()
+            .map(
+                uri ->
+                    AppCatalogSidecars.requireSafeMetadataUri(uri, "app." + appId + ".screenshot"))
+            .toList();
+    return List.copyOf(normalized);
+  }
+
   private static List<String> normalizePermissions(List<String> permissions, String appId)
       throws AppCatalogException {
     Objects.requireNonNull(permissions, "permissions");
     Set<String> normalized = new LinkedHashSet<>();
     for (String permission : permissions) {
-      String value =
-          AppCatalogSidecars.requireNonBlankSingleLine(
-                  permission, "app." + appId + ".permissions", code())
-              .toLowerCase(Locale.ROOT);
-      if (!PERMISSION_PATTERN.matcher(value).matches()) {
-        throw AppCatalogSidecars.invalidEntry("invalid permission for app." + appId + ": " + value);
-      }
-      normalized.add(value);
+      normalized.add(normalizePermission(permission, "app." + appId + ".permissions"));
     }
     return List.copyOf(normalized);
+  }
+
+  static String normalizePermission(String permission, String fieldName)
+      throws AppCatalogException {
+    String value =
+        AppCatalogSidecars.requireNonBlankSingleLine(permission, fieldName, code())
+            .toLowerCase(Locale.ROOT);
+    if (!PERMISSION_PATTERN.matcher(value).matches()) {
+      throw AppCatalogSidecars.invalidEntry("invalid permission for " + fieldName + ": " + value);
+    }
+    return value;
+  }
+
+  private static Map<String, String> normalizePermissionRationales(
+      Map<String, String> permissionRationales, List<String> permissions, String appId)
+      throws AppCatalogException {
+    Objects.requireNonNull(permissionRationales, "permissionRationales");
+    Set<String> declaredPermissions = new LinkedHashSet<>(permissions);
+    Map<String, String> normalized = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : permissionRationales.entrySet()) {
+      String permission =
+          normalizePermission(entry.getKey(), "app." + appId + ".permissions.rationale permission");
+      if (!declaredPermissions.contains(permission)) {
+        throw AppCatalogSidecars.invalidEntry(
+            "app."
+                + appId
+                + ".permissions.rationale."
+                + permission
+                + " has no declared permission");
+      }
+      String rationale =
+          AppCatalogSidecars.requireBoundedSingleLine(
+              entry.getValue(),
+              "app." + appId + ".permissions.rationale." + permission,
+              code(),
+              MAX_PERMISSION_RATIONALE_CHARS);
+      normalized.put(permission, rationale);
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(normalized));
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntry.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntry.java
@@ -198,6 +198,18 @@ public record AppCatalogEntry(
         Map.of());
   }
 
+  boolean hasStoreMetadata() {
+    return homepage.isPresent()
+        || source.isPresent()
+        || license.isPresent()
+        || !categories.isEmpty()
+        || compatibility.minimumCryptaVersion().isPresent()
+        || review.hasCatalogFields()
+        || !changelog.isEmpty()
+        || !screenshots.isEmpty()
+        || !permissionRationales.isEmpty();
+  }
+
   /**
    * Normalizes an app id using the signed-bundle manifest rules.
    *
@@ -288,7 +300,7 @@ public record AppCatalogEntry(
       throws AppCatalogException {
     Objects.requireNonNull(permissionRationales, "permissionRationales");
     Set<String> declaredPermissions = new LinkedHashSet<>(permissions);
-    Map<String, String> normalized = new LinkedHashMap<>();
+    Map<String, String> byPermission = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : permissionRationales.entrySet()) {
       String permission =
           normalizePermission(entry.getKey(), "app." + appId + ".permissions.rationale permission");
@@ -306,8 +318,18 @@ public record AppCatalogEntry(
               "app." + appId + ".permissions.rationale." + permission,
               code(),
               MAX_PERMISSION_RATIONALE_CHARS);
-      normalized.put(permission, rationale);
+      String previous = byPermission.putIfAbsent(permission, rationale);
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry("duplicate permission rationale for " + permission);
+      }
     }
-    return Collections.unmodifiableMap(new LinkedHashMap<>(normalized));
+    Map<String, String> ordered = new LinkedHashMap<>();
+    for (String permission : permissions) {
+      String rationale = byPermission.get(permission);
+      if (rationale != null) {
+        ordered.put(permission, rationale);
+      }
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(ordered));
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntryDescriptor.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntryDescriptor.java
@@ -27,7 +27,7 @@ import java.util.TreeMap;
  * ignored; all other lines must use {@code key=value}. Unknown keys are rejected because a typo in
  * a catalog descriptor should fail before the catalog is signed.
  *
- * <p>The supported v1 shape is:
+ * <p>The supported descriptor shape is:
  *
  * <pre>{@code
  * artifact.path=/abs/path/to/app.zip
@@ -278,7 +278,10 @@ public record AppCatalogEntryDescriptor(
               PERMISSION_RATIONALE_PREFIX + permission,
               AppCatalogSidecars.INVALID_CATALOG_ENTRY,
               MAX_PERMISSION_RATIONALE_CHARS);
-      normalized.put(permission, rationale);
+      String previous = normalized.putIfAbsent(permission, rationale);
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry("duplicate permission rationale for " + permission);
+      }
     }
     return Collections.unmodifiableMap(new LinkedHashMap<>(normalized));
   }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntryDescriptor.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogEntryDescriptor.java
@@ -6,10 +6,16 @@ import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * One developer-authored descriptor used to create a catalog entry.
@@ -31,6 +37,17 @@ import java.util.Optional;
  * version=Optional version consistency check
  * permissions=queue.read,queue.write
  * app.id=optional app-id consistency check
+ * homepage=https://example.invalid/app
+ * source=https://example.invalid/repo
+ * license=MIT
+ * categories=productivity,network
+ * minimumCryptaVersion=0.1.0
+ * review.status=reviewed
+ * review.note=Reviewed for local operator safety.
+ * permissions.rationale.queue.read=Reads the local transfer queue.
+ * screenshot.1=https://example.invalid/assets/shot-1.png
+ * changelog.summary=Adds queue retry controls.
+ * changelog.uri=https://example.invalid/apps/app-1.2.0-changelog.txt
  * }</pre>
  *
  * <p>{@code artifact.path}, {@code bundle.uri}, and {@code summary} are required. The local
@@ -38,8 +55,8 @@ import java.util.Optional;
  * bundle.size.bytes}, compute lowercase {@code bundle.sha256}, and inspect the root {@code
  * cryptad-app.properties}. {@code app.id} and {@code version} do not replace manifest values; when
  * present, they must match the artifact manifest so the generated catalog can install through the
- * same runtime checks used for updates. {@code bundle.uri} is the URI that will be written into the
- * public catalog for installers to fetch.
+ * same runtime checks used for updates. Optional store metadata is written into the public signed
+ * catalog and remains advisory display input for operators.
  *
  * @param artifactPath absolute path to the local ZIP artifact inspected during catalog authoring
  * @param bundleUri public artifact URI written into the catalog entry
@@ -47,7 +64,16 @@ import java.util.Optional;
  * @param appIdOverride optional app-id consistency check against the artifact manifest
  * @param nameOverride optional display name override for catalog presentation
  * @param versionOverride optional version consistency check against the artifact manifest
+ * @param homepage optional operator-facing project homepage URI
+ * @param source optional operator-facing source-code URI
+ * @param license optional license identifier or short license name
+ * @param categories normalized catalog category tags
+ * @param compatibility advisory compatibility metadata
+ * @param review advisory human-review metadata
+ * @param changelog optional change metadata for this catalog version
+ * @param screenshots optional screenshot URIs displayed as links
  * @param permissionsOverride optional permission list override; an empty list means no permissions
+ * @param permissionRationales permission-keyed rationale text for install/update review
  * @see AppCatalogWriter
  */
 public record AppCatalogEntryDescriptor(
@@ -57,23 +83,46 @@ public record AppCatalogEntryDescriptor(
     Optional<String> appIdOverride,
     Optional<String> nameOverride,
     Optional<String> versionOverride,
-    Optional<List<String>> permissionsOverride) {
+    Optional<URI> homepage,
+    Optional<URI> source,
+    Optional<String> license,
+    List<String> categories,
+    AppCatalogCompatibilityMetadata compatibility,
+    AppCatalogReviewMetadata review,
+    AppCatalogChangelog changelog,
+    List<URI> screenshots,
+    Optional<List<String>> permissionsOverride,
+    Map<String, String> permissionRationales) {
   private static final String ARTIFACT_PATH = "artifact.path";
   private static final String BUNDLE_URI = "bundle.uri";
   private static final String SUMMARY_PROPERTY = "summary";
   private static final String APP_ID = "app.id";
   private static final String NAME = "name";
   private static final String VERSION = "version";
+  private static final String HOMEPAGE_PROPERTY = "homepage";
+  private static final String SOURCE_PROPERTY = "source";
+  private static final String LICENSE_PROPERTY = "license";
+  private static final String CATEGORIES_PROPERTY = "categories";
+  private static final String MINIMUM_CRYPTA_VERSION = "minimumCryptaVersion";
+  private static final String REVIEW_STATUS = "review.status";
+  private static final String REVIEW_NOTE = "review.note";
+  private static final String CHANGELOG_SUMMARY = "changelog.summary";
+  private static final String CHANGELOG_URI = "changelog.uri";
+  private static final String SCREENSHOT_PREFIX = "screenshot.";
   private static final String PERMISSIONS = "permissions";
+  private static final String PERMISSION_RATIONALE_PREFIX = "permissions.rationale.";
+  private static final int MAX_LICENSE_CHARS = 128;
+  private static final int MAX_PERMISSION_RATIONALE_CHARS = 512;
 
   /**
    * Creates a normalized descriptor snapshot.
    *
    * <p>The constructor validates the fields that belong to the descriptor itself: absolute local
-   * artifact path, safe public artifact URI, single-line summary and overrides, and immutable
-   * optional collections. It does not read the artifact; {@link AppCatalogWriter} performs that
-   * filesystem work when building a catalog. This split keeps parse-time errors focused on
-   * descriptor syntax and authoring errors focused on artifact contents.
+   * artifact path, safe public artifact URI, single-line summary and overrides, immutable optional
+   * collections, safe display URIs, and advisory metadata. It does not read the artifact; {@link
+   * AppCatalogWriter} performs that filesystem work when building a catalog. Permission rationales
+   * are checked against the artifact manifest or permission override when the writer creates the
+   * final {@link AppCatalogEntry}.
    *
    * @param artifactPath absolute local ZIP artifact path used only while authoring
    * @param bundleUri public artifact URI written into the generated catalog entry
@@ -81,7 +130,16 @@ public record AppCatalogEntryDescriptor(
    * @param appIdOverride optional app-id consistency check against the artifact manifest
    * @param nameOverride optional display name override for catalog presentation
    * @param versionOverride optional version consistency check against the artifact manifest
+   * @param homepage optional operator-facing project homepage URI
+   * @param source optional operator-facing source-code URI
+   * @param license optional license identifier or short license name
+   * @param categories normalized catalog category tags
+   * @param compatibility advisory compatibility metadata
+   * @param review advisory human-review metadata
+   * @param changelog optional change metadata for this catalog version
+   * @param screenshots optional screenshot URIs displayed as links
    * @param permissionsOverride optional permission override list copied into immutable state
+   * @param permissionRationales permission-keyed rationale text for install/update review
    * @throws AppCatalogException if descriptor metadata is malformed
    */
   public AppCatalogEntryDescriptor {
@@ -96,8 +154,20 @@ public record AppCatalogEntryDescriptor(
     nameOverride = nameOverride.map(rawValue -> normalizeOptionalText(rawValue, NAME));
     Objects.requireNonNull(versionOverride, VERSION);
     versionOverride = versionOverride.map(rawValue -> normalizeOptionalText(rawValue, VERSION));
+    Objects.requireNonNull(homepage, HOMEPAGE_PROPERTY);
+    homepage = homepage.map(rawUri -> normalizeMetadataUri(rawUri, HOMEPAGE_PROPERTY));
+    Objects.requireNonNull(source, SOURCE_PROPERTY);
+    source = source.map(rawUri -> normalizeMetadataUri(rawUri, SOURCE_PROPERTY));
+    Objects.requireNonNull(license, LICENSE_PROPERTY);
+    license = license.map(AppCatalogEntryDescriptor::normalizeLicenseText);
+    categories = normalizeCategories(categories);
+    Objects.requireNonNull(compatibility, "compatibility");
+    Objects.requireNonNull(review, "review");
+    Objects.requireNonNull(changelog, "changelog");
+    screenshots = normalizeScreenshots(screenshots);
     Objects.requireNonNull(permissionsOverride, PERMISSIONS);
     permissionsOverride = permissionsOverride.map(List::copyOf);
+    permissionRationales = normalizePermissionRationales(permissionRationales);
   }
 
   /**
@@ -134,7 +204,21 @@ public record AppCatalogEntryDescriptor(
             removeOptional(properties, APP_ID),
             removeOptional(properties, NAME),
             removeOptional(properties, VERSION),
-            removeOptionalPermissions(properties));
+            removeOptional(properties, HOMEPAGE_PROPERTY)
+                .map(value -> parseUri(value, HOMEPAGE_PROPERTY)),
+            removeOptional(properties, SOURCE_PROPERTY)
+                .map(value -> parseUri(value, SOURCE_PROPERTY)),
+            removeOptional(properties, LICENSE_PROPERTY),
+            parseCategories(removeOptional(properties, CATEGORIES_PROPERTY).orElse(null)),
+            new AppCatalogCompatibilityMetadata(removeOptional(properties, MINIMUM_CRYPTA_VERSION)),
+            parseReview(properties),
+            new AppCatalogChangelog(
+                removeOptional(properties, CHANGELOG_SUMMARY),
+                removeOptional(properties, CHANGELOG_URI)
+                    .map(value -> parseUri(value, CHANGELOG_URI))),
+            parseScreenshots(properties),
+            removeOptionalPermissions(properties),
+            parsePermissionRationales(properties));
     if (!properties.isEmpty()) {
       throw AppCatalogSidecars.invalidEntry(
           "unsupported catalog entry descriptor property: "
@@ -156,6 +240,49 @@ public record AppCatalogEntryDescriptor(
         rawValue, fieldName, AppCatalogSidecars.INVALID_CATALOG_ENTRY);
   }
 
+  private static URI normalizeMetadataUri(URI uri, String fieldName) {
+    return AppCatalogSidecars.requireSafeMetadataUri(uri, fieldName);
+  }
+
+  private static String normalizeLicenseText(String value) {
+    return AppCatalogSidecars.requireBoundedSingleLine(
+        value, LICENSE_PROPERTY, AppCatalogSidecars.INVALID_CATALOG_ENTRY, MAX_LICENSE_CHARS);
+  }
+
+  private static List<String> normalizeCategories(List<String> categories) {
+    Objects.requireNonNull(categories, CATEGORIES_PROPERTY);
+    Set<String> normalized = new LinkedHashSet<>();
+    for (String category : categories) {
+      normalized.add(AppCatalogEntry.normalizeCategory(category, CATEGORIES_PROPERTY));
+    }
+    return List.copyOf(normalized);
+  }
+
+  private static List<URI> normalizeScreenshots(List<URI> screenshots) {
+    Objects.requireNonNull(screenshots, "screenshots");
+    return screenshots.stream()
+        .map(uri -> AppCatalogSidecars.requireSafeMetadataUri(uri, SCREENSHOT_PREFIX))
+        .toList();
+  }
+
+  private static Map<String, String> normalizePermissionRationales(
+      Map<String, String> permissionRationales) {
+    Objects.requireNonNull(permissionRationales, "permissionRationales");
+    Map<String, String> normalized = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : permissionRationales.entrySet()) {
+      String permission =
+          AppCatalogEntry.normalizePermission(entry.getKey(), PERMISSION_RATIONALE_PREFIX);
+      String rationale =
+          AppCatalogSidecars.requireBoundedSingleLine(
+              entry.getValue(),
+              PERMISSION_RATIONALE_PREFIX + permission,
+              AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+              MAX_PERMISSION_RATIONALE_CHARS);
+      normalized.put(permission, rationale);
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(normalized));
+  }
+
   private static Path parseArtifactPath(String rawPath, Path descriptorFile) {
     try {
       return Path.of(
@@ -170,12 +297,9 @@ public record AppCatalogEntryDescriptor(
   }
 
   private static URI parseBundleUri(String rawUri, Path descriptorFile) {
-    String value =
-        AppCatalogSidecars.requireNonBlankSingleLine(
-            rawUri, BUNDLE_URI, AppCatalogSidecars.INVALID_CATALOG_ENTRY);
     try {
-      return new URI(value);
-    } catch (URISyntaxException exception) {
+      return parseUri(rawUri, BUNDLE_URI);
+    } catch (AppCatalogException exception) {
       throw new AppCatalogException(
           AppCatalogSidecars.INVALID_CATALOG_ENTRY,
           "invalid " + BUNDLE_URI + " in " + descriptorFile.getFileName(),
@@ -183,16 +307,72 @@ public record AppCatalogEntryDescriptor(
     }
   }
 
-  private static String removeRequired(Map<String, String> properties, String key) {
-    String value = properties.remove(key);
-    if (value == null) {
-      throw AppCatalogSidecars.invalidEntry("missing catalog entry descriptor property: " + key);
+  private static URI parseUri(String rawUri, String fieldName) {
+    String value =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            rawUri, fieldName, AppCatalogSidecars.INVALID_CATALOG_ENTRY);
+    try {
+      return new URI(value);
+    } catch (URISyntaxException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY, "invalid " + fieldName, exception);
     }
-    return value;
   }
 
-  private static Optional<String> removeOptional(Map<String, String> properties, String key) {
-    return Optional.ofNullable(properties.remove(key));
+  private static List<String> parseCategories(String rawCategories) {
+    if (rawCategories == null || rawCategories.isBlank()) {
+      return List.of();
+    }
+    List<String> categories = new ArrayList<>();
+    for (String category : rawCategories.split(",", -1)) {
+      categories.add(category.trim());
+    }
+    return categories;
+  }
+
+  private static AppCatalogReviewMetadata parseReview(Map<String, String> properties) {
+    Optional<String> statusText = removeOptional(properties, REVIEW_STATUS);
+    AppCatalogReviewStatus status =
+        statusText
+            .map(value -> AppCatalogReviewStatus.parse(value, REVIEW_STATUS))
+            .orElse(AppCatalogReviewStatus.UNREVIEWED);
+    return new AppCatalogReviewMetadata(status, removeOptional(properties, REVIEW_NOTE));
+  }
+
+  private static List<URI> parseScreenshots(Map<String, String> properties) {
+    List<String> keys =
+        properties.keySet().stream().filter(key -> key.startsWith(SCREENSHOT_PREFIX)).toList();
+    if (keys.isEmpty()) {
+      return List.of();
+    }
+    SortedMap<Integer, URI> indexed = new TreeMap<>();
+    for (String key : keys) {
+      String indexText = key.substring(SCREENSHOT_PREFIX.length());
+      if (!isPositiveDecimal(indexText)) {
+        throw AppCatalogSidecars.invalidEntry("invalid screenshot index: " + key);
+      }
+      int index = parsePositiveIndex(indexText, key);
+      URI previous = indexed.putIfAbsent(index, parseUri(properties.remove(key), key));
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry("duplicate screenshot index: " + key);
+      }
+    }
+    List<URI> screenshots = new ArrayList<>(indexed.size());
+    int expected = 1;
+    for (Map.Entry<Integer, URI> entry : indexed.entrySet()) {
+      if (entry.getKey() != expected) {
+        throw AppCatalogSidecars.invalidEntry(
+            "missing "
+                + SCREENSHOT_PREFIX
+                + expected
+                + " before "
+                + SCREENSHOT_PREFIX
+                + entry.getKey());
+      }
+      screenshots.add(entry.getValue());
+      expected++;
+    }
+    return List.copyOf(screenshots);
   }
 
   private static Optional<List<String>> removeOptionalPermissions(Map<String, String> properties) {
@@ -208,5 +388,56 @@ public record AppCatalogEntryDescriptor(
       permissions.add(permission.trim());
     }
     return Optional.of(permissions);
+  }
+
+  private static Map<String, String> parsePermissionRationales(Map<String, String> properties) {
+    List<String> keys =
+        properties.keySet().stream()
+            .filter(key -> key.startsWith(PERMISSION_RATIONALE_PREFIX))
+            .toList();
+    Map<String, String> rationales = new LinkedHashMap<>();
+    for (String key : keys) {
+      String rawPermission = key.substring(PERMISSION_RATIONALE_PREFIX.length());
+      String permission = AppCatalogEntry.normalizePermission(rawPermission, key);
+      String previous = rationales.putIfAbsent(permission, properties.remove(key));
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry("duplicate permission rationale for " + permission);
+      }
+    }
+    return rationales;
+  }
+
+  private static boolean isPositiveDecimal(String value) {
+    if (value.isEmpty() || value.charAt(0) == '0') {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char digit = value.charAt(i);
+      if (digit < '0' || digit > '9') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int parsePositiveIndex(String value, String key) {
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY, "invalid screenshot index: " + key, exception);
+    }
+  }
+
+  private static String removeRequired(Map<String, String> properties, String key) {
+    String value = properties.remove(key);
+    if (value == null) {
+      throw AppCatalogSidecars.invalidEntry("missing catalog entry descriptor property: " + key);
+    }
+    return value;
+  }
+
+  private static Optional<String> removeOptional(Map<String, String> properties, String key) {
+    return Optional.ofNullable(properties.remove(key));
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogParser.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogParser.java
@@ -53,7 +53,7 @@ public final class AppCatalogParser {
     List<String> entryIds = parseEntryIds(removeRequired(properties, "catalog.entries"));
     List<AppCatalogEntry> entries = new ArrayList<>(entryIds.size());
     for (String appId : entryIds) {
-      entries.add(parseEntry(properties, appId));
+      entries.add(parseEntry(properties, appId, version));
     }
     if (!properties.isEmpty()) {
       throw AppCatalogSidecars.invalidEntry(
@@ -65,7 +65,7 @@ public final class AppCatalogParser {
   private static int parseVersion(String versionText) throws AppCatalogException {
     try {
       int version = Integer.parseInt(versionText);
-      if (version != 1) {
+      if (!AppCatalog.isSupportedVersion(version)) {
         throw AppCatalogSidecars.invalidEntry("unsupported catalog.version: " + version);
       }
       return version;
@@ -102,8 +102,8 @@ public final class AppCatalogParser {
     return List.copyOf(entryIds);
   }
 
-  private static AppCatalogEntry parseEntry(Map<String, String> properties, String appId)
-      throws AppCatalogException {
+  private static AppCatalogEntry parseEntry(
+      Map<String, String> properties, String appId, int version) throws AppCatalogException {
     String prefix = "app." + appId + ".";
     String declaredId = removeRequired(properties, prefix + "id");
     String normalizedDeclaredId = AppCatalogEntry.normalizeAppId(declaredId);
@@ -112,31 +112,39 @@ public final class AppCatalogParser {
           "catalog.entries id does not match app." + appId + ".id");
     }
     List<String> permissions = parsePermissions(removeRequired(properties, prefix + "permissions"));
+    boolean storeMetadataAllowed = version == AppCatalog.VERSION_STORE_METADATA;
     return new AppCatalogEntry(
         declaredId,
         removeRequired(properties, prefix + "name"),
         removeRequired(properties, prefix + "version"),
         removeRequired(properties, prefix + "summary"),
-        removeOptional(properties, prefix + "homepage")
-            .map(value -> parseUri(value, prefix + "homepage")),
-        removeOptional(properties, prefix + "source")
-            .map(value -> parseUri(value, prefix + "source")),
-        removeOptional(properties, prefix + "license"),
-        parseCategories(removeOptional(properties, prefix + "categories").orElse(null)),
-        new AppCatalogCompatibilityMetadata(
-            removeOptional(properties, prefix + "minimumCryptaVersion")),
-        parseReview(properties, prefix),
-        new AppCatalogChangelog(
-            removeOptional(properties, prefix + "changelog.summary"),
-            removeOptional(properties, prefix + "changelog.uri")
-                .map(value -> parseUri(value, prefix + "changelog.uri"))),
-        parseScreenshots(properties, prefix),
+        parseStoreMetadataUri(properties, prefix + "homepage", storeMetadataAllowed),
+        parseStoreMetadataUri(properties, prefix + "source", storeMetadataAllowed),
+        storeMetadataAllowed ? removeOptional(properties, prefix + "license") : Optional.empty(),
+        storeMetadataAllowed
+            ? parseCategories(removeOptional(properties, prefix + "categories").orElse(null))
+            : List.of(),
+        storeMetadataAllowed
+            ? new AppCatalogCompatibilityMetadata(
+                removeOptional(properties, prefix + "minimumCryptaVersion"))
+            : AppCatalogCompatibilityMetadata.EMPTY,
+        storeMetadataAllowed ? parseReview(properties, prefix) : AppCatalogReviewMetadata.EMPTY,
+        storeMetadataAllowed ? parseChangelog(properties, prefix) : AppCatalogChangelog.EMPTY,
+        storeMetadataAllowed ? parseScreenshots(properties, prefix) : List.of(),
         parseUri(removeRequired(properties, prefix + "bundle.uri"), prefix + "bundle.uri"),
         removeRequired(properties, prefix + "bundle.sha256"),
         parseSize(removeRequired(properties, prefix + "bundle.size.bytes"), appId),
         removeRequired(properties, prefix + "bundle.type"),
         permissions,
-        parsePermissionRationales(properties, prefix));
+        storeMetadataAllowed ? parsePermissionRationales(properties, prefix) : Map.of());
+  }
+
+  private static Optional<URI> parseStoreMetadataUri(
+      Map<String, String> properties, String fieldName, boolean storeMetadataAllowed) {
+    if (!storeMetadataAllowed) {
+      return Optional.empty();
+    }
+    return removeOptional(properties, fieldName).map(value -> parseUri(value, fieldName));
   }
 
   private static long parseSize(String sizeText, String appId) throws AppCatalogException {
@@ -192,6 +200,13 @@ public final class AppCatalogParser {
             .map(value -> AppCatalogReviewStatus.parse(value, prefix + "review.status"))
             .orElse(AppCatalogReviewStatus.UNREVIEWED);
     return new AppCatalogReviewMetadata(status, removeOptional(properties, prefix + "review.note"));
+  }
+
+  private static AppCatalogChangelog parseChangelog(Map<String, String> properties, String prefix) {
+    return new AppCatalogChangelog(
+        removeOptional(properties, prefix + "changelog.summary"),
+        removeOptional(properties, prefix + "changelog.uri")
+            .map(value -> parseUri(value, prefix + "changelog.uri")));
   }
 
   private static List<URI> parseScreenshots(Map<String, String> properties, String prefix) {

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogParser.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogParser.java
@@ -1,13 +1,18 @@
 package network.crypta.platform.appcatalog;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * Strict parser for {@code cryptad-app-catalog.properties}.
@@ -106,23 +111,32 @@ public final class AppCatalogParser {
       throw AppCatalogSidecars.invalidEntry(
           "catalog.entries id does not match app." + appId + ".id");
     }
-    try {
-      return new AppCatalogEntry(
-          declaredId,
-          removeRequired(properties, prefix + "name"),
-          removeRequired(properties, prefix + "version"),
-          removeRequired(properties, prefix + "summary"),
-          URI.create(removeRequired(properties, prefix + "bundle.uri")),
-          removeRequired(properties, prefix + "bundle.sha256"),
-          parseSize(removeRequired(properties, prefix + "bundle.size.bytes"), appId),
-          removeRequired(properties, prefix + "bundle.type"),
-          parsePermissions(removeRequired(properties, prefix + "permissions")));
-    } catch (IllegalArgumentException exception) {
-      throw new AppCatalogException(
-          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
-          "invalid app." + appId + ".bundle.uri",
-          exception);
-    }
+    List<String> permissions = parsePermissions(removeRequired(properties, prefix + "permissions"));
+    return new AppCatalogEntry(
+        declaredId,
+        removeRequired(properties, prefix + "name"),
+        removeRequired(properties, prefix + "version"),
+        removeRequired(properties, prefix + "summary"),
+        removeOptional(properties, prefix + "homepage")
+            .map(value -> parseUri(value, prefix + "homepage")),
+        removeOptional(properties, prefix + "source")
+            .map(value -> parseUri(value, prefix + "source")),
+        removeOptional(properties, prefix + "license"),
+        parseCategories(removeOptional(properties, prefix + "categories").orElse(null)),
+        new AppCatalogCompatibilityMetadata(
+            removeOptional(properties, prefix + "minimumCryptaVersion")),
+        parseReview(properties, prefix),
+        new AppCatalogChangelog(
+            removeOptional(properties, prefix + "changelog.summary"),
+            removeOptional(properties, prefix + "changelog.uri")
+                .map(value -> parseUri(value, prefix + "changelog.uri"))),
+        parseScreenshots(properties, prefix),
+        parseUri(removeRequired(properties, prefix + "bundle.uri"), prefix + "bundle.uri"),
+        removeRequired(properties, prefix + "bundle.sha256"),
+        parseSize(removeRequired(properties, prefix + "bundle.size.bytes"), appId),
+        removeRequired(properties, prefix + "bundle.type"),
+        permissions,
+        parsePermissionRationales(properties, prefix));
   }
 
   private static long parseSize(String sizeText, String appId) throws AppCatalogException {
@@ -147,6 +161,115 @@ public final class AppCatalogParser {
     return permissions;
   }
 
+  private static List<String> parseCategories(String rawCategories) {
+    if (rawCategories == null || rawCategories.isBlank()) {
+      return List.of();
+    }
+    List<String> categories = new ArrayList<>();
+    for (String category : rawCategories.split(",", -1)) {
+      categories.add(category.trim());
+    }
+    return categories;
+  }
+
+  private static URI parseUri(String rawUri, String fieldName) {
+    String value =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            rawUri, fieldName, AppCatalogSidecars.INVALID_CATALOG_ENTRY);
+    try {
+      return new URI(value);
+    } catch (URISyntaxException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY, "invalid " + fieldName, exception);
+    }
+  }
+
+  private static AppCatalogReviewMetadata parseReview(
+      Map<String, String> properties, String prefix) {
+    Optional<String> statusText = removeOptional(properties, prefix + "review.status");
+    AppCatalogReviewStatus status =
+        statusText
+            .map(value -> AppCatalogReviewStatus.parse(value, prefix + "review.status"))
+            .orElse(AppCatalogReviewStatus.UNREVIEWED);
+    return new AppCatalogReviewMetadata(status, removeOptional(properties, prefix + "review.note"));
+  }
+
+  private static List<URI> parseScreenshots(Map<String, String> properties, String prefix) {
+    String screenshotPrefix = prefix + "screenshot.";
+    List<String> keys =
+        properties.keySet().stream().filter(key -> key.startsWith(screenshotPrefix)).toList();
+    if (keys.isEmpty()) {
+      return List.of();
+    }
+    SortedMap<Integer, URI> indexed = new TreeMap<>();
+    for (String key : keys) {
+      String indexText = key.substring(screenshotPrefix.length());
+      if (!isPositiveDecimal(indexText)) {
+        throw AppCatalogSidecars.invalidEntry("invalid screenshot index: " + key);
+      }
+      int index = parsePositiveIndex(indexText, key);
+      URI previous = indexed.putIfAbsent(index, parseUri(properties.remove(key), key));
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry("duplicate screenshot index: " + key);
+      }
+    }
+    List<URI> screenshots = new ArrayList<>(indexed.size());
+    int expected = 1;
+    for (Map.Entry<Integer, URI> entry : indexed.entrySet()) {
+      if (entry.getKey() != expected) {
+        throw AppCatalogSidecars.invalidEntry(
+            "missing "
+                + screenshotPrefix
+                + expected
+                + " before "
+                + screenshotPrefix
+                + entry.getKey());
+      }
+      screenshots.add(entry.getValue());
+      expected++;
+    }
+    return List.copyOf(screenshots);
+  }
+
+  private static Map<String, String> parsePermissionRationales(
+      Map<String, String> properties, String prefix) {
+    String rationalePrefix = prefix + "permissions.rationale.";
+    List<String> keys =
+        properties.keySet().stream().filter(key -> key.startsWith(rationalePrefix)).toList();
+    Map<String, String> rationales = new LinkedHashMap<>();
+    for (String key : keys) {
+      String rawPermission = key.substring(rationalePrefix.length());
+      String permission = AppCatalogEntry.normalizePermission(rawPermission, key);
+      String previous = rationales.putIfAbsent(permission, properties.remove(key));
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry("duplicate permission rationale for " + permission);
+      }
+    }
+    return rationales;
+  }
+
+  private static boolean isPositiveDecimal(String value) {
+    if (value.isEmpty() || value.charAt(0) == '0') {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char digit = value.charAt(i);
+      if (digit < '0' || digit > '9') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int parsePositiveIndex(String value, String key) {
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY, "invalid screenshot index: " + key, exception);
+    }
+  }
+
   private static String removeRequired(Map<String, String> properties, String key)
       throws AppCatalogException {
     String value = properties.remove(key);
@@ -154,5 +277,9 @@ public final class AppCatalogParser {
       throw AppCatalogSidecars.invalidEntry("missing " + key);
     }
     return value;
+  }
+
+  private static Optional<String> removeOptional(Map<String, String> properties, String key) {
+    return Optional.ofNullable(properties.remove(key));
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogReviewMetadata.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogReviewMetadata.java
@@ -1,0 +1,79 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Advisory human-review metadata for one catalog app.
+ *
+ * <p>Catalog publishers can use this value to describe the human review state they want operators
+ * to see before an installation or update. The metadata is authenticated as part of the signed
+ * catalog, so an operator can tell which trusted catalog source made the claim. It is still only
+ * advisory. It does not turn a catalog into a code-signing authority, bypass artifact digest
+ * checks, replace signed-bundle verification, grant app permissions, or block install/update on its
+ * own.
+ *
+ * <p>The status is intentionally small and enumerable so Platform API and Web Shell clients can
+ * render consistent badges. The optional note gives the publisher one concise line of context, such
+ * as what was reviewed or why the operator should use caution. Longer review reports should use
+ * catalog documentation or a changelog URI rather than this field.
+ *
+ * <p>Instances are immutable and validate the note at construction time. The note is trimmed,
+ * bounded, and single-line, which keeps the deterministic catalog sidecar format readable and
+ * prevents metadata from introducing extra properties through embedded line breaks.
+ *
+ * @param status advisory review status declared by the catalog publisher
+ * @param note optional single-line review note shown to operators
+ * @see AppCatalogReviewStatus
+ * @see AppCatalogEntry#review()
+ */
+public record AppCatalogReviewMetadata(AppCatalogReviewStatus status, Optional<String> note) {
+  private static final int MAX_REVIEW_NOTE_CHARS = 512;
+
+  /**
+   * Empty advisory review metadata used by catalogs without explicit review fields.
+   *
+   * <p>This value maps to {@link AppCatalogReviewStatus#UNREVIEWED} with no note. Writers omit
+   * review properties for it, while API responses can still expose a stable review object.
+   */
+  public static final AppCatalogReviewMetadata EMPTY =
+      new AppCatalogReviewMetadata(AppCatalogReviewStatus.UNREVIEWED, Optional.empty());
+
+  /**
+   * Creates validated review metadata.
+   *
+   * <p>The constructor does not interpret the review as trust. It only ensures the value is safe to
+   * store in a signed catalog sidecar and expose through Platform API JSON. A blank present note is
+   * rejected because callers should use {@link Optional#empty()} when no note exists.
+   *
+   * @param status advisory review status declared by the catalog publisher
+   * @param note optional single-line note explaining the status for operators
+   * @throws NullPointerException if the status or optional wrapper is {@code null}
+   * @throws AppCatalogException if the note is blank, multi-line, or too long
+   */
+  public AppCatalogReviewMetadata {
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(note, "note");
+    note =
+        note.map(
+            rawNote ->
+                AppCatalogSidecars.requireBoundedSingleLine(
+                    rawNote,
+                    "review.note",
+                    AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+                    MAX_REVIEW_NOTE_CHARS));
+  }
+
+  /**
+   * Returns whether this value should be written to a catalog sidecar.
+   *
+   * <p>The minimal catalog format stays compact by omitting default review metadata. A non-default
+   * status or any present note is meaningful catalog data and should be serialized so the signed
+   * sidecar carries the publisher's advisory review state.
+   *
+   * @return {@code true} when a non-default status or a note is present
+   */
+  public boolean hasCatalogFields() {
+    return status != AppCatalogReviewStatus.UNREVIEWED || note.isPresent();
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogReviewStatus.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogReviewStatus.java
@@ -1,0 +1,112 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Locale;
+
+/**
+ * Advisory human-review state carried by a signed app catalog entry.
+ *
+ * <p>This enum is the stable vocabulary for the optional {@code app.<id>.review.status} catalog
+ * property. A catalog signature authenticates which trusted catalog source supplied the status, but
+ * the status itself is publisher metadata. It does not replace signed catalog verification,
+ * artifact digest checks, signed-bundle verification, AppHost validation, or operator policy.
+ *
+ * <p>The values are deliberately few so API clients and the Web Shell can render predictable badges
+ * without inventing trust semantics. {@link #REJECTED}, for example, communicates the publisher's
+ * recommendation, but the installation/update endpoints still use the same verified catalog and
+ * bundle flow. Operators can decide how to treat that advisory signal.
+ *
+ * <p>Parsing is strict and case-insensitive after trimming. Unsupported values fail closed as
+ * malformed catalog entries so typoed review metadata does not silently become a new status.
+ *
+ * @see AppCatalogReviewMetadata
+ * @see AppCatalogEntry#review()
+ */
+public enum AppCatalogReviewStatus {
+  /**
+   * No human review status was declared by the catalog publisher.
+   *
+   * <p>This is the default for minimal or older catalogs. It means the catalog made no review
+   * claim; it does not mean the app is unsafe or safe.
+   */
+  UNREVIEWED("unreviewed"),
+
+  /**
+   * The catalog publisher says the app was reviewed for local operator use.
+   *
+   * <p>The exact review process is defined by the publisher's catalog policy, not by the catalog
+   * format. Runtime verification remains unchanged.
+   */
+  REVIEWED("reviewed"),
+
+  /**
+   * The catalog publisher wants operators to inspect the app with extra care.
+   *
+   * <p>This status is suitable for apps with unusual permissions, compatibility uncertainty, or
+   * other publisher-supplied caveats that should be visible before install or update.
+   */
+  CAUTION("caution"),
+
+  /**
+   * The catalog publisher does not recommend installing the app.
+   *
+   * <p>The value is advisory metadata rather than an endpoint-level block. UI clients should make
+   * the warning visible while preserving the signed-catalog trust boundary.
+   */
+  REJECTED("rejected");
+
+  /**
+   * Stable lower-case value used in catalog sidecars and Platform API JSON.
+   *
+   * <p>The field is separate from the enum constant name so the wire/catalog spelling stays stable
+   * even if Java naming or documentation changes.
+   */
+  private final String catalogValue;
+
+  /**
+   * Creates one enum constant with its serialized catalog spelling.
+   *
+   * @param catalogValue lower-case value accepted in sidecars and emitted through API responses
+   */
+  AppCatalogReviewStatus(String catalogValue) {
+    this.catalogValue = catalogValue;
+  }
+
+  /**
+   * Parses a catalog review status from sidecar text.
+   *
+   * <p>The parser trims the raw value, rejects blank or multi-line input, then compares the
+   * remaining text case-insensitively against the supported catalog spellings. It is used by both
+   * signed-catalog parsing and descriptor authoring so typos fail before metadata reaches the Web
+   * Shell or Platform API response surface.
+   *
+   * @param value raw status text read from a catalog or descriptor sidecar
+   * @param fieldName catalog field name to include in validation diagnostics
+   * @return parsed review status with stable catalog spelling
+   * @throws AppCatalogException if the value is blank, multi-line, too long, or unsupported
+   */
+  public static AppCatalogReviewStatus parse(String value, String fieldName)
+      throws AppCatalogException {
+    String normalized =
+        AppCatalogSidecars.requireBoundedSingleLine(
+                value, fieldName, AppCatalogSidecars.INVALID_CATALOG_ENTRY, 32)
+            .toLowerCase(Locale.ROOT);
+    for (AppCatalogReviewStatus status : values()) {
+      if (status.catalogValue.equals(normalized)) {
+        return status;
+      }
+    }
+    throw AppCatalogSidecars.invalidEntry(fieldName + " is not a supported review status");
+  }
+
+  /**
+   * Returns the lower-case value written into catalog sidecars and Platform API JSON.
+   *
+   * <p>Callers should use this method instead of {@link #name()} whenever they serialize review
+   * metadata. The returned value is deterministic, lower-case, and independent of Java enum naming.
+   *
+   * @return stable lower-case catalog value for this review status
+   */
+  public String catalogValue() {
+    return catalogValue;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
@@ -212,6 +212,25 @@ final class AppCatalogSidecars {
   }
 
   /**
+   * Requires a non-blank single-line value that fits a caller-defined display bound.
+   *
+   * @param value raw metadata value
+   * @param fieldName field name used in diagnostics
+   * @param errorCode catalog error code to attach to validation failures
+   * @param maxChars maximum accepted character count after trimming
+   * @return trimmed single-line value
+   * @throws AppCatalogException if the value is blank, multi-line, or too long
+   */
+  static String requireBoundedSingleLine(
+      String value, String fieldName, String errorCode, int maxChars) throws AppCatalogException {
+    String normalized = requireNonBlankSingleLine(value, fieldName, errorCode);
+    if (normalized.length() > maxChars) {
+      throw new AppCatalogException(errorCode, fieldName + " exceeds the allowed length");
+    }
+    return normalized;
+  }
+
+  /**
    * Requires a lowercase SHA-256 digest string.
    *
    * @param value raw digest text from catalog metadata
@@ -251,6 +270,42 @@ final class AppCatalogSidecars {
     URI normalized = normalizeUri(uri, INVALID_CATALOG_ENTRY, "artifact URI");
     requireSupportedScheme(normalized, INVALID_CATALOG_ENTRY, "artifact URI");
     return normalized;
+  }
+
+  /**
+   * Validates and normalizes an operator-facing metadata URI.
+   *
+   * <p>Display metadata is never fetched by the catalog installer. The policy still rejects
+   * user-info, fragments, local file paths, and non-HTTPS remote schemes except explicit loopback
+   * HTTP for local development.
+   *
+   * @param uri URI from optional catalog display metadata
+   * @param fieldName field name used in diagnostics
+   * @return normalized metadata URI
+   * @throws AppCatalogException if the URI is not safe to expose through the catalog API
+   */
+  static URI requireSafeMetadataUri(URI uri, String fieldName) throws AppCatalogException {
+    URI normalized = normalizeUri(uri, INVALID_CATALOG_ENTRY, fieldName);
+    String scheme = normalized.getScheme();
+    if (scheme == null) {
+      throw new AppCatalogException(
+          INVALID_CATALOG_ENTRY, fieldName + " must include a URI scheme");
+    }
+    String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
+    switch (normalizedScheme) {
+      case "https" -> {
+        requireRemoteHttpUri(normalized, INVALID_CATALOG_ENTRY, fieldName);
+        return normalized;
+      }
+      case "http" -> {
+        requireRemoteHttpUri(normalized, INVALID_CATALOG_ENTRY, fieldName);
+        if (isLocalhost(normalized.getHost())) {
+          return normalized;
+        }
+      }
+      default -> throw unsupportedScheme(INVALID_CATALOG_ENTRY, fieldName, scheme);
+    }
+    throw unsupportedScheme(INVALID_CATALOG_ENTRY, fieldName, scheme);
   }
 
   /**

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogWriter.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogWriter.java
@@ -136,11 +136,20 @@ public final class AppCatalogWriter {
         descriptor.nameOverride().orElse(manifest.appName()),
         version,
         descriptor.summary(),
+        descriptor.homepage(),
+        descriptor.source(),
+        descriptor.license(),
+        descriptor.categories(),
+        descriptor.compatibility(),
+        descriptor.review(),
+        descriptor.changelog(),
+        descriptor.screenshots(),
         descriptor.bundleUri(),
         artifact.sha256(),
         artifact.sizeBytes(),
         AppCatalogEntry.ZIP_BUNDLE_TYPE,
-        descriptor.permissionsOverride().orElse(manifest.permissions()));
+        descriptor.permissionsOverride().orElse(manifest.permissions()),
+        descriptor.permissionRationales());
   }
 
   private static void requireManifestAppIdMatch(
@@ -354,7 +363,8 @@ public final class AppCatalogWriter {
   }
 
   private static void createSafeCatalogOutputParent(Path parent) throws IOException {
-    Path existingAncestor = parent;
+    Path outputParent = Objects.requireNonNull(parent, "parent");
+    Path existingAncestor = outputParent;
     while (existingAncestor != null && !Files.exists(existingAncestor, LinkOption.NOFOLLOW_LINKS)) {
       existingAncestor = existingAncestor.getParent();
     }
@@ -363,9 +373,10 @@ public final class AppCatalogWriter {
             || !Files.isDirectory(existingAncestor, LinkOption.NOFOLLOW_LINKS))) {
       throw new IOException("catalog output parent must be a real directory: " + existingAncestor);
     }
-    Files.createDirectories(parent);
-    if (Files.isSymbolicLink(parent) || !Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
-      throw new IOException("catalog output parent must be a real directory: " + parent);
+    Files.createDirectories(outputParent);
+    if (Files.isSymbolicLink(outputParent)
+        || !Files.isDirectory(outputParent, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IOException("catalog output parent must be a real directory: " + outputParent);
     }
   }
 
@@ -395,17 +406,54 @@ public final class AppCatalogWriter {
     appendProperty(builder, prefix + "name", entry.name());
     appendProperty(builder, prefix + "version", entry.version());
     appendProperty(builder, prefix + "summary", entry.summary());
+    entry.homepage().ifPresent(uri -> appendProperty(builder, prefix + "homepage", uri.toString()));
+    entry.source().ifPresent(uri -> appendProperty(builder, prefix + "source", uri.toString()));
+    entry.license().ifPresent(value -> appendProperty(builder, prefix + "license", value));
+    if (!entry.categories().isEmpty()) {
+      appendProperty(builder, prefix + "categories", joinValues(entry.categories()));
+    }
+    entry
+        .compatibility()
+        .minimumCryptaVersion()
+        .ifPresent(value -> appendProperty(builder, prefix + "minimumCryptaVersion", value));
+    if (entry.review().hasCatalogFields()) {
+      appendProperty(builder, prefix + "review.status", entry.review().status().catalogValue());
+      entry
+          .review()
+          .note()
+          .ifPresent(value -> appendProperty(builder, prefix + "review.note", value));
+    }
+    if (!entry.permissionRationales().isEmpty()) {
+      entry
+          .permissionRationales()
+          .forEach(
+              (permission, rationale) ->
+                  appendProperty(
+                      builder, prefix + "permissions.rationale." + permission, rationale));
+    }
+    for (int index = 0; index < entry.screenshots().size(); index++) {
+      appendProperty(
+          builder, prefix + "screenshot." + (index + 1), entry.screenshots().get(index).toString());
+    }
+    entry
+        .changelog()
+        .summary()
+        .ifPresent(value -> appendProperty(builder, prefix + "changelog.summary", value));
+    entry
+        .changelog()
+        .uri()
+        .ifPresent(uri -> appendProperty(builder, prefix + "changelog.uri", uri.toString()));
     appendProperty(builder, prefix + "bundle.uri", entry.bundleUri().toString());
     appendProperty(builder, prefix + "bundle.sha256", entry.bundleSha256());
     appendProperty(builder, prefix + "bundle.size.bytes", Long.toString(entry.bundleSizeBytes()));
     appendProperty(builder, prefix + "bundle.type", entry.bundleType());
-    appendProperty(builder, prefix + "permissions", joinPermissions(entry.permissions()));
+    appendProperty(builder, prefix + "permissions", joinValues(entry.permissions()));
   }
 
-  private static String joinPermissions(List<String> permissions) {
+  private static String joinValues(List<String> values) {
     StringJoiner joiner = new StringJoiner(",");
-    for (String permission : permissions) {
-      joiner.add(permission);
+    for (String value : values) {
+      joiner.add(value);
     }
     return joiner.toString();
   }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogWriter.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogWriter.java
@@ -73,7 +73,7 @@ public final class AppCatalogWriter {
     List<AppCatalogEntry> entries = buildEntries(checkedRequest.entryDescriptorFiles());
     AppCatalog catalog =
         new AppCatalog(
-            1,
+            catalogVersion(entries),
             checkedRequest.catalogId(),
             checkedRequest.catalogName(),
             checkedRequest.generatedAt(),
@@ -102,6 +102,7 @@ public final class AppCatalogWriter {
    */
   public static byte[] serialize(AppCatalog catalog) {
     AppCatalog checkedCatalog = Objects.requireNonNull(catalog, CATALOG_PARAMETER_NAME);
+    requireCatalogVersionMatchesEntries(checkedCatalog);
     StringBuilder builder = new StringBuilder();
     appendProperty(builder, "catalog.version", Integer.toString(checkedCatalog.version()));
     appendProperty(builder, "catalog.id", checkedCatalog.catalogId());
@@ -122,6 +123,27 @@ public final class AppCatalogWriter {
       entries.add(toEntry(descriptor, artifact));
     }
     return List.copyOf(entries);
+  }
+
+  private static int catalogVersion(List<AppCatalogEntry> entries) {
+    for (AppCatalogEntry entry : entries) {
+      if (entry.hasStoreMetadata()) {
+        return AppCatalog.VERSION_STORE_METADATA;
+      }
+    }
+    return AppCatalog.VERSION_MINIMAL;
+  }
+
+  private static void requireCatalogVersionMatchesEntries(AppCatalog catalog) {
+    if (catalog.version() == AppCatalog.VERSION_STORE_METADATA) {
+      return;
+    }
+    for (AppCatalogEntry entry : catalog.entries()) {
+      if (entry.hasStoreMetadata()) {
+        throw AppCatalogSidecars.invalidEntry(
+            "catalog.version 2 is required when app-store metadata is present");
+      }
+    }
   }
 
   private static AppCatalogEntry toEntry(

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogEntryDescriptorTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogEntryDescriptorTest.java
@@ -34,7 +34,18 @@ class AppCatalogEntryDescriptorTest {
                 "app.id= Sample-App ",
                 "name= Sample App ",
                 "version= 0.1.0 ",
-                "permissions= "),
+                "homepage=https://example.invalid/app",
+                "source=https://example.invalid/repo",
+                "license= MIT ",
+                "categories=Productivity,network,productivity",
+                "minimumCryptaVersion= 0.1.0 ",
+                "review.status= reviewed ",
+                "review.note= Reviewed for local operator safety. ",
+                "permissions= ",
+                "permissions.rationale.queue.read= Reads the local transfer queue. ",
+                "screenshot.1=https://example.invalid/assets/shot-1.png",
+                "changelog.summary= Adds queue retry controls. ",
+                "changelog.uri=https://example.invalid/changelog.txt"),
             StandardCharsets.UTF_8);
 
     AppCatalogEntryDescriptor parsed = AppCatalogEntryDescriptor.parse(descriptor);
@@ -45,7 +56,45 @@ class AppCatalogEntryDescriptorTest {
     assertEquals(Optional.of("Sample-App"), parsed.appIdOverride());
     assertEquals(Optional.of("Sample App"), parsed.nameOverride());
     assertEquals(Optional.of("0.1.0"), parsed.versionOverride());
+    assertEquals("https://example.invalid/app", parsed.homepage().orElseThrow().toString());
+    assertEquals("https://example.invalid/repo", parsed.source().orElseThrow().toString());
+    assertEquals(Optional.of("MIT"), parsed.license());
+    assertEquals(List.of("productivity", "network"), parsed.categories());
+    assertEquals("0.1.0", parsed.compatibility().minimumCryptaVersion().orElseThrow());
+    assertEquals(AppCatalogReviewStatus.REVIEWED, parsed.review().status());
+    assertEquals("Reviewed for local operator safety.", parsed.review().note().orElseThrow());
     assertEquals(Optional.of(List.of()), parsed.permissionsOverride());
+    assertEquals(
+        "Reads the local transfer queue.", parsed.permissionRationales().get("queue.read"));
+    assertEquals(
+        List.of(URI.create("https://example.invalid/assets/shot-1.png")), parsed.screenshots());
+    assertEquals("Adds queue retry controls.", parsed.changelog().summary().orElseThrow());
+    assertEquals(
+        "https://example.invalid/changelog.txt", parsed.changelog().uri().orElseThrow().toString());
+  }
+
+  @Test
+  void parse_whenDescriptorOmitsStoreMetadata_expectEmptyMetadata() throws Exception {
+    Path artifact = tempDir.resolve("sample-app.zip").toAbsolutePath().normalize();
+    URI bundleUri = URI.create("https://example.invalid/apps/sample-app.zip");
+    Path descriptor =
+        descriptor(
+            "artifact.path=" + artifact,
+            "bundle.uri=" + bundleUri,
+            "summary=Sample app catalog entry");
+
+    AppCatalogEntryDescriptor parsed = AppCatalogEntryDescriptor.parse(descriptor);
+
+    assertEquals(Optional.empty(), parsed.homepage());
+    assertEquals(Optional.empty(), parsed.source());
+    assertEquals(Optional.empty(), parsed.license());
+    assertEquals(List.of(), parsed.categories());
+    assertEquals(Optional.empty(), parsed.compatibility().minimumCryptaVersion());
+    assertEquals(AppCatalogReviewMetadata.EMPTY, parsed.review());
+    assertEquals(AppCatalogChangelog.EMPTY, parsed.changelog());
+    assertEquals(List.of(), parsed.screenshots());
+    assertEquals(Optional.empty(), parsed.permissionsOverride());
+    assertTrue(parsed.permissionRationales().isEmpty());
   }
 
   @Test
@@ -84,6 +133,58 @@ class AppCatalogEntryDescriptorTest {
 
     assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
     assertTrue(exception.getMessage().contains("unsupported catalog entry descriptor property"));
+  }
+
+  @Test
+  void parse_whenDescriptorMetadataUriUsesFileScheme_expectInvalidCatalogEntry() throws Exception {
+    Path descriptor =
+        descriptor(
+            "artifact.path=" + tempDir.resolve("sample-app.zip").toAbsolutePath().normalize(),
+            "bundle.uri=https://example.invalid/apps/sample-app.zip",
+            "summary=Sample app catalog entry",
+            "homepage=file:///tmp/sample-app");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> AppCatalogEntryDescriptor.parse(descriptor));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  @Test
+  void parse_whenDescriptorScreenshotIndexesHaveGap_expectInvalidCatalogEntry() throws Exception {
+    Path descriptor =
+        descriptor(
+            "artifact.path=" + tempDir.resolve("sample-app.zip").toAbsolutePath().normalize(),
+            "bundle.uri=https://example.invalid/apps/sample-app.zip",
+            "summary=Sample app catalog entry",
+            "screenshot.2=https://example.invalid/assets/shot-2.png");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> AppCatalogEntryDescriptor.parse(descriptor));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  @Test
+  void parse_whenPermissionRationaleKeysNormalizeToDuplicate_expectInvalidCatalogEntry()
+      throws Exception {
+    Path descriptor =
+        descriptor(
+            "artifact.path=" + tempDir.resolve("sample-app.zip").toAbsolutePath().normalize(),
+            "bundle.uri=https://example.invalid/apps/sample-app.zip",
+            "summary=Sample app catalog entry",
+            "permissions.rationale.queue.read=Reads queues.",
+            "permissions.rationale.QUEUE.READ=Reads queues again.");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> AppCatalogEntryDescriptor.parse(descriptor));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  private Path descriptor(String... properties) throws Exception {
+    return Files.writeString(
+        tempDir.resolve("entry.properties"), lines(properties), StandardCharsets.UTF_8);
   }
 
   private static String lines(String... values) {

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogMetadataTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogMetadataTest.java
@@ -1,0 +1,95 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AppCatalogMetadataTest {
+  @Test
+  void parse_whenReviewStatusUsesMixedCaseAndWhitespace_expectNormalizedStatus() {
+    AppCatalogReviewStatus status = AppCatalogReviewStatus.parse(" Reviewed ", "review.status");
+
+    assertEquals(AppCatalogReviewStatus.REVIEWED, status);
+    assertEquals("reviewed", status.catalogValue());
+  }
+
+  @Test
+  void parse_whenReviewStatusIsUnsupported_expectInvalidCatalogEntry() {
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> AppCatalogReviewStatus.parse("trusted", "review.status"));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  @Test
+  void hasCatalogFields_whenReviewIsDefault_expectFalse() {
+    assertFalse(AppCatalogReviewMetadata.EMPTY.hasCatalogFields());
+  }
+
+  @Test
+  void hasCatalogFields_whenReviewHasNote_expectTrue() {
+    AppCatalogReviewMetadata review =
+        new AppCatalogReviewMetadata(
+            AppCatalogReviewStatus.UNREVIEWED, Optional.of("Review pending."));
+
+    assertTrue(review.hasCatalogFields());
+    assertEquals("Review pending.", review.note().orElseThrow());
+  }
+
+  @Test
+  void reviewMetadata_whenNoteIsBlank_expectInvalidCatalogEntry() {
+    Optional<String> blankNote = Optional.of("   ");
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> new AppCatalogReviewMetadata(AppCatalogReviewStatus.CAUTION, blankNote));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  @Test
+  void isEmpty_whenChangelogHasNoFields_expectTrue() {
+    assertTrue(AppCatalogChangelog.EMPTY.isEmpty());
+  }
+
+  @Test
+  void isEmpty_whenChangelogHasSummary_expectFalse() {
+    AppCatalogChangelog changelog =
+        new AppCatalogChangelog(Optional.of("Adds queue retry controls."), Optional.empty());
+
+    assertFalse(changelog.isEmpty());
+  }
+
+  @Test
+  void changelog_whenUriHasFragment_expectInvalidCatalogEntry() {
+    Optional<String> noSummary = Optional.empty();
+    Optional<URI> fragmentUri =
+        Optional.of(URI.create("https://example.invalid/changelog.txt#section"));
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> new AppCatalogChangelog(noSummary, fragmentUri));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+
+  @Test
+  void compatibilityMetadata_whenVersionIsTooLong_expectInvalidCatalogEntry() {
+    Optional<String> tooLongVersion = Optional.of("1".repeat(97));
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class, () -> new AppCatalogCompatibilityMetadata(tooLongVersion));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+  }
+}

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogParserTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogParserTest.java
@@ -62,7 +62,7 @@ class AppCatalogParserTest {
         AppCatalogParser.parse(
             bytes(
                 """
-                catalog.version=1
+                catalog.version=2
                 catalog.id=core
                 catalog.name=Crypta Core Apps
                 catalog.generatedAt=%s
@@ -94,6 +94,7 @@ class AppCatalogParserTest {
 
     AppCatalogEntry entry = catalog.entries().getFirst();
 
+    assertEquals(AppCatalog.VERSION_STORE_METADATA, catalog.version());
     assertEquals("https://example.invalid/app", entry.homepage().orElseThrow().toString());
     assertEquals("https://example.invalid/repo", entry.source().orElseThrow().toString());
     assertEquals("MIT", entry.license().orElseThrow());
@@ -110,6 +111,16 @@ class AppCatalogParserTest {
     assertEquals("Adds queue retry controls.", entry.changelog().summary().orElseThrow());
     assertEquals(
         "https://example.invalid/changelog.txt", entry.changelog().uri().orElseThrow().toString());
+  }
+
+  @Test
+  void parse_whenVersionOneCatalogDeclaresStoreMetadata_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                "app.queue-manager.homepage=https://example.invalid/app\n"
+                    + "app.queue-manager.bundle.uri="));
   }
 
   @Test
@@ -175,7 +186,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenReviewStatusIsMalformed_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.bundle.uri=",
                 "app.queue-manager.review.status=trusted\napp.queue-manager.bundle.uri="));
@@ -184,7 +195,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenCategoryIsMalformed_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.bundle.uri=",
                 "app.queue-manager.categories=bad category\napp.queue-manager.bundle.uri="));
@@ -193,7 +204,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenMetadataUriUsesUnsafeScheme_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.bundle.uri=",
                 "app.queue-manager.homepage=http://example.invalid/app\n"
@@ -205,7 +216,7 @@ class AppCatalogParserTest {
     AppCatalog catalog =
         AppCatalogParser.parse(
             bytes(
-                validSingleEntryCatalog()
+                validStoreMetadataCatalog()
                     .replace(
                         "app.queue-manager.bundle.uri=",
                         "app.queue-manager.homepage=http://localhost:8080/app\n"
@@ -219,7 +230,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenPermissionRationaleDoesNotMatchDeclaredPermission_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.bundle.uri=",
                 "app.queue-manager.permissions.rationale.queue.write=Writes queues.\n"
@@ -229,7 +240,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenPermissionRationaleKeysNormalizeToDuplicate_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.permissions=queue.read",
                 """
@@ -242,7 +253,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenScreenshotIndexesHaveGap_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.bundle.uri=",
                 "app.queue-manager.screenshot.2=https://example.invalid/assets/shot-2.png\n"
@@ -252,7 +263,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenScreenshotCountExceedsCap_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.bundle.uri=",
                 """
@@ -272,7 +283,7 @@ class AppCatalogParserTest {
   @Test
   void parse_whenReviewNoteIsBlank_expectInvalidCatalogEntry() {
     assertInvalidEntry(
-        validSingleEntryCatalog()
+        validStoreMetadataCatalog()
             .replace(
                 "app.queue-manager.bundle.uri=",
                 "app.queue-manager.review.note=   \napp.queue-manager.bundle.uri="));
@@ -305,6 +316,10 @@ class AppCatalogParserTest {
     app.queue-manager.permissions=queue.read
     """
         .formatted(GENERATED_AT, SHA256);
+  }
+
+  private static String validStoreMetadataCatalog() {
+    return validSingleEntryCatalog().replace("catalog.version=1", "catalog.version=2");
   }
 
   private static byte[] bytes(String value) {

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogParserTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogParserTest.java
@@ -57,6 +57,62 @@ class AppCatalogParserTest {
   }
 
   @Test
+  void parse_whenCatalogHasOptionalStoreMetadata_expectMetadataNormalized() {
+    AppCatalog catalog =
+        AppCatalogParser.parse(
+            bytes(
+                """
+                catalog.version=1
+                catalog.id=core
+                catalog.name=Crypta Core Apps
+                catalog.generatedAt=%s
+                catalog.entries=queue-manager
+                app.queue-manager.id=queue-manager
+                app.queue-manager.name=Queue Manager
+                app.queue-manager.version=1.2.0
+                app.queue-manager.summary=Manage transfer queues.
+                app.queue-manager.homepage=https://example.invalid/app
+                app.queue-manager.source=https://example.invalid/repo
+                app.queue-manager.license=MIT
+                app.queue-manager.categories=Productivity,network,productivity
+                app.queue-manager.minimumCryptaVersion=0.1.0
+                app.queue-manager.review.status=reviewed
+                app.queue-manager.review.note=Reviewed for local operator safety.
+                app.queue-manager.permissions.rationale.queue.read=Reads the local transfer queue.
+                app.queue-manager.permissions.rationale.queue.write=Updates queue state.
+                app.queue-manager.screenshot.1=https://example.invalid/assets/shot-1.png
+                app.queue-manager.screenshot.2=https://example.invalid/assets/shot-2.png
+                app.queue-manager.changelog.summary=Adds queue retry controls.
+                app.queue-manager.changelog.uri=https://example.invalid/changelog.txt
+                app.queue-manager.bundle.uri=https://example.invalid/queue-manager.zip
+                app.queue-manager.bundle.sha256=%s
+                app.queue-manager.bundle.size.bytes=0
+                app.queue-manager.bundle.type=zip
+                app.queue-manager.permissions=queue.read,queue.write
+                """
+                    .formatted(GENERATED_AT, SHA256)));
+
+    AppCatalogEntry entry = catalog.entries().getFirst();
+
+    assertEquals("https://example.invalid/app", entry.homepage().orElseThrow().toString());
+    assertEquals("https://example.invalid/repo", entry.source().orElseThrow().toString());
+    assertEquals("MIT", entry.license().orElseThrow());
+    assertEquals(List.of("productivity", "network"), entry.categories());
+    assertEquals("0.1.0", entry.compatibility().minimumCryptaVersion().orElseThrow());
+    assertEquals(AppCatalogReviewStatus.REVIEWED, entry.review().status());
+    assertEquals("Reviewed for local operator safety.", entry.review().note().orElseThrow());
+    assertEquals("Reads the local transfer queue.", entry.permissionRationales().get("queue.read"));
+    assertEquals(
+        List.of(
+            java.net.URI.create("https://example.invalid/assets/shot-1.png"),
+            java.net.URI.create("https://example.invalid/assets/shot-2.png")),
+        entry.screenshots());
+    assertEquals("Adds queue retry controls.", entry.changelog().summary().orElseThrow());
+    assertEquals(
+        "https://example.invalid/changelog.txt", entry.changelog().uri().orElseThrow().toString());
+  }
+
+  @Test
   void parse_whenEntriesAreBlank_expectCatalogWithoutEntries() {
     AppCatalog catalog =
         AppCatalogParser.parse(
@@ -114,6 +170,112 @@ class AppCatalogParserTest {
             .replace(
                 "app.queue-manager.bundle.size.bytes=0",
                 "app.queue-manager.bundle.size.bytes=NaN"));
+  }
+
+  @Test
+  void parse_whenReviewStatusIsMalformed_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                "app.queue-manager.review.status=trusted\napp.queue-manager.bundle.uri="));
+  }
+
+  @Test
+  void parse_whenCategoryIsMalformed_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                "app.queue-manager.categories=bad category\napp.queue-manager.bundle.uri="));
+  }
+
+  @Test
+  void parse_whenMetadataUriUsesUnsafeScheme_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                "app.queue-manager.homepage=http://example.invalid/app\n"
+                    + "app.queue-manager.bundle.uri="));
+  }
+
+  @Test
+  void parse_whenMetadataUriUsesLoopbackHttp_expectAccepted() {
+    AppCatalog catalog =
+        AppCatalogParser.parse(
+            bytes(
+                validSingleEntryCatalog()
+                    .replace(
+                        "app.queue-manager.bundle.uri=",
+                        "app.queue-manager.homepage=http://localhost:8080/app\n"
+                            + "app.queue-manager.bundle.uri=")));
+
+    AppCatalogEntry entry = catalog.entries().getFirst();
+
+    assertEquals("http://localhost:8080/app", entry.homepage().orElseThrow().toString());
+  }
+
+  @Test
+  void parse_whenPermissionRationaleDoesNotMatchDeclaredPermission_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                "app.queue-manager.permissions.rationale.queue.write=Writes queues.\n"
+                    + "app.queue-manager.bundle.uri="));
+  }
+
+  @Test
+  void parse_whenPermissionRationaleKeysNormalizeToDuplicate_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.permissions=queue.read",
+                """
+                app.queue-manager.permissions.rationale.queue.read=Reads queues.
+                app.queue-manager.permissions.rationale.QUEUE.READ=Reads queues again.
+                app.queue-manager.permissions=queue.read\
+                """));
+  }
+
+  @Test
+  void parse_whenScreenshotIndexesHaveGap_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                "app.queue-manager.screenshot.2=https://example.invalid/assets/shot-2.png\n"
+                    + "app.queue-manager.bundle.uri="));
+  }
+
+  @Test
+  void parse_whenScreenshotCountExceedsCap_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                """
+                app.queue-manager.screenshot.1=https://example.invalid/assets/shot-1.png
+                app.queue-manager.screenshot.2=https://example.invalid/assets/shot-2.png
+                app.queue-manager.screenshot.3=https://example.invalid/assets/shot-3.png
+                app.queue-manager.screenshot.4=https://example.invalid/assets/shot-4.png
+                app.queue-manager.screenshot.5=https://example.invalid/assets/shot-5.png
+                app.queue-manager.screenshot.6=https://example.invalid/assets/shot-6.png
+                app.queue-manager.screenshot.7=https://example.invalid/assets/shot-7.png
+                app.queue-manager.screenshot.8=https://example.invalid/assets/shot-8.png
+                app.queue-manager.screenshot.9=https://example.invalid/assets/shot-9.png
+                app.queue-manager.bundle.uri=\
+                """));
+  }
+
+  @Test
+  void parse_whenReviewNoteIsBlank_expectInvalidCatalogEntry() {
+    assertInvalidEntry(
+        validSingleEntryCatalog()
+            .replace(
+                "app.queue-manager.bundle.uri=",
+                "app.queue-manager.review.note=   \napp.queue-manager.bundle.uri="));
   }
 
   private static void assertInvalidEntry(String catalogText) {

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogWriterTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogWriterTest.java
@@ -1,6 +1,7 @@
 package network.crypta.platform.appcatalog;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,7 +11,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import network.crypta.platform.appdist.AppBundleManifestParser;
@@ -81,7 +85,7 @@ class AppCatalogWriterTest {
 
     String expected =
         lines(
-            "catalog.version=1",
+            "catalog.version=2",
             "catalog.id=core",
             "catalog.name=Crypta Core Apps",
             "catalog.generatedAt=2026-04-21T18:22:40Z",
@@ -108,6 +112,7 @@ class AppCatalogWriterTest {
             "app.queue-manager.bundle.type=zip",
             "app.queue-manager.permissions=queue.inspect,queue.read");
 
+    assertEquals(AppCatalog.VERSION_STORE_METADATA, result.catalog().version());
     assertEquals(expected, new String(result.catalogBytes(), StandardCharsets.UTF_8));
     assertEquals(expected, Files.readString(outputFile));
     assertEquals(outputFile.toAbsolutePath().normalize(), result.catalogFile().orElseThrow());
@@ -136,9 +141,49 @@ class AppCatalogWriterTest {
     assertEquals(
         List.of(PUBLISHER_APP_ID, QUEUE_APP_ID),
         result.catalog().entries().stream().map(AppCatalogEntry::appId).toList());
+    assertEquals(AppCatalog.VERSION_MINIMAL, result.catalog().version());
     assertTrue(
         new String(result.catalogBytes(), StandardCharsets.UTF_8)
             .contains("catalog.entries=publisher,queue-manager\n"));
+  }
+
+  @Test
+  void serialize_whenVersionOneCatalogHasStoreMetadata_expectInvalidCatalogEntry() {
+    AppCatalogEntry entry =
+        directEntryWithStoreMetadata(
+            Map.of(QUEUE_READ_PERMISSION, "Reads the local transfer queue."));
+    AppCatalog catalog =
+        new AppCatalog(
+            AppCatalog.VERSION_MINIMAL, CATALOG_ID, CATALOG_NAME, GENERATED_AT, List.of(entry));
+
+    AppCatalogException exception = captureInvalidEntry(() -> AppCatalogWriter.serialize(catalog));
+
+    assertTrue(exception.getMessage().contains("catalog.version 2 is required"));
+  }
+
+  @Test
+  void serialize_whenPermissionRationalesAreUnordered_expectDeclaredPermissionOrder() {
+    Map<String, String> rationales = new LinkedHashMap<>();
+    rationales.put("queue.write", "Writes queue state.");
+    rationales.put(QUEUE_READ_PERMISSION, "Reads queue state.");
+    AppCatalogEntry entry = directEntryWithStoreMetadata(rationales);
+    AppCatalog catalog =
+        new AppCatalog(
+            AppCatalog.VERSION_STORE_METADATA,
+            CATALOG_ID,
+            CATALOG_NAME,
+            GENERATED_AT,
+            List.of(entry));
+
+    String serialized = new String(AppCatalogWriter.serialize(catalog), StandardCharsets.UTF_8);
+    int readIndex =
+        serialized.indexOf("app.queue-manager.permissions.rationale.queue.read=Reads queue state.");
+    int writeIndex =
+        serialized.indexOf(
+            "app.queue-manager.permissions.rationale.queue.write=Writes queue state.");
+
+    assertTrue(readIndex >= 0);
+    assertTrue(writeIndex > readIndex);
   }
 
   @Test
@@ -284,6 +329,28 @@ class AppCatalogWriterTest {
 
   private AppCatalogBuildRequest request(List<Path> descriptors) {
     return new AppCatalogBuildRequest(CATALOG_ID, CATALOG_NAME, GENERATED_AT, descriptors);
+  }
+
+  private static AppCatalogEntry directEntryWithStoreMetadata(Map<String, String> rationales) {
+    return new AppCatalogEntry(
+        QUEUE_APP_ID,
+        QUEUE_APP_NAME,
+        QUEUE_APP_VERSION,
+        LOCAL_QUEUE_SUMMARY,
+        Optional.of(URI.create("https://example.invalid/apps/queue-manager")),
+        Optional.empty(),
+        Optional.empty(),
+        List.of(),
+        AppCatalogCompatibilityMetadata.EMPTY,
+        AppCatalogReviewMetadata.EMPTY,
+        AppCatalogChangelog.EMPTY,
+        List.of(),
+        URI.create(QUEUE_BUNDLE_URI),
+        "0".repeat(64),
+        0L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of(QUEUE_READ_PERMISSION, "queue.write"),
+        rationales);
   }
 
   private Path descriptor(

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogWriterTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogWriterTest.java
@@ -60,6 +60,18 @@ class AppCatalogWriterTest {
             name=Catalog Queue Manager
             version=%s
             permissions=queue.inspect,QUEUE.READ,queue.inspect
+            homepage=https://example.invalid/apps/queue-manager
+            source=https://example.invalid/src/queue-manager
+            license=MIT
+            categories=Productivity,network,productivity
+            minimumCryptaVersion=0.1.0
+            review.status=reviewed
+            review.note=Reviewed for local operator safety.
+            permissions.rationale.queue.inspect=Inspects queue metadata.
+            permissions.rationale.queue.read=Reads the local transfer queue.
+            screenshot.1=https://example.invalid/assets/queue-1.png
+            changelog.summary=Adds queue retry controls.
+            changelog.uri=https://example.invalid/changelog.txt
             """
                 .formatted(QUEUE_APP_VERSION));
     Path outputFile = tempDir.resolve("catalog").resolve(AppCatalogSignature.CATALOG_FILE_NAME);
@@ -78,6 +90,18 @@ class AppCatalogWriterTest {
             "app.queue-manager.name=Catalog Queue Manager",
             "app.queue-manager.version=" + QUEUE_APP_VERSION,
             "app.queue-manager.summary=Manage local Crypta transfer queues.",
+            "app.queue-manager.homepage=https://example.invalid/apps/queue-manager",
+            "app.queue-manager.source=https://example.invalid/src/queue-manager",
+            "app.queue-manager.license=MIT",
+            "app.queue-manager.categories=productivity,network",
+            "app.queue-manager.minimumCryptaVersion=0.1.0",
+            "app.queue-manager.review.status=reviewed",
+            "app.queue-manager.review.note=Reviewed for local operator safety.",
+            "app.queue-manager.permissions.rationale.queue.inspect=Inspects queue metadata.",
+            "app.queue-manager.permissions.rationale.queue.read=Reads the local transfer queue.",
+            "app.queue-manager.screenshot.1=https://example.invalid/assets/queue-1.png",
+            "app.queue-manager.changelog.summary=Adds queue retry controls.",
+            "app.queue-manager.changelog.uri=https://example.invalid/changelog.txt",
             "app.queue-manager.bundle.uri=" + bundleUri,
             "app.queue-manager.bundle.sha256=" + sha256(artifact),
             "app.queue-manager.bundle.size.bytes=" + Files.size(artifact),

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
@@ -381,6 +381,7 @@ class CryptaAppCliTest {
     String catalog = Files.readString(catalogFile, StandardCharsets.UTF_8);
     assertEquals(CommandLine.ExitCode.OK, result.exitCode());
     assertTrue(result.out().contains("Created catalog: dev with 1 entry"));
+    assertTrue(catalog.contains("catalog.version=2\n"));
     assertTrue(catalog.contains("catalog.generatedAt=2026-04-29T00:00:00Z\n"));
     assertTrue(catalog.contains("app.sample-app.id=sample-app\n"));
     assertTrue(catalog.contains("app.sample-app.homepage=https://example.invalid/sample-app\n"));
@@ -447,7 +448,9 @@ class CryptaAppCliTest {
         "Development Apps",
         "--entry",
         descriptor.toString());
+    String catalog = Files.readString(catalogFile, StandardCharsets.UTF_8);
 
+    assertTrue(catalog.contains("catalog.version=1\n"));
     CliResult signResult =
         runCli(
             "catalog",

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
@@ -349,7 +349,18 @@ class CryptaAppCliTest {
         lines(
             "artifact.path=" + outputZip.toAbsolutePath().normalize(),
             "bundle.uri=" + outputZip.toUri(),
-            "summary=Sample catalog entry."),
+            "summary=Sample catalog entry.",
+            "homepage=https://example.invalid/sample-app",
+            "source=https://example.invalid/sample-app/source",
+            "license=MIT",
+            "categories=Productivity,network",
+            "minimumCryptaVersion=0.1.0",
+            "review.status=reviewed",
+            "review.note=Reviewed for local operator safety.",
+            "permissions.rationale.queue.read=Reads the local transfer queue.",
+            "screenshot.1=https://example.invalid/sample-app/shot-1.png",
+            "changelog.summary=Adds queue retry controls.",
+            "changelog.uri=https://example.invalid/sample-app/changelog.txt"),
         StandardCharsets.UTF_8);
 
     CliResult result =
@@ -372,6 +383,25 @@ class CryptaAppCliTest {
     assertTrue(result.out().contains("Created catalog: dev with 1 entry"));
     assertTrue(catalog.contains("catalog.generatedAt=2026-04-29T00:00:00Z\n"));
     assertTrue(catalog.contains("app.sample-app.id=sample-app\n"));
+    assertTrue(catalog.contains("app.sample-app.homepage=https://example.invalid/sample-app\n"));
+    assertTrue(
+        catalog.contains("app.sample-app.source=https://example.invalid/sample-app/source\n"));
+    assertTrue(catalog.contains("app.sample-app.license=MIT\n"));
+    assertTrue(catalog.contains("app.sample-app.categories=productivity,network\n"));
+    assertTrue(catalog.contains("app.sample-app.minimumCryptaVersion=0.1.0\n"));
+    assertTrue(catalog.contains("app.sample-app.review.status=reviewed\n"));
+    assertTrue(
+        catalog.contains("app.sample-app.review.note=Reviewed for local operator safety.\n"));
+    assertTrue(
+        catalog.contains(
+            "app.sample-app.permissions.rationale.queue.read=Reads the local transfer queue.\n"));
+    assertTrue(
+        catalog.contains(
+            "app.sample-app.screenshot.1=https://example.invalid/sample-app/shot-1.png\n"));
+    assertTrue(catalog.contains("app.sample-app.changelog.summary=Adds queue retry controls.\n"));
+    assertTrue(
+        catalog.contains(
+            "app.sample-app.changelog.uri=https://example.invalid/sample-app/changelog.txt\n"));
     assertTrue(catalog.contains("app.sample-app.permissions=queue.read\n"));
     assertTrue(catalog.contains("app.sample-app.bundle.size.bytes=" + Files.size(outputZip)));
     assertTrue(catalog.contains("app.sample-app.bundle.sha256=" + sha256Hex(outputZip)));

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -575,8 +575,55 @@ a {
   background: rgba(255, 255, 255, 0.025);
 }
 
+.catalog-app-card.is-update-available {
+  border-color: rgba(255, 209, 125, 0.36);
+  background: rgba(255, 209, 125, 0.055);
+}
+
+.catalog-app-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
 .catalog-app-title {
   margin: 0;
+}
+
+.metadata-link {
+  color: var(--shell-accent);
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  overflow-wrap: anywhere;
+}
+
+.metadata-link-list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 20px;
+}
+
+.metadata-chip-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.metadata-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(123, 220, 255, 0.12);
+  color: var(--shell-text);
+  font-size: 0.86rem;
+  font-weight: 700;
 }
 
 .app-ui-entry {
@@ -597,6 +644,38 @@ a {
 }
 
 .permission-list li {
+  overflow-wrap: anywhere;
+}
+
+.permission-review-list {
+  display: grid;
+  gap: 10px;
+}
+
+.permission-review-item {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-left: 3px solid rgba(123, 220, 255, 0.72);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.permission-review-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.permission-name {
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.permission-rationale {
+  margin: 0;
+  color: var(--shell-muted);
   overflow-wrap: anywhere;
 }
 

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -1107,6 +1107,182 @@
     return form;
   }
 
+  function stringList(value) {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.filter((entry) => typeof entry === "string" && entry.length > 0);
+  }
+
+  function recordValue(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  }
+
+  function normalizedStatus(value, fallback) {
+    const raw = typeof value === "string" && value.length > 0 ? value : fallback;
+    if (typeof raw !== "string" || raw.length === 0) {
+      return "Unavailable";
+    }
+    return raw
+      .replace(/[_-]+/g, " ")
+      .toLowerCase()
+      .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+
+  function safeMetadataUri(value) {
+    if (typeof value !== "string" || value.length === 0) {
+      return null;
+    }
+    try {
+      const url = new URL(value);
+      return url.protocol === "https:" || url.protocol === "http:" ? url.toString() : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function metadataLinkNode(value, label) {
+    const href = safeMetadataUri(value);
+    if (!href) {
+      return scalar(value);
+    }
+    const link = document.createElement("a");
+    link.className = "metadata-link";
+    link.href = href;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = typeof label === "string" && label ? label : value;
+    return link;
+  }
+
+  function metadataLinkListNode(values) {
+    const links = stringList(values);
+    if (!links.length) {
+      return "Unavailable";
+    }
+    const list = document.createElement("ul");
+    list.className = "metadata-link-list";
+    links.forEach((value, index) => {
+      const item = document.createElement("li");
+      item.append(metadataLinkNode(value, `Screenshot ${index + 1}`));
+      list.append(item);
+    });
+    return list;
+  }
+
+  function chipListNode(values) {
+    const entries = stringList(values);
+    if (!entries.length) {
+      return "Unavailable";
+    }
+    const list = document.createElement("span");
+    list.className = "metadata-chip-list";
+    entries.forEach((entry) => {
+      list.append(text("span", "metadata-chip", entry));
+    });
+    return list;
+  }
+
+  function reviewTone(status) {
+    const normalized = typeof status === "string" ? status.toLowerCase().replace(/[-\s]+/g, "_") : "";
+    if (normalized.includes("reject") || normalized.includes("block") || normalized.includes("unsafe")) {
+      return "is-error";
+    }
+    if (normalized.includes("unreview") || normalized.includes("not_review") || normalized.includes("pending")) {
+      return "is-warning";
+    }
+    if (normalized.includes("review") || normalized.includes("approve") || normalized.includes("verified")) {
+      return "is-success";
+    }
+    return "is-warning";
+  }
+
+  function compatibilityTone(compatibility) {
+    if (!compatibility || Object.keys(compatibility).length === 0) {
+      return "is-warning";
+    }
+    if (compatibility.satisfied === false) {
+      return "is-error";
+    }
+    if (compatibility.satisfied === true) {
+      return "is-success";
+    }
+    const status = typeof compatibility.status === "string" ? compatibility.status.toLowerCase() : "";
+    return status.includes("unsatisfied") || status.includes("unsupported") ? "is-error" : "is-warning";
+  }
+
+  function compatibilityLabel(compatibility) {
+    if (!compatibility || Object.keys(compatibility).length === 0) {
+      return "Compatibility unknown";
+    }
+    if (compatibility.satisfied === false) {
+      return "Compatibility warning";
+    }
+    if (compatibility.satisfied === true) {
+      return "Compatible";
+    }
+    return normalizedStatus(compatibility.status, "Compatibility advisory");
+  }
+
+  function versionTone(app) {
+    if (app.updateAvailable || app.versionDifferent) {
+      return "is-warning";
+    }
+    return app.installed ? "is-success" : "";
+  }
+
+  function versionLabel(app) {
+    if (app.updateAvailable) {
+      return "Update available";
+    }
+    if (app.versionDifferent) {
+      return "Version differs";
+    }
+    if (app.installed) {
+      return "Installed version";
+    }
+    return "Available";
+  }
+
+  function versionSummary(app) {
+    const catalogVersion = typeof app.version === "string" && app.version ? app.version : "Unavailable";
+    const installedVersion =
+      typeof app.installedVersion === "string" && app.installedVersion ? app.installedVersion : "Unavailable";
+    if (!app.installed) {
+      return `Not installed; catalog version ${catalogVersion}`;
+    }
+    if (app.updateAvailable) {
+      return `Update available: installed ${installedVersion}, catalog ${catalogVersion}`;
+    }
+    if (app.versionDifferent) {
+      return `Installed ${installedVersion} differs from catalog ${catalogVersion}`;
+    }
+    if (typeof app.versionStatus === "string" && app.versionStatus.length > 0) {
+      return normalizedStatus(app.versionStatus);
+    }
+    return `Installed ${installedVersion}; catalog ${catalogVersion}`;
+  }
+
+  function permissionDeltaStatus(permission, delta) {
+    if (stringList(delta.added).includes(permission)) {
+      return ["Added on install/update", "is-warning"];
+    }
+    if (stringList(delta.removed).includes(permission)) {
+      return ["Removed by catalog version", "is-warning"];
+    }
+    if (stringList(delta.unchanged).includes(permission)) {
+      return ["Already granted", "is-success"];
+    }
+    return null;
+  }
+
+  function permissionRationale(permission, rationales) {
+    const value = rationales[permission];
+    return typeof value === "string" && value.length > 0
+      ? value
+      : "No permission rationale supplied.";
+  }
+
   function renderAppCard(app) {
     const card = document.createElement("article");
     card.className = "app-card";
@@ -1415,26 +1591,170 @@
     return card;
   }
 
+  function catalogReviewDetailsNode(app) {
+    const review = recordValue(app.review);
+    const details = document.createElement("details");
+    details.className = "json-details catalog-review-details";
+    const summary = document.createElement("summary");
+    summary.textContent = "Review and trust";
+    details.append(summary);
+    details.append(
+      definitionList([
+        ["Catalog trust", "Signed catalog metadata"],
+        ["Review status", normalizedStatus(review.status, "Unreviewed")],
+        ["Review note", scalar(review.note)],
+        ["Review semantics", "Advisory metadata; catalog and bundle verification still control installation."],
+      ]),
+    );
+    return details;
+  }
+
+  function catalogCompatibilityDetailsNode(app) {
+    const compatibility = recordValue(app.compatibility);
+    const details = document.createElement("details");
+    details.className = "json-details catalog-compatibility-details";
+    const summary = document.createElement("summary");
+    summary.textContent = "Compatibility";
+    details.append(summary);
+    details.append(
+      definitionList([
+        ["Minimum Crypta version", scalar(compatibility.minimumCryptaVersion)],
+        ["Current Crypta version", scalar(compatibility.currentCryptaVersion)],
+        ["Satisfied", compatibility.satisfied == null ? "Advisory" : compatibility.satisfied ? "Yes" : "No"],
+        ["Status", normalizedStatus(compatibility.status, "Advisory")],
+        ["Advisory", compatibility.advisory === false ? "No" : "Yes"],
+      ]),
+    );
+    return details;
+  }
+
+  function catalogPermissionReviewDetailsNode(app) {
+    const details = document.createElement("details");
+    details.className = "json-details catalog-permission-details";
+    const summary = document.createElement("summary");
+    summary.textContent = "Permission review";
+    details.append(summary);
+
+    const permissions = stringList(app.permissions);
+    const rationales = recordValue(app.permissionRationales);
+    const delta = recordValue(app.permissionDelta);
+    details.append(
+      definitionList([
+        ["Added", formatPermissions(delta.added)],
+        ["Removed", formatPermissions(delta.removed)],
+        ["Unchanged", formatPermissions(delta.unchanged)],
+      ]),
+    );
+
+    if (!permissions.length) {
+      details.append(text("p", "empty-state", "No permissions declared by this catalog version."));
+      return details;
+    }
+
+    const list = document.createElement("div");
+    list.className = "permission-review-list";
+    permissions.forEach((permission) => {
+      const item = document.createElement("div");
+      item.className = "permission-review-item";
+
+      const header = document.createElement("div");
+      header.className = "permission-review-header";
+      header.append(text("span", "permission-name", permission));
+      const deltaStatus = permissionDeltaStatus(permission, delta);
+      if (deltaStatus) {
+        header.append(createPill(deltaStatus[0], deltaStatus[1]));
+      }
+
+      item.append(header, text("p", "permission-rationale", permissionRationale(permission, rationales)));
+      list.append(item);
+    });
+    details.append(list);
+    return details;
+  }
+
+  function catalogReleaseDetailsNode(app) {
+    const changelog = recordValue(app.changelog);
+    const bundle = recordValue(app.bundle);
+    const details = document.createElement("details");
+    details.className = "json-details catalog-release-details";
+    const summary = document.createElement("summary");
+    summary.textContent = "Release metadata";
+    details.append(summary);
+    details.append(
+      definitionList([
+        ["Changelog summary", scalar(changelog.summary)],
+        ["Changelog link", metadataLinkNode(changelog.uri)],
+        ["Screenshot links", metadataLinkListNode(app.screenshots)],
+        ["Bundle URI", metadataLinkNode(bundle.uri)],
+        ["Bundle type", scalar(bundle.type)],
+        ["Bundle size", formatBytes(bundle.sizeBytes)],
+        ["Bundle SHA-256", scalar(bundle.sha256)],
+      ]),
+    );
+    return details;
+  }
+
   function renderCatalogAppCard(catalog, app) {
     const card = document.createElement("section");
     card.className = "catalog-app-card";
-    card.append(text("h4", "catalog-app-title", appDisplayName(app)));
+    if (app.updateAvailable) {
+      card.className += " is-update-available";
+    }
+
+    const review = recordValue(app.review);
+    const compatibility = recordValue(app.compatibility);
+    const header = document.createElement("div");
+    header.className = "catalog-app-header";
+    const heading = document.createElement("div");
+    heading.className = "app-card-heading";
+    heading.append(
+      text("h4", "catalog-app-title", appDisplayName(app)),
+      text("p", "app-card-subtitle", typeof app.appId === "string" && app.appId ? app.appId : "Unavailable"),
+    );
+    const pills = document.createElement("div");
+    pills.className = "app-card-pills";
+    pills.append(createPill("Signed catalog"));
+    pills.append(createPill(normalizedStatus(review.status, "Unreviewed"), reviewTone(review.status)));
+    pills.append(createPill(versionLabel(app), versionTone(app)));
+    pills.append(createPill(compatibilityLabel(compatibility), compatibilityTone(compatibility)));
+    header.append(heading, pills);
+    card.append(header);
     card.append(
       definitionList([
         ["App ID", scalar(app.appId)],
-        ["Version", scalar(app.version)],
+        ["Catalog version", scalar(app.version)],
         ["Installed version", scalar(app.installedVersion)],
+        ["Version change", versionSummary(app)],
         ["Summary", scalar(app.summary)],
+        ["Homepage", metadataLinkNode(app.homepage)],
+        ["Source", metadataLinkNode(app.source)],
+        ["License", scalar(app.license)],
+        ["Categories", chipListNode(app.categories)],
+        ["Review status", normalizedStatus(review.status, "Unreviewed")],
+        ["Review note", scalar(review.note)],
         ["Permissions", formatPermissions(app.permissions)],
+        ["Permission changes", `+${stringList(recordValue(app.permissionDelta).added).length} / -${stringList(recordValue(app.permissionDelta).removed).length}`],
+        ["Compatibility", compatibilityLabel(compatibility)],
+        ["Minimum Crypta version", scalar(compatibility.minimumCryptaVersion)],
+        ["Changelog", scalar(recordValue(app.changelog).summary)],
         ["Installed", app.installed ? "Yes" : "No"],
         ["Running", app.running ? "Yes" : "No"],
       ]),
     );
+    card.append(catalogReviewDetailsNode(app));
+    card.append(catalogCompatibilityDetailsNode(app));
+    card.append(catalogPermissionReviewDetailsNode(app));
+    card.append(catalogReleaseDetailsNode(app));
     if (formPassword) {
       const actions = document.createElement("div");
       actions.className = "app-card-actions";
       const action = app.installed ? "update" : "install";
-      const form = buildCatalogActionForm(catalog, app, action, app.installed ? "Update" : "Install");
+      const label = app.installed
+        ? app.updateAvailable || app.versionDifferent
+          ? "Update from catalog"
+          : "Update installed app"
+        : "Install from catalog";
+      const form = buildCatalogActionForm(catalog, app, action, label);
       if (form) {
         actions.append(form);
         card.append(actions);

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -1757,9 +1757,11 @@
       actions.className = "app-card-actions";
       const action = app.installed ? "update" : "install";
       const label = app.installed
-        ? app.updateAvailable || app.versionDifferent
+        ? app.updateAvailable
           ? "Update from catalog"
-          : "Update installed app"
+          : app.versionDifferent
+            ? "Apply catalog version"
+            : "Update installed app"
         : "Install from catalog";
       const form = buildCatalogActionForm(catalog, app, action, label);
       if (form) {

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -1201,19 +1201,26 @@
     if (!compatibility || Object.keys(compatibility).length === 0) {
       return "is-warning";
     }
+    const status = typeof compatibility.status === "string" ? compatibility.status.toLowerCase() : "";
+    if (status === "not_declared") {
+      return "is-warning";
+    }
     if (compatibility.satisfied === false) {
       return "is-error";
     }
     if (compatibility.satisfied === true) {
       return "is-success";
     }
-    const status = typeof compatibility.status === "string" ? compatibility.status.toLowerCase() : "";
     return status.includes("unsatisfied") || status.includes("unsupported") ? "is-error" : "is-warning";
   }
 
   function compatibilityLabel(compatibility) {
     if (!compatibility || Object.keys(compatibility).length === 0) {
       return "Compatibility unknown";
+    }
+    const status = typeof compatibility.status === "string" ? compatibility.status.toLowerCase() : "";
+    if (status === "not_declared") {
+      return "Compatibility not declared";
     }
     if (compatibility.satisfied === false) {
       return "Compatibility warning";

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -82,6 +82,7 @@ class WebShellResourcesTest {
     assertPeerMutationSubmissionOrder(script);
     assertPeerLoadSequencing(script);
     assertAppsMarkersPresent(script);
+    assertAppStoreMetadataMarkersPresent(script);
     assertAppsSubmissionOrder(script);
     assertAppsLoadSequencing(script);
     assertPublisherMarkersPresent(script);
@@ -103,6 +104,9 @@ class WebShellResourcesTest {
     assertTrue(stylesheet.contains(".permission-list {"));
     assertTrue(stylesheet.contains(".app-audit-event.is-denied {"));
     assertTrue(stylesheet.contains(".catalog-app-card {"));
+    assertTrue(stylesheet.contains(".catalog-app-card.is-update-available {"));
+    assertTrue(stylesheet.contains(".metadata-link-list {"));
+    assertTrue(stylesheet.contains(".permission-review-list {"));
     assertTrue(stylesheet.contains(".publisher-forms {"));
     assertTrue(stylesheet.contains(".publisher-result-actions {"));
     assertTrue(stylesheet.contains(".status-pill.is-success::before {"));
@@ -395,6 +399,36 @@ class WebShellResourcesTest {
     assertTrue(script.contains("action === \"uninstall\""));
     assertTrue(script.contains("App lifecycle actions unavailable in read-only mode."));
     assertTrue(script.contains("Catalog actions unavailable in read-only mode."));
+  }
+
+  private static void assertAppStoreMetadataMarkersPresent(String script) {
+    assertTrue(script.contains("function safeMetadataUri(value)"));
+    assertTrue(script.contains("function metadataLinkNode(value, label)"));
+    assertTrue(script.contains("function metadataLinkListNode(values)"));
+    assertTrue(script.contains("function catalogReviewDetailsNode(app)"));
+    assertTrue(script.contains("function catalogCompatibilityDetailsNode(app)"));
+    assertTrue(script.contains("function catalogPermissionReviewDetailsNode(app)"));
+    assertTrue(script.contains("function catalogReleaseDetailsNode(app)"));
+    assertTrue(script.contains("Review and trust"));
+    assertTrue(
+        script.contains(
+            "Advisory metadata; catalog and bundle verification still control installation."));
+    assertTrue(script.contains("Permission review"));
+    assertTrue(script.contains("Release metadata"));
+    assertTrue(script.contains("[\"Homepage\", metadataLinkNode(app.homepage)]"));
+    assertTrue(script.contains("[\"Source\", metadataLinkNode(app.source)]"));
+    assertTrue(script.contains("[\"Categories\", chipListNode(app.categories)]"));
+    assertTrue(script.contains("[\"Permission changes\","));
+    assertTrue(script.contains("[\"Screenshot links\", metadataLinkListNode(app.screenshots)]"));
+    assertTrue(script.contains("link.rel = \"noopener noreferrer\";"));
+    assertTrue(
+        script.contains(
+            "link.textContent = typeof label === \"string\" && label ? label : value;"));
+    assertTrue(script.contains("pills.append(createPill(\"Signed catalog\"));"));
+    assertTrue(script.contains("pills.append(createPill(versionLabel(app), versionTone(app)));"));
+    assertTrue(script.contains("No permission rationale supplied."));
+    assertTrue(script.contains("Update from catalog"));
+    assertTrue(script.contains("Install from catalog"));
   }
 
   private static void assertAppsSubmissionOrder(String script) {

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -429,6 +429,7 @@ class WebShellResourcesTest {
     assertTrue(script.contains("pills.append(createPill(versionLabel(app), versionTone(app)));"));
     assertTrue(script.contains("No permission rationale supplied."));
     assertTrue(script.contains("Update from catalog"));
+    assertTrue(script.contains("Apply catalog version"));
     assertTrue(script.contains("Install from catalog"));
   }
 

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -83,6 +83,7 @@ class WebShellResourcesTest {
     assertPeerLoadSequencing(script);
     assertAppsMarkersPresent(script);
     assertAppStoreMetadataMarkersPresent(script);
+    assertCompatibilityUndeclaredPrecedesSuccess(script);
     assertAppsSubmissionOrder(script);
     assertAppsLoadSequencing(script);
     assertPublisherMarkersPresent(script);
@@ -429,6 +430,21 @@ class WebShellResourcesTest {
     assertTrue(script.contains("No permission rationale supplied."));
     assertTrue(script.contains("Update from catalog"));
     assertTrue(script.contains("Install from catalog"));
+  }
+
+  private static void assertCompatibilityUndeclaredPrecedesSuccess(String script) {
+    int toneStart = script.indexOf("function compatibilityTone(compatibility)");
+    int toneUndeclaredIndex = script.indexOf("status === \"not_declared\"", toneStart);
+    int toneSuccessIndex = script.indexOf("compatibility.satisfied === true", toneStart);
+    assertTrue(toneUndeclaredIndex > toneStart);
+    assertTrue(toneSuccessIndex > toneUndeclaredIndex);
+
+    int labelStart = script.indexOf("function compatibilityLabel(compatibility)");
+    int labelUndeclaredIndex = script.indexOf("status === \"not_declared\"", labelStart);
+    int labelSuccessIndex = script.indexOf("compatibility.satisfied === true", labelStart);
+    assertTrue(labelUndeclaredIndex > labelStart);
+    assertTrue(labelSuccessIndex > labelUndeclaredIndex);
+    assertTrue(script.contains("Compatibility not declared"));
   }
 
   private static void assertAppsSubmissionOrder(String script) {

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -1,6 +1,7 @@
 package network.crypta.platform.api;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -10,9 +11,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import network.crypta.platform.api.json.PlatformApiJsonWriter;
+import network.crypta.platform.appcatalog.AppCatalogChangelog;
+import network.crypta.platform.appcatalog.AppCatalogCompatibilityMetadata;
 import network.crypta.platform.appcatalog.AppCatalogEntry;
 import network.crypta.platform.appcatalog.AppCatalogInstallPlan;
 import network.crypta.platform.appcatalog.AppCatalogManager;
+import network.crypta.platform.appcatalog.AppCatalogReviewMetadata;
 import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostConfigurationException;
@@ -129,6 +133,7 @@ class PlatformApiRouterTest {
   private static final long APP_PID = 4242L;
   private static final long MANIFEST_DATA_QUOTA_BYTES = 4096L;
   private static final long MANIFEST_CACHE_QUOTA_BYTES = 8192L;
+  private static final String CATALOG_MINIMUM_CRYPTA_VERSION = "1400";
 
   @Mock private RuntimePorts runtimePorts;
   @Mock private NodeInfoPort nodeInfoPort;
@@ -2037,6 +2042,32 @@ class PlatformApiRouterTest {
   }
 
   @Test
+  void route_whenCatalogAppHasMinimumCryptaVersion_expectComparableBuildVersion() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    when(nodeInfoPort.greeting())
+        .thenReturn(
+            new NodeGreetingSnapshot(
+                "Cryptad", "Cryptad,1481,1.0,1481", 1481, "abc123", true, "gzip", "en"));
+    when(catalogManager.listApps("core"))
+        .thenReturn(List.of(catalogEntryWithMinimumCryptaVersion()));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+
+    PlatformApiResponse response =
+        catalogRouter.route(request("GET", List.of("app-catalogs", "core", "apps"), Map.of()));
+
+    assertEquals(200, response.statusCode());
+    assertTrue(response.body().contains("\"currentCryptaVersion\":\"1481\""));
+    assertTrue(
+        response
+            .body()
+            .contains("\"minimumCryptaVersion\":\"" + CATALOG_MINIMUM_CRYPTA_VERSION + "\""));
+    assertTrue(response.body().contains("\"status\":\"satisfied\""));
+    assertFalse(response.body().contains("Cryptad,1481,1.0,1481"));
+  }
+
+  @Test
   void route_whenAppsListRequested_expectAppsEnvelopeAndMergedRunningState() throws Exception {
     InstalledAppSnapshot installed = installedSnapshot();
     RunningAppSnapshot running = runningSnapshot();
@@ -3246,6 +3277,28 @@ class PlatformApiRouterTest {
         0L,
         AppCatalogEntry.ZIP_BUNDLE_TYPE,
         List.of("network.access"));
+  }
+
+  private AppCatalogEntry catalogEntryWithMinimumCryptaVersion() {
+    return new AppCatalogEntry(
+        APP_ID,
+        APP_NAME,
+        APP_VERSION,
+        "Catalog app summary",
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        List.of(),
+        new AppCatalogCompatibilityMetadata(Optional.of(CATALOG_MINIMUM_CRYPTA_VERSION)),
+        AppCatalogReviewMetadata.EMPTY,
+        AppCatalogChangelog.EMPTY,
+        List.of(),
+        URI.create("https://example.invalid/artifact.zip"),
+        "0".repeat(64),
+        0L,
+        AppCatalogEntry.ZIP_BUNDLE_TYPE,
+        List.of("network.access"),
+        Map.of());
   }
 
   private static Map<String, Object> summary(


### PR DESCRIPTION
## Summary
- Extend signed app catalogs with metadata-capable schema support for review state, source/homepage/license/category data, permission rationales, screenshots, changelog links, and advisory compatibility hints.
- Expose richer catalog app metadata through Platform API, including installed/catalog version comparison, update availability, permission deltas, review metadata, and compatibility status.
- Upgrade the Web Shell Apps catalog surface to show richer app details before install/update while keeping remote screenshots as links and preserving the existing signed-catalog trust model.
- Teach `crypta-app catalog create` and docs about metadata descriptors, minimal `catalog.version=1` output, and `catalog.version=2` output when store metadata is present.

## Testing
- `./gradlew spotlessApply`
- `git diff --check`
- `./gradlew :platform-api:test :platform-appcatalog:test :platform-devtools:test :platform-web-shell:test :test --tests '*PlatformApiRouterTest'`