### PR TITLE
feat(appcatalog): Fetch catalogs over Crypta

### DIFF
--- a/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
+++ b/bridge-http-runtime/src/main/java/network/crypta/clients/http/bridge/CoreHttpShellRuntimeSupport.java
@@ -27,6 +27,7 @@ import network.crypta.node.RequestPriorityClasses;
 import network.crypta.node.SecurityLevels.NETWORK_THREAT_LEVEL;
 import network.crypta.node.SecurityLevels.PHYSICAL_THREAT_LEVEL;
 import network.crypta.node.SemiOrderedShutdownHook;
+import network.crypta.platform.appcatalog.AppCatalogManager.TrustedKeyProvider;
 import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.appcatalog.AppCatalogSourceStore;
 import network.crypta.platform.appdist.AppBundleVerifier;
@@ -292,10 +293,34 @@ public record CoreHttpShellRuntimeSupport(
     AppHost appHost =
         new LocalProcessAppHost(layout, createInstallVerificationPolicy(trustConfiguration));
     AppCatalogManager appCatalogManager =
-        new AppCatalogManager(
-            new AppCatalogSourceStore(layout.dataDir().resolve("apps").resolve("catalogs")),
-            () -> loadTrustedAppKeys(trustConfiguration));
+        createAppCatalogManager(layout, trustConfiguration, core.getRuntimePorts());
     return new AppPlatformServices(appHost, appCatalogManager);
+  }
+
+  /**
+   * Creates the signed app-catalog manager for the current node layout.
+   *
+   * <p>The catalog store is kept under the AppHost data tree so catalog source metadata follows the
+   * same node-specific storage root as installed apps. Runtime content fetch support is optional
+   * for tests and older bridge wiring; when it is unavailable the manager still supports local and
+   * HTTP catalog sources and reports Crypta fetch unavailability through its own error path.
+   *
+   * @param layout node-specific AppHost directory layout
+   * @param trustConfiguration configured catalog and bundle trust inputs
+   * @param runtimePorts runtime service ports, or {@code null} when not available
+   * @return app-catalog manager wired to the current node storage and runtime fetch port
+   */
+  private static AppCatalogManager createAppCatalogManager(
+      AppHostLayout layout,
+      AppHostTrustConfiguration trustConfiguration,
+      RuntimePorts runtimePorts) {
+    AppCatalogSourceStore catalogSourceStore =
+        new AppCatalogSourceStore(layout.dataDir().resolve("apps").resolve("catalogs"));
+    TrustedKeyProvider trustedCatalogKeys = () -> loadTrustedAppKeys(trustConfiguration);
+    return runtimePorts == null
+        ? new AppCatalogManager(catalogSourceStore, trustedCatalogKeys)
+        : new AppCatalogManager(
+            catalogSourceStore, trustedCatalogKeys, runtimePorts.contentFetch());
   }
 
   private static AppInstallVerificationPolicy createInstallVerificationPolicy(

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -200,6 +200,24 @@ Supported catalog sources:
 - Absolute local paths or `file:` URIs to `cryptad-app-catalog.properties`.
 - `https:` URIs.
 - `http:` URIs only for loopback hosts such as `localhost` or `127.0.0.1`.
+- `crypta:` URIs for public catalog-over-Crypta sources.
+
+`crypta:` catalog sources use these forms:
+
+- Mutable/path-like catalog keys:
+  `crypta:USK@<catalog-key>/<catalog-path>/cryptad-app-catalog.properties` or
+  `crypta:SSK@<catalog-key>/<catalog-path>/cryptad-app-catalog.properties`.
+  The signature sidecar is the sibling
+  `crypta:USK@<catalog-key>/<catalog-path>/cryptad-app-catalog.signature` or
+  `crypta:SSK@<catalog-key>/<catalog-path>/cryptad-app-catalog.signature`.
+- Immutable CHK v1 catalogs:
+  `crypta:CHK@<catalog-key>?signature=CHK@<signature-key>`. The catalog CHK contains
+  `cryptad-app-catalog.properties` bytes, and the `signature` companion CHK contains the matching
+  `cryptad-app-catalog.signature` bytes.
+
+`crypta:` is a catalog transport, not a trust boundary. The catalog signature must still verify
+against a configured trusted catalog key. Install and update flows still verify the catalog entry's
+artifact size and SHA-256, then verify the extracted signed bundle before AppHost receives it.
 
 Remote fetches use the JDK HTTP client with finite timeouts, no automatic redirects, and size caps
 for catalog, signature, and artifact downloads. Artifact bytes are written to catalog-owned scratch
@@ -208,6 +226,11 @@ directory. The extractor rejects artifacts with more than 4096 ZIP entries, abso
 `..`, Windows drive prefixes, backslash path separators, duplicate normalized entries, and rootless
 bundles. It drops macOS archive metadata entries such as `__MACOSX/**` and AppleDouble `._*` files
 before signed-bundle verification, so those files are not installed as app payload.
+
+PR-210 supports `crypta:` for catalog sources only. Catalog entry artifact URIs still use `file:`,
+`https:`, or loopback `http:` sources. A catalog entry with
+`app.<id>.bundle.uri=crypta:...` is rejected with a stable unsupported artifact URI scheme error
+unless `platform-appcatalog` adds explicit Crypta artifact fetching in a later change.
 
 ## Platform API flow
 
@@ -223,6 +246,12 @@ GET    /api/v1/app-catalogs/{catalogId}/apps/{appId}
 POST   /api/v1/app-catalogs/{catalogId}/apps/{appId}/install
 POST   /api/v1/app-catalogs/{catalogId}/apps/{appId}/update
 ```
+
+Refresh failures update the catalog source's last-attempt and last-failure status, but they do not
+replace or delete the last successfully verified catalog sidecars. Catalog listing, detail,
+install, and update operations continue to use the last verified catalog until a later refresh
+verifies a replacement. Already installed apps are not removed or rolled back because a catalog
+refresh failed.
 
 Install and update endpoints prepare a verified temporary staged bundle, then delegate to
 `AppHost.installFromDirectory(...)` or `AppHost.updateFromDirectory(...)`. Existing local
@@ -250,6 +279,6 @@ present. Review metadata remains separate from signed catalog trust.
 ## Future work
 
 Manifest permissions are enforced for app-process Platform API calls as described in
-[app-permissions-and-audit.md](app-permissions-and-audit.md). Catalog distribution over Crypta
-keys, public app-store governance, background app update scheduling, and remote screenshot proxying
-remain future work.
+[app-permissions-and-audit.md](app-permissions-and-audit.md). Public app-store governance,
+background app update scheduling, Crypta artifact fetching, and remote screenshot proxying remain
+future work.

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -230,6 +230,12 @@ rationales explain declared permissions; they do not grant capabilities.
 the ZIP after creating the catalog; the generated catalog records its size and lowercase SHA-256
 digest.
 
+`bundle.uri` is the public ZIP artifact location written into the signed catalog entry. In PR-210,
+catalog entries can use `file:`, `https:`, or loopback `http:` artifact URIs. `crypta:` catalog
+sources are supported by the runtime catalog refresh flow, but `bundle.uri=crypta:...` is rejected
+unless `platform-appcatalog` adds explicit Crypta artifact fetching. Keep Crypta keys for the
+catalog properties and catalog signature sidecars, not for app bundle artifacts, in this PR.
+
 Create the catalog properties file:
 
 ```bash
@@ -260,6 +266,13 @@ crypta-app catalog verify \
 
 The sign command writes `cryptad-app-catalog.signature` beside
 `cryptad-app-catalog.properties`. Do not rewrite, sort, or reformat the catalog after signing.
+
+`crypta-app` does not publish catalogs or signatures to Crypta in PR-210. To offer a public
+catalog-over-Crypta source, create and sign the catalog locally, then publish
+`cryptad-app-catalog.properties` and `cryptad-app-catalog.signature` with the existing Crypta
+publishing workflow. Runtime catalog sources can reference a path-like USK/SSK catalog location
+with sibling signature sidecar, or the CHK v1 companion form
+`crypta:CHK@<catalog-key>?signature=CHK@<signature-key>`.
 
 ## First-party Gradle workflow
 

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -16,8 +16,9 @@ Related but documented elsewhere:
   [app-catalogs.md](app-catalogs.md)
 - App-owned static UI routing for installed bundles: [app-owned-ui.md](app-owned-ui.md)
 - Browser SDK helpers for app-owned static UI: [platform-sdk-js.md](platform-sdk-js.md)
-- Catalog distribution over Crypta keys, browser-side bundle uploads, and app sandboxing remain
-  future platform work.
+- Public catalog-over-Crypta source syntax and trust boundaries: [app-catalogs.md](app-catalogs.md)
+- Browser-side bundle uploads, Crypta artifact fetching, and app sandboxing remain future platform
+  work.
 
 ## Bundle Files
 
@@ -325,7 +326,6 @@ Preferred local patterns:
 
 ## Future Work
 
-Catalog distribution over Crypta keys, public catalog governance, background app-update
-scheduling, remote screenshot proxying, and app sandboxing remain later platform work. Signed
-bundles now carry the manifest metadata and staged browser assets needed by app-owned static UI
-routes.
+Public catalog governance, background app-update scheduling, Crypta artifact fetching, remote
+screenshot proxying, and app sandboxing remain later platform work. Signed bundles now carry the
+manifest metadata and staged browser assets needed by app-owned static UI routes.

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiResponse.java
@@ -109,6 +109,8 @@ public record PlatformApiResponse(
       case 404 -> "Not Found";
       case 405 -> "Method Not Allowed";
       case 409 -> "Conflict";
+      case 502 -> "Bad Gateway";
+      case 503 -> "Service Unavailable";
       case 500 -> "Internal Server Error";
       default -> "Platform API";
     };

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
@@ -1,13 +1,17 @@
 package network.crypta.platform.api.appcatalogs;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import network.crypta.platform.api.PlatformApiException;
@@ -64,6 +68,15 @@ public final class AppCatalogsApiHandler {
   private static final String COMPATIBILITY_NOT_SATISFIED = "not_satisfied";
   private static final String COMPATIBILITY_UNKNOWN = "unknown";
   private static final String SOURCE_FIELD = "source";
+  private static final String SOURCE_TYPE_FIELD = "sourceType";
+  private static final String SOURCE_KIND_FIELD = "sourceKind";
+  private static final String LAST_ATTEMPT_AT_FIELD = "lastAttemptAt";
+  private static final String LAST_SUCCESSFUL_REFRESH_AT_FIELD = "lastSuccessfulRefreshAt";
+  private static final String LAST_FETCH_STATUS_FIELD = "lastFetchStatus";
+  private static final String LAST_FETCH_ERROR_CODE_FIELD = "lastFetchErrorCode";
+  private static final String LAST_FETCH_ERROR_MESSAGE_FIELD = "lastFetchErrorMessage";
+  private static final String LAST_RESOLVED_URI_FIELD = "lastResolvedUri";
+  private static final String FETCH_STATUS_SUCCESS = "success";
 
   private final AppCatalogManager catalogManager;
   private final AppHost appHost;
@@ -338,15 +351,85 @@ public final class AppCatalogsApiHandler {
   }
 
   private Map<String, Object> summarizeCatalog(AppCatalogSourceSnapshot snapshot) {
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    String sourceKind = sourceKind(snapshot);
+    String refreshedAt = snapshot.refreshedAt().toString();
+    String lastSuccessfulRefreshAt =
+        timestampField(snapshot, LAST_SUCCESSFUL_REFRESH_AT_FIELD, refreshedAt);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(15);
     json.put("catalogId", snapshot.catalogId());
     json.put("name", snapshot.name());
     json.put(SOURCE_FIELD, snapshot.sourceUri().toString());
+    json.put(SOURCE_TYPE_FIELD, sourceKind);
+    json.put(SOURCE_KIND_FIELD, sourceKind);
     json.put("generatedAt", snapshot.generatedAt().toString());
     json.put("appCount", snapshot.appCount());
     json.put("addedAt", snapshot.addedAt().toString());
-    json.put("refreshedAt", snapshot.refreshedAt().toString());
+    json.put("refreshedAt", refreshedAt);
+    json.put(LAST_ATTEMPT_AT_FIELD, timestampField(snapshot, LAST_ATTEMPT_AT_FIELD, refreshedAt));
+    json.put(LAST_SUCCESSFUL_REFRESH_AT_FIELD, lastSuccessfulRefreshAt);
+    json.put(LAST_FETCH_STATUS_FIELD, lastFetchStatus(snapshot));
+    json.put(LAST_FETCH_ERROR_CODE_FIELD, stringField(snapshot, LAST_FETCH_ERROR_CODE_FIELD, null));
+    json.put(
+        LAST_FETCH_ERROR_MESSAGE_FIELD,
+        stringField(snapshot, LAST_FETCH_ERROR_MESSAGE_FIELD, null));
+    json.put(
+        LAST_RESOLVED_URI_FIELD,
+        stringField(snapshot, LAST_RESOLVED_URI_FIELD, snapshot.sourceUri().toString()));
     return json;
+  }
+
+  private static String sourceKind(AppCatalogSourceSnapshot snapshot) {
+    String explicitKind = stringField(snapshot, SOURCE_KIND_FIELD, null);
+    if (explicitKind != null) {
+      return explicitKind.toLowerCase(Locale.ROOT);
+    }
+    String scheme = snapshot.sourceUri().getScheme();
+    return scheme == null || scheme.isBlank()
+        ? VERSION_STATUS_UNKNOWN
+        : scheme.toLowerCase(Locale.ROOT);
+  }
+
+  private static String timestampField(
+      AppCatalogSourceSnapshot snapshot, String accessorName, String fallback) {
+    Object value = snapshotAccessorValue(snapshot, accessorName);
+    if (value == null) {
+      return fallback;
+    }
+    if (value instanceof Instant instant) {
+      return instant.toString();
+    }
+    String text = value.toString();
+    return text.isBlank() ? fallback : text;
+  }
+
+  private static String stringField(
+      AppCatalogSourceSnapshot snapshot, String accessorName, String fallback) {
+    Object value = snapshotAccessorValue(snapshot, accessorName);
+    if (value == null) {
+      return fallback;
+    }
+    String text = value instanceof Enum<?> enumValue ? enumValue.name() : value.toString();
+    text = text.trim();
+    return text.isEmpty() ? fallback : text;
+  }
+
+  private static String lastFetchStatus(AppCatalogSourceSnapshot snapshot) {
+    return stringField(snapshot, LAST_FETCH_STATUS_FIELD, FETCH_STATUS_SUCCESS)
+        .toLowerCase(Locale.ROOT);
+  }
+
+  private static Object snapshotAccessorValue(
+      AppCatalogSourceSnapshot snapshot, String accessorName) {
+    try {
+      Method method = snapshot.getClass().getMethod(accessorName);
+      Object value = method.invoke(snapshot);
+      if (value instanceof Optional<?> optional) {
+        return optional.orElse(null);
+      }
+      return value;
+    } catch (ReflectiveOperationException | SecurityException _) {
+      return null;
+    }
   }
 
   private Map<String, Object> summarizeEntry(AppCatalogEntry entry) {
@@ -374,7 +457,8 @@ public final class AppCatalogsApiHandler {
     json.put(
         "versionDifferent", versionDifferent(entry.version(), installedVersion, installed != null));
     json.put(
-        "updateAvailable", updateAvailable(entry.version(), installedVersion, installed != null));
+        "updateAvailable",
+        updateAvailable(entry.version(), installedVersion, installed != null).orElse(null));
     json.put("versionStatus", versionStatus(entry.version(), installedVersion, installed != null));
     json.put("permissionDelta", summarizePermissionDelta(entry.permissions(), installed));
     json.put("running", running != null);
@@ -476,19 +560,19 @@ public final class AppCatalogsApiHandler {
     return !catalogVersion.equals(installedVersion);
   }
 
-  private static Boolean updateAvailable(
+  private static Optional<Boolean> updateAvailable(
       String catalogVersion, String installedVersion, boolean installed) {
     if (!installed) {
-      return false;
+      return Optional.of(false);
     }
     if (catalogVersion == null || installedVersion == null) {
-      return null;
+      return Optional.empty();
     }
     if (catalogVersion.equals(installedVersion)) {
-      return false;
+      return Optional.of(false);
     }
     Integer comparison = compareDottedNumericVersions(catalogVersion, installedVersion);
-    return comparison == null ? null : comparison > 0;
+    return comparison == null ? Optional.empty() : Optional.of(comparison > 0);
   }
 
   private static String versionStatus(
@@ -579,6 +663,10 @@ public final class AppCatalogsApiHandler {
           new PlatformApiException(404, exception.errorCode(), exception.getMessage());
       case "catalog_conflict" ->
           new PlatformApiException(409, exception.errorCode(), exception.getMessage());
+      case "catalog_fetch_unavailable" ->
+          new PlatformApiException(503, exception.errorCode(), exception.getMessage());
+      case "catalog_fetch_failed" ->
+          new PlatformApiException(502, exception.errorCode(), exception.getMessage());
       default -> new PlatformApiException(400, exception.errorCode(), exception.getMessage());
     };
   }

--- a/platform-api/src/test/java/network/crypta/platform/api/PlatformApiResponseTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/PlatformApiResponseTest.java
@@ -1,0 +1,14 @@
+package network.crypta.platform.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("java:S100")
+class PlatformApiResponseTest {
+  @Test
+  void reasonPhrase_whenGatewayStatusCodesUsed_expectStandardPhrases() {
+    assertEquals("Bad Gateway", PlatformApiResponse.reasonPhrase(502));
+    assertEquals("Service Unavailable", PlatformApiResponse.reasonPhrase(503));
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
@@ -2,15 +2,20 @@ package network.crypta.platform.api.appcatalogs;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.appcatalog.AppCatalogChangelog;
 import network.crypta.platform.appcatalog.AppCatalogCompatibilityMetadata;
 import network.crypta.platform.appcatalog.AppCatalogEntry;
+import network.crypta.platform.appcatalog.AppCatalogException;
+import network.crypta.platform.appcatalog.AppCatalogFetchStatus;
 import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.appcatalog.AppCatalogReviewMetadata;
 import network.crypta.platform.appcatalog.AppCatalogReviewStatus;
+import network.crypta.platform.appcatalog.AppCatalogSourceSnapshot;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppPaths;
@@ -25,7 +30,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +44,59 @@ class AppCatalogsApiHandlerTest {
   @Mock private AppHost appHost;
 
   @TempDir private Path tempDir;
+
+  @Test
+  void listCatalogs_whenSnapshotHasSourceUri_expectSourceKindAndSyncFields() throws Exception {
+    AppCatalogsApiHandler handler = new AppCatalogsApiHandler(catalogManager, appHost, () -> null);
+    Instant generatedAt = Instant.parse("2026-04-24T12:00:00Z");
+    Instant addedAt = Instant.parse("2026-04-24T12:01:00Z");
+    Instant refreshedAt = Instant.parse("2026-04-24T12:02:00Z");
+    AppCatalogSourceSnapshot snapshot =
+        new AppCatalogSourceSnapshot(
+            "core",
+            "Core Apps",
+            URI.create("https://example.invalid/cryptad-app-catalog.properties"),
+            generatedAt,
+            2,
+            addedAt,
+            refreshedAt,
+            refreshedAt,
+            refreshedAt,
+            AppCatalogFetchStatus.SUCCESS,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of("https://example.invalid/cryptad-app-catalog.properties"));
+    when(catalogManager.listCatalogs()).thenReturn(List.of(snapshot));
+
+    Map<String, Object> catalog = handler.listCatalogs().getFirst();
+
+    assertEquals("core", catalog.get("catalogId"));
+    assertEquals("Core Apps", catalog.get("name"));
+    assertEquals("https://example.invalid/cryptad-app-catalog.properties", catalog.get("source"));
+    assertEquals("https", catalog.get("sourceType"));
+    assertEquals("https", catalog.get("sourceKind"));
+    assertEquals(generatedAt.toString(), catalog.get("generatedAt"));
+    assertEquals(2, catalog.get("appCount"));
+    assertEquals(addedAt.toString(), catalog.get("addedAt"));
+    assertEquals(refreshedAt.toString(), catalog.get("refreshedAt"));
+    assertEquals(refreshedAt.toString(), catalog.get("lastAttemptAt"));
+    assertEquals(refreshedAt.toString(), catalog.get("lastSuccessfulRefreshAt"));
+    assertEquals("success", catalog.get("lastFetchStatus"));
+    assertNull(catalog.get("lastFetchErrorCode"));
+    assertNull(catalog.get("lastFetchErrorMessage"));
+    assertEquals(
+        "https://example.invalid/cryptad-app-catalog.properties", catalog.get("lastResolvedUri"));
+  }
+
+  @Test
+  void listCatalogs_whenCatalogSourceOrFetchFails_expectStableStatusCodes() throws Exception {
+    assertCatalogFailureStatus("unsupported_catalog_source", 400);
+    assertCatalogFailureStatus("invalid_catalog_source", 400);
+    assertCatalogFailureStatus("catalog_fetch_unavailable", 503);
+    assertCatalogFailureStatus("catalog_fetch_failed", 502);
+    assertCatalogFailureStatus("invalid_catalog_signature", 400);
+    assertCatalogFailureStatus("catalog_signature_missing", 400);
+  }
 
   @Test
   void listApps_whenEntryHasStoreMetadataAndInstalledAppDiffers_expectReviewMetadata()
@@ -223,6 +283,19 @@ class AppCatalogsApiHandlerTest {
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
 
     return handler.listApps("core").getFirst();
+  }
+
+  private void assertCatalogFailureStatus(String code, int statusCode) throws Exception {
+    reset(catalogManager);
+    AppCatalogsApiHandler handler = new AppCatalogsApiHandler(catalogManager, appHost, () -> null);
+    when(catalogManager.listCatalogs()).thenThrow(new AppCatalogException(code, "catalog failed"));
+
+    PlatformApiException exception =
+        assertThrows(PlatformApiException.class, handler::listCatalogs);
+
+    assertEquals(statusCode, exception.statusCode());
+    assertEquals(code, exception.errorCode());
+    assertEquals("catalog failed", exception.getMessage());
   }
 
   private AppCatalogEntry richCatalogEntry() {

--- a/platform-appcatalog/build.gradle.kts
+++ b/platform-appcatalog/build.gradle.kts
@@ -10,6 +10,7 @@ val mainSourceSet = sourceSets.named("main")
 
 dependencies {
   api(project(":platform-appdist"))
+  api(project(":runtime-spi"))
 
   compileOnly(libs.jetbrainsAnnotations)
 

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetchStatus.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetchStatus.java
@@ -1,0 +1,80 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Locale;
+
+/**
+ * Last observed refresh-attempt status for a configured signed app catalog source.
+ *
+ * <p>The value is written to catalog-source metadata and surfaced through the Platform API so the
+ * Web Shell can distinguish a healthy source from a source whose most recent refresh failed. It is
+ * intentionally about the last attempt, not about catalog trust. A source can report {@link
+ * #FAILED} while the previously verified catalog remains installed, listable, and usable.
+ *
+ * <p>The enum stores a stable lowercase metadata token rather than relying on Java enum names in
+ * files. That keeps on-disk metadata and API display text consistent even though Java callers use
+ * conventional uppercase constants.
+ */
+public enum AppCatalogFetchStatus {
+  /**
+   * The most recent refresh attempt fetched and verified signed catalog sidecars.
+   *
+   * <p>This status means both catalog bytes and signature bytes passed the normal signed-catalog
+   * verification path. It does not make the transport trusted; catalog keys and signatures remain
+   * the authority for catalog authenticity.
+   */
+  SUCCESS("success"),
+
+  /**
+   * The most recent refresh attempt failed before replacing the last verified sidecars.
+   *
+   * <p>This status preserves the distinction between a failed sync and a bad cache. The source may
+   * still have a valid prior catalog snapshot, and callers should keep showing that snapshot while
+   * also reporting the failed attempt metadata.
+   */
+  FAILED("failed");
+
+  /** Lowercase token persisted in source metadata and exposed as UI-facing status text. */
+  private final String metadataValue;
+
+  /**
+   * Creates one status with its stable serialized metadata token.
+   *
+   * @param metadataValue lowercase token written into {@code catalog-source.properties}
+   */
+  AppCatalogFetchStatus(String metadataValue) {
+    this.metadataValue = metadataValue;
+  }
+
+  /**
+   * Returns the stable token used in persisted source metadata.
+   *
+   * @return lowercase value written to and read from catalog-source metadata
+   */
+  String metadataValue() {
+    return metadataValue;
+  }
+
+  /**
+   * Parses a persisted fetch-status token.
+   *
+   * <p>The parser accepts the lowercase metadata values produced by {@link #metadataValue()} and
+   * rejects blank, multiline, or unknown values with the same stable catalog-source error used for
+   * malformed source metadata. Callers use this when reading source state from disk.
+   *
+   * @param value persisted {@code source.lastFetchStatus} text to parse
+   * @return matching status enum for the persisted metadata token
+   */
+  static AppCatalogFetchStatus parse(String value) {
+    String normalized =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+                value, "source.lastFetchStatus", AppCatalogSidecars.INVALID_CATALOG_SOURCE)
+            .toLowerCase(Locale.ROOT);
+    for (AppCatalogFetchStatus status : values()) {
+      if (status.metadataValue.equals(normalized)) {
+        return status;
+      }
+    }
+    throw new AppCatalogException(
+        AppCatalogSidecars.INVALID_CATALOG_SOURCE, "unsupported source.lastFetchStatus: " + value);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetcher.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetcher.java
@@ -16,14 +16,17 @@ import network.crypta.runtime.spi.ContentFetchException;
 import network.crypta.runtime.spi.ContentFetchPort;
 
 /**
- * Fetches catalog properties and signature sidecars from local files or HTTP(S).
+ * Fetches catalog properties and signature sidecars from local files, HTTP(S), or Crypta content.
  *
  * <p>The fetcher uses finite JDK {@link HttpClient} timeouts, disables automatic redirects, and
  * enforces separate byte limits for catalog and signature payloads. Plain HTTP is accepted only for
  * loopback hosts by the source validation layer; non-local remote catalogs must use HTTPS.
  *
  * <p>A source points at {@code cryptad-app-catalog.properties}; the matching signature URI is
- * resolved as its sibling {@code cryptad-app-catalog.signature}. This class fetches bytes only. It
+ * resolved as its sibling {@code cryptad-app-catalog.signature}, except for CHK-backed Crypta
+ * sources that must declare an explicit immutable signature companion. When a Crypta catalog fetch
+ * reports a resolved USK or SSK key, the signature sidecar is fetched from the matching resolved
+ * sibling so both sidecars come from the same edition. This class fetches bytes only. It
  * deliberately does not parse or verify the sidecars so callers can preserve the exact catalog
  * bytes for signature verification and persistence.
  */
@@ -110,7 +113,7 @@ public final class AppCatalogFetcher {
               CATALOG_PROPERTIES_DESCRIPTION);
       FetchedBytes signatureBytes =
           fetchCryptaBytes(
-              cryptaUri.signatureFetchKey(),
+              cryptaUri.signatureFetchKeyForResolvedCatalog(catalogBytes.resolvedUri()),
               AppCatalogSidecars.MAX_SIGNATURE_BYTES,
               CATALOG_SIGNATURE_DESCRIPTION);
       return new FetchedCatalog(

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetcher.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogFetcher.java
@@ -10,6 +10,10 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Objects;
+import network.crypta.runtime.spi.BoundedContentFetchRequest;
+import network.crypta.runtime.spi.BoundedContentFetchResult;
+import network.crypta.runtime.spi.ContentFetchException;
+import network.crypta.runtime.spi.ContentFetchPort;
 
 /**
  * Fetches catalog properties and signature sidecars from local files or HTTP(S).
@@ -25,8 +29,11 @@ import java.util.Objects;
  */
 public final class AppCatalogFetcher {
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+  private static final String CATALOG_PROPERTIES_DESCRIPTION = "catalog properties";
+  private static final String CATALOG_SIGNATURE_DESCRIPTION = "catalog signature";
 
   private final HttpClient httpClient;
+  private final ContentFetchPort contentFetchPort;
 
   /**
    * Creates a fetcher with the default no-redirect JDK HTTP client.
@@ -36,11 +43,7 @@ public final class AppCatalogFetcher {
    * blocking catalog operations indefinitely.
    */
   public AppCatalogFetcher() {
-    this(
-        HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .followRedirects(HttpClient.Redirect.NEVER)
-            .build());
+    this(defaultHttpClient(), null);
   }
 
   /**
@@ -53,7 +56,34 @@ public final class AppCatalogFetcher {
    * @param httpClient client used for HTTP and HTTPS catalog retrieval
    */
   public AppCatalogFetcher(HttpClient httpClient) {
+    this(httpClient, null);
+  }
+
+  /**
+   * Creates a fetcher with the default HTTP client and a Crypta content fetch collaborator.
+   *
+   * <p>The runtime SPI port is used only for {@code crypta:} catalog sources. Existing file, HTTPS,
+   * and loopback HTTP sources continue to use their original fetch paths.
+   *
+   * @param contentFetchPort runtime content fetch port for {@code crypta:} sources
+   */
+  public AppCatalogFetcher(ContentFetchPort contentFetchPort) {
+    this(defaultHttpClient(), contentFetchPort);
+  }
+
+  /**
+   * Creates a fetcher with explicit HTTP and optional Crypta content fetch collaborators.
+   *
+   * <p>The content fetch port is optional so tests and embeddings that do not support Crypta
+   * catalog sources can keep using the same fetcher. Attempting to fetch a {@code crypta:} source
+   * without the port fails closed with {@code catalog_fetch_unavailable}.
+   *
+   * @param httpClient client used for HTTP and HTTPS catalog retrieval
+   * @param contentFetchPort runtime content fetch port for {@code crypta:} sources, or {@code null}
+   */
+  public AppCatalogFetcher(HttpClient httpClient, ContentFetchPort contentFetchPort) {
     this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+    this.contentFetchPort = contentFetchPort;
   }
 
   /**
@@ -71,12 +101,30 @@ public final class AppCatalogFetcher {
    */
   public FetchedCatalog fetch(AppCatalogSource source) throws IOException {
     AppCatalogSource checkedSource = Objects.requireNonNull(source, "source");
+    if (checkedSource.kind() == AppCatalogSourceKind.CRYPTA) {
+      CryptaCatalogUri cryptaUri = checkedSource.cryptaCatalogUri();
+      FetchedBytes catalogBytes =
+          fetchCryptaBytes(
+              cryptaUri.catalogFetchKey(),
+              AppCatalogSidecars.MAX_CATALOG_BYTES,
+              CATALOG_PROPERTIES_DESCRIPTION);
+      FetchedBytes signatureBytes =
+          fetchCryptaBytes(
+              cryptaUri.signatureFetchKey(),
+              AppCatalogSidecars.MAX_SIGNATURE_BYTES,
+              CATALOG_SIGNATURE_DESCRIPTION);
+      return new FetchedCatalog(
+          catalogBytes.bytes(), signatureBytes.bytes(), catalogBytes.resolvedUri());
+    }
     return new FetchedCatalog(
-        fetchBytes(checkedSource.uri(), AppCatalogSidecars.MAX_CATALOG_BYTES, "catalog properties"),
+        fetchBytes(
+            checkedSource.uri(),
+            AppCatalogSidecars.MAX_CATALOG_BYTES,
+            CATALOG_PROPERTIES_DESCRIPTION),
         fetchBytes(
             checkedSource.signatureUri(),
             AppCatalogSidecars.MAX_SIGNATURE_BYTES,
-            "catalog signature"));
+            CATALOG_SIGNATURE_DESCRIPTION));
   }
 
   private byte[] fetchBytes(URI uri, long maxBytes, String description) throws IOException {
@@ -86,6 +134,63 @@ public final class AppCatalogFetcher {
           Path.of(uri), maxBytes, description, AppCatalogSidecars.INVALID_CATALOG_SOURCE);
     }
     return fetchRemoteBytes(uri, maxBytes, description);
+  }
+
+  private FetchedBytes fetchCryptaBytes(String fetchKey, long maxBytes, String description) {
+    ContentFetchPort port = requireContentFetchPort();
+    try {
+      BoundedContentFetchResult result =
+          port.fetchContent(
+              new BoundedContentFetchRequest(fetchKey, maxBytes, REQUEST_TIMEOUT, description));
+      byte[] bytes = result.bytes();
+      if (bytes.length > maxBytes) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.CATALOG_FETCH_FAILED, description + " exceeds the allowed size");
+      }
+      return new FetchedBytes(bytes, result.resolvedUri());
+    } catch (ContentFetchException exception) {
+      throw new AppCatalogException(
+          mapContentFetchErrorCode(exception, description),
+          "failed to fetch " + description,
+          exception);
+    } catch (IllegalArgumentException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          "invalid Crypta catalog fetch request",
+          exception);
+    }
+  }
+
+  private static HttpClient defaultHttpClient() {
+    return HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build();
+  }
+
+  private ContentFetchPort requireContentFetchPort() {
+    if (contentFetchPort == null) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.CATALOG_FETCH_UNAVAILABLE,
+          "Crypta catalog fetch runtime is unavailable");
+    }
+    return contentFetchPort;
+  }
+
+  private static String mapContentFetchErrorCode(
+      ContentFetchException exception, String description) {
+    String errorCode = exception.errorCode();
+    if (ContentFetchException.INVALID_CATALOG_SOURCE.equals(errorCode)) {
+      return AppCatalogSidecars.INVALID_CATALOG_SOURCE;
+    }
+    if (AppCatalogSidecars.CATALOG_FETCH_UNAVAILABLE.equals(errorCode)) {
+      return AppCatalogSidecars.CATALOG_FETCH_UNAVAILABLE;
+    }
+    if (CATALOG_SIGNATURE_DESCRIPTION.equals(description)
+        && AppCatalogSidecars.CATALOG_SIGNATURE_MISSING.equals(errorCode)) {
+      return AppCatalogSidecars.CATALOG_SIGNATURE_MISSING;
+    }
+    return AppCatalogSidecars.CATALOG_FETCH_FAILED;
   }
 
   private byte[] fetchRemoteBytes(URI uri, long maxBytes, String description) {
@@ -121,6 +226,25 @@ public final class AppCatalogFetcher {
     } catch (IOException exception) {
       throw new AppCatalogException(
           AppCatalogSidecars.INVALID_CATALOG_SOURCE, "failed to read " + description, exception);
+    }
+  }
+
+  @SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+  private static final class FetchedBytes {
+    private final byte[] bytes;
+    private final String resolvedUri;
+
+    private FetchedBytes(byte[] bytes, String resolvedUri) {
+      this.bytes = Objects.requireNonNull(bytes, "bytes").clone();
+      this.resolvedUri = resolvedUri;
+    }
+
+    private byte[] bytes() {
+      return bytes.clone();
+    }
+
+    private String resolvedUri() {
+      return resolvedUri;
     }
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
@@ -225,7 +225,12 @@ public final class AppCatalogManager {
       }
       return catalog;
     } catch (AppCatalogException exception) {
-      recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, exception);
+      recordRefreshFailure(
+          normalizedCatalogId,
+          stored,
+          attemptedAt,
+          exception,
+          resolvedCatalogUri(fetched, stored.source()));
       throw exception;
     }
   }
@@ -315,8 +320,23 @@ public final class AppCatalogManager {
       StoredCatalogSource stored,
       Instant attemptedAt,
       AppCatalogException exception) {
+    recordRefreshFailure(
+        normalizedCatalogId,
+        stored,
+        attemptedAt,
+        exception,
+        stored.source().resolvedCatalogFetchUri());
+  }
+
+  private void recordRefreshFailure(
+      String normalizedCatalogId,
+      StoredCatalogSource stored,
+      Instant attemptedAt,
+      AppCatalogException exception,
+      String resolvedUri) {
     try {
-      sourceStore.recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, exception);
+      sourceStore.recordRefreshFailure(
+          normalizedCatalogId, stored, attemptedAt, exception, resolvedUri);
     } catch (IOException metadataException) {
       exception.addSuppressed(metadataException);
     }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import network.crypta.platform.appdist.TrustedAppKeys;
+import network.crypta.runtime.spi.ContentFetchPort;
 
 /**
  * Coordinates signed catalog sources, refreshes, artifact staging, and bundle verification.
@@ -46,6 +47,28 @@ public final class AppCatalogManager {
         sourceStore,
         trustedKeyProvider,
         new AppCatalogFetcher(),
+        new AppCatalogArtifactDownloader(),
+        new AppCatalogBundleExtractor());
+  }
+
+  /**
+   * Creates a manager with a runtime content fetch port for {@code crypta:} catalog sources.
+   *
+   * <p>The supplied port is used only as bounded content transport. Catalog signatures and trusted
+   * catalog keys remain the authentication boundary for fetched catalogs.
+   *
+   * @param sourceStore file-backed catalog source store
+   * @param trustedKeyProvider provider for the current trusted app/catalog keys
+   * @param contentFetchPort runtime content fetch port for {@code crypta:} sources
+   */
+  public AppCatalogManager(
+      AppCatalogSourceStore sourceStore,
+      TrustedKeyProvider trustedKeyProvider,
+      ContentFetchPort contentFetchPort) {
+    this(
+        sourceStore,
+        trustedKeyProvider,
+        new AppCatalogFetcher(contentFetchPort),
         new AppCatalogArtifactDownloader(),
         new AppCatalogBundleExtractor());
   }
@@ -118,7 +141,12 @@ public final class AppCatalogManager {
     }
     Instant now = Instant.now();
     sourceStore.write(catalog, source, fetched, now, now);
-    return AppCatalogSourceSnapshot.of(catalog, source, now, now);
+    return AppCatalogSourceSnapshot.of(
+        catalog,
+        source,
+        now,
+        now,
+        AppCatalogSourceRefreshMetadata.success(now, resolvedCatalogUri(fetched, source)));
   }
 
   /**
@@ -149,17 +177,57 @@ public final class AppCatalogManager {
     String normalizedCatalogId = normalizeCatalogIdForLookup(catalogId);
     StoredCatalogSource stored = sourceStore.read(normalizedCatalogId);
     TrustedAppKeys trustedKeys = trustedKeyProvider.trustedKeys();
-    FetchedCatalog fetched = fetcher.fetch(stored.source());
+    Instant attemptedAt = Instant.now();
+    FetchedCatalog fetched = fetchForRefresh(normalizedCatalogId, stored, attemptedAt);
     AppCatalog catalog =
-        AppCatalogVerifier.verify(fetched.catalogBytes(), fetched.signatureBytes(), trustedKeys);
-    if (!normalizedCatalogId.equals(catalog.catalogId())) {
-      throw new AppCatalogException(
-          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
-          "refreshed catalog id does not match configured source: " + normalizedCatalogId);
+        verifyForRefresh(normalizedCatalogId, stored, attemptedAt, fetched, trustedKeys);
+    sourceStore.write(catalog, stored.source(), fetched, stored.addedAt(), attemptedAt);
+    return AppCatalogSourceSnapshot.of(
+        catalog,
+        stored.source(),
+        stored.addedAt(),
+        attemptedAt,
+        AppCatalogSourceRefreshMetadata.success(
+            attemptedAt, resolvedCatalogUri(fetched, stored.source())));
+  }
+
+  private FetchedCatalog fetchForRefresh(
+      String normalizedCatalogId, StoredCatalogSource stored, Instant attemptedAt) {
+    try {
+      return fetcher.fetch(stored.source());
+    } catch (AppCatalogException exception) {
+      recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, exception);
+      throw exception;
+    } catch (IOException exception) {
+      AppCatalogException catalogException =
+          new AppCatalogException(
+              AppCatalogSidecars.CATALOG_FETCH_FAILED,
+              "failed to refresh catalog source: " + normalizedCatalogId,
+              exception);
+      recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, catalogException);
+      throw catalogException;
     }
-    Instant refreshedAt = Instant.now();
-    sourceStore.write(catalog, stored.source(), fetched, stored.addedAt(), refreshedAt);
-    return AppCatalogSourceSnapshot.of(catalog, stored.source(), stored.addedAt(), refreshedAt);
+  }
+
+  private AppCatalog verifyForRefresh(
+      String normalizedCatalogId,
+      StoredCatalogSource stored,
+      Instant attemptedAt,
+      FetchedCatalog fetched,
+      TrustedAppKeys trustedKeys) {
+    try {
+      AppCatalog catalog =
+          AppCatalogVerifier.verify(fetched.catalogBytes(), fetched.signatureBytes(), trustedKeys);
+      if (!normalizedCatalogId.equals(catalog.catalogId())) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+            "refreshed catalog id does not match configured source: " + normalizedCatalogId);
+      }
+      return catalog;
+    } catch (AppCatalogException exception) {
+      recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, exception);
+      throw exception;
+    }
   }
 
   /**
@@ -239,7 +307,19 @@ public final class AppCatalogManager {
       StoredCatalogSource stored, TrustedAppKeys trustedKeys) {
     AppCatalog catalog = verifyStoredCatalog(stored, trustedKeys);
     return AppCatalogSourceSnapshot.of(
-        catalog, stored.source(), stored.addedAt(), stored.refreshedAt());
+        catalog, stored.source(), stored.addedAt(), stored.refreshedAt(), stored.refreshMetadata());
+  }
+
+  private void recordRefreshFailure(
+      String normalizedCatalogId,
+      StoredCatalogSource stored,
+      Instant attemptedAt,
+      AppCatalogException exception) {
+    try {
+      sourceStore.recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, exception);
+    } catch (IOException metadataException) {
+      exception.addSuppressed(metadataException);
+    }
   }
 
   private static AppCatalog verifyStoredCatalog(
@@ -256,6 +336,10 @@ public final class AppCatalogManager {
     } catch (AppCatalogException _) {
       throw new AppCatalogException(AppCatalogSidecars.CATALOG_NOT_FOUND, "Catalog not found.");
     }
+  }
+
+  private static String resolvedCatalogUri(FetchedCatalog fetched, AppCatalogSource source) {
+    return fetched.resolvedCatalogUri().orElseGet(source::resolvedCatalogFetchUri);
   }
 
   /**

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSidecars.java
@@ -31,6 +31,18 @@ final class AppCatalogSidecars {
   /** Error code used when an operator-configured catalog source cannot be used safely. */
   static final String INVALID_CATALOG_SOURCE = "invalid_catalog_source";
 
+  /** Error code used when a catalog source transport is not supported by the runtime. */
+  static final String UNSUPPORTED_CATALOG_SOURCE = "unsupported_catalog_source";
+
+  /** Error code used when a Crypta catalog source cannot be fetched because no runtime is wired. */
+  static final String CATALOG_FETCH_UNAVAILABLE = "catalog_fetch_unavailable";
+
+  /** Error code used when a catalog source fetch fails after source validation. */
+  static final String CATALOG_FETCH_FAILED = "catalog_fetch_failed";
+
+  /** Error code used when a catalog signature sidecar is missing. */
+  static final String CATALOG_SIGNATURE_MISSING = "catalog_signature_missing";
+
   /** Error code used when catalog signature metadata or verification fails. */
   static final String INVALID_CATALOG_SIGNATURE = "invalid_catalog_signature";
 
@@ -66,6 +78,24 @@ final class AppCatalogSidecars {
 
   /** Optional UTF-8 byte-order mark accepted only at the start of text sidecars. */
   private static final char UTF_8_BOM = '\uFEFF';
+
+  /** Diagnostic field name used for operator-configured catalog source URIs. */
+  private static final String CATALOG_SOURCE_URI_FIELD = "catalog source URI";
+
+  /** Diagnostic field name used for authenticated app bundle artifact URIs. */
+  private static final String ARTIFACT_URI_FIELD = "artifact URI";
+
+  /** URI scheme for remote TLS-backed catalog and metadata sources. */
+  private static final String HTTPS_SCHEME = "https";
+
+  /** URI scheme for loopback-only plaintext development sources. */
+  private static final String HTTP_SCHEME = "http";
+
+  /** URI scheme for local filesystem sources. */
+  private static final String FILE_SCHEME = "file";
+
+  /** URI scheme for Crypta network content sources. */
+  private static final String CRYPTA_SCHEME = "crypta";
 
   /** Strict lowercase hexadecimal SHA-256 digest grammar for catalog artifact metadata. */
   private static final Pattern LOWERCASE_SHA256_PATTERN = Pattern.compile("[0-9a-f]{64}");
@@ -254,8 +284,8 @@ final class AppCatalogSidecars {
    * @throws AppCatalogException if the URI is not absolute or uses an unsupported scheme
    */
   static URI requireSafeCatalogSourceUri(URI uri) throws AppCatalogException {
-    URI normalized = normalizeUri(uri, INVALID_CATALOG_SOURCE, "catalog source URI");
-    requireSupportedScheme(normalized, INVALID_CATALOG_SOURCE, "catalog source URI");
+    URI normalized = normalizeUri(uri, INVALID_CATALOG_SOURCE, CATALOG_SOURCE_URI_FIELD);
+    requireSupportedSourceScheme(normalized);
     return normalized;
   }
 
@@ -267,8 +297,11 @@ final class AppCatalogSidecars {
    * @throws AppCatalogException if the URI is not absolute or uses an unsupported scheme
    */
   static URI requireSafeArtifactUri(URI uri) throws AppCatalogException {
-    URI normalized = normalizeUri(uri, INVALID_CATALOG_ENTRY, "artifact URI");
-    requireSupportedScheme(normalized, INVALID_CATALOG_ENTRY, "artifact URI");
+    URI normalized = normalizeUri(uri, INVALID_CATALOG_ENTRY, ARTIFACT_URI_FIELD);
+    if (CRYPTA_SCHEME.equalsIgnoreCase(normalized.getScheme())) {
+      throw unsupportedArtifactScheme(normalized.getScheme());
+    }
+    requireSupportedArtifactScheme(normalized);
     return normalized;
   }
 
@@ -293,11 +326,11 @@ final class AppCatalogSidecars {
     }
     String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
     switch (normalizedScheme) {
-      case "https" -> {
+      case HTTPS_SCHEME -> {
         requireRemoteHttpUri(normalized, INVALID_CATALOG_ENTRY, fieldName);
         return normalized;
       }
-      case "http" -> {
+      case HTTP_SCHEME -> {
         requireRemoteHttpUri(normalized, INVALID_CATALOG_ENTRY, fieldName);
         if (isLocalhost(normalized.getHost())) {
           return normalized;
@@ -383,38 +416,65 @@ final class AppCatalogSidecars {
   }
 
   /**
-   * Applies catalog transport scheme policy to a normalized URI.
+   * Applies authenticated bundle artifact transport policy to a normalized URI.
    *
-   * @param uri absolute URI to validate
-   * @param errorCode catalog error code for validation failures
-   * @param fieldName field name used in diagnostics
+   * @param uri absolute artifact URI to validate
    * @throws AppCatalogException if the URI scheme is unsupported or unsafe
    */
-  private static void requireSupportedScheme(URI uri, String errorCode, String fieldName)
-      throws AppCatalogException {
+  private static void requireSupportedArtifactScheme(URI uri) throws AppCatalogException {
     String scheme = uri.getScheme();
     if (scheme == null) {
-      throw new AppCatalogException(errorCode, fieldName + " must include a URI scheme");
+      throw new AppCatalogException(
+          INVALID_CATALOG_ENTRY, ARTIFACT_URI_FIELD + " must include a URI scheme");
     }
     String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
     switch (normalizedScheme) {
-      case "https" -> {
-        requireRemoteHttpUri(uri, errorCode, fieldName);
+      case HTTPS_SCHEME -> {
+        requireRemoteHttpUri(uri, INVALID_CATALOG_ENTRY, ARTIFACT_URI_FIELD);
         return;
       }
-      case "file" -> {
-        requireLocalFileUri(uri, errorCode, fieldName);
+      case FILE_SCHEME -> {
+        requireLocalFileUri(uri, INVALID_CATALOG_ENTRY, ARTIFACT_URI_FIELD);
         return;
       }
-      case "http" -> {
-        requireRemoteHttpUri(uri, errorCode, fieldName);
+      case HTTP_SCHEME -> {
+        requireRemoteHttpUri(uri, INVALID_CATALOG_ENTRY, ARTIFACT_URI_FIELD);
         if (isLocalhost(uri.getHost())) {
           return;
         }
       }
-      default -> throw unsupportedScheme(errorCode, fieldName, scheme);
+      default -> throw unsupportedArtifactScheme(scheme);
     }
-    throw unsupportedScheme(errorCode, fieldName, scheme);
+    throw unsupportedArtifactScheme(scheme);
+  }
+
+  private static void requireSupportedSourceScheme(URI uri) {
+    String scheme = uri.getScheme();
+    if (scheme == null) {
+      throw new AppCatalogException(
+          INVALID_CATALOG_SOURCE, CATALOG_SOURCE_URI_FIELD + " must include a URI scheme");
+    }
+    String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
+    switch (normalizedScheme) {
+      case HTTPS_SCHEME ->
+          requireRemoteHttpUri(uri, INVALID_CATALOG_SOURCE, CATALOG_SOURCE_URI_FIELD);
+      case FILE_SCHEME ->
+          requireLocalFileUri(uri, INVALID_CATALOG_SOURCE, CATALOG_SOURCE_URI_FIELD);
+      case HTTP_SCHEME -> {
+        requireRemoteHttpUri(uri, INVALID_CATALOG_SOURCE, CATALOG_SOURCE_URI_FIELD);
+        if (isLocalhost(uri.getHost())) {
+          return;
+        }
+        throw unsupportedScheme(UNSUPPORTED_CATALOG_SOURCE, CATALOG_SOURCE_URI_FIELD, scheme);
+      }
+      case CRYPTA_SCHEME -> CryptaCatalogUri.parse(uri.toString());
+      default ->
+          throw unsupportedScheme(UNSUPPORTED_CATALOG_SOURCE, CATALOG_SOURCE_URI_FIELD, scheme);
+    }
+  }
+
+  private static AppCatalogException unsupportedArtifactScheme(String scheme) {
+    return unsupportedScheme(INVALID_CATALOG_ENTRY, ARTIFACT_URI_FIELD, scheme);
   }
 
   private static AppCatalogException unsupportedScheme(

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSource.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSource.java
@@ -13,12 +13,13 @@ import java.util.regex.Pattern;
  * <p>A source identifies the catalog properties file. The matching signature is resolved as a
  * sibling named {@code cryptad-app-catalog.signature}. Local filesystem paths are converted to
  * {@code file:} URIs at construction time so the fetcher can apply one scheme-based policy for
- * local, HTTPS, and loopback-HTTP sources.
+ * local, HTTPS, loopback-HTTP, and Crypta sources.
  *
  * <p>The source model stores a URI, not raw operator input. Parsing accepts common local path
  * forms, including Windows drive-letter paths, before falling back to URI handling. Remote
  * non-loopback sources must use HTTPS. Plain HTTP is reserved for explicit loopback development and
- * test sources after host validation in {@link AppCatalogSidecars}.
+ * test sources after host validation in {@link AppCatalogSidecars}. Crypta sources are accepted as
+ * {@code crypta:USK@...}, {@code crypta:SSK@...}, or {@code crypta:CHK@...?signature=CHK@...}.
  *
  * @param uri absolute source URI for {@code cryptad-app-catalog.properties}
  */
@@ -56,6 +57,9 @@ public record AppCatalogSource(URI uri) {
     String value =
         AppCatalogSidecars.requireNonBlankSingleLine(
             rawSource, "source", AppCatalogSidecars.INVALID_CATALOG_SOURCE);
+    if (value.toLowerCase(java.util.Locale.ROOT).startsWith("crypta:")) {
+      return new AppCatalogSource(CryptaCatalogUri.parse(value).toUri());
+    }
     if (WINDOWS_DRIVE_PATH_PATTERN.matcher(value).matches()) {
       return parseLocalPathSource(value, null);
     }
@@ -97,7 +101,51 @@ public record AppCatalogSource(URI uri) {
    * @return sibling signature URI for this source
    */
   public URI signatureUri() {
+    if (kind() == AppCatalogSourceKind.CRYPTA) {
+      return cryptaCatalogUri().signatureUri();
+    }
     return uri.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME);
+  }
+
+  /**
+   * Returns the source transport family.
+   *
+   * @return normalized source kind for fetch and API status metadata
+   */
+  public AppCatalogSourceKind kind() {
+    return switch (uri.getScheme().toLowerCase(java.util.Locale.ROOT)) {
+      case "file" -> AppCatalogSourceKind.FILE;
+      case "http" -> AppCatalogSourceKind.HTTP;
+      case "https" -> AppCatalogSourceKind.HTTPS;
+      case "crypta" -> AppCatalogSourceKind.CRYPTA;
+      default ->
+          throw new AppCatalogException(
+              AppCatalogSidecars.UNSUPPORTED_CATALOG_SOURCE,
+              "unsupported catalog source URI scheme: " + uri.getScheme());
+    };
+  }
+
+  /**
+   * Returns the URI or Crypta key used by the runtime fetch layer for the catalog sidecar.
+   *
+   * <p>For Crypta sources this strips the {@code crypta:} scheme and any CHK signature companion
+   * query. For existing file, HTTP, and HTTPS sources it is the normalized source URI string.
+   *
+   * @return resolved fetch target for diagnostic metadata
+   */
+  public String resolvedCatalogFetchUri() {
+    if (kind() == AppCatalogSourceKind.CRYPTA) {
+      return cryptaCatalogUri().catalogFetchKey();
+    }
+    return uri.toString();
+  }
+
+  CryptaCatalogUri cryptaCatalogUri() {
+    if (kind() != AppCatalogSourceKind.CRYPTA) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, "catalog source is not a crypta URI");
+    }
+    return CryptaCatalogUri.parse(uri.toString());
   }
 
   /**

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceKind.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceKind.java
@@ -1,0 +1,47 @@
+package network.crypta.platform.appcatalog;
+
+/**
+ * Transport family used by a configured signed app catalog source.
+ *
+ * <p>The kind describes how catalog properties and signature sidecars are fetched. It is not a
+ * trust decision. Every source kind still feeds the same signed-catalog verifier, and catalog keys
+ * remain the authority for accepting catalog metadata. The enum exists so managers, stores, API
+ * responses, and shell UI can talk about source behavior without repeatedly parsing URI schemes.
+ *
+ * <p>{@link #HTTP} is intentionally narrower than a generic web source: app catalogs only accept
+ * loopback HTTP for local development. Public remote distribution should use {@link #HTTPS} or
+ * {@link #CRYPTA}; local operator-managed files use {@link #FILE}.
+ */
+public enum AppCatalogSourceKind {
+  /**
+   * Local filesystem source represented as a {@code file:} URI.
+   *
+   * <p>This kind covers operator-managed catalog files on the node host. The source is fetched from
+   * local storage, but signatures are still verified before the catalog can replace stored state.
+   */
+  FILE,
+
+  /**
+   * Loopback-only plaintext development source represented as an {@code http:} URI.
+   *
+   * <p>Only localhost-style hosts are accepted for this kind. It is useful for local tooling and
+   * tests, not for public catalog distribution.
+   */
+  HTTP,
+
+  /**
+   * Remote TLS source represented as an {@code https:} URI.
+   *
+   * <p>This kind fetches catalog sidecars over HTTPS. TLS protects the transport, while catalog
+   * signatures still provide the application-level authenticity check.
+   */
+  HTTPS,
+
+  /**
+   * Crypta content source represented as a {@code crypta:} URI.
+   *
+   * <p>This kind fetches catalog sidecars through the runtime content-fetch port. Crypta keys are
+   * treated as transport locations; signed catalog verification remains mandatory.
+   */
+  CRYPTA
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceRefreshMetadata.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceRefreshMetadata.java
@@ -1,0 +1,118 @@
+package network.crypta.platform.appcatalog;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable sync metadata for one configured app catalog source.
+ *
+ * <p>This record separates a refresh attempt from a verified refresh. A failed fetch, missing
+ * signature, or invalid signature updates the attempt fields but does not move {@link
+ * #lastSuccessfulRefreshAt()}. That distinction lets the manager keep serving the last verified
+ * catalog while the API and Web Shell report the failed sync attempt.
+ *
+ * <p>Error text is stored only as bounded single-line diagnostic metadata. It is intended for
+ * operator-facing status displays and logs, not for reconstructing stack traces or exposing raw
+ * transport errors. The resolved URI is likewise diagnostic: for Crypta USK fetches it may show the
+ * edition reported by the runtime fetch layer, but catalog signatures remain the trust boundary.
+ *
+ * @param lastAttemptAt timestamp of the most recent source refresh attempt
+ * @param lastSuccessfulRefreshAt timestamp of the most recent verified catalog refresh
+ * @param lastFetchStatus status of the most recent refresh attempt
+ * @param lastFetchErrorCode stable error code from the last failed attempt, when present
+ * @param lastFetchErrorMessage safe diagnostic text from the last failed attempt, when present
+ * @param lastResolvedUri transport-reported resolved URI or fetch key, when available
+ */
+record AppCatalogSourceRefreshMetadata(
+    Instant lastAttemptAt,
+    Instant lastSuccessfulRefreshAt,
+    AppCatalogFetchStatus lastFetchStatus,
+    Optional<String> lastFetchErrorCode,
+    Optional<String> lastFetchErrorMessage,
+    Optional<String> lastResolvedUri) {
+  /** Maximum persisted characters for a UI-safe refresh failure message. */
+  private static final int MAX_ERROR_MESSAGE_CHARS = 512;
+
+  /**
+   * Validates and normalizes refresh metadata.
+   *
+   * <p>The constructor keeps the record internally consistent. Successful metadata cannot carry an
+   * error code or message, and failed messages are normalized before storage so they remain safe
+   * for property files and compact API responses.
+   */
+  AppCatalogSourceRefreshMetadata {
+    Objects.requireNonNull(lastAttemptAt, "lastAttemptAt");
+    Objects.requireNonNull(lastSuccessfulRefreshAt, "lastSuccessfulRefreshAt");
+    Objects.requireNonNull(lastFetchStatus, "lastFetchStatus");
+    Objects.requireNonNull(lastFetchErrorCode, "lastFetchErrorCode");
+    Objects.requireNonNull(lastFetchErrorMessage, "lastFetchErrorMessage");
+    Objects.requireNonNull(lastResolvedUri, "lastResolvedUri");
+    lastFetchErrorMessage =
+        lastFetchErrorMessage.map(AppCatalogSourceRefreshMetadata::normalizeErrorMessage);
+    if (lastFetchStatus == AppCatalogFetchStatus.SUCCESS
+        && (lastFetchErrorCode.isPresent() || lastFetchErrorMessage.isPresent())) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          "successful catalog fetch metadata must not include an error");
+    }
+  }
+
+  /**
+   * Creates metadata for a newly verified catalog refresh.
+   *
+   * <p>All attempt and success timestamps point at the same instant because the refresh completed.
+   * Error fields are empty, and the resolved URI captures the source location or transport-reported
+   * final URI that produced the verified catalog bytes.
+   *
+   * @param refreshedAt instant when the verified catalog was written
+   * @param resolvedUri source URI or transport-resolved fetch key for diagnostics
+   * @return success metadata suitable for persisting with verified sidecars
+   */
+  static AppCatalogSourceRefreshMetadata success(Instant refreshedAt, String resolvedUri) {
+    return new AppCatalogSourceRefreshMetadata(
+        refreshedAt,
+        refreshedAt,
+        AppCatalogFetchStatus.SUCCESS,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(resolvedUri));
+  }
+
+  /**
+   * Returns metadata for a failed refresh attempt without changing the last successful timestamp.
+   *
+   * <p>The returned value records the new attempt time and stable error details while preserving
+   * the previous success time. Managers use this after fetch or verification failures so stored
+   * catalog sidecars remain authoritative until a later refresh verifies successfully.
+   *
+   * @param attemptedAt instant when the failed refresh attempt started
+   * @param exception catalog-layer failure containing the stable error code
+   * @param resolvedUri source URI or fetch key to report for the failed attempt
+   * @return failed-attempt metadata preserving the prior success timestamp
+   */
+  AppCatalogSourceRefreshMetadata failedAttempt(
+      Instant attemptedAt, AppCatalogException exception, String resolvedUri) {
+    return new AppCatalogSourceRefreshMetadata(
+        attemptedAt,
+        lastSuccessfulRefreshAt,
+        AppCatalogFetchStatus.FAILED,
+        Optional.of(exception.errorCode()),
+        Optional.ofNullable(exception.getMessage()),
+        Optional.ofNullable(resolvedUri));
+  }
+
+  /**
+   * Converts error text into bounded single-line status metadata.
+   *
+   * @param value raw exception message or runtime fetch diagnostic text
+   * @return trimmed single-line value capped for property files and API responses
+   */
+  private static String normalizeErrorMessage(String value) {
+    String singleLine = value.replace('\n', ' ').replace('\r', ' ').replace('\t', ' ').trim();
+    if (singleLine.length() <= MAX_ERROR_MESSAGE_CHARS) {
+      return singleLine;
+    }
+    return singleLine.substring(0, MAX_ERROR_MESSAGE_CHARS);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceSnapshot.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceSnapshot.java
@@ -3,6 +3,7 @@ package network.crypta.platform.appcatalog;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * API-friendly snapshot of one configured catalog source.
@@ -23,6 +24,12 @@ import java.util.Objects;
  * @param appCount number of app entries currently available
  * @param addedAt timestamp when the source was first configured locally
  * @param refreshedAt timestamp when the stored catalog was last fetched and verified
+ * @param lastAttemptAt timestamp when the source was last refresh-attempted
+ * @param lastSuccessfulRefreshAt timestamp when the source was last successfully verified
+ * @param lastFetchStatus status of the most recent refresh attempt
+ * @param lastFetchErrorCode stable error code from the most recent failed refresh attempt
+ * @param lastFetchErrorMessage diagnostic message from the most recent failed refresh attempt
+ * @param lastResolvedUri source URI or Crypta key used by the last fetch attempt
  */
 public record AppCatalogSourceSnapshot(
     String catalogId,
@@ -31,7 +38,13 @@ public record AppCatalogSourceSnapshot(
     Instant generatedAt,
     int appCount,
     Instant addedAt,
-    Instant refreshedAt) {
+    Instant refreshedAt,
+    Instant lastAttemptAt,
+    Instant lastSuccessfulRefreshAt,
+    AppCatalogFetchStatus lastFetchStatus,
+    Optional<String> lastFetchErrorCode,
+    Optional<String> lastFetchErrorMessage,
+    Optional<String> lastResolvedUri) {
   /**
    * Creates a validated source snapshot.
    *
@@ -46,6 +59,12 @@ public record AppCatalogSourceSnapshot(
    * @param appCount number of app entries currently available
    * @param addedAt timestamp when the source was first configured locally
    * @param refreshedAt timestamp when the stored catalog was last fetched and verified
+   * @param lastAttemptAt timestamp when the source was last refresh-attempted
+   * @param lastSuccessfulRefreshAt timestamp when the source was last successfully verified
+   * @param lastFetchStatus status of the most recent refresh attempt
+   * @param lastFetchErrorCode stable error code from the most recent failed refresh attempt
+   * @param lastFetchErrorMessage diagnostic message from the most recent failed refresh attempt
+   * @param lastResolvedUri source URI or Crypta key used by the last fetch attempt
    */
   public AppCatalogSourceSnapshot {
     catalogId = AppCatalog.normalizeCatalogId(catalogId);
@@ -59,10 +78,20 @@ public record AppCatalogSourceSnapshot(
     }
     Objects.requireNonNull(addedAt, "addedAt");
     Objects.requireNonNull(refreshedAt, "refreshedAt");
+    Objects.requireNonNull(lastAttemptAt, "lastAttemptAt");
+    Objects.requireNonNull(lastSuccessfulRefreshAt, "lastSuccessfulRefreshAt");
+    Objects.requireNonNull(lastFetchStatus, "lastFetchStatus");
+    Objects.requireNonNull(lastFetchErrorCode, "lastFetchErrorCode");
+    Objects.requireNonNull(lastFetchErrorMessage, "lastFetchErrorMessage");
+    Objects.requireNonNull(lastResolvedUri, "lastResolvedUri");
   }
 
   static AppCatalogSourceSnapshot of(
-      AppCatalog catalog, AppCatalogSource source, Instant addedAt, Instant refreshedAt) {
+      AppCatalog catalog,
+      AppCatalogSource source,
+      Instant addedAt,
+      Instant refreshedAt,
+      AppCatalogSourceRefreshMetadata refreshMetadata) {
     return new AppCatalogSourceSnapshot(
         catalog.catalogId(),
         catalog.name(),
@@ -70,6 +99,22 @@ public record AppCatalogSourceSnapshot(
         catalog.generatedAt(),
         catalog.entries().size(),
         addedAt,
-        refreshedAt);
+        refreshedAt,
+        refreshMetadata.lastAttemptAt(),
+        refreshMetadata.lastSuccessfulRefreshAt(),
+        refreshMetadata.lastFetchStatus(),
+        refreshMetadata.lastFetchErrorCode(),
+        refreshMetadata.lastFetchErrorMessage(),
+        refreshMetadata.lastResolvedUri());
+  }
+
+  /**
+   * Returns the configured source transport family.
+   *
+   * @return normalized source kind derived from {@link #sourceUri()}
+   */
+  @SuppressWarnings("unused")
+  public AppCatalogSourceKind sourceKind() {
+    return new AppCatalogSource(sourceUri).kind();
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
@@ -218,11 +218,20 @@ public final class AppCatalogSourceStore {
       Instant attemptedAt,
       AppCatalogException exception)
       throws IOException {
+    recordRefreshFailure(
+        catalogId, stored, attemptedAt, exception, stored.source().resolvedCatalogFetchUri());
+  }
+
+  void recordRefreshFailure(
+      String catalogId,
+      StoredCatalogSource stored,
+      Instant attemptedAt,
+      AppCatalogException exception,
+      String resolvedUri)
+      throws IOException {
     String normalizedCatalogId = AppCatalog.normalizeCatalogId(catalogId);
     AppCatalogSourceRefreshMetadata metadata =
-        stored
-            .refreshMetadata()
-            .failedAttempt(attemptedAt, exception, stored.source().resolvedCatalogFetchUri());
+        stored.refreshMetadata().failedAttempt(attemptedAt, exception, resolvedUri);
     Path directory = catalogDirectory(normalizedCatalogId);
     sourceMetadataWriter.write(
         directory,

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * File-backed store for configured app catalog sources and their verified sidecars.
@@ -36,6 +37,12 @@ public final class AppCatalogSourceStore {
   private static final String SOURCE_URI_KEY = "source.uri";
   private static final String ADDED_AT_KEY = "source.addedAt";
   private static final String REFRESHED_AT_KEY = "source.refreshedAt";
+  private static final String LAST_ATTEMPT_AT_KEY = "source.lastAttemptAt";
+  private static final String LAST_SUCCESSFUL_REFRESH_AT_KEY = "source.lastSuccessfulRefreshAt";
+  private static final String LAST_FETCH_STATUS_KEY = "source.lastFetchStatus";
+  private static final String LAST_FETCH_ERROR_CODE_KEY = "source.lastFetchErrorCode";
+  private static final String LAST_FETCH_ERROR_MESSAGE_KEY = "source.lastFetchErrorMessage";
+  private static final String LAST_RESOLVED_URI_KEY = "source.lastResolvedUri";
 
   private final Path rootDirectory;
   private final SourceMetadataWriter sourceMetadataWriter;
@@ -188,7 +195,13 @@ public final class AppCatalogSourceStore {
       sourceMetadataWriter.write(
           directory,
           sourceFile,
-          serializeSource(catalog.catalogId(), source, addedAt, refreshedAt));
+          serializeSource(
+              catalog.catalogId(),
+              source,
+              addedAt,
+              refreshedAt,
+              AppCatalogSourceRefreshMetadata.success(
+                  refreshedAt, resolvedCatalogUri(fetchedCatalog, source))));
     } catch (IOException exception) {
       if (previousFetchedCatalog == null) {
         cleanupIncompleteAdd(directory, exception);
@@ -197,6 +210,29 @@ public final class AppCatalogSourceStore {
       }
       throw exception;
     }
+  }
+
+  void recordRefreshFailure(
+      String catalogId,
+      StoredCatalogSource stored,
+      Instant attemptedAt,
+      AppCatalogException exception)
+      throws IOException {
+    String normalizedCatalogId = AppCatalog.normalizeCatalogId(catalogId);
+    AppCatalogSourceRefreshMetadata metadata =
+        stored
+            .refreshMetadata()
+            .failedAttempt(attemptedAt, exception, stored.source().resolvedCatalogFetchUri());
+    Path directory = catalogDirectory(normalizedCatalogId);
+    sourceMetadataWriter.write(
+        directory,
+        directory.resolve(SOURCE_FILE_NAME),
+        serializeSource(
+            normalizedCatalogId,
+            stored.source(),
+            stored.addedAt(),
+            stored.refreshedAt(),
+            metadata));
   }
 
   /**
@@ -231,12 +267,46 @@ public final class AppCatalogSourceStore {
     Instant addedAt = parseInstant(removeRequired(properties, ADDED_AT_KEY), ADDED_AT_KEY);
     Instant refreshedAt =
         parseInstant(removeRequired(properties, REFRESHED_AT_KEY), REFRESHED_AT_KEY);
+    AppCatalogSourceRefreshMetadata refreshMetadata =
+        parseRefreshMetadata(properties, refreshedAt, source);
     if (!properties.isEmpty()) {
       throw new AppCatalogException(
           AppCatalogSidecars.INVALID_CATALOG_SOURCE,
           "unsupported catalog source property: " + properties.keySet().iterator().next());
     }
-    return new StoredCatalogSource(source, addedAt, refreshedAt, readFetchedCatalog(directory));
+    return new StoredCatalogSource(
+        source, addedAt, refreshedAt, refreshMetadata, readFetchedCatalog(directory));
+  }
+
+  private static AppCatalogSourceRefreshMetadata parseRefreshMetadata(
+      Map<String, String> properties, Instant refreshedAt, AppCatalogSource source) {
+    Optional<String> lastAttemptAtText = removeOptional(properties, LAST_ATTEMPT_AT_KEY);
+    Instant lastAttemptAt =
+        lastAttemptAtText
+            .map(value -> parseInstant(value, LAST_ATTEMPT_AT_KEY))
+            .orElse(refreshedAt);
+    Optional<String> lastSuccessfulRefreshAtText =
+        removeOptional(properties, LAST_SUCCESSFUL_REFRESH_AT_KEY);
+    Instant lastSuccessfulRefreshAt =
+        lastSuccessfulRefreshAtText
+            .map(value -> parseInstant(value, LAST_SUCCESSFUL_REFRESH_AT_KEY))
+            .orElse(refreshedAt);
+    AppCatalogFetchStatus lastFetchStatus =
+        removeOptional(properties, LAST_FETCH_STATUS_KEY)
+            .map(AppCatalogFetchStatus::parse)
+            .orElse(AppCatalogFetchStatus.SUCCESS);
+    Optional<String> errorCode = removeOptional(properties, LAST_FETCH_ERROR_CODE_KEY);
+    Optional<String> errorMessage = removeOptional(properties, LAST_FETCH_ERROR_MESSAGE_KEY);
+    Optional<String> lastResolvedUri =
+        removeOptional(properties, LAST_RESOLVED_URI_KEY)
+            .or(() -> Optional.of(source.resolvedCatalogFetchUri()));
+    return new AppCatalogSourceRefreshMetadata(
+        lastAttemptAt,
+        lastSuccessfulRefreshAt,
+        lastFetchStatus,
+        errorCode,
+        errorMessage,
+        lastResolvedUri);
   }
 
   private FetchedCatalog readFetchedCatalog(Path directory) throws IOException {
@@ -368,25 +438,65 @@ public final class AppCatalogSourceStore {
     return value;
   }
 
+  private static Optional<String> removeOptional(Map<String, String> properties, String key) {
+    return Optional.ofNullable(properties.remove(key));
+  }
+
   private static String serializeSource(
-      String catalogId, AppCatalogSource source, Instant addedAt, Instant refreshedAt) {
-    return SOURCE_VERSION_KEY
-        + "=1\n"
-        + CATALOG_ID_KEY
-        + "="
-        + catalogId
-        + "\n"
-        + SOURCE_URI_KEY
-        + "="
-        + source.displayUri()
-        + "\n"
-        + ADDED_AT_KEY
-        + "="
-        + addedAt
-        + "\n"
-        + REFRESHED_AT_KEY
-        + "="
-        + refreshedAt
-        + "\n";
+      String catalogId,
+      AppCatalogSource source,
+      Instant addedAt,
+      Instant refreshedAt,
+      AppCatalogSourceRefreshMetadata refreshMetadata) {
+    StringBuilder builder =
+        new StringBuilder()
+            .append(SOURCE_VERSION_KEY)
+            .append("=1\n")
+            .append(CATALOG_ID_KEY)
+            .append('=')
+            .append(catalogId)
+            .append('\n')
+            .append(SOURCE_URI_KEY)
+            .append('=')
+            .append(source.displayUri())
+            .append('\n')
+            .append(ADDED_AT_KEY)
+            .append('=')
+            .append(addedAt)
+            .append('\n')
+            .append(REFRESHED_AT_KEY)
+            .append('=')
+            .append(refreshedAt)
+            .append('\n')
+            .append(LAST_ATTEMPT_AT_KEY)
+            .append('=')
+            .append(refreshMetadata.lastAttemptAt())
+            .append('\n')
+            .append(LAST_SUCCESSFUL_REFRESH_AT_KEY)
+            .append('=')
+            .append(refreshMetadata.lastSuccessfulRefreshAt())
+            .append('\n')
+            .append(LAST_FETCH_STATUS_KEY)
+            .append('=')
+            .append(refreshMetadata.lastFetchStatus().metadataValue())
+            .append('\n');
+    refreshMetadata
+        .lastFetchErrorCode()
+        .ifPresent(value -> appendProperty(builder, LAST_FETCH_ERROR_CODE_KEY, value));
+    refreshMetadata
+        .lastFetchErrorMessage()
+        .ifPresent(value -> appendProperty(builder, LAST_FETCH_ERROR_MESSAGE_KEY, value));
+    refreshMetadata
+        .lastResolvedUri()
+        .ifPresent(value -> appendProperty(builder, LAST_RESOLVED_URI_KEY, value));
+    return builder.toString();
+  }
+
+  private static void appendProperty(StringBuilder builder, String key, String value) {
+    builder.append(key).append('=').append(value).append('\n');
+  }
+
+  private static String resolvedCatalogUri(FetchedCatalog fetchedCatalog, AppCatalogSource source) {
+    return fetchedCatalog.resolvedCatalogUri().orElseGet(source::resolvedCatalogFetchUri);
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/CryptaCatalogUri.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/CryptaCatalogUri.java
@@ -147,6 +147,29 @@ public record CryptaCatalogUri(
   }
 
   /**
+   * Resolves the signature fetch key that matches a fetched catalog result.
+   *
+   * <p>CHK catalog sources use an explicit immutable signature companion, so the companion from the
+   * original source is always returned. USK and SSK sources use sibling sidecars. When the runtime
+   * fetch layer reports a resolved catalog key, such as a newer concrete USK edition, the signature
+   * sibling is derived from that resolved catalog key so catalog properties and signature bytes
+   * come from the same edition. If the runtime cannot report a resolved key, the original sibling
+   * signature key is used.
+   *
+   * @param resolvedCatalogFetchKey final catalog key reported by the runtime fetch layer, or {@code
+   *     null} when unavailable
+   * @return bare Crypta key to fetch for the catalog signature sidecar
+   */
+  String signatureFetchKeyForResolvedCatalog(String resolvedCatalogFetchKey) {
+    if (!usesSiblingSignatureSidecar() || resolvedCatalogFetchKey == null) {
+      return signatureFetchKey;
+    }
+    String resolvedKey = normalizeResolvedCatalogFetchKey(resolvedCatalogFetchKey);
+    requireCompatibleResolvedKeyKind(resolvedKey);
+    return siblingSignatureKey(resolvedKey);
+  }
+
+  /**
    * Rejects unsupported query shapes before deriving fetch keys.
    *
    * @param catalogKey parsed catalog key portion before any signature companion
@@ -181,6 +204,54 @@ public record CryptaCatalogUri(
           "crypta USK/SSK catalog source must include a path-like key");
     }
     return catalogKey.substring(0, slashIndex + 1) + AppCatalogSignature.SIGNATURE_FILE_NAME;
+  }
+
+  /**
+   * Reports whether this catalog source derives its signature from a sibling path.
+   *
+   * @return {@code true} for path-like USK and SSK sources
+   */
+  private boolean usesSiblingSignatureSidecar() {
+    return catalogFetchKey.startsWith(USK_PREFIX) || catalogFetchKey.startsWith(SSK_PREFIX);
+  }
+
+  /**
+   * Normalizes the resolved catalog key reported by the runtime fetch layer.
+   *
+   * <p>Runtime implementations normally return bare Crypta keys, but accepting a redundant {@code
+   * crypta:} prefix keeps the catalog layer tolerant of future adapters while still rejecting
+   * queries, fragments, blank values, multiline values, and invalid URI syntax.
+   *
+   * @param resolvedCatalogFetchKey raw resolved key reported for the catalog fetch
+   * @return bare resolved Crypta key
+   */
+  private static String normalizeResolvedCatalogFetchKey(String resolvedCatalogFetchKey) {
+    String normalized =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            Objects.requireNonNull(resolvedCatalogFetchKey, "resolvedCatalogFetchKey"),
+            "resolved catalog Crypta key",
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE);
+    if (normalized.toLowerCase(Locale.ROOT).startsWith(SCHEME_PREFIX)) {
+      normalized = normalized.substring(SCHEME_PREFIX.length());
+    }
+    normalized = requireKey(normalized, "resolved catalog Crypta key");
+    requireUriSyntax(SCHEME_PREFIX + normalized, "resolved crypta catalog source");
+    return normalized;
+  }
+
+  /**
+   * Ensures a resolved sibling source keeps the same mutable key family as the requested source.
+   *
+   * @param resolvedKey normalized bare resolved catalog key
+   */
+  private void requireCompatibleResolvedKeyKind(String resolvedKey) {
+    if ((catalogFetchKey.startsWith(USK_PREFIX) && resolvedKey.startsWith(USK_PREFIX))
+        || (catalogFetchKey.startsWith(SSK_PREFIX) && resolvedKey.startsWith(SSK_PREFIX))) {
+      return;
+    }
+    throw new AppCatalogException(
+        AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+        "resolved crypta catalog source must keep the original key kind");
   }
 
   /**

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/CryptaCatalogUri.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/CryptaCatalogUri.java
@@ -1,0 +1,221 @@
+package network.crypta.platform.appcatalog;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Parsed {@code crypta:} catalog source with explicit catalog and signature fetch keys.
+ *
+ * <p>The {@code crypta:} prefix is a catalog-source transport marker. It is not passed to the
+ * runtime content layer; callers use {@link #catalogFetchKey()} and {@link #signatureFetchKey()} to
+ * obtain the underlying Crypta keys. The original display URI is retained so source metadata and
+ * API responses can show the operator-configured value.
+ *
+ * <p>Crypta catalog sources deliberately keep Crypta keys outside {@link URI#resolve(String)}.
+ * Freenet-style keys are opaque to the JDK URI resolver, so signature sidecar resolution is
+ * specified directly here. USK and SSK catalog keys must be slash-delimited path-like keys and use
+ * the sibling {@link AppCatalogSignature#SIGNATURE_FILE_NAME}. CHK catalog keys are immutable and
+ * ambiguous as bare values, so they require an explicit {@code ?signature=CHK@...} companion.
+ *
+ * @param catalogFetchKey bare Crypta key used to fetch catalog properties bytes
+ * @param signatureFetchKey bare Crypta key used to fetch signature sidecar bytes
+ * @param displayUri normalized {@code crypta:} URI shown in source metadata
+ */
+public record CryptaCatalogUri(
+    String catalogFetchKey, String signatureFetchKey, String displayUri) {
+  /** Scheme marker used by operator-facing catalog source URIs. */
+  private static final String SCHEME_PREFIX = "crypta:";
+
+  /** Diagnostic field name used for operator-facing Crypta catalog source URIs. */
+  private static final String CATALOG_SOURCE_FIELD = "crypta catalog source";
+
+  /** Query fragment that introduces an explicit CHK signature sidecar companion. */
+  private static final String SIGNATURE_QUERY_PREFIX = "?signature=";
+
+  /** Prefix used by immutable Crypta content keys. */
+  private static final String CHK_PREFIX = "CHK@";
+
+  /** Prefix used by signed-subspace Crypta keys. */
+  private static final String SSK_PREFIX = "SSK@";
+
+  /** Prefix used by updatable signed-subspace Crypta keys. */
+  private static final String USK_PREFIX = "USK@";
+
+  /**
+   * Creates a validated Crypta catalog URI value.
+   *
+   * <p>The canonical constructor enforces the same invariants as {@link #parse(String)} for callers
+   * that construct the value directly. Fetch keys must be bare Crypta keys without URI query or
+   * fragment text, and the display URI plus derived signature display URI must be accepted by the
+   * JDK URI parser. Invalid values fail closed with {@code invalid_catalog_source}.
+   */
+  public CryptaCatalogUri {
+    catalogFetchKey = requireKey(catalogFetchKey, "catalog Crypta key");
+    signatureFetchKey = requireKey(signatureFetchKey, "catalog signature Crypta key");
+    displayUri =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            displayUri, CATALOG_SOURCE_FIELD, AppCatalogSidecars.INVALID_CATALOG_SOURCE);
+    if (!displayUri.toLowerCase(Locale.ROOT).startsWith(SCHEME_PREFIX)) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          CATALOG_SOURCE_FIELD + " must use the crypta scheme");
+    }
+    requireUriSyntax(displayUri, CATALOG_SOURCE_FIELD);
+    requireUriSyntax(SCHEME_PREFIX + signatureFetchKey, "crypta catalog signature source");
+  }
+
+  /**
+   * Parses one operator-provided {@code crypta:} catalog source.
+   *
+   * <p>The parser accepts {@code crypta:USK@...}, {@code crypta:SSK@...}, and the explicit CHK
+   * companion form {@code crypta:CHK@...?signature=CHK@...}. It rejects fragments, extra query
+   * parameters, bare CHK sources without a signature companion, and malformed URI syntax. The
+   * returned value contains bare fetch keys suitable for the runtime content-fetch port.
+   *
+   * @param rawSource catalog source text supplied by an operator or API request
+   * @return parsed value with explicit catalog and signature fetch keys
+   */
+  static CryptaCatalogUri parse(String rawSource) {
+    String value =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            rawSource, "source", AppCatalogSidecars.INVALID_CATALOG_SOURCE);
+    if (!value.toLowerCase(Locale.ROOT).startsWith(SCHEME_PREFIX)) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          CATALOG_SOURCE_FIELD + " must use the crypta scheme");
+    }
+    String body = value.substring(SCHEME_PREFIX.length());
+    if (body.indexOf('#') >= 0) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          CATALOG_SOURCE_FIELD + " must not include a fragment");
+    }
+    int signatureQueryIndex = body.indexOf(SIGNATURE_QUERY_PREFIX);
+    String catalogKey = signatureQueryIndex >= 0 ? body.substring(0, signatureQueryIndex) : body;
+    String signatureKey =
+        signatureQueryIndex >= 0
+            ? body.substring(signatureQueryIndex + SIGNATURE_QUERY_PREFIX.length())
+            : null;
+    validateNoExtraQuery(catalogKey, signatureKey);
+    if (catalogKey.startsWith(CHK_PREFIX)) {
+      if (signatureKey == null || !signatureKey.startsWith(CHK_PREFIX)) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+            "crypta CHK catalog source requires a CHK signature companion");
+      }
+      return new CryptaCatalogUri(catalogKey, signatureKey, value);
+    }
+    if (catalogKey.startsWith(USK_PREFIX) || catalogKey.startsWith(SSK_PREFIX)) {
+      if (signatureKey != null) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+            "crypta USK/SSK catalog source must not include a signature query");
+      }
+      return new CryptaCatalogUri(catalogKey, siblingSignatureKey(catalogKey), value);
+    }
+    throw new AppCatalogException(
+        AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+        CATALOG_SOURCE_FIELD + " must start with USK@, SSK@, or CHK@");
+  }
+
+  /**
+   * Returns the operator-facing catalog source URI.
+   *
+   * <p>This URI keeps the {@code crypta:} transport marker. It is useful for source metadata,
+   * diagnostics, and API responses, but callers should not pass it directly to the runtime fetch
+   * layer because that layer expects the bare Crypta key.
+   *
+   * @return validated display URI for the catalog source
+   */
+  URI toUri() {
+    return requireUriSyntax(displayUri, CATALOG_SOURCE_FIELD);
+  }
+
+  /**
+   * Returns the display URI for the resolved catalog signature sidecar.
+   *
+   * <p>USK and SSK sources use the sibling signature filename. CHK sources return the explicit
+   * signature companion supplied in the source query. The URI is for catalog-source metadata and
+   * sidecar diagnostics; fetchers use {@link #signatureFetchKey()} for the runtime request.
+   *
+   * @return validated {@code crypta:} URI for the signature sidecar source
+   */
+  URI signatureUri() {
+    return requireUriSyntax(SCHEME_PREFIX + signatureFetchKey, "crypta catalog signature source");
+  }
+
+  /**
+   * Rejects unsupported query shapes before deriving fetch keys.
+   *
+   * @param catalogKey parsed catalog key portion before any signature companion
+   * @param signatureKey parsed signature key companion, or {@code null} when absent
+   */
+  private static void validateNoExtraQuery(String catalogKey, String signatureKey) {
+    if (catalogKey.indexOf('?') >= 0
+        || (signatureKey != null
+            && (signatureKey.indexOf('?') >= 0
+                || signatureKey.indexOf('&') >= 0
+                || signatureKey.isBlank()))) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, "invalid " + CATALOG_SOURCE_FIELD + " query");
+    }
+  }
+
+  /**
+   * Derives the USK or SSK signature key from the catalog key path.
+   *
+   * <p>The derivation is intentionally simple and fail-closed: only path-like keys with a final
+   * slash-delimited filename have an unambiguous sibling. Bare keys or keys ending in a slash are
+   * rejected so the fetcher never silently skips signature verification or guesses a sidecar.
+   *
+   * @param catalogKey bare USK or SSK key for the catalog properties file
+   * @return sibling key that points to {@link AppCatalogSignature#SIGNATURE_FILE_NAME}
+   */
+  private static String siblingSignatureKey(String catalogKey) {
+    int slashIndex = catalogKey.lastIndexOf('/');
+    if (slashIndex <= 0 || slashIndex == catalogKey.length() - 1) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE,
+          "crypta USK/SSK catalog source must include a path-like key");
+    }
+    return catalogKey.substring(0, slashIndex + 1) + AppCatalogSignature.SIGNATURE_FILE_NAME;
+  }
+
+  /**
+   * Normalizes and validates one bare Crypta fetch key.
+   *
+   * @param value raw key value to validate
+   * @param fieldName diagnostic field name used in thrown catalog exceptions
+   * @return nonblank single-line key without URI query or fragment text
+   */
+  private static String requireKey(String value, String fieldName) {
+    String normalized =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+            Objects.requireNonNull(value, fieldName),
+            fieldName,
+            AppCatalogSidecars.INVALID_CATALOG_SOURCE);
+    if (normalized.indexOf('#') >= 0 || normalized.indexOf('?') >= 0) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, fieldName + " must be a bare Crypta key");
+    }
+    return normalized;
+  }
+
+  /**
+   * Validates URI syntax and converts JDK parser failures to catalog errors.
+   *
+   * @param value URI text to validate
+   * @param fieldName diagnostic field name used in thrown catalog exceptions
+   * @return parsed URI when the syntax is accepted by {@link URI}
+   */
+  private static URI requireUriSyntax(String value, String fieldName) {
+    try {
+      return new URI(value);
+    } catch (URISyntaxException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_SOURCE, "invalid " + fieldName, exception);
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/FetchedCatalog.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/FetchedCatalog.java
@@ -1,6 +1,7 @@
 package network.crypta.platform.appcatalog;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Holds the exact catalog sidecar bytes retrieved from one catalog source.
@@ -14,10 +15,10 @@ import java.util.Objects;
  * accessor methods return fresh copies and its constructor clones inputs immediately. That keeps
  * cached sidecar bytes stable even when test fixtures or fetch buffers are reused by callers.
  */
-@SuppressWarnings({"java:S6206", "ClassCanBeRecord"})
 public final class FetchedCatalog {
   private final byte[] catalogBytes;
   private final byte[] signatureBytes;
+  private final String resolvedCatalogUri;
 
   /**
    * Creates a fetched catalog sidecar pair.
@@ -29,8 +30,30 @@ public final class FetchedCatalog {
    * @param signatureBytes exact bytes of {@code cryptad-app-catalog.signature}
    */
   public FetchedCatalog(byte[] catalogBytes, byte[] signatureBytes) {
+    this(catalogBytes, signatureBytes, null);
+  }
+
+  /**
+   * Creates a fetched catalog sidecar pair with optional resolved source metadata.
+   *
+   * <p>The resolved URI is diagnostic metadata reported by a transport implementation, for example
+   * the latest URI observed while fetching a mutable Crypta source. It is not used for trust
+   * decisions.
+   *
+   * @param catalogBytes exact bytes of {@code cryptad-app-catalog.properties}
+   * @param signatureBytes exact bytes of {@code cryptad-app-catalog.signature}
+   * @param resolvedCatalogUri transport-reported resolved catalog URI, or {@code null}
+   */
+  public FetchedCatalog(byte[] catalogBytes, byte[] signatureBytes, String resolvedCatalogUri) {
     this.catalogBytes = Objects.requireNonNull(catalogBytes, "catalogBytes").clone();
     this.signatureBytes = Objects.requireNonNull(signatureBytes, "signatureBytes").clone();
+    this.resolvedCatalogUri =
+        resolvedCatalogUri == null
+            ? null
+            : AppCatalogSidecars.requireNonBlankSingleLine(
+                resolvedCatalogUri,
+                "resolved catalog URI",
+                AppCatalogSidecars.INVALID_CATALOG_SOURCE);
   }
 
   /**
@@ -55,5 +78,14 @@ public final class FetchedCatalog {
    */
   public byte[] signatureBytes() {
     return signatureBytes.clone();
+  }
+
+  /**
+   * Returns transport-reported resolved catalog URI metadata, when available.
+   *
+   * @return optional resolved catalog URI
+   */
+  public Optional<String> resolvedCatalogUri() {
+    return Optional.ofNullable(resolvedCatalogUri);
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/StoredCatalogSource.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/StoredCatalogSource.java
@@ -13,7 +13,12 @@ import java.time.Instant;
  * @param source validated source URI used for refresh operations
  * @param addedAt local timestamp when the source was first persisted
  * @param refreshedAt local timestamp when sidecars were last fetched and verified
+ * @param refreshMetadata latest fetch attempt metadata
  * @param fetchedCatalog exact catalog and signature bytes cached by the source store
  */
 record StoredCatalogSource(
-    AppCatalogSource source, Instant addedAt, Instant refreshedAt, FetchedCatalog fetchedCatalog) {}
+    AppCatalogSource source,
+    Instant addedAt,
+    Instant refreshedAt,
+    AppCatalogSourceRefreshMetadata refreshMetadata,
+    FetchedCatalog fetchedCatalog) {}

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -77,6 +77,7 @@ class AppCatalogManagerTest {
   private static final String CRYPTA_CATALOG_SOURCE = "crypta:" + CRYPTA_CATALOG_KEY;
   private static final String BASIC_CATALOG_PROPERTIES = "catalog.version=1\n";
   private static final String BASIC_CATALOG_SIGNATURE = "catalog.signature.version=1\n";
+  private static final String MALFORMED_KEY_VALUE_LINE = "not-a-key-value-line\n";
   private static final String CATALOG_SOURCE_STORE_DIRECTORY = "store";
   private static final String FINDER_METADATA = "finder metadata";
   private static final String UNEXPECTED_HTTP_FETCH = "unexpected HTTP fetch";
@@ -155,7 +156,7 @@ class AppCatalogManagerTest {
     Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
     Files.writeString(
         catalog.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME),
-        "not-a-key-value-line\n",
+        MALFORMED_KEY_VALUE_LINE,
         StandardCharsets.UTF_8);
     AppCatalogManager manager = manager(trustedKeys(keyPair));
     String catalogSource = catalog.toString();
@@ -550,7 +551,7 @@ class AppCatalogManagerTest {
                 CRYPTA_CATALOG_KEY,
                 Files.readAllBytes(catalog),
                 CRYPTA_SIGNATURE_KEY,
-                "not-a-key-value-line\n".getBytes(StandardCharsets.UTF_8)));
+                MALFORMED_KEY_VALUE_LINE.getBytes(StandardCharsets.UTF_8)));
     AppCatalogManager manager = manager(trustedKeys(keyPair), contentFetchPort);
 
     AppCatalogException exception =
@@ -617,6 +618,42 @@ class AppCatalogManagerTest {
     assertEquals(
         Optional.of(AppCatalogSidecars.CATALOG_FETCH_FAILED), snapshot.lastFetchErrorCode());
     assertEquals(snapshot.refreshedAt(), snapshot.lastSuccessfulRefreshAt());
+  }
+
+  @Test
+  void refresh_whenCryptaVerificationFailsAfterResolvedFetch_expectMetadataUsesResolvedUri()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    byte[] catalogBytes = Files.readAllBytes(catalog);
+    byte[] validSignatureBytes =
+        Files.readAllBytes(catalog.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME));
+    String resolvedCatalogKey = "USK@example/catalog/99/cryptad-app-catalog.properties";
+    String resolvedSignatureKey = "USK@example/catalog/99/cryptad-app-catalog.signature";
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(CRYPTA_CATALOG_KEY, catalogBytes, CRYPTA_SIGNATURE_KEY, validSignatureBytes));
+    AppCatalogManager manager = manager(trustedKeys(keyPair), contentFetchPort);
+    manager.addSource(CRYPTA_CATALOG_SOURCE);
+    contentFetchPort.replaceContent(
+        Map.of(
+            CRYPTA_CATALOG_KEY,
+            catalogBytes,
+            resolvedSignatureKey,
+            MALFORMED_KEY_VALUE_LINE.getBytes(StandardCharsets.UTF_8)),
+        Map.of(CRYPTA_CATALOG_KEY, resolvedCatalogKey));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> manager.refresh(CATALOG_ID));
+    AppCatalogSourceSnapshot snapshot = manager.listCatalogs().getFirst();
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SIGNATURE, exception.errorCode());
+    assertEquals(AppCatalogFetchStatus.FAILED, snapshot.lastFetchStatus());
+    assertEquals(
+        Optional.of(AppCatalogSidecars.INVALID_CATALOG_SIGNATURE), snapshot.lastFetchErrorCode());
+    assertEquals(Optional.of(resolvedCatalogKey), snapshot.lastResolvedUri());
   }
 
   @Test
@@ -1156,8 +1193,8 @@ class AppCatalogManagerTest {
   }
 
   private static final class FakeContentFetchPort implements ContentFetchPort {
-    private final Map<String, byte[]> content;
-    private final Map<String, String> resolvedUris;
+    private final Map<String, byte[]> content = new java.util.LinkedHashMap<>();
+    private final Map<String, String> resolvedUris = new java.util.LinkedHashMap<>();
     private final java.util.ArrayList<String> requestedKeys = new java.util.ArrayList<>();
     private ContentFetchException failure;
 
@@ -1166,8 +1203,7 @@ class AppCatalogManagerTest {
     }
 
     private FakeContentFetchPort(Map<String, byte[]> content, Map<String, String> resolvedUris) {
-      this.content = Map.copyOf(content);
-      this.resolvedUris = Map.copyOf(resolvedUris);
+      replaceContent(content, resolvedUris);
     }
 
     @Override
@@ -1197,6 +1233,15 @@ class AppCatalogManagerTest {
       this.failure =
           new ContentFetchException(
               ContentFetchException.CATALOG_FETCH_FAILED, "content fetch failed", failure);
+    }
+
+    private void replaceContent(Map<String, byte[]> content, Map<String, String> resolvedUris) {
+      this.content.clear();
+      this.content.putAll(content);
+      this.resolvedUris.clear();
+      this.resolvedUris.putAll(resolvedUris);
+      failure = null;
+      requestedKeys.clear();
     }
 
     private List<String> requestedKeys() {

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -64,8 +64,22 @@ class AppCatalogManagerTest {
   private static final String STAGING_CATALOG_ID = "staging";
   private static final String APP_ID = "queue-manager";
   private static final String APP_VERSION = "1.0.0";
+  private static final String APP_NAME = "Queue Manager";
+  private static final String APP_SUMMARY = "Manage local Crypta transfer queues.";
   private static final String ARTIFACT_ZIP = "queue-manager.zip";
   private static final String EXECUTABLE_PATH = "bin/tool";
+  private static final String QUEUE_READ_PERMISSION = "queue.read";
+  private static final String QUEUE_WRITE_PERMISSION = "queue.write";
+  private static final String CRYPTA_CATALOG_KEY =
+      "USK@example/catalog/cryptad-app-catalog.properties";
+  private static final String CRYPTA_SIGNATURE_KEY =
+      "USK@example/catalog/cryptad-app-catalog.signature";
+  private static final String CRYPTA_CATALOG_SOURCE = "crypta:" + CRYPTA_CATALOG_KEY;
+  private static final String BASIC_CATALOG_PROPERTIES = "catalog.version=1\n";
+  private static final String BASIC_CATALOG_SIGNATURE = "catalog.signature.version=1\n";
+  private static final String CATALOG_SOURCE_STORE_DIRECTORY = "store";
+  private static final String FINDER_METADATA = "finder metadata";
+  private static final String UNEXPECTED_HTTP_FETCH = "unexpected HTTP fetch";
   private static final int LOCAL_FILE_HEADER_SIGNATURE = 0x04034B50;
   private static final int CENTRAL_DIRECTORY_HEADER_SIGNATURE = 0x02014B50;
   private static final int END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054B50;
@@ -412,40 +426,56 @@ class AppCatalogManagerTest {
   @Test
   void fetch_whenCryptaSourceUsesContentFetchPort_expectCatalogAndSignatureBytes()
       throws Exception {
-    byte[] catalogBytes = "catalog.version=1\n".getBytes(StandardCharsets.UTF_8);
-    byte[] signatureBytes = "catalog.signature.version=1\n".getBytes(StandardCharsets.UTF_8);
+    byte[] catalogBytes = BASIC_CATALOG_PROPERTIES.getBytes(StandardCharsets.UTF_8);
+    byte[] signatureBytes = BASIC_CATALOG_SIGNATURE.getBytes(StandardCharsets.UTF_8);
     FakeContentFetchPort contentFetchPort =
         new FakeContentFetchPort(
-            Map.of(
-                "USK@example/catalog/cryptad-app-catalog.properties",
-                catalogBytes,
-                "USK@example/catalog/cryptad-app-catalog.signature",
-                signatureBytes));
+            Map.of(CRYPTA_CATALOG_KEY, catalogBytes, CRYPTA_SIGNATURE_KEY, signatureBytes));
     AppCatalogFetcher fetcher =
         new AppCatalogFetcher(
-            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
-            contentFetchPort);
-    AppCatalogSource source =
-        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse(CRYPTA_CATALOG_SOURCE);
 
     FetchedCatalog fetched = fetcher.fetch(source);
 
     assertEquals(
-        List.of(
-            "USK@example/catalog/cryptad-app-catalog.properties",
-            "USK@example/catalog/cryptad-app-catalog.signature"),
-        contentFetchPort.requestedKeys());
+        List.of(CRYPTA_CATALOG_KEY, CRYPTA_SIGNATURE_KEY), contentFetchPort.requestedKeys());
     org.junit.jupiter.api.Assertions.assertArrayEquals(catalogBytes, fetched.catalogBytes());
     org.junit.jupiter.api.Assertions.assertArrayEquals(signatureBytes, fetched.signatureBytes());
+  }
+
+  @Test
+  void fetch_whenCryptaCatalogResolvesToUskEdition_expectSignatureFetchedFromResolvedEdition()
+      throws Exception {
+    byte[] catalogBytes = BASIC_CATALOG_PROPERTIES.getBytes(StandardCharsets.UTF_8);
+    byte[] signatureBytes = BASIC_CATALOG_SIGNATURE.getBytes(StandardCharsets.UTF_8);
+    String requestedCatalogKey = "USK@example/catalog/41/cryptad-app-catalog.properties";
+    String resolvedCatalogKey = "USK@example/catalog/42/cryptad-app-catalog.properties";
+    String resolvedSignatureKey = "USK@example/catalog/42/cryptad-app-catalog.signature";
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(requestedCatalogKey, catalogBytes, resolvedSignatureKey, signatureBytes),
+            Map.of(requestedCatalogKey, resolvedCatalogKey));
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse("crypta:" + requestedCatalogKey);
+
+    FetchedCatalog fetched = fetcher.fetch(source);
+
+    assertEquals(
+        List.of(requestedCatalogKey, resolvedSignatureKey), contentFetchPort.requestedKeys());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(catalogBytes, fetched.catalogBytes());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(signatureBytes, fetched.signatureBytes());
+    assertEquals(Optional.of(resolvedCatalogKey), fetched.resolvedCatalogUri());
   }
 
   @Test
   void fetch_whenCryptaRuntimeIsUnavailable_expectCatalogFetchUnavailable() {
     AppCatalogFetcher fetcher =
         new AppCatalogFetcher(
-            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")), null);
-    AppCatalogSource source =
-        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), null);
+    AppCatalogSource source = AppCatalogSource.parse(CRYPTA_CATALOG_SOURCE);
 
     AppCatalogException exception =
         assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
@@ -462,10 +492,8 @@ class AppCatalogManagerTest {
         };
     AppCatalogFetcher fetcher =
         new AppCatalogFetcher(
-            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
-            contentFetchPort);
-    AppCatalogSource source =
-        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse(CRYPTA_CATALOG_SOURCE);
 
     AppCatalogException exception =
         assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
@@ -480,15 +508,13 @@ class AppCatalogManagerTest {
           byte[] bytes =
               "catalog signature".equals(request.purpose())
                   ? new byte[(int) AppCatalogSidecars.MAX_SIGNATURE_BYTES + 1]
-                  : "catalog.version=1\n".getBytes(StandardCharsets.UTF_8);
+                  : BASIC_CATALOG_PROPERTIES.getBytes(StandardCharsets.UTF_8);
           return new BoundedContentFetchResult(bytes, request.uri(), null, null);
         };
     AppCatalogFetcher fetcher =
         new AppCatalogFetcher(
-            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
-            contentFetchPort);
-    AppCatalogSource source =
-        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse(CRYPTA_CATALOG_SOURCE);
 
     AppCatalogException exception =
         assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
@@ -500,15 +526,11 @@ class AppCatalogManagerTest {
   void fetch_whenCryptaSignatureIsMissing_expectCatalogSignatureMissing() {
     FakeContentFetchPort contentFetchPort =
         new FakeContentFetchPort(
-            Map.of(
-                "USK@example/catalog/cryptad-app-catalog.properties",
-                "catalog.version=1\n".getBytes(StandardCharsets.UTF_8)));
+            Map.of(CRYPTA_CATALOG_KEY, BASIC_CATALOG_PROPERTIES.getBytes(StandardCharsets.UTF_8)));
     AppCatalogFetcher fetcher =
         new AppCatalogFetcher(
-            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
-            contentFetchPort);
-    AppCatalogSource source =
-        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse(CRYPTA_CATALOG_SOURCE);
 
     AppCatalogException exception =
         assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
@@ -525,16 +547,14 @@ class AppCatalogManagerTest {
     FakeContentFetchPort contentFetchPort =
         new FakeContentFetchPort(
             Map.of(
-                "USK@example/catalog/cryptad-app-catalog.properties",
+                CRYPTA_CATALOG_KEY,
                 Files.readAllBytes(catalog),
-                "USK@example/catalog/cryptad-app-catalog.signature",
+                CRYPTA_SIGNATURE_KEY,
                 "not-a-key-value-line\n".getBytes(StandardCharsets.UTF_8)));
     AppCatalogManager manager = manager(trustedKeys(keyPair), contentFetchPort);
 
     AppCatalogException exception =
-        assertThrows(
-            AppCatalogException.class,
-            () -> manager.addSource("crypta:USK@example/catalog/cryptad-app-catalog.properties"));
+        assertThrows(AppCatalogException.class, () -> manager.addSource(CRYPTA_CATALOG_SOURCE));
 
     assertEquals(AppCatalogSidecars.INVALID_CATALOG_SIGNATURE, exception.errorCode());
   }
@@ -547,14 +567,14 @@ class AppCatalogManagerTest {
     Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
     Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
     String sourceKey = "USK@example/catalog/latest/cryptad-app-catalog.properties";
-    String signatureKey = "USK@example/catalog/latest/cryptad-app-catalog.signature";
     String resolvedUri = "USK@example/catalog/42/cryptad-app-catalog.properties";
+    String resolvedSignatureKey = "USK@example/catalog/42/cryptad-app-catalog.signature";
     FakeContentFetchPort contentFetchPort =
         new FakeContentFetchPort(
             Map.of(
                 sourceKey,
                 Files.readAllBytes(catalog),
-                signatureKey,
+                resolvedSignatureKey,
                 Files.readAllBytes(
                     catalog.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME))),
             Map.of(sourceKey, resolvedUri));
@@ -577,13 +597,13 @@ class AppCatalogManagerTest {
     FakeContentFetchPort contentFetchPort =
         new FakeContentFetchPort(
             Map.of(
-                "USK@example/catalog/cryptad-app-catalog.properties",
+                CRYPTA_CATALOG_KEY,
                 Files.readAllBytes(catalog),
-                "USK@example/catalog/cryptad-app-catalog.signature",
+                CRYPTA_SIGNATURE_KEY,
                 Files.readAllBytes(
                     catalog.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME))));
     AppCatalogManager manager = manager(trustedKeys(keyPair), contentFetchPort);
-    manager.addSource("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+    manager.addSource(CRYPTA_CATALOG_SOURCE);
     contentFetchPort.failWith(new IOException("content fetch failed"));
 
     AppCatalogException exception =
@@ -607,7 +627,8 @@ class AppCatalogManagerTest {
     Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
     Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
     TrustedAppKeys trustedKeys = trustedKeys(keyPair);
-    AppCatalogSourceStore sourceStore = new AppCatalogSourceStore(tempDir.resolve("store"));
+    AppCatalogSourceStore sourceStore =
+        new AppCatalogSourceStore(tempDir.resolve(CATALOG_SOURCE_STORE_DIRECTORY));
     AppCatalogManager manager = new AppCatalogManager(sourceStore, () -> trustedKeys);
     manager.addSource(catalog.toString());
     AppCatalogSourceSnapshot beforeRefresh = manager.listCatalogs().getFirst();
@@ -633,7 +654,7 @@ class AppCatalogManagerTest {
   void entry_whenArtifactUriIsCrypta_expectInvalidCatalogEntry() {
     URI artifactUri = URI.create("crypta:CHK@bundle-key?signature=CHK@signature-key");
     String artifactDigest = "0".repeat(64);
-    List<String> permissions = List.of("queue.read");
+    List<String> permissions = List.of(QUEUE_READ_PERMISSION);
 
     AppCatalogException exception =
         assertThrows(
@@ -641,9 +662,9 @@ class AppCatalogManagerTest {
             () ->
                 new AppCatalogEntry(
                     APP_ID,
-                    "Queue Manager",
+                    APP_NAME,
                     APP_VERSION,
-                    "Manage local Crypta transfer queues.",
+                    APP_SUMMARY,
                     artifactUri,
                     artifactDigest,
                     1L,
@@ -788,7 +809,8 @@ class AppCatalogManagerTest {
     Path catalog =
         signedCatalog(
             STAGING_CATALOG_ID, artifact, keyPair, sha256(artifact), Files.size(artifact));
-    AppCatalogSourceStore sourceStore = new AppCatalogSourceStore(tempDir.resolve("store"));
+    AppCatalogSourceStore sourceStore =
+        new AppCatalogSourceStore(tempDir.resolve(CATALOG_SOURCE_STORE_DIRECTORY));
     AppCatalogManager manager = new AppCatalogManager(sourceStore, () -> trustedKeys);
 
     manager.addSource(catalog.toString());
@@ -803,17 +825,17 @@ class AppCatalogManagerTest {
 
   private AppCatalogManager manager(TrustedAppKeys trustedKeys) {
     return new AppCatalogManager(
-        new AppCatalogSourceStore(tempDir.resolve("store")), () -> trustedKeys);
+        new AppCatalogSourceStore(tempDir.resolve(CATALOG_SOURCE_STORE_DIRECTORY)),
+        () -> trustedKeys);
   }
 
   private AppCatalogManager manager(
       TrustedAppKeys trustedKeys, FakeContentFetchPort contentFetchPort) {
     return new AppCatalogManager(
-        new AppCatalogSourceStore(tempDir.resolve("store")),
+        new AppCatalogSourceStore(tempDir.resolve(CATALOG_SOURCE_STORE_DIRECTORY)),
         () -> trustedKeys,
         new AppCatalogFetcher(
-            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
-            contentFetchPort),
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort),
         new AppCatalogArtifactDownloader(),
         new AppCatalogBundleExtractor());
   }
@@ -827,12 +849,13 @@ class AppCatalogManagerTest {
         """
         manifest.version=1
         app.id=%s
-        app.name=Queue Manager
+        app.name=%s
         app.version=%s
         app.exec=bin/launch.sh
-        app.permissions=queue.read,queue.write
+        app.permissions=%s,%s
         """
-            .formatted(APP_ID, APP_VERSION),
+            .formatted(
+                APP_ID, APP_NAME, APP_VERSION, QUEUE_READ_PERMISSION, QUEUE_WRITE_PERMISSION),
         StandardCharsets.UTF_8);
     AppBundleSigner.sign(root, KEY_ID, keyPair.getPrivate());
     return root;
@@ -849,12 +872,18 @@ class AppCatalogManagerTest {
         """
         manifest.version=1
         app.id=%s
-        app.name=Queue Manager
+        app.name=%s
         app.version=%s
         app.exec=%s
-        app.permissions=queue.read,queue.write
+        app.permissions=%s,%s
         """
-            .formatted(APP_ID, APP_VERSION, EXECUTABLE_PATH),
+            .formatted(
+                APP_ID,
+                APP_NAME,
+                APP_VERSION,
+                EXECUTABLE_PATH,
+                QUEUE_READ_PERMISSION,
+                QUEUE_WRITE_PERMISSION),
         StandardCharsets.UTF_8);
     AppBundleSigner.sign(root, KEY_ID, keyPair.getPrivate());
     return root;
@@ -879,14 +908,14 @@ class AppCatalogManagerTest {
         catalog.generatedAt=%s
         catalog.entries=%s
         app.%s.id=%s
-        app.%s.name=Queue Manager
+        app.%s.name=%s
         app.%s.version=%s
-        app.%s.summary=Manage local Crypta transfer queues.
+        app.%s.summary=%s
         app.%s.bundle.uri=%s
         app.%s.bundle.sha256=%s
         app.%s.bundle.size.bytes=%d
         app.%s.bundle.type=zip
-        app.%s.permissions=queue.read,queue.write
+        app.%s.permissions=%s,%s
         """
             .formatted(
                 catalogId,
@@ -895,9 +924,11 @@ class AppCatalogManagerTest {
                 APP_ID,
                 APP_ID,
                 APP_ID,
+                APP_NAME,
                 APP_ID,
                 APP_VERSION,
                 APP_ID,
+                APP_SUMMARY,
                 APP_ID,
                 artifact.toUri(),
                 APP_ID,
@@ -905,7 +936,9 @@ class AppCatalogManagerTest {
                 APP_ID,
                 artifactSize,
                 APP_ID,
-                APP_ID),
+                APP_ID,
+                QUEUE_READ_PERMISSION,
+                QUEUE_WRITE_PERMISSION),
         StandardCharsets.UTF_8);
     AppCatalogSigner.sign(catalog, KEY_ID, keyPair.getPrivate());
     return catalog;
@@ -941,15 +974,15 @@ class AppCatalogManagerTest {
         zip.closeEntry();
       }
       zip.putNextEntry(new ZipEntry("._cryptad-app.properties"));
-      zip.write("finder metadata".getBytes(StandardCharsets.UTF_8));
+      zip.write(FINDER_METADATA.getBytes(StandardCharsets.UTF_8));
       zip.closeEntry();
       zip.putNextEntry(new ZipEntry("__MACOSX/"));
       zip.closeEntry();
       zip.putNextEntry(new ZipEntry("__MACOSX/._cryptad-app.properties"));
-      zip.write("finder metadata".getBytes(StandardCharsets.UTF_8));
+      zip.write(FINDER_METADATA.getBytes(StandardCharsets.UTF_8));
       zip.closeEntry();
       zip.putNextEntry(new ZipEntry("bin/._launch.sh"));
-      zip.write("finder metadata".getBytes(StandardCharsets.UTF_8));
+      zip.write(FINDER_METADATA.getBytes(StandardCharsets.UTF_8));
       zip.closeEntry();
     }
     return targetZip;
@@ -1080,27 +1113,27 @@ class AppCatalogManagerTest {
   private static AppCatalogEntry remoteEntry() {
     return new AppCatalogEntry(
         APP_ID,
-        "Queue Manager",
+        APP_NAME,
         APP_VERSION,
-        "Manage local Crypta transfer queues.",
+        APP_SUMMARY,
         URI.create("http://localhost/queue-manager.zip"),
         "0".repeat(64),
         1L,
         AppCatalogEntry.ZIP_BUNDLE_TYPE,
-        List.of("queue.read"));
+        List.of(QUEUE_READ_PERMISSION));
   }
 
   private static AppCatalogEntry localEntry(Path artifact) {
     return new AppCatalogEntry(
         APP_ID,
-        "Queue Manager",
+        APP_NAME,
         APP_VERSION,
-        "Manage local Crypta transfer queues.",
+        APP_SUMMARY,
         artifact.toUri(),
         "0".repeat(64),
         1L,
         AppCatalogEntry.ZIP_BUNDLE_TYPE,
-        List.of("queue.read"));
+        List.of(QUEUE_READ_PERMISSION));
   }
 
   private static HttpHeaders contentLength(String value) {

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -41,10 +41,15 @@ import network.crypta.platform.appdist.AppBundleSignature;
 import network.crypta.platform.appdist.AppBundleSigner;
 import network.crypta.platform.appdist.TrustedAppKey;
 import network.crypta.platform.appdist.TrustedAppKeys;
+import network.crypta.runtime.spi.BoundedContentFetchRequest;
+import network.crypta.runtime.spi.BoundedContentFetchResult;
+import network.crypta.runtime.spi.ContentFetchException;
+import network.crypta.runtime.spi.ContentFetchPort;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -303,8 +308,6 @@ class AppCatalogManagerTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "http://127.example.com/cryptad-app-catalog.properties",
-        "ftp://example.invalid/cryptad-app-catalog.properties",
         "https:/cryptad-app-catalog.properties",
         "file:cryptad-app-catalog.properties",
         "file://localhost/tmp/cryptad-app-catalog.properties"
@@ -318,6 +321,24 @@ class AppCatalogManagerTest {
             () -> AppCatalogSidecars.requireSafeCatalogSourceUri(source));
 
     assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://127.example.com/cryptad-app-catalog.properties",
+        "ftp://example.invalid/cryptad-app-catalog.properties"
+      })
+  void requireSafeCatalogSourceUri_whenSchemeIsUnsupported_expectUnsupportedCatalogSource(
+      String sourceValue) {
+    URI source = URI.create(sourceValue);
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> AppCatalogSidecars.requireSafeCatalogSourceUri(source));
+
+    assertEquals(AppCatalogSidecars.UNSUPPORTED_CATALOG_SOURCE, exception.errorCode());
   }
 
   @ParameterizedTest
@@ -351,6 +372,285 @@ class AppCatalogManagerTest {
         AppCatalogSource.parse("C:/Cryptad/catalog/cryptad-app-catalog.properties");
 
     assertEquals("file", source.uri().getScheme());
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      delimiter = '|',
+      textBlock =
+          """
+          crypta:USK@example/catalog/cryptad-app-catalog.properties | USK@example/catalog/cryptad-app-catalog.properties | crypta:USK@example/catalog/cryptad-app-catalog.signature
+          crypta:SSK@example/catalog/cryptad-app-catalog.properties | SSK@example/catalog/cryptad-app-catalog.properties | crypta:SSK@example/catalog/cryptad-app-catalog.signature
+          crypta:CHK@catalog-key?signature=CHK@signature-key | CHK@catalog-key | crypta:CHK@signature-key
+          """)
+  void parse_whenCryptaCatalogSourceIsValid_expectRuntimeKeyAndSignature(
+      String sourceValue, String expectedFetchUri, String expectedSignatureUri) {
+    AppCatalogSource source = AppCatalogSource.parse(sourceValue);
+
+    assertEquals(AppCatalogSourceKind.CRYPTA, source.kind());
+    assertEquals(expectedFetchUri, source.resolvedCatalogFetchUri());
+    assertEquals(URI.create(expectedSignatureUri), source.signatureUri());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "crypta:CHK@catalog-key",
+        "crypta:USK@example",
+        "crypta:USK@example/catalog bad/cryptad-app-catalog.properties",
+        "crypta:USK@example/catalog/cryptad-app-catalog.properties#fragment",
+        "crypta:SSK@example/catalog/cryptad-app-catalog.properties?signature=CHK@signature-key",
+        "crypta:CHK@catalog-key?signature=CHK@signature-key&extra=1"
+      })
+  void parse_whenCryptaCatalogSourceIsInvalid_expectInvalidCatalogSource(String sourceValue) {
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> AppCatalogSource.parse(sourceValue));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  @Test
+  void fetch_whenCryptaSourceUsesContentFetchPort_expectCatalogAndSignatureBytes()
+      throws Exception {
+    byte[] catalogBytes = "catalog.version=1\n".getBytes(StandardCharsets.UTF_8);
+    byte[] signatureBytes = "catalog.signature.version=1\n".getBytes(StandardCharsets.UTF_8);
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(
+                "USK@example/catalog/cryptad-app-catalog.properties",
+                catalogBytes,
+                "USK@example/catalog/cryptad-app-catalog.signature",
+                signatureBytes));
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
+            contentFetchPort);
+    AppCatalogSource source =
+        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+
+    FetchedCatalog fetched = fetcher.fetch(source);
+
+    assertEquals(
+        List.of(
+            "USK@example/catalog/cryptad-app-catalog.properties",
+            "USK@example/catalog/cryptad-app-catalog.signature"),
+        contentFetchPort.requestedKeys());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(catalogBytes, fetched.catalogBytes());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(signatureBytes, fetched.signatureBytes());
+  }
+
+  @Test
+  void fetch_whenCryptaRuntimeIsUnavailable_expectCatalogFetchUnavailable() {
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")), null);
+    AppCatalogSource source =
+        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
+
+    assertEquals(AppCatalogSidecars.CATALOG_FETCH_UNAVAILABLE, exception.errorCode());
+  }
+
+  @Test
+  void fetch_whenCryptaRuntimeRejectsSource_expectInvalidCatalogSource() {
+    ContentFetchPort contentFetchPort =
+        _ -> {
+          throw new ContentFetchException(
+              ContentFetchException.INVALID_CATALOG_SOURCE, "invalid runtime key");
+        };
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
+            contentFetchPort);
+    AppCatalogSource source =
+        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+  }
+
+  @Test
+  void fetch_whenCryptaRuntimeReturnsOversizedSignature_expectCatalogFetchFailed() {
+    ContentFetchPort contentFetchPort =
+        request -> {
+          byte[] bytes =
+              "catalog signature".equals(request.purpose())
+                  ? new byte[(int) AppCatalogSidecars.MAX_SIGNATURE_BYTES + 1]
+                  : "catalog.version=1\n".getBytes(StandardCharsets.UTF_8);
+          return new BoundedContentFetchResult(bytes, request.uri(), null, null);
+        };
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
+            contentFetchPort);
+    AppCatalogSource source =
+        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
+
+    assertEquals(AppCatalogSidecars.CATALOG_FETCH_FAILED, exception.errorCode());
+  }
+
+  @Test
+  void fetch_whenCryptaSignatureIsMissing_expectCatalogSignatureMissing() {
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(
+                "USK@example/catalog/cryptad-app-catalog.properties",
+                "catalog.version=1\n".getBytes(StandardCharsets.UTF_8)));
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
+            contentFetchPort);
+    AppCatalogSource source =
+        AppCatalogSource.parse("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
+
+    assertEquals(AppCatalogSidecars.CATALOG_SIGNATURE_MISSING, exception.errorCode());
+  }
+
+  @Test
+  void addSource_whenCryptaSignatureIsInvalid_expectInvalidCatalogSignature() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(
+                "USK@example/catalog/cryptad-app-catalog.properties",
+                Files.readAllBytes(catalog),
+                "USK@example/catalog/cryptad-app-catalog.signature",
+                "not-a-key-value-line\n".getBytes(StandardCharsets.UTF_8)));
+    AppCatalogManager manager = manager(trustedKeys(keyPair), contentFetchPort);
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> manager.addSource("crypta:USK@example/catalog/cryptad-app-catalog.properties"));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SIGNATURE, exception.errorCode());
+  }
+
+  @Test
+  void addSource_whenCryptaFetchReportsResolvedUri_expectSnapshotRecordsResolvedUri()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    String sourceKey = "USK@example/catalog/latest/cryptad-app-catalog.properties";
+    String signatureKey = "USK@example/catalog/latest/cryptad-app-catalog.signature";
+    String resolvedUri = "USK@example/catalog/42/cryptad-app-catalog.properties";
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(
+                sourceKey,
+                Files.readAllBytes(catalog),
+                signatureKey,
+                Files.readAllBytes(
+                    catalog.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME))),
+            Map.of(sourceKey, resolvedUri));
+    AppCatalogManager manager = manager(trustedKeys(keyPair), contentFetchPort);
+
+    AppCatalogSourceSnapshot snapshot =
+        manager.addSource("crypta:USK@example/catalog/latest/cryptad-app-catalog.properties");
+
+    assertEquals(Optional.of(resolvedUri), snapshot.lastResolvedUri());
+    assertEquals(Optional.of(resolvedUri), manager.listCatalogs().getFirst().lastResolvedUri());
+  }
+
+  @Test
+  void refresh_whenCryptaFetchFails_expectPreviousVerifiedCatalogPreservedAndMetadataUpdated()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(
+                "USK@example/catalog/cryptad-app-catalog.properties",
+                Files.readAllBytes(catalog),
+                "USK@example/catalog/cryptad-app-catalog.signature",
+                Files.readAllBytes(
+                    catalog.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME))));
+    AppCatalogManager manager = manager(trustedKeys(keyPair), contentFetchPort);
+    manager.addSource("crypta:USK@example/catalog/cryptad-app-catalog.properties");
+    contentFetchPort.failWith(new IOException("content fetch failed"));
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> manager.refresh(CATALOG_ID));
+    List<AppCatalogEntry> entries = manager.listApps(CATALOG_ID);
+    AppCatalogSourceSnapshot snapshot = manager.listCatalogs().getFirst();
+
+    assertEquals(AppCatalogSidecars.CATALOG_FETCH_FAILED, exception.errorCode());
+    assertEquals(APP_ID, entries.getFirst().appId());
+    assertEquals(AppCatalogFetchStatus.FAILED, snapshot.lastFetchStatus());
+    assertEquals(
+        Optional.of(AppCatalogSidecars.CATALOG_FETCH_FAILED), snapshot.lastFetchErrorCode());
+    assertEquals(snapshot.refreshedAt(), snapshot.lastSuccessfulRefreshAt());
+  }
+
+  @Test
+  void refresh_whenPersistenceWriteFails_expectIOExceptionAndNoFetchFailureMetadata()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path bundle = signedBundle(keyPair);
+    Path artifact = zipDirectory(bundle, tempDir.resolve(ARTIFACT_ZIP));
+    Path catalog = signedCatalog(artifact, keyPair, sha256(artifact), Files.size(artifact));
+    TrustedAppKeys trustedKeys = trustedKeys(keyPair);
+    AppCatalogSourceStore sourceStore = new AppCatalogSourceStore(tempDir.resolve("store"));
+    AppCatalogManager manager = new AppCatalogManager(sourceStore, () -> trustedKeys);
+    manager.addSource(catalog.toString());
+    AppCatalogSourceSnapshot beforeRefresh = manager.listCatalogs().getFirst();
+    AppCatalogSourceStore failingStore =
+        new AppCatalogSourceStore(
+            sourceStore.rootDirectory(),
+            (_, _, _) -> {
+              throw new IOException("metadata write failed");
+            });
+    AppCatalogManager failingManager = new AppCatalogManager(failingStore, () -> trustedKeys);
+
+    IOException exception =
+        assertThrows(IOException.class, () -> failingManager.refresh(CATALOG_ID));
+    AppCatalogSourceSnapshot afterRefresh = manager.listCatalogs().getFirst();
+
+    assertEquals("metadata write failed", exception.getMessage());
+    assertEquals(beforeRefresh.refreshedAt(), afterRefresh.refreshedAt());
+    assertEquals(AppCatalogFetchStatus.SUCCESS, afterRefresh.lastFetchStatus());
+    assertTrue(afterRefresh.lastFetchErrorCode().isEmpty());
+  }
+
+  @Test
+  void entry_whenArtifactUriIsCrypta_expectInvalidCatalogEntry() {
+    URI artifactUri = URI.create("crypta:CHK@bundle-key?signature=CHK@signature-key");
+    String artifactDigest = "0".repeat(64);
+    List<String> permissions = List.of("queue.read");
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () ->
+                new AppCatalogEntry(
+                    APP_ID,
+                    "Queue Manager",
+                    APP_VERSION,
+                    "Manage local Crypta transfer queues.",
+                    artifactUri,
+                    artifactDigest,
+                    1L,
+                    AppCatalogEntry.ZIP_BUNDLE_TYPE,
+                    permissions));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
   }
 
   @Test
@@ -504,6 +804,18 @@ class AppCatalogManagerTest {
   private AppCatalogManager manager(TrustedAppKeys trustedKeys) {
     return new AppCatalogManager(
         new AppCatalogSourceStore(tempDir.resolve("store")), () -> trustedKeys);
+  }
+
+  private AppCatalogManager manager(
+      TrustedAppKeys trustedKeys, FakeContentFetchPort contentFetchPort) {
+    return new AppCatalogManager(
+        new AppCatalogSourceStore(tempDir.resolve("store")),
+        () -> trustedKeys,
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException("unexpected HTTP fetch")),
+            contentFetchPort),
+        new AppCatalogArtifactDownloader(),
+        new AppCatalogBundleExtractor());
   }
 
   private Path signedBundle(KeyPair keyPair) throws IOException {
@@ -808,6 +1120,55 @@ class AppCatalogManagerTest {
   private static TrustedAppKeys trustedKeys(KeyPair keyPair) {
     return TrustedAppKeys.of(
         new TrustedAppKey(KEY_ID, AppBundleSignature.SIGNATURE_ALGORITHM, keyPair.getPublic()));
+  }
+
+  private static final class FakeContentFetchPort implements ContentFetchPort {
+    private final Map<String, byte[]> content;
+    private final Map<String, String> resolvedUris;
+    private final java.util.ArrayList<String> requestedKeys = new java.util.ArrayList<>();
+    private ContentFetchException failure;
+
+    private FakeContentFetchPort(Map<String, byte[]> content) {
+      this(content, Map.of());
+    }
+
+    private FakeContentFetchPort(Map<String, byte[]> content, Map<String, String> resolvedUris) {
+      this.content = Map.copyOf(content);
+      this.resolvedUris = Map.copyOf(resolvedUris);
+    }
+
+    @Override
+    public BoundedContentFetchResult fetchContent(BoundedContentFetchRequest request)
+        throws ContentFetchException {
+      requestedKeys.add(request.uri());
+      if (failure != null) {
+        throw failure;
+      }
+      byte[] bytes = content.get(request.uri());
+      if (bytes == null) {
+        throw new ContentFetchException(
+            "catalog signature".equals(request.purpose())
+                ? AppCatalogSidecars.CATALOG_SIGNATURE_MISSING
+                : ContentFetchException.CATALOG_FETCH_FAILED,
+            "content is unavailable");
+      }
+      if (bytes.length > request.maxBytes()) {
+        throw new ContentFetchException(
+            ContentFetchException.CATALOG_FETCH_FAILED, "content exceeds the allowed size");
+      }
+      return new BoundedContentFetchResult(
+          bytes, request.uri(), resolvedUris.get(request.uri()), null);
+    }
+
+    private void failWith(IOException failure) {
+      this.failure =
+          new ContentFetchException(
+              ContentFetchException.CATALOG_FETCH_FAILED, "content fetch failed", failure);
+    }
+
+    private List<String> requestedKeys() {
+      return List.copyOf(requestedKeys);
+    }
   }
 
   private static final class CloseRecordingInputStream extends ByteArrayInputStream {

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
@@ -45,6 +45,12 @@ class AppCatalogSourceStoreTest {
     assertEquals(source, stored.source());
     assertEquals(ADDED_AT, stored.addedAt());
     assertEquals(REFRESHED_AT, stored.refreshedAt());
+    assertEquals(REFRESHED_AT, stored.refreshMetadata().lastAttemptAt());
+    assertEquals(REFRESHED_AT, stored.refreshMetadata().lastSuccessfulRefreshAt());
+    assertEquals(AppCatalogFetchStatus.SUCCESS, stored.refreshMetadata().lastFetchStatus());
+    assertTrue(stored.refreshMetadata().lastFetchErrorCode().isEmpty());
+    assertEquals(
+        source.resolvedCatalogFetchUri(), stored.refreshMetadata().lastResolvedUri().orElseThrow());
     assertArrayEquals(fetchedCatalog.catalogBytes(), stored.fetchedCatalog().catalogBytes());
     assertArrayEquals(fetchedCatalog.signatureBytes(), stored.fetchedCatalog().signatureBytes());
   }
@@ -122,8 +128,60 @@ class AppCatalogSourceStoreTest {
 
     assertEquals("metadata write failed", exception.getMessage());
     assertEquals(REFRESHED_AT, stored.refreshedAt());
+    assertEquals(AppCatalogFetchStatus.SUCCESS, stored.refreshMetadata().lastFetchStatus());
     assertArrayEquals(original.catalogBytes(), stored.fetchedCatalog().catalogBytes());
     assertArrayEquals(original.signatureBytes(), stored.fetchedCatalog().signatureBytes());
+  }
+
+  @Test
+  void recordRefreshFailure_whenRefreshFails_expectAttemptMetadataUpdatedOnly() throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    FetchedCatalog original = fetchedCatalog("core");
+    AppCatalogSource source = source("core");
+    store.write(catalog("core"), source, original, ADDED_AT, REFRESHED_AT);
+    StoredCatalogSource beforeFailure = store.read("core");
+    Instant failedAt = REFRESHED_AT.plusSeconds(60);
+
+    store.recordRefreshFailure(
+        "core",
+        beforeFailure,
+        failedAt,
+        new AppCatalogException(AppCatalogSidecars.CATALOG_FETCH_FAILED, "fetch failed"));
+    StoredCatalogSource stored = store.read("core");
+
+    assertEquals(REFRESHED_AT, stored.refreshedAt());
+    assertEquals(failedAt, stored.refreshMetadata().lastAttemptAt());
+    assertEquals(REFRESHED_AT, stored.refreshMetadata().lastSuccessfulRefreshAt());
+    assertEquals(AppCatalogFetchStatus.FAILED, stored.refreshMetadata().lastFetchStatus());
+    assertEquals(
+        AppCatalogSidecars.CATALOG_FETCH_FAILED,
+        stored.refreshMetadata().lastFetchErrorCode().orElseThrow());
+    assertArrayEquals(original.catalogBytes(), stored.fetchedCatalog().catalogBytes());
+    assertArrayEquals(original.signatureBytes(), stored.fetchedCatalog().signatureBytes());
+  }
+
+  @Test
+  void recordRefreshFailure_whenMessageHasUnsafeText_expectStoredMessageIsSafeSingleLine()
+      throws Exception {
+    AppCatalogSourceStore store = new AppCatalogSourceStore(tempDir.resolve(STORE_DIRECTORY));
+    FetchedCatalog original = fetchedCatalog("core");
+    AppCatalogSource source = source("core");
+    store.write(catalog("core"), source, original, ADDED_AT, REFRESHED_AT);
+    StoredCatalogSource beforeFailure = store.read("core");
+    String unsafeMessage = "fetch failed\nwith\ttabs\r" + "x".repeat(600);
+
+    store.recordRefreshFailure(
+        "core",
+        beforeFailure,
+        REFRESHED_AT.plusSeconds(60),
+        new AppCatalogException(AppCatalogSidecars.CATALOG_FETCH_FAILED, unsafeMessage));
+    StoredCatalogSource stored = store.read("core");
+
+    String storedMessage = stored.refreshMetadata().lastFetchErrorMessage().orElseThrow();
+    assertFalse(storedMessage.contains("\n"));
+    assertFalse(storedMessage.contains("\r"));
+    assertFalse(storedMessage.contains("\t"));
+    assertTrue(storedMessage.length() <= 512);
   }
 
   @Test

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
@@ -409,6 +409,49 @@ class CryptaAppCliTest {
   }
 
   @Test
+  void catalogCreate_whenDescriptorUsesCryptaBundleUri_expectUnsupportedArtifactSchemeFailure()
+      throws Exception {
+    Path appDir = tempDir.resolve("sample-app");
+    Path outputZip = tempDir.resolve("sample-app.zip");
+    Path descriptor = tempDir.resolve("entry.properties");
+    Path catalogFile = tempDir.resolve("cryptad-app-catalog.properties");
+    runCli(
+        "init",
+        "--dir",
+        appDir.toString(),
+        "--app-id",
+        "sample-app",
+        "--name",
+        "Sample App",
+        "--version",
+        "0.1.0");
+    runCli("pack", "--bundle-dir", appDir.toString(), "--output", outputZip.toString());
+    Files.writeString(
+        descriptor,
+        lines(
+            "artifact.path=" + outputZip.toAbsolutePath().normalize(),
+            "bundle.uri=crypta:CHK@sample-bundle?signature=CHK@sample-signature",
+            "summary=Sample catalog entry."),
+        StandardCharsets.UTF_8);
+
+    CliResult result =
+        runCli(
+            "catalog",
+            "create",
+            "--catalog-file",
+            catalogFile.toString(),
+            "--catalog-id",
+            "dev",
+            "--name",
+            "Development Apps",
+            "--entry",
+            descriptor.toString());
+
+    assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode());
+    assertTrue(result.err().contains("unsupported artifact URI scheme: crypta"));
+  }
+
+  @Test
   void catalogSignAndVerify_whenCatalogCliRoundTrips_expectSuccess() throws Exception {
     Path appDir = tempDir.resolve("sample-app");
     Path outputZip = tempDir.resolve("sample-app.zip");

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -1546,10 +1546,78 @@
     sections.apps.append(list);
   }
 
+  function catalogSourceKind(catalog) {
+    const rawKind =
+      typeof catalog.sourceKind === "string" && catalog.sourceKind
+        ? catalog.sourceKind
+        : typeof catalog.sourceType === "string" && catalog.sourceType
+          ? catalog.sourceType
+          : "";
+    const normalizedKind = rawKind.trim().toLowerCase();
+    if (normalizedKind) {
+      return normalizedKind;
+    }
+    const source = typeof catalog.source === "string" ? catalog.source : "";
+    try {
+      const url = new URL(source, window.location.href);
+      const protocol = url.protocol.replace(":", "").toLowerCase();
+      return protocol || "unknown";
+    } catch (error) {
+      return "unknown";
+    }
+  }
+
+  function catalogLastSuccessfulRefreshAt(catalog) {
+    return typeof catalog.lastSuccessfulRefreshAt === "string" && catalog.lastSuccessfulRefreshAt
+      ? catalog.lastSuccessfulRefreshAt
+      : catalog.refreshedAt;
+  }
+
+  function catalogFetchStatus(catalog) {
+    return typeof catalog.lastFetchStatus === "string" && catalog.lastFetchStatus
+      ? catalog.lastFetchStatus.toLowerCase()
+      : "";
+  }
+
+  function catalogFetchFailed(catalog) {
+    const status = catalogFetchStatus(catalog);
+    if (status && status !== "success" && status !== "ok" && status !== "refreshed") {
+      return true;
+    }
+    return Boolean(catalog.lastFetchErrorCode || catalog.lastFetchErrorMessage);
+  }
+
+  function catalogLastFailedAttempt(catalog) {
+    if (!catalogFetchFailed(catalog)) {
+      return "Unavailable";
+    }
+    return formatIsoTimestamp(catalog.lastAttemptAt);
+  }
+
+  function catalogFetchWarningNode(catalog) {
+    if (catalogSourceKind(catalog) !== "crypta" || !catalogFetchFailed(catalog)) {
+      return null;
+    }
+    const details = [];
+    if (catalog.lastFetchErrorCode) {
+      details.push(scalar(catalog.lastFetchErrorCode));
+    }
+    if (catalog.lastFetchErrorMessage) {
+      details.push(scalar(catalog.lastFetchErrorMessage));
+    }
+    const suffix = details.length ? ` ${details.join(": ")}` : "";
+    return text(
+      "p",
+      "status-message is-warning",
+      `Crypta catalog refresh failed; showing last successful app listing.${suffix}`,
+    );
+  }
+
   function renderCatalogCard(catalog) {
     const card = document.createElement("article");
     card.className = "app-card";
     const title = typeof catalog.name === "string" && catalog.name ? catalog.name : scalar(catalog.catalogId);
+    const sourceKind = catalogSourceKind(catalog);
     const header = document.createElement("div");
     header.className = "app-card-header";
     const heading = document.createElement("div");
@@ -1558,16 +1626,30 @@
     const pills = document.createElement("div");
     pills.className = "app-card-pills";
     pills.append(createPill("Signed catalog"));
+    pills.append(createPill(sourceKind));
+    if (catalogFetchFailed(catalog)) {
+      pills.append(createPill("refresh failed", "is-warning"));
+    }
     pills.append(createPill(`${Array.isArray(catalog.apps) ? catalog.apps.length : 0} apps`));
     header.append(heading, pills);
     card.append(header);
     card.append(
       definitionList([
+        ["Source type", sourceKind],
         ["Source", scalar(catalog.source)],
+        ["Resolved source", scalar(catalog.lastResolvedUri)],
         ["Generated", formatIsoTimestamp(catalog.generatedAt)],
-        ["Refreshed", formatIsoTimestamp(catalog.refreshedAt)],
+        ["Last successful refresh", formatIsoTimestamp(catalogLastSuccessfulRefreshAt(catalog))],
+        ["Last failed attempt", catalogLastFailedAttempt(catalog)],
       ]),
     );
+    const fetchWarning = catalogFetchWarningNode(catalog);
+    if (fetchWarning) {
+      card.append(fetchWarning);
+    }
+    if (catalog.appsError) {
+      card.append(text("p", "error-state", `Catalog apps unavailable: ${catalog.appsError}`));
+    }
     if (formPassword) {
       const actions = document.createElement("div");
       actions.className = "app-card-actions";
@@ -2827,8 +2909,14 @@
     if (!catalog || typeof catalog !== "object" || typeof catalog.catalogId !== "string") {
       return catalog;
     }
-    const apps = await loadJson(apiUrl(`app-catalogs/${encodeURIComponent(catalog.catalogId)}/apps`));
-    return { ...catalog, apps: apps && Array.isArray(apps.apps) ? apps.apps : [] };
+    try {
+      const apps = await loadJson(apiUrl(`app-catalogs/${encodeURIComponent(catalog.catalogId)}/apps`));
+      return { ...catalog, apps: apps && Array.isArray(apps.apps) ? apps.apps : [] };
+    } catch (error) {
+      const appsError =
+        error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
+      return { ...catalog, apps: [], appsError };
+    }
   }
 
   async function dismissAlert(form) {

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -369,6 +369,10 @@ class WebShellResourcesTest {
     assertTrue(script.contains("app-log-tail"));
     assertTrue(script.contains("function renderApps(data)"));
     assertTrue(script.contains("function renderCatalogs(catalogs, catalogError)"));
+    assertTrue(script.contains("function catalogSourceKind(catalog)"));
+    assertTrue(script.contains("function catalogLastSuccessfulRefreshAt(catalog)"));
+    assertTrue(script.contains("function catalogFetchFailed(catalog)"));
+    assertTrue(script.contains("function catalogFetchWarningNode(catalog)"));
     assertTrue(script.contains("Catalogs unavailable: ${catalogError}"));
     assertTrue(script.contains("function renderCatalogCard(catalog)"));
     assertTrue(script.contains("function renderCatalogAppCard(catalog, app)"));
@@ -384,6 +388,20 @@ class WebShellResourcesTest {
     assertTrue(script.contains("installedSnapshot.apps.map(loadAppRuntimeDetails)"));
     assertTrue(script.contains("loadOptionalJson(apiUrl(\"app-catalogs\"))"));
     assertTrue(script.contains("catalogsSnapshot.catalogs.map(loadCatalogApps)"));
+    assertTrue(script.contains("typeof catalog.sourceKind === \"string\" && catalog.sourceKind"));
+    assertTrue(script.contains("typeof catalog.sourceType === \"string\" && catalog.sourceType"));
+    assertTrue(script.contains("pills.append(createPill(sourceKind));"));
+    assertTrue(script.contains("pills.append(createPill(\"refresh failed\", \"is-warning\"));"));
+    assertTrue(script.contains("[\"Source type\", sourceKind]"));
+    assertTrue(script.contains("[\"Resolved source\", scalar(catalog.lastResolvedUri)]"));
+    assertTrue(
+        script.contains(
+            "[\"Last successful refresh\","
+                + " formatIsoTimestamp(catalogLastSuccessfulRefreshAt(catalog))]"));
+    assertTrue(script.contains("[\"Last failed attempt\", catalogLastFailedAttempt(catalog)]"));
+    assertTrue(
+        script.contains("Crypta catalog refresh failed; showing last successful app listing."));
+    assertTrue(script.contains("catalog.appsError"));
     assertTrue(
         script.contains(
             "const apps = await"

--- a/runtime-node/gradle/owned-output-patterns.txt
+++ b/runtime-node/gradle/owned-output-patterns.txt
@@ -387,6 +387,7 @@ network/crypta/runtime/alerts/UserAlertManager*
 network/crypta/runtime/core/package-info*
 network/crypta/runtime/core/LegacyConfigPort*
 network/crypta/runtime/core/LegacyConnectivityPort*
+network/crypta/runtime/core/LegacyContentFetchPort*
 network/crypta/runtime/core/LegacyCoreUpdateActionPort*
 network/crypta/runtime/core/LegacyNodeInfoPort*
 network/crypta/runtime/core/LegacyPeerPort*

--- a/runtime-node/src/main/java/network/crypta/runtime/core/LegacyContentFetchPort.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/core/LegacyContentFetchPort.java
@@ -1,0 +1,434 @@
+package network.crypta.runtime.core;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import network.crypta.client.FetchContext;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchResult;
+import network.crypta.client.HighLevelSimpleClient;
+import network.crypta.client.async.ClientContext;
+import network.crypta.client.async.ClientGetCallback;
+import network.crypta.client.async.ClientGetter;
+import network.crypta.keys.FreenetURI;
+import network.crypta.node.NodeClientCore;
+import network.crypta.node.RequestClient;
+import network.crypta.node.RequestStarter;
+import network.crypta.runtime.spi.BoundedContentFetchRequest;
+import network.crypta.runtime.spi.BoundedContentFetchResult;
+import network.crypta.runtime.spi.ContentFetchException;
+import network.crypta.runtime.spi.ContentFetchPort;
+import network.crypta.support.api.Bucket;
+import network.crypta.support.io.ResumeFailedException;
+
+/**
+ * Daemon-backed implementation of the bounded runtime content-fetch SPI.
+ *
+ * <p>The adapter uses the existing non-persistent high-level client fetch layer, applies the
+ * caller's byte limit to both output and intermediate data, and waits only for the caller-supplied
+ * timeout. If the timeout expires, the underlying {@link ClientGetter} is canceled through the core
+ * {@link ClientContext}. Successful payloads are materialized only after the fetch result size has
+ * been checked against the requested maximum, and fetched buckets are freed on every materialized
+ * outcome.
+ *
+ * <p>The port is intentionally narrow. It is used by infrastructure callers that need bounded
+ * access to Crypta content, such as signed app catalog properties and signature sidecars, without
+ * exposing daemon client classes through {@code runtime-spi}. Fetch redirects that report a newer
+ * USK edition are followed within one overall timeout budget and a small redirect cap. The returned
+ * resolved URI is diagnostic metadata only; signature verification remains the catalog trust
+ * boundary.
+ */
+final class LegacyContentFetchPort implements ContentFetchPort {
+  /**
+   * Priority class used for bounded infrastructure fetches.
+   *
+   * <p>Catalog refreshes are operational maintenance, so they use the same priority family as
+   * update work instead of interactive browsing.
+   */
+  private static final short FETCH_PRIORITY_CLASS = RequestStarter.UPDATE_PRIORITY_CLASS;
+
+  /**
+   * Maximum permanent redirects followed during one bounded fetch.
+   *
+   * <p>The cap prevents a redirect cycle from consuming the caller's whole timeout through
+   * unbounded queue starts while still allowing normal USK edition advancement.
+   */
+  private static final int MAX_REDIRECTS = 8;
+
+  /** Node core used to create transient clients and cancel active getters on timeout. */
+  private final NodeClientCore core;
+
+  /**
+   * Creates a content-fetch port bound to one node core.
+   *
+   * @param core daemon core that owns the high-level fetch client and client context
+   */
+  LegacyContentFetchPort(NodeClientCore core) {
+    this.core = Objects.requireNonNull(core);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation parses the request URI as a daemon {@link FreenetURI}, starts a
+   * non-persistent fetch, follows permanent redirects with an overall timeout budget, and returns a
+   * defensive byte-array result. Invalid daemon URIs are reported as {@code
+   * invalid_catalog_source}; timeouts and fetch failures use stable runtime SPI error codes.
+   */
+  @Override
+  public BoundedContentFetchResult fetchContent(BoundedContentFetchRequest request)
+      throws ContentFetchException {
+    Objects.requireNonNull(request, "request");
+    FreenetURI uri = parseUri(request);
+    HighLevelSimpleClient client = core.makeClient(FETCH_PRIORITY_CLASS, false, false);
+    RequestClient requestClient = (RequestClient) client;
+    FetchOutcome outcome = fetchFollowingRedirects(request, client, requestClient, uri);
+    byte[] bytes = materializeResult(request, outcome.result());
+    String resolvedUri = outcome.resolvedUri() == null ? null : outcome.resolvedUri().toString();
+    return new BoundedContentFetchResult(
+        bytes, request.uri(), resolvedUri, "Fetched " + bytes.length + " bytes");
+  }
+
+  /**
+   * Parses the JDK-only request URI into the daemon URI type.
+   *
+   * @param request bounded fetch request carrying the raw URI string
+   * @return daemon URI suitable for the high-level client fetch layer
+   * @throws ContentFetchException if the URI cannot be parsed by daemon URI rules
+   */
+  private static FreenetURI parseUri(BoundedContentFetchRequest request)
+      throws ContentFetchException {
+    try {
+      return new FreenetURI(request.uri());
+    } catch (MalformedURLException exception) {
+      throw new ContentFetchException(
+          ContentFetchException.INVALID_CATALOG_SOURCE,
+          "Invalid content fetch URI for " + request.purpose(),
+          exception);
+    }
+  }
+
+  /**
+   * Builds a fetch context that enforces the caller's byte bound.
+   *
+   * @param client high-level client that owns the default fetch context template
+   * @param maxBytes maximum accepted output and temporary bytes for this fetch
+   * @return fetch context configured for bounded unfiltered content retrieval
+   */
+  private static FetchContext boundedFetchContext(HighLevelSimpleClient client, long maxBytes) {
+    FetchContext fetchContext = client.getFetchContext();
+    fetchContext.setMaxOutputLength(maxBytes);
+    fetchContext.setMaxTempLength(maxBytes);
+    fetchContext.setFilterData(false);
+    return fetchContext;
+  }
+
+  /**
+   * Executes a bounded fetch and follows permanent redirects within one timeout budget.
+   *
+   * <p>Crypta USK fetches can report newer editions through {@link
+   * FetchException.FetchExceptionMode#PERMANENT_REDIRECT}. This loop treats redirects with a
+   * concrete {@link FetchException#newURI} as retry targets and preserves the original request's
+   * timeout across all attempts. Other fetch failures are mapped to the runtime SPI error contract.
+   *
+   * @param request original bounded fetch request
+   * @param client high-level client used to start transient fetches
+   * @param requestClient request-client identity associated with callbacks
+   * @param initialUri first daemon URI to fetch
+   * @return fetch result and final daemon URI reported by the getter
+   * @throws ContentFetchException if timeout, redirect limit, or non-redirect fetch failure occurs
+   */
+  private FetchOutcome fetchFollowingRedirects(
+      BoundedContentFetchRequest request,
+      HighLevelSimpleClient client,
+      RequestClient requestClient,
+      FreenetURI initialUri)
+      throws ContentFetchException {
+    long deadlineNanos = deadlineNanos(request.timeout());
+    FreenetURI currentUri = initialUri;
+    int redirects = 0;
+    while (true) {
+      FetchContext fetchContext = boundedFetchContext(client, request.maxBytes());
+      FetchCompletionCallback callback = new FetchCompletionCallback(requestClient);
+      ClientGetter getter;
+      try {
+        getter = startFetch(client, currentUri, request.maxBytes(), fetchContext, callback);
+        FetchResult result = waitForResult(request, callback, getter, deadlineNanos);
+        return new FetchOutcome(result, getter.getURI() == null ? currentUri : getter.getURI());
+      } catch (FetchException exception) {
+        FreenetURI redirectUri = redirectTarget(exception);
+        if (redirectUri == null) {
+          throw mapFetchException(exception);
+        }
+        if (redirects >= MAX_REDIRECTS) {
+          throw new ContentFetchException(
+              ContentFetchException.CATALOG_FETCH_FAILED,
+              "Content fetch redirect limit exceeded for " + request.purpose(),
+              exception);
+        }
+        redirects++;
+        currentUri = redirectUri;
+      }
+    }
+  }
+
+  /**
+   * Starts one transient high-level client fetch.
+   *
+   * @param client high-level client that owns fetch scheduling
+   * @param uri daemon URI to fetch for this attempt
+   * @param maxBytes maximum bytes accepted by the high-level fetch call
+   * @param fetchContext context carrying output and temp byte limits
+   * @param callback callback completed by the asynchronous fetch
+   * @return getter handle used for cancellation and final URI reporting
+   * @throws FetchException if the fetch cannot be queued or fails synchronously
+   */
+  private static ClientGetter startFetch(
+      HighLevelSimpleClient client,
+      FreenetURI uri,
+      long maxBytes,
+      FetchContext fetchContext,
+      FetchCompletionCallback callback)
+      throws FetchException {
+    return client.fetch(uri, maxBytes, callback, fetchContext, FETCH_PRIORITY_CLASS);
+  }
+
+  /**
+   * Waits for one asynchronous fetch attempt to complete.
+   *
+   * <p>The method cancels the getter on timeout or interruption. Fetch exceptions are rethrown so
+   * the redirect loop can inspect permanent redirects before the failure is converted to the
+   * runtime SPI error envelope.
+   *
+   * @param request original request, used for stable error messages
+   * @param callback callback future completed by the high-level fetch layer
+   * @param getter active getter that should be canceled when waiting stops early
+   * @param deadlineNanos absolute {@link System#nanoTime()} deadline for the overall fetch
+   * @return completed fetch result for the current attempt
+   * @throws ContentFetchException if waiting times out, is interrupted, or fails unexpectedly
+   * @throws FetchException if the fetch layer reports a fetch failure
+   */
+  private FetchResult waitForResult(
+      BoundedContentFetchRequest request,
+      FetchCompletionCallback callback,
+      ClientGetter getter,
+      long deadlineNanos)
+      throws ContentFetchException, FetchException {
+    long remainingNanos = remainingNanos(deadlineNanos);
+    if (remainingNanos <= 0L) {
+      getter.cancel(core.getClientContext());
+      throw timeoutException(request, null);
+    }
+    try {
+      return callback.result().get(remainingNanos, TimeUnit.NANOSECONDS);
+    } catch (TimeoutException exception) {
+      getter.cancel(core.getClientContext());
+      throw timeoutException(request, exception);
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      getter.cancel(core.getClientContext());
+      throw new ContentFetchException(
+          ContentFetchException.CATALOG_FETCH_FAILED,
+          "Interrupted while fetching " + request.purpose(),
+          exception);
+    } catch (ExecutionException exception) {
+      Throwable cause = exception.getCause();
+      if (cause instanceof FetchException fetchException) {
+        throw fetchException;
+      }
+      throw new ContentFetchException(
+          ContentFetchException.CATALOG_FETCH_FAILED,
+          "Failed fetching " + request.purpose(),
+          cause);
+    }
+  }
+
+  /**
+   * Creates the stable timeout exception used by the runtime SPI.
+   *
+   * @param request original request, used to include the diagnostic purpose
+   * @param cause optional timeout cause from the waiting operation
+   * @return content-fetch exception with {@code catalog_fetch_timeout}
+   */
+  private static ContentFetchException timeoutException(
+      BoundedContentFetchRequest request, Throwable cause) {
+    return new ContentFetchException(
+        ContentFetchException.CATALOG_FETCH_TIMEOUT,
+        "Timed out fetching " + request.purpose(),
+        cause);
+  }
+
+  /**
+   * Materializes a bounded fetch result and always releases the source bucket.
+   *
+   * <p>The method checks both the bucket-reported size and the final byte-array length. The second
+   * check protects against unusual bucket implementations whose size changes or reports
+   * inaccurately while being read. The daemon bucket is owned through try-with-resources so
+   * successful reads, oversized results, and I/O failures all release the bucket.
+   *
+   * @param request bounded request containing the maximum byte count and purpose
+   * @param result daemon fetch result whose bucket is owned by this adapter
+   * @return detached bytes from the fetch result
+   * @throws ContentFetchException if the result is oversized or cannot be read
+   */
+  static byte[] materializeResult(BoundedContentFetchRequest request, FetchResult result)
+      throws ContentFetchException {
+    try (Bucket bucket = result.asBucket()) {
+      long resultSize = bucket.size();
+      if (resultSize > request.maxBytes()) {
+        throw oversizedContentException(request);
+      }
+      byte[] bytes = result.asByteArray();
+      if (bytes.length > request.maxBytes()) {
+        throw oversizedContentException(request);
+      }
+      return bytes;
+    } catch (IOException exception) {
+      throw new ContentFetchException(
+          ContentFetchException.CATALOG_FETCH_FAILED,
+          "Failed reading fetched content for " + request.purpose(),
+          exception);
+    }
+  }
+
+  private static ContentFetchException oversizedContentException(
+      BoundedContentFetchRequest request) {
+    return new ContentFetchException(
+        ContentFetchException.CATALOG_FETCH_FAILED,
+        "Fetched content exceeded " + request.maxBytes() + " bytes for " + request.purpose());
+  }
+
+  /**
+   * Converts a non-redirect fetch failure into the runtime SPI error envelope.
+   *
+   * @param exception daemon fetch exception that should be exposed only through a stable code
+   * @return content-fetch exception with {@code catalog_fetch_failed}
+   */
+  private static ContentFetchException mapFetchException(FetchException exception) {
+    return new ContentFetchException(
+        ContentFetchException.CATALOG_FETCH_FAILED,
+        "Content fetch failed: " + exception.getMessage(),
+        exception);
+  }
+
+  /**
+   * Extracts a retry target from a permanent redirect fetch exception.
+   *
+   * @param exception daemon fetch exception reported by the high-level client
+   * @return redirected daemon URI, or {@code null} when the exception should not be retried
+   */
+  static FreenetURI redirectTarget(FetchException exception) {
+    if (exception.mode == FetchException.FetchExceptionMode.PERMANENT_REDIRECT) {
+      return exception.newURI;
+    }
+    return null;
+  }
+
+  /**
+   * Computes the absolute timeout deadline for one bounded fetch request.
+   *
+   * @param timeout positive caller-supplied timeout duration
+   * @return absolute {@link System#nanoTime()} deadline, saturated at {@link Long#MAX_VALUE}
+   */
+  private static long deadlineNanos(Duration timeout) {
+    long now = System.nanoTime();
+    long timeoutNanos = timeoutNanos(timeout);
+    long safeNow = Math.max(now, 0L);
+    if (timeoutNanos > Long.MAX_VALUE - safeNow) {
+      return Long.MAX_VALUE;
+    }
+    return now + timeoutNanos;
+  }
+
+  /**
+   * Converts a timeout duration to nanoseconds with saturation.
+   *
+   * @param timeout positive timeout duration from the request
+   * @return timeout nanoseconds, or {@link Long#MAX_VALUE} when the duration overflows
+   */
+  private static long timeoutNanos(Duration timeout) {
+    try {
+      return timeout.toNanos();
+    } catch (ArithmeticException _) {
+      return Long.MAX_VALUE;
+    }
+  }
+
+  /**
+   * Returns the time remaining before an absolute deadline.
+   *
+   * @param deadlineNanos absolute {@link System#nanoTime()} deadline
+   * @return non-negative remaining nanoseconds
+   */
+  private static long remainingNanos(long deadlineNanos) {
+    return Math.max(deadlineNanos - System.nanoTime(), 0L);
+  }
+
+  /**
+   * Completed fetch attempt and the URI that should be reported as resolved metadata.
+   *
+   * @param result daemon fetch result whose bucket still needs materialization and release
+   * @param resolvedUri final URI reported by the getter, or the attempted URI as a fallback
+   */
+  private record FetchOutcome(FetchResult result, FreenetURI resolvedUri) {}
+
+  /**
+   * Callback bridge from the daemon fetch API to a {@link CompletableFuture}.
+   *
+   * <p>The high-level fetch API completes through callback methods, while the runtime SPI needs a
+   * bounded synchronous return. This bridge stores only the request-client identity required by the
+   * fetch layer and completes a future with either the {@link FetchResult} or the reported {@link
+   * FetchException}. Persistent resume is rejected because these fetches are deliberately
+   * transient.
+   */
+  private static final class FetchCompletionCallback implements ClientGetCallback {
+    /** Request-client identity returned to the high-level fetch scheduler. */
+    private final RequestClient requestClient;
+
+    /** Future completed exactly once by success or failure callbacks. */
+    private final CompletableFuture<FetchResult> result = new CompletableFuture<>();
+
+    /**
+     * Creates a callback bridge for one fetch attempt.
+     *
+     * @param requestClient request-client identity associated with the transient fetch
+     */
+    private FetchCompletionCallback(RequestClient requestClient) {
+      this.requestClient = Objects.requireNonNull(requestClient);
+    }
+
+    /**
+     * Returns the future completed by the fetch callbacks.
+     *
+     * @return future carrying a fetch result or fetch exception
+     */
+    private CompletableFuture<FetchResult> result() {
+      return result;
+    }
+
+    @Override
+    public void onSuccess(FetchResult result, ClientGetter state) {
+      this.result.complete(result);
+    }
+
+    @Override
+    public void onFailure(FetchException exception) {
+      result.completeExceptionally(exception);
+    }
+
+    @Override
+    public void onResume(ClientContext context) throws ResumeFailedException {
+      throw new ResumeFailedException("Transient runtime content fetch cannot be resumed");
+    }
+
+    @Override
+    public RequestClient getRequestClient() {
+      return requestClient;
+    }
+  }
+}

--- a/runtime-node/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
+++ b/runtime-node/src/main/java/network/crypta/runtime/core/LegacyRuntimePorts.java
@@ -15,6 +15,7 @@ import network.crypta.runtime.spi.ConfigPort;
 import network.crypta.runtime.spi.ConnectionsPagePort;
 import network.crypta.runtime.spi.ConnectionsSupportPort;
 import network.crypta.runtime.spi.ConnectivityPort;
+import network.crypta.runtime.spi.ContentFetchPort;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
 import network.crypta.runtime.spi.DarknetMessagingPort;
@@ -61,6 +62,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   private final ExecutionPort executionPort;
   private final RandomnessPort randomnessPort;
   private final TransferAccessPort transferAccessPort;
+  private final ContentFetchPort contentFetchPort;
   private final LifecyclePort lifecyclePort;
   private final ConfigPort configPort;
   private final ConnectivityPort connectivityPort;
@@ -151,6 +153,7 @@ public final class LegacyRuntimePorts implements RuntimePorts {
             return LegacyRuntimePorts.this.core.getAllowedDownloadDirs();
           }
         };
+    this.contentFetchPort = new LegacyContentFetchPort(core);
     this.lifecyclePort =
         new LifecyclePort() {
           @Override
@@ -239,6 +242,17 @@ public final class LegacyRuntimePorts implements RuntimePorts {
   @Override
   public TransferAccessPort transferAccess() {
     return transferAccessPort;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The returned port delegates to the daemon's existing high-level client fetch stack and keeps
+   * URI parsing, request cancellation, and bucket materialization inside runtime-node.
+   */
+  @Override
+  public ContentFetchPort contentFetch() {
+    return contentFetchPort;
   }
 
   /**

--- a/runtime-node/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
+++ b/runtime-node/src/test/java/network/crypta/runtime/RuntimeNodeKernelSplitPrepBoundaryTest.java
@@ -151,6 +151,30 @@ class RuntimeNodeKernelSplitPrepBoundaryTest {
   }
 
   @Test
+  void runtimeNodeContentFetch_whenCheckingRuntimePortsWiring_expectLegacyAdapterRegistered()
+      throws IOException {
+    Path repoRoot = repoRoot();
+    String runtimePortsSource =
+        Files.readString(
+            repoRoot.resolve(
+                Path.of(
+                    "runtime-node",
+                    "src",
+                    "main",
+                    "java",
+                    "network",
+                    "crypta",
+                    "runtime",
+                    "core",
+                    "LegacyRuntimePorts.java")));
+
+    assertTrue(runtimePortsSource.contains("private final ContentFetchPort contentFetchPort;"));
+    assertTrue(
+        runtimePortsSource.contains("this.contentFetchPort = new LegacyContentFetchPort(core);"));
+    assertTrue(runtimePortsSource.contains("public ContentFetchPort contentFetch()"));
+  }
+
+  @Test
   void runtimeNodePhaseTwo_whenCheckingMovedLeafOwnership_expectMovedLeafTypesAbsent()
       throws IOException {
     Path repoRoot = repoRoot();

--- a/runtime-node/src/test/java/network/crypta/runtime/core/LegacyContentFetchPortTest.java
+++ b/runtime-node/src/test/java/network/crypta/runtime/core/LegacyContentFetchPortTest.java
@@ -1,0 +1,125 @@
+package network.crypta.runtime.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import network.crypta.client.ClientMetadata;
+import network.crypta.client.FetchException;
+import network.crypta.client.FetchResult;
+import network.crypta.keys.FreenetURI;
+import network.crypta.runtime.spi.BoundedContentFetchRequest;
+import network.crypta.runtime.spi.ContentFetchException;
+import network.crypta.support.io.ArrayBucket;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LegacyContentFetchPortTest {
+  @Test
+  void redirectTarget_whenPermanentRedirectCarriesUri_expectUriReturned() {
+    FreenetURI redirectUri = FreenetURI.EMPTY_CHK_URI;
+    FetchException exception =
+        new FetchException(FetchException.FetchExceptionMode.PERMANENT_REDIRECT, redirectUri);
+
+    assertSame(redirectUri, LegacyContentFetchPort.redirectTarget(exception));
+  }
+
+  @Test
+  void redirectTarget_whenPermanentRedirectHasNoUri_expectNoRetryTarget() {
+    FetchException exception =
+        new FetchException(FetchException.FetchExceptionMode.PERMANENT_REDIRECT, (FreenetURI) null);
+
+    assertNull(LegacyContentFetchPort.redirectTarget(exception));
+  }
+
+  @Test
+  void redirectTarget_whenModeIsNotPermanentRedirect_expectNoRetryTarget() {
+    FetchException exception =
+        new FetchException(
+            FetchException.FetchExceptionMode.DATA_NOT_FOUND, FreenetURI.EMPTY_CHK_URI);
+
+    assertNull(LegacyContentFetchPort.redirectTarget(exception));
+  }
+
+  @Test
+  void materializeResult_whenWithinBound_expectBytesReturnedAndBucketFreed()
+      throws ContentFetchException {
+    TrackingBucket bucket = new TrackingBucket(new byte[] {1, 2});
+    FetchResult result = FetchResult.create(new ClientMetadata("application/octet-stream"), bucket);
+    BoundedContentFetchRequest request =
+        new BoundedContentFetchRequest("CHK@test", 2, Duration.ofSeconds(1), "catalog test");
+
+    byte[] bytes = LegacyContentFetchPort.materializeResult(request, result);
+
+    assertArrayEquals(new byte[] {1, 2}, bytes);
+    assertTrue(bucket.freed());
+  }
+
+  @Test
+  void materializeResult_whenReportedSizeExceedsBound_expectBucketFreed() {
+    TrackingBucket bucket = new TrackingBucket(new byte[] {1, 2});
+    FetchResult result = FetchResult.create(new ClientMetadata("application/octet-stream"), bucket);
+    BoundedContentFetchRequest request =
+        new BoundedContentFetchRequest(
+            "CHK@test", 1, Duration.ofSeconds(1), "oversized catalog test");
+
+    ContentFetchException exception =
+        assertThrows(
+            ContentFetchException.class,
+            () -> LegacyContentFetchPort.materializeResult(request, result));
+
+    assertEquals(ContentFetchException.CATALOG_FETCH_FAILED, exception.errorCode());
+    assertTrue(bucket.freed());
+  }
+
+  @Test
+  void materializeResult_whenBucketReadFails_expectBucketFreed() {
+    ThrowingReadBucket bucket = new ThrowingReadBucket(new byte[] {1});
+    FetchResult result = FetchResult.create(new ClientMetadata("application/octet-stream"), bucket);
+    BoundedContentFetchRequest request =
+        new BoundedContentFetchRequest("CHK@test", 1, Duration.ofSeconds(1), "catalog test");
+
+    ContentFetchException exception =
+        assertThrows(
+            ContentFetchException.class,
+            () -> LegacyContentFetchPort.materializeResult(request, result));
+
+    assertEquals(ContentFetchException.CATALOG_FETCH_FAILED, exception.errorCode());
+    assertTrue(bucket.freed());
+  }
+
+  private static class TrackingBucket extends ArrayBucket {
+    private boolean freed;
+
+    private TrackingBucket(byte[] initData) {
+      super(initData);
+    }
+
+    @Override
+    public void free() {
+      freed = true;
+      super.free();
+    }
+
+    boolean freed() {
+      return freed;
+    }
+  }
+
+  private static final class ThrowingReadBucket extends TrackingBucket {
+    private ThrowingReadBucket(byte[] initData) {
+      super(initData);
+    }
+
+    @Override
+    public InputStream getInputStreamUnbuffered() throws IOException {
+      throw new IOException("read failed");
+    }
+  }
+}

--- a/runtime-spi/build.gradle.kts
+++ b/runtime-spi/build.gradle.kts
@@ -4,3 +4,9 @@ plugins {
 }
 
 version = rootProject.version
+
+dependencies {
+  testImplementation(libs.junitJupiterApi)
+  testRuntimeOnly(libs.junitJupiterEngine)
+  testRuntimeOnly(libs.junitPlatformLauncher)
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/BoundedContentFetchRequest.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/BoundedContentFetchRequest.java
@@ -1,0 +1,67 @@
+package network.crypta.runtime.spi;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Detached request for a bounded runtime content fetch.
+ *
+ * <p>The record deliberately carries only JDK-level values so callers can request content without
+ * depending on daemon URI or fetch types. The {@code purpose} value is a caller-supplied diagnostic
+ * label, not a policy selector; implementations may include it in logs and exception messages.
+ * Callers should keep it short, stable, and free of secrets because it can appear in failure text.
+ *
+ * <p>Every request must define both a byte limit and a timeout. Implementations are expected to
+ * apply the byte limit before returning materialized bytes and to stop waiting when the timeout
+ * expires. The SPI does not prescribe URI syntax; a runtime implementation may accept Crypta keys,
+ * content-addressed URIs, or other node-owned fetch locations and should report unsupported values
+ * through {@link ContentFetchException#INVALID_CATALOG_SOURCE}.
+ *
+ * @param uri content URI string to fetch; must be nonblank and single-line
+ * @param maxBytes maximum number of payload bytes the caller is willing to materialize
+ * @param timeout maximum wall-clock wait for this fetch
+ * @param purpose nonblank single-line diagnostic label for the caller's use case
+ */
+public record BoundedContentFetchRequest(
+    String uri, long maxBytes, Duration timeout, String purpose) {
+  /**
+   * Creates a validated bounded content fetch request.
+   *
+   * <p>Validation is intentionally limited to transport-neutral constraints. The URI is required to
+   * be a single-line nonblank string, but runtime-specific parsing remains the implementation's
+   * responsibility. The byte and timeout bounds must be positive so a request can never mean
+   * "unbounded" by accident.
+   *
+   * @throws NullPointerException if {@code uri}, {@code timeout}, or {@code purpose} is {@code
+   *     null}
+   * @throws IllegalArgumentException if a text value is blank or multi-line, {@code maxBytes} is
+   *     not positive, or {@code timeout} is not positive
+   */
+  public BoundedContentFetchRequest {
+    requireSingleLineText(uri, "uri");
+    if (maxBytes <= 0) {
+      throw new IllegalArgumentException("maxBytes must be positive");
+    }
+    Objects.requireNonNull(timeout, "timeout");
+    if (timeout.isZero() || timeout.isNegative()) {
+      throw new IllegalArgumentException("timeout must be positive");
+    }
+    requireSingleLineText(purpose, "purpose");
+  }
+
+  /**
+   * Validates a request text field that may be copied into diagnostics.
+   *
+   * @param value raw text value to validate
+   * @param name field name used in exception messages
+   */
+  private static void requireSingleLineText(String value, String name) {
+    Objects.requireNonNull(value, name);
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(name + " must be nonblank");
+    }
+    if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+      throw new IllegalArgumentException(name + " must be single-line");
+    }
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/BoundedContentFetchResult.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/BoundedContentFetchResult.java
@@ -1,0 +1,187 @@
+package network.crypta.runtime.spi;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Detached result for a bounded runtime content fetch.
+ *
+ * <p>The payload is defensively copied on construction and on access so callers can retain or
+ * mutate the returned array without affecting the stored result. {@code resolvedUri} and {@code
+ * statusMessage} are optional diagnostic values and may be {@code null}.
+ *
+ * <p>The result is intentionally a small in-memory value. Implementations should only create it
+ * after they have enforced the caller's byte bound and released any runtime-owned temporary
+ * storage. The {@code requestedUri} echoes the caller input for correlation, while {@code
+ * resolvedUri} can report transport-specific resolution such as a newer USK edition. Neither field
+ * is a trust signal for catalog or bundle verification.
+ */
+public final class BoundedContentFetchResult {
+  private static final String REQUESTED_URI_FIELD = "requestedUri";
+
+  private final byte[] bytes;
+  private final String requestedUri;
+  private final String resolvedUri;
+  private final String statusMessage;
+  private final int bytesLength;
+
+  /**
+   * Creates a detached fetch result.
+   *
+   * <p>All textual diagnostics are constrained to a single line so higher layers can safely place
+   * them in logs, JSON fields, or source metadata without preserving arbitrary line breaks.
+   * Optional fields may be {@code null}; when present they must be nonblank.
+   *
+   * @param bytes fetched content bytes; copied defensively
+   * @param requestedUri original URI string requested by the caller; must be nonblank and
+   *     single-line
+   * @param resolvedUri final URI string reported by the implementation, or {@code null} when not
+   *     available
+   * @param statusMessage optional human-readable status text, or {@code null}
+   * @throws NullPointerException if {@code bytes} or {@code requestedUri} is {@code null}
+   * @throws IllegalArgumentException if a URI/status text value is blank where not nullable, or
+   *     multi-line
+   */
+  public BoundedContentFetchResult(
+      byte[] bytes, String requestedUri, String resolvedUri, String statusMessage) {
+    this.bytes = Objects.requireNonNull(bytes, "bytes").clone();
+    this.bytesLength = this.bytes.length;
+    requireRequestedUri(requestedUri);
+    requireNullableSingleLineText(resolvedUri, "resolvedUri");
+    requireNullableSingleLineText(statusMessage, "statusMessage");
+    this.requestedUri = requestedUri;
+    this.resolvedUri = resolvedUri;
+    this.statusMessage = statusMessage;
+  }
+
+  /**
+   * Returns a defensive copy of the fetched bytes.
+   *
+   * @return copied payload bytes that the caller can mutate safely
+   */
+  public byte[] bytes() {
+    return bytes.clone();
+  }
+
+  /**
+   * Returns the URI originally requested by the caller.
+   *
+   * <p>This value is retained for diagnostics and correlation only. Catalog and bundle authenticity
+   * must still be established by the signed catalog, artifact digest, and signed bundle
+   * verification layers.
+   *
+   * @return original nonblank single-line URI string
+   */
+  public String requestedUri() {
+    return requestedUri;
+  }
+
+  /**
+   * Returns the final URI reported by the runtime fetch implementation.
+   *
+   * <p>Mutable Crypta keys such as USKs may resolve to a newer concrete edition. Implementations
+   * that cannot provide a resolved value leave this field {@code null}.
+   *
+   * @return resolved URI string, or {@code null} when unavailable
+   */
+  public String resolvedUri() {
+    return resolvedUri;
+  }
+
+  /**
+   * Returns optional transport status text from the runtime fetch implementation.
+   *
+   * <p>The message is a bounded single-line diagnostic for operator display or logs. Callers must
+   * not parse it for policy decisions.
+   *
+   * @return status message, or {@code null} when no message was supplied
+   */
+  public String statusMessage() {
+    return statusMessage;
+  }
+
+  /**
+   * Compares two detached fetch results by payload bytes and diagnostic fields.
+   *
+   * @param obj candidate object to compare
+   * @return {@code true} when the payload and all diagnostic fields are equal
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof BoundedContentFetchResult other)) {
+      return false;
+    }
+    return Arrays.equals(bytes, other.bytes)
+        && Objects.equals(requestedUri, other.requestedUri)
+        && Objects.equals(resolvedUri, other.resolvedUri)
+        && Objects.equals(statusMessage, other.statusMessage);
+  }
+
+  /**
+   * Returns a hash derived from the payload bytes and diagnostic fields.
+   *
+   * @return hash code consistent with {@link #equals(Object)}
+   */
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(bytes);
+    result = 31 * result + Objects.hash(requestedUri, resolvedUri, statusMessage);
+    return result;
+  }
+
+  /**
+   * Returns a diagnostic representation without embedding the fetched payload.
+   *
+   * @return string containing the payload length and diagnostic fields
+   */
+  @Override
+  public String toString() {
+    return "BoundedContentFetchResult[bytesLength="
+        + bytesLength
+        + ", "
+        + REQUESTED_URI_FIELD
+        + "="
+        + requestedUri
+        + ", resolvedUri="
+        + resolvedUri
+        + ", statusMessage="
+        + statusMessage
+        + ']';
+  }
+
+  /**
+   * Validates the required requested-URI diagnostic field.
+   *
+   * @param value raw requested URI text to validate
+   */
+  private static void requireRequestedUri(String value) {
+    Objects.requireNonNull(value, REQUESTED_URI_FIELD);
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(REQUESTED_URI_FIELD + " must be nonblank");
+    }
+    if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+      throw new IllegalArgumentException(REQUESTED_URI_FIELD + " must be single-line");
+    }
+  }
+
+  /**
+   * Validates an optional single-line diagnostic field.
+   *
+   * @param value optional text value to validate, or {@code null}
+   * @param name field name used in exception messages
+   */
+  private static void requireNullableSingleLineText(String value, String name) {
+    if (value == null) {
+      return;
+    }
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(name + " must be nonblank when present");
+    }
+    if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+      throw new IllegalArgumentException(name + " must be single-line");
+    }
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ContentFetchException.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ContentFetchException.java
@@ -1,0 +1,104 @@
+package network.crypta.runtime.spi;
+
+import java.io.Serial;
+import java.util.Objects;
+
+/**
+ * Checked exception for bounded runtime content fetch failures.
+ *
+ * <p>The {@linkplain #errorCode() error code} is the stable programmatic contract. Messages are for
+ * logs and user-facing mapping context and may include implementation-specific detail.
+ *
+ * <p>This type belongs to the JDK-only runtime SPI. It deliberately uses strings rather than daemon
+ * fetch enums so platform modules can map failures without depending on runtime-node classes. Code
+ * that catches this exception should branch on {@link #errorCode()} and treat {@link #getMessage()}
+ * as diagnostic text only. The message can be shown after normal UI sanitization, but it is not
+ * part of the compatibility contract.
+ */
+public class ContentFetchException extends Exception {
+  /** Serialization identifier for the checked exception type. */
+  @Serial private static final long serialVersionUID = 1L;
+
+  /**
+   * Fetch could not complete successfully for a runtime or network reason.
+   *
+   * <p>Use this code when a bounded request is syntactically valid but the runtime cannot return
+   * bytes: content is unavailable, fetch state fails, a result exceeds the requested byte limit, or
+   * the implementation cannot read the fetched payload.
+   */
+  public static final String CATALOG_FETCH_FAILED = "catalog_fetch_failed";
+
+  /**
+   * Fetch did not complete before the caller-supplied timeout.
+   *
+   * <p>Callers can map this separately from generic failures when they want UI text or retry
+   * behavior to distinguish slow content retrieval from permanent fetch errors.
+   */
+  public static final String CATALOG_FETCH_TIMEOUT = "catalog_fetch_timeout";
+
+  /**
+   * Caller supplied a URI that the runtime fetch implementation cannot parse or use.
+   *
+   * <p>The runtime implementation should use this code before starting a fetch when the URI string
+   * is malformed or unsupported for that implementation.
+   */
+  public static final String INVALID_CATALOG_SOURCE = "invalid_catalog_source";
+
+  /** Stable machine-readable code used by callers for API and UI mapping. */
+  private final String errorCode;
+
+  /**
+   * Creates a fetch exception with a stable error code and detail message.
+   *
+   * <p>The constructor validates only the error code. The human-readable message follows normal
+   * {@link Exception} behavior and should be written by callers as short diagnostic text.
+   *
+   * @param errorCode stable machine-readable error code; must be nonblank and single-line
+   * @param message human-readable detail message
+   */
+  public ContentFetchException(String errorCode, String message) {
+    super(message);
+    this.errorCode = validateErrorCode(errorCode);
+  }
+
+  /**
+   * Creates a fetch exception with a stable error code, detail message, and cause.
+   *
+   * <p>Use this overload when retaining a lower-level failure helps logs or callers that inspect
+   * suppressed/causal chains. The stable error code remains the primary contract for API mapping.
+   *
+   * @param errorCode stable machine-readable error code; must be nonblank and single-line
+   * @param message human-readable detail message
+   * @param cause underlying failure retained for diagnostics
+   */
+  public ContentFetchException(String errorCode, String message, Throwable cause) {
+    super(message, cause);
+    this.errorCode = validateErrorCode(errorCode);
+  }
+
+  /**
+   * Returns the stable machine-readable failure code.
+   *
+   * @return stable error code such as {@link #CATALOG_FETCH_FAILED}
+   */
+  public String errorCode() {
+    return errorCode;
+  }
+
+  /**
+   * Validates one stable error-code token.
+   *
+   * @param errorCode raw error-code text supplied by the throwing implementation
+   * @return validated nonblank single-line error code
+   */
+  private static String validateErrorCode(String errorCode) {
+    Objects.requireNonNull(errorCode, "errorCode");
+    if (errorCode.isBlank()) {
+      throw new IllegalArgumentException("errorCode must be nonblank");
+    }
+    if (errorCode.indexOf('\n') >= 0 || errorCode.indexOf('\r') >= 0) {
+      throw new IllegalArgumentException("errorCode must be single-line");
+    }
+    return errorCode;
+  }
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/ContentFetchPort.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/ContentFetchPort.java
@@ -1,0 +1,42 @@
+package network.crypta.runtime.spi;
+
+/**
+ * Runtime capability for fetching bounded content bytes from the node.
+ *
+ * <p>This port is intended for infrastructure flows that need to retrieve a small runtime-owned
+ * document, such as a signed catalog, without depending on daemon URI, client, bucket, or fetch
+ * classes. Callers must provide a strict byte limit and timeout for each request. Implementations
+ * are responsible for enforcing those bounds before returning materialized bytes.
+ *
+ * <p>The SPI stays JDK-only: request and result values contain strings, durations, byte arrays, and
+ * checked exceptions only. URI parsing and network-specific behavior remain implementation details
+ * of the daemon-backed adapter.
+ *
+ * <p>Implementations should avoid creating durable queue state for these requests unless their
+ * runtime cannot fetch content any other way. A call should either return detached bytes or throw a
+ * {@link ContentFetchException} with a stable code that higher layers can map. The port is a
+ * transport bridge, not a trust boundary; callers that fetch signed catalogs or bundles must still
+ * perform their own signature and digest checks.
+ *
+ * @see RuntimePorts#contentFetch()
+ * @see BoundedContentFetchRequest
+ * @see BoundedContentFetchResult
+ */
+public interface ContentFetchPort {
+  /**
+   * Fetches one bounded content document.
+   *
+   * <p>The returned byte array is detached from the implementation's internal buffers. Failures are
+   * reported through stable string error codes so higher layers can map them without depending on
+   * daemon-specific exception enums. Implementations should honor the request timeout as an
+   * end-to-end wait budget and should cancel or release runtime fetch resources when the budget is
+   * exhausted.
+   *
+   * @param request bounded request describing URI, byte limit, timeout, and purpose
+   * @return detached content bytes plus requested and resolved URI metadata
+   * @throws ContentFetchException if the URI is invalid, the fetch times out, the byte limit is
+   *     exceeded, or the runtime fetch fails
+   */
+  BoundedContentFetchResult fetchContent(BoundedContentFetchRequest request)
+      throws ContentFetchException;
+}

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/RuntimePorts.java
@@ -17,6 +17,7 @@ package network.crypta.runtime.spi;
  * @see ExecutionPort
  * @see RandomnessPort
  * @see TransferAccessPort
+ * @see ContentFetchPort
  * @see LifecyclePort
  * @see ConfigPort
  * @see ConnectivityPort
@@ -79,6 +80,18 @@ public interface RuntimePorts {
    */
   @SuppressWarnings("unused")
   TransferAccessPort transferAccess();
+
+  /**
+   * Returns the bounded runtime content-fetch capability exposed to infrastructure code.
+   *
+   * <p>This port lets higher layers fetch small runtime-owned documents, such as signed catalogs,
+   * without depending on daemon-only URI, client, bucket, or fetch exception types. Callers must
+   * supply byte and timeout bounds for each request, and implementations return detached byte
+   * arrays only after enforcing those bounds.
+   *
+   * @return bounded content-fetch runtime port for JDK-only fetch requests
+   */
+  ContentFetchPort contentFetch();
 
   /**
    * Returns the lifecycle capability exposed to infrastructure code.

--- a/runtime-spi/src/test/java/network/crypta/runtime/spi/BoundedContentFetchRequestTest.java
+++ b/runtime-spi/src/test/java/network/crypta/runtime/spi/BoundedContentFetchRequestTest.java
@@ -1,0 +1,59 @@
+package network.crypta.runtime.spi;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class BoundedContentFetchRequestTest {
+  private static final String VALID_URI = "CHK@example";
+  private static final long VALID_MAX_BYTES = 1L;
+  private static final Duration VALID_TIMEOUT = Duration.ofSeconds(1);
+  private static final String VALID_PURPOSE = "catalog";
+
+  @Test
+  void constructor_whenValuesAreValid_expectFieldsPreserved() {
+    Duration timeout = Duration.ofSeconds(5);
+
+    BoundedContentFetchRequest request =
+        new BoundedContentFetchRequest(VALID_URI, 4096L, timeout, "catalog refresh");
+
+    assertEquals(VALID_URI, request.uri());
+    assertEquals(4096L, request.maxBytes());
+    assertEquals(timeout, request.timeout());
+    assertEquals("catalog refresh", request.purpose());
+  }
+
+  @Test
+  void constructor_whenUriIsBlank_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BoundedContentFetchRequest(" ", VALID_MAX_BYTES, VALID_TIMEOUT, VALID_PURPOSE));
+  }
+
+  @Test
+  void constructor_whenPurposeIsMultiline_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BoundedContentFetchRequest(VALID_URI, VALID_MAX_BYTES, VALID_TIMEOUT, "cat\nalog"));
+  }
+
+  @Test
+  void constructor_whenMaxBytesIsNotPositive_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BoundedContentFetchRequest(VALID_URI, 0L, VALID_TIMEOUT, VALID_PURPOSE));
+  }
+
+  @Test
+  void constructor_whenTimeoutIsNotPositive_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BoundedContentFetchRequest(
+                VALID_URI, VALID_MAX_BYTES, Duration.ZERO, VALID_PURPOSE));
+  }
+}

--- a/runtime-spi/src/test/java/network/crypta/runtime/spi/BoundedContentFetchResultTest.java
+++ b/runtime-spi/src/test/java/network/crypta/runtime/spi/BoundedContentFetchResultTest.java
@@ -1,0 +1,71 @@
+package network.crypta.runtime.spi;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class BoundedContentFetchResultTest {
+  @Test
+  void constructor_whenBytesMutatedAfterConstruction_expectStoredCopyUnaffected() {
+    byte[] bytes = {1, 2, 3};
+    BoundedContentFetchResult result =
+        new BoundedContentFetchResult(bytes, "CHK@requested", "CHK@resolved", "ok");
+
+    bytes[0] = 9;
+
+    assertArrayEquals(new byte[] {1, 2, 3}, result.bytes());
+  }
+
+  @Test
+  void bytes_whenReturnedArrayMutated_expectStoredCopyUnaffected() {
+    BoundedContentFetchResult result =
+        new BoundedContentFetchResult(new byte[] {4, 5, 6}, "CHK@requested", null, null);
+
+    byte[] firstRead = result.bytes();
+    firstRead[0] = 9;
+
+    assertArrayEquals(new byte[] {4, 5, 6}, result.bytes());
+  }
+
+  @Test
+  void constructor_whenOptionalValuesAreNull_expectAccepted() {
+    BoundedContentFetchResult result =
+        new BoundedContentFetchResult(new byte[] {7}, "CHK@requested", null, null);
+
+    assertEquals("CHK@requested", result.requestedUri());
+    assertNull(result.resolvedUri());
+    assertNull(result.statusMessage());
+  }
+
+  @Test
+  void constructor_whenRequestedUriIsBlank_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BoundedContentFetchResult(new byte[] {1}, " ", null, null));
+  }
+
+  @Test
+  void constructor_whenResolvedUriIsMultiline_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BoundedContentFetchResult(new byte[] {1}, "CHK@requested", "CHK@x\n", null));
+  }
+
+  @Test
+  void constructor_whenStatusMessageIsBlank_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BoundedContentFetchResult(new byte[] {1}, "CHK@requested", null, " "));
+  }
+
+  @Test
+  void constructor_whenStatusMessageIsMultiline_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new BoundedContentFetchResult(new byte[] {1}, "CHK@requested", null, "ok\nbad"));
+  }
+}

--- a/runtime-spi/src/test/java/network/crypta/runtime/spi/ContentFetchExceptionTest.java
+++ b/runtime-spi/src/test/java/network/crypta/runtime/spi/ContentFetchExceptionTest.java
@@ -1,0 +1,46 @@
+package network.crypta.runtime.spi;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class ContentFetchExceptionTest {
+  private static final String FAILURE_MESSAGE = "failed";
+
+  @Test
+  void constructor_whenErrorCodeSupplied_expectStableCodeReturned() {
+    ContentFetchException exception =
+        new ContentFetchException(ContentFetchException.CATALOG_FETCH_FAILED, FAILURE_MESSAGE);
+
+    assertEquals(ContentFetchException.CATALOG_FETCH_FAILED, exception.errorCode());
+    assertEquals(FAILURE_MESSAGE, exception.getMessage());
+  }
+
+  @Test
+  void constructor_whenCauseSupplied_expectCausePreserved() {
+    RuntimeException cause = new RuntimeException("source");
+    ContentFetchException exception =
+        new ContentFetchException(ContentFetchException.CATALOG_FETCH_TIMEOUT, "timeout", cause);
+
+    assertEquals(ContentFetchException.CATALOG_FETCH_TIMEOUT, exception.errorCode());
+    assertSame(cause, exception.getCause());
+  }
+
+  @Test
+  void constructor_whenErrorCodeIsBlank_expectIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> throwExceptionWithErrorCode(" "));
+  }
+
+  @Test
+  void constructor_whenErrorCodeIsMultiline_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class, () -> throwExceptionWithErrorCode("catalog\nfailed"));
+  }
+
+  private static void throwExceptionWithErrorCode(String errorCode) throws ContentFetchException {
+    throw new ContentFetchException(errorCode, FAILURE_MESSAGE);
+  }
+}

--- a/runtime-spi/src/test/java/network/crypta/runtime/spi/RuntimeSpiJdkOnlyBoundaryTest.java
+++ b/runtime-spi/src/test/java/network/crypta/runtime/spi/RuntimeSpiJdkOnlyBoundaryTest.java
@@ -1,0 +1,46 @@
+package network.crypta.runtime.spi;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class RuntimeSpiJdkOnlyBoundaryTest {
+  private static final Pattern IMPORT_PATTERN =
+      Pattern.compile("^import(?:\\s+static)?\\s+([^;]+);$");
+
+  @Test
+  void runtimeSpiMainSources_whenScanningImports_expectJdkOnlyImports() throws IOException {
+    Path mainJava = Path.of("src", "main", "java");
+    List<String> violations = new ArrayList<>();
+
+    for (Path sourceFile : findJavaSources(mainJava)) {
+      for (String line : Files.readAllLines(sourceFile)) {
+        Matcher matcher = IMPORT_PATTERN.matcher(line);
+        if (matcher.matches() && !matcher.group(1).startsWith("java.")) {
+          violations.add(sourceFile + " -> " + matcher.group(1));
+        }
+      }
+    }
+
+    assertTrue(
+        violations.isEmpty(),
+        "runtime-spi main sources must remain JDK-only imports."
+            + System.lineSeparator()
+            + String.join(System.lineSeparator(), violations));
+  }
+
+  private static List<Path> findJavaSources(Path root) throws IOException {
+    try (Stream<Path> stream = Files.walk(root)) {
+      return stream.filter(path -> path.toString().endsWith(".java")).sorted().toList();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a JDK-only runtime content fetch SPI plus a runtime-node adapter for bounded Crypta content retrieval, including timeout/size handling and USK redirect support.
- Add `crypta:` catalog source parsing, signature sidecar resolution, signed catalog fetch/refresh handling, and refresh metadata that preserves the last verified catalog after failed attempts.
- Expose catalog source kind and sync status through Platform API and Web Shell, update docs for supported Crypta catalog syntax, and keep `crypta:` artifact URIs explicitly unsupported for this PR.
- Add focused tests across runtime SPI, runtime-node, platform-appcatalog, platform-api, platform-web-shell, and platform-devtools coverage touched by the change.

## How to test
- `./gradlew spotlessApply`
- `git diff HEAD --check`
- `git diff --staged --check`
- `./gradlew :runtime-spi:test --tests '*ContentFetchExceptionTest'`
- `./gradlew sonarlintFile -Psonarlint.file=runtime-spi/src/test/java/network/crypta/runtime/spi/ContentFetchExceptionTest.java`

## Notes
- Base branch: `develop`
- Catalog distribution over Crypta remains transport only; signed catalog verification and trusted catalog keys remain the trust boundary.